### PR TITLE
[UniForm] update v3 rfc

### DIFF
--- a/protocol_rfcs/iceberg-compat-v3.md
+++ b/protocol_rfcs/iceberg-compat-v3.md
@@ -39,3 +39,11 @@ When this feature is supported and enabled, writers must:
 - Block replacing partitioned tables with a differently-named partition spec
   - e.g. replacing a table partitioned by `part_a INT` with partition spec `part_b INT` must be blocked
   - e.g. replacing a table partitioned by `part_a INT` with partition spec `part_a LONG` is allowed
+- Require that the table schema contains only data types in the following allow-list: [`byte`, `short`, `integer`, `long`, `float`, `double`, `decimal`, `string`, `binary`, `boolean`, `timestamp`, `timestampNTZ`, `date`, `array`, `map`, `struct`, `variant`, `geometry`, `geography`].
+- When the [Type Widening](#type-widening) table feature is supported, require that all type changes applied on the table are in the following allow-list:
+  - `byte` -> `short`, `integer`, or `long`
+  - `short` -> `integer` or `long`
+  - `integer` -> `long`
+  - `float` -> `double`
+  - `decimal(p, s)` -> `decimal(p', s)` where `p' > p`
+- Require that any column write default is a literal value.

--- a/protocol_rfcs/iceberg-compat-v3.md
+++ b/protocol_rfcs/iceberg-compat-v3.md
@@ -45,5 +45,5 @@ When this feature is supported and enabled, writers must:
   - `short` -> `integer` or `long`
   - `integer` -> `long`
   - `float` -> `double`
-  - `decimal(p, s)` -> `decimal(p', s)` where `p' > p`
+  - `decimal(p, s)` -> `decimal(q, s)` where `q > p`
 - Require that any column write default is a literal value.


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (Protocol RFC)

## Description

Adds three writer requirements to the IcebergCompatV3 RFC that are present in the runtime implementation but missing from the spec:

1. **Allowed data types** — specifies the type allow-list for V3: the IcebergCompatV2 list extended with `variant`, `geometry`, and `geography`.
2. **Type widening** — when the [Type Widening](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#type-widening) feature is supported, lists all Iceberg-compatible type changes explicitly:
   - integer promotions (`byte`/`short`/`integer` → larger integral type)
   - `float` → `double`
   - `decimal(p, s)` → `decimal(p', s)` where `p' > p`
   
   Unlike IcebergCompatV1/V2, which refer to the Iceberg V2 spec, V3 enumerates the allowed changes directly because the Iceberg V3 spec adds `date → timestamp` and `unknown → any` which are not yet supported.
3. **Column write defaults** — requires that any column write default is a literal value.

## How was this patch tested?

Documentation-only change. Each addition was verified against the existing runtime implementation.

## Does this PR introduce _any_ user-facing changes?

No.