### PR TITLE
[TEST ONLY] Trigger release integration validation

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -55,6 +55,9 @@ jobs:
           key: spark-dist-${{ runner.os }}-${{ matrix.spark_version }}
       - name: Set up pinned Unity Catalog
         uses: ./.github/actions/setup-unitycatalog
+        env:
+          SPARK_VERSION: ${{ matrix.spark_major_minor }}
+          SPARK_MAJOR_MINOR: ${{ matrix.spark_major_minor }}
       - name: Download Spark distributions
         run: bash project/scripts/install-spark.sh "${SPARK_VERSION}"
       - name: Run Scala + Python integration tests
@@ -91,6 +94,9 @@ jobs:
           key: spark-dist-${{ runner.os }}-4.0.1
       - name: Set up pinned Unity Catalog
         uses: ./.github/actions/setup-unitycatalog
+        env:
+          SPARK_VERSION: "4.0"
+          SPARK_MAJOR_MINOR: "4.0"
       - name: Download Spark distributions
         run: bash project/scripts/install-spark.sh "${SPARK_VERSION}"
       - name: Run Iceberg integration tests

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -1,0 +1,111 @@
+name: "Integration Tests (Release Validation)"
+
+on:
+  pull_request:
+    paths-ignore:
+      - '**.md'
+      - '**.txt'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  SBT_OPTS: "-Dsbt.coursier.home-dir=/home/runner/.cache/coursier -Dsbt.ivy.home=/home/runner/.ivy2"
+
+jobs:
+  generate-spark-info:
+    name: "Generate Spark Version Info"
+    runs-on: ubuntu-24.04
+    outputs:
+      spark_full_version_list: ${{ steps.generate.outputs.spark_full_version_list }}
+      spark_version_cache_key: ${{ steps.generate.outputs.spark_version_cache_key }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: "zulu"
+          java-version: "17"
+      - name: Generate Spark version info
+        id: generate
+        run: |
+          RELEASED=$(python3 project/scripts/get_spark_version_info.py --released-spark-versions)
+          FULL_VERSION_LIST="[]"
+          for SHORT in $(echo "$RELEASED" | jq -r '.[]'); do
+            FULL=$(python3 project/scripts/get_spark_version_info.py --get-field "$SHORT" fullVersion | jq -r)
+            FULL_VERSION_LIST=$(echo "$FULL_VERSION_LIST" | jq -c --arg v "$FULL" '. + [$v]')
+          done
+          echo "spark_full_version_list=$FULL_VERSION_LIST" >> $GITHUB_OUTPUT
+          echo "Full version list: $FULL_VERSION_LIST"
+          CACHE_KEY=$(echo "$FULL_VERSION_LIST" | jq -r '[.[]] | join("-")')
+          echo "spark_version_cache_key=$CACHE_KEY" >> $GITHUB_OUTPUT
+
+  scala-python-integration:
+    name: "Scala + Python Integration"
+    needs: generate-spark-info
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: "zulu"
+          java-version: "17"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Cache SBT and dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.sbt
+            ~/.ivy2/cache
+            ~/.coursier/cache
+            ~/.cache/coursier
+          key: sbt-integration-scala-python-${{ runner.os }}
+      - name: Cache Spark distributions
+        uses: actions/cache@v4
+        with:
+          path: ~/spark-*-bin-hadoop3
+          key: spark-dist-${{ runner.os }}-${{ needs.generate-spark-info.outputs.spark_version_cache_key }}
+      - name: Download Spark distributions
+        run: |
+          for full_spark_version in $(echo '${{ needs.generate-spark-info.outputs.spark_full_version_list }}' | jq -r '.[]'); do
+            bash project/scripts/install-spark.sh "$full_spark_version"
+          done
+      - name: Run Scala + Python integration tests
+        run: python run-integration-tests.py --use-local --no-pip
+
+  iceberg-integration:
+    name: "Iceberg Integration"
+    needs: generate-spark-info
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: "zulu"
+          java-version: "17"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Cache SBT and dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.sbt
+            ~/.ivy2/cache
+            ~/.coursier/cache
+            ~/.cache/coursier
+          key: sbt-integration-iceberg-${{ runner.os }}
+      - name: Cache Spark distributions
+        uses: actions/cache@v4
+        with:
+          path: ~/spark-*-bin-hadoop3
+          key: spark-dist-${{ runner.os }}-${{ needs.generate-spark-info.outputs.spark_version_cache_key }}
+      - name: Download Spark distributions
+        run: |
+          for full_spark_version in $(echo '${{ needs.generate-spark-info.outputs.spark_full_version_list }}' | jq -r '.[]'); do
+            bash project/scripts/install-spark.sh "$full_spark_version"
+          done
+      - name: Run Iceberg integration tests
+        run: python run-integration-tests.py --use-local --run-iceberg-integration-tests --iceberg-lib-version 1.10.1

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -21,8 +21,8 @@ jobs:
       spark_full_version_list: ${{ steps.generate.outputs.spark_full_version_list }}
       spark_version_cache_key: ${{ steps.generate.outputs.spark_version_cache_key }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           distribution: "zulu"
           java-version: "17"
@@ -45,16 +45,16 @@ jobs:
     needs: generate-spark-info
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           distribution: "zulu"
           java-version: "17"
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.10'
       - name: Cache SBT and dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             ~/.sbt
@@ -63,7 +63,7 @@ jobs:
             ~/.cache/coursier
           key: sbt-integration-scala-python-${{ runner.os }}
       - name: Cache Spark distributions
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/spark-*-bin-hadoop3
           key: spark-dist-${{ runner.os }}-${{ needs.generate-spark-info.outputs.spark_version_cache_key }}
@@ -80,16 +80,16 @@ jobs:
     needs: generate-spark-info
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           distribution: "zulu"
           java-version: "17"
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.10'
       - name: Cache SBT and dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             ~/.sbt
@@ -98,7 +98,7 @@ jobs:
             ~/.cache/coursier
           key: sbt-integration-iceberg-${{ runner.os }}
       - name: Cache Spark distributions
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/spark-*-bin-hadoop3
           key: spark-dist-${{ runner.os }}-${{ needs.generate-spark-info.outputs.spark_version_cache_key }}

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -14,36 +14,22 @@ env:
   SBT_OPTS: "-Dsbt.coursier.home-dir=/home/runner/.cache/coursier -Dsbt.ivy.home=/home/runner/.ivy2"
 
 jobs:
-  generate-spark-info:
-    name: "Generate Spark Version Info"
-    runs-on: ubuntu-24.04
-    outputs:
-      spark_full_version_list: ${{ steps.generate.outputs.spark_full_version_list }}
-      spark_version_cache_key: ${{ steps.generate.outputs.spark_version_cache_key }}
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
-        with:
-          distribution: "zulu"
-          java-version: "17"
-      - name: Generate Spark version info
-        id: generate
-        run: |
-          RELEASED=$(python3 project/scripts/get_spark_version_info.py --released-spark-versions)
-          FULL_VERSION_LIST="[]"
-          for SHORT in $(echo "$RELEASED" | jq -r '.[]'); do
-            FULL=$(python3 project/scripts/get_spark_version_info.py --get-field "$SHORT" fullVersion | jq -r)
-            FULL_VERSION_LIST=$(echo "$FULL_VERSION_LIST" | jq -c --arg v "$FULL" '. + [$v]')
-          done
-          echo "spark_full_version_list=$FULL_VERSION_LIST" >> $GITHUB_OUTPUT
-          echo "Full version list: $FULL_VERSION_LIST"
-          CACHE_KEY=$(echo "$FULL_VERSION_LIST" | jq -r '[.[]] | join("-")')
-          echo "spark_version_cache_key=$CACHE_KEY" >> $GITHUB_OUTPUT
-
   scala-python-integration:
-    name: "Scala + Python Integration"
-    needs: generate-spark-info
+    name: "Scala + Python Integration / Spark ${{ matrix.spark_version }}"
     runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - spark_version: "4.0.1"
+            spark_major_minor: "4.0"
+          - spark_version: "4.1.0"
+            spark_major_minor: "4.1"
+          - spark_version: "4.1.2"
+            spark_major_minor: "4.1"
+    env:
+      SPARK_VERSION: ${{ matrix.spark_version }}
+      SPARK_MAJOR_MINOR: ${{ matrix.spark_major_minor }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
@@ -61,24 +47,25 @@ jobs:
             ~/.ivy2/cache
             ~/.coursier/cache
             ~/.cache/coursier
-          key: sbt-integration-scala-python-${{ runner.os }}
+          key: sbt-integration-scala-python-${{ runner.os }}-${{ matrix.spark_version }}
       - name: Cache Spark distributions
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/spark-*-bin-hadoop3
-          key: spark-dist-${{ runner.os }}-${{ needs.generate-spark-info.outputs.spark_version_cache_key }}
+          key: spark-dist-${{ runner.os }}-${{ matrix.spark_version }}
+      - name: Set up pinned Unity Catalog
+        uses: ./.github/actions/setup-unitycatalog
       - name: Download Spark distributions
-        run: |
-          for full_spark_version in $(echo '${{ needs.generate-spark-info.outputs.spark_full_version_list }}' | jq -r '.[]'); do
-            bash project/scripts/install-spark.sh "$full_spark_version"
-          done
+        run: bash project/scripts/install-spark.sh "${SPARK_VERSION}"
       - name: Run Scala + Python integration tests
-        run: python run-integration-tests.py --use-local --no-pip
+        run: python run-integration-tests.py --use-local --no-pip --spark-version "${SPARK_VERSION}"
 
   iceberg-integration:
-    name: "Iceberg Integration"
-    needs: generate-spark-info
+    name: "Iceberg Integration / Spark 4.0.1"
     runs-on: ubuntu-24.04
+    env:
+      SPARK_VERSION: "4.0.1"
+      SPARK_MAJOR_MINOR: "4.0"
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
@@ -96,22 +83,20 @@ jobs:
             ~/.ivy2/cache
             ~/.coursier/cache
             ~/.cache/coursier
-          key: sbt-integration-iceberg-${{ runner.os }}
+          key: sbt-integration-iceberg-${{ runner.os }}-4.0.1
       - name: Cache Spark distributions
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/spark-*-bin-hadoop3
-          key: spark-dist-${{ runner.os }}-${{ needs.generate-spark-info.outputs.spark_version_cache_key }}
+          key: spark-dist-${{ runner.os }}-4.0.1
+      - name: Set up pinned Unity Catalog
+        uses: ./.github/actions/setup-unitycatalog
       - name: Download Spark distributions
-        run: |
-          for full_spark_version in $(echo '${{ needs.generate-spark-info.outputs.spark_full_version_list }}' | jq -r '.[]'); do
-            bash project/scripts/install-spark.sh "$full_spark_version"
-          done
+        run: bash project/scripts/install-spark.sh "${SPARK_VERSION}"
       - name: Run Iceberg integration tests
-        run: |
-          build/sbt exportSparkVersionsJson
-          tmp_json=$(mktemp)
-          jq 'map(.supportIceberg = (if .shortVersion == "4.0" then "true" else "false" end))' \
-            target/spark-versions.json > "$tmp_json"
-          mv "$tmp_json" target/spark-versions.json
-          python run-integration-tests.py --use-local --run-iceberg-integration-tests --iceberg-lib-version 1.10.1
+        run: >
+          python run-integration-tests.py
+          --use-local
+          --run-iceberg-integration-tests
+          --spark-version "${SPARK_VERSION}"
+          --iceberg-lib-version 1.10.1

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -108,4 +108,10 @@ jobs:
             bash project/scripts/install-spark.sh "$full_spark_version"
           done
       - name: Run Iceberg integration tests
-        run: python run-integration-tests.py --use-local --run-iceberg-integration-tests --iceberg-lib-version 1.10.1
+        run: |
+          build/sbt exportSparkVersionsJson
+          tmp_json=$(mktemp)
+          jq 'map(.supportIceberg = (if .shortVersion == "4.0" then "true" else "false" end))' \
+            target/spark-versions.json > "$tmp_json"
+          mv "$tmp_json" target/spark-versions.json
+          python run-integration-tests.py --use-local --run-iceberg-integration-tests --iceberg-lib-version 1.10.1

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -63,6 +63,34 @@ jobs:
       - name: Run Scala + Python integration tests
         run: python run-integration-tests.py --use-local --no-pip --spark-version "${SPARK_VERSION}"
 
+  flink-integration:
+    name: "Flink Integration"
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
+        with:
+          distribution: "zulu"
+          java-version: "17"
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.10'
+      - name: Cache SBT and dependencies
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: |
+            ~/.sbt
+            ~/.ivy2/cache
+            ~/.coursier/cache
+            ~/.cache/coursier
+          key: sbt-integration-flink-${{ runner.os }}
+      # flink has unitycatalog-client as a compile-scope dep.
+      # Publish the pinned UC build locally before sbt runs.
+      - name: Set up pinned Unity Catalog
+        uses: ./.github/actions/setup-unitycatalog
+      - name: Run Flink integration tests
+        run: python run-integration-tests.py --flink-only
+
   iceberg-integration:
     name: "Iceberg Integration / Spark 4.0.1"
     runs-on: ubuntu-24.04

--- a/project/scripts/install-spark.sh
+++ b/project/scripts/install-spark.sh
@@ -23,6 +23,9 @@ case "$full_spark_version" in
   4.1.0)
     TARBALL_SHA512="fff7f929d98779b096a2d2395b1b9db1ce277660f3852dd45e1457c373013f2669074315252181a3cea291d8f3a726c70f7f9b247e723edbf8080f40888edde1"
     ;;
+  4.1.2)
+    TARBALL_SHA512="490510e13e97da9493302bb33a802574bc417fcc107441419d1a0f87f2b372000db6e26f831a2bf92bc4b18bdf2c9023b1b6f2d021afdc7d6c19c8a11c03e685"
+    ;;
   *)
     echo "ERROR: No hardened SHA512 for Spark ${full_spark_version}." >&2
     echo "Add the checksum from: https://archive.apache.org/dist/spark/spark-${full_spark_version}/spark-${full_spark_version}-bin-hadoop3.tgz.sha512" >&2

