### PR TITLE
[4.3][Spark] Carry forward unrecognized delta.* properties on catalog-managed REPLACE (#6985)

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
@@ -166,9 +166,22 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
       operation: TableCreationModes.CreationMode
     ): Table = recordFrameProfile(
         "DeltaCatalog", "createDeltaTable") {
+    // `delta.*` properties carried forward from a catalog-managed REPLACE that this Delta version
+    // does not recognize arrive tagged with [[AbstractDeltaCatalogClient.CARRY_FORWARD_PREFIX]].
+    // Collect them (prefix stripped) and exclude the tagged entries from `tableProperties` -- the
+    // map that becomes `tableDesc.properties` and is fed to `DeltaConfigs.validateConfigurations`.
+    // This keeps the literal prefixed key from being persisted and lets the real key skip the
+    // unknown-key check that would otherwise reject it. They are NOT dropped from the commit:
+    // re-merged into the solidified table below, they land in the committed metadata configuration
+    // like any other table property.
+    val carriedForwardProps = allTableProperties.asScala.collect {
+      case (k, v) if k.startsWith(AbstractDeltaCatalogClient.CARRY_FORWARD_PREFIX) =>
+        k.stripPrefix(AbstractDeltaCatalogClient.CARRY_FORWARD_PREFIX) -> v
+    }.toMap
     // These two keys are tableProperties in data source v2 but not in v1, so we have to filter
     // them out. Otherwise property consistency checks will fail.
     val tableProperties = allTableProperties.asScala.filterKeys {
+      case k if k.startsWith(AbstractDeltaCatalogClient.CARRY_FORWARD_PREFIX) => false
       case TableCatalog.PROP_LOCATION => false
       case TableCatalog.PROP_PROVIDER => false
       case TableCatalog.PROP_COMMENT => false
@@ -256,12 +269,19 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
       comment = commentOpt
     )
 
-    val withDb =
-      verifyTableAndSolidify(
+    val withDb = {
+      val solidified = verifyTableAndSolidify(
         tableDesc,
         None,
         maybeClusterBySpec
       )
+      // Solidify validates `tableDesc.properties`; the carried-forward keys were held out above so
+      // validation can't reject them, then merged into the solidified table here. `withDb` is what
+      // `CreateDeltaTableCommand` commits, so these keys end up in the new metadata's
+      // configuration.
+      if (carriedForwardProps.isEmpty) solidified
+      else solidified.copy(properties = solidified.properties ++ carriedForwardProps)
+    }
 
     val writer = sourceQuery.map { df =>
       val catalogTbl = Some(tableDesc)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClient.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClient.scala
@@ -163,6 +163,14 @@ private[delta] object AbstractDeltaCatalogClient extends Logging {
     "org.apache.spark.sql.delta.catalog.UCDeltaCatalogClientImpl"
 
   /**
+   * Marks a carried-forward `delta.*` property (from a catalog-managed REPLACE) that this Delta
+   * version doesn't recognize, so it can bypass validation and survive into the replaced table.
+   * Intentionally neither `delta.`- nor `option.`-prefixed so it rides untouched through the
+   * property plumbing until `AbstractDeltaCatalog.createDeltaTable` strips and re-injects it.
+   */
+  private[delta] val CARRY_FORWARD_PREFIX: String = "__replaceCarryForward."
+
+  /**
    * Returns a [[AbstractDeltaCatalogClient]] wrapped in [[Some]] unless the catalog has
    * opted out via `deltaRestApi.enabled=false`, in which case returns [[None]]. The flag
    * defaults to `true` when absent, so any UC catalog goes through the UC Delta API path

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImpl.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImpl.scala
@@ -22,6 +22,7 @@ import java.util.concurrent.atomic.AtomicLong
 
 import scala.jdk.CollectionConverters._
 import scala.jdk.OptionConverters._
+import scala.util.control.NonFatal
 
 import io.delta.storage.commit.{TableIdentifier => StorageTableIdentifier}
 import io.delta.storage.commit.actions.{AbstractDomainMetadata, AbstractProtocol}
@@ -45,7 +46,7 @@ import org.apache.spark.sql.catalyst.catalog.{
   CatalogTableType
 }
 import org.apache.spark.sql.connector.catalog.{CatalogV2Util, Identifier, Table, TableCatalog, V1Table}
-import org.apache.spark.sql.delta.{CatalogOwnedTableFeature, ClusteringTableFeature, DeltaConfigs, DeltaErrors, DeltaThrowable, TableFeature}
+import org.apache.spark.sql.delta.{CatalogOwnedTableFeature, ClusteringTableFeature, DeltaConfigs, DeltaErrors, MaterializedRowCommitVersion, MaterializedRowId, TableFeature}
 import org.apache.spark.sql.delta.actions.{Action, AddFile, CommitInfo, DomainMetadata, Metadata, Protocol, RemoveFile, TableFeatureProtocolUtils}
 import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils.FEATURE_PROP_SUPPORTED
 import org.apache.spark.sql.delta.coordinatedcommits.UCTokenBasedRestClientFactory
@@ -168,50 +169,91 @@ private[catalog] class UCDeltaCatalogClientImpl(
   private def lower(key: String) = key.toLowerCase(java.util.Locale.ROOT)
 
   /**
-   * Lower case keys of all table properties that should be skipped instead of carrying forward to
-   * the REPLACE-ed table.
+   * Lower case keys of `delta.*` properties to skip instead of carrying forward on REPLACE. Delta
+   * manages each of these itself on the commit, so a carried value would be stale, conflicting, or
+   * simply ignored -- whether recomputed from other state, derived from the feature set, or
+   * re-applied from the existing snapshot's metadata (see the per-entry reason). Properties that
+   * *define* the table's shape (table features, feature-enablement configs) are deliberately NOT
+   * here -- those must carry forward.
    */
   private val propertiesToSkipCarryForwardOnReplace = Set(
     // Clustering has DDL-only enablement (`CLUSTER BY`); carrying it as a property would
     // both throw on REPLACE (`DELTA_CREATE_TABLE_SET_CLUSTERING_TABLE_FEATURE_NOT_ALLOWED`)
     // and block legitimate transitions away from a clustered table.
     lower(TableFeatureProtocolUtils.propertyKey(ClusteringTableFeature)),
-    // delta.columnMapping.maxColumnId changes as table schema changes. Not worth carrying forward.
-    lower(DeltaConfigs.COLUMN_MAPPING_MAX_ID.key))
+    // delta.columnMapping.maxColumnId is derived from the table schema. Not worth carrying forward.
+    lower(DeltaConfigs.COLUMN_MAPPING_MAX_ID.key),
+    // Protocol versions are derived from the feature set; Delta recomputes them from the carried
+    // features, so a carried value would wrongly pin the protocol.
+    lower(DeltaConfigs.MIN_READER_VERSION.key),
+    lower(DeltaConfigs.MIN_WRITER_VERSION.key),
+    // Row-tracking materialized column names are not derived, but Delta re-applies them from the
+    // existing snapshot's metadata on commit (MaterializedRow*.updateMaterializedColumnName,
+    // overwriting any carried value), so carrying them is redundant.
+    lower(MaterializedRowId.MATERIALIZED_COLUMN_NAME_PROP),
+    lower(MaterializedRowCommitVersion.MATERIALIZED_COLUMN_NAME_PROP),
+    // `delta.rowTracking.rowIdHighWaterMark` is a UC-side projection of Delta's
+    // `RowTrackingMetadataDomain` action (Delta itself stores the high water mark as domain
+    // metadata, not as a `delta.*` property -- "not recognized by this version of Delta" if
+    // injected as a property). Carrying it forward as an unknown property turns a no-op REPLACE
+    // into a real metadata update on the UC side and bumps `lastUpdateVersion`. Re-derived
+    // server-side from the post-replace snapshot's domain metadata; do not carry.
+    "delta.rowtracking.rowidhighwatermark",
+    // Metastore-only bookkeeping keys -- not real table config; re-derived by the UpdateCatalog
+    // hook from the new snapshot.
+    lower(DeltaConfigs.METASTORE_LAST_UPDATE_VERSION),
+    lower(DeltaConfigs.METASTORE_LAST_COMMIT_TIMESTAMP))
 
-  /**
-   * Returns whether `(key, value)` from an existing table's config should be carried forward
-   * when building the REPLACE-augmented property map.
-   */
-  private def isSafeToCarryForwardOnReplace(key: String, value: String): Boolean = {
+  /** Whether `key` from an existing table's config is eligible to carry forward on REPLACE. */
+  private def isSafeToCarryForwardOnReplace(key: String): Boolean = {
     val lKey = lower(key)
-    // Only `delta.*` keys are carried; non-`delta.*` user properties (e.g. `Foo=Bar`)
-    // follow normal REPLACE semantics -- the user's new TBLPROPERTIES is authoritative.
+    // Only `delta.*` keys are carried; non-`delta.*` user properties (e.g. `Foo=Bar`) follow
+    // normal REPLACE semantics where the caller's new TBLPROPERTIES is authoritative.
     if (!lKey.startsWith("delta.")) return false
     if (propertiesToSkipCarryForwardOnReplace.contains(lKey)) return false
-    // Defer remaining acceptance to Delta's own per-entry validator -- single source of truth
-    // for "would this survive the next commit". This would also filter out Delta-internal metadata
-    // like `delta.lastCommitTimestamp` (unregistered) and `delta.columnMapping.maxColumnId`
-    // (non-editable) that `validateConfigurations` would otherwise reject, if they weren't
-    // filtered out by propertiesToSkipCarryForwardOnReplace already.
-    passesDeltaConfigValidation(key, value)
+    true
+  }
+
+  /** Carries one eligible existing-table `(key, value)` into the REPLACE-augmented `augmented`. */
+  private def carryForwardExistingProperty(
+      augmented: util.Map[String, String], key: String, value: String): Unit = {
+    if (!isSafeToCarryForwardOnReplace(key)) return
+    if (passesDeltaConfigValidation(key, value)) {
+      // Recognized with a valid value: carry as-is. Caller value (if any) wins via `putIfAbsent`,
+      // and it is re-validated downstream like any other property.
+      augmented.putIfAbsent(key, value)
+    } else if (passesDeltaConfigValidation(key, value, allowArbitraryProperties = true) &&
+        !augmented.containsKey(key)) {
+      // Unknown to this Delta version (e.g. `delta.dummy_fake_key`): tag it so the create path
+      // re-injects it after `validateConfigurations`, which would otherwise reject the unknown key.
+      // Unknown keys are inert (Delta never reads them), so preserving them is safe -- but only
+      // when the caller didn't supply the key, keeping the "caller wins" precedence.
+      augmented.put(AbstractDeltaCatalogClient.CARRY_FORWARD_PREFIX + key, value)
+    }
+    // Else: a recognized key whose value this version can't parse (an organic config Delta
+    // generates/derives, e.g. `delta.columnMapping.mode` from a newer engine). Drop it and let
+    // Delta produce the value rather than injecting one it rejects. The allowArbitraryProperties
+    // check above separates this from an unknown key: it accepts unknown keys but still parses
+    // values of recognized ones.
   }
 
   /**
-   * True iff [[DeltaConfigs.validateConfiguration]] would accept `(key, value)` as a Delta
-   * table property. Wraps the validator to convert its throw-on-bad behavior into a
-   * boolean predicate.
+   * True iff [[DeltaConfigs.validateConfiguration]] accepts `(key, value)` as a Delta table
+   * property, converting its throw-on-bad behavior into a boolean.
    */
-  private def passesDeltaConfigValidation(key: String, value: String): Boolean = {
+  private def passesDeltaConfigValidation(
+      key: String, value: String, allowArbitraryProperties: Boolean = false): Boolean = {
     try {
       DeltaConfigs.validateConfiguration(
-        key, value, allowArbitraryProperties = false, allConfigurations = Map.empty)
+        key, value, allowArbitraryProperties, allConfigurations = Map.empty)
       true
     } catch {
-      // Delta's structured-error exceptions for bad keys (DELTA_UNKNOWN_CONFIGURATION,
-      // DELTA_CANNOT_MODIFY_TABLE_PROPERTY, etc.), and the raw IllegalArgumentException
-      // raised by `require(...)` in the value parser.
-      case _: DeltaThrowable | _: IllegalArgumentException =>
+      // `validateConfiguration` signals "not an acceptable Delta property" by throwing: an unknown
+      // key (DELTA_UNKNOWN_CONFIGURATION), a non-editable key, or any value-parser failure
+      // (IllegalArgumentException from `require(...)`, ColumnMappingUnsupportedException for an
+      // unknown column-mapping mode, etc.). Treat any non-fatal throw as "does not pass" rather
+      // than enumerating the parser's exception types, which has proven incomplete.
+      case NonFatal(_) =>
         logDebug(log"Skipping invalid Delta config " +
           log"'${MDC(DeltaLogKeys.CONFIG_KEY, key)}'='${MDC(DeltaLogKeys.CONFIG, value)}'.")
         false
@@ -345,11 +387,12 @@ private[catalog] class UCDeltaCatalogClientImpl(
     // Carry forward the existing table's `delta.*` properties (feature flags, checkpoint
     // policy, column-mapping mode, row-tracking state, etc.) so REPLACE doesn't silently
     // strip critical configs that downstream (Table Service / commit validation) would
-    // reject as unsupported changes. Caller-supplied TBLPROPERTIES on the REPLACE win via
-    // `putIfAbsent`. See [[isSafeToCarryForwardOnReplace]] for the carry-forward criteria.
+    // reject as unsupported changes. See [[carryForwardExistingProperty]] for how each entry
+    // is carried (recognized vs unrecognized) and the caller-wins precedence.
     Option(info.getMetadata.getConfiguration).foreach { existingConfig =>
       existingConfig.asScala.foreach { case (k, v) =>
-        if (v != null && isSafeToCarryForwardOnReplace(k, v)) augmented.putIfAbsent(k, v)
+        // `null` values are engine-generated-at-commit sentinels (see applySuggestedProperties).
+        if (v != null) carryForwardExistingProperty(augmented, k, v)
       }
     }
     // Re-emit the existing provider so downstream sees USING <provider> even if the caller

--- a/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
@@ -595,17 +595,88 @@ class AbstractDeltaCatalogClientRoutingSuite extends QueryTest with DeltaSQLComm
         "carrying it would also block REPLACE transitions away from a clustered table")
   }
 
-  test("loadTableAndBuildReplaceProps: does NOT carry Delta-internal / non-editable keys") {
+  test("loadTableAndBuildReplaceProps: does NOT carry derived / internal keys (not even tagged)") {
     val client = replaceClient(existingDeltaTableInfo(additionalConfig = Map(
-      // Delta-internal metadata that's not in DeltaConfigs.entries.
+      // Metastore-only bookkeeping; re-derived by the UpdateCatalog hook from the new snapshot.
       "delta.lastCommitTimestamp" -> "1234567890",
-      // Registered but non-editable; rejected by `DELTA_CANNOT_MODIFY_TABLE_PROPERTY`.
-      "delta.columnMapping.maxColumnId" -> "5")))
+      "delta.lastUpdateVersion" -> "7",
+      // Derived from the table schema.
+      "delta.columnMapping.maxColumnId" -> "5",
+      // Protocol versions, derived from the feature set.
+      "delta.minReaderVersion" -> "3",
+      "delta.minWriterVersion" -> "7",
+      // Engine-generated row-tracking materialized column names.
+      "delta.rowTracking.materializedRowIdColumnName" -> "_row-id-col-abc",
+      "delta.rowTracking.materializedRowCommitVersionColumnName" -> "_row-commit-version-col-xyz")))
     val out = client.loadTableAndBuildReplaceProps(
       Identifier.of(Array("sch"), "tbl"),
       stageProps("delta.feature.catalogManaged" -> "supported"))
-    assert(!out.containsKey("delta.lastCommitTimestamp"))
-    assert(!out.containsKey("delta.columnMapping.maxColumnId"))
+    val prefix = AbstractDeltaCatalogClient.CARRY_FORWARD_PREFIX
+    Seq(
+      "delta.lastCommitTimestamp",
+      "delta.lastUpdateVersion",
+      "delta.columnMapping.maxColumnId",
+      "delta.minReaderVersion",
+      "delta.minWriterVersion",
+      "delta.rowTracking.materializedRowIdColumnName",
+      "delta.rowTracking.materializedRowCommitVersionColumnName")
+      .foreach { k =>
+        assert(!out.containsKey(k), s"$k must not be carried forward")
+        assert(!out.containsKey(prefix + k), s"$k must not be tagged for carry-forward either")
+      }
+  }
+
+  test("loadTableAndBuildReplaceProps: carries forward existing arbitrary delta.* keys tagged " +
+      "for downstream re-injection") {
+    val client = replaceClient(existingDeltaTableInfo(additionalConfig = Map(
+      "delta.dummy_fake_key" -> "dummyValue",
+      "delta.random" -> "1")))
+    val out = client.loadTableAndBuildReplaceProps(
+      Identifier.of(Array("sch"), "tbl"),
+      stageProps("delta.feature.catalogManaged" -> "supported"))
+    val prefix = AbstractDeltaCatalogClient.CARRY_FORWARD_PREFIX
+    // Keys unknown to this Delta version are carried under the prefix so they bypass downstream
+    // `validateConfigurations` (which would reject them as DELTA_UNKNOWN_CONFIGURATION) and get
+    // re-injected after validation.
+    assert(out.get(prefix + "delta.dummy_fake_key") === "dummyValue")
+    assert(out.get(prefix + "delta.random") === "1")
+    // They must NOT appear under the bare key, which would hit validation and throw.
+    assert(!out.containsKey("delta.dummy_fake_key"))
+    assert(!out.containsKey("delta.random"))
+  }
+
+  test("loadTableAndBuildReplaceProps: does NOT carry a recognized key whose value this Delta " +
+      "version rejects (left to Delta's organic generation)") {
+    // `delta.columnMapping.mode` is a config this Delta version recognizes and manages, but the
+    // value `index` is one it doesn't know (e.g. a mode a newer engine introduced). Unlike a
+    // genuinely unknown key, this is an organic config Delta generates/derives itself, so the
+    // unparseable value must NOT be carried -- neither under the bare key nor tagged -- and is
+    // left to Delta's own handling.
+    val client = replaceClient(existingDeltaTableInfo(additionalConfig = Map(
+      "delta.columnMapping.mode" -> "index")))
+    val out = client.loadTableAndBuildReplaceProps(
+      Identifier.of(Array("sch"), "tbl"),
+      stageProps("delta.feature.catalogManaged" -> "supported"))
+    val prefix = AbstractDeltaCatalogClient.CARRY_FORWARD_PREFIX
+    assert(!out.containsKey("delta.columnMapping.mode"))
+    assert(!out.containsKey(prefix + "delta.columnMapping.mode"))
+  }
+
+  test("loadTableAndBuildReplaceProps: caller-supplied unknown delta.* is not tagged " +
+      "(stays subject to downstream validation)") {
+    val client = replaceClient(existingDeltaTableInfo(additionalConfig = Map(
+      "delta.random" -> "from-existing")))
+    val out = client.loadTableAndBuildReplaceProps(
+      Identifier.of(Array("sch"), "tbl"),
+      stageProps(
+        "delta.feature.catalogManaged" -> "supported",
+        "delta.random" -> "from-caller"))
+    val prefix = AbstractDeltaCatalogClient.CARRY_FORWARD_PREFIX
+    // Caller wins: their value stays under the bare key and is NOT tagged, so it reaches
+    // `validateConfigurations` downstream and is rejected -- the other half of the asymmetry.
+    assert(out.get("delta.random") === "from-caller")
+    assert(!out.containsKey(prefix + "delta.random"),
+      "a caller-supplied key must not be tagged for validation-bypass")
   }
 
   test("loadTableAndBuildReplaceProps: caller TBLPROPERTIES wins over carried-forward value") {

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaManagedReplaceSemanticsTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaManagedReplaceSemanticsTest.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.UUID;
 import org.apache.hadoop.fs.Path;
 import org.apache.spark.sql.catalyst.analysis.CannotReplaceMissingTableException;
+import org.apache.spark.sql.delta.sources.DeltaSQLConf;
 import org.junit.jupiter.api.Test;
 
 public class UCDeltaManagedReplaceSemanticsTest extends UCDeltaTableIntegrationBaseTest {
@@ -236,6 +237,75 @@ public class UCDeltaManagedReplaceSemanticsTest extends UCDeltaTableIntegrationB
             assertThat(tableProperty(fullTableName, "myapp.version")).isEqualTo("2");
           });
     }
+  }
+
+  // An existing managed table can carry `delta.*` properties this Delta build does not recognize
+  // (e.g. `delta.random`). Such keys can only be set with `allowArbitraryProperties` on, since
+  // normal validation rejects unknown `delta.*` keys.
+  // A later REPLACE that does NOT restate them -- with validation back on -- must carry them
+  // forward into the replaced table rather than dropping them or failing the REPLACE.
+  @Test
+  public void testCarryForwardOfArbitraryDeltaPropertyOnManagedReplace() throws Exception {
+    String tableName = "carry_fwd_arbitrary_" + UUID.randomUUID().toString().replace("-", "");
+    String fullTableName = fullTableName(tableName);
+    String arbitraryPropsConf = DeltaSQLConf.ALLOW_ARBITRARY_TABLE_PROPERTIES().key();
+    try {
+      // Seed the table with unknown delta.* keys -- only possible with arbitrary props allowed.
+      spark().conf().set(arbitraryPropsConf, "true");
+      sql(
+          "CREATE TABLE %s (i INT, s STRING) USING DELTA TBLPROPERTIES ("
+              + "'delta.feature.catalogManaged'='supported', "
+              + "'delta.dummy_fake_key'='dummyValue', "
+              + "'delta.random'='carried')",
+          fullTableName);
+      sql("INSERT INTO %s VALUES (1, 'old')", fullTableName);
+      long versionBefore = currentVersion(fullTableName);
+
+      // Validation back on: a bare REPLACE that doesn't restate the unknown keys must still carry
+      // them forward (they bypass validateConfigurations via the carry-forward tagging path).
+      spark().conf().set(arbitraryPropsConf, "false");
+      sql("REPLACE TABLE %s (i INT, s STRING) USING DELTA", fullTableName);
+
+      // The REPLACE actually committed and replaced the data (bare REPLACE leaves the table empty),
+      // so the property carry-forward below is asserted on the post-REPLACE table.
+      assertThat(currentVersion(fullTableName)).isEqualTo(versionBefore + 1);
+      assertThat(sql("SELECT COUNT(*) FROM %s", fullTableName)).containsExactly(row("0"));
+      // SHOW TBLPROPERTIES resolves from the Delta snapshot metadata, so this confirms the keys
+      // are persisted in the committed `Metadata.configuration`, not merely in the catalog.
+      assertThat(tableProperty(fullTableName, "delta.dummy_fake_key")).isEqualTo("dummyValue");
+      assertThat(tableProperty(fullTableName, "delta.random")).isEqualTo("carried");
+    } finally {
+      spark().conf().set(arbitraryPropsConf, "false");
+      sql("DROP TABLE IF EXISTS %s", fullTableName);
+    }
+  }
+
+  // The flip side of carry-forward: a caller that explicitly puts an unknown `delta.*` key in the
+  // REPLACE TBLPROPERTIES (with validation on) must be rejected -- only the existing table's
+  // already-committed value is grandfathered, never fresh caller input. The existing table must
+  // survive the rejected REPLACE intact.
+  @Test
+  public void testCallerSpecifiedUnknownDeltaPropertyIsRejectedOnManagedReplace() throws Exception {
+    withNewTable(
+        "reject_caller_unknown_delta",
+        "i INT, s STRING",
+        TableType.MANAGED,
+        fullTableName -> {
+          sql("INSERT INTO %s VALUES (1, 'old')", fullTableName);
+          long versionBefore = currentVersion(fullTableName);
+
+          assertThrowsWithCauseContaining(
+              "DELTA_UNKNOWN_CONFIGURATION",
+              () ->
+                  sql(
+                      "REPLACE TABLE %s (i INT, s STRING) USING DELTA TBLPROPERTIES ("
+                          + "'delta.feature.catalogManaged'='supported', 'delta.random'='x')",
+                      fullTableName));
+
+          // The rejected REPLACE must not have committed a new version.
+          assertThat(currentVersion(fullTableName)).isEqualTo(versionBefore);
+          assertThat(sql("SELECT * FROM %s", fullTableName)).containsExactly(row("1", "old"));
+        });
   }
 
   // Schema change (adding a column) during REPLACE succeeds through UC updateTable.


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
[Spark] Carry forward unrecognized delta.* properties on catalog-managed REPLACE

When a catalog-managed Delta table is REPLACE-d, preserve the existing delta.* properties that this Delta version does not recognize, instead of silently dropping them.

- Unknown existing keys are carried forward (tagged through staging, re-injected after config validation) so they survive into the replaced table.
- Caller-supplied unknown keys remain rejected.
- Recognized keys whose value this version cannot parse are not carried; they are left for Delta to regenerate.

## How was this patch tested?
Covered by unit tests and a UC integration test.

## Does this PR introduce _any_ user-facing changes? No.
