### PR TITLE
[Flink][Upsert Step 4] Add DeltaUpsertWriterTask, upsert merge strategies, and RowKind routing

### DIFF
--- a/flink/src/main/java/io/delta/flink/sink/DeltaSinkConf.java
+++ b/flink/src/main/java/io/delta/flink/sink/DeltaSinkConf.java
@@ -16,6 +16,8 @@
 
 package io.delta.flink.sink;
 
+import io.delta.flink.sink.mergestrategy.AppendOnly;
+import io.delta.flink.sink.mergestrategy.CoWUpsert;
 import io.delta.kernel.internal.types.DataTypeJsonSerDe;
 import io.delta.kernel.types.StructField;
 import io.delta.kernel.types.StructType;
@@ -286,6 +288,18 @@ public class DeltaSinkConf implements Serializable {
       this.sinkSchema = DataTypeJsonSerDe.deserializeStructType(this.sinkSchemaString);
     }
     return this.sinkSchema;
+  }
+
+  /**
+   * Creates a fresh {@link MergeStrategy} for the configured {@link WriteMode}.
+   *
+   * <p>Returns a new instance on every call — merge strategies hold per-checkpoint state and must
+   * not be shared across {@link DeltaSinkWriter} instances.
+   *
+   * @return {@link CoWUpsert} when in upsert mode; {@link AppendOnly} otherwise
+   */
+  public MergeStrategy createMergeStrategy() {
+    return isUpsert() ? new CoWUpsert() : new AppendOnly();
   }
 
   /**

--- a/flink/src/main/java/io/delta/flink/sink/DeltaSinkWriter.java
+++ b/flink/src/main/java/io/delta/flink/sink/DeltaSinkWriter.java
@@ -16,24 +16,18 @@
 
 package io.delta.flink.sink;
 
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
-import com.github.benmanes.caffeine.cache.RemovalCause;
-import com.github.benmanes.caffeine.cache.RemovalListener;
-import io.delta.flink.Conf;
+import io.delta.flink.sink.mergestrategy.Upsert;
 import io.delta.flink.table.DeltaTable;
 import io.delta.kernel.expressions.Literal;
+import io.delta.kernel.types.StructType;
 import java.io.IOException;
 import java.util.*;
-import java.util.stream.Collectors;
 import org.apache.flink.api.common.eventtime.Watermark;
 import org.apache.flink.api.connector.sink2.CommittingSinkWriter;
-import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
 import org.apache.flink.streaming.api.connector.sink2.SupportsPreWriteTopology;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.binary.BinaryRowData;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,9 +56,7 @@ import org.slf4j.LoggerFactory;
  * durable data files and describing their effects via {@code DeltaWriterResult}, allowing commit
  * coordination and deduplication to be handled centrally.
  */
