### PR TITLE
[SQL] Rename v2 read DSv2 classes to DeltaV2*

### DIFF
--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/V1V2SourceSchemaLogCompatibilitySuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/V1V2SourceSchemaLogCompatibilitySuite.scala
@@ -34,7 +34,7 @@ import org.apache.spark.sql.{DataFrame, Row}
 
 /**
  * Verifies that a single stream's schema tracking log is interchangeable between the V1 (legacy
- * DeltaSource) and V2 (Kernel-based SparkMicroBatchStream) connectors. Each test alternates the
+ * DeltaSource) and V2 (Kernel-based DeltaV2MicroBatchStream) connectors. Each test alternates the
  * connector across stream restarts that share the same checkpoint and schema location, exercising
  * schema log initialization, non-additive evolution, and additive-then-non-additive sequences.
  */

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
@@ -1518,7 +1518,7 @@ object DeltaSource extends DeltaLogging {
   /**
    * Build the latest offset based on the last indexedFile. The function also checks if latest
    * version is valid by comparing with previous version.
-   * Public for use by SparkMicroBatchStream.
+   * Public for use by DeltaV2MicroBatchStream.
    * @param tableId The table ID
    * @param fileVersion The version of the last indexed file.
    * @param fileIndex The index of the last indexed file.

--- a/spark/v2/src/main/java-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogScan.java
+++ b/spark/v2/src/main/java-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogScan.java
@@ -55,7 +55,7 @@ public class DeltaChangelogScan implements Scan {
 
   // TODO: implement toMicroBatchStream() so spark.readStream...loadChangelog(...) can drive a
   // streaming CDC read through this Changelog. The existing streaming-CDC entrypoint
-  // (SparkMicroBatchStream + readChangeFeed=true) provides the wire format today, but it bypasses
+  // (DeltaV2MicroBatchStream + readChangeFeed=true) provides the wire format today, but it bypasses
   // the catalog-driven Changelog API that SPARK-56687 (PR apache/spark#55637) builds on for
   // streaming netChanges post-processing.
 }

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
@@ -26,7 +26,7 @@ import io.delta.kernel.engine.Engine;
 import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.internal.rowtracking.RowTracking;
 import io.delta.spark.internal.v2.read.MetadataEvolutionHandler;
-import io.delta.spark.internal.v2.read.SparkScanBuilder;
+import io.delta.spark.internal.v2.read.DeltaV2ScanBuilder;
 import io.delta.spark.internal.v2.read.cdc.CDCSchemaContext;
 import io.delta.spark.internal.v2.snapshot.DeltaSnapshotManager;
 import io.delta.spark.internal.v2.snapshot.SnapshotManagerFactory;
@@ -385,7 +385,7 @@ public class DeltaV2Table implements Table, SupportsRead, SupportsWrite, Support
                         stats,
                         schemaProvider.getDataSchema(),
                         schemaProvider.getPartitionSchema()));
-    return new SparkScanBuilder(
+    return new DeltaV2ScanBuilder(
         name(),
         initialSnapshot,
         snapshotManager,

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/ColumnReorderReadFunction.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/ColumnReorderReadFunction.java
@@ -36,7 +36,7 @@ import scala.runtime.AbstractFunction1;
 
 /**
  * Reorders a Parquet reader's {@code readDataSchema ++ partitionSchema} output into the DDL field
- * order declared by {@link SparkScan#readSchema()}.
+ * order declared by {@link DeltaV2Scan#readSchema()}.
  */
 public class ColumnReorderReadFunction
     extends AbstractFunction1<PartitionedFile, Iterator<InternalRow>> implements Serializable {

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2Batch.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2Batch.java
@@ -33,7 +33,7 @@ import org.apache.spark.sql.internal.SQLConf;
 import org.apache.spark.sql.sources.Filter;
 import org.apache.spark.sql.types.StructType;
 
-public class SparkBatch implements Batch {
+public class DeltaV2Batch implements Batch {
   private final Snapshot snapshot;
   private final StructType readDataSchema;
   private final StructType dataSchema;
@@ -51,7 +51,7 @@ public class SparkBatch implements Batch {
   private scala.collection.immutable.Map<String, String> scalaOptions;
   private final List<PartitionedFile> partitionedFiles;
 
-  public SparkBatch(
+  public DeltaV2Batch(
       Snapshot snapshot,
       StructType dataSchema,
       StructType partitionSchema,
@@ -93,7 +93,7 @@ public class SparkBatch implements Batch {
   @Override
   public PartitionReaderFactory createReaderFactory() {
     // Non-CDC plain table scan. Write-time CDF streaming reads route through
-    // SparkMicroBatchStream; read-time Auto-CDF batch reads route through DeltaChangelogBatch.
+    // DeltaV2MicroBatchStream; read-time Auto-CDF batch reads route through DeltaChangelogBatch.
     return PartitionUtils.createDeltaParquetReaderFactory(
         snapshot,
         dataSchema,
@@ -109,9 +109,9 @@ public class SparkBatch implements Batch {
   @Override
   public boolean equals(Object obj) {
     if (this == obj) return true;
-    if (!(obj instanceof SparkBatch)) return false;
+    if (!(obj instanceof DeltaV2Batch)) return false;
 
-    SparkBatch that = (SparkBatch) obj;
+    DeltaV2Batch that = (DeltaV2Batch) obj;
     return Objects.equals(this.snapshot, that.snapshot)
         && Objects.equals(this.readDataSchema, that.readDataSchema)
         && Objects.equals(this.dataSchema, that.dataSchema)

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2MicroBatchStream.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2MicroBatchStream.java
@@ -109,10 +109,10 @@ import scala.runtime.AbstractFunction2;
 import scala.util.matching.Regex;
 
 // TODO(#5318): Use DeltaErrors error framework for consistent error handling.
-public class SparkMicroBatchStream
+public class DeltaV2MicroBatchStream
     implements MicroBatchStream, SupportsAdmissionControl, SupportsTriggerAvailableNow {
 
-  private static final Logger logger = LoggerFactory.getLogger(SparkMicroBatchStream.class);
+  private static final Logger logger = LoggerFactory.getLogger(DeltaV2MicroBatchStream.class);
 
   private static final String FILE_IDX_COL = "_file_idx";
 
@@ -225,7 +225,7 @@ public class SparkMicroBatchStream
   private final boolean useDistributedInitialSnapshot;
   private final StorageLevel snapshotCacheStorageLevel;
 
-  public SparkMicroBatchStream(
+  public DeltaV2MicroBatchStream(
       DeltaSnapshotManager snapshotManager,
       Snapshot snapshotAtSourceInit,
       Configuration hadoopConf,

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2PartitionReader.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2PartitionReader.java
@@ -24,7 +24,7 @@ import org.apache.spark.sql.execution.datasources.PartitionedFile;
 import scala.Function1;
 import scala.collection.Iterator;
 
-public class SparkPartitionReader<T> implements PartitionReader<T> {
+public class DeltaV2PartitionReader<T> implements PartitionReader<T> {
   // Function that produces an Iterator for a given file.
   private final Function1<PartitionedFile, Iterator<InternalRow>> readFunc;
   private final FilePartition partition;
@@ -35,7 +35,7 @@ public class SparkPartitionReader<T> implements PartitionReader<T> {
   // Current iterator for the file being read.
   private Iterator<T> currentIterator = null;
 
-  public SparkPartitionReader(
+  public DeltaV2PartitionReader(
       Function1<PartitionedFile, Iterator<InternalRow>> readFunc, FilePartition partition) {
     this.readFunc = java.util.Objects.requireNonNull(readFunc, "readFunc");
     this.partition = java.util.Objects.requireNonNull(partition, "partition");

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2ReaderFactory.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2ReaderFactory.java
@@ -25,11 +25,11 @@ import org.apache.spark.sql.vectorized.ColumnarBatch;
 import scala.Function1;
 import scala.collection.Iterator;
 
-public class SparkReaderFactory implements PartitionReaderFactory {
+public class DeltaV2ReaderFactory implements PartitionReaderFactory {
   private Function1<PartitionedFile, Iterator<InternalRow>> readFunc;
   private boolean supportsColumnar;
 
-  public SparkReaderFactory(
+  public DeltaV2ReaderFactory(
       Function1<PartitionedFile, Iterator<InternalRow>> readFunc, boolean supportsColumnar) {
     this.readFunc = readFunc;
     this.supportsColumnar = supportsColumnar;
@@ -37,7 +37,7 @@ public class SparkReaderFactory implements PartitionReaderFactory {
 
   @Override
   public PartitionReader<ColumnarBatch> createColumnarReader(InputPartition partition) {
-    return new SparkPartitionReader<ColumnarBatch>(readFunc, (FilePartition) partition);
+    return new DeltaV2PartitionReader<ColumnarBatch>(readFunc, (FilePartition) partition);
   }
 
   @Override
@@ -47,6 +47,6 @@ public class SparkReaderFactory implements PartitionReaderFactory {
 
   @Override
   public PartitionReader<InternalRow> createReader(InputPartition partition) {
-    return new SparkPartitionReader<InternalRow>(readFunc, (FilePartition) partition);
+    return new DeltaV2PartitionReader<InternalRow>(readFunc, (FilePartition) partition);
   }
 }

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2Scan.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2Scan.java
@@ -60,7 +60,7 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 import scala.Option;
 
 /** Spark DSV2 Scan implementation backed by Delta Kernel. */
-public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntimeV2Filtering {
+public class DeltaV2Scan implements Scan, SupportsReportStatistics, SupportsRuntimeV2Filtering {
 
   private final DeltaSnapshotManager snapshotManager;
   private final Snapshot initialSnapshot;
@@ -105,7 +105,7 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
       appliedRuntimePredicates = new HashSet<>();
 
   // TODO(#6743): bundle scan-level schemas into a single ScanSchemaContext.
-  public SparkScan(
+  public DeltaV2Scan(
       DeltaSnapshotManager snapshotManager,
       Snapshot initialSnapshot,
       StructType tableSchema,
@@ -200,7 +200,7 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
               + "connector. Either remove the CDC read option or use a streaming read.");
     }
     ensurePlanned();
-    return new SparkBatch(
+    return new DeltaV2Batch(
         initialSnapshot,
         dataSchema,
         partitionSchema,
@@ -217,7 +217,7 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
   @Override
   public MicroBatchStream toMicroBatchStream(String checkpointLocation) {
     // Loads a fresh snapshot as the baseline for schema change detection and table identity
-    // checks. SparkScan's initialSnapshot is from analysis time and may be stale by stream
+    // checks. DeltaV2Scan's initialSnapshot is from analysis time and may be stale by stream
     // start/restart.
     // Matches V1's DeltaDataSource.createSource() behavior.
     Snapshot latestSnapshot = snapshotManager.loadLatestSnapshot();
@@ -236,7 +236,7 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
             Option.apply(checkpointLocation),
             /* mergeConsecutiveSchemaChanges= */ false);
 
-    return new SparkMicroBatchStream(
+    return new DeltaV2MicroBatchStream(
         snapshotManager,
         latestSnapshot,
         hadoopConf,
@@ -631,7 +631,7 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    SparkScan that = (SparkScan) o;
+    DeltaV2Scan that = (DeltaV2Scan) o;
     return Objects.equals(initialSnapshot.getPath(), that.initialSnapshot.getPath())
         && initialSnapshot.getVersion() == that.initialSnapshot.getVersion()
         && Objects.equals(dataSchema, that.dataSchema)

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2ScanBuilder.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2ScanBuilder.java
@@ -38,7 +38,7 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
  * A Spark ScanBuilder implementation that wraps Delta Kernel's ScanBuilder. This allows Spark to
  * use Delta Kernel for reading Delta tables.
  */
-public class SparkScanBuilder
+public class DeltaV2ScanBuilder
     implements ScanBuilder, SupportsPushDownRequiredColumns, SupportsPushDownFilters {
 
   private io.delta.kernel.ScanBuilder kernelScanBuilder;
@@ -60,7 +60,7 @@ public class SparkScanBuilder
   private Filter[] dataFilters;
 
   /**
-   * Creates a SparkScanBuilder with the given snapshot and configuration.
+   * Creates a DeltaV2ScanBuilder with the given snapshot and configuration.
    *
    * @param tableName the name of the table
    * @param initialSnapshot Snapshot created during connector setup
@@ -71,7 +71,7 @@ public class SparkScanBuilder
    * @param catalogStats optional V2 Statistics converted from catalog stats
    * @param options scan options
    */
-  public SparkScanBuilder(
+  public DeltaV2ScanBuilder(
       String tableName,
       io.delta.kernel.Snapshot initialSnapshot,
       DeltaSnapshotManager snapshotManager,
@@ -174,7 +174,7 @@ public class SparkScanBuilder
 
   @Override
   public org.apache.spark.sql.connector.read.Scan build() {
-    return new SparkScan(
+    return new DeltaV2Scan(
         snapshotManager,
         initialSnapshot,
         tableSchema,

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/MetadataEvolutionHandler.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/MetadataEvolutionHandler.java
@@ -506,7 +506,7 @@ public class MetadataEvolutionHandler {
    * <p>The persisted metadata is the source of truth for the analyzed schema. With {@code
    * mergeConsecutiveSchemaChanges=true}, the merger folds consecutive metadata-only commits and
    * writes the merged entry back to the durable schema log; the execution-time {@link
-   * SparkMicroBatchStream} then re-reads the same merged entry via {@link
+   * DeltaV2MicroBatchStream} then re-reads the same merged entry via {@link
    * DeltaSourceMetadataTrackingLog#getCurrentTrackedMetadata}.
    */
   public static Optional<PersistedMetadata> getPersistedMetadataForMicroBatchStream(
@@ -723,7 +723,7 @@ public class MetadataEvolutionHandler {
     try (CloseableIterator<CommitActions> commitsIter =
         // Always include CDC: the merger must stop on any file action
         StreamingHelper.getCommitActionsFromRangeUnsafe(
-            engine, commitRange, tablePath, SparkMicroBatchStream.CDC_ACTION_SET)) {
+            engine, commitRange, tablePath, DeltaV2MicroBatchStream.CDC_ACTION_SET)) {
       while (commitsIter.hasNext()) {
         try (CommitActions commit = commitsIter.next()) {
           long version = commit.getVersion();

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/PartitionUtils.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/PartitionUtils.java
@@ -25,7 +25,7 @@ import io.delta.kernel.internal.actions.Protocol;
 import io.delta.kernel.internal.tablefeatures.TableFeatures;
 import io.delta.spark.internal.v2.read.ColumnReorderReadFunction;
 import io.delta.spark.internal.v2.read.DeltaParquetFileFormatV2;
-import io.delta.spark.internal.v2.read.SparkReaderFactory;
+import io.delta.spark.internal.v2.read.DeltaV2ReaderFactory;
 import io.delta.spark.internal.v2.read.cdc.CDCReadFunction;
 import io.delta.spark.internal.v2.read.cdc.CDCSchemaContext;
 import io.delta.spark.internal.v2.read.deletionvector.DeletionVectorReadFunction;
@@ -453,7 +453,7 @@ public class PartitionUtils {
             partitionSchema,
             ddlOrderedReadOutputSchema);
 
-    return new SparkReaderFactory(readFunc, enableVectorizedReader);
+    return new DeltaV2ReaderFactory(readFunc, enableVectorizedReader);
   }
 
   /**

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2WriteBuilder.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2WriteBuilder.java
@@ -32,7 +32,7 @@ import org.apache.spark.sql.types.StructType;
 
 /**
  * WriteBuilder for DSv2 batch writes to Delta tables. Mirrors the read-side {@code
- * SparkScanBuilder} pattern: takes table-level state and Spark's {@link LogicalWriteInfo}, and
+ * DeltaV2ScanBuilder} pattern: takes table-level state and Spark's {@link LogicalWriteInfo}, and
  * builds a {@link DeltaV2BatchWrite} (which implements both Write and BatchWrite).
  *
  * <p>Schema validation uses the shared V1 utility {@code SchemaMergingUtils.mergeSchemas} to check

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/V2StreamingReadTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/V2StreamingReadTest.java
@@ -241,8 +241,8 @@ public class V2StreamingReadTest extends V2TestBase {
    * thread. If that thread is blocked inside Kernel's {@code DefaultJsonHandler} reading delta log
    * JSON files via NIO channels, the interrupt causes a {@link
    * java.nio.channels.ClosedByInterruptException} wrapped in a {@code KernelEngineException}. The
-   * fix in {@code SparkMicroBatchStream.latestOffset()} and {@code
-   * SparkMicroBatchStream.planInputPartitions()} re-wraps this as an {@link
+   * fix in {@code DeltaV2MicroBatchStream.latestOffset()} and {@code
+   * DeltaV2MicroBatchStream.planInputPartitions()} re-wraps this as an {@link
    * java.io.UncheckedIOException} so Spark's {@code isInterruptedByStop} recognizes it as a clean
    * shutdown.
    */

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2BatchTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2BatchTest.java
@@ -37,7 +37,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-public class SparkBatchTest extends DeltaV2TestBase {
+public class DeltaV2BatchTest extends DeltaV2TestBase {
 
   private static String tablePath;
   private static final String tableName = "deltatbl_partitioned_batch";
@@ -58,7 +58,7 @@ public class SparkBatchTest extends DeltaV2TestBase {
   // Cases where two batches built from the same table must be equal. city/date are partition
   // columns (exercise pushedToKernelFiltersSet); name/cnt are data columns and per
   // ExpressionUtils.classifyFilter have isDataFilter=true, so they flow into
-  // SparkBatch.dataFilters and exercise the dataFiltersSet branch of equals/hashCode.
+  // DeltaV2Batch.dataFilters and exercise the dataFiltersSet branch of equals/hashCode.
   static Stream<Arguments> equalBatchCasesProvider() {
     Filter cityEq = new EqualTo("city", "hz");
     Filter dateEq = new EqualTo("date", "20180520");
@@ -80,17 +80,17 @@ public class SparkBatchTest extends DeltaV2TestBase {
   @ParameterizedTest(name = "{0}: batches should be equal")
   @MethodSource("equalBatchCasesProvider")
   public void testEqualsAndHashCode(String description, Filter[] filters1, Filter[] filters2) {
-    SparkScanBuilder builder1 = (SparkScanBuilder) table.newScanBuilder(options);
+    DeltaV2ScanBuilder builder1 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
     if (filters1.length > 0) {
       builder1.pushFilters(filters1);
     }
-    Batch batch1 = ((SparkScan) builder1.build()).toBatch();
+    Batch batch1 = ((DeltaV2Scan) builder1.build()).toBatch();
 
-    SparkScanBuilder builder2 = (SparkScanBuilder) table.newScanBuilder(options);
+    DeltaV2ScanBuilder builder2 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
     if (filters2.length > 0) {
       builder2.pushFilters(filters2);
     }
-    Batch batch2 = ((SparkScan) builder2.build()).toBatch();
+    Batch batch2 = ((DeltaV2Scan) builder2.build()).toBatch();
 
     assertEquals(batch1, batch2);
     assertEquals(batch1.hashCode(), batch2.hashCode());
@@ -98,12 +98,12 @@ public class SparkBatchTest extends DeltaV2TestBase {
 
   @Test
   public void testEqualsWithDifferentPushedFilters() {
-    SparkScanBuilder builder1 = (SparkScanBuilder) table.newScanBuilder(options);
-    Batch batch1 = ((SparkScan) builder1.build()).toBatch();
+    DeltaV2ScanBuilder builder1 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    Batch batch1 = ((DeltaV2Scan) builder1.build()).toBatch();
 
-    SparkScanBuilder builder2 = (SparkScanBuilder) table.newScanBuilder(options);
+    DeltaV2ScanBuilder builder2 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
     builder2.pushFilters(new Filter[] {new EqualTo("city", "hz")});
-    Batch batch2 = ((SparkScan) builder2.build()).toBatch();
+    Batch batch2 = ((DeltaV2Scan) builder2.build()).toBatch();
 
     assertNotEquals(batch1, batch2);
     assertNotEquals(batch1.hashCode(), batch2.hashCode());

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2MicroBatchStreamCDCTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2MicroBatchStreamCDCTest.java
@@ -57,8 +57,8 @@ import scala.collection.JavaConverters;
 import scala.collection.immutable.Map$;
 import scala.collection.immutable.Seq;
 
-/** Tests for SparkMicroBatchStream CDC (Change Data Capture) support and DSv1/DSv2 parity. */
-public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
+/** Tests for DeltaV2MicroBatchStream CDC (Change Data Capture) support and DSv1/DSv2 parity. */
+public class DeltaV2MicroBatchStreamCDCTest extends DeltaV2TestBase {
 
   // TODO(cdf3): Add test for CDF enabled in initial snapshot but disabled in a later commit.
 
@@ -71,7 +71,7 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
 
     Configuration hadoopConf = new Configuration();
     PathBasedSnapshotManager snapshotManager = new PathBasedSnapshotManager(tablePath, hadoopConf);
-    SparkMicroBatchStream stream =
+    DeltaV2MicroBatchStream stream =
         createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
 
     RuntimeException exception =
@@ -108,7 +108,7 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
 
     Configuration hadoopConf = new Configuration();
     PathBasedSnapshotManager snapshotManager = new PathBasedSnapshotManager(tablePath, hadoopConf);
-    SparkMicroBatchStream stream =
+    DeltaV2MicroBatchStream stream =
         createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
 
     long initVersion = snapshotManager.loadLatestSnapshot().getVersion();
@@ -128,7 +128,7 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
 
     Configuration hadoopConf = new Configuration();
     PathBasedSnapshotManager snapshotManager = new PathBasedSnapshotManager(tablePath, hadoopConf);
-    SparkMicroBatchStream stream =
+    DeltaV2MicroBatchStream stream =
         createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
 
     // Init snapshot has CDF=on (v3), but startVersion=0 had CDF=off. The check must use the
@@ -150,7 +150,7 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
 
     Configuration hadoopConf = new Configuration();
     PathBasedSnapshotManager snapshotManager = new PathBasedSnapshotManager(tablePath, hadoopConf);
-    SparkMicroBatchStream stream =
+    DeltaV2MicroBatchStream stream =
         createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
     long latestVersion = snapshotManager.loadLatestSnapshot().getVersion();
 
@@ -159,7 +159,7 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
     assertDoesNotThrow(() -> stream.validateCDFEnabledOnTable(latestVersion + 1));
   }
 
-  private static final SparkMicroBatchStreamTest.ScenarioSetup CDC_TWO_INSERT_SETUP =
+  private static final DeltaV2MicroBatchStreamTest.ScenarioSetup CDC_TWO_INSERT_SETUP =
       (tableName, tempDir) -> {
         sql("INSERT INTO %s VALUES (1, 'User1'), (2, 'User2')", tableName);
         sql("INSERT INTO %s VALUES (3, 'User3')", tableName);
@@ -179,13 +179,13 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
             noMaxBytes),
         Arguments.of(
             "Empty table (no data files)",
-            (SparkMicroBatchStreamTest.ScenarioSetup) (t, d) -> {},
+            (DeltaV2MicroBatchStreamTest.ScenarioSetup) (t, d) -> {},
             /* isInitialSnapshot= */ true,
             noMaxFiles,
             noMaxBytes),
         Arguments.of(
             "Multiple inserts (5 versions)",
-            (SparkMicroBatchStreamTest.ScenarioSetup)
+            (DeltaV2MicroBatchStreamTest.ScenarioSetup)
                 (t, d) -> {
                   for (int i = 1; i <= 5; i++) {
                     sql("INSERT INTO %s VALUES (%d, 'V%d')", t, i, i);
@@ -231,7 +231,7 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
   @MethodSource("cdcFileChangesParameters")
   public void testGetFileChangesForCDC(
       String testDescription,
-      SparkMicroBatchStreamTest.ScenarioSetup setup,
+      DeltaV2MicroBatchStreamTest.ScenarioSetup setup,
       boolean isInitialSnapshot,
       Optional<Integer> maxFiles,
       Optional<Long> maxBytes,
@@ -267,7 +267,7 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
     // DSv2
     Configuration hadoopConf = new Configuration();
     PathBasedSnapshotManager snapshotManager = new PathBasedSnapshotManager(tablePath, hadoopConf);
-    SparkMicroBatchStream stream =
+    DeltaV2MicroBatchStream stream =
         createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
     List<IndexedFile> dsv2Files = new ArrayList<>();
     try (CloseableIterator<IndexedFile> iter =
@@ -283,7 +283,7 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
     if (isInitialSnapshot) {
       assertCDCFileChangesMatch(dsv1Files, dsv2Files);
     } else {
-      SparkMicroBatchStreamTest.compareFileChanges(dsv1Files, dsv2Files);
+      DeltaV2MicroBatchStreamTest.compareFileChanges(dsv1Files, dsv2Files);
     }
   }
 
@@ -322,7 +322,7 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
             /* isInitialSnapshot= */ false,
             /* maxFiles= */ Optional.empty(),
             /* maxBytes= */ Optional.empty());
-    SparkMicroBatchStreamTest.compareFileChanges(dsv1Unlimited, dsv2Unlimited);
+    DeltaV2MicroBatchStreamTest.compareFileChanges(dsv1Unlimited, dsv2Unlimited);
 
     Set<Long> unlimitedVersions = new HashSet<>();
     for (IndexedFile f : dsv2Unlimited) {
@@ -350,7 +350,7 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
             /* isInitialSnapshot= */ false,
             /* maxFiles= */ Optional.of(1),
             /* maxBytes= */ Optional.empty());
-    SparkMicroBatchStreamTest.compareFileChanges(dsv1Limited, dsv2Limited);
+    DeltaV2MicroBatchStreamTest.compareFileChanges(dsv1Limited, dsv2Limited);
 
     Set<Long> limitedVersions = new HashSet<>();
     for (IndexedFile f : dsv2Limited) {
@@ -413,7 +413,7 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
             /* isInitialSnapshot= */ false,
             /* maxFiles= */ Optional.of(1),
             /* maxBytes= */ Optional.empty());
-    SparkMicroBatchStreamTest.compareFileChanges(dsv1Call1, dsv2Call1);
+    DeltaV2MicroBatchStreamTest.compareFileChanges(dsv1Call1, dsv2Call1);
 
     // Verify no END sentinel in partial result
     boolean dsv2HasEnd =
@@ -479,7 +479,7 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
             /* isInitialSnapshot= */ false,
             /* maxFiles= */ Optional.empty(),
             /* maxBytes= */ Optional.of(maxBytes));
-    SparkMicroBatchStreamTest.compareFileChanges(dsv1Files, dsv2Files);
+    DeltaV2MicroBatchStreamTest.compareFileChanges(dsv1Files, dsv2Files);
 
     long v2DataFiles =
         dsv2Files.stream().filter(f -> f.getVersion() == 2 && f.hasFileAction()).count();
@@ -511,7 +511,7 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
     sql("INSERT INTO %s VALUES (1, 'User1'), (2, 'User2')", tableName);
 
     long commitVersion = 2;
-    SparkMicroBatchStream stream = createStream(tablePath);
+    DeltaV2MicroBatchStream stream = createStream(tablePath);
     CommitActions commit = getCommitActions(tablePath, commitVersion);
 
     List<IndexedFile> files;
@@ -557,7 +557,7 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
     sql("DELETE FROM %s WHERE id = 1", tableName);
 
     long commitVersion = 3;
-    SparkMicroBatchStream stream = createStream(tablePath);
+    DeltaV2MicroBatchStream stream = createStream(tablePath);
     CommitActions commit = getCommitActions(tablePath, commitVersion);
 
     List<IndexedFile> files;
@@ -603,7 +603,7 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
     long commitVersion = 3;
     writeSyntheticNoopMergeCommit(tablePath, commitVersion);
 
-    SparkMicroBatchStream stream = createStream(tablePath);
+    DeltaV2MicroBatchStream stream = createStream(tablePath);
 
     // Verify the commit has file actions (the synthetic commit has Add + Remove).
     CommitActions rawCommit = getCommitActions(tablePath, commitVersion);
@@ -684,7 +684,7 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
             /* isInitialSnapshot= */ false,
             /* maxFiles= */ Optional.empty(),
             /* maxBytes= */ Optional.empty());
-    SparkMicroBatchStreamTest.compareFileChanges(dsv1Files, dsv2Files);
+    DeltaV2MicroBatchStreamTest.compareFileChanges(dsv1Files, dsv2Files);
 
     // Verify ordering: RemoveFile (delete) before AddFile (insert) in delta log
     List<IndexedFile> dataFiles = new ArrayList<>();
@@ -711,7 +711,7 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
     sql("INSERT INTO %s VALUES (1, 'User1')", tableName);
 
     long commitVersion = 2;
-    SparkMicroBatchStream stream = createStream(tablePath);
+    DeltaV2MicroBatchStream stream = createStream(tablePath);
     CommitActions commit = getCommitActions(tablePath, commitVersion);
 
     DeltaSourceOffset endOffset =
@@ -830,7 +830,7 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
     sql("ALTER TABLE %s ADD COLUMNS (c3 INT)", tableName); // v3 metadata-only
 
     String schemaLogPath = new File(tempDir, "schema_log").getAbsolutePath();
-    SparkMicroBatchStream stream =
+    DeltaV2MicroBatchStream stream =
         createStreamWithSeededTrackingLog(tablePath, schemaLogPath, /* seededVersion= */ 2L);
 
     long commitVersion = 3L;
@@ -889,7 +889,7 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
     sql("INSERT INTO %s VALUES (2, 'b', 99)", tableName); // v4 post-barrier
 
     String schemaLogPath = new File(tempDir, "schema_log").getAbsolutePath();
-    SparkMicroBatchStream stream =
+    DeltaV2MicroBatchStream stream =
         createStreamWithSeededTrackingLog(tablePath, schemaLogPath, /* seededVersion= */ 2L);
 
     // Drive the stream from v2 (inclusive). Expected output structure:
@@ -942,7 +942,7 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
         tableName); // v3 protocol-only
 
     String schemaLogPath = new File(tempDir, "schema_log").getAbsolutePath();
-    SparkMicroBatchStream stream =
+    DeltaV2MicroBatchStream stream =
         createStreamWithSeededTrackingLog(tablePath, schemaLogPath, /* seededVersion= */ 2L);
 
     long commitVersion = 3L;
@@ -985,7 +985,7 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
     sql("ALTER TABLE %s ADD COLUMNS (c3 INT)", tableName); // v3 metadata-only
 
     String schemaLogPath = new File(tempDir, "schema_log").getAbsolutePath();
-    SparkMicroBatchStream stream =
+    DeltaV2MicroBatchStream stream =
         createStreamWithSeededTrackingLog(tablePath, schemaLogPath, /* seededVersion= */ 2L);
 
     long commitVersion = 3L;
@@ -1022,7 +1022,7 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
    * {@code seededVersion}. {@code mergeConsecutiveSchemaChanges=false} so the merger doesn't fold
    * later metadata into the seeded entry — useful when the test wants a specific divergence point.
    */
-  private SparkMicroBatchStream createStreamWithSeededTrackingLog(
+  private DeltaV2MicroBatchStream createStreamWithSeededTrackingLog(
       String tablePath, String schemaLogPath, long seededVersion) {
     Configuration hadoopConf = new Configuration();
     PathBasedSnapshotManager snapshotManager = new PathBasedSnapshotManager(tablePath, hadoopConf);
@@ -1064,7 +1064,7 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
     StructType tableSchema =
         io.delta.spark.internal.v2.utils.SchemaUtils.convertKernelSchemaToSparkSchema(
             seededSnapshot.getSchema());
-    return new SparkMicroBatchStream(
+    return new DeltaV2MicroBatchStream(
         snapshotManager,
         latestSnapshot,
         hadoopConf,
@@ -1124,7 +1124,7 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
       throws Exception {
     Configuration hadoopConf = new Configuration();
     PathBasedSnapshotManager snapshotManager = new PathBasedSnapshotManager(tablePath, hadoopConf);
-    SparkMicroBatchStream stream =
+    DeltaV2MicroBatchStream stream =
         createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
     List<IndexedFile> files = new ArrayList<>();
     try (CloseableIterator<IndexedFile> iter =
@@ -1180,13 +1180,13 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
         /* filters= */ emptySeq);
   }
 
-  private SparkMicroBatchStream createTestStreamWithDefaults(
+  private DeltaV2MicroBatchStream createTestStreamWithDefaults(
       PathBasedSnapshotManager snapshotManager, Configuration hadoopConf, DeltaOptions options) {
     io.delta.kernel.Snapshot snapshot = snapshotManager.loadLatestSnapshot();
     StructType tableSchema =
         io.delta.spark.internal.v2.utils.SchemaUtils.convertKernelSchemaToSparkSchema(
             snapshot.getSchema());
-    return new SparkMicroBatchStream(
+    return new DeltaV2MicroBatchStream(
         snapshotManager,
         snapshot,
         hadoopConf,
@@ -1203,7 +1203,7 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
         /* metadataPath= */ "");
   }
 
-  private SparkMicroBatchStream createStream(String tablePath) {
+  private DeltaV2MicroBatchStream createStream(String tablePath) {
     Configuration hadoopConf = new Configuration();
     PathBasedSnapshotManager snapshotManager = new PathBasedSnapshotManager(tablePath, hadoopConf);
     return createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
@@ -1351,7 +1351,7 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
     DeltaLog deltaLog = DeltaLog.forTable(spark, new Path(tablePath));
     deltaLog.update(false, Option.empty(), Option.empty());
 
-    SparkMicroBatchStream stream = createStream(tablePath);
+    DeltaV2MicroBatchStream stream = createStream(tablePath);
     CommitActions commit = getCommitActions(tablePath, commitVersion);
 
     List<IndexedFile> files;
@@ -1445,7 +1445,7 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
     createEmptyTestTable(tablePath, tableName);
     sql("INSERT INTO %s VALUES (1, 'A')", tableName);
 
-    SparkMicroBatchStream stream = createStream(tablePath);
+    DeltaV2MicroBatchStream stream = createStream(tablePath);
 
     // Simulate a "Some+None" DV-diff result: the CDCDataFile is from fromDVDiff but the backing
     // AddFile has NO deletion vector (restore case). hasDeletionVector() returns false.
@@ -1497,7 +1497,7 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
 
   private void assertCDCFileChangesMatch(
       List<org.apache.spark.sql.delta.sources.IndexedFile> dsv1Files, List<IndexedFile> dsv2Files) {
-    SparkMicroBatchStreamTest.compareFileChanges(dsv1Files, dsv2Files);
+    DeltaV2MicroBatchStreamTest.compareFileChanges(dsv1Files, dsv2Files);
 
     // CDC metadata (only on DSv2 data files, not sentinels)
     for (int i = 0; i < dsv2Files.size(); i++) {

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2MicroBatchStreamTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2MicroBatchStreamTest.java
@@ -75,13 +75,13 @@ import scala.collection.JavaConverters;
 import scala.collection.immutable.Map$;
 import scala.collection.immutable.Seq;
 
-public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
+public class DeltaV2MicroBatchStreamTest extends DeltaV2TestBase {
 
   /**
-   * Helper method to create a minimal SparkMicroBatchStream instance for tests that only check for
+   * Helper method to create a minimal DeltaV2MicroBatchStream instance for tests that only check for
    * UnsupportedOperationException.
    */
-  private SparkMicroBatchStream createTestStream(File tempDir) {
+  private DeltaV2MicroBatchStream createTestStream(File tempDir) {
     String tablePath = tempDir.getAbsolutePath();
     String tableName = "test_unsupported_" + System.nanoTime();
     createEmptyTestTable(tablePath, tableName);
@@ -96,7 +96,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
 
   @Test
   public void testLatestOffset_throwsUnsupportedOperationException(@TempDir File tempDir) {
-    SparkMicroBatchStream microBatchStream = createTestStream(tempDir);
+    DeltaV2MicroBatchStream microBatchStream = createTestStream(tempDir);
     IllegalStateException exception =
         assertThrows(IllegalStateException.class, () -> microBatchStream.latestOffset());
   }
@@ -118,7 +118,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
     Configuration hadoopConf = new Configuration();
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(testTablePath, hadoopConf);
-    SparkMicroBatchStream stream =
+    DeltaV2MicroBatchStream stream =
         createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
 
     // Get the latest version
@@ -145,7 +145,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
   @Test
   public void testDeserializeOffset_ValidJson(@TempDir File tempDir) throws Exception {
     String tablePath = tempDir.getAbsolutePath();
-    SparkMicroBatchStream stream = createTestStream(tempDir);
+    DeltaV2MicroBatchStream stream = createTestStream(tempDir);
 
     DeltaLog deltaLog = DeltaLog.forTable(spark, new Path(tablePath));
     String tableId = deltaLog.tableId();
@@ -163,7 +163,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
 
   @Test
   public void testDeserializeOffset_MismatchedTableId(@TempDir File tempDir) throws Exception {
-    SparkMicroBatchStream stream = createTestStream(tempDir);
+    DeltaV2MicroBatchStream stream = createTestStream(tempDir);
 
     // Create offset with wrong tableId
     String wrongTableId = "wrong-table-id";
@@ -185,7 +185,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
 
   @Test
   public void testDeserializeOffset_InvalidJson(@TempDir File tempDir) {
-    SparkMicroBatchStream stream = createTestStream(tempDir);
+    DeltaV2MicroBatchStream stream = createTestStream(tempDir);
     String invalidJson = "{this is not valid json}";
     assertThrows(RuntimeException.class, () -> stream.deserializeOffset(invalidJson));
   }
@@ -193,7 +193,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
   @Test
   public void testDeserializeOffset_WithInitialSnapshot(@TempDir File tempDir) throws Exception {
     String tablePath = tempDir.getAbsolutePath();
-    SparkMicroBatchStream stream = createTestStream(tempDir);
+    DeltaV2MicroBatchStream stream = createTestStream(tempDir);
 
     DeltaLog deltaLog = DeltaLog.forTable(spark, new Path(tablePath));
     String tableId = deltaLog.tableId();
@@ -214,7 +214,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
   @Test
   public void testCommit_NoOp(@TempDir File tempDir) throws Exception {
     String tablePath = tempDir.getAbsolutePath();
-    SparkMicroBatchStream stream = createTestStream(tempDir);
+    DeltaV2MicroBatchStream stream = createTestStream(tempDir);
 
     DeltaLog deltaLog = DeltaLog.forTable(spark, new Path(tablePath));
     String tableId = deltaLog.tableId();
@@ -225,7 +225,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
 
   @Test
   public void testStop_NoOp(@TempDir File tempDir) {
-    SparkMicroBatchStream stream = createTestStream(tempDir);
+    DeltaV2MicroBatchStream stream = createTestStream(tempDir);
     assertDoesNotThrow(() -> stream.stop());
   }
 
@@ -271,7 +271,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
     Configuration hadoopConf = new Configuration();
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(testTablePath, hadoopConf);
-    SparkMicroBatchStream stream =
+    DeltaV2MicroBatchStream stream =
         createTestStreamWithDefaults(snapshotManager, hadoopConf, options);
     Offset initialOffset = stream.initialOffset();
     Offset dsv2Offset = stream.latestOffset(initialOffset, readLimit);
@@ -305,7 +305,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
 
   /**
    * Parameterized test that verifies parity between DSv1 DeltaSource.getFileChanges and DSv2
-   * SparkMicroBatchStream.getFileChanges using Delta Kernel APIs.
+   * DeltaV2MicroBatchStream.getFileChanges using Delta Kernel APIs.
    *
    * <p>Tests both regular delta log streaming and initial snapshot scenarios.
    *
@@ -363,11 +363,11 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
     }
     deltaChanges.close();
 
-    // dsv2 SparkMicroBatchStream
+    // dsv2 DeltaV2MicroBatchStream
     Configuration hadoopConf = new Configuration();
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(testTablePath, hadoopConf);
-    SparkMicroBatchStream stream =
+    DeltaV2MicroBatchStream stream =
         createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
     Optional<DeltaSourceOffset> endOffsetOption = ScalaUtils.toJavaOptional(scalaEndOffset);
     try (CloseableIterator<IndexedFile> kernelChanges =
@@ -495,7 +495,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
 
   /**
    * Test that verifies parity between DSv1 DeltaSource.getFileChangesWithRateLimit and DSv2
-   * SparkMicroBatchStream.getFileChangesWithRateLimit.
+   * DeltaV2MicroBatchStream.getFileChangesWithRateLimit.
    *
    * <p>Tests both regular delta log streaming and initial snapshot scenarios with rate limiting.
    */
@@ -541,11 +541,11 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
     }
     deltaChanges.close();
 
-    // dsv2 SparkMicroBatchStream
+    // dsv2 DeltaV2MicroBatchStream
     Configuration hadoopConf = new Configuration();
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(testTablePath, hadoopConf);
-    SparkMicroBatchStream stream =
+    DeltaV2MicroBatchStream stream =
         createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
     // We need a separate AdmissionLimits object for DSv2 because the method is stateful.
     Optional<DeltaSource.AdmissionLimits> dsv2Limits =
@@ -724,11 +724,11 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
     }
     deltaChanges.close();
 
-    // Test DSv2 SparkMicroBatchStream
+    // Test DSv2 DeltaV2MicroBatchStream
     Configuration hadoopConf = new Configuration();
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(testTablePath, hadoopConf);
-    SparkMicroBatchStream stream =
+    DeltaV2MicroBatchStream stream =
         createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
     try (CloseableIterator<IndexedFile> kernelChanges =
         stream.getFileChanges(
@@ -784,7 +784,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
     Configuration hadoopConf = new Configuration();
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(testTablePath, hadoopConf);
-    SparkMicroBatchStream stream =
+    DeltaV2MicroBatchStream stream =
         createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
 
     // Get file changes from version 0 (which will include versions 1-4)
@@ -893,11 +893,11 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
             },
             String.format("DSv1 should throw on REMOVE for scenario: %s", testDescription));
 
-    // Test DSv2 SparkMicroBatchStream
+    // Test DSv2 DeltaV2MicroBatchStream
     Configuration hadoopConf = new Configuration();
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(testTablePath, hadoopConf);
-    SparkMicroBatchStream stream =
+    DeltaV2MicroBatchStream stream =
         createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
 
     AtomicInteger dsv2SuccessfulCalls = new AtomicInteger(0);
@@ -1081,7 +1081,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
     Configuration hadoopConf = new Configuration();
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(testTablePath, hadoopConf);
-    SparkMicroBatchStream stream =
+    DeltaV2MicroBatchStream stream =
         createTestStreamWithDefaults(snapshotManager, hadoopConf, options);
     try (CloseableIterator<IndexedFile> kernelChanges =
         stream.getFileChanges(fromVersion, fromIndex, isInitialSnapshot, Optional.empty())) {
@@ -1148,7 +1148,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
     Configuration hadoopConf = new Configuration();
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(testTablePath, hadoopConf);
-    SparkMicroBatchStream stream =
+    DeltaV2MicroBatchStream stream =
         createTestStreamWithDefaults(snapshotManager, hadoopConf, options);
 
     AtomicInteger dsv2SuccessfulCalls = new AtomicInteger(0);
@@ -1496,7 +1496,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
     Configuration hadoopConf = spark.sessionState().newHadoopConf();
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(testTablePath, hadoopConf);
-    SparkMicroBatchStream stream =
+    DeltaV2MicroBatchStream stream =
         createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
 
     // Get file changes from version 1 onwards
@@ -1529,7 +1529,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
 
   /**
    * Parameterized test that verifies parity between DSv1 DeltaSource.latestOffset and DSv2
-   * SparkMicroBatchStream.latestOffset.
+   * DeltaV2MicroBatchStream.latestOffset.
    */
   @ParameterizedTest
   @MethodSource("latestOffsetParameters")
@@ -1564,7 +1564,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
     Configuration hadoopConf = new Configuration();
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(testTablePath, hadoopConf);
-    SparkMicroBatchStream stream =
+    DeltaV2MicroBatchStream stream =
         createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
     Offset v2EndOffset = stream.latestOffset(startOffset, readLimit);
 
@@ -1683,7 +1683,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
     Configuration hadoopConf = new Configuration();
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(testTablePath, hadoopConf);
-    SparkMicroBatchStream stream =
+    DeltaV2MicroBatchStream stream =
         createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
     List<Offset> dsv2Offsets =
         advanceOffsetSequenceDsv2(stream, startOffset, numIterations, readLimit);
@@ -1809,7 +1809,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
     Configuration hadoopConf = new Configuration();
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(testTablePath, hadoopConf);
-    SparkMicroBatchStream stream =
+    DeltaV2MicroBatchStream stream =
         createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
     Offset dsv2Offset = stream.latestOffset(startOffset, readLimit);
 
@@ -1900,7 +1900,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
     Configuration hadoopConf = new Configuration();
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(testTablePath, hadoopConf);
-    SparkMicroBatchStream stream =
+    DeltaV2MicroBatchStream stream =
         createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
     // Enable availableNow
     stream.prepareForTriggerAvailableNow();
@@ -2048,8 +2048,8 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
     StructType dataSchema = deltaSnapshot.metadata().schema();
     StructType partitionSchema = deltaSnapshot.metadata().partitionSchema();
 
-    SparkMicroBatchStream stream =
-        new SparkMicroBatchStream(
+    DeltaV2MicroBatchStream stream =
+        new DeltaV2MicroBatchStream(
             snapshotManager,
             snapshotManager.loadLatestSnapshot(),
             spark.sessionState().newHadoopConf(),
@@ -2236,8 +2236,8 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
                 .filter(f -> !partitionColNames.contains(f.name()))
                 .toArray(StructField[]::new));
 
-    SparkMicroBatchStream stream =
-        new SparkMicroBatchStream(
+    DeltaV2MicroBatchStream stream =
+        new DeltaV2MicroBatchStream(
             snapshotManager,
             snapshotManager.loadLatestSnapshot(),
             spark.sessionState().newHadoopConf(),
@@ -2456,7 +2456,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
 
   /**
    * Parameterized test that verifies parity between DSv1 DeltaSource.getStartingVersion and DSv2
-   * SparkMicroBatchStream.getStartingVersion.
+   * DeltaV2MicroBatchStream.getStartingVersion.
    */
   @ParameterizedTest
   @MethodSource("getStartingVersionParameters")
@@ -2516,7 +2516,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
     // dsv2
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(testTablePath, new Configuration());
-    SparkMicroBatchStream dsv2Stream =
+    DeltaV2MicroBatchStream dsv2Stream =
         createTestStreamWithDefaults(snapshotManager, new Configuration(), emptyDeltaOptions());
     Optional<Long> dsv2Result = dsv2Stream.getStartingVersion();
 
@@ -2646,7 +2646,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
     // dsv2
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(testTablePath, new Configuration());
-    SparkMicroBatchStream dsv2Stream =
+    DeltaV2MicroBatchStream dsv2Stream =
         createTestStreamWithDefaults(
             snapshotManager,
             new Configuration(),
@@ -2662,7 +2662,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
 
   /**
    * Test that verifies parity between DSv1 DeltaSource.getStartingVersion and DSv2
-   * SparkMicroBatchStream.getStartingVersion when using startingTimestamp option.
+   * DeltaV2MicroBatchStream.getStartingVersion when using startingTimestamp option.
    *
    * <p>Uses ICT (In-Commit Timestamps) so we can read exact commit timestamps from the delta log
    * and test the boundary case where startingTimestamp exactly equals a commit time.
@@ -2737,7 +2737,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
       // dsv2
       PathBasedSnapshotManager snapshotManager =
           new PathBasedSnapshotManager(testTablePath, new Configuration());
-      SparkMicroBatchStream dsv2Stream =
+      DeltaV2MicroBatchStream dsv2Stream =
           createTestStreamWithDefaults(
               snapshotManager,
               new Configuration(),
@@ -2761,7 +2761,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
     // dsv2
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(testTablePath, new Configuration());
-    SparkMicroBatchStream dsv2Stream =
+    DeltaV2MicroBatchStream dsv2Stream =
         createTestStreamWithDefaults(
             snapshotManager,
             new Configuration(),
@@ -2823,11 +2823,11 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
       DeltaLog deltaLog = DeltaLog.forTable(spark, new Path(testTablePath));
       DeltaSource deltaSource = createDeltaSource(deltaLog, testTablePath);
 
-      // Create DSv2 SparkMicroBatchStream
+      // Create DSv2 DeltaV2MicroBatchStream
       Configuration hadoopConf = new Configuration();
       PathBasedSnapshotManager snapshotManager =
           new PathBasedSnapshotManager(testTablePath, hadoopConf);
-      SparkMicroBatchStream stream =
+      DeltaV2MicroBatchStream stream =
           createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
 
       // Execute schema change after source initialization to ensure forward change
@@ -2944,11 +2944,11 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
       }
       deltaChanges.close();
 
-      // Test DSv2 SparkMicroBatchStream
+      // Test DSv2 DeltaV2MicroBatchStream
       Configuration hadoopConf = new Configuration();
       PathBasedSnapshotManager snapshotManager =
           new PathBasedSnapshotManager(testTablePath, hadoopConf);
-      SparkMicroBatchStream stream =
+      DeltaV2MicroBatchStream stream =
           createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
       try (CloseableIterator<IndexedFile> kernelChanges =
           stream.getFileChanges(
@@ -3000,11 +3000,11 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
       DeltaLog deltaLog = DeltaLog.forTable(spark, new Path(testTablePath));
       DeltaSource deltaSource = createDeltaSource(deltaLog, testTablePath);
 
-      // Create DSv2 SparkMicroBatchStream
+      // Create DSv2 DeltaV2MicroBatchStream
       Configuration hadoopConf = new Configuration();
       PathBasedSnapshotManager snapshotManager =
           new PathBasedSnapshotManager(testTablePath, hadoopConf);
-      SparkMicroBatchStream stream =
+      DeltaV2MicroBatchStream stream =
           createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
 
       // Execute schema change after source initialization to ensure forward change
@@ -3109,11 +3109,11 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
       DeltaLog deltaLog = DeltaLog.forTable(spark, new Path(testTablePath));
       DeltaSource deltaSource = createDeltaSource(deltaLog, testTablePath);
 
-      // Create DSv2 SparkMicroBatchStream
+      // Create DSv2 DeltaV2MicroBatchStream
       Configuration hadoopConf = new Configuration();
       PathBasedSnapshotManager snapshotManager =
           new PathBasedSnapshotManager(testTablePath, hadoopConf);
-      SparkMicroBatchStream stream =
+      DeltaV2MicroBatchStream stream =
           createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
 
       DeltaUnsupportedOperationException dsv1Exception =
@@ -3241,11 +3241,11 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
             element ->
                 element.toString().contains("checkReadIncompatibleSchemaChangeOnStreamStartOnce"));
 
-    // Test DSv2 SparkMicroBatchStream
+    // Test DSv2 DeltaV2MicroBatchStream
     Configuration hadoopConf = new Configuration();
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(testTablePath, hadoopConf);
-    SparkMicroBatchStream stream =
+    DeltaV2MicroBatchStream stream =
         createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
     DeltaUnsupportedOperationException dsv2Exception =
         assertThrows(
@@ -3320,7 +3320,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
 
       // Stream constructed BEFORE the schema change — pre-change snapshot is still the latest.
       StructType preChangeSchema = loadSparkSchemaAtVersion(snapshotManager, startVersion);
-      SparkMicroBatchStream streamPreChange =
+      DeltaV2MicroBatchStream streamPreChange =
           createSchemaTrackingTestStream(
               snapshotManager,
               hadoopConf,
@@ -3365,7 +3365,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
       StructType postChangeSchema =
           io.delta.spark.internal.v2.utils.SchemaUtils.convertKernelSchemaToSparkSchema(
               snapshotManager.loadLatestSnapshot().getSchema());
-      SparkMicroBatchStream streamPostChange =
+      DeltaV2MicroBatchStream streamPostChange =
           createSchemaTrackingTestStream(
               snapshotManager,
               hadoopConf,
@@ -3464,7 +3464,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
 
       // Round 1: post-change schema (analysis would bind to the latest snapshot since the log
       // is empty). First latestOffset runs eager-init and throws.
-      SparkMicroBatchStream streamForEagerInit =
+      DeltaV2MicroBatchStream streamForEagerInit =
           createSchemaTrackingTestStream(
               snapshotManager,
               hadoopConf,
@@ -3485,7 +3485,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
       assertEquals(startVersion, afterInit.deltaCommitVersion());
 
       // Round 2: pre-change schema (the log entry now carries it).
-      SparkMicroBatchStream streamForBarrier =
+      DeltaV2MicroBatchStream streamForBarrier =
           createSchemaTrackingTestStream(
               snapshotManager,
               hadoopConf,
@@ -3519,7 +3519,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
       assertPostChangeSchema.accept(evolved.dataSchema());
 
       // Round 3: post-change schema. Advance barrier → POST_BARRIER, commit succeeds.
-      SparkMicroBatchStream streamForPostBarrier =
+      DeltaV2MicroBatchStream streamForPostBarrier =
           createSchemaTrackingTestStream(
               snapshotManager,
               hadoopConf,
@@ -3583,7 +3583,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
 
     // Populate the tracking log via eager init on a default-options stream so that
     // shouldTrackMetadataChange() returns true on the next stream.
-    SparkMicroBatchStream streamForInit =
+    DeltaV2MicroBatchStream streamForInit =
         createSchemaTrackingTestStream(
             snapshotManager,
             hadoopConf,
@@ -3600,7 +3600,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
     // With the log populated, a stream configured with failOnDataLoss=false must reject the first
     // change-log scan.
     DeltaOptions failOnDataLossFalse = createDeltaOptions("failOnDataLoss", "false");
-    SparkMicroBatchStream stream =
+    DeltaV2MicroBatchStream stream =
         createSchemaTrackingTestStream(
             snapshotManager,
             hadoopConf,
@@ -3943,7 +3943,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
     Configuration hadoopConf = new Configuration();
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(testTablePath, hadoopConf);
-    SparkMicroBatchStream stream =
+    DeltaV2MicroBatchStream stream =
         createTestStreamWithDefaults(snapshotManager, hadoopConf, options);
     try (CloseableIterator<IndexedFile> dsv2Changes =
         stream.getFileChanges(
@@ -4006,7 +4006,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
     Configuration hadoopConf = new Configuration();
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(testTablePath, hadoopConf);
-    SparkMicroBatchStream stream =
+    DeltaV2MicroBatchStream stream =
         createTestStreamWithDefaults(snapshotManager, hadoopConf, defaultOptions);
     io.delta.kernel.exceptions.StartVersionNotFoundException dsv2Exception =
         assertThrows(
@@ -4053,7 +4053,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(testTablePath, hadoopConf);
     DeltaOptions options = createDeltaOptions("failOnDataLoss", "false");
-    SparkMicroBatchStream stream =
+    DeltaV2MicroBatchStream stream =
         createTestStreamWithDefaults(snapshotManager, hadoopConf, options);
 
     // Reading from version 1 (which exists) should throw InvalidTableException because
@@ -4240,7 +4240,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
   }
 
   private List<Offset> advanceOffsetSequenceDsv2(
-      SparkMicroBatchStream stream, Offset startOffset, int numIterations, ReadLimit limit) {
+      DeltaV2MicroBatchStream stream, Offset startOffset, int numIterations, ReadLimit limit) {
     List<Offset> offsets = new ArrayList<>();
     offsets.add(startOffset);
 
@@ -4289,15 +4289,15 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
         /* filters= */ emptySeq);
   }
 
-  /** Helper method to create a SparkMicroBatchStream with default values for testing. */
-  private SparkMicroBatchStream createTestStreamWithDefaults(
+  /** Helper method to create a DeltaV2MicroBatchStream with default values for testing. */
+  private DeltaV2MicroBatchStream createTestStreamWithDefaults(
       PathBasedSnapshotManager snapshotManager, Configuration hadoopConf, DeltaOptions options) {
     io.delta.kernel.Snapshot snapshot = snapshotManager.loadLatestSnapshot();
     String tablePath = ((io.delta.kernel.internal.SnapshotImpl) snapshot).getPath();
     StructType tableSchema =
         io.delta.spark.internal.v2.utils.SchemaUtils.convertKernelSchemaToSparkSchema(
             snapshot.getSchema());
-    return new SparkMicroBatchStream(
+    return new DeltaV2MicroBatchStream(
         snapshotManager,
         snapshot,
         hadoopConf,
@@ -4314,7 +4314,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
         /* metadataPath= */ tablePath + "/_checkpoint");
   }
 
-  private SparkMicroBatchStream createSchemaTrackingTestStream(
+  private DeltaV2MicroBatchStream createSchemaTrackingTestStream(
       PathBasedSnapshotManager snapshotManager,
       Configuration hadoopConf,
       DeltaOptions options,
@@ -4323,7 +4323,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
       Option<DeltaSourceMetadataTrackingLog> metadataTrackingLog,
       String metadataPath) {
     io.delta.kernel.Snapshot snapshot = snapshotManager.loadLatestSnapshot();
-    return new SparkMicroBatchStream(
+    return new DeltaV2MicroBatchStream(
         snapshotManager,
         snapshot,
         hadoopConf,
@@ -4370,7 +4370,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
   }
 
   private List<Integer> readIdsBetweenOffsets(
-      SparkMicroBatchStream stream, Offset startOffset, Offset endOffset) throws Exception {
+      DeltaV2MicroBatchStream stream, Offset startOffset, Offset endOffset) throws Exception {
     InputPartition[] partitions = stream.planInputPartitions(startOffset, endOffset);
     PartitionReaderFactory readerFactory = stream.createReaderFactory();
     List<Integer> ids = new ArrayList<>();
@@ -4409,7 +4409,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
    * reader is closed.
    */
   private List<InternalRow> readRowsBetweenOffsets(
-      SparkMicroBatchStream stream, Offset startOffset, Offset endOffset) throws Exception {
+      DeltaV2MicroBatchStream stream, Offset startOffset, Offset endOffset) throws Exception {
     InputPartition[] partitions = stream.planInputPartitions(startOffset, endOffset);
     PartitionReaderFactory readerFactory = stream.createReaderFactory();
     List<InternalRow> rows = new ArrayList<>();
@@ -4447,7 +4447,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
    * scenarios that drop or rename the leading column.
    */
   private long countRowsBetweenOffsets(
-      SparkMicroBatchStream stream, Offset startOffset, Offset endOffset) throws Exception {
+      DeltaV2MicroBatchStream stream, Offset startOffset, Offset endOffset) throws Exception {
     InputPartition[] partitions = stream.planInputPartitions(startOffset, endOffset);
     PartitionReaderFactory readerFactory = stream.createReaderFactory();
     long count = 0L;
@@ -4521,10 +4521,10 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
             deltaLog, testTablePath, createDeltaOptions("startingVersion", startingVersion));
     scala.Option<Object> dsv1Result = deltaSource.getStartingVersion();
 
-    // DSv2: Create SparkMicroBatchStream and get starting version
+    // DSv2: Create DeltaV2MicroBatchStream and get starting version
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(testTablePath, new Configuration());
-    SparkMicroBatchStream dsv2Stream =
+    DeltaV2MicroBatchStream dsv2Stream =
         createTestStreamWithDefaults(
             snapshotManager,
             new Configuration(),
@@ -4579,7 +4579,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
       Configuration hadoopConf = new Configuration();
       PathBasedSnapshotManager snapshotManager =
           new PathBasedSnapshotManager(testTablePath, hadoopConf);
-      SparkMicroBatchStream stream =
+      DeltaV2MicroBatchStream stream =
           createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
 
       long version = 5L;
@@ -4620,18 +4620,18 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
     // KernelEngineException wrapping ClosedByInterruptException -> present
     ClosedByInterruptException cbie = new ClosedByInterruptException();
     assertThat(
-            SparkMicroBatchStream.findClosedByInterruptCause(
+            DeltaV2MicroBatchStream.findClosedByInterruptCause(
                 new io.delta.kernel.exceptions.KernelEngineException("readJsonFile", cbie)))
         .isPresent()
         .contains(cbie);
 
     // Plain RuntimeException -> empty
-    assertThat(SparkMicroBatchStream.findClosedByInterruptCause(new RuntimeException("unrelated")))
+    assertThat(DeltaV2MicroBatchStream.findClosedByInterruptCause(new RuntimeException("unrelated")))
         .isEmpty();
 
     // KernelEngineException wrapping a different IOException -> empty
     assertThat(
-            SparkMicroBatchStream.findClosedByInterruptCause(
+            DeltaV2MicroBatchStream.findClosedByInterruptCause(
                 new io.delta.kernel.exceptions.KernelEngineException(
                     "readJsonFile", new java.io.FileNotFoundException("missing"))))
         .isEmpty();
@@ -4665,7 +4665,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
         };
 
     try (CloseableIterator<IndexedFile> wrapped =
-        SparkMicroBatchStream.wrapIteratorWithCommitClose(
+        DeltaV2MicroBatchStream.wrapIteratorWithCommitClose(
             inner, newTrackingCommitActions(commitClosed))) {
       while (wrapped.hasNext()) {
         wrapped.next();
@@ -4701,7 +4701,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
         };
 
     try (CloseableIterator<IndexedFile> wrapped =
-        SparkMicroBatchStream.wrapIteratorWithCommitClose(
+        DeltaV2MicroBatchStream.wrapIteratorWithCommitClose(
             inner, newTrackingCommitActions(commitClosed))) {
       assertTrue(wrapped.hasNext());
       wrapped.next();
@@ -4736,7 +4736,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
         };
 
     CloseableIterator<IndexedFile> wrapped =
-        SparkMicroBatchStream.wrapIteratorWithCommitClose(
+        DeltaV2MicroBatchStream.wrapIteratorWithCommitClose(
             inner, newTrackingCommitActions(commitClosed));
     try {
       wrapped.close();
@@ -4791,7 +4791,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
 
     assertDoesNotThrow(
         () ->
-            SparkMicroBatchStream.validateSchemaCompatibilityOnStartup(
+            DeltaV2MicroBatchStream.validateSchemaCompatibilityOnStartup(
                 dataSchema, partitionSchema, snapshotSchema));
   }
 
@@ -4808,7 +4808,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
 
     assertDoesNotThrow(
         () ->
-            SparkMicroBatchStream.validateSchemaCompatibilityOnStartup(
+            DeltaV2MicroBatchStream.validateSchemaCompatibilityOnStartup(
                 dataSchema, partitionSchema, snapshotSchema));
   }
 
@@ -4830,7 +4830,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
         assertThrows(
             DeltaIllegalStateException.class,
             () ->
-                SparkMicroBatchStream.validateSchemaCompatibilityOnStartup(
+                DeltaV2MicroBatchStream.validateSchemaCompatibilityOnStartup(
                     dataSchema, partitionSchema, snapshotSchema));
     assertTrue(ex.getMessage().contains("DELTA_STREAMING_SCHEMA_MISMATCH_ON_RESTART"));
   }
@@ -4851,7 +4851,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
         assertThrows(
             DeltaIllegalStateException.class,
             () ->
-                SparkMicroBatchStream.validateSchemaCompatibilityOnStartup(
+                DeltaV2MicroBatchStream.validateSchemaCompatibilityOnStartup(
                     dataSchema, partitionSchema, snapshotSchema));
     assertTrue(ex.getMessage().contains("DELTA_STREAMING_SCHEMA_MISMATCH_ON_RESTART"));
   }
@@ -4871,7 +4871,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
         assertThrows(
             DeltaIllegalStateException.class,
             () ->
-                SparkMicroBatchStream.validateSchemaCompatibilityOnStartup(
+                DeltaV2MicroBatchStream.validateSchemaCompatibilityOnStartup(
                     dataSchema, partitionSchema, snapshotSchema));
     assertTrue(ex.getMessage().contains("DELTA_STREAMING_SCHEMA_MISMATCH_ON_RESTART"));
   }
@@ -4885,7 +4885,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
 
     assertDoesNotThrow(
         () ->
-            SparkMicroBatchStream.validateSchemaCompatibilityOnStartup(
+            DeltaV2MicroBatchStream.validateSchemaCompatibilityOnStartup(
                 dataSchema, partitionSchema, snapshotSchema));
   }
 
@@ -4899,7 +4899,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
         assertThrows(
             DeltaIllegalStateException.class,
             () ->
-                SparkMicroBatchStream.validateSchemaCompatibilityOnStartup(
+                DeltaV2MicroBatchStream.validateSchemaCompatibilityOnStartup(
                     dataSchema, partitionSchema, snapshotSchema));
     assertTrue(ex.getMessage().contains("DELTA_STREAMING_SCHEMA_MISMATCH_ON_RESTART"));
   }
@@ -4912,7 +4912,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
 
     assertDoesNotThrow(
         () ->
-            SparkMicroBatchStream.validateSchemaCompatibilityOnStartup(
+            DeltaV2MicroBatchStream.validateSchemaCompatibilityOnStartup(
                 dataSchema, partitionSchema, snapshotSchema));
   }
 
@@ -4938,7 +4938,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
       Configuration hadoopConf = spark.sessionState().newHadoopConf();
       PathBasedSnapshotManager snapshotManager =
           new PathBasedSnapshotManager(testTablePath, hadoopConf);
-      SparkMicroBatchStream stream =
+      DeltaV2MicroBatchStream stream =
           createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
 
       long version = snapshotManager.loadLatestSnapshot().getVersion();
@@ -5000,7 +5000,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
       Configuration hadoopConf = spark.sessionState().newHadoopConf();
       PathBasedSnapshotManager snapshotManager =
           new PathBasedSnapshotManager(testTablePath, hadoopConf);
-      SparkMicroBatchStream stream =
+      DeltaV2MicroBatchStream stream =
           createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
 
       long version = snapshotManager.loadLatestSnapshot().getVersion();
@@ -5080,14 +5080,14 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
       Configuration hadoopConf = spark.sessionState().newHadoopConf();
       PathBasedSnapshotManager snapshotManager =
           new PathBasedSnapshotManager(testTablePath, hadoopConf);
-      SparkMicroBatchStream stream =
+      DeltaV2MicroBatchStream stream =
           createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
 
       long version = snapshotManager.loadLatestSnapshot().getVersion();
 
       // Access the internal AtomicReference via reflection
       java.lang.reflect.Field cacheField =
-          SparkMicroBatchStream.class.getDeclaredField("cachedDataFrameSnapshot");
+          DeltaV2MicroBatchStream.class.getDeclaredField("cachedDataFrameSnapshot");
       cacheField.setAccessible(true);
       @SuppressWarnings("unchecked")
       java.util.concurrent.atomic.AtomicReference<DataFrameSnapshotCache> cacheRef =
@@ -5133,7 +5133,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
       Configuration hadoopConf = spark.sessionState().newHadoopConf();
       PathBasedSnapshotManager snapshotManager =
           new PathBasedSnapshotManager(testTablePath, hadoopConf);
-      SparkMicroBatchStream stream =
+      DeltaV2MicroBatchStream stream =
           createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
 
       long version = snapshotManager.loadLatestSnapshot().getVersion();

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2ScanBuilderTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2ScanBuilderTest.java
@@ -42,7 +42,7 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-public class SparkScanBuilderTest extends DeltaV2TestBase {
+public class DeltaV2ScanBuilderTest extends DeltaV2TestBase {
 
   @Test
   public void testBuild_returnsScanWithExpectedSchema(@TempDir File tempDir) {
@@ -71,8 +71,8 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
               DataTypes.createStructField("name", DataTypes.StringType, true),
               DataTypes.createStructField("dep_id", DataTypes.IntegerType, true)
             });
-    SparkScanBuilder builder =
-        new SparkScanBuilder(
+    DeltaV2ScanBuilder builder =
+        new DeltaV2ScanBuilder(
             tableName,
             snapshot,
             snapshotManager,
@@ -92,7 +92,7 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
     builder.pruneColumns(expectedSparkSchema);
     Scan scan = builder.build();
 
-    assertTrue(scan instanceof SparkScan);
+    assertTrue(scan instanceof DeltaV2Scan);
     assertEquals(expectedSparkSchema, scan.readSchema());
   }
 
@@ -123,8 +123,8 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
               DataTypes.createStructField("name", DataTypes.StringType, true),
               DataTypes.createStructField("dep_id", DataTypes.IntegerType, true)
             });
-    SparkScanBuilder builder =
-        new SparkScanBuilder(
+    DeltaV2ScanBuilder builder =
+        new DeltaV2ScanBuilder(
             tableName,
             snapshot,
             snapshotManager,
@@ -150,8 +150,8 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
     }
   }
 
-  private StructType getRequiredDataSchema(SparkScanBuilder builder) throws Exception {
-    Field field = SparkScanBuilder.class.getDeclaredField("requiredDataSchema");
+  private StructType getRequiredDataSchema(DeltaV2ScanBuilder builder) throws Exception {
+    Field field = DeltaV2ScanBuilder.class.getDeclaredField("requiredDataSchema");
     field.setAccessible(true);
     return (StructType) field.get(builder);
   }
@@ -183,8 +183,8 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
               DataTypes.createStructField("name", DataTypes.StringType, true),
               DataTypes.createStructField("dep_id", DataTypes.IntegerType, true)
             });
-    SparkScanBuilder builder =
-        new SparkScanBuilder(
+    DeltaV2ScanBuilder builder =
+        new DeltaV2ScanBuilder(
             tableName,
             snapshot,
             snapshotManager,
@@ -200,13 +200,13 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
 
     assertNotNull(microBatchStream, "MicroBatchStream should not be null");
     assertTrue(
-        microBatchStream instanceof SparkMicroBatchStream,
-        "MicroBatchStream should be an instance of SparkMicroBatchStream");
+        microBatchStream instanceof DeltaV2MicroBatchStream,
+        "MicroBatchStream should be an instance of DeltaV2MicroBatchStream");
   }
 
   @Test
   public void testPushFilters_singleSupportedDataFilter(@TempDir File tempDir) throws Exception {
-    SparkScanBuilder builder = createTestScanBuilder(tempDir);
+    DeltaV2ScanBuilder builder = createTestScanBuilder(tempDir);
 
     checkSupportsPushDownFilters(
         builder,
@@ -226,7 +226,7 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
 
   @Test
   public void testPushFilters_singleUnsupportedDataFilter(@TempDir File tempDir) throws Exception {
-    SparkScanBuilder builder = createTestScanBuilder(tempDir);
+    DeltaV2ScanBuilder builder = createTestScanBuilder(tempDir);
 
     checkSupportsPushDownFilters(
         builder,
@@ -244,7 +244,7 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
   @Test
   public void testPushFilters_singleSupportedDataFilter_StringStartsWith(@TempDir File tempDir)
       throws Exception {
-    SparkScanBuilder builder = createTestScanBuilder(tempDir);
+    DeltaV2ScanBuilder builder = createTestScanBuilder(tempDir);
 
     checkSupportsPushDownFilters(
         builder,
@@ -267,7 +267,7 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
 
   @Test
   public void testPushFilters_multiSupportedDataFilters(@TempDir File tempDir) throws Exception {
-    SparkScanBuilder builder = createTestScanBuilder(tempDir);
+    DeltaV2ScanBuilder builder = createTestScanBuilder(tempDir);
 
     checkSupportsPushDownFilters(
         builder,
@@ -296,7 +296,7 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
   @Test
   public void testPushFilters_mixedSupportedAndUnsupportedDataFilters(@TempDir File tempDir)
       throws Exception {
-    SparkScanBuilder builder = createTestScanBuilder(tempDir);
+    DeltaV2ScanBuilder builder = createTestScanBuilder(tempDir);
 
     checkSupportsPushDownFilters(
         builder,
@@ -320,7 +320,7 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
   @Test
   public void testPushFilters_singleSupportedPartitionFilter(@TempDir File tempDir)
       throws Exception {
-    SparkScanBuilder builder = createTestScanBuilder(tempDir);
+    DeltaV2ScanBuilder builder = createTestScanBuilder(tempDir);
 
     checkSupportsPushDownFilters(
         builder,
@@ -341,7 +341,7 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
   @Test
   public void testPushFilters_singleUnsupportedPartitionFilter(@TempDir File tempDir)
       throws Exception {
-    SparkScanBuilder builder = createTestScanBuilder(tempDir);
+    DeltaV2ScanBuilder builder = createTestScanBuilder(tempDir);
 
     checkSupportsPushDownFilters(
         builder,
@@ -363,7 +363,7 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
   @Test
   public void testPushFilters_multiSupportedPartitionFilters(@TempDir File tempDir)
       throws Exception {
-    SparkScanBuilder builder = createTestScanBuilder(tempDir);
+    DeltaV2ScanBuilder builder = createTestScanBuilder(tempDir);
 
     checkSupportsPushDownFilters(
         builder,
@@ -392,7 +392,7 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
   @Test
   public void testPushFilters_mixedSupportedAndUnsupportedPartitionFilters(@TempDir File tempDir)
       throws Exception {
-    SparkScanBuilder builder = createTestScanBuilder(tempDir);
+    DeltaV2ScanBuilder builder = createTestScanBuilder(tempDir);
 
     checkSupportsPushDownFilters(
         builder,
@@ -422,7 +422,7 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
 
   @Test
   public void testPushFilters_mixedFilters(@TempDir File tempDir) throws Exception {
-    SparkScanBuilder builder = createTestScanBuilder(tempDir);
+    DeltaV2ScanBuilder builder = createTestScanBuilder(tempDir);
 
     checkSupportsPushDownFilters(
         builder,
@@ -469,7 +469,7 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
 
   @Test
   public void testPushFilters_ORFilters(@TempDir File tempDir) throws Exception {
-    SparkScanBuilder builder = createTestScanBuilder(tempDir);
+    DeltaV2ScanBuilder builder = createTestScanBuilder(tempDir);
 
     checkSupportsPushDownFilters(
         builder,
@@ -501,7 +501,7 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
   @Test
   public void testPushFilters_ORSupportedAndUnsupportedDataFilters(@TempDir File tempDir)
       throws Exception {
-    SparkScanBuilder builder = createTestScanBuilder(tempDir);
+    DeltaV2ScanBuilder builder = createTestScanBuilder(tempDir);
 
     // OR(supported, unsupported) cannot be partially pushed: if one branch is unsupported,
     // the whole OR must remain for post-scan evaluation and nothing is pushed to the kernel.
@@ -524,7 +524,7 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
   @Test
   public void testPushFilters_ORSupportedDataAndPartitionFilters(@TempDir File tempDir)
       throws Exception {
-    SparkScanBuilder builder = createTestScanBuilder(tempDir);
+    DeltaV2ScanBuilder builder = createTestScanBuilder(tempDir);
 
     checkSupportsPushDownFilters(
         builder,
@@ -568,7 +568,7 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
    */
   @Test
   public void testPushFilters_mixedORandAND(@TempDir File tempDir) throws Exception {
-    SparkScanBuilder builder = createTestScanBuilder(tempDir);
+    DeltaV2ScanBuilder builder = createTestScanBuilder(tempDir);
 
     checkSupportsPushDownFilters(
         builder,
@@ -617,7 +617,7 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
 
   @Test
   public void testPushFilters_NOTFilters(@TempDir File tempDir) throws Exception {
-    SparkScanBuilder builder = createTestScanBuilder(tempDir);
+    DeltaV2ScanBuilder builder = createTestScanBuilder(tempDir);
 
     checkSupportsPushDownFilters(
         builder,
@@ -641,7 +641,7 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
   @Test
   public void testPushFilters_NOTSupportedDataANDSupportedPartitionFilters(@TempDir File tempDir)
       throws Exception {
-    SparkScanBuilder builder = createTestScanBuilder(tempDir);
+    DeltaV2ScanBuilder builder = createTestScanBuilder(tempDir);
 
     checkSupportsPushDownFilters(
         builder,
@@ -685,7 +685,7 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
   @Test
   public void testPushFilters_NOTSupportedDataANDUnsupportedDataFilters(@TempDir File tempDir)
       throws Exception {
-    SparkScanBuilder builder = createTestScanBuilder(tempDir);
+    DeltaV2ScanBuilder builder = createTestScanBuilder(tempDir);
 
     checkSupportsPushDownFilters(
         builder,
@@ -706,7 +706,7 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
   @Test
   public void testPushFilters_NOTSupportedDataORSupportedPartitionFilters(@TempDir File tempDir)
       throws Exception {
-    SparkScanBuilder builder = createTestScanBuilder(tempDir);
+    DeltaV2ScanBuilder builder = createTestScanBuilder(tempDir);
 
     checkSupportsPushDownFilters(
         builder,
@@ -744,7 +744,7 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
   @Test
   public void testPushFilters_NOTSupportedDataORUnsupportedDataFilters(@TempDir File tempDir)
       throws Exception {
-    SparkScanBuilder builder = createTestScanBuilder(tempDir);
+    DeltaV2ScanBuilder builder = createTestScanBuilder(tempDir);
 
     // NOT(OR(supported, unsupported)): the OR branch contains an unsupported filter
     // (StringEndsWith),
@@ -768,7 +768,7 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
   }
 
   private void checkSupportsPushDownFilters(
-      SparkScanBuilder builder,
+      DeltaV2ScanBuilder builder,
       Filter[] inputFilters,
       Filter[] expectedPostScanFilters,
       Filter[] expectedPushedFilters,
@@ -800,7 +800,7 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
     assertEquals(expectedKernelScanBuilderPredicate, predicateOpt);
   }
 
-  private SparkScanBuilder createTestScanBuilder(File tempDir) {
+  private DeltaV2ScanBuilder createTestScanBuilder(File tempDir) {
     StructType dataSchema =
         DataTypes.createStructType(
             new StructField[] {
@@ -827,7 +827,7 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
    */
   @Test
   public void testPushFilters_decimalWideningEndToEnd(@TempDir File tempDir) throws Exception {
-    SparkScanBuilder builder = createDecimalTestScanBuilder(tempDir);
+    DeltaV2ScanBuilder builder = createDecimalTestScanBuilder(tempDir);
 
     // price = 100.00 where literal is Decimal(5,2) and column is Decimal(7,2)
     Filter[] sparkFilter = new Filter[] {new EqualTo("price", new BigDecimal("100.00"))};
@@ -852,7 +852,7 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
   @Test
   public void testPushFilters_decimalRejectionPartialPushDown(@TempDir File tempDir)
       throws Exception {
-    SparkScanBuilder builder = createDecimalTestScanBuilder(tempDir);
+    DeltaV2ScanBuilder builder = createDecimalTestScanBuilder(tempDir);
 
     // AND(price > 99.999, price < 200.00): left side has scale=3 exceeding column's scale=2
     Filter[] sparkFilter =
@@ -875,7 +875,7 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
         Optional.of(kernelPredicate)); // expected kernelScanBuilder.predicate
   }
 
-  private SparkScanBuilder createDecimalTestScanBuilder(File tempDir) {
+  private DeltaV2ScanBuilder createDecimalTestScanBuilder(File tempDir) {
     StructType dataSchema =
         DataTypes.createStructType(
             new StructField[] {
@@ -896,11 +896,11 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
   }
 
   /**
-   * Shared helper for creating a SparkScanBuilder with the given schemas. Both
+   * Shared helper for creating a DeltaV2ScanBuilder with the given schemas. Both
    * createTestScanBuilder and createDecimalTestScanBuilder delegate to this method to avoid
    * duplicating snapshot loading and builder instantiation logic.
    */
-  private SparkScanBuilder createScanBuilder(
+  private DeltaV2ScanBuilder createScanBuilder(
       File tempDir, StructType dataSchema, StructType partitionSchema, StructType tableSchema) {
     String path = tempDir.getAbsolutePath();
     String tableName = String.format("test_%d", System.currentTimeMillis());
@@ -922,7 +922,7 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(path, spark.sessionState().newHadoopConf());
     Snapshot snapshot = snapshotManager.loadLatestSnapshot();
-    return new SparkScanBuilder(
+    return new DeltaV2ScanBuilder(
         tableName,
         snapshot,
         snapshotManager,
@@ -933,24 +933,24 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
         CaseInsensitiveStringMap.empty());
   }
 
-  private Predicate[] getPushedKernelPredicates(SparkScanBuilder builder) throws Exception {
+  private Predicate[] getPushedKernelPredicates(DeltaV2ScanBuilder builder) throws Exception {
     // TODO: replace reflection with other testing manners, possibly Mockito ArgumentCaptor
-    Field field = SparkScanBuilder.class.getDeclaredField("pushedKernelPredicates");
+    Field field = DeltaV2ScanBuilder.class.getDeclaredField("pushedKernelPredicates");
     field.setAccessible(true);
     return (Predicate[]) field.get(builder);
   }
 
-  private Filter[] getDataFilters(SparkScanBuilder builder) throws Exception {
+  private Filter[] getDataFilters(DeltaV2ScanBuilder builder) throws Exception {
     // TODO: replace reflection with other testing manners, possibly Mockito ArgumentCaptor
-    Field field = SparkScanBuilder.class.getDeclaredField("dataFilters");
+    Field field = DeltaV2ScanBuilder.class.getDeclaredField("dataFilters");
     field.setAccessible(true);
     return (Filter[]) field.get(builder);
   }
 
-  private Optional<Predicate> getKernelScanBuilderPredicate(SparkScanBuilder builder)
+  private Optional<Predicate> getKernelScanBuilderPredicate(DeltaV2ScanBuilder builder)
       throws Exception {
     // TODO: replace reflection with other testing manners, possibly Mockito ArgumentCaptor
-    Field field = SparkScanBuilder.class.getDeclaredField("kernelScanBuilder");
+    Field field = DeltaV2ScanBuilder.class.getDeclaredField("kernelScanBuilder");
     field.setAccessible(true);
     Object kernelScanBuilder = field.get(builder);
 

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2ScanTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2ScanTest.java
@@ -37,7 +37,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-public class SparkScanTest extends DeltaV2TestBase {
+public class DeltaV2ScanTest extends DeltaV2TestBase {
 
   private static String tablePath;
   private static final String tableName = "deltatbl_partitioned";
@@ -109,8 +109,8 @@ public class SparkScanTest extends DeltaV2TestBase {
   @Test
   public void testColumnarSupportModeReturnsSupported() {
     // Table schema uses simple types (INT, STRING) which are batch-read-compatible
-    SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan = (SparkScan) builder.build();
+    DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
     assertEquals(
         Scan.ColumnarSupportMode.SUPPORTED,
@@ -122,14 +122,14 @@ public class SparkScanTest extends DeltaV2TestBase {
   public void testColumnarSupportModeDoesNotTriggerPlanning() throws Exception {
     // Calling columnarSupportMode() must NOT trigger file planning (the whole point of the
     // override is to avoid the early planInputPartitions() call that PARTITION_DEFINED causes).
-    SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan = (SparkScan) builder.build();
+    DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
     // Call columnarSupportMode before any planning
     scan.columnarSupportMode();
 
     // Verify the scan has not been planned yet
-    Field plannedField = SparkScan.class.getDeclaredField("planned");
+    Field plannedField = DeltaV2Scan.class.getDeclaredField("planned");
     plannedField.setAccessible(true);
     assertFalse(
         (boolean) plannedField.get(scan), "columnarSupportMode() should not trigger file planning");
@@ -160,8 +160,8 @@ public class SparkScanTest extends DeltaV2TestBase {
                         Identifier.of(new String[] {"spark_catalog", "default"}, mapTableName),
                         path,
                         options);
-                SparkScanBuilder builder = (SparkScanBuilder) mapTable.newScanBuilder(options);
-                SparkScan scan = (SparkScan) builder.build();
+                DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) mapTable.newScanBuilder(options);
+                DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
                 assertEquals(
                     Scan.ColumnarSupportMode.UNSUPPORTED,
@@ -180,8 +180,8 @@ public class SparkScanTest extends DeltaV2TestBase {
         "spark.sql.parquet.enableVectorizedReader",
         "false",
         () -> {
-          SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(options);
-          SparkScan scan = (SparkScan) builder.build();
+          DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+          DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
           assertEquals(
               Scan.ColumnarSupportMode.UNSUPPORTED,
@@ -192,7 +192,7 @@ public class SparkScanTest extends DeltaV2TestBase {
 
   @Test
   public void testColumnarSupportModeWithMetadataColumnPruned() {
-    SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(options);
+    DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) table.newScanBuilder(options);
     StructType prunedSchema =
         new StructType()
             .add("name", DataTypes.StringType)
@@ -202,7 +202,7 @@ public class SparkScanTest extends DeltaV2TestBase {
             .add("part", DataTypes.IntegerType);
     builder.pruneColumns(prunedSchema);
 
-    SparkScan scan = (SparkScan) builder.build();
+    DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
     assertEquals(
         Scan.ColumnarSupportMode.UNSUPPORTED,
@@ -234,8 +234,8 @@ public class SparkScanTest extends DeltaV2TestBase {
                   Identifier.of(new String[] {"spark_catalog", "default"}, dvTableName),
                   dvPath,
                   options);
-          SparkScanBuilder builder = (SparkScanBuilder) dvTable.newScanBuilder(options);
-          SparkScan scan = (SparkScan) builder.build();
+          DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) dvTable.newScanBuilder(options);
+          DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
           // DV-enabled table with simple types should still return SUPPORTED because the
           // DV column (ByteType) is batch-compatible
@@ -253,8 +253,8 @@ public class SparkScanTest extends DeltaV2TestBase {
 
   @Test
   public void testGetDataSchemaPartitionSchemaReadDataSchemaOptionsConfiguration() {
-    SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan = (SparkScan) builder.build();
+    DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
     // Table schema: (part INT, date STRING, city STRING, name STRING, cnt INT)
     // Partition columns: (date STRING, city STRING, part INT)
@@ -304,8 +304,8 @@ public class SparkScanTest extends DeltaV2TestBase {
 
   @Test
   public void testGetTablePathReturnsTablePath() {
-    SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan = (SparkScan) builder.build();
+    DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
     String retrievedPath = scan.getTablePath();
     assertNotNull(retrievedPath, "getTablePath should not return null");
@@ -326,8 +326,8 @@ public class SparkScanTest extends DeltaV2TestBase {
     optionsWithHadoop.put("dfs.replication", "2");
     CaseInsensitiveStringMap optionsWithHadoopMap = new CaseInsensitiveStringMap(optionsWithHadoop);
 
-    SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(optionsWithHadoopMap);
-    SparkScan scan = (SparkScan) builder.build();
+    DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) table.newScanBuilder(optionsWithHadoopMap);
+    DeltaV2Scan scan = (DeltaV2Scan) builder.build();
     Configuration configuration = scan.getConfiguration();
 
     assertEquals(
@@ -342,7 +342,7 @@ public class SparkScanTest extends DeltaV2TestBase {
 
   @Test
   public void testGetReadDataSchemaWithColumnPruning() {
-    SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(options);
+    DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) table.newScanBuilder(options);
 
     StructType prunedSchema =
         new StructType()
@@ -352,7 +352,7 @@ public class SparkScanTest extends DeltaV2TestBase {
             .add("part", DataTypes.IntegerType);
     builder.pruneColumns(prunedSchema);
 
-    SparkScan scan = (SparkScan) builder.build();
+    DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
     StructType dataSchema = scan.getDataSchema();
     StructType readDataSchema = scan.getReadDataSchema();
@@ -492,9 +492,9 @@ public class SparkScanTest extends DeltaV2TestBase {
       List<String> remainingPartitionValueAfterDpp)
       throws Exception {
     ScanBuilder newBuilder = table.newScanBuilder(scanOptions);
-    SparkScanBuilder builder = (SparkScanBuilder) newBuilder;
+    DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) newBuilder;
     Scan scan = builder.build();
-    SparkScan sparkScan = (SparkScan) scan;
+    DeltaV2Scan sparkScan = (DeltaV2Scan) scan;
 
     List<PartitionedFile> beforeDppFiles = getPartitionedFiles(sparkScan);
     // make a copy for comparison after DPP
@@ -531,44 +531,44 @@ public class SparkScanTest extends DeltaV2TestBase {
     assertEquals(afterDppTotalBytes, afterDppEstimatedSize);
   }
 
-  private static List<PartitionedFile> getPartitionedFiles(SparkScan scan) throws Exception {
+  private static List<PartitionedFile> getPartitionedFiles(DeltaV2Scan scan) throws Exception {
     scan.estimateStatistics(); // ensurePlanned
-    Field field = SparkScan.class.getDeclaredField("partitionedFiles");
+    Field field = DeltaV2Scan.class.getDeclaredField("partitionedFiles");
     field.setAccessible(true);
     return (List<PartitionedFile>) field.get(scan);
   }
 
-  private static long getTotalBytes(SparkScan scan) throws Exception {
+  private static long getTotalBytes(DeltaV2Scan scan) throws Exception {
     scan.estimateStatistics(); // ensurePlanned
-    Field field = SparkScan.class.getDeclaredField("totalBytes");
+    Field field = DeltaV2Scan.class.getDeclaredField("totalBytes");
     field.setAccessible(true);
     return (long) field.get(scan);
   }
 
-  private static long getEstimatedSizeInBytes(SparkScan scan) throws Exception {
+  private static long getEstimatedSizeInBytes(DeltaV2Scan scan) throws Exception {
     scan.estimateStatistics(); // ensurePlanned
-    Field field = SparkScan.class.getDeclaredField("estimatedSizeInBytes");
+    Field field = DeltaV2Scan.class.getDeclaredField("estimatedSizeInBytes");
     field.setAccessible(true);
     return (long) field.get(scan);
   }
 
-  private static org.apache.spark.sql.sources.Filter[] getDataFilters(SparkScan scan)
+  private static org.apache.spark.sql.sources.Filter[] getDataFilters(DeltaV2Scan scan)
       throws Exception {
-    Field field = SparkScan.class.getDeclaredField("dataFilters");
+    Field field = DeltaV2Scan.class.getDeclaredField("dataFilters");
     field.setAccessible(true);
     return (org.apache.spark.sql.sources.Filter[]) field.get(scan);
   }
 
-  private static long getTotalRows(SparkScan scan) throws Exception {
+  private static long getTotalRows(DeltaV2Scan scan) throws Exception {
     scan.estimateStatistics(); // ensurePlanned
-    Field field = SparkScan.class.getDeclaredField("totalRows");
+    Field field = DeltaV2Scan.class.getDeclaredField("totalRows");
     field.setAccessible(true);
     return (long) field.get(scan);
   }
 
-  private static boolean isRowCountKnown(SparkScan scan) throws Exception {
+  private static boolean isRowCountKnown(DeltaV2Scan scan) throws Exception {
     scan.estimateStatistics(); // ensurePlanned
-    Field field = SparkScan.class.getDeclaredField("rowCountKnown");
+    Field field = DeltaV2Scan.class.getDeclaredField("rowCountKnown");
     field.setAccessible(true);
     return (boolean) field.get(scan);
   }
@@ -581,8 +581,8 @@ public class SparkScanTest extends DeltaV2TestBase {
   public void testNumRowsEmptyWhenStatsDisabled() throws Exception {
     // With CBO and planStats disabled (the default), numRows() should return empty even when all
     // files have stats, matching V1 behavior (LogicalRelation.computeStats()).
-    SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan = (SparkScan) builder.build();
+    DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
     assertFalse(
         isRowCountKnown(scan), "rowCountKnown should be false when CBO and planStats are disabled");
@@ -598,8 +598,8 @@ public class SparkScanTest extends DeltaV2TestBase {
         "spark.sql.cbo.planStats.enabled",
         "true",
         () -> {
-          SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(options);
-          SparkScan scan = (SparkScan) builder.build();
+          DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+          DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
           assertTrue(isRowCountKnown(scan), "Row count should be known when all files have stats");
           assertEquals(5L, getTotalRows(scan), "Total rows should match the 5 inserted rows");
@@ -617,8 +617,8 @@ public class SparkScanTest extends DeltaV2TestBase {
         "spark.sql.cbo.planStats.enabled",
         "true",
         () -> {
-          SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(options);
-          SparkScan scan = (SparkScan) builder.build();
+          DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+          DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
           assertEquals(
               5L, scan.estimateStatistics().numRows().getAsLong(), "5 rows before filtering");
@@ -644,8 +644,8 @@ public class SparkScanTest extends DeltaV2TestBase {
         "spark.sql.cbo.planStats.enabled",
         "true",
         () -> {
-          SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(options);
-          SparkScan scan = (SparkScan) builder.build();
+          DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+          DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
           scan.filter(new Predicate[] {negativeCityPredicate}); // city=zz doesn't exist
 
@@ -685,8 +685,8 @@ public class SparkScanTest extends DeltaV2TestBase {
           "spark.sql.cbo.planStats.enabled",
           "true",
           () -> {
-            SparkScanBuilder builder = (SparkScanBuilder) mixedStatsTable.newScanBuilder(options);
-            SparkScan scan = (SparkScan) builder.build();
+            DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) mixedStatsTable.newScanBuilder(options);
+            DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
             assertFalse(
                 isRowCountKnown(scan), "rowCountKnown should be false when some files lack stats");
@@ -709,8 +709,8 @@ public class SparkScanTest extends DeltaV2TestBase {
     cdcOptions.put("readChangeFeed", "true");
     CaseInsensitiveStringMap cdcOptionsMap = new CaseInsensitiveStringMap(cdcOptions);
 
-    SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(cdcOptionsMap);
-    SparkScan scan = (SparkScan) builder.build();
+    DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) table.newScanBuilder(cdcOptionsMap);
+    DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
     StructType schema = scan.readSchema();
 
@@ -735,8 +735,8 @@ public class SparkScanTest extends DeltaV2TestBase {
   @Test
   public void testReadSchema_nonCdcRead_returnsDataAndPartitionSchema() {
     // Without readChangeFeed, readSchema() returns readDataSchema + partitionSchema.
-    SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan = (SparkScan) builder.build();
+    DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
     StructType schema = scan.readSchema();
 
@@ -760,7 +760,7 @@ public class SparkScanTest extends DeltaV2TestBase {
     cdcOptions.put("readChangeFeed", "true");
     CaseInsensitiveStringMap cdcOptionsMap = new CaseInsensitiveStringMap(cdcOptions);
 
-    SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(cdcOptionsMap);
+    DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) table.newScanBuilder(cdcOptionsMap);
     StructType requiredSchema =
         new StructType()
             .add("name", DataTypes.StringType)
@@ -770,7 +770,7 @@ public class SparkScanTest extends DeltaV2TestBase {
             .add("date", DataTypes.StringType);
     builder.pruneColumns(requiredSchema);
 
-    SparkScan scan = (SparkScan) builder.build();
+    DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
     // readDataSchema reflects pruning: only "name" remains (cnt dropped, partition + CDC filtered)
     StructType readDataSchema = scan.getReadDataSchema();
@@ -794,8 +794,8 @@ public class SparkScanTest extends DeltaV2TestBase {
     cdcOptions.put("readChangeFeed", "true");
     CaseInsensitiveStringMap cdcOptionsMap = new CaseInsensitiveStringMap(cdcOptions);
 
-    SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(cdcOptionsMap);
-    SparkScan scan = (SparkScan) builder.build();
+    DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) table.newScanBuilder(cdcOptionsMap);
+    DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
     // Sanity: scan still advertises the CDC schema (this is needed for the streaming path).
     StructType advertised = scan.readSchema();
@@ -815,8 +815,8 @@ public class SparkScanTest extends DeltaV2TestBase {
     cdcOptions.put("readChangeData", "true");
     CaseInsensitiveStringMap cdcOptionsMap = new CaseInsensitiveStringMap(cdcOptions);
 
-    SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(cdcOptionsMap);
-    SparkScan scan = (SparkScan) builder.build();
+    DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) table.newScanBuilder(cdcOptionsMap);
+    DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
     assertEquals(8, scan.readSchema().fields().length);
     UnsupportedOperationException e =
@@ -832,7 +832,7 @@ public class SparkScanTest extends DeltaV2TestBase {
 
     assertThrows(
         IllegalArgumentException.class,
-        () -> ((SparkScanBuilder) table.newScanBuilder(cdcOptionsMap)).build());
+        () -> ((DeltaV2ScanBuilder) table.newScanBuilder(cdcOptionsMap)).build());
   }
 
   @Test
@@ -841,8 +841,8 @@ public class SparkScanTest extends DeltaV2TestBase {
     nonCdcOptions.put("readChangeFeed", "false");
     CaseInsensitiveStringMap nonCdcOptionsMap = new CaseInsensitiveStringMap(nonCdcOptions);
 
-    SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(nonCdcOptionsMap);
-    SparkScan scan = (SparkScan) builder.build();
+    DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) table.newScanBuilder(nonCdcOptionsMap);
+    DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
     StructType schema = scan.readSchema();
     assertThrows(IllegalArgumentException.class, () -> schema.fieldIndex("_change_type"));
@@ -856,11 +856,11 @@ public class SparkScanTest extends DeltaV2TestBase {
   @Test
   public void testEqualsAndHashCode() {
     // Create two scans from the same table with same options
-    SparkScanBuilder builder1 = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan1 = (SparkScan) builder1.build();
+    DeltaV2ScanBuilder builder1 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan1 = (DeltaV2Scan) builder1.build();
 
-    SparkScanBuilder builder2 = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan2 = (SparkScan) builder2.build();
+    DeltaV2ScanBuilder builder2 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan2 = (DeltaV2Scan) builder2.build();
 
     // Same table, same options should be equal
     assertEquals(scan1, scan2);
@@ -869,14 +869,14 @@ public class SparkScanTest extends DeltaV2TestBase {
 
   @Test
   public void testEqualsWithDifferentOptions() {
-    SparkScanBuilder builder1 = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan1 = (SparkScan) builder1.build();
+    DeltaV2ScanBuilder builder1 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan1 = (DeltaV2Scan) builder1.build();
 
     Map<String, String> differentOptions = new HashMap<>();
     differentOptions.put("customOption", "value");
     CaseInsensitiveStringMap optionsMap = new CaseInsensitiveStringMap(differentOptions);
-    SparkScanBuilder builder2 = (SparkScanBuilder) table.newScanBuilder(optionsMap);
-    SparkScan scan2 = (SparkScan) builder2.build();
+    DeltaV2ScanBuilder builder2 = (DeltaV2ScanBuilder) table.newScanBuilder(optionsMap);
+    DeltaV2Scan scan2 = (DeltaV2Scan) builder2.build();
 
     // Different options should not be equal and hashCodes should differ
     assertNotEquals(scan1, scan2);
@@ -886,19 +886,19 @@ public class SparkScanTest extends DeltaV2TestBase {
   @Test
   public void testEqualsWithSameFilters() {
     // Both scans with equivalent filters created separately (not same instance)
-    SparkScanBuilder builder1 = (SparkScanBuilder) table.newScanBuilder(options);
+    DeltaV2ScanBuilder builder1 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
     builder1.pushFilters(
         new org.apache.spark.sql.sources.Filter[] {
           new org.apache.spark.sql.sources.EqualTo("city", "hz")
         });
-    SparkScan scan1 = (SparkScan) builder1.build();
+    DeltaV2Scan scan1 = (DeltaV2Scan) builder1.build();
 
-    SparkScanBuilder builder2 = (SparkScanBuilder) table.newScanBuilder(options);
+    DeltaV2ScanBuilder builder2 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
     builder2.pushFilters(
         new org.apache.spark.sql.sources.Filter[] {
           new org.apache.spark.sql.sources.EqualTo("city", "hz")
         });
-    SparkScan scan2 = (SparkScan) builder2.build();
+    DeltaV2Scan scan2 = (DeltaV2Scan) builder2.build();
 
     // Same options and equivalent filters should be equal
     assertEquals(scan1, scan2);
@@ -908,16 +908,16 @@ public class SparkScanTest extends DeltaV2TestBase {
   @Test
   public void testEqualsWithDifferentFilters() {
     // Scan without filters
-    SparkScanBuilder builder1 = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan1 = (SparkScan) builder1.build();
+    DeltaV2ScanBuilder builder1 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan1 = (DeltaV2Scan) builder1.build();
 
     // Scan with filters pushed
-    SparkScanBuilder builder2 = (SparkScanBuilder) table.newScanBuilder(options);
+    DeltaV2ScanBuilder builder2 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
     builder2.pushFilters(
         new org.apache.spark.sql.sources.Filter[] {
           new org.apache.spark.sql.sources.EqualTo("city", "hz")
         });
-    SparkScan scan2 = (SparkScan) builder2.build();
+    DeltaV2Scan scan2 = (DeltaV2Scan) builder2.build();
 
     // Same options but different filters should not be equal and hashCodes should differ
     assertNotEquals(scan1, scan2);
@@ -931,13 +931,13 @@ public class SparkScanTest extends DeltaV2TestBase {
     org.apache.spark.sql.sources.Filter dateEq =
         new org.apache.spark.sql.sources.EqualTo("date", "20180520");
 
-    SparkScanBuilder builder1 = (SparkScanBuilder) table.newScanBuilder(options);
+    DeltaV2ScanBuilder builder1 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
     builder1.pushFilters(new org.apache.spark.sql.sources.Filter[] {cityEq, dateEq});
-    SparkScan scan1 = (SparkScan) builder1.build();
+    DeltaV2Scan scan1 = (DeltaV2Scan) builder1.build();
 
-    SparkScanBuilder builder2 = (SparkScanBuilder) table.newScanBuilder(options);
+    DeltaV2ScanBuilder builder2 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
     builder2.pushFilters(new org.apache.spark.sql.sources.Filter[] {dateEq, cityEq});
-    SparkScan scan2 = (SparkScan) builder2.build();
+    DeltaV2Scan scan2 = (DeltaV2Scan) builder2.build();
 
     assertEquals(scan1, scan2);
     assertEquals(scan1.hashCode(), scan2.hashCode());
@@ -948,19 +948,19 @@ public class SparkScanTest extends DeltaV2TestBase {
     // city/date are partition columns, so the test above only exercises pushedToKernelFiltersSet.
     // name and cnt are data columns (per the partitioned table schema), so per
     // ExpressionUtils.classifyFilter these filters have isDataFilter=true and flow into
-    // SparkScan.dataFilters, exercising the dataFiltersSet branch of equals/hashCode.
+    // DeltaV2Scan.dataFilters, exercising the dataFiltersSet branch of equals/hashCode.
     org.apache.spark.sql.sources.Filter nameEq =
         new org.apache.spark.sql.sources.EqualTo("name", "x");
     org.apache.spark.sql.sources.Filter cntGt =
         new org.apache.spark.sql.sources.GreaterThan("cnt", 10);
 
-    SparkScanBuilder builder1 = (SparkScanBuilder) table.newScanBuilder(options);
+    DeltaV2ScanBuilder builder1 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
     builder1.pushFilters(new org.apache.spark.sql.sources.Filter[] {nameEq, cntGt});
-    SparkScan scan1 = (SparkScan) builder1.build();
+    DeltaV2Scan scan1 = (DeltaV2Scan) builder1.build();
 
-    SparkScanBuilder builder2 = (SparkScanBuilder) table.newScanBuilder(options);
+    DeltaV2ScanBuilder builder2 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
     builder2.pushFilters(new org.apache.spark.sql.sources.Filter[] {cntGt, nameEq});
-    SparkScan scan2 = (SparkScan) builder2.build();
+    DeltaV2Scan scan2 = (DeltaV2Scan) builder2.build();
 
     // Sanity check that dataFilters is actually populated, otherwise this test would trivially
     // pass without exercising the dataFiltersSet path it's intended to cover.
@@ -978,8 +978,8 @@ public class SparkScanTest extends DeltaV2TestBase {
   @Test
   public void testEstimatedSizeMatchesStatistics() throws Exception {
     // Test that estimateStatistics().sizeInBytes() returns the estimatedSizeInBytes field
-    SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan = (SparkScan) builder.build();
+    DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
     long estimatedSizeFromStats = scan.estimateStatistics().sizeInBytes().getAsLong();
     long estimatedSizeFromField = getEstimatedSizeInBytes(scan);
@@ -1006,7 +1006,7 @@ public class SparkScanTest extends DeltaV2TestBase {
     //   readSchema().defaultSize() = 20 + 44 = 64
     //   outputRowSize = 8 + 64 = 72
     //   estimatedBytes = (totalBytes * 72) / 76
-    SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(options);
+    DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) table.newScanBuilder(options);
 
     // Prune columns to only include 'name' (a data column) and partition columns
     // This simulates: SELECT name, date, city, part FROM table
@@ -1018,7 +1018,7 @@ public class SparkScanTest extends DeltaV2TestBase {
             .add("part", DataTypes.IntegerType);
     builder.pruneColumns(prunedSchema);
 
-    SparkScan scan = (SparkScan) builder.build();
+    DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
     long totalBytes = getTotalBytes(scan);
     long estimatedSize = getEstimatedSizeInBytes(scan);
@@ -1043,7 +1043,7 @@ public class SparkScanTest extends DeltaV2TestBase {
     // Test that column pruning and runtime filtering work together correctly
     // Using same formula as testEstimatedSizeWithColumnPruning:
     //   estimatedBytes = (totalBytes * 72) / 76
-    SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(options);
+    DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) table.newScanBuilder(options);
 
     // Prune columns to only include 'name' column
     StructType prunedSchema =
@@ -1054,7 +1054,7 @@ public class SparkScanTest extends DeltaV2TestBase {
             .add("part", DataTypes.IntegerType);
     builder.pruneColumns(prunedSchema);
 
-    SparkScan scan = (SparkScan) builder.build();
+    DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
     // Get initial stats with column pruning
     long initialTotalBytes = getTotalBytes(scan);
@@ -1090,8 +1090,8 @@ public class SparkScanTest extends DeltaV2TestBase {
   @Test
   public void testEstimatedSizeZeroAfterFilteringOutAllFiles() throws Exception {
     // Test that filtering out all files results in zero for both sizes
-    SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan = (SparkScan) builder.build();
+    DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
     // Apply filter that matches nothing
     scan.filter(new Predicate[] {negativeCityPredicate}); // city=zz doesn't exist
@@ -1115,10 +1115,10 @@ public class SparkScanTest extends DeltaV2TestBase {
   @Test
   public void testEqualsAndHashCodeWithSameRuntimeFilter() {
     // Same filter applied to both scans (same instance)
-    SparkScanBuilder builder1 = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan1 = (SparkScan) builder1.build();
-    SparkScanBuilder builder2 = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan2 = (SparkScan) builder2.build();
+    DeltaV2ScanBuilder builder1 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan1 = (DeltaV2Scan) builder1.build();
+    DeltaV2ScanBuilder builder2 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan2 = (DeltaV2Scan) builder2.build();
 
     scan1.filter(new Predicate[] {cityPredicate});
     scan2.filter(new Predicate[] {cityPredicate});
@@ -1130,10 +1130,10 @@ public class SparkScanTest extends DeltaV2TestBase {
   @Test
   public void testEqualsAndHashCodeWithEquivalentRuntimeFilters() {
     // Equivalent filters (different instances)
-    SparkScanBuilder builder1 = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan1 = (SparkScan) builder1.build();
-    SparkScanBuilder builder2 = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan2 = (SparkScan) builder2.build();
+    DeltaV2ScanBuilder builder1 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan1 = (DeltaV2Scan) builder1.build();
+    DeltaV2ScanBuilder builder2 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan2 = (DeltaV2Scan) builder2.build();
 
     scan1.filter(new Predicate[] {cityPredicate});
 
@@ -1152,10 +1152,10 @@ public class SparkScanTest extends DeltaV2TestBase {
   @Test
   public void testEqualsAndHashCodeWithMultipleRuntimeFiltersInSameOrder() {
     // Multiple filters in same order
-    SparkScanBuilder builder1 = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan1 = (SparkScan) builder1.build();
-    SparkScanBuilder builder2 = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan2 = (SparkScan) builder2.build();
+    DeltaV2ScanBuilder builder1 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan1 = (DeltaV2Scan) builder1.build();
+    DeltaV2ScanBuilder builder2 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan2 = (DeltaV2Scan) builder2.build();
 
     scan1.filter(new Predicate[] {cityPredicate, datePredicate});
     scan2.filter(new Predicate[] {cityPredicate, datePredicate});
@@ -1167,10 +1167,10 @@ public class SparkScanTest extends DeltaV2TestBase {
   @Test
   public void testEqualsAndHashCodeWithIdempotentRuntimeFilters() {
     // Filter idempotency - applying same filter once vs twice
-    SparkScanBuilder builder1 = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan1 = (SparkScan) builder1.build();
-    SparkScanBuilder builder2 = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan2 = (SparkScan) builder2.build();
+    DeltaV2ScanBuilder builder1 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan1 = (DeltaV2Scan) builder1.build();
+    DeltaV2ScanBuilder builder2 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan2 = (DeltaV2Scan) builder2.build();
 
     scan1.filter(new Predicate[] {cityPredicate});
     scan2.filter(new Predicate[] {cityPredicate});
@@ -1183,10 +1183,10 @@ public class SparkScanTest extends DeltaV2TestBase {
   @Test
   public void testEqualsAndHashCodeWithSeparateRuntimeFilterCalls() {
     // Multiple separate filter() calls vs single call with multiple filters
-    SparkScanBuilder builder1 = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan1 = (SparkScan) builder1.build();
-    SparkScanBuilder builder2 = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan2 = (SparkScan) builder2.build();
+    DeltaV2ScanBuilder builder1 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan1 = (DeltaV2Scan) builder1.build();
+    DeltaV2ScanBuilder builder2 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan2 = (DeltaV2Scan) builder2.build();
 
     scan1.filter(new Predicate[] {cityPredicate});
     scan1.filter(new Predicate[] {datePredicate});
@@ -1199,10 +1199,10 @@ public class SparkScanTest extends DeltaV2TestBase {
   @Test
   public void testEqualsAndHashCodeWithRuntimeFiltersInDifferentOrder() {
     // Same filters in different order (order-independent)
-    SparkScanBuilder builder1 = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan1 = (SparkScan) builder1.build();
-    SparkScanBuilder builder2 = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan2 = (SparkScan) builder2.build();
+    DeltaV2ScanBuilder builder1 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan1 = (DeltaV2Scan) builder1.build();
+    DeltaV2ScanBuilder builder2 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan2 = (DeltaV2Scan) builder2.build();
 
     scan1.filter(new Predicate[] {cityPredicate, datePredicate});
     scan2.filter(new Predicate[] {datePredicate, cityPredicate});
@@ -1215,10 +1215,10 @@ public class SparkScanTest extends DeltaV2TestBase {
   public void testEqualsAndHashCodeWithNonPartitionColumnRuntimeFilters() {
     // Non-partition column predicates should not affect equality
     // Only partition column predicates should be tracked
-    SparkScanBuilder builder1 = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan1 = (SparkScan) builder1.build();
-    SparkScanBuilder builder2 = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan2 = (SparkScan) builder2.build();
+    DeltaV2ScanBuilder builder1 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan1 = (DeltaV2Scan) builder1.build();
+    DeltaV2ScanBuilder builder2 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan2 = (DeltaV2Scan) builder2.build();
 
     // cityPredicate is on partition column, dataPredicate is on non-partition column (cnt)
     scan1.filter(new Predicate[] {cityPredicate});
@@ -1232,10 +1232,10 @@ public class SparkScanTest extends DeltaV2TestBase {
   @Test
   public void testNotEqualsWithDifferentRuntimeFilters() {
     // Different filters
-    SparkScanBuilder builder1 = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan1 = (SparkScan) builder1.build();
-    SparkScanBuilder builder2 = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan2 = (SparkScan) builder2.build();
+    DeltaV2ScanBuilder builder1 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan1 = (DeltaV2Scan) builder1.build();
+    DeltaV2ScanBuilder builder2 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan2 = (DeltaV2Scan) builder2.build();
 
     scan1.filter(new Predicate[] {cityPredicate});
     scan2.filter(new Predicate[] {datePredicate});
@@ -1247,10 +1247,10 @@ public class SparkScanTest extends DeltaV2TestBase {
   @Test
   public void testNotEqualsWithAndWithoutRuntimeFilter() {
     // One with filter, one without
-    SparkScanBuilder builder1 = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan1 = (SparkScan) builder1.build();
-    SparkScanBuilder builder2 = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan2 = (SparkScan) builder2.build();
+    DeltaV2ScanBuilder builder1 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan1 = (DeltaV2Scan) builder1.build();
+    DeltaV2ScanBuilder builder2 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan2 = (DeltaV2Scan) builder2.build();
 
     scan2.filter(new Predicate[] {cityPredicate});
 
@@ -1311,10 +1311,10 @@ public class SparkScanTest extends DeltaV2TestBase {
           Identifier id = Identifier.of(new String[] {"default"}, tblName);
           DeltaV2Table sparkTable = new DeltaV2Table(id, catalogTable, Collections.emptyMap());
 
-          SparkScanBuilder builder =
-              (SparkScanBuilder)
+          DeltaV2ScanBuilder builder =
+              (DeltaV2ScanBuilder)
                   sparkTable.newScanBuilder(new CaseInsensitiveStringMap(new HashMap<>()));
-          SparkScan scan = (SparkScan) builder.build();
+          DeltaV2Scan scan = (DeltaV2Scan) builder.build();
           Statistics stats = scan.estimateStatistics();
 
           // numRows comes from per-file (post-prune) stats
@@ -1368,10 +1368,10 @@ public class SparkScanTest extends DeltaV2TestBase {
         () -> {
           Identifier id = Identifier.of(new String[] {"default"}, tblName);
           DeltaV2Table sparkTable = new DeltaV2Table(id, catalogTable, Collections.emptyMap());
-          SparkScanBuilder builder =
-              (SparkScanBuilder)
+          DeltaV2ScanBuilder builder =
+              (DeltaV2ScanBuilder)
                   sparkTable.newScanBuilder(new CaseInsensitiveStringMap(new HashMap<>()));
-          SparkScan scan = (SparkScan) builder.build();
+          DeltaV2Scan scan = (DeltaV2Scan) builder.build();
           Statistics stats = scan.estimateStatistics();
 
           // Per-file numRows wins over catalog stats.
@@ -1414,10 +1414,10 @@ public class SparkScanTest extends DeltaV2TestBase {
           () -> {
             Identifier id = Identifier.of(new String[] {"default"}, tblName);
             DeltaV2Table sparkTable = new DeltaV2Table(id, catalogTable, Collections.emptyMap());
-            SparkScanBuilder builder =
-                (SparkScanBuilder)
+            DeltaV2ScanBuilder builder =
+                (DeltaV2ScanBuilder)
                     sparkTable.newScanBuilder(new CaseInsensitiveStringMap(new HashMap<>()));
-            SparkScan scan = (SparkScan) builder.build();
+            DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
             assertFalse(
                 isRowCountKnown(scan),
@@ -1464,10 +1464,10 @@ public class SparkScanTest extends DeltaV2TestBase {
           Identifier id = Identifier.of(new String[] {"default"}, tblName);
           DeltaV2Table sparkTable = new DeltaV2Table(id, catalogTable, Collections.emptyMap());
 
-          SparkScanBuilder builder =
-              (SparkScanBuilder)
+          DeltaV2ScanBuilder builder =
+              (DeltaV2ScanBuilder)
                   sparkTable.newScanBuilder(new CaseInsensitiveStringMap(new HashMap<>()));
-          SparkScan scan = (SparkScan) builder.build();
+          DeltaV2Scan scan = (DeltaV2Scan) builder.build();
           Statistics stats = scan.estimateStatistics();
 
           // With CBO disabled, numRows should be empty (matching V1 behavior)
@@ -1511,10 +1511,10 @@ public class SparkScanTest extends DeltaV2TestBase {
                 DeltaV2Table sparkTable =
                     new DeltaV2Table(id, catalogTable, Collections.emptyMap());
 
-                SparkScanBuilder builder =
-                    (SparkScanBuilder)
+                DeltaV2ScanBuilder builder =
+                    (DeltaV2ScanBuilder)
                         sparkTable.newScanBuilder(new CaseInsensitiveStringMap(new HashMap<>()));
-                SparkScan scan = (SparkScan) builder.build();
+                DeltaV2Scan scan = (DeltaV2Scan) builder.build();
                 Statistics stats = scan.estimateStatistics();
 
                 // With planStatsEnabled, numRows should be present (from per-file stats)
@@ -1547,10 +1547,10 @@ public class SparkScanTest extends DeltaV2TestBase {
           Identifier id = Identifier.of(new String[] {"default"}, tblName);
           DeltaV2Table sparkTable = new DeltaV2Table(id, path);
 
-          SparkScanBuilder builder =
-              (SparkScanBuilder)
+          DeltaV2ScanBuilder builder =
+              (DeltaV2ScanBuilder)
                   sparkTable.newScanBuilder(new CaseInsensitiveStringMap(new HashMap<>()));
-          SparkScan scan = (SparkScan) builder.build();
+          DeltaV2Scan scan = (DeltaV2Scan) builder.build();
           Statistics stats = scan.estimateStatistics();
 
           // Per-file Delta stats (numRecords in the transaction log) are available even without
@@ -1615,10 +1615,10 @@ public class SparkScanTest extends DeltaV2TestBase {
           Identifier id = Identifier.of(new String[] {"default"}, tblName);
           DeltaV2Table sparkTable = new DeltaV2Table(id, catalogTable, Collections.emptyMap());
 
-          SparkScanBuilder builder =
-              (SparkScanBuilder)
+          DeltaV2ScanBuilder builder =
+              (DeltaV2ScanBuilder)
                   sparkTable.newScanBuilder(new CaseInsensitiveStringMap(new HashMap<>()));
-          SparkScan scan = (SparkScan) builder.build();
+          DeltaV2Scan scan = (DeltaV2Scan) builder.build();
           Statistics stats = scan.estimateStatistics();
 
           assertTrue(stats.numRows().isPresent(), "numRows should be present");
@@ -1682,15 +1682,15 @@ public class SparkScanTest extends DeltaV2TestBase {
                 DeltaV2Table sparkTable =
                     new DeltaV2Table(id, catalogTable, Collections.emptyMap());
 
-                SparkScanBuilder builder =
-                    (SparkScanBuilder)
+                DeltaV2ScanBuilder builder =
+                    (DeltaV2ScanBuilder)
                         sparkTable.newScanBuilder(new CaseInsensitiveStringMap(new HashMap<>()));
 
                 // Prune to only 'name' column to trigger column projection estimation
                 StructType prunedSchema = new StructType().add("name", DataTypes.StringType);
                 builder.pruneColumns(prunedSchema);
 
-                SparkScan scan = (SparkScan) builder.build();
+                DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
                 long totalBytes = getTotalBytes(scan);
                 long estimatedSize = getEstimatedSizeInBytes(scan);
@@ -1742,10 +1742,10 @@ public class SparkScanTest extends DeltaV2TestBase {
           Identifier id = Identifier.of(new String[] {"default"}, tblName);
           DeltaV2Table sparkTable = new DeltaV2Table(id, catalogTable, Collections.emptyMap());
 
-          SparkScanBuilder builder =
-              (SparkScanBuilder)
+          DeltaV2ScanBuilder builder =
+              (DeltaV2ScanBuilder)
                   sparkTable.newScanBuilder(new CaseInsensitiveStringMap(new HashMap<>()));
-          SparkScan scan = (SparkScan) builder.build();
+          DeltaV2Scan scan = (DeltaV2Scan) builder.build();
           Statistics stats = scan.estimateStatistics();
 
           // Per-file Delta stats (numRecords in the transaction log) provide numRows even when
@@ -1787,10 +1787,10 @@ public class SparkScanTest extends DeltaV2TestBase {
           Identifier id = Identifier.of(new String[] {"default"}, tblName);
           DeltaV2Table sparkTable = new DeltaV2Table(id, catalogTable, Collections.emptyMap());
 
-          SparkScanBuilder builder =
-              (SparkScanBuilder)
+          DeltaV2ScanBuilder builder =
+              (DeltaV2ScanBuilder)
                   sparkTable.newScanBuilder(new CaseInsensitiveStringMap(new HashMap<>()));
-          SparkScan scan = (SparkScan) builder.build();
+          DeltaV2Scan scan = (DeltaV2Scan) builder.build();
           Statistics stats = scan.estimateStatistics();
 
           // Per-file stats provide numRows even when catalog stats lack it

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkGoldenTableTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkGoldenTableTest.java
@@ -145,8 +145,8 @@ public class SparkGoldenTableTest {
               }
             });
     ScanBuilder builder = table.newScanBuilder(scanOptions);
-    assertTrue((builder instanceof SparkScanBuilder));
-    SparkScanBuilder scanBuilder = (SparkScanBuilder) builder;
+    assertTrue((builder instanceof DeltaV2ScanBuilder));
+    DeltaV2ScanBuilder scanBuilder = (DeltaV2ScanBuilder) builder;
     assertEquals(expectedDataSchema, scanBuilder.getDataSchema());
     assertEquals(expectedPartitionSchema, scanBuilder.getPartitionSchema());
     CaseInsensitiveStringMap combinedOptions =
@@ -161,8 +161,8 @@ public class SparkGoldenTableTest {
     assertEquals(combinedOptions, scanBuilder.getOptions());
 
     Scan scan1 = scanBuilder.build();
-    assertTrue(scan1 instanceof SparkScan);
-    SparkScan sparkScan1 = (SparkScan) scan1;
+    assertTrue(scan1 instanceof DeltaV2Scan);
+    DeltaV2Scan sparkScan1 = (DeltaV2Scan) scan1;
     assertEquals(expectedDataSchema, sparkScan1.getDataSchema());
     assertEquals(expectedDataSchema, sparkScan1.getReadDataSchema());
     assertEquals(expectedPartitionSchema, sparkScan1.getPartitionSchema());
@@ -177,8 +177,8 @@ public class SparkGoldenTableTest {
             });
     scanBuilder.pruneColumns(prunedSchema);
     Scan scan2 = scanBuilder.build();
-    assertTrue(scan2 instanceof SparkScan);
-    SparkScan sparkScan2 = (SparkScan) scan2;
+    assertTrue(scan2 instanceof DeltaV2Scan);
+    DeltaV2Scan sparkScan2 = (DeltaV2Scan) scan2;
     assertEquals(expectedDataSchema, sparkScan2.getDataSchema());
     StructType expectedReadDataSchemaAfterPrune =
         DataTypes.createStructType(new StructField[] {expectedDataSchema.fields()[0]});
@@ -322,8 +322,8 @@ public class SparkGoldenTableTest {
     // city = 'hz' AND date = '20180520'
     org.apache.spark.sql.connector.expressions.filter.Predicate andPredicate =
         new org.apache.spark.sql.connector.expressions.filter.Predicate(
-            "AND", new Expression[] {SparkScanTest.cityPredicate, SparkScanTest.datePredicate});
-    SparkScanTest.checkSupportsRuntimeFilters(
+            "AND", new Expression[] {DeltaV2ScanTest.cityPredicate, DeltaV2ScanTest.datePredicate});
+    DeltaV2ScanTest.checkSupportsRuntimeFilters(
         table,
         options,
         new org.apache.spark.sql.connector.expressions.filter.Predicate[] {andPredicate},
@@ -332,49 +332,49 @@ public class SparkGoldenTableTest {
     // city = 'hz' OR date = '20180520'
     org.apache.spark.sql.connector.expressions.filter.Predicate orPredicate =
         new org.apache.spark.sql.connector.expressions.filter.Predicate(
-            "OR", new Expression[] {SparkScanTest.cityPredicate, SparkScanTest.datePredicate});
-    SparkScanTest.checkSupportsRuntimeFilters(
+            "OR", new Expression[] {DeltaV2ScanTest.cityPredicate, DeltaV2ScanTest.datePredicate});
+    DeltaV2ScanTest.checkSupportsRuntimeFilters(
         table,
         scanOptions,
         new org.apache.spark.sql.connector.expressions.filter.Predicate[] {orPredicate},
         Arrays.asList("city=hz", "date=20180520"));
 
     //  city = 'hz', cnt > 10
-    SparkScanTest.checkSupportsRuntimeFilters(
+    DeltaV2ScanTest.checkSupportsRuntimeFilters(
         table,
         options,
         new org.apache.spark.sql.connector.expressions.filter.Predicate[] {
-          SparkScanTest.cityPredicate, SparkScanTest.dataPredicate
+          DeltaV2ScanTest.cityPredicate, DeltaV2ScanTest.dataPredicate
         },
         Arrays.asList("city=hz"));
 
     //  city = 'hz' OR cnt > 10
     org.apache.spark.sql.connector.expressions.filter.Predicate orDataPredicate =
         new org.apache.spark.sql.connector.expressions.filter.Predicate(
-            "OR", new Expression[] {SparkScanTest.cityPredicate, SparkScanTest.dataPredicate});
-    SparkScanTest.checkSupportsRuntimeFilters(
+            "OR", new Expression[] {DeltaV2ScanTest.cityPredicate, DeltaV2ScanTest.dataPredicate});
+    DeltaV2ScanTest.checkSupportsRuntimeFilters(
         table,
         options,
         new org.apache.spark.sql.connector.expressions.filter.Predicate[] {orDataPredicate},
-        SparkScanTest.allCities);
+        DeltaV2ScanTest.allCities);
 
     // city = date
-    SparkScanTest.checkSupportsRuntimeFilters(
+    DeltaV2ScanTest.checkSupportsRuntimeFilters(
         table,
         options,
         new org.apache.spark.sql.connector.expressions.filter.Predicate[] {
-          SparkScanTest.negativeInterColPredicate
+          DeltaV2ScanTest.negativeInterColPredicate
         },
         Arrays.asList());
 
     // city <> date
-    SparkScanTest.checkSupportsRuntimeFilters(
+    DeltaV2ScanTest.checkSupportsRuntimeFilters(
         table,
         options,
         new org.apache.spark.sql.connector.expressions.filter.Predicate[] {
-          SparkScanTest.interColPredicate
+          DeltaV2ScanTest.interColPredicate
         },
-        SparkScanTest.allCities);
+        DeltaV2ScanTest.allCities);
   }
 
   private void checkSupportsPushDownFilters(
@@ -388,7 +388,7 @@ public class SparkGoldenTableTest {
       Optional<Predicate> expectedKernelScanBuilderPredicate)
       throws Exception {
     ScanBuilder newBuilder = table.newScanBuilder(scanOptions);
-    SparkScanBuilder builder = (SparkScanBuilder) newBuilder;
+    DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) newBuilder;
 
     Filter[] postScanFilters = builder.pushFilters(inputFilters);
 
@@ -414,21 +414,21 @@ public class SparkGoldenTableTest {
     assertEquals(expectedKernelScanBuilderPredicate, predicateOpt);
   }
 
-  private Predicate[] getPushedKernelPredicates(SparkScanBuilder builder) throws Exception {
-    Field field = SparkScanBuilder.class.getDeclaredField("pushedKernelPredicates");
+  private Predicate[] getPushedKernelPredicates(DeltaV2ScanBuilder builder) throws Exception {
+    Field field = DeltaV2ScanBuilder.class.getDeclaredField("pushedKernelPredicates");
     field.setAccessible(true);
     return (Predicate[]) field.get(builder);
   }
 
-  private Filter[] getDataFilters(SparkScanBuilder builder) throws Exception {
-    Field field = SparkScanBuilder.class.getDeclaredField("dataFilters");
+  private Filter[] getDataFilters(DeltaV2ScanBuilder builder) throws Exception {
+    Field field = DeltaV2ScanBuilder.class.getDeclaredField("dataFilters");
     field.setAccessible(true);
     return (Filter[]) field.get(builder);
   }
 
-  private Optional<Predicate> getKernelScanBuilderPredicate(SparkScanBuilder builder)
+  private Optional<Predicate> getKernelScanBuilderPredicate(DeltaV2ScanBuilder builder)
       throws Exception {
-    Field field = SparkScanBuilder.class.getDeclaredField("kernelScanBuilder");
+    Field field = DeltaV2ScanBuilder.class.getDeclaredField("kernelScanBuilder");
     field.setAccessible(true);
     Object kernelScanBuilder = field.get(builder);
     Field predicateField = kernelScanBuilder.getClass().getDeclaredField("predicate");
@@ -461,8 +461,8 @@ public class SparkGoldenTableTest {
         new CaseInsensitiveStringMap(
             java.util.Collections.singletonMap("another_option_key", "another_option_value"));
     ScanBuilder builder = table.newScanBuilder(options);
-    assertTrue((builder instanceof SparkScanBuilder));
-    SparkScanBuilder scanBuilder = (SparkScanBuilder) builder;
+    assertTrue((builder instanceof DeltaV2ScanBuilder));
+    DeltaV2ScanBuilder scanBuilder = (DeltaV2ScanBuilder) builder;
 
     assertEquals(expectedSchema, scanBuilder.getDataSchema());
     assertTrue(scanBuilder.getPartitionSchema().isEmpty());
@@ -470,8 +470,8 @@ public class SparkGoldenTableTest {
 
     // Initial scan (no pruning)
     Scan scan1 = scanBuilder.build();
-    assertTrue(scan1 instanceof SparkScan);
-    SparkScan sparkScan1 = (SparkScan) scan1;
+    assertTrue(scan1 instanceof DeltaV2Scan);
+    DeltaV2Scan sparkScan1 = (DeltaV2Scan) scan1;
     assertEquals(expectedSchema, sparkScan1.getDataSchema());
     assertEquals(expectedSchema, sparkScan1.getReadDataSchema());
     assertTrue(sparkScan1.getPartitionSchema().isEmpty());
@@ -481,8 +481,8 @@ public class SparkGoldenTableTest {
     scanBuilder.pruneColumns(prunedSchema);
 
     Scan scan2 = scanBuilder.build();
-    assertTrue(scan2 instanceof SparkScan);
-    SparkScan sparkScan2 = (SparkScan) scan2;
+    assertTrue(scan2 instanceof DeltaV2Scan);
+    DeltaV2Scan sparkScan2 = (DeltaV2Scan) scan2;
     assertEquals(expectedSchema, sparkScan2.getDataSchema());
     assertEquals(prunedSchema, sparkScan2.getReadDataSchema());
     assertTrue(sparkScan2.getPartitionSchema().isEmpty());


### PR DESCRIPTION
## Description

Rename the Delta Kernel DSv2 read-path implementations in
`io.delta.spark.internal.v2.read` to the `DeltaV2*` convention, matching the
`DeltaV2Table` and `DeltaV2WriteBuilder` classes already in the package:

- `SparkScan` -> `DeltaV2Scan`
- `SparkScanBuilder` -> `DeltaV2ScanBuilder`
- `SparkMicroBatchStream` -> `DeltaV2MicroBatchStream`
- `SparkBatch` -> `DeltaV2Batch`
- `SparkReaderFactory` -> `DeltaV2ReaderFactory`
- `SparkPartitionReader` -> `DeltaV2PartitionReader`

The rename only changes identifiers (class files, class names, imports,
`instanceof`/cast checks, pattern matches, comments) and the corresponding test
classes. No behavior change.

## How was this patch tested?

Existing tests, with all class references updated to the new names.

## Does this PR introduce _any_ user-facing change?

No.