### PR TITLE
[Spark][Test] Add UC integration tests for ALTER table-property and mid-stream schema change

### DIFF
--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableAlterTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableAlterTest.java
@@ -95,6 +95,119 @@ public class UCDeltaTableAlterTest extends UCDeltaTableIntegrationBaseTest {
         });
   }
 
+  // Lock a table down via ALTER SET so further row-removing mutations (DELETE / UPDATE) are
+  // rejected, while INSERT (append) keeps working. The typical flow is "the table is finalized,
+  // lock it"; nobody sets appendOnly at CREATE-time. Verifies that the prop sticks (in UC
+  // metadata + SHOW TBLPROPERTIES) and that Delta enforces it on both a DELETE and an UPDATE,
+  // since both rewrite rows the contract forbids.
+  @Test
+  public void testAlterTableEnableAppendOnlyLocksOutMutations() throws Exception {
+    withNewTable(
+        "alter_enable_append_only_test",
+        "id INT, name STRING",
+        TableType.MANAGED,
+        tableName -> {
+          sql("INSERT INTO %s VALUES (1, 'a')", tableName);
+
+          sql("ALTER TABLE %s SET TBLPROPERTIES ('delta.appendOnly' = 'true')", tableName);
+
+          assertEquals("true", tableProperty(tableName, "delta.appendOnly"));
+          assertEquals(
+              "true",
+              loadTableViaDeltaRest(tableName)
+                  .getMetadata()
+                  .getProperties()
+                  .get("delta.appendOnly"));
+
+          // INSERT still allowed -- appendOnly only blocks operations that remove or rewrite
+          // existing rows.
+          sql("INSERT INTO %s VALUES (2, 'b')", tableName);
+          check(
+              sql("SELECT id, name FROM %s ORDER BY id", tableName),
+              List.of(row("1", "a"), row("2", "b")));
+
+          List<String> appendOnlyErrors =
+              List.of("appendOnly", "append-only", "DELTA_CANNOT_MODIFY_APPEND_ONLY");
+          assertThrowsWithCauseContainingAny(
+              appendOnlyErrors, () -> sql("DELETE FROM %s WHERE id = 1", tableName));
+          assertThrowsWithCauseContainingAny(
+              appendOnlyErrors, () -> sql("UPDATE %s SET name = 'x' WHERE id = 1", tableName));
+        });
+  }
+
+  // VACUUM retention tuning: operators adjust these two durations to balance storage costs
+  // against the time-travel / history-debugging window. Both are string-encoded intervals that
+  // should round-trip through UC's metadata unchanged. The SET path is the entire contract
+  // here -- Delta's enforcement at VACUUM time is covered by Delta's own suite.
+  @Test
+  public void testAlterTableSetVacuumRetentionDurationsUpdatesUcDeltaMetadata() throws Exception {
+    withNewTable(
+        "alter_set_retention_durations_test",
+        "id INT, name STRING",
+        TableType.MANAGED,
+        tableName -> {
+          sql(
+              "ALTER TABLE %s SET TBLPROPERTIES ("
+                  + "'delta.logRetentionDuration' = 'interval 14 days', "
+                  + "'delta.deletedFileRetentionDuration' = 'interval 2 days')",
+              tableName);
+
+          assertEquals("interval 14 days", tableProperty(tableName, "delta.logRetentionDuration"));
+          assertEquals(
+              "interval 2 days", tableProperty(tableName, "delta.deletedFileRetentionDuration"));
+
+          Map<String, String> properties =
+              loadTableViaDeltaRest(tableName).getMetadata().getProperties();
+          assertEquals("interval 14 days", properties.get("delta.logRetentionDuration"));
+          assertEquals("interval 2 days", properties.get("delta.deletedFileRetentionDuration"));
+
+          sql(
+              "ALTER TABLE %s UNSET TBLPROPERTIES ("
+                  + "'delta.logRetentionDuration', 'delta.deletedFileRetentionDuration')",
+              tableName);
+
+          assertNull(tableProperty(tableName, "delta.logRetentionDuration"));
+          assertNull(tableProperty(tableName, "delta.deletedFileRetentionDuration"));
+
+          properties = loadTableViaDeltaRest(tableName).getMetadata().getProperties();
+          assertFalse(properties.containsKey("delta.logRetentionDuration"));
+          assertFalse(properties.containsKey("delta.deletedFileRetentionDuration"));
+        });
+  }
+
+  // Pin current behaviour of ALTER TABLE SET ('delta.enableTypeWidening' = 'true') on a managed
+  // CCv2 Delta table: the SET succeeds, the prop appears in UC metadata, the writer feature
+  // lands in the protocol, and a subsequent ALTER COLUMN ... TYPE widens for real with the new
+  // value round-tripping. If a future change either no-ops this SET or rejects it, every
+  // assertion below flips and forces a review.
+  @Test
+  public void testAlterTableEnableTypeWideningOnManagedCcv2PinsCurrentBehavior() throws Exception {
+    withNewTable(
+        "alter_enable_type_widening_test",
+        "id INT, name STRING",
+        TableType.MANAGED,
+        tableName -> {
+          sql("ALTER TABLE %s SET TBLPROPERTIES ('delta.enableTypeWidening' = 'true')", tableName);
+
+          assertEquals("true", tableProperty(tableName, "delta.enableTypeWidening"));
+          Map<String, String> properties =
+              loadTableViaDeltaRest(tableName).getMetadata().getProperties();
+          assertEquals("true", properties.get("delta.enableTypeWidening"));
+          assertEquals("supported", properties.get("delta.feature.typeWidening"));
+
+          // Confirm the enablement is not a no-op: a subsequent widening ALTER actually works
+          // and a value that overflows INT round-trips. 9223372036854775807 is Long.MAX_VALUE;
+          // it can only be stored once the column has been widened to BIGINT, so a successful
+          // INSERT + SELECT here is direct evidence that the widening took effect.
+          sql("INSERT INTO %s VALUES (1, 'a')", tableName);
+          sql("ALTER TABLE %s ALTER COLUMN id TYPE BIGINT", tableName);
+          sql("INSERT INTO %s VALUES (9223372036854775807, 'b')", tableName);
+          check(
+              sql("SELECT id, name FROM %s ORDER BY id", tableName),
+              List.of(row("1", "a"), row("9223372036854775807", "b")));
+        });
+  }
+
   @Test
   public void testAlterTableProtocolDerivedPropertiesNoOpButCommit() throws Exception {
     withNewTable(

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableDataFrameStreamingTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableDataFrameStreamingTest.java
@@ -240,6 +240,58 @@ public class UCDeltaTableDataFrameStreamingTest extends UCDeltaTableIntegrationB
   }
 
   /**
+   * Verifies that an ALTER TABLE DROP COLUMN during an active streaming read surfaces a structured
+   * schema-change error, rather than silently producing rows with the old schema. DROP COLUMN is a
+   * non-additive schema evolution that requires the reader to either restart with the new schema or
+   * use {@code schemaTrackingLocation}; without either, the stream must fail loudly.
+   *
+   * <p>This complements {@link #testStreamingDeleteFailsWithHelpfulError}, which covers the
+   * DELETE-data-change failure; here the table data is unchanged but the schema is.
+   */
+  @TestAllTableTypes
+  public void testStreamingFailsWhenColumnIsDroppedMidStream(TableType tableType) throws Exception {
+    withNewTable(
+        "streaming_drop_column_mid_stream_test",
+        "id INT, dropme STRING",
+        // partitionFields
+        null,
+        tableType,
+        // Column-mapping is required for DROP COLUMN to be allowed.
+        "'delta.columnMapping.mode'='name'",
+        tableName -> {
+          sql("INSERT INTO %s VALUES (1, 'a'), (2, 'b'), (3, 'c')", tableName);
+
+          List<Integer> result = new ArrayList<>();
+          StreamingQuery query =
+              spark()
+                  .readStream()
+                  .format("delta")
+                  .table(tableName)
+                  .writeStream()
+                  .option("checkpointLocation", checkpoint())
+                  .foreachBatch(
+                      (VoidFunction2<Dataset<Row>, Long>) (df, id) -> result.addAll(ids(df)))
+                  .start();
+          try {
+            query.processAllAvailable();
+            assertThat(result).containsExactlyInAnyOrder(1, 2, 3);
+
+            sql("ALTER TABLE %s DROP COLUMN (dropme)", tableName);
+            sql("INSERT INTO %s VALUES (4)", tableName);
+
+            // Anchor on Delta's streaming-source error class family. The two members today are
+            // DELTA_STREAMING_INCOMPATIBLE_SCHEMA_CHANGE and ...USE_SCHEMA_LOG; matching the
+            // shared prefix is specific enough to reject unrelated "schema"-mentioning errors
+            // while tolerating Delta-side additions to the family.
+            assertStreamingThrowsContaining(
+                query::processAllAvailable, "DELTA_STREAMING_INCOMPATIBLE_SCHEMA_CHANGE");
+          } finally {
+            query.stop();
+          }
+        });
+  }
+
+  /**
    * CDF streaming reads work for both EXTERNAL and MANAGED tables.
    *
    * <p>Verifies that inserts and a delete produce the expected typed change events. Under the


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
[Spark][Test] Add UC integration tests for ALTER table-property and mid-stream schema change

New tests under `spark/unitycatalog/src/test/java/io/sparkuctest/`:

- `UCDeltaTableAlterTest`:
  - `testAlterTableEnableAppendOnlyLocksOutMutations`: ALTER sets `delta.appendOnly`, INSERT keeps working, DELETE + UPDATE rejected.
  - `testAlterTableSetVacuumRetentionDurationsUpdatesUcDeltaMetadata`: SET / UNSET `delta.logRetentionDuration` and `delta.deletedFileRetentionDuration`; values round-trip through UC.
  - `testAlterTableEnableTypeWideningOnManagedCcv2PinsCurrentBehavior`: pin that ALTER SET `delta.enableTypeWidening` succeeds, lands the writer feature, and a follow-up `ALTER COLUMN id TYPE BIGINT` actually widens.
- `UCDeltaTableDataFrameStreamingTest.testStreamingFailsWhenColumnIsDroppedMidStream`: DROP COLUMN during an active stream surfaces `DELTA_STREAMING_INCOMPATIBLE_SCHEMA_CHANGE`. Runs on EXTERNAL + MANAGED.

## How was this patch tested?
CI

## Does this PR introduce _any_ user-facing changes?
No.