--- a/project/scripts/install-spark.sh
+++ b/project/scripts/install-spark.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+# Download and extract a single Spark binary distribution.
+# Single source of truth for Spark download logic across CI workflows.
+#
+# Usage:
+#   bash project/scripts/install-spark.sh <spark_full_version>
+#
+# Arguments:
+#   spark_full_version  Full Spark version, e.g. "4.0.1"
+#
+# The version is extracted to ~/spark-<version>-bin-hadoop3.
+# To add a new version, append its SHA512 from:
+#   https://archive.apache.org/dist/spark/spark-<version>/spark-<version>-bin-hadoop3.tgz.sha512
+set -eu
+
+full_spark_version="${1:?Usage: install-spark.sh <spark_full_version>}"
+
+# SHA512 checksums from official Apache release assets.
+case "$full_spark_version" in
+  4.0.1)
+    TARBALL_SHA512="9198602c6b931b46686f32a25793b3bb58b522cd98a5b6a94d2484bae32e3e7b520d60f4bffe72ba29ff5c9ecd862443841ee47dde0f2f9e1bf52539f7baef41"
+    ;;
+  4.1.0)
+    TARBALL_SHA512="fff7f929d98779b096a2d2395b1b9db1ce277660f3852dd45e1457c373013f2669074315252181a3cea291d8f3a726c70f7f9b247e723edbf8080f40888edde1"
+    ;;
+  *)
+    echo "ERROR: No hardened SHA512 for Spark ${full_spark_version}." >&2
+    echo "Add the checksum from: https://archive.apache.org/dist/spark/spark-${full_spark_version}/spark-${full_spark_version}-bin-hadoop3.tgz.sha512" >&2
+    exit 1
+    ;;
+esac
+
+if [ -d ~/spark-${full_spark_version}-bin-hadoop3 ]; then
+  echo "Spark ${full_spark_version} already present, skipping download."
+else
+  echo "Downloading Spark ${full_spark_version}..."
+  TARBALL="spark-${full_spark_version}-bin-hadoop3.tgz"
+  wget -q "https://archive.apache.org/dist/spark/spark-${full_spark_version}/${TARBALL}"
+  echo "${TARBALL_SHA512}  ${TARBALL}" | sha512sum -c -
+  tar xzf "${TARBALL}" -C ~/
+  rm "${TARBALL}"
+  echo "Spark ${full_spark_version} installed to ~/spark-${full_spark_version}-bin-hadoop3."
+fi

