### PR TITLE
Update V2RowTrackingReadTest.java to fix flaky test

### DIFF
--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/V2RowTrackingReadTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/V2RowTrackingReadTest.java
@@ -260,9 +260,14 @@ public class V2RowTrackingReadTest extends DeltaV2TestBase {
             dvRtPath));
 
     // Insert enough rows to encourage DV-based deletes (instead of full-file rewrites).
+    // Use coalesce(1) so that all rows land in a single file, making the base row-id
+    // assignment deterministic (row_id == position in the file == id).  Without this,
+    // spark.range() creates N partitions (N = available cores) and the per-file base
+    // row-ids become non-deterministic and therefore make the test flaky.
     spark
         .range(1000)
         .selectExpr("id", "cast(id as string) as name")
+        .coalesce(1)
         .write()
         .format("delta")
         .mode("append")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
The DV test writes 1000 rows via spark.range(1000) which creates N partitions (N = available CPU cores). Delta's RowId.assignFreshRowIds() assigns base row-ids in the order files appear in the commit, which is determined by non-deterministic task-completion order inside DelayedCommitProtocol.commitJob(). With resource contention, tasks complete out of partition order, causing the assertEquals(id, rowId) assertion to fail intermittently.

Fix: add coalesce(1) before the write so all rows land in a single file, making the row-id assignment deterministic (row_id == position in file == data id). The DV test still exercises the important code path (reading a file with deletion vectors and row tracking) since 1000 rows in one file is large enough for DV-based deletes.

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
CI passes, ran tests locally
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
