### PR TITLE
[Release] Prepare Delta 4.3.0: remove Spark 4.2 preview, set release version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1833,6 +1833,13 @@ lazy val releaseSettings = Seq(
   releasePublishArtifactsAction := PgpKeys.publishSigned.value,
   releaseCrossBuild := true,
   pgpPassphrase := sys.env.get("PGP_PASSPHRASE").map(_.toArray),
+  // Allow local Maven overwrites for release versions. The cross-Spark publish workflow
+  // publishes modules like delta-contribs (no Spark suffix) in both the backward-compat
+  // step and the per-version steps, producing identical artifacts. SBT 1.9+ blocks
+  // overwriting release artifacts by default; this restores the prior behavior for local
+  // publishing only (remote publish via publishSigned is unaffected).
+  publishLocalConfiguration := publishLocalConfiguration.value.withOverwrite(true),
+  publishM2Configuration := publishM2Configuration.value.withOverwrite(true),
 
   // TODO: This isn't working yet ...
   sonatypeProfileName := "io.delta", // sonatype account domain name prefix / group ID

--- a/project/CrossSparkVersions.scala
+++ b/project/CrossSparkVersions.scala
@@ -286,17 +286,6 @@ object SparkVersionSpec {
     jacksonVersion = "2.18.2"
   )
 
-  private val spark42Preview = SparkVersionSpec(
-    fullVersion = "4.2.0-preview5",
-    targetJvm = "17",
-    additionalSourceDir = Some("scala-shims/spark-4.2"),
-    supportIceberg = false,
-    supportHudi = false,
-    antlr4Version = "4.13.1",
-    additionalJavaOptions = java17TestSettings,
-    jacksonVersion = "2.18.2"
-  )
-
   /** Default Spark version */
   val DEFAULT = spark41
 
@@ -304,7 +293,7 @@ object SparkVersionSpec {
   val MASTER: Option[SparkVersionSpec] = None
 
   /** All supported Spark versions - internal use only */
-  val ALL_SPECS = Seq(spark40, spark41, spark42Preview)
+  val ALL_SPECS = Seq(spark40, spark41)
 }
 
 /** See docs on top of this file */

--- a/project/tests/test_cross_spark_publish.py
+++ b/project/tests/test_cross_spark_publish.py
@@ -108,7 +108,6 @@ class SparkVersionSpec:
 SPARK_VERSIONS: Dict[str, SparkVersionSpec] = {
     "4.0.1": SparkVersionSpec(suffix="_4.0", support_iceberg=True, support_hudi=True),
     "4.1.0": SparkVersionSpec(suffix="_4.1", support_iceberg=True, support_hudi=False),
-    "4.2.0-preview5": SparkVersionSpec(suffix="_4.2", support_iceberg=False, support_hudi=False)
 }
 
 # The default Spark version

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "4.3.0-SNAPSHOT"
+ThisBuild / version := "4.3.0"


### PR DESCRIPTION
## Summary

Prepares the `branch-4.3` release branch for the Delta 4.3.0 release:

- **Set version to `4.3.0`** in `version.sbt` (was `4.3.0-SNAPSHOT`)
- **Remove Spark 4.2 preview** (`4.2.0-preview5`) from `ALL_SPECS` in `CrossSparkVersions.scala` — Spark 4.2 is not yet GA and should not be included in the release build matrix

After this change, the release will publish artifacts for Spark 4.0 and 4.1 only:
- Unsuffixed backward-compat artifacts (e.g., `delta-spark_2.13:4.3.0`)
- Spark-versioned artifacts (e.g., `delta-spark_4.0_2.13:4.3.0`, `delta-spark_4.1_2.13:4.3.0`)

## Test plan

- [ ] Verify `build/sbt compile` succeeds with only Spark 4.0/4.1 in ALL_SPECS
- [ ] Verify `build/sbt exportSparkVersionsJson` outputs only 4.0 and 4.1 entries