--- a/run-integration-tests.py
+++ b/run-integration-tests.py
@@ -99,7 +99,29 @@ def load_spark_version_specs(root_dir):
         return json.load(f)
 
 
-def publish_all_variants(root_dir, spark_specs):
+def get_spark_major_minor(spark_version):
+    parts = spark_version.split(".")
+    if len(parts) < 2:
+        raise Exception("Spark version must include major.minor: %s" % spark_version)
+    return "%s.%s" % (parts[0], parts[1])
+
+
+def matching_spark_specs(spark_specs, spark_version):
+    if spark_version is None:
+        return spark_specs
+
+    requested_short_version = get_spark_major_minor(spark_version)
+    filtered_specs = [
+        spec for spec in spark_specs if spec["shortVersion"] == requested_short_version
+    ]
+    if not filtered_specs:
+        raise Exception(
+            "No Spark spec found for %s. Available specs: %s" %
+            (spark_version, ", ".join([spec["fullVersion"] for spec in spark_specs])))
+    return filtered_specs
+
+
+def publish_all_variants(root_dir, spark_specs, spark_version=None):
     """
     Publishes all artifact variants once upfront (replaces per-function publishM2 calls).
 
@@ -112,7 +134,7 @@ def publish_all_variants(root_dir, spark_specs):
 
     # Step 2: suffixed for each non-master Spark version
     # Clean between publishes to avoid stale class files from different Spark shims
-    for spec in spark_specs:
+    for spec in matching_spark_specs(spark_specs, spark_version):
         if spec.get("isMaster", False):
             continue
         spark_version = spec["fullVersion"]
@@ -176,6 +198,28 @@ def get_spark_variants(spark_specs):
         })
 
     return variants
+
+
+def filter_spark_variants(variants, spark_specs, spark_version):
+    if spark_version is None:
+        return variants
+
+    requested_short_version = get_spark_major_minor(spark_version)
+    # Validate against CrossSparkVersions' major.minor specs. This intentionally allows patch
+    # runtime versions like 4.1.2 to reuse the 4.1 artifact family.
+    matching_spark_specs(spark_specs, spark_version)
+
+    filtered_variants = []
+    for variant in variants:
+        variant_short_version = get_spark_major_minor(variant["spark_version"])
+        if variant_short_version == requested_short_version:
+            runtime_variant = dict(variant)
+            runtime_variant["spark_version"] = spark_version
+            filtered_variants.append(runtime_variant)
+
+    if not filtered_variants:
+        raise Exception("No integration test variants found for Spark %s" % spark_version)
+    return filtered_variants
 
 
 def run_scala_integration_tests(root_dir, version, test_name, extra_maven_repo, scala_version,
@@ -797,6 +841,12 @@ if __name__ == "__main__":
         action="store_true",
         help="Generate JARs from local source code and use to run tests")
     parser.add_argument(
+        "--spark-version",
+        required=False,
+        default=None,
+        help="In --use-local mode, run only variants matching this Spark major.minor. " +
+             "Patch versions such as 4.1.2 reuse the matching major.minor artifact suffix.")
+    parser.add_argument(
         "--run-storage-s3-dynamodb-integration-tests",
         required=False,
         default=False,
@@ -881,8 +931,9 @@ if __name__ == "__main__":
     if args.use_local:
         spark_specs = load_spark_version_specs(root_dir)
         clear_artifact_cache()
-        publish_all_variants(root_dir, spark_specs)
+        publish_all_variants(root_dir, spark_specs, args.spark_version)
         variants = get_spark_variants(spark_specs)
+        variants = filter_spark_variants(variants, spark_specs, args.spark_version)
 
     run_python = not args.scala_only and not args.pip_only
     run_scala = not args.python_only and not args.pip_only
@@ -986,7 +1037,10 @@ if __name__ == "__main__":
             run_python_integration_tests(root_dir, args.version, args.test, args.maven_repo,
                                          variant)
 
-        test_missing_delta_storage_jar(root_dir, args.version, args.use_local)
+        if any(variant["suffix"] == "" for variant in variants):
+            test_missing_delta_storage_jar(root_dir, args.version, args.use_local)
+        else:
+            print("Skipping 'missing_delta_storage_jar' - unsuffixed variant not selected")
 
     if run_pip:
         if args.use_testpypi and args.use_localpypiartifact is not None:

--- a/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
@@ -903,15 +903,12 @@ object Snapshot extends DeltaLogging {
       spark: SparkSession,
       deltaLog: DeltaLog,
       file: FileStatus): (StructType, Long) = {
-    // Converter used to convert Parquet `MessageType` to Spark SQL `StructType`
-    val converter = new ParquetToSparkSchemaConverter(
-      assumeBinaryIsString = spark.sessionState.conf.isParquetBinaryAsString,
-      assumeInt96IsTimestamp = spark.sessionState.conf.isParquetINT96AsTimestamp)
-
     val conf = deltaLog.newDeltaHadoopConf()
+    // Converter used to convert Parquet `MessageType` to Spark SQL `StructType`
+    val converter = new ParquetToSparkSchemaConverter(spark.sessionState.conf)
 
     val parquetMetadata = {
-      ParquetFileReader.readFooter(deltaLog.newDeltaHadoopConf(), file.getPath)
+      ParquetFileReader.readFooter(conf, file.getPath)
     }
     val rowCount = parquetMetadata.getBlocks.asScala.map(_.getRowCount).sum
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/convert/ConvertUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/convert/ConvertUtils.scala
@@ -334,14 +334,7 @@ trait ConvertUtilsBase extends DeltaLogging {
 /**
  * Configuration for fetching Parquet schema.
  *
- * @param assumeBinaryIsString: whether unannotated BINARY fields should be assumed to be Spark
- *                              SQL [[StringType]] fields.
- * @param assumeInt96IsTimestamp: whether unannotated INT96 fields should be assumed to be Spark
- *                                SQL [[TimestampType]] fields.
  * @param ignoreCorruptFiles: a boolean indicating whether corrupt files should be ignored during
  *                            schema retrieval.
  */
-case class ParquetSchemaFetchConfig(
-  assumeBinaryIsString: Boolean,
-  assumeInt96IsTimestamp: Boolean,
-  ignoreCorruptFiles: Boolean)
+case class ParquetSchemaFetchConfig(ignoreCorruptFiles: Boolean)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/convert/ParquetFileManifest.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/convert/ParquetFileManifest.scala
@@ -57,10 +57,7 @@ class ManualListingFileManifest(
       }.toMap
       val footerSeq = DeltaFileOperations.readParquetFootersInParallel(
         conf.value.value, fileStatuses.map(_.toFileStatus), fetchConfig.ignoreCorruptFiles)
-      val schemaConverter = new ParquetToSparkSchemaConverter(
-        assumeBinaryIsString = fetchConfig.assumeBinaryIsString,
-        assumeInt96IsTimestamp = fetchConfig.assumeInt96IsTimestamp
-      )
+      val schemaConverter = new ParquetToSparkSchemaConverter(conf.value.value)
       footerSeq.map { footer =>
         val fileStatus = pathToStatusMapping(footer.getFile.toString)
         val schema = ParquetFileFormat.readSchemaFromFooter(footer, schemaConverter)
@@ -138,10 +135,7 @@ class CatalogFileManifest(
           conf.value.value,
           fileStatuses.map(_.toFileStatus),
           fetchConfig.ignoreCorruptFiles)
-        val schemaConverter = new ParquetToSparkSchemaConverter(
-          assumeBinaryIsString = fetchConfig.assumeBinaryIsString,
-          assumeInt96IsTimestamp = fetchConfig.assumeInt96IsTimestamp
-        )
+        val schemaConverter = new ParquetToSparkSchemaConverter(conf.value.value)
         footerSeq.map { footer =>
           val schema = ParquetFileFormat.readSchemaFromFooter(footer, schemaConverter)
           val fileStatus = pathToFile(footer.getFile.toString)
@@ -211,10 +205,7 @@ class MetadataLogFileManifest(
       }.toMap
       val footerSeq = DeltaFileOperations.readParquetFootersInParallel(
         conf.value.value, fileStatuses.map(_.toFileStatus), fetchConfig.ignoreCorruptFiles)
-      val schemaConverter = new ParquetToSparkSchemaConverter(
-        assumeBinaryIsString = fetchConfig.assumeBinaryIsString,
-        assumeInt96IsTimestamp = fetchConfig.assumeInt96IsTimestamp
-      )
+      val schemaConverter = new ParquetToSparkSchemaConverter(conf.value.value)
       footerSeq.map { footer =>
         val fileStatus = pathToStatusMapping(footer.getFile.toString)
         val schema = ParquetFileFormat.readSchemaFromFooter(footer, schemaConverter)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/convert/ParquetTable.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/convert/ParquetTable.scala
@@ -54,9 +54,14 @@ class ParquetTable(
   }
 
   protected lazy val serializableConf: SerializableConfiguration = {
-    // scalastyle:off deltahadoopconfiguration
     val sqlConf = spark.sessionState.conf
+    // scalastyle:off deltahadoopconfiguration
     val hadoopConf = spark.sessionState.newHadoopConf()
+    // scalastyle:on deltahadoopconfiguration
+
+    // ParquetToSparkSchemaConverter(Configuration) requires these SQLConf values to be
+    // present in the Hadoop conf. newHadoopConf only includes SQL configs explicitly set
+    // by the user, so copy the required values here just like Spark's Parquet reader does.
     hadoopConf.setBoolean(SQLConf.PARQUET_BINARY_AS_STRING.key, sqlConf.isParquetBinaryAsString)
     hadoopConf.setBoolean(SQLConf.PARQUET_INT96_AS_TIMESTAMP.key, sqlConf.isParquetINT96AsTimestamp)
     hadoopConf.setBoolean(SQLConf.CASE_SENSITIVE.key, sqlConf.caseSensitiveAnalysis)
@@ -66,11 +71,7 @@ class ParquetTable(
     hadoopConf.setBoolean(
       SQLConf.LEGACY_PARQUET_NANOS_AS_LONG.key,
       sqlConf.legacyParquetNanosAsLong)
-    hadoopConf.setBoolean(
-      SQLConf.PARQUET_FIELD_ID_READ_ENABLED.key,
-      sqlConf.parquetFieldIdReadEnabled)
     new SerializableConfiguration(hadoopConf)
-    // scalastyle:on deltahadoopconfiguration
   }
 
   override val partitionSchema: StructType = {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/convert/ParquetTable.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/convert/ParquetTable.scala
@@ -28,6 +28,7 @@ import org.apache.spark.sql.{AnalysisException, SparkSession}
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.execution.datasources.PartitioningUtils
 import org.apache.spark.sql.execution.datasources.parquet.{ParquetFileFormat, ParquetToSparkSchemaConverter}
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.SerializableConfiguration
 
@@ -54,7 +55,21 @@ class ParquetTable(
 
   protected lazy val serializableConf: SerializableConfiguration = {
     // scalastyle:off deltahadoopconfiguration
-    new SerializableConfiguration(spark.sessionState.newHadoopConf())
+    val sqlConf = spark.sessionState.conf
+    val hadoopConf = spark.sessionState.newHadoopConf()
+    hadoopConf.setBoolean(SQLConf.PARQUET_BINARY_AS_STRING.key, sqlConf.isParquetBinaryAsString)
+    hadoopConf.setBoolean(SQLConf.PARQUET_INT96_AS_TIMESTAMP.key, sqlConf.isParquetINT96AsTimestamp)
+    hadoopConf.setBoolean(SQLConf.CASE_SENSITIVE.key, sqlConf.caseSensitiveAnalysis)
+    hadoopConf.setBoolean(
+      SQLConf.PARQUET_INFER_TIMESTAMP_NTZ_ENABLED.key,
+      sqlConf.parquetInferTimestampNTZEnabled)
+    hadoopConf.setBoolean(
+      SQLConf.LEGACY_PARQUET_NANOS_AS_LONG.key,
+      sqlConf.legacyParquetNanosAsLong)
+    hadoopConf.setBoolean(
+      SQLConf.PARQUET_FIELD_ID_READ_ENABLED.key,
+      sqlConf.parquetFieldIdReadEnabled)
+    new SerializableConfiguration(hadoopConf)
     // scalastyle:on deltahadoopconfiguration
   }
 
@@ -71,11 +86,7 @@ class ParquetTable(
   override val format: String = "parquet"
 
   val fileManifest: ConvertTargetFileManifest = {
-    val fetchConfig = ParquetSchemaFetchConfig(
-      spark.sessionState.conf.isParquetBinaryAsString,
-      spark.sessionState.conf.isParquetINT96AsTimestamp,
-      spark.sessionState.conf.ignoreCorruptFiles
-    )
+    val fetchConfig = ParquetSchemaFetchConfig(spark.sessionState.conf.ignoreCorruptFiles)
     if (spark.sessionState.conf.getConf(DeltaSQLConf.DELTA_CONVERT_USE_METADATA_LOG) &&
       FileStreamSink.hasMetadata(Seq(basePath), serializableConf.value, spark.sessionState.conf)) {
       new MetadataLogFileManifest(spark, basePath, partitionSchema, fetchConfig, serializableConf)


### PR DESCRIPTION
## Purpose

Temporary PR to trigger release-validation integration tests requested for the UC / table-service validation work.

This PR is **test-only** and is **not intended to merge into master**. After the signal is collected, this PR should be closed.

## What This Adds

- Adds `.github/workflows/integration_test.yaml` to run broader release-validation integration tests on PR CI.
- Adds `project/scripts/install-spark.sh` to download pinned Spark binary distributions with SHA512 verification.
- Adds `--spark-version` filtering to `run-integration-tests.py` so each CI job runs only the intended Spark runtime instead of all Spark variants in one runner.

## CI Coverage

The Integration Tests workflow now creates separate jobs/checks:

| Job | What it validates |
| --- | --- |
| `Scala + Python Integration / Spark 4.0.1` | `_4.0` Delta artifacts against Spark `4.0.1` |
| `Scala + Python Integration / Spark 4.1.0` | default unsuffixed + `_4.1` Delta artifacts against Spark `4.1.0` |
| `Scala + Python Integration / Spark 4.1.2` | default unsuffixed + `_4.1` Delta artifacts against Spark `4.1.2` |
| `Iceberg Integration / Spark 4.0.1` | Iceberg integration path with Spark `4.0.1` and Iceberg `1.10.1` |

Each job sets `SPARK_VERSION` / `SPARK_MAJOR_MINOR` before UC setup, so the pinned UC build publishes the matching connector, for example:

- `unitycatalog-spark_4.0_2.13` for Spark `4.0.1`
- `unitycatalog-spark_4.1_2.13` for Spark `4.1.0` and `4.1.2`

`4.1.2` is a runtime patch-version check; it reuses the existing Spark `4.1` Delta artifact family.

## Related Local Validation

The separate UC table-service validation should be run locally with the focused UCDelta test pattern:

```bash
build/sbt 'sparkUnityCatalog/testOnly io.sparkuctest.UCDelta*'
```

Do not run the broader `io.sparkuctest.*` pattern for that validation, because `UnityCatalogSupportTest` resets the UC-related environment settings in-process.

## Current CI Run

https://github.com/delta-io/delta/actions/runs/27288371931