-public class DeltaSinkWriter
-    implements CommittingSinkWriter<RowData, DeltaWriterResult>,
-        RemovalListener<Map<String, String>, DeltaWriterTask> {
+public class DeltaSinkWriter implements CommittingSinkWriter<RowData, DeltaWriterResult> {
   private static final Logger LOG = LoggerFactory.getLogger(DeltaSinkWriter.class);
 
   private final String jobId;
@@ -74,13 +66,14 @@ public class DeltaSinkWriter
   private final DeltaTable deltaTable;
   private final DeltaSinkConf conf;
 
-  private final Cache<Map<String, String>, DeltaWriterTask> writerTasksByPartition;
-
-  private final List<DeltaWriterResult> completedWrites;
-
   private final SinkWriterMetricGroup metricGroup;
-  private final Counter numFilesWrittenCounter;
   private volatile long lastSendTimeMs;
+
+  /**
+   * Strategy that owns per-checkpoint upsert/delete bookkeeping and turns it into Delta actions.
+   * Selected once at construction from {@link DeltaSinkConf#getWriteMode()}.
+   */
+  private final MergeStrategy mergeStrategy;
 
   private DeltaSinkWriter(
       String jobId,
@@ -95,25 +88,16 @@ public class DeltaSinkWriter
 
     this.deltaTable = deltaTable;
     this.conf = conf;
-    this.writerTasksByPartition =
-        Caffeine.newBuilder()
-            .executor(Runnable::run)
-            .maximumSize(Conf.getInstance().getSinkWriterNumConcurrentFiles())
-            .removalListener(this)
-            .build();
-    this.completedWrites = new ArrayList<>();
 
     this.metricGroup = metricGroup;
-    this.numFilesWrittenCounter = metricGroup.counter("numFilesWritten");
     metricGroup.setCurrentSendTimeGauge(() -> lastSendTimeMs);
-    metricGroup.gauge("activePartitions", () -> (long) this.writerTasksByPartition.asMap().size());
-    metricGroup.gauge(
-        "resultBufferSize",
-        () ->
-            this.writerTasksByPartition.asMap().values().stream()
-                .map(DeltaWriterTask::getResultBuffer)
-                .mapToLong(List::size)
-                .sum());
+
+    this.mergeStrategy = conf.createMergeStrategy();
+    this.mergeStrategy.init(this);
+    LOG.debug(
+        "DeltaSinkWriter created in {} mode (primary-key ordinals = {})",
+        conf.getWriteMode(),
+        Arrays.toString(conf.getPrimaryKeyOrdinals()));
   }
 
   /**
@@ -126,25 +110,40 @@ public class DeltaSinkWriter
    */
   @Override
   public void write(RowData element, Context context) throws IOException, InterruptedException {
-    try {
-      final Map<String, Literal> partitionValues =
-          Conversions.FlinkToDelta.partitionValues(
-              deltaTable.getSchema(), deltaTable.getPartitionColumns(), element);
-
-      Map<String, String> writerKey =
-          partitionValues.entrySet().stream()
-              .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().toString()));
-
-      writerTasksByPartition
-          .get(
-              writerKey,
-              (key) ->
-                  new DeltaWriterTask(
-                      jobId, subtaskId, attemptNumber, deltaTable, conf, partitionValues))
-          .write(element, context);
-    } catch (IOException | InterruptedException e) {
-      metricGroup.getNumRecordsSendErrorsCounter().inc();
-      throw e;
+    final Map<String, Literal> partitionValues =
+        Conversions.FlinkToDelta.partitionValues(
+            deltaTable.getSchema(), deltaTable.getPartitionColumns(), element);
+    // "Trust the provided RowKind" upsert policy:
+    //   - INSERT is taken at face value: the source claims this PK is new, so we just append.
+    //     This keeps the hot path cheap for INSERT-heavy workloads (e.g. CDC bootstrap).
+    //     Trade-off: if the source can redeliver an INSERT for a PK already in the table
+    //     across a checkpoint boundary (operator-induced source replay, CDC re-snapshot,
+    //     at-least-once source), the sink will produce duplicate rows for that PK. Flink's
+    //     own failover within a checkpoint is still safe via the transactional committer.
+    //   - UPDATE_AFTER carries a new image for an existing key. We record the PK so the
+    //     merge step removes the pre-image, then fall through to the INSERT case to append
+    //     the new image as a regular AddFile.
+    //   - UPDATE_BEFORE conveys no information the matching UPDATE_AFTER doesn't already
+    //     carry, so we drop it. Flink elides it for PK sinks anyway.
+    //   - DELETE records the PK; the merge step emits the corresponding RemoveFile/DV
+    //     without appending a row.
+    switch (element.getRowKind()) {
+      case INSERT:
+        mergeStrategy.insert(extractPrimaryKey(element), partitionValues, element, context);
+        break;
+      case UPDATE_AFTER:
+        mergeStrategy.upsert(extractPrimaryKey(element), partitionValues, element, context);
+        break;
+      case UPDATE_BEFORE:
+        // Dropped — see policy comment above.
+        break;
+      case DELETE:
+        mergeStrategy.delete(extractPrimaryKey(element), partitionValues);
+        break;
+      default:
+        // Defensive: if Flink ever introduces a new RowKind, we'd rather fail loudly than
+        // silently treat the row as a no-op while still incrementing the metric counters.
+        throw new IllegalStateException("Unexpected RowKind: " + element.getRowKind());
     }
 
     // Recording Metrics
@@ -154,15 +153,66 @@ public class DeltaSinkWriter
     this.metricGroup.getNumRecordsSendCounter().inc();
   }
 
+  public DeltaTable getTable() {
+    return deltaTable;
+  }
+
+  public DeltaSinkConf getConf() {
+    return conf;
+  }
+
+  /**
+   * Factory for the writer task that backs a single partition in the current checkpoint. Upsert
+   * mode needs the dedup-aware {@link DeltaUpsertWriterTask}; append mode uses the plain {@link
+   * DeltaWriterTask}.
+   */
+  public DeltaWriterTask newWriterTask(Map<String, Literal> partitionValues) {
+    if (mergeStrategy instanceof Upsert) {
+      return new DeltaUpsertWriterTask(
+          jobId,
+          subtaskId,
+          attemptNumber,
+          deltaTable,
+          conf,
+          partitionValues,
+          (Upsert) mergeStrategy);
+    }
+    return new DeltaWriterTask(jobId, subtaskId, attemptNumber, deltaTable, conf, partitionValues);
+  }
+
+  /**
+   * Extracts the primary-key values of {@code row} as a {@code List<Object>} in PK column order.
+   *
+   * <p>Uses {@link RowData#isNullAt} + {@link RowData}'s typed accessors so primitive types are
+   * boxed without going through the more expensive generic field access path.
+   */
+  private List<Literal> extractPrimaryKey(RowData row) {
+    StructType schema = conf.getSinkSchema();
+    int[] ordinals = conf.getPrimaryKeyOrdinals();
+    List<Literal> key = new ArrayList<>(ordinals.length);
+    for (int ord : ordinals) {
+      key.add(Conversions.FlinkToDelta.data(schema, row, ord));
+    }
+    return key;
+  }
+
+  /**
+   * Delegates to {@link MergeStrategy#merge()} to flush all pending writer tasks and materialize
+   * any upsert/delete bookkeeping into Delta actions for the current checkpoint. Bumps the {@code
+   * numFilesWritten} counter by the number of resulting writes — accounting at this layer keeps the
+   * metric a writer concern instead of threading the metric group through every {@link
+   * MergeStrategy}.
+   */
   @Override
   public Collection<DeltaWriterResult> prepareCommit() {
     LOG.debug("Preparing commits");
-
-    writerTasksByPartition.invalidateAll();
-
-    List<DeltaWriterResult> results = List.copyOf(completedWrites);
-    completedWrites.clear();
-    return results;
+    try {
+      Collection<DeltaWriterResult> results = mergeStrategy.merge();
+      metricGroup.counter("numFilesWritten").inc(results.size());
+      return results;
+    } catch (IOException e) {
+      throw new RuntimeException("merge failed for checkpoint", e);
+    }
   }
 
   @Override
@@ -178,24 +228,6 @@ public class DeltaSinkWriter
     // close the DeltaTable will interrupt ongoing operations such as log-replay
     LOG.debug("Force closing the Writer. Interrupting running table loading");
     this.deltaTable.close();
-  }
-
-  @Override
-  public void onRemoval(
-      @Nullable Map<String, String> key, @Nullable DeltaWriterTask value, RemovalCause cause) {
-    // Close the evicted task and collect its result
-    try {
-      if (value != null) {
-        long startMs = System.currentTimeMillis();
-        List<DeltaWriterResult> results = value.complete();
-        lastSendTimeMs = System.currentTimeMillis() - startMs;
-
-        numFilesWrittenCounter.inc(results.size());
-        completedWrites.addAll(results);
-      }
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
   }
 
   public static class Builder {

--- a/flink/src/main/java/io/delta/flink/sink/DeltaUpsertWriterTask.java
+++ b/flink/src/main/java/io/delta/flink/sink/DeltaUpsertWriterTask.java
@@ -38,17 +38,17 @@ import org.apache.flink.table.data.RowData;
  */
 public class DeltaUpsertWriterTask extends DeltaWriterTask {
 
-  /** PK hash &rarr; current index into {@link #buffer} for rows still live in memory. */
-  private final Map<Integer, Integer> keyToPositionInMemory;
+  /** PK key &rarr; current index into {@link #buffer} for rows still live in memory. */
+  private final Map<String, Integer> keyToPositionInMemory;
 
   /** {@code true} when {@link #buffer} contains {@code null} holes left by {@link #erase}. */
   private boolean sparseMemory = false;
 
   /**
-   * One entry per dumped Parquet file (in dump order): PK hash &rarr; row index in that file. Used
+   * One entry per dumped Parquet file (in dump order): PK key &rarr; row index in that file. Used
    * by {@link #markAsRemoved} to locate rows produced earlier in the checkpoint.
    */
-  private final List<Map<Integer, Integer>> keyToPositionInFiles;
+  private final List<Map<String, Integer>> keyToPositionInFiles;
 
   /** Parallel to {@link #keyToPositionInFiles}: row indices to scrub via DV at complete time. */
   private final List<Set<Integer>> positionsToRemove;
@@ -79,14 +79,14 @@ public class DeltaUpsertWriterTask extends DeltaWriterTask {
    */
   public boolean write(List<Literal> primaryKey, RowData element, SinkWriter.Context context)
       throws IOException, InterruptedException {
-    int keyHash = MergeStrategy.keyHash(primaryKey);
-    int index = markAsRemoved(keyHash);
+    String key = MergeStrategy.keyString(primaryKey);
+    int index = markAsRemoved(key);
     if (index >= 0) {
       buffer.set(index, element);
       highWatermark = Math.max(highWatermark, context.currentWatermark());
       lowWatermark = Math.min(lowWatermark, context.currentWatermark());
     } else {
-      keyToPositionInMemory.put(keyHash, buffer.size());
+      keyToPositionInMemory.put(key, buffer.size());
       super.write(element, context);
     }
     return index != -1;
@@ -100,7 +100,7 @@ public class DeltaUpsertWriterTask extends DeltaWriterTask {
    * @return {@code true} if a prior row was found and marked for removal
    */
   public boolean erase(List<Literal> primaryKey) {
-    int removeIndex = markAsRemoved(MergeStrategy.keyHash(primaryKey));
+    int removeIndex = markAsRemoved(MergeStrategy.keyString(primaryKey));
     sparseMemory |= removeIndex >= 0;
     return removeIndex != -1;
   }
@@ -160,20 +160,20 @@ public class DeltaUpsertWriterTask extends DeltaWriterTask {
   }
 
   /**
-   * Marks the row for {@code keyHash} as removed: nulls its slot in {@link #buffer} if it is still
-   * in memory, or adds its position to {@link #positionsToRemove} if it has already been dumped to
-   * a Parquet file earlier in this checkpoint.
+   * Marks the row for {@code key} as removed: nulls its slot in {@link #buffer} if it is still in
+   * memory, or adds its position to {@link #positionsToRemove} if it has already been dumped to a
+   * Parquet file earlier in this checkpoint.
    *
    * @return the in-memory slot index ({@code >= 0}); {@code -2} if the row was on disk; {@code -1}
-   *     if no row for {@code keyHash} was tracked
+   *     if no row for {@code key} was tracked
    */
-  protected int markAsRemoved(int keyHash) {
-    int existIndex = keyToPositionInMemory.getOrDefault(keyHash, -1);
+  protected int markAsRemoved(String key) {
+    int existIndex = keyToPositionInMemory.getOrDefault(key, -1);
     if (existIndex >= 0) {
       buffer.set(existIndex, null);
     } else {
       for (int i = 0; i < keyToPositionInFiles.size(); i++) {
-        int index = keyToPositionInFiles.get(i).getOrDefault(keyHash, -1);
+        int index = keyToPositionInFiles.get(i).getOrDefault(key, -1);
         if (index >= 0 && !positionsToRemove.get(i).contains(index)) {
           positionsToRemove.get(i).add(index);
           existIndex = -2;
@@ -194,7 +194,7 @@ public class DeltaUpsertWriterTask extends DeltaWriterTask {
       return;
     }
     int writeIndex = 0;
-    int[] keyToPositionArray = new int[buffer.size()];
+    String[] keyToPositionArray = new String[buffer.size()];
     keyToPositionInMemory.forEach((key, value) -> keyToPositionArray[value] = key);
     keyToPositionInMemory.clear();
     for (int readIndex = 0; readIndex < buffer.size(); readIndex++) {

--- a/flink/src/main/java/io/delta/flink/sink/DeltaUpsertWriterTask.java
+++ b/flink/src/main/java/io/delta/flink/sink/DeltaUpsertWriterTask.java
@@ -1,0 +1,212 @@
+/*
+ *  Copyright (2026) The Delta Lake Project Authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.delta.flink.sink;
+
+import io.delta.flink.sink.mergestrategy.Upsert;
+import io.delta.flink.table.DeltaTable;
+import io.delta.kernel.data.Row;
+import io.delta.kernel.expressions.Literal;
+import java.io.IOException;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.apache.commons.lang3.Validate;
+import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.table.data.RowData;
+
+/**
+ * A {@link DeltaWriterTask} that supports update and delete by primary key.
+ *
+ * <p>Within a checkpoint the task tracks every PK it has seen so a repeat write for the same PK
+ * overwrites the in-memory row in place, and a write or delete for a PK already flushed to a
+ * Parquet file earlier in this checkpoint queues that row's position for deletion-vector scrubbing.
+ * {@link #complete()} stamps those DVs onto the per-file {@code AddFile} actions.
+ */
+public class DeltaUpsertWriterTask extends DeltaWriterTask {
+
+  /** PK hash &rarr; current index into {@link #buffer} for rows still live in memory. */
+  private final Map<Integer, Integer> keyToPositionInMemory;
+
+  /** {@code true} when {@link #buffer} contains {@code null} holes left by {@link #erase}. */
+  private boolean sparseMemory = false;
+
+  /**
+   * One entry per dumped Parquet file (in dump order): PK hash &rarr; row index in that file. Used
+   * by {@link #markAsRemoved} to locate rows produced earlier in the checkpoint.
+   */
+  private final List<Map<Integer, Integer>> keyToPositionInFiles;
+
+  /** Parallel to {@link #keyToPositionInFiles}: row indices to scrub via DV at complete time. */
+  private final List<Set<Integer>> positionsToRemove;
+
+  private final Upsert algorithm;
+
+  public DeltaUpsertWriterTask(
+      String jobId,
+      int subtaskId,
+      int attemptNumber,
+      DeltaTable deltaTable,
+      DeltaSinkConf conf,
+      Map<String, Literal> partitionValues,
+      Upsert algorithm) {
+    super(jobId, subtaskId, attemptNumber, deltaTable, conf, partitionValues);
+    keyToPositionInMemory = new HashMap<>();
+    keyToPositionInFiles = new ArrayList<>();
+    positionsToRemove = new ArrayList<>();
+    this.algorithm = algorithm;
+  }
+
+  /**
+   * Records {@code element} under {@code primaryKey}. If a row for this PK already lives in the
+   * buffer it is replaced in place; if it lives only in an already-dumped file the new row is
+   * appended and the old one is queued for DV scrubbing.
+   *
+   * @return {@code true} if a prior row for {@code primaryKey} was found (in memory or on disk)
+   */
+  public boolean write(List<Literal> primaryKey, RowData element, SinkWriter.Context context)
+      throws IOException, InterruptedException {
+    int keyHash = MergeStrategy.keyHash(primaryKey);
+    int index = markAsRemoved(keyHash);
+    if (index >= 0) {
+      buffer.set(index, element);
+      highWatermark = Math.max(highWatermark, context.currentWatermark());
+      lowWatermark = Math.min(lowWatermark, context.currentWatermark());
+    } else {
+      keyToPositionInMemory.put(keyHash, buffer.size());
+      super.write(element, context);
+    }
+    return index != -1;
+  }
+
+  /**
+   * Removes any row in this checkpoint matching {@code primaryKey}. An in-memory row is nulled out
+   * (compacted on the next dump); a row already on disk is queued for DV scrubbing in {@link
+   * #complete()}.
+   *
+   * @return {@code true} if a prior row was found and marked for removal
+   */
+  public boolean erase(List<Literal> primaryKey) {
+    int removeIndex = markAsRemoved(MergeStrategy.keyHash(primaryKey));
+    sparseMemory |= removeIndex >= 0;
+    return removeIndex != -1;
+  }
+
+  /**
+   * Compacts the buffer, snapshots the surviving PK-to-row-position map so later operations in the
+   * same checkpoint can still locate rows in this file, then delegates to {@link
+   * DeltaWriterTask#dump()} to write the Parquet file. No-op when nothing remains to flush.
+   */
+  @Override
+  protected void dump() throws IOException {
+    compressInMemoryBuffer();
+    if (keyToPositionInMemory.isEmpty()) {
+      return;
+    }
+    keyToPositionInFiles.add(Map.copyOf(keyToPositionInMemory));
+    positionsToRemove.add(new HashSet<>());
+    super.dump();
+    keyToPositionInMemory.clear();
+  }
+
+  /**
+   * Flushes the remaining buffer and decorates each {@link DeltaWriterResult} with a deletion
+   * vector covering the row positions that later writes in this checkpoint superseded; results
+   * without queued removals are returned unchanged.
+   */
+  @Override
+  public List<DeltaWriterResult> complete() throws IOException {
+    List<DeltaWriterResult> results = super.complete();
+    // Make sure the number of AddFiles is the same as recorded indices
+    // Require each dump to generate exactly one AddFile for now.
+    Validate.isTrue(results.size() == positionsToRemove.size());
+
+    // Map every (writerResult, positionsToRemove) pair to a freshly-built DeltaWriterResult.
+    // Neither the input `results` list nor the original DeltaWriterResults are mutated:
+    // when there's no DV to add we return the original reference unchanged; when there is,
+    // we allocate a new result that shares only the immutable WriterResultContext.
+
+    return IntStream.range(0, results.size())
+        .<Optional<DeltaWriterResult>>mapToObj(
+            i -> {
+              DeltaWriterResult result = results.get(i);
+              Set<Integer> positions = positionsToRemove.get(i);
+              if (positions.isEmpty()) {
+                return Optional.of(result);
+              }
+              if (positions.size() == keyToPositionInFiles.get(i).size()) {
+                return Optional.empty();
+              }
+              Row stagedAction = result.getDeltaActions().get(0);
+              Row marked = algorithm.markRemovesOnStaged(deltaTable, stagedAction, positions);
+              return Optional.of(new DeltaWriterResult(List.of(marked), result.getContext()));
+            })
+        .filter(Optional::isPresent)
+        .map(Optional::get)
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Marks the row for {@code keyHash} as removed: nulls its slot in {@link #buffer} if it is still
+   * in memory, or adds its position to {@link #positionsToRemove} if it has already been dumped to
+   * a Parquet file earlier in this checkpoint.
+   *
+   * @return the in-memory slot index ({@code >= 0}); {@code -2} if the row was on disk; {@code -1}
+   *     if no row for {@code keyHash} was tracked
+   */
+  protected int markAsRemoved(int keyHash) {
+    int existIndex = keyToPositionInMemory.getOrDefault(keyHash, -1);
+    if (existIndex >= 0) {
+      buffer.set(existIndex, null);
+    } else {
+      for (int i = 0; i < keyToPositionInFiles.size(); i++) {
+        int index = keyToPositionInFiles.get(i).getOrDefault(keyHash, -1);
+        if (index >= 0 && !positionsToRemove.get(i).contains(index)) {
+          positionsToRemove.get(i).add(index);
+          existIndex = -2;
+          break;
+        }
+      }
+    }
+    return existIndex;
+  }
+
+  /**
+   * Two-pointer pass that removes the {@code null} holes left by {@link #erase} from {@link
+   * #buffer} and rebuilds {@link #keyToPositionInMemory} with the compacted indices. No-op when the
+   * buffer is known to be dense.
+   */
+  protected void compressInMemoryBuffer() {
+    if (!sparseMemory) {
+      return;
+    }
+    int writeIndex = 0;
+    int[] keyToPositionArray = new int[buffer.size()];
+    keyToPositionInMemory.forEach((key, value) -> keyToPositionArray[value] = key);
+    keyToPositionInMemory.clear();
+    for (int readIndex = 0; readIndex < buffer.size(); readIndex++) {
+      if (buffer.get(readIndex) != null) {
+        if (writeIndex != readIndex) {
+          buffer.set(writeIndex, buffer.get(readIndex));
+        }
+        keyToPositionInMemory.put(keyToPositionArray[readIndex], writeIndex);
+        writeIndex++;
+      }
+    }
+    buffer.subList(writeIndex, buffer.size()).clear();
+    sparseMemory = false;
+  }
+}

--- a/flink/src/main/java/io/delta/flink/sink/DeltaWriterTask.java
+++ b/flink/src/main/java/io/delta/flink/sink/DeltaWriterTask.java
@@ -56,18 +56,18 @@ public class DeltaWriterTask {
   private final int attemptNumber;
   private final Map<String, Literal> partitionValues;
 
-  private final DeltaTable deltaTable;
+  protected final DeltaTable deltaTable;
   private final DeltaSinkConf conf;
 
   private final StructType writeSchema;
-  private final List<RowData> buffer;
+  protected final List<RowData> buffer;
 
   private final List<DeltaWriterResult> resultBuffer;
 
   private final DeltaSinkConf.FileRollingStrategy fileRollingStrategy;
 
-  private long lowWatermark = Long.MAX_VALUE;
-  private long highWatermark = -1;
+  protected long lowWatermark = Long.MAX_VALUE;
+  protected long highWatermark = -1;
 
   public DeltaWriterTask(
       String jobId,
@@ -91,10 +91,6 @@ public class DeltaWriterTask {
     this.fileRollingStrategy = conf.createFileRollingStrategy();
   }
 
-  protected List<DeltaWriterResult> getResultBuffer() {
-    return resultBuffer;
-  }
-
   /** Add a single row to write buffer, and optionally trigger the write to file. */
   public void write(RowData element, SinkWriter.Context context)
       throws IOException, InterruptedException {
@@ -111,7 +107,7 @@ public class DeltaWriterTask {
   /**
    * Write the current buffer content to file and store the generated writer results in resultBuffer
    */
-  private void dump() throws IOException {
+  protected void dump() throws IOException {
     LOG.debug(
         "Writing {} elements to Parquet, partition: {}, jobId: {}, subtaskId: {}, attemptNumber: {}",
         buffer.size(),

--- a/flink/src/main/java/io/delta/flink/sink/MergeStrategy.java
+++ b/flink/src/main/java/io/delta/flink/sink/MergeStrategy.java
@@ -17,21 +17,24 @@
 package io.delta.flink.sink;
 
 import io.delta.flink.table.DeltaTable;
-import io.delta.kernel.data.Row;
 import io.delta.kernel.expressions.Literal;
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.table.data.RowData;
 
 /**
  * Performing the row-level merge that turns an incoming upsert/delete stream into Delta {@code
  * Add}/{@code Remove} file actions.
  *
  * <p>A strategy owns the per-checkpoint bookkeeping it needs to do its job. {@link DeltaSinkWriter}
- * pushes primary-key information into the strategy as rows arrive ({@link #recordUpsert} for {@code
- * INSERT}/{@code UPDATE_AFTER}; {@link #recordDelete} for {@code DELETE}) and calls {@link #merge}
- * once per checkpoint to materialize that bookkeeping into Delta actions and reset internal state.
+ * pushes primary-key information into the strategy as rows arrive ({@link #upsert} for {@code
+ * INSERT}/{@code UPDATE_AFTER}; {@link #delete} for {@code DELETE}) and calls {@link #merge} once
+ * per checkpoint to materialize that bookkeeping into Delta actions and reset internal state.
  *
  * <p>Implementations are responsible for emitting:
  *
@@ -46,19 +49,61 @@ import java.util.Map;
  *
  * <p>Implementations must be {@link Serializable} so the writer can be shipped to TaskManagers.
  * Implementations should keep their internal state empty between checkpoints (i.e. {@link #merge}
- * must clear whatever {@link #recordUpsert} / {@link #recordDelete} accumulated).
+ * must clear whatever {@link #upsert} / {@link #delete} accumulated).
  */
 public interface MergeStrategy extends Serializable {
 
   /**
-   * Records the primary key of an {@code INSERT} or {@code UPDATE_AFTER} row written during the
-   * current checkpoint, so the strategy can later remove any pre-existing row that shares this key.
-   * The new row itself has already been appended by the writer via {@link DeltaTable#writeParquet}.
+   * Stable cache key for a per-partition writer task; collapses {@link Literal} partition values to
+   * their string form so logically-equal partitions hash to the same bucket.
+   */
+  static Map<String, String> writerKey(Map<String, Literal> partitionValues) {
+    return partitionValues.entrySet().stream()
+        .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().toString()));
+  }
+
+  /**
+   * Hash of a composite primary key. Strategies use this as the index into per-partition PK
+   * tracking; collisions are tolerated by the consumers (see {@link DeltaUpsertWriterTask}).
+   */
+  static int keyHash(List<Literal> keys) {
+    return Arrays.hashCode(keys.stream().map(Literal::toString).toArray());
+  }
+
+  /**
+   * Binds the strategy to the owning writer for the lifetime of the writer (called once after
+   * construction). Strategies that need access to the table, schema or partition columns read them
+   * from {@code writer}.
+   */
+  void init(DeltaSinkWriter writer);
+
+  /**
+   * Records an {@code INSERT} row written during the current checkpoint. The new row is appended to
+   * the partition's writer task with no pre-image bookkeeping; see {@link #upsert} for the update
+   * path that also schedules pre-image removal.
    *
    * @param primaryKey the primary-key values, not null but individual elements may be null
    * @param partitionValues the partition column values of the row; empty for unpartitioned tables
+   * @param content the actual row written
    */
-  void recordUpsert(List<Literal> primaryKey, Map<String, Literal> partitionValues);
+  void insert(
+      List<Literal> primaryKey,
+      Map<String, Literal> partitionValues,
+      RowData content,
+      SinkWriter.Context context);
+  /**
+   * Records an {@code UPDATE_AFTER} row written during the current checkpoint, so the strategy can
+   * later remove any pre-existing row that shares this key.
+   *
+   * @param primaryKey the primary-key values, not null but individual elements may be null
+   * @param partitionValues the partition column values of the row; empty for unpartitioned tables
+   * @param content the actual row written
+   */
+  void upsert(
+      List<Literal> primaryKey,
+      Map<String, Literal> partitionValues,
+      RowData content,
+      SinkWriter.Context context);
 
   /**
    * Records the primary key of a {@code DELETE} row observed during the current checkpoint. The
@@ -68,20 +113,15 @@ public interface MergeStrategy extends Serializable {
    * @param primaryKey the primary-key values, not null but individual elements may be null
    * @param partitionValues the partition column values of the row; empty for unpartitioned tables
    */
-  void recordDelete(List<Literal> primaryKey, Map<String, Literal> partitionValues);
+  void delete(List<Literal> primaryKey, Map<String, Literal> partitionValues);
 
   /**
    * Resolves the recorded checkpoint work into Delta actions and clears internal state.
    *
    * <p>If no records were observed since the last call, returns an empty list.
    *
-   * @param table the target Delta table; implementations may use it to read the current snapshot
-   *     and to write replacement data files via {@link DeltaTable#writeParquet}
-   * @param conf the sink configuration, providing the schema, primary-key columns, and rolling
-   *     strategy
-   * @return additional actions to include in the commit. Empty if no existing files need
-   *     modification.
+   * @return actions to include in the commit.
    * @throws IOException if reading existing files or writing replacement files fails
    */
-  List<Row> merge(DeltaTable table, DeltaSinkConf conf) throws IOException;
+  List<DeltaWriterResult> merge() throws IOException;
 }

--- a/flink/src/main/java/io/delta/flink/sink/MergeStrategy.java
+++ b/flink/src/main/java/io/delta/flink/sink/MergeStrategy.java
@@ -20,9 +20,9 @@ import io.delta.flink.table.DeltaTable;
 import io.delta.kernel.expressions.Literal;
 import java.io.IOException;
 import java.io.Serializable;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import org.apache.flink.api.connector.sink2.SinkWriter;
 import org.apache.flink.table.data.RowData;
@@ -55,19 +55,43 @@ public interface MergeStrategy extends Serializable {
 
   /**
    * Stable cache key for a per-partition writer task; collapses {@link Literal} partition values to
-   * their string form so logically-equal partitions hash to the same bucket.
+   * a canonical string so logically-equal partitions hash to the same bucket. A null-valued {@link
+   * Literal} is encoded distinctly from a literal whose string value is {@code "null"}.
    */
   static Map<String, String> writerKey(Map<String, Literal> partitionValues) {
     return partitionValues.entrySet().stream()
-        .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().toString()));
+        .collect(Collectors.toMap(Map.Entry::getKey, entry -> encodeLiteral(entry.getValue())));
   }
 
   /**
-   * Hash of a composite primary key. Strategies use this as the index into per-partition PK
-   * tracking; collisions are tolerated by the consumers (see {@link DeltaUpsertWriterTask}).
+   * Canonical, lossless string key for a composite primary key. Values are already in primary-key
+   * ordinal order, so no sorting is needed; each value is escaped so distinct keys cannot collide
+   * on the {@code ;} delimiter. A null-valued {@link Literal} is encoded with a marker that
+   * escaping can never produce, so it is distinguished from a literal whose string value is {@code
+   * "null"}.
    */
-  static int keyHash(List<Literal> keys) {
-    return Arrays.hashCode(keys.stream().map(Literal::toString).toArray());
+  static String keyString(List<Literal> keys) {
+    return keys.stream().map(MergeStrategy::encodeLiteral).collect(Collectors.joining(";"));
+  }
+
+  /**
+   * Encodes a single non-null {@link Literal} to a canonical string fragment: a null-valued literal
+   * becomes the marker {@code \0} (which escaping can never produce), every other value is its
+   * string form with {@code \} and {@code ;} escaped.
+   */
+  static String encodeLiteral(Literal literal) {
+    Objects.requireNonNull(literal, "literal must not be null");
+    return literal.getValue() == null
+        ? "\\0"
+        : literal.toString().replace("\\", "\\\\").replace(";", "\\;");
+  }
+
+  /**
+   * Encodes a single {@link Object} to a canonical string fragment: mirror the behavior of {@link
+   * #encodeLiteral}
+   */
+  static String encodeObject(Object input) {
+    return input == null ? "\\0" : input.toString().replace("\\", "\\\\").replace(";", "\\;");
   }
 
   /**
@@ -82,7 +106,7 @@ public interface MergeStrategy extends Serializable {
    * the partition's writer task with no pre-image bookkeeping; see {@link #upsert} for the update
    * path that also schedules pre-image removal.
    *
-   * @param primaryKey the primary-key values, not null but individual elements may be null
+   * @param primaryKey the primary-key values, not null and does not contain null elements.
    * @param partitionValues the partition column values of the row; empty for unpartitioned tables
    * @param content the actual row written
    */
@@ -95,7 +119,7 @@ public interface MergeStrategy extends Serializable {
    * Records an {@code UPDATE_AFTER} row written during the current checkpoint, so the strategy can
    * later remove any pre-existing row that shares this key.
    *
-   * @param primaryKey the primary-key values, not null but individual elements may be null
+   * @param primaryKey the primary-key values, not null and does not contain null elements
    * @param partitionValues the partition column values of the row; empty for unpartitioned tables
    * @param content the actual row written
    */
@@ -110,7 +134,7 @@ public interface MergeStrategy extends Serializable {
    * {@code DELETE} row itself is <em>not</em> appended to the table — the strategy must remove the
    * existing row with this key.
    *
-   * @param primaryKey the primary-key values, not null but individual elements may be null
+   * @param primaryKey the primary-key values, not null and does not contain null elements
    * @param partitionValues the partition column values of the row; empty for unpartitioned tables
    */
   void delete(List<Literal> primaryKey, Map<String, Literal> partitionValues);

--- a/flink/src/main/java/io/delta/flink/sink/mergestrategy/AppendOnly.java
+++ b/flink/src/main/java/io/delta/flink/sink/mergestrategy/AppendOnly.java
@@ -99,7 +99,9 @@ public class AppendOnly
   @Override
   public List<DeltaWriterResult> merge() {
     writerTasksByPartition.invalidateAll();
-    return this.completedWrites;
+    List<DeltaWriterResult> results = List.copyOf(completedWrites);
+    completedWrites.clear();
+    return results;
   }
 
   @Override

--- a/flink/src/main/java/io/delta/flink/sink/mergestrategy/AppendOnly.java
+++ b/flink/src/main/java/io/delta/flink/sink/mergestrategy/AppendOnly.java
@@ -16,40 +16,102 @@
 
 package io.delta.flink.sink.mergestrategy;
 
-import io.delta.flink.sink.DeltaSinkConf;
-import io.delta.flink.sink.MergeStrategy;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.RemovalCause;
+import com.github.benmanes.caffeine.cache.RemovalListener;
+import io.delta.flink.Conf;
+import io.delta.flink.sink.*;
 import io.delta.flink.table.DeltaTable;
-import io.delta.kernel.data.Row;
+import io.delta.flink.table.ExceptionUtils;
 import io.delta.kernel.expressions.Literal;
-import java.util.Collections;
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.table.data.RowData;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
- * No-op {@link MergeStrategy} used by append-mode sinks.
+ * {@link MergeStrategy} used by append-mode sinks.
  *
  * <p>In append mode every incoming row is written via {@link DeltaTable#writeParquet} and no
- * existing files need to be modified. The writer must never call {@link #recordUpsert} or {@link
- * #recordDelete} in append mode; if it does, that's a programming error and we fail loudly.
+ * existing files need to be modified. The writer must never call {@link #delete} in append mode; if
+ * it does, that's a programming error and we fail loudly.
  */
-public class AppendOnly implements MergeStrategy {
+public class AppendOnly
+    implements MergeStrategy, RemovalListener<Map<String, String>, DeltaWriterTask> {
+
+  private Cache<Map<String, String>, DeltaWriterTask> writerTasksByPartition;
+
+  private DeltaSinkWriter writer;
+
+  private List<DeltaWriterResult> completedWrites;
+
+  public void init(DeltaSinkWriter writer) {
+    this.writer = writer;
+    this.completedWrites = new ArrayList<>();
+    this.writerTasksByPartition =
+        Caffeine.newBuilder()
+            .executor(Runnable::run)
+            .maximumSize(Conf.getInstance().getSinkWriterNumConcurrentFiles())
+            .removalListener(this)
+            .build();
+  }
 
   @Override
-  public void recordUpsert(List<Literal> primaryKey, Map<String, Literal> partitionValues) {
+  public void insert(
+      List<Literal> primaryKey,
+      Map<String, Literal> partitionValues,
+      RowData element,
+      SinkWriter.Context context) {
+
+    try {
+      writerTasksByPartition
+          .get(
+              MergeStrategy.writerKey(partitionValues),
+              (key) -> writer.newWriterTask(partitionValues))
+          .write(element, context);
+    } catch (Exception e) {
+      throw ExceptionUtils.wrap(e);
+    }
+  }
+
+  @Override
+  public void upsert(
+      List<Literal> primaryKey,
+      Map<String, Literal> partitionValues,
+      RowData element,
+      SinkWriter.Context context) {
     throw new IllegalStateException(
-        "AppendOnlyMergeStrategy received an upsert record; this should only happen in "
+        "AppendOnlyMergeStrategy received a upsert record; this should only happen in "
             + "upsert mode.");
   }
 
   @Override
-  public void recordDelete(List<Literal> primaryKey, Map<String, Literal> partitionValues) {
+  public void delete(List<Literal> primaryKey, Map<String, Literal> partitionValues) {
     throw new IllegalStateException(
         "AppendOnlyMergeStrategy received a delete record; this should only happen in "
             + "upsert mode.");
   }
 
   @Override
-  public List<Row> merge(DeltaTable table, DeltaSinkConf conf) {
-    return Collections.emptyList();
+  public List<DeltaWriterResult> merge() {
+    writerTasksByPartition.invalidateAll();
+    return this.completedWrites;
+  }
+
+  @Override
+  public void onRemoval(
+      @Nullable Map<String, String> key, @Nullable DeltaWriterTask value, RemovalCause cause) {
+    // Close the evicted task and collect its result
+    try {
+      if (value != null) {
+        completedWrites.addAll(value.complete());
+      }
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/flink/src/main/java/io/delta/flink/sink/mergestrategy/CoWUpsert.java
+++ b/flink/src/main/java/io/delta/flink/sink/mergestrategy/CoWUpsert.java
@@ -19,6 +19,7 @@ package io.delta.flink.sink.mergestrategy;
 import static io.delta.kernel.internal.util.Utils.singletonCloseableIterator;
 
 import io.delta.flink.kernel.ColumnVectorUtils;
+import io.delta.flink.table.AbstractKernelTable;
 import io.delta.flink.table.DeltaTable;
 import io.delta.kernel.data.ColumnarBatch;
 import io.delta.kernel.data.FilteredColumnarBatch;
@@ -28,6 +29,7 @@ import io.delta.kernel.expressions.Literal;
 import io.delta.kernel.internal.InternalScanFileUtils;
 import io.delta.kernel.internal.actions.AddFile;
 import io.delta.kernel.internal.actions.SingleAction;
+import io.delta.kernel.internal.data.GenericRow;
 import io.delta.kernel.types.*;
 import io.delta.kernel.utils.CloseableIterator;
 import io.delta.kernel.utils.FileStatus;
@@ -35,106 +37,20 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.time.LocalDate;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.BiPredicate;
+import org.apache.commons.lang3.Validate;
 
 /**
  * Copy-on-write {@link Upsert}: for each candidate file, read it through Kernel, build a selection
  * vector that masks out rows matching the deletion filter, write the survivors to a new Parquet
  * file co-located with the source, and emit a {@code RemoveFile} for the source plus zero-or-more
  * {@code AddFile}s for the rewrite.
- *
- * <p>The {@code RemoveFile} is built via {@link
- * io.delta.kernel.internal.actions.AddFile#toRemoveFileRow}, so it carries over the source's stats,
- * partition values, tags, baseRowId, defaultRowCommitVersion and deletion vector — every field
- * Delta requires for an {@code extendedFileMetadata} RemoveFile.
  */
 public class CoWUpsert extends Upsert {
-
-  public CoWUpsert() {
-    super(new ScanLocator());
-  }
-
-  /**
-   * Read the source Parquet, mask out rows matching {@code filter} via a selection vector, stream
-   * the survivors through {@link DeltaTable#writeParquet} (co-located with the source), and prepend
-   * a {@code RemoveFile} for the source to the resulting {@code AddFile} stream. If every row
-   * matches the filter, no {@code AddFile} is emitted — just the {@code RemoveFile}.
-   *
-   * @throws UncheckedIOException if the Parquet read or write fails
-   */
-  @Override
-  protected CloseableIterator<Row> deleteRecords(
-      Row addFile, BiPredicate<ColumnarBatch, Integer> filter) {
-    Engine engine = table.getEngine();
-    final StructType schema = table.getSchema();
-
-    // Source file metadata from the scan file row.
-    final FileStatus source = InternalScanFileUtils.getAddFileStatus(addFile);
-    final Map<String, String> partStrings = InternalScanFileUtils.getPartitionValues(addFile);
-    // addFile has the SCAN_FILE_SCHEMA shape (add, tableRoot), not the SingleAction shape.
-    // Use InternalScanFileUtils.ADD_FILE_ORDINAL — the ordinal of "add" within SCAN_FILE_SCHEMA.
-    final AddFile sourceAddFile =
-        new AddFile(addFile.getStruct(InternalScanFileUtils.ADD_FILE_ORDINAL));
-
-    // Convert serialized partition values to typed Literals — required by table.writeParquet for
-    // the new AddFile.
-    final Map<String, Literal> partLiterals = toLiteralPartitionMap(schema, partStrings);
-
-    // Read → filter → write pipeline. The filter is applied lazily, batch-by-batch, via a
-    // selection vector so we don't materialize whole rows just to drop a few.
-    final CloseableIterator<FilteredColumnarBatch> survivors;
-    final CloseableIterator<Row> addActions;
-    try {
-      survivors =
-          engine
-              .getParquetHandler()
-              .readParquetFiles(singletonCloseableIterator(source), schema, Optional.empty())
-              .map(result -> applyDeletionFilter(result.getData(), filter));
-
-      // Co-locate the rewrite with the source file so the new file inherits the same partition
-      // directory layout (Delta requires AddFile.partitionValues to match the path-encoded
-      // partition; staying in the same folder is the safest way to keep them consistent).
-      // ParquetFileWriter generates UUID-suffixed filenames so two rewrites of the same source
-      // file can't collide.
-      String pathSuffix = sourceAddFile.getPath();
-      int slash = sourceAddFile.getPath().lastIndexOf('/');
-      if (slash >= 0) {
-        pathSuffix = sourceAddFile.getPath().substring(0, slash);
-      }
-      addActions = table.writeParquet(pathSuffix, survivors, partLiterals);
-    } catch (IOException e) {
-      throw new UncheckedIOException("Failed to rewrite " + sourceAddFile.getPath(), e);
-    }
-
-    // RemoveFile for the source file. AddFile.toRemoveFileRow carries over path, partition
-    // values, size, stats, tags, baseRowId, defaultRowCommitVersion and deletionVector — i.e.
-    // every field Delta requires for an "extendedFileMetadata" RemoveFile.
-    final Row removeAction =
-        SingleAction.createRemoveFileSingleAction(
-            sourceAddFile.toRemoveFileRow(true /* dataChange */, Optional.empty()));
-
-    // Emit RemoveFile first, then the AddFile(s). Delta commits don't care about action order
-    // within the same commit, but emitting Remove-before-Add reads more naturally.
-    return singletonCloseableIterator(removeAction).combine(addActions);
-  }
-
-  /**
-   * Wrap {@code batch} with a selection vector that excludes rows matching {@code filter}.
-   *
-   * <p>{@link FilteredColumnarBatch}'s selection vector follows the SQL convention <em>"true =
-   * keep, false = drop"</em>. Our caller's contract is the opposite — {@code filter.test(...)}
-   * returns {@code true} for rows to be <em>deleted</em> — so we negate when building the selection
-   * vector. The underlying batch's column vectors are reused unmodified; no per-row materialization
-   * on the rewrite path.
-   */
-  private static FilteredColumnarBatch applyDeletionFilter(
-      ColumnarBatch batch, BiPredicate<ColumnarBatch, Integer> filter) {
-    return new FilteredColumnarBatch(
-        batch, ColumnVectorUtils.filter(batch.getSize(), rowId -> !filter.test(batch, rowId)));
-  }
-
   /**
    * Convert the partition string map from a scan-file row into a typed-Literal map keyed by the
    * partition column names — the form expected by {@link DeltaTable#writeParquet}.
@@ -181,5 +97,120 @@ public class CoWUpsert extends Upsert {
     }
     throw new UnsupportedOperationException(
         "Unsupported partition column type for upsert rewrite: " + type);
+  }
+
+  public CoWUpsert() {
+    super(new ScanLocator());
+  }
+
+  /**
+   * Read the source Parquet, mask out rows matching {@code filter} via a selection vector, stream
+   * the survivors through {@link DeltaTable#writeParquet} (co-located with the source), and prepend
+   * a {@code RemoveFile} for the source to the resulting {@code AddFile} stream. If every row
+   * matches the filter, no {@code AddFile} is emitted — just the {@code RemoveFile}.
+   *
+   * @throws UncheckedIOException if the Parquet read or write fails
+   */
+  @Override
+  protected CloseableIterator<Row> deleteRecords(
+      Row addFile, BiPredicate<ColumnarBatch, Integer> filter) {
+    Engine engine = table.getEngine();
+    final StructType schema = table.getSchema();
+
+    final FileStatus source = InternalScanFileUtils.getAddFileStatus(addFile);
+    final Map<String, String> partStrings = InternalScanFileUtils.getPartitionValues(addFile);
+    final AddFile sourceAddFile =
+        new AddFile(addFile.getStruct(InternalScanFileUtils.ADD_FILE_ORDINAL));
+
+    final Map<String, Literal> partLiterals = toLiteralPartitionMap(schema, partStrings);
+
+    final CloseableIterator<FilteredColumnarBatch> survivors;
+    final CloseableIterator<Row> addActions;
+    try {
+      survivors =
+          engine
+              .getParquetHandler()
+              .readParquetFiles(singletonCloseableIterator(source), schema, Optional.empty())
+              .map(
+                  result -> {
+                    ColumnarBatch batch = result.getData();
+                    return new FilteredColumnarBatch(
+                        batch,
+                        ColumnVectorUtils.filter(
+                            batch.getSize(), rowId -> !filter.test(batch, rowId)));
+                  });
+      String pathSuffix = sourceAddFile.getPath();
+      int slash = sourceAddFile.getPath().lastIndexOf('/');
+      if (slash >= 0) {
+        pathSuffix = sourceAddFile.getPath().substring(0, slash);
+      }
+      addActions = table.writeParquet(pathSuffix, survivors, partLiterals);
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to rewrite " + sourceAddFile.getPath(), e);
+    }
+
+    final Row removeAction =
+        SingleAction.createRemoveFileSingleAction(
+            sourceAddFile.toRemoveFileRow(true /* dataChange */, Optional.empty()));
+
+    return singletonCloseableIterator(removeAction).combine(addActions);
+  }
+
+  @Override
+  public Row markRemovesOnStaged(DeltaTable table, Row stagedAction, Set<Integer> removePositions) {
+    AbstractKernelTable kernelTable = (AbstractKernelTable) table;
+    Engine engine = kernelTable.getEngine();
+    StructType schema = kernelTable.getSchema();
+    Row stagedAddFile = stagedAction.getStruct(SingleAction.ADD_FILE_ORDINAL);
+    AddFile stagedAddFileObj = new AddFile(stagedAddFile);
+    Row stagedAddFileWrapped =
+        new GenericRow(
+            InternalScanFileUtils.SCAN_FILE_SCHEMA,
+            Map.of(
+                InternalScanFileUtils.ADD_FILE_ORDINAL,
+                stagedAddFile,
+                InternalScanFileUtils.SCAN_FILE_SCHEMA.indexOf("tableRoot"),
+                kernelTable.getTablePath().toString()));
+    Map<String, Literal> partLiterals =
+        toLiteralPartitionMap(
+            schema, InternalScanFileUtils.getPartitionValues(stagedAddFileWrapped));
+
+    FileStatus source = InternalScanFileUtils.getAddFileStatus(stagedAddFileWrapped);
+    int[] globalRowOffset = {0};
+
+    CloseableIterator<FilteredColumnarBatch> survivors;
+    CloseableIterator<Row> addActions;
+    try {
+      survivors =
+          engine
+              .getParquetHandler()
+              .readParquetFiles(singletonCloseableIterator(source), schema, Optional.empty())
+              .map(
+                  result -> {
+                    ColumnarBatch batch = result.getData();
+                    int batchStart = globalRowOffset[0];
+                    globalRowOffset[0] += batch.getSize();
+                    return new FilteredColumnarBatch(
+                        batch,
+                        ColumnVectorUtils.filter(
+                            batch.getSize(),
+                            rowId -> !removePositions.contains(batchStart + rowId)));
+                  });
+
+      String pathSuffix = stagedAddFileObj.getPath();
+      int slash = pathSuffix.lastIndexOf('/');
+      if (slash >= 0) pathSuffix = pathSuffix.substring(0, slash);
+
+      addActions = kernelTable.writeParquet(pathSuffix, survivors, partLiterals);
+    } catch (IOException e) {
+      throw new UncheckedIOException(
+          "Failed to rewrite staged file " + stagedAddFileObj.getPath(), e);
+    }
+
+    List<Row> actions = addActions.toInMemoryList();
+    Validate.isTrue(
+        !actions.isEmpty(),
+        "writeParquet produced no output — caller must ensure at least one row survives");
+    return actions.get(0);
   }
 }

--- a/flink/src/main/java/io/delta/flink/sink/mergestrategy/MoRUpsert.java
+++ b/flink/src/main/java/io/delta/flink/sink/mergestrategy/MoRUpsert.java
@@ -16,9 +16,11 @@
 
 package io.delta.flink.sink.mergestrategy;
 
+import io.delta.flink.table.DeltaTable;
 import io.delta.kernel.data.ColumnarBatch;
 import io.delta.kernel.data.Row;
 import io.delta.kernel.utils.CloseableIterator;
+import java.util.Set;
 import java.util.function.BiPredicate;
 
 /**
@@ -37,6 +39,11 @@ public class MoRUpsert extends Upsert {
   @Override
   protected CloseableIterator<Row> deleteRecords(
       Row addFile, BiPredicate<ColumnarBatch, Integer> filter) {
-    throw new UnsupportedOperationException("Not implemented");
+    throw new UnsupportedOperationException("MoRUpsert not implemented");
+  }
+
+  @Override
+  public Row markRemovesOnStaged(DeltaTable table, Row stagedAddFile, Set<Integer> positions) {
+    throw new UnsupportedOperationException("MoRUpsert not implemented");
   }
 }

--- a/flink/src/main/java/io/delta/flink/sink/mergestrategy/Upsert.java
+++ b/flink/src/main/java/io/delta/flink/sink/mergestrategy/Upsert.java
@@ -16,41 +16,27 @@
 
 package io.delta.flink.sink.mergestrategy;
 
-import io.delta.flink.sink.DeltaSinkConf;
-import io.delta.flink.sink.MergeStrategy;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.RemovalCause;
+import com.github.benmanes.caffeine.cache.RemovalListener;
+import io.delta.flink.Conf;
+import io.delta.flink.kernel.ColumnVectorUtils;
+import io.delta.flink.sink.*;
 import io.delta.flink.table.AbstractKernelTable;
 import io.delta.flink.table.DeltaTable;
-import io.delta.kernel.data.ColumnVector;
+import io.delta.flink.table.ExceptionUtils;
 import io.delta.kernel.data.ColumnarBatch;
 import io.delta.kernel.data.Row;
 import io.delta.kernel.expressions.Literal;
-import io.delta.kernel.types.BinaryType;
-import io.delta.kernel.types.BooleanType;
-import io.delta.kernel.types.ByteType;
-import io.delta.kernel.types.DataType;
-import io.delta.kernel.types.DateType;
-import io.delta.kernel.types.DecimalType;
-import io.delta.kernel.types.DoubleType;
-import io.delta.kernel.types.FloatType;
-import io.delta.kernel.types.IntegerType;
-import io.delta.kernel.types.LongType;
-import io.delta.kernel.types.ShortType;
-import io.delta.kernel.types.StringType;
-import io.delta.kernel.types.TimestampNTZType;
-import io.delta.kernel.types.TimestampType;
 import io.delta.kernel.utils.CloseableIterator;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.function.BiPredicate;
 import java.util.stream.Collectors;
+import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.table.data.RowData;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Abstract base for upsert merge strategies. Owns the per-checkpoint PK bookkeeping (upserted /
@@ -61,7 +47,8 @@ import java.util.stream.Collectors;
  * <p>Subclasses choose how to materialize deletes, for example by rewriting matched files or by
  * writing deletion vectors over them.
  */
-public abstract class Upsert implements MergeStrategy {
+public abstract class Upsert
+    implements MergeStrategy, RemovalListener<Map<String, String>, DeltaWriterTask> {
   /**
    * Primary-key values (in {@link DeltaSinkConf#getPrimaryKeyOrdinals()} order) of every {@code
    * INSERT}/{@code UPDATE_AFTER} row recorded during the current checkpoint.
@@ -74,71 +61,138 @@ public abstract class Upsert implements MergeStrategy {
   /** Indices for quick search of pks. */
   private final Set<List<String>> primaryKeyIndices = new HashSet<>();
 
-  /**
-   * Distinct partition value maps touched during the checkpoint. Keyed by a stringified form of the
-   * partition map so we deduplicate cheaply; the value is the original {@code Literal}-based map
-   * used to bound the scan in {@link #merge}.
-   */
-  private final Map<Map<String, String>, Map<String, Literal>> touchedPartitions =
-      new LinkedHashMap<>();
-
-  protected transient AbstractKernelTable table;
+  protected DeltaSinkWriter writer;
+  protected AbstractKernelTable table;
 
   private final RowLocator rowLocator;
 
+  private final Cache<Map<String, String>, DeltaUpsertWriterTask> writerTasksByPartition;
+
+  private final List<DeltaWriterResult> completedWrites;
+
+  /**
+   * @param rowLocator selects which existing files to scan for PKs that need pre-image removal when
+   *     {@link #merge} runs at checkpoint boundaries.
+   */
   protected Upsert(RowLocator rowLocator) {
     this.rowLocator = Objects.requireNonNull(rowLocator, "rowLocator");
+    this.completedWrites = new ArrayList<>();
+    this.writerTasksByPartition =
+        Caffeine.newBuilder()
+            .executor(Runnable::run)
+            .maximumSize(Conf.getInstance().getSinkWriterNumConcurrentFiles())
+            .removalListener(this)
+            .build();
   }
 
   @Override
-  public void recordUpsert(List<Literal> primaryKey, Map<String, Literal> partitionValues) {
-    upsertedPrimaryKeys.add(primaryKey);
-    cachePrimaryKey(primaryKey);
-    cachePartition(partitionValues);
+  public void init(DeltaSinkWriter writer) {
+    this.writer = writer;
+    table = (AbstractKernelTable) writer.getTable();
   }
 
   @Override
-  public void recordDelete(List<Literal> primaryKey, Map<String, Literal> partitionValues) {
-    deletedPrimaryKeys.add(primaryKey);
-    cachePrimaryKey(primaryKey);
-    cachePartition(partitionValues);
-  }
-
-  @Override
-  public List<Row> merge(DeltaTable table, DeltaSinkConf conf) throws IOException {
-    this.table = (AbstractKernelTable) table;
-    boolean hasWork = !upsertedPrimaryKeys.isEmpty() || !deletedPrimaryKeys.isEmpty();
+  public void insert(
+      List<Literal> primaryKey,
+      Map<String, Literal> partitionValues,
+      RowData element,
+      SinkWriter.Context context) {
     try {
-      if (!hasWork) {
-        return Collections.emptyList();
-      }
-
-      // 1. Locate all data files that pending scan.
-      List<List<Literal>> pkToDelete = new ArrayList<>();
-      pkToDelete.addAll(upsertedPrimaryKeys);
-      pkToDelete.addAll(deletedPrimaryKeys);
-      CloseableIterator<Row> addFiles =
-          rowLocator.find(table, conf.getPrimaryKeyOrdinals(), pkToDelete);
-
-      // 2. Delete rows from found data files.
-      BiPredicate<ColumnarBatch, Integer> filter =
-          (batch, rowId) ->
-              primaryKeyIndices.contains(
-                  extractPrimaryKey(conf.getPrimaryKeyOrdinals(), batch, rowId));
-      return addFiles.flatMap(addFile -> deleteRecords(addFile, filter)).toInMemoryList();
-    } finally {
-      upsertedPrimaryKeys.clear();
-      deletedPrimaryKeys.clear();
-      primaryKeyIndices.clear();
-      touchedPartitions.clear();
+      // Route INSERT through the 3-arg, PK-aware write so the row participates in same-batch
+      // dedup with any later UPDATE_AFTER / DELETE on the same PK. The dump-time guard in
+      // DeltaUpsertWriterTask short-circuits when keyToPositionInMemory is empty, so failing to
+      // track the PK here would silently drop the row at commit time.
+      getWriterTask(partitionValues).write(primaryKey, element, context);
+    } catch (Exception e) {
+      throw ExceptionUtils.wrap(e);
     }
+  }
+
+  @Override
+  public void upsert(
+      List<Literal> primaryKey,
+      Map<String, Literal> partitionValues,
+      RowData element,
+      SinkWriter.Context context) {
+    try {
+      if (!getWriterTask(partitionValues).write(primaryKey, element, context)) {
+        upsertedPrimaryKeys.add(primaryKey);
+        cachePrimaryKey(primaryKey);
+      }
+    } catch (Exception e) {
+      throw ExceptionUtils.wrap(e);
+    }
+  }
+
+  @Override
+  public void delete(List<Literal> primaryKey, Map<String, Literal> partitionValues) {
+    try {
+      if (!getWriterTask(partitionValues).erase(primaryKey)) {
+        deletedPrimaryKeys.add(primaryKey);
+        cachePrimaryKey(primaryKey);
+      }
+    } catch (Exception e) {
+      throw ExceptionUtils.wrap(e);
+    }
+  }
+
+  @Override
+  public List<DeltaWriterResult> merge() throws IOException {
+    AbstractKernelTable table = (AbstractKernelTable) writer.getTable();
+    DeltaSinkConf conf = writer.getConf();
+
+    // Dump all Writer Tasks
+    writerTasksByPartition.invalidateAll();
+
+    if (!upsertedPrimaryKeys.isEmpty() || !deletedPrimaryKeys.isEmpty()) {
+      try {
+        // 1. Locate all data files that pending scan.
+        List<List<Literal>> pkToDelete = new ArrayList<>();
+        pkToDelete.addAll(upsertedPrimaryKeys);
+        pkToDelete.addAll(deletedPrimaryKeys);
+        CloseableIterator<Row> addFiles =
+            rowLocator.find(table, conf.getPrimaryKeyOrdinals(), pkToDelete);
+
+        // 2. Delete rows from found data files.
+        BiPredicate<ColumnarBatch, Integer> filter =
+            (batch, rowId) ->
+                primaryKeyIndices.contains(
+                    extractPrimaryKey(conf.getPrimaryKeyOrdinals(), batch, rowId));
+        completedWrites.add(
+            new DeltaWriterResult(
+                addFiles.flatMap(addFile -> deleteRecords(addFile, filter)).toInMemoryList(),
+                new WriterResultContext()));
+      } finally {
+        upsertedPrimaryKeys.clear();
+        deletedPrimaryKeys.clear();
+        primaryKeyIndices.clear();
+      }
+    }
+    return this.completedWrites;
+  }
+
+  @Override
+  public void onRemoval(
+      @Nullable Map<String, String> key, @Nullable DeltaWriterTask value, RemovalCause cause) {
+    try {
+      if (value != null) {
+        completedWrites.addAll(value.complete());
+      }
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  protected DeltaUpsertWriterTask getWriterTask(Map<String, Literal> partitionValues) {
+    return writerTasksByPartition.get(
+        MergeStrategy.writerKey(partitionValues),
+        (key) -> (DeltaUpsertWriterTask) writer.newWriterTask(partitionValues));
   }
 
   /**
    * Emit the Delta actions needed to logically delete from {@code addFile} every row matched by
    * {@code filter}. Called once per candidate file returned by {@link RowLocator#find}; the
-   * returned iterator is flattened into {@link #merge}'s overall result. Implementations may assume
-   * {@link #table} has been initialized by the surrounding {@code merge(...)} call.
+   * returned iterator is flattened into {@link #merge}'s overall result.
    *
    * @param addFile scan-file row in Kernel's {@code Scan.getScanFiles(...)} shape
    * @param filter row-level predicate; {@code true} to remove the row, {@code false} to keep it
@@ -147,6 +201,15 @@ public abstract class Upsert implements MergeStrategy {
   protected abstract CloseableIterator<Row> deleteRecords(
       Row addFile, BiPredicate<ColumnarBatch, Integer> filter);
 
+  /**
+   * Mark rows at {@code removePositions} as deleted within a staged (not-yet-committed) file and
+   * return the replacement action row. Callers must ensure at least one row survives (i.e. {@code
+   * removePositions.size() < totalRowsInFile}); the all-deleted case must be handled before this
+   * call.
+   */
+  public abstract Row markRemovesOnStaged(
+      DeltaTable table, Row stagedAddFile, Set<Integer> removePositions);
+
   private void cachePrimaryKey(List<Literal> primaryKey) {
     primaryKeyIndices.add(
         primaryKey.stream()
@@ -154,57 +217,14 @@ public abstract class Upsert implements MergeStrategy {
             .collect(Collectors.toList()));
   }
 
-  private void cachePartition(Map<String, Literal> partitionValues) {
-    Map<String, String> dedupKey =
-        partitionValues.entrySet().stream()
-            .collect(Collectors.toMap(Map.Entry::getKey, e -> String.valueOf(e.getValue())));
-    touchedPartitions.putIfAbsent(dedupKey, partitionValues);
-  }
-
   private List<String> extractPrimaryKey(int[] ordinals, ColumnarBatch data, Integer rowId) {
     List<String> key = new ArrayList<>(ordinals.length);
     for (int ord : ordinals) {
       key.add(
-          Optional.ofNullable(columnVectorValue(data.getColumnVector(ord), rowId))
+          Optional.ofNullable(ColumnVectorUtils.get(data.getColumnVector(ord), rowId))
               .map(Object::toString)
               .orElse(""));
     }
     return key;
-  }
-
-  private Object columnVectorValue(ColumnVector input, int rowId) {
-    if (input.isNullAt(rowId)) {
-      return null;
-    }
-    DataType type = input.getDataType();
-    if (type.equivalent(BooleanType.BOOLEAN)) {
-      return input.getBoolean(rowId);
-    } else if (type.equivalent(ByteType.BYTE)) {
-      return input.getByte(rowId);
-    } else if (type.equivalent(ShortType.SHORT)) {
-      return input.getShort(rowId);
-    } else if (type.equivalent(IntegerType.INTEGER)) {
-      return input.getInt(rowId);
-    } else if (type.equivalent(LongType.LONG)) {
-      return input.getLong(rowId);
-    } else if (type.equivalent(FloatType.FLOAT)) {
-      return input.getFloat(rowId);
-    } else if (type.equivalent(DoubleType.DOUBLE)) {
-      return input.getDouble(rowId);
-    } else if (type.equivalent(StringType.STRING)) {
-      return input.getString(rowId);
-    } else if (type.equivalent(BinaryType.BINARY)) {
-      return input.getBinary(rowId);
-    } else if (type.equivalent(DateType.DATE)) {
-      return input.getInt(rowId);
-    } else if (type.equivalent(TimestampType.TIMESTAMP)) {
-      return input.getLong(rowId);
-    } else if (type.equivalent(TimestampNTZType.TIMESTAMP_NTZ)) {
-      return input.getLong(rowId);
-    } else if (type instanceof DecimalType) {
-      return input.getDecimal(rowId);
-    } else {
-      throw new UnsupportedOperationException("Unsupported column vector type: " + type);
-    }
   }
 }

--- a/flink/src/main/java/io/delta/flink/sink/mergestrategy/Upsert.java
+++ b/flink/src/main/java/io/delta/flink/sink/mergestrategy/Upsert.java
@@ -33,7 +33,6 @@ import io.delta.kernel.utils.CloseableIterator;
 import java.io.IOException;
 import java.util.*;
 import java.util.function.BiPredicate;
-import java.util.stream.Collectors;
 import org.apache.flink.api.connector.sink2.SinkWriter;
 import org.apache.flink.table.data.RowData;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -59,7 +58,7 @@ public abstract class Upsert
   private final List<List<Literal>> deletedPrimaryKeys = new ArrayList<>();
 
   /** Indices for quick search of pks. */
-  private final Set<List<String>> primaryKeyIndices = new HashSet<>();
+  private final Set<String> primaryKeyIndices = new HashSet<>();
 
   protected DeltaSinkWriter writer;
   protected AbstractKernelTable table;
@@ -117,7 +116,7 @@ public abstract class Upsert
     try {
       if (!getWriterTask(partitionValues).write(primaryKey, element, context)) {
         upsertedPrimaryKeys.add(primaryKey);
-        cachePrimaryKey(primaryKey);
+        primaryKeyIndices.add(MergeStrategy.keyString(primaryKey));
       }
     } catch (Exception e) {
       throw ExceptionUtils.wrap(e);
@@ -129,7 +128,7 @@ public abstract class Upsert
     try {
       if (!getWriterTask(partitionValues).erase(primaryKey)) {
         deletedPrimaryKeys.add(primaryKey);
-        cachePrimaryKey(primaryKey);
+        primaryKeyIndices.add(MergeStrategy.keyString(primaryKey));
       }
     } catch (Exception e) {
       throw ExceptionUtils.wrap(e);
@@ -168,7 +167,9 @@ public abstract class Upsert
         primaryKeyIndices.clear();
       }
     }
-    return this.completedWrites;
+    List<DeltaWriterResult> results = List.copyOf(completedWrites);
+    completedWrites.clear();
+    return results;
   }
 
   @Override
@@ -210,21 +211,11 @@ public abstract class Upsert
   public abstract Row markRemovesOnStaged(
       DeltaTable table, Row stagedAddFile, Set<Integer> removePositions);
 
-  private void cachePrimaryKey(List<Literal> primaryKey) {
-    primaryKeyIndices.add(
-        primaryKey.stream()
-            .map(key -> Optional.ofNullable(key).map(Object::toString).orElse(""))
-            .collect(Collectors.toList()));
-  }
-
-  private List<String> extractPrimaryKey(int[] ordinals, ColumnarBatch data, Integer rowId) {
+  private String extractPrimaryKey(int[] ordinals, ColumnarBatch data, Integer rowId) {
     List<String> key = new ArrayList<>(ordinals.length);
     for (int ord : ordinals) {
-      key.add(
-          Optional.ofNullable(ColumnVectorUtils.get(data.getColumnVector(ord), rowId))
-              .map(Object::toString)
-              .orElse(""));
+      key.add(MergeStrategy.encodeObject(ColumnVectorUtils.get(data.getColumnVector(ord), rowId)));
     }
-    return key;
+    return String.join(";", key);
   }
 }

--- a/flink/src/test/java/io/delta/flink/sink/DeltaSinkWriterTest.java
+++ b/flink/src/test/java/io/delta/flink/sink/DeltaSinkWriterTest.java
@@ -16,21 +16,37 @@
 
 package io.delta.flink.sink;
 
+import static io.delta.kernel.internal.util.Utils.singletonCloseableIterator;
+import static io.delta.kernel.internal.util.Utils.toCloseableIterator;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.delta.flink.TestHelper;
 import io.delta.flink.table.HadoopTable;
+import io.delta.kernel.Scan;
+import io.delta.kernel.Snapshot;
+import io.delta.kernel.TableManager;
+import io.delta.kernel.data.FilteredColumnarBatch;
+import io.delta.kernel.data.Row;
 import io.delta.kernel.defaults.engine.DefaultEngine;
+import io.delta.kernel.engine.Engine;
+import io.delta.kernel.internal.InternalScanFileUtils;
+import io.delta.kernel.internal.data.ScanStateRow;
 import io.delta.kernel.types.*;
+import io.delta.kernel.utils.CloseableIterable;
+import io.delta.kernel.utils.CloseableIterator;
+import io.delta.kernel.utils.FileStatus;
 import java.lang.management.ManagementFactory;
 import java.net.URI;
 import java.util.*;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.StringData;
+import org.apache.flink.types.RowKind;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -340,5 +356,471 @@ class DeltaSinkWriterTest extends TestHelper {
                 new TestSinkWriterContext(i * 100, i * 100));
           }
         });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Upsert-mode tests: verify the RowKind routing in DeltaSinkWriter.write and
+  // the wiring between the writer and its MergeStrategy at prepareCommit time.
+  //
+  // These tests assert on the *logical* row content of the table after committing
+  // the actions produced by prepareCommit. We deliberately do NOT inspect the
+  // physical action shape (AddFile / RemoveFile / deletion vectors) so the same
+  // expectations remain valid when the merge strategy switches from Copy-on-Write
+  // to Merge-on-Read.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void testUpsertInsertOnEmptyTable() throws Exception {
+    withTempDir(
+        dir -> {
+          StructType schema =
+              new StructType().add("id", IntegerType.INTEGER).add("part", StringType.STRING);
+          HadoopTable table =
+              new HadoopTable(
+                  URI.create(dir.getAbsolutePath()),
+                  Collections.emptyMap(),
+                  schema,
+                  Collections.emptyList());
+          table.open();
+
+          DeltaSinkWriter sinkWriter = newSinkWriter(table, upsertConf(schema, new int[] {0}));
+
+          GenericRowData row = GenericRowData.of(5, StringData.fromString("p0"));
+          row.setRowKind(RowKind.INSERT);
+          sinkWriter.write(row, new TestSinkWriterContext(0, 0));
+
+          commitResults(table, sinkWriter.prepareCommit());
+
+          List<List<Object>> rows = readAllRows(dir.getAbsolutePath(), schema);
+          assertEquals(List.of(List.of(5, "p0")), rows);
+        });
+  }
+
+  @Test
+  void testUpsertUpdateAfterReplacesPreImage() throws Exception {
+    withTempDir(
+        dir -> {
+          StructType schema =
+              new StructType().add("id", IntegerType.INTEGER).add("part", StringType.STRING);
+          HadoopTable table =
+              new HadoopTable(
+                  URI.create(dir.getAbsolutePath()),
+                  Collections.emptyMap(),
+                  schema,
+                  Collections.emptyList());
+          table.open();
+
+          prePopulate(
+              table,
+              schema,
+              List.of(
+                  GenericRowData.of(1, StringData.fromString("old")),
+                  GenericRowData.of(5, StringData.fromString("old")),
+                  GenericRowData.of(9, StringData.fromString("old"))));
+
+          DeltaSinkWriter sinkWriter = newSinkWriter(table, upsertConf(schema, new int[] {0}));
+
+          GenericRowData row = GenericRowData.of(5, StringData.fromString("new"));
+          row.setRowKind(RowKind.UPDATE_AFTER);
+          sinkWriter.write(row, new TestSinkWriterContext(0, 0));
+
+          commitResults(table, sinkWriter.prepareCommit());
+
+          // id=5 now carries the new image; id=1 and id=9 are untouched.
+          List<List<Object>> rows = sortById(readAllRows(dir.getAbsolutePath(), schema));
+          assertEquals(List.of(List.of(1, "old"), List.of(5, "new"), List.of(9, "old")), rows);
+        });
+  }
+
+  @Test
+  void testUpsertDeleteRemovesPreImage() throws Exception {
+    withTempDir(
+        dir -> {
+          StructType schema =
+              new StructType().add("id", IntegerType.INTEGER).add("part", StringType.STRING);
+          HadoopTable table =
+              new HadoopTable(
+                  URI.create(dir.getAbsolutePath()),
+                  Collections.emptyMap(),
+                  schema,
+                  Collections.emptyList());
+          table.open();
+
+          prePopulate(
+              table,
+              schema,
+              List.of(
+                  GenericRowData.of(1, StringData.fromString("a")),
+                  GenericRowData.of(7, StringData.fromString("b")),
+                  GenericRowData.of(9, StringData.fromString("c"))));
+
+          DeltaSinkWriter sinkWriter = newSinkWriter(table, upsertConf(schema, new int[] {0}));
+
+          GenericRowData row = GenericRowData.of(7, StringData.fromString("b"));
+          row.setRowKind(RowKind.DELETE);
+          sinkWriter.write(row, new TestSinkWriterContext(0, 0));
+
+          commitResults(table, sinkWriter.prepareCommit());
+
+          List<List<Object>> rows = sortById(readAllRows(dir.getAbsolutePath(), schema));
+          assertEquals(List.of(List.of(1, "a"), List.of(9, "c")), rows);
+        });
+  }
+
+  @Test
+  void testUpsertUpdateBeforeIsDropped() throws Exception {
+    withTempDir(
+        dir -> {
+          StructType schema =
+              new StructType().add("id", IntegerType.INTEGER).add("part", StringType.STRING);
+          HadoopTable table =
+              new HadoopTable(
+                  URI.create(dir.getAbsolutePath()),
+                  Collections.emptyMap(),
+                  schema,
+                  Collections.emptyList());
+          table.open();
+
+          prePopulate(table, schema, List.of(GenericRowData.of(11, StringData.fromString("kept"))));
+
+          DeltaSinkWriter sinkWriter = newSinkWriter(table, upsertConf(schema, new int[] {0}));
+
+          GenericRowData row = GenericRowData.of(11, StringData.fromString("dropped"));
+          row.setRowKind(RowKind.UPDATE_BEFORE);
+          sinkWriter.write(row, new TestSinkWriterContext(0, 0));
+
+          // UPDATE_BEFORE produces no work for the writer or the merge strategy. The
+          // pre-existing row must remain in the table untouched.
+          commitResults(table, sinkWriter.prepareCommit());
+
+          List<List<Object>> rows = readAllRows(dir.getAbsolutePath(), schema);
+          assertEquals(List.of(List.of(11, "kept")), rows);
+        });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Same-batch reconciliation: multiple events on the same PK within a single
+  // checkpoint should resolve locally before commit. The current writer streams
+  // every INSERT/UPDATE_AFTER straight to the partition Parquet and only runs
+  // merge against the pre-checkpoint snapshot, so all three of these currently
+  // fail. They lock in the expected semantics for the upcoming fix.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void testUpsertTwoUpdateAfterSamePkInBatchKeepsOnlyLatest() throws Exception {
+    withTempDir(
+        dir -> {
+          StructType schema =
+              new StructType().add("id", IntegerType.INTEGER).add("part", StringType.STRING);
+          HadoopTable table =
+              new HadoopTable(
+                  URI.create(dir.getAbsolutePath()),
+                  Collections.emptyMap(),
+                  schema,
+                  Collections.emptyList());
+          table.open();
+
+          prePopulate(table, schema, List.of(GenericRowData.of(5, StringData.fromString("old"))));
+
+          DeltaSinkWriter sinkWriter = newSinkWriter(table, upsertConf(schema, new int[] {0}));
+
+          // Two UPDATE_AFTERs land in the same checkpoint for the same PK. The second one is
+          // the "latest" image and should be the only survivor in the committed table.
+          GenericRowData first = GenericRowData.of(5, StringData.fromString("A"));
+          first.setRowKind(RowKind.UPDATE_AFTER);
+          sinkWriter.write(first, new TestSinkWriterContext(0, 0));
+
+          GenericRowData second = GenericRowData.of(5, StringData.fromString("B"));
+          second.setRowKind(RowKind.UPDATE_AFTER);
+          sinkWriter.write(second, new TestSinkWriterContext(0, 0));
+
+          commitResults(table, sinkWriter.prepareCommit());
+
+          // Expected: a single row (5, "B"). Currently the writer commits BOTH (5, "A") and
+          // (5, "B") because per-batch dedup isn't implemented yet.
+          assertEquals(
+              List.of(List.of(5, "B")), sortById(readAllRows(dir.getAbsolutePath(), schema)));
+        });
+  }
+
+  @Test
+  void testUpsertInsertThenUpdateAfterSamePkInBatchKeepsLatest() throws Exception {
+    withTempDir(
+        dir -> {
+          StructType schema =
+              new StructType().add("id", IntegerType.INTEGER).add("part", StringType.STRING);
+          HadoopTable table =
+              new HadoopTable(
+                  URI.create(dir.getAbsolutePath()),
+                  Collections.emptyMap(),
+                  schema,
+                  Collections.emptyList());
+          table.open();
+
+          DeltaSinkWriter sinkWriter = newSinkWriter(table, upsertConf(schema, new int[] {0}));
+
+          // INSERT a brand-new PK, then immediately UPDATE_AFTER it within the same checkpoint.
+          // Net effect should be a single row carrying the updated image.
+          GenericRowData inserted = GenericRowData.of(5, StringData.fromString("inserted"));
+          inserted.setRowKind(RowKind.INSERT);
+          sinkWriter.write(inserted, new TestSinkWriterContext(0, 0));
+
+          GenericRowData updated = GenericRowData.of(5, StringData.fromString("updated"));
+          updated.setRowKind(RowKind.UPDATE_AFTER);
+          sinkWriter.write(updated, new TestSinkWriterContext(0, 0));
+
+          commitResults(table, sinkWriter.prepareCommit());
+
+          // Expected: a single row (5, "updated"). Currently both rows are committed because
+          // the INSERT-then-UPDATE_AFTER pair is not collapsed pre-commit.
+          assertEquals(
+              List.of(List.of(5, "updated")), sortById(readAllRows(dir.getAbsolutePath(), schema)));
+        });
+  }
+
+  @Test
+  void testUpsertUpdateAfterThenDeleteSamePkInBatchRemovesRow() throws Exception {
+    withTempDir(
+        dir -> {
+          StructType schema =
+              new StructType().add("id", IntegerType.INTEGER).add("part", StringType.STRING);
+          HadoopTable table =
+              new HadoopTable(
+                  URI.create(dir.getAbsolutePath()),
+                  Collections.emptyMap(),
+                  schema,
+                  Collections.emptyList());
+          table.open();
+
+          prePopulate(
+              table,
+              schema,
+              List.of(
+                  GenericRowData.of(1, StringData.fromString("a")),
+                  GenericRowData.of(5, StringData.fromString("old")),
+                  GenericRowData.of(9, StringData.fromString("c"))));
+
+          DeltaSinkWriter sinkWriter = newSinkWriter(table, upsertConf(schema, new int[] {0}));
+
+          // UPDATE_AFTER followed by DELETE within the same checkpoint. The DELETE should
+          // supersede the in-batch UPDATE_AFTER and remove the row entirely; the new image
+          // (5, "transient") must not be left behind in the new partition Parquet.
+          GenericRowData transientUpdate = GenericRowData.of(5, StringData.fromString("transient"));
+          transientUpdate.setRowKind(RowKind.UPDATE_AFTER);
+          sinkWriter.write(transientUpdate, new TestSinkWriterContext(0, 0));
+
+          GenericRowData deletion = GenericRowData.of(5, StringData.fromString("transient"));
+          deletion.setRowKind(RowKind.DELETE);
+          sinkWriter.write(deletion, new TestSinkWriterContext(0, 0));
+
+          commitResults(table, sinkWriter.prepareCommit());
+
+          // Expected: id=5 is gone; only ids 1 and 9 remain. Currently the new image
+          // (5, "transient") survives in the just-written Parquet because DELETE doesn't
+          // rescind the buffered UPDATE_AFTER.
+          List<List<Object>> rows = sortById(readAllRows(dir.getAbsolutePath(), schema));
+          assertEquals(List.of(List.of(1, "a"), List.of(9, "c")), rows);
+        });
+  }
+
+  @Test
+  void testAppendModeUpdateAfterThrows() {
+    withTempDir(
+        dir -> {
+          StructType schema =
+              new StructType().add("id", IntegerType.INTEGER).add("part", StringType.STRING);
+          HadoopTable table =
+              new HadoopTable(
+                  URI.create(dir.getAbsolutePath()),
+                  Collections.emptyMap(),
+                  schema,
+                  Collections.emptyList());
+          table.open();
+
+          DeltaSinkWriter sinkWriter =
+              newSinkWriter(table, new DeltaSinkConf(schema, Collections.emptyMap()));
+
+          GenericRowData row = GenericRowData.of(1, StringData.fromString("p0"));
+          row.setRowKind(RowKind.UPDATE_AFTER);
+          assertThrows(
+              IllegalStateException.class,
+              () -> sinkWriter.write(row, new TestSinkWriterContext(0, 0)));
+        });
+  }
+
+  @Test
+  void testAppendModeDeleteThrows() {
+    withTempDir(
+        dir -> {
+          StructType schema =
+              new StructType().add("id", IntegerType.INTEGER).add("part", StringType.STRING);
+          HadoopTable table =
+              new HadoopTable(
+                  URI.create(dir.getAbsolutePath()),
+                  Collections.emptyMap(),
+                  schema,
+                  Collections.emptyList());
+          table.open();
+
+          DeltaSinkWriter sinkWriter =
+              newSinkWriter(table, new DeltaSinkConf(schema, Collections.emptyMap()));
+
+          GenericRowData row = GenericRowData.of(1, StringData.fromString("p0"));
+          row.setRowKind(RowKind.DELETE);
+          assertThrows(
+              IllegalStateException.class,
+              () -> sinkWriter.write(row, new TestSinkWriterContext(0, 0)));
+        });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Test-only helpers
+  // ---------------------------------------------------------------------------
+
+  /** Build an upsert-mode {@link DeltaSinkConf} for the given schema and PK ordinals. */
+  private static DeltaSinkConf upsertConf(StructType schema, int[] pkOrdinals) {
+    Map<String, String> opts = new HashMap<>();
+    opts.put("write.mode", "upsert");
+    opts.put(
+        "primary_key",
+        Arrays.stream(pkOrdinals).mapToObj(Integer::toString).collect(Collectors.joining(",")));
+    return new DeltaSinkConf(schema, opts);
+  }
+
+  /** Build a {@link DeltaSinkWriter} with the standard test wiring. */
+  private static DeltaSinkWriter newSinkWriter(HadoopTable table, DeltaSinkConf conf) {
+    return new DeltaSinkWriter.Builder()
+        .withJobId("test-job")
+        .withSubtaskId(0)
+        .withAttemptNumber(1)
+        .withDeltaTable(table)
+        .withConf(conf)
+        .withMetricGroup(UnregisteredMetricsGroup.createSinkWriterMetricGroup())
+        .build();
+  }
+
+  /**
+   * Write the given rows into {@code table} via a {@link DeltaWriterTask} and commit them. After
+   * this returns, {@code table}'s snapshot reflects the new AddFile actions.
+   */
+  private static void prePopulate(HadoopTable table, StructType schema, List<GenericRowData> rows)
+      throws Exception {
+    DeltaSinkConf conf = new DeltaSinkConf(schema, Collections.emptyMap());
+    DeltaWriterTask task =
+        new DeltaWriterTask(
+            "setup-job",
+            /* subtaskId= */ 0,
+            /* attemptNumber= */ 0,
+            table,
+            conf,
+            Collections.emptyMap());
+    for (GenericRowData row : rows) {
+      task.write(row, new TestSinkWriterContext(0, 0));
+    }
+    commitActions(table, task.complete());
+  }
+
+  /** Commit the actions inside {@code results} into {@code table}. */
+  private static void commitResults(HadoopTable table, Collection<DeltaWriterResult> results) {
+    if (results.isEmpty()) {
+      return;
+    }
+    commitActions(table, results);
+  }
+
+  private static final AtomicLong TXN_COUNTER = new AtomicLong();
+
+  /**
+   * Test commits set this so the protocol picks up the {@code deletionVectors} reader/writer
+   * feature. {@link io.delta.flink.sink.mergestrategy.MoRUpsert} emits {@code AddFile}s that carry
+   * a DV, and reading them back through {@link io.delta.kernel.Scan#transformPhysicalData} requires
+   * the protocol to advertise the feature so the physical schema includes the row-index metadata
+   * column. Production sinks are expected to enable this property by other means.
+   */
+  private static final Map<String, String> ENABLE_DV_PROPERTIES =
+      Map.of("delta.enableDeletionVectors", "true");
+
+  private static void commitActions(HadoopTable table, Collection<DeltaWriterResult> results) {
+    List<Row> actions = new ArrayList<>();
+    for (DeltaWriterResult r : results) {
+      actions.addAll(r.getDeltaActions());
+    }
+    if (actions.isEmpty()) {
+      return;
+    }
+    // Use a unique txnId per commit. Reusing the same (appId, txnId) pair makes Delta treat
+    // the second commit as an idempotent duplicate and silently skip it, which would mask the
+    // logical effect of the merge strategy from the assertions below.
+    table.commit(
+        CloseableIterable.inMemoryIterable(toCloseableIterator(actions.iterator())),
+        "test-app",
+        TXN_COUNTER.incrementAndGet(),
+        ENABLE_DV_PROPERTIES);
+  }
+
+  /**
+   * Read all logical rows of the table at {@code tablePath} through the Kernel scan API. Each row
+   * is returned as a {@code List<Object>} whose entries are the column values in schema order.
+   *
+   * <p>This reader honors any deletion vectors / logical row filtering that the strategy may have
+   * applied, so the result reflects the table's logical view regardless of whether the merge ran as
+   * Copy-on-Write or Merge-on-Read.
+   */
+  private static List<List<Object>> readAllRows(String tablePath, StructType schema)
+      throws Exception {
+    Engine engine = DefaultEngine.create(new Configuration());
+    Snapshot snapshot = TableManager.loadSnapshot(tablePath).build(engine);
+    Scan scan = snapshot.getScanBuilder().withReadSchema(schema).build();
+    Row scanState = scan.getScanState(engine);
+    StructType physicalReadSchema = ScanStateRow.getPhysicalDataReadSchema(scanState);
+
+    List<List<Object>> rows = new ArrayList<>();
+    try (CloseableIterator<FilteredColumnarBatch> scanFileIter = scan.getScanFiles(engine)) {
+      while (scanFileIter.hasNext()) {
+        FilteredColumnarBatch scanFilesBatch = scanFileIter.next();
+        try (CloseableIterator<Row> scanFileRows = scanFilesBatch.getRows()) {
+          while (scanFileRows.hasNext()) {
+            Row scanFileRow = scanFileRows.next();
+            FileStatus fileStatus = InternalScanFileUtils.getAddFileStatus(scanFileRow);
+            try (CloseableIterator<FilteredColumnarBatch> transformedData =
+                Scan.transformPhysicalData(
+                    engine,
+                    scanState,
+                    scanFileRow,
+                    engine
+                        .getParquetHandler()
+                        .readParquetFiles(
+                            singletonCloseableIterator(fileStatus),
+                            physicalReadSchema,
+                            Optional.empty())
+                        .map(res -> res.getData()))) {
+              while (transformedData.hasNext()) {
+                FilteredColumnarBatch batch = transformedData.next();
+                try (CloseableIterator<Row> rowIter = batch.getRows()) {
+                  while (rowIter.hasNext()) {
+                    rows.add(rowToList(rowIter.next(), schema));
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    return rows;
+  }
+
+  private static List<Object> rowToList(Row row, StructType schema) {
+    List<Object> cells = new ArrayList<>(schema.length());
+    for (int i = 0; i < schema.length(); i++) {
+      cells.add(row.isNullAt(i) ? null : Conversions.DeltaToJava.data(schema, row, i));
+    }
+    return cells;
+  }
+
+  /** Sort {@code rows} ascending by the first column (assumed integer-typed id). */
+  private static List<List<Object>> sortById(List<List<Object>> rows) {
+    rows.sort(Comparator.comparingInt(r -> (Integer) r.get(0)));
+    return rows;
   }
 }

--- a/flink/src/test/java/io/delta/flink/sink/DeltaSinkWriterTest.java
+++ b/flink/src/test/java/io/delta/flink/sink/DeltaSinkWriterTest.java
@@ -98,6 +98,61 @@ class DeltaSinkWriterTest extends TestHelper {
   }
 
   @Test
+  void testPrepareCommitDoesNotReemitPreviousResultsAppendMode() {
+    withTempDir(
+        dir -> {
+          StructType schema =
+              new StructType().add("id", IntegerType.INTEGER).add("part", StringType.STRING);
+          HadoopTable table =
+              new HadoopTable(
+                  URI.create(dir.getAbsolutePath()),
+                  Collections.emptyMap(),
+                  schema,
+                  Collections.emptyList());
+          table.open();
+
+          DeltaSinkWriter sinkWriter =
+              newSinkWriter(table, new DeltaSinkConf(schema, Collections.emptyMap()));
+
+          for (int i = 0; i < 5; i++) {
+            sinkWriter.write(
+                GenericRowData.of(i, StringData.fromString("p0")), new TestSinkWriterContext(0, 0));
+          }
+          assertEquals(1, sinkWriter.prepareCommit().size());
+
+          // A second checkpoint with no new input must return nothing; the prior checkpoint's
+          // results must not be re-emitted (completedWrites must be cleared on each merge).
+          assertEquals(0, sinkWriter.prepareCommit().size());
+        });
+  }
+
+  @Test
+  void testPrepareCommitDoesNotReemitPreviousResultsUpsertMode() throws Exception {
+    withTempDir(
+        dir -> {
+          StructType schema =
+              new StructType().add("id", IntegerType.INTEGER).add("part", StringType.STRING);
+          HadoopTable table =
+              new HadoopTable(
+                  URI.create(dir.getAbsolutePath()),
+                  Collections.emptyMap(),
+                  schema,
+                  Collections.emptyList());
+          table.open();
+
+          DeltaSinkWriter sinkWriter = newSinkWriter(table, upsertConf(schema, new int[] {0}));
+
+          GenericRowData row = GenericRowData.of(5, StringData.fromString("p0"));
+          row.setRowKind(RowKind.INSERT);
+          sinkWriter.write(row, new TestSinkWriterContext(0, 0));
+          assertEquals(1, sinkWriter.prepareCommit().size());
+
+          // Second checkpoint, no new input: must not re-emit the prior checkpoint's AddFile.
+          assertEquals(0, sinkWriter.prepareCommit().size());
+        });
+  }
+
+  @Test
   void testWriteToEmptyTableUsingMultiplePartitions() {
     withTempDir(
         dir -> {

--- a/flink/src/test/java/io/delta/flink/sink/DeltaUpsertWriterTaskTest.java
+++ b/flink/src/test/java/io/delta/flink/sink/DeltaUpsertWriterTaskTest.java
@@ -1,0 +1,499 @@
+/*
+ *  Copyright (2026) The Delta Lake Project Authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.delta.flink.sink;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.delta.flink.TestHelper;
+import io.delta.flink.sink.mergestrategy.ScanLocator;
+import io.delta.flink.sink.mergestrategy.Upsert;
+import io.delta.flink.table.DeltaTable;
+import io.delta.flink.table.HadoopTable;
+import io.delta.kernel.data.ColumnarBatch;
+import io.delta.kernel.data.Row;
+import io.delta.kernel.expressions.Literal;
+import io.delta.kernel.internal.actions.AddFile;
+import io.delta.kernel.internal.actions.SingleAction;
+import io.delta.kernel.types.IntegerType;
+import io.delta.kernel.types.StringType;
+import io.delta.kernel.types.StructType;
+import io.delta.kernel.utils.CloseableIterator;
+import java.io.File;
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiPredicate;
+import java.util.stream.Collectors;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.StringData;
+import org.junit.jupiter.api.Test;
+
+/** JUnit test suite for {@link DeltaUpsertWriterTask}. */
+class DeltaUpsertWriterTaskTest extends TestHelper {
+
+  private static final StructType SCHEMA =
+      new StructType().add("id", IntegerType.INTEGER).add("name", StringType.STRING);
+
+  // ===========================================================================
+  // In-memory behaviors: write / erase / replace, before any dump.
+  // ===========================================================================
+
+  @Test
+  void testAppendDistinctPksProducesSingleFileInOrder() {
+    withTempDir(
+        dir -> {
+          HadoopTable table = openTable(dir);
+          DeltaUpsertWriterTask task = newTask(table, defaultConf());
+
+          for (int i = 0; i < 5; i++) {
+            boolean replaced = task.write(pk(i), row(i, "v" + i), new TestSinkWriterContext(0, 0));
+            assertFalse(replaced, "first write of a PK never reports replacement");
+          }
+
+          List<DeltaWriterResult> results = task.complete();
+          assertEquals(1, results.size());
+          AddFile addFile = addFileOf(results.get(0));
+          assertFalse(addFile.getDeletionVector().isPresent(), "no DV on a fresh file");
+
+          List<Row> rows = readParquet(absolutePath(dir, addFile), SCHEMA);
+          assertEquals(5, rows.size());
+          for (int i = 0; i < 5; i++) {
+            assertEquals(i, rows.get(i).getInt(0));
+            assertEquals("v" + i, rows.get(i).getString(1));
+          }
+        });
+  }
+
+  @Test
+  void testInBatchReplaceSamePkKeepsLatestImage() {
+    withTempDir(
+        dir -> {
+          HadoopTable table = openTable(dir);
+          DeltaUpsertWriterTask task = newTask(table, defaultConf());
+
+          assertFalse(task.write(pk(5), row(5, "A"), new TestSinkWriterContext(0, 0)));
+          // Second write for the same PK must report a replacement and overwrite in place.
+          assertTrue(task.write(pk(5), row(5, "B"), new TestSinkWriterContext(0, 0)));
+
+          List<DeltaWriterResult> results = task.complete();
+          assertEquals(1, results.size());
+
+          List<Row> rows = readParquet(absolutePath(dir, addFileOf(results.get(0))), SCHEMA);
+          assertEquals(1, rows.size());
+          assertEquals(5, rows.get(0).getInt(0));
+          assertEquals("B", rows.get(0).getString(1));
+        });
+  }
+
+  @Test
+  void testEraseInMemoryRowYieldsNoFile() {
+    withTempDir(
+        dir -> {
+          HadoopTable table = openTable(dir);
+          DeltaUpsertWriterTask task = newTask(table, defaultConf());
+
+          task.write(pk(7), row(7, "x"), new TestSinkWriterContext(0, 0));
+          assertTrue(task.erase(pk(7)), "erase of an in-batch row reports success");
+
+          // Compaction wipes the only buffered row, so the override short-circuits and no
+          // AddFile is produced.
+          assertTrue(task.complete().isEmpty(), "no file when every buffered row was erased");
+        });
+  }
+
+  @Test
+  void testEraseMissingPkIsNoop() {
+    withTempDir(
+        dir -> {
+          HadoopTable table = openTable(dir);
+          DeltaUpsertWriterTask task = newTask(table, defaultConf());
+
+          assertFalse(task.erase(pk(42)), "erase of an unknown PK returns false");
+          assertTrue(task.complete().isEmpty());
+        });
+  }
+
+  @Test
+  void testEraseThenReWriteSamePk() {
+    withTempDir(
+        dir -> {
+          HadoopTable table = openTable(dir);
+          DeltaUpsertWriterTask task = newTask(table, defaultConf());
+
+          task.write(pk(3), row(3, "before"), new TestSinkWriterContext(0, 0));
+          task.erase(pk(3));
+          // The slot left behind by erase is reused for the re-written row.
+          task.write(pk(3), row(3, "after"), new TestSinkWriterContext(0, 0));
+
+          List<DeltaWriterResult> results = task.complete();
+          assertEquals(1, results.size());
+          List<Row> rows = readParquet(absolutePath(dir, addFileOf(results.get(0))), SCHEMA);
+          assertEquals(1, rows.size());
+          assertEquals("after", rows.get(0).getString(1));
+        });
+  }
+
+  @Test
+  void testCompactionRemovesGapsInMiddle() {
+    withTempDir(
+        dir -> {
+          HadoopTable table = openTable(dir);
+          DeltaUpsertWriterTask task = newTask(table, defaultConf());
+
+          task.write(pk(1), row(1, "A"), new TestSinkWriterContext(0, 0));
+          task.write(pk(2), row(2, "B"), new TestSinkWriterContext(0, 0));
+          task.write(pk(3), row(3, "C"), new TestSinkWriterContext(0, 0));
+          // Punch a hole in the middle of the buffer and verify compaction closes it cleanly
+          // (no nulls bleed through into Parquet, and the surviving order is A, C).
+          task.erase(pk(2));
+
+          List<DeltaWriterResult> results = task.complete();
+          assertEquals(1, results.size());
+          List<Row> rows = readParquet(absolutePath(dir, addFileOf(results.get(0))), SCHEMA);
+          assertEquals(List.of(1, 3), List.of(rows.get(0).getInt(0), rows.get(1).getInt(0)));
+        });
+  }
+
+  @Test
+  void testCompleteOnEmptyTaskYieldsNothing() {
+    withTempDir(
+        dir -> {
+          HadoopTable table = openTable(dir);
+          DeltaUpsertWriterTask task = newTask(table, defaultConf());
+
+          // No writes at all -- complete must not produce phantom AddFiles, and must not trip
+          // the internal results-vs-positionsToRemove invariant.
+          assertTrue(task.complete().isEmpty());
+        });
+  }
+
+  // ===========================================================================
+  // Cross-dump behaviors: position tracking and algorithm delegation when a PK
+  // touches an already-rolled file. Tests use SpyUpsert — algorithm-agnostic.
+  // ===========================================================================
+
+  @Test
+  void testAllRowsErasedAfterDumpDropsFileFromOutput() {
+    withTempDir(
+        dir -> {
+          HadoopTable table = openTable(dir);
+          SpyUpsert spy = new SpyUpsert();
+          // rollAfter(2) flushes pk(0)+"A" and pk(1)+"B" into file 0 as soon as the second write
+          // arrives. Both rows are then erased, so every row in the only staged file is deleted
+          // and complete() must return an empty list (the fully-deleted file is dropped before
+          // the algorithm is ever called).
+          DeltaUpsertWriterTask task = newTask(table, rollAfter(2), spy);
+
+          task.write(pk(0), row(0, "A"), new TestSinkWriterContext(0, 0));
+          task.write(pk(1), row(1, "B"), new TestSinkWriterContext(0, 0));
+          assertTrue(task.erase(pk(0)), "erase of a dumped row must return true");
+          assertTrue(task.erase(pk(1)), "erase of a dumped row must return true");
+
+          assertTrue(
+              task.complete().isEmpty(),
+              "fully-deleted staged file must be dropped from complete() output");
+          assertTrue(
+              spy.capturedPositions.isEmpty(),
+              "fully-deleted file is dropped before reaching the algorithm");
+        });
+  }
+
+  @Test
+  void testRollingProducesMultipleFilesWithNoDelegation() {
+    withTempDir(
+        dir -> {
+          HadoopTable table = openTable(dir);
+          SpyUpsert spy = new SpyUpsert();
+          DeltaUpsertWriterTask task = newTask(table, rollAfter(2), spy);
+
+          for (int i = 0; i < 4; i++) {
+            task.write(pk(i), row(i, "v" + i), new TestSinkWriterContext(0, 0));
+          }
+
+          List<DeltaWriterResult> results = task.complete();
+          assertEquals(2, results.size(), "two rolls -> two AddFiles");
+          assertTrue(
+              spy.capturedPositions.isEmpty(), "no PK touched twice — algorithm never called");
+          // Files are unchanged by the algorithm: first [0, 1], second [2, 3].
+          assertEquals(
+              List.of(0, 1),
+              idsOf(readParquet(absolutePath(dir, addFileOf(results.get(0))), SCHEMA)));
+          assertEquals(
+              List.of(2, 3),
+              idsOf(readParquet(absolutePath(dir, addFileOf(results.get(1))), SCHEMA)));
+        });
+  }
+
+  @Test
+  void testInBatchUpdateAcrossRollDelegatesPositionToAlgorithm() {
+    withTempDir(
+        dir -> {
+          HadoopTable table = openTable(dir);
+          SpyUpsert spy = new SpyUpsert();
+          DeltaUpsertWriterTask task = newTask(table, rollAfter(2), spy);
+
+          // PK 0 lands in file 0; PK 1 triggers the roll. Then PK 0 is updated — markAsRemoved
+          // must locate the old row (position 0) in the just-dumped file and queue it.
+          task.write(pk(0), row(0, "old"), new TestSinkWriterContext(0, 0));
+          task.write(pk(1), row(1, "B"), new TestSinkWriterContext(0, 0));
+          assertTrue(
+              task.write(pk(0), row(0, "new"), new TestSinkWriterContext(0, 0)),
+              "second write of PK 0 (now on disk in file 0) must report replacement");
+
+          List<DeltaWriterResult> results = task.complete();
+          assertEquals(2, results.size());
+
+          // File 0: algorithm was called with position 0 (the stale pk(0) row).
+          assertEquals(1, spy.capturedPositions.size());
+          assertEquals(Set.of(0), spy.capturedPositions.get(0));
+
+          // File 1: the updated image of PK 0 — no positions queued, returned unchanged.
+          List<Row> file1Rows = readParquet(absolutePath(dir, addFileOf(results.get(1))), SCHEMA);
+          assertEquals(1, file1Rows.size());
+          assertEquals(0, file1Rows.get(0).getInt(0));
+          assertEquals("new", file1Rows.get(0).getString(1));
+        });
+  }
+
+  @Test
+  void testEraseAcrossRollDelegatesPositionToAlgorithm() {
+    withTempDir(
+        dir -> {
+          HadoopTable table = openTable(dir);
+          SpyUpsert spy = new SpyUpsert();
+          DeltaUpsertWriterTask task = newTask(table, rollAfter(2), spy);
+
+          task.write(pk(0), row(0, "A"), new TestSinkWriterContext(0, 0));
+          task.write(pk(1), row(1, "B"), new TestSinkWriterContext(0, 0));
+          assertTrue(
+              task.erase(pk(0)), "erase of a PK that has already been dumped must report success");
+
+          // No writes follow the erase. complete() yields exactly one result for the modified file.
+          List<DeltaWriterResult> results = task.complete();
+          assertEquals(1, results.size());
+
+          // Algorithm was called with position 0 (the erased pk(0) row in file 0).
+          assertEquals(1, spy.capturedPositions.size());
+          assertEquals(Set.of(0), spy.capturedPositions.get(0));
+        });
+  }
+
+  @Test
+  void testEraseUnknownPkAfterRollReturnsFalse() {
+    withTempDir(
+        dir -> {
+          HadoopTable table = openTable(dir);
+          SpyUpsert spy = new SpyUpsert();
+          DeltaUpsertWriterTask task = newTask(table, rollAfter(2), spy);
+
+          // Roll file 0 = [0, 1], then ask markAsRemoved about a PK that lives in *no* file.
+          // The file-scan loop must walk every entry, find nothing, and return -1.
+          task.write(pk(0), row(0, "A"), new TestSinkWriterContext(0, 0));
+          task.write(pk(1), row(1, "B"), new TestSinkWriterContext(0, 0));
+          assertFalse(task.erase(pk(42)), "erase of an unknown PK returns false even after rolls");
+
+          List<DeltaWriterResult> results = task.complete();
+          assertEquals(1, results.size());
+          assertTrue(
+              spy.capturedPositions.isEmpty(),
+              "no positions queued — algorithm must not be called");
+          // File is unchanged (algorithm not called): content is still [0, 1].
+          assertEquals(
+              List.of(0, 1),
+              idsOf(readParquet(absolutePath(dir, addFileOf(results.get(0))), SCHEMA)));
+        });
+  }
+
+  @Test
+  void testRepeatedSamePkAcrossMultipleRollsCancelsFullyDeletedFiles() {
+    withTempDir(
+        dir -> {
+          HadoopTable table = openTable(dir);
+          SpyUpsert spy = new SpyUpsert();
+          // rollAfter(1): every write produces its own file, so each re-write of the same PK
+          // forces markAsRemoved to walk past the previously-removed entries and find the
+          // *current* live copy in the latest file.
+          DeltaUpsertWriterTask task = newTask(table, rollAfter(1), spy);
+
+          task.write(pk(7), row(7, "v1"), new TestSinkWriterContext(0, 0));
+          task.write(pk(7), row(7, "v2"), new TestSinkWriterContext(0, 0));
+          task.write(pk(7), row(7, "v3"), new TestSinkWriterContext(0, 0));
+
+          List<DeltaWriterResult> results = task.complete();
+          assertEquals(1, results.size(), "two files are cancelled out");
+          assertTrue(
+              spy.capturedPositions.isEmpty(),
+              "fully-deleted files are dropped before the algorithm is called");
+
+          // Only file 2's row survives; its on-disk content is v3 (unchanged by algorithm).
+          List<Row> file2Rows = readParquet(absolutePath(dir, addFileOf(results.get(0))), SCHEMA);
+          assertEquals(1, file2Rows.size());
+          assertEquals("v3", file2Rows.get(0).getString(1));
+        });
+  }
+
+  @Test
+  void testMultiplePositionsInOneDumpedFileDelegatedToAlgorithm() {
+    withTempDir(
+        dir -> {
+          HadoopTable table = openTable(dir);
+          SpyUpsert spy = new SpyUpsert();
+          DeltaUpsertWriterTask task = newTask(table, rollAfter(4), spy);
+
+          // File 0: rows 0..3 (PKs 0..3).
+          for (int i = 0; i < 4; i++) {
+            task.write(pk(i), row(i, "v" + i), new TestSinkWriterContext(0, 0));
+          }
+          // After the roll, touch two distinct rows in file 0: PK 0 via re-write, PK 2 via erase.
+          task.write(pk(0), row(0, "v0-updated"), new TestSinkWriterContext(0, 0));
+          task.erase(pk(2));
+
+          List<DeltaWriterResult> results = task.complete();
+          assertEquals(2, results.size());
+
+          // File 0: algorithm was called with positions 0 (pk0) and 2 (pk2).
+          assertEquals(1, spy.capturedPositions.size());
+          assertEquals(Set.of(0, 2), spy.capturedPositions.get(0));
+
+          // File 1: the updated image of PK 0 — no positions queued, returned unchanged.
+          List<Row> file1Rows = readParquet(absolutePath(dir, addFileOf(results.get(1))), SCHEMA);
+          assertEquals(1, file1Rows.size());
+          assertEquals(0, file1Rows.get(0).getInt(0));
+          assertEquals("v0-updated", file1Rows.get(0).getString(1));
+        });
+  }
+
+  // ===========================================================================
+  // Watermark propagation across both write paths (append + in-memory replace).
+  // ===========================================================================
+
+  @Test
+  void testWatermarksTrackBothAppendAndInMemoryReplace() {
+    withTempDir(
+        dir -> {
+          HadoopTable table = openTable(dir);
+          DeltaUpsertWriterTask task = newTask(table, defaultConf());
+
+          // First write goes through super.write (the append path). Second write replaces in
+          // memory and must extend the watermark window from the override itself.
+          task.write(pk(5), row(5, "early"), new TestSinkWriterContext(100, 100));
+          task.write(pk(5), row(5, "late"), new TestSinkWriterContext(500, 500));
+
+          List<DeltaWriterResult> results = task.complete();
+          assertEquals(1, results.size());
+          WriterResultContext ctx = results.get(0).getContext();
+          assertEquals(100, ctx.getLowWatermark());
+          assertEquals(500, ctx.getHighWatermark());
+        });
+  }
+
+  // ===========================================================================
+  // Helpers
+  // ===========================================================================
+
+  private HadoopTable openTable(File dir) {
+    HadoopTable table =
+        new HadoopTable(
+            URI.create(dir.getAbsolutePath()),
+            Collections.emptyMap(),
+            SCHEMA,
+            Collections.emptyList());
+    table.open();
+    return table;
+  }
+
+  private DeltaSinkConf defaultConf() {
+    return new DeltaSinkConf(SCHEMA, Collections.emptyMap());
+  }
+
+  /** A {@link DeltaSinkConf} that forces a file roll after every {@code n} writes. */
+  private DeltaSinkConf rollAfter(int n) {
+    return new DeltaSinkConf(
+        SCHEMA, Map.of("file_rolling.strategy", "count", "file_rolling.count", String.valueOf(n)));
+  }
+
+  private DeltaUpsertWriterTask newTask(HadoopTable table, DeltaSinkConf conf) {
+    return newTask(table, conf, new SpyUpsert());
+  }
+
+  private DeltaUpsertWriterTask newTask(HadoopTable table, DeltaSinkConf conf, Upsert algorithm) {
+    return new DeltaUpsertWriterTask(
+        /* jobId= */ "test-job",
+        /* subtaskId= */ 0,
+        /* attemptNumber= */ 0,
+        table,
+        conf,
+        Collections.emptyMap(),
+        algorithm);
+  }
+
+  private static List<Literal> pk(int id) {
+    return List.of(Literal.ofInt(id));
+  }
+
+  private static GenericRowData row(int id, String name) {
+    return GenericRowData.of(id, StringData.fromString(name));
+  }
+
+  private static AddFile addFileOf(DeltaWriterResult result) {
+    Row action = result.getDeltaActions().get(0);
+    return new AddFile(action.getStruct(SingleAction.ADD_FILE_ORDINAL));
+  }
+
+  private static Path absolutePath(File dir, AddFile addFile) {
+    return dir.toPath().resolve(addFile.getPath()).toAbsolutePath();
+  }
+
+  private static List<Integer> idsOf(List<Row> rows) {
+    return rows.stream().map(r -> r.getInt(0)).collect(Collectors.toList());
+  }
+
+  /**
+   * Algorithm-agnostic test double. Captures the positions passed to {@link #markRemovesOnStaged}
+   * and returns the staged action unchanged — no file rewrite, no DV. This lets task-level tests
+   * assert on *what* positions were queued without depending on any specific algorithm's output
+   * format.
+   */
+  private static final class SpyUpsert extends Upsert {
+
+    final List<Set<Integer>> capturedPositions = new ArrayList<>();
+
+    SpyUpsert() {
+      super(new ScanLocator());
+    }
+
+    @Override
+    public Row markRemovesOnStaged(
+        DeltaTable table, Row stagedAddFile, Set<Integer> removePositions) {
+      capturedPositions.add(new HashSet<>(removePositions));
+      return stagedAddFile;
+    }
+
+    @Override
+    protected CloseableIterator<Row> deleteRecords(
+        Row addFile, BiPredicate<ColumnarBatch, Integer> filter) {
+      throw new UnsupportedOperationException("deleteRecords not called in task unit tests");
+    }
+  }
+}

--- a/flink/src/test/java/io/delta/flink/sink/DeltaUpsertWriterTaskTest.java
+++ b/flink/src/test/java/io/delta/flink/sink/DeltaUpsertWriterTaskTest.java
@@ -107,6 +107,28 @@ class DeltaUpsertWriterTaskTest extends TestHelper {
   }
 
   @Test
+  void testCompositeKeysWithDelimiterInValueAreDistinct() {
+    withTempDir(
+        dir -> {
+          HadoopTable table = openTable(dir);
+          DeltaUpsertWriterTask task = newTask(table, defaultConf());
+
+          // Two distinct composite PKs that a naive join(";") would collapse to "a;b;c".
+          // The canonical key escapes the delimiter, so they must remain separate rows.
+          List<Literal> pk1 = List.of(Literal.ofString("a;b"), Literal.ofString("c"));
+          List<Literal> pk2 = List.of(Literal.ofString("a"), Literal.ofString("b;c"));
+
+          assertFalse(task.write(pk1, row(1, "first"), new TestSinkWriterContext(0, 0)));
+          assertFalse(task.write(pk2, row(2, "second"), new TestSinkWriterContext(0, 0)));
+
+          List<DeltaWriterResult> results = task.complete();
+          assertEquals(1, results.size());
+          List<Row> rows = readParquet(absolutePath(dir, addFileOf(results.get(0))), SCHEMA);
+          assertEquals(2, rows.size());
+        });
+  }
+
+  @Test
   void testEraseInMemoryRowYieldsNoFile() {
     withTempDir(
         dir -> {

--- a/flink/src/test/java/io/delta/flink/sink/MergeStrategyTest.java
+++ b/flink/src/test/java/io/delta/flink/sink/MergeStrategyTest.java
@@ -1,0 +1,60 @@
+/*
+ *  Copyright (2026) The Delta Lake Project Authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.delta.flink.sink;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.delta.kernel.expressions.Literal;
+import io.delta.kernel.types.StringType;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/** JUnit test suite for {@link MergeStrategy}. */
+class MergeStrategyTest {
+
+  @Test
+  void testKeyStringDistinguishesNullLiteralFromStringNull() {
+    String nullLiteralKey = MergeStrategy.keyString(List.of(Literal.ofNull(StringType.STRING)));
+    String stringNullKey = MergeStrategy.keyString(List.of(Literal.ofString("null")));
+    assertNotEquals(nullLiteralKey, stringNullKey);
+
+    // Encoding is deterministic for equal inputs.
+    assertEquals(
+        nullLiteralKey, MergeStrategy.keyString(List.of(Literal.ofNull(StringType.STRING))));
+    assertEquals(stringNullKey, MergeStrategy.keyString(List.of(Literal.ofString("null"))));
+  }
+
+  @Test
+  void testKeyStringRejectsNullLiteral() {
+    assertThrows(
+        NullPointerException.class,
+        () -> MergeStrategy.keyString(Collections.singletonList((Literal) null)));
+  }
+
+  @Test
+  void testWriterKeyDistinguishesNullLiteralFromStringNull() {
+    Map<String, String> nullPartition =
+        MergeStrategy.writerKey(Map.of("part", Literal.ofNull(StringType.STRING)));
+    Map<String, String> stringNullPartition =
+        MergeStrategy.writerKey(Map.of("part", Literal.ofString("null")));
+    assertNotEquals(nullPartition, stringNullPartition);
+  }
+}

--- a/flink/src/test/java/io/delta/flink/sink/mergestrategy/CoWUpsertTest.java
+++ b/flink/src/test/java/io/delta/flink/sink/mergestrategy/CoWUpsertTest.java
@@ -49,6 +49,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BiPredicate;
+import java.util.stream.Collectors;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.StringData;
 import org.junit.jupiter.api.Test;
@@ -58,10 +59,9 @@ import org.junit.jupiter.api.Test;
  *
  * <p>This suite exercises the file-rewrite half of the upsert pipeline in isolation — it supplies a
  * scan-file row and a row-level filter directly, bypassing {@link
- * io.delta.flink.sink.MergeStrategy#recordUpsert} / {@link
- * io.delta.flink.sink.MergeStrategy#recordDelete} / {@link Upsert#merge}. End-to-end tests of the
- * full merge pipeline (including {@link RowLocator} and the PK-driven filter construction) are out
- * of scope here.
+ * io.delta.flink.sink.MergeStrategy#upsert} / {@link io.delta.flink.sink.MergeStrategy#delete} /
+ * {@link Upsert#merge}. End-to-end tests of the full merge pipeline (including {@link RowLocator}
+ * and the PK-driven filter construction) are out of scope here.
  *
  * <p>{@link CoWUpsert#deleteRecords} is {@code protected}, so we wrap it in a tiny test-only
  * subclass ({@link ExposedCoWUpsert}) that exposes the method plus the {@code table} field.
@@ -348,6 +348,75 @@ class CoWUpsertTest extends TestHelper {
   }
 
   // -------------------------------------------------------------------------
+  // markRemovesOnStaged tests
+  // -------------------------------------------------------------------------
+
+  @Test
+  void testMarkRemovesOnStagedDropsSomeRows() {
+    withTempDir(
+        dir -> {
+          HadoopTable table = openTable(dir, SCHEMA, Collections.emptyList());
+          Row stagedAction = stageFile(table, SCHEMA, 5);
+
+          Row result = new CoWUpsert().markRemovesOnStaged(table, stagedAction, Set.of(0, 2));
+
+          AddFile resultAddFile = addFileOf(result);
+          Path newFile = dir.toPath().resolve(resultAddFile.getPath()).toAbsolutePath();
+          List<Row> survivors = readParquet(newFile, SCHEMA);
+
+          // Positions 0 and 2 (ids 0 and 2) were dropped; 3 rows survive.
+          assertEquals(3, survivors.size());
+          List<Integer> survivorIds =
+              survivors.stream().map(r -> r.getInt(0)).collect(Collectors.toList());
+          assertFalse(survivorIds.contains(0), "id 0 should have been removed");
+          assertFalse(survivorIds.contains(2), "id 2 should have been removed");
+          assertTrue(survivorIds.contains(1), "id 1 should survive");
+          assertTrue(survivorIds.contains(3), "id 3 should survive");
+          assertTrue(survivorIds.contains(4), "id 4 should survive");
+        });
+  }
+
+  @Test
+  void testMarkRemovesOnStagedCoLocatedWithSource() {
+    withTempDir(
+        dir -> {
+          HadoopTable table = openTable(dir, SCHEMA, Collections.emptyList());
+          Row stagedAction = stageFile(table, SCHEMA, 4);
+
+          Row result = new CoWUpsert().markRemovesOnStaged(table, stagedAction, Set.of(0));
+
+          AddFile source = addFileOf(stagedAction);
+          AddFile rewrite = addFileOf(result);
+
+          // The rewritten file must land in the same parent directory as the source.
+          assertEquals(
+              parentDir(source.getPath()),
+              parentDir(rewrite.getPath()),
+              "rewrite must be co-located with the staged source file");
+        });
+  }
+
+  @Test
+  void testMarkRemovesOnStagedSingleRow() {
+    withTempDir(
+        dir -> {
+          HadoopTable table = openTable(dir, SCHEMA, Collections.emptyList());
+          Row stagedAction = stageFile(table, SCHEMA, 3);
+
+          Row result = new CoWUpsert().markRemovesOnStaged(table, stagedAction, Set.of(2));
+
+          AddFile resultAddFile = addFileOf(result);
+          Path newFile = dir.toPath().resolve(resultAddFile.getPath()).toAbsolutePath();
+          List<Row> survivors = readParquet(newFile, SCHEMA);
+
+          // Row at position 2 (id=2) is removed; survivors are id=0 and id=1 in order.
+          assertEquals(2, survivors.size());
+          assertEquals(0, survivors.get(0).getInt(0));
+          assertEquals(1, survivors.get(1).getInt(0));
+        });
+  }
+
+  // -------------------------------------------------------------------------
   // Helpers
   // -------------------------------------------------------------------------
 
@@ -512,5 +581,42 @@ class CoWUpsertTest extends TestHelper {
     assertTrue(
         action.isNullAt(SingleAction.REMOVE_FILE_ORDINAL),
         "did not expect the action to also carry a RemoveFile");
+  }
+
+  /**
+   * Write {@code numRows} rows via a {@link DeltaWriterTask}, call {@code complete()}, and return
+   * the single {@code SingleAction(AddFile)} row from the result. The file is on disk but NOT
+   * committed to the table.
+   */
+  private Row stageFile(HadoopTable table, StructType schema, int numRows) {
+    DeltaSinkConf conf = new DeltaSinkConf(schema, Collections.emptyMap());
+    DeltaWriterTask task =
+        new DeltaWriterTask(
+            "test-job",
+            /* subtaskId= */ 0,
+            /* attemptNumber= */ 0,
+            table,
+            conf,
+            Collections.emptyMap());
+    try {
+      for (int i = 0; i < numRows; i++) {
+        task.write(
+            GenericRowData.of(Integer.valueOf(i), StringData.fromString("row-" + i)),
+            new TestSinkWriterContext(0, 0));
+      }
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+
+    List<DeltaWriterResult> results;
+    try {
+      results = task.complete();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+    assertEquals(1, results.size(), "stageFile: expected exactly one result");
+    List<Row> actions = results.get(0).getDeltaActions();
+    assertEquals(1, actions.size(), "stageFile: expected exactly one action");
+    return actions.get(0);
   }
 }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [x] Flink
- [ ] Kernel
- [ ] Other

## Description

Step 4 of the Flink upsert sink stack. Introduces the writer-side upsert engine. These pieces are mutually dependent (`DeltaUpsertWriterTask` ↔ `Upsert` ↔ `DeltaSinkWriter`) and cannot be split across stacked commits, so they land together. (This PR absorbs the former "Route RowKind through MergeStrategy" PR #6934, now closed.)

- **`DeltaUpsertWriterTask`** — dedup-aware writer task that tracks per-PK buffer positions, replaces in place on repeat writes, and delegates removal of superseded rows in already-dumped files to the configured `Upsert` algorithm via `markRemovesOnStaged`.
- **Merge strategies** — `MergeStrategy` gains `init`/`insert`/`upsert`/`delete`/`merge`; the `Upsert` base owns the per-partition writer-task cache and per-checkpoint PK bookkeeping; `AppendOnly` handles the append path and rejects `upsert`/`delete`. `DeltaSinkConf.createMergeStrategy()` factory selects the strategy.
- **`DeltaSinkWriter`** — routes by `RowKind` (`INSERT`/`UPDATE_AFTER` → `insert`/`upsert`, `DELETE` → `delete`, `UPDATE_BEFORE` dropped) through the `MergeStrategy`, exposes `getTable()`/`getConf()`/`newWriterTask()`, and bumps `numFilesWritten` in `prepareCommit()`.
- **`DeltaWriterTask`** — minor protected-visibility tweaks so `DeltaUpsertWriterTask` can extend it.

Tests: `DeltaUpsertWriterTaskTest` (algorithm-agnostic, via a `SpyUpsert` double), `DeltaSinkWriterTest` upsert paths, and `CoWUpsertTest` updates.

Stack:
- Built on the conf+builder PR (#6933), now **merged** into `master`.
- Followed by the SQL DDL hookup (#6935) and the MoR PR (#6977), which also depends on the DV-support PR (#6964).

Part of #5901.

## How was this patch tested?

- `build/sbt "flink/testOnly io.delta.flink.sink.DeltaUpsertWriterTaskTest io.delta.flink.sink.DeltaSinkWriterTest io.delta.flink.sink.DeltaSinkConfTest io.delta.flink.sink.DeltaSinkTest io.delta.flink.sink.mergestrategy.CoWUpsertTest"` — all pass.

## Does this PR introduce _any_ user-facing changes?

Yes (via the option introduced in #6933): with `write.mode='upsert'` the sink applies in-batch dedup and pre-image scrubbing on commit. `INSERT`, `UPDATE_AFTER`, and `DELETE` are honored; `UPDATE_BEFORE` is dropped. Append-mode sinks fail loudly on `UPDATE_AFTER`/`DELETE`.
