### PR TITLE
[Spark][4.3] Read-time CDF via table_changes() in DSv2 (#6857)

### DIFF
--- a/spark-unified/src/main/scala-shims/spark-4.0/io/delta/internal/ResolveTableChangesV2.scala
+++ b/spark-unified/src/main/scala-shims/spark-4.0/io/delta/internal/ResolveTableChangesV2.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.internal
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.rules.Rule
+
+/** No-op shim of `ResolveTableChangesV2` for Spark 4.0. */
+class ResolveTableChangesV2(session: SparkSession) extends Rule[LogicalPlan] {
+  override def apply(plan: LogicalPlan): LogicalPlan = plan
+}

--- a/spark-unified/src/main/scala-shims/spark-4.1/io/delta/internal/ResolveTableChangesV2.scala
+++ b/spark-unified/src/main/scala-shims/spark-4.1/io/delta/internal/ResolveTableChangesV2.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.internal
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.rules.Rule
+
+/** No-op shim of `ResolveTableChangesV2` for Spark 4.1. */
+class ResolveTableChangesV2(session: SparkSession) extends Rule[LogicalPlan] {
+  override def apply(plan: LogicalPlan): LogicalPlan = plan
+}

--- a/spark-unified/src/main/scala-shims/spark-4.2/io/delta/internal/ResolveTableChangesV2.scala
+++ b/spark-unified/src/main/scala-shims/spark-4.2/io/delta/internal/ResolveTableChangesV2.scala
@@ -1,0 +1,105 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.internal
+
+import io.delta.spark.internal.v2.catalog.DeltaV2Table
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.analysis.ChangelogInfoUtils
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.connector.catalog.{ChangelogInfo, Identifier}
+import org.apache.spark.sql.delta.{DeltaErrors, TableChanges}
+import org.apache.spark.sql.delta.catalog.{ChangelogSupport, DeltaV2TableMarker}
+import org.apache.spark.sql.delta.commands.cdc.CDCReader
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.execution.datasources.v2.{ChangelogTable, DataSourceV2Relation, DataSourceV2RelationShim}
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+/**
+ * Resolves CDF reads against V2 [[DeltaV2Table]] tables (`table_changes(...)` and
+ * `.option("readChangeFeed", "true").table(name)`) into the kernel-based DSv2 changelog plan.
+ *
+ * V1 [[org.apache.spark.sql.delta.catalog.DeltaTableV2]] CDC reads stay on the legacy path
+ * handled by [[org.apache.spark.sql.delta.DeltaAnalysis]]'s `TableChanges` rule -- the V1 rule
+ * skips itself when it sees a [[org.apache.spark.sql.delta.catalog.DeltaV2TableMarker]]
+ * child (the marker `DeltaV2Table` mixes in) so this rule can take over without contention.
+ */
+class ResolveTableChangesV2(session: SparkSession) extends Rule[LogicalPlan] {
+
+  override def apply(plan: LogicalPlan): LogicalPlan = {
+
+    if (!session.sessionState.conf.getConf(DeltaSQLConf.DELTA_CHANGELOG_V2_ENABLED)) return plan
+
+    plan.resolveOperators {
+      // `table_changes('t', 0, 5)` where the catalog returned DeltaV2Table. Rewrite the inner
+      // `DataSourceV2Relation(DeltaV2Table)` into a `ChangelogTable` plan; the result replaces
+      // the entire `TableChanges` node.
+      case tc: TableChanges if tc.child.resolved &&
+        plan.exists(DeltaV2TableMarker.isDeltaV2TableRelation) =>
+        tc.child.transformDown {
+          case DataSourceV2RelationShim(_: DeltaV2Table,
+          _, Some(catalog: ChangelogSupport), Some(ident), options) =>
+            buildChangelogRelation(catalog, ident, options)
+        }
+
+      // `.option("readChangeFeed", "true").table(name)` where the catalog returned DeltaV2Table
+      // (no `TableChanges` wrapper -- the relation flows straight into the query).
+      case DataSourceV2RelationShim(_: DeltaV2Table,
+      _, Some(catalog: ChangelogSupport), Some(ident), options)
+        if CDCReader.isCDCRead(options) =>
+        buildChangelogRelation(catalog, ident, options)
+    }
+  }
+
+  /**
+   * Builds a Spark DSv2 CDC relation for a Delta DSv2 table using the provided reader options.
+   */
+  private def buildChangelogRelation(
+      catalog: ChangelogSupport,
+      ident: Identifier,
+      options: CaseInsensitiveStringMap): LogicalPlan = {
+    rejectUnsupportedOptions(options)
+    // We can use [[ChangelogInfoUtils.fromOptions]] directly here because Spark's CDC options
+    // match Delta's CDF options, e.p. startingVersion, endingVersion.
+    val baseInfo = ChangelogInfoUtils.fromOptions(
+      options,
+      session.sessionState.conf.sessionLocalTimeZone)
+    val info = new ChangelogInfo(
+      baseInfo.range(),
+      ChangelogInfo.DeduplicationMode.DROP_CARRYOVERS,
+      /* computeUpdates = */ true)
+    val changelog = catalog.loadChangelog(ident, info)
+    DataSourceV2Relation.create(
+      ChangelogTable(changelog, info), Some(catalog), Some(ident), options)
+  }
+
+  /**
+   * Rejects options that aren't supposed to be supported with Delta CDF, even though Spark's CDC
+   * implementation can support these modes.
+   */
+  private def rejectUnsupportedOptions(options: CaseInsensitiveStringMap): Unit = {
+    val unsupportedOptions = Seq(
+      "computeUpdates",
+      "deduplicationMode",
+      "startingBoundInclusive",
+      "endingBoundInclusive")
+    unsupportedOptions.foreach { key =>
+      if (options.containsKey(key)) throw DeltaErrors.changelogUnsupportedOption(key)
+    }
+  }
+}

--- a/spark-unified/src/main/scala/io/delta/sql/DeltaSparkSessionExtension.scala
+++ b/spark-unified/src/main/scala/io/delta/sql/DeltaSparkSessionExtension.scala
@@ -16,7 +16,7 @@
 
 package io.delta.sql
 
-import io.delta.internal.{ApplyV2ReadOptions, ApplyV2Streaming}
+import io.delta.internal.{ApplyV2ReadOptions, ApplyV2Streaming, ResolveTableChangesV2}
 import org.apache.spark.sql.SparkSessionExtensions
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.rules.Rule
@@ -89,6 +89,11 @@ class DeltaSparkSessionExtension extends AbstractDeltaSparkSessionExtension {
     // ApplyV2Streaming so it sees both V1-converted and catalog-loaded relations.
     extensions.injectResolutionRule { _ =>
       new ApplyV2ReadOptions
+    }
+
+    // Resolve CDF batch reads against the V2 DeltaV2Table to Spark's DSv2 CDC implementation.
+    extensions.injectResolutionRule { session =>
+      new ResolveTableChangesV2(session)
     }
   }
 

--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -436,6 +436,12 @@
     ],
     "sqlState" : "0AKDE"
   },
+  "DELTA_CHANGELOG_UNSUPPORTED_OPTION" : {
+    "message" : [
+      "The `<option>` option is not supported by the read-time CDC reader. Remove it from your query."
+    ],
+    "sqlState" : "0AKDC"
+  },
   "DELTA_CHANGE_DATA_FEED_INCOMPATIBLE_DATA_SCHEMA" : {
     "message" : [
       "Retrieving table changes between version <start> and <end> failed because of an incompatible data schema.",

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
@@ -27,8 +27,8 @@ import org.apache.spark.sql.delta.Relocated._
 import org.apache.spark.sql.delta.DataFrameUtils
 import org.apache.spark.sql.delta.DeltaErrors.{TemporallyUnstableInputException, TimestampEarlierThanCommitRetentionException}
 import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils
+import org.apache.spark.sql.delta.catalog.{DeltaTableV2, DeltaV2TableMarker}
 import org.apache.spark.sql.delta.catalog.DeltaCatalogV1
-import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.catalog.IcebergTablePlaceHolder
 import org.apache.spark.sql.delta.commands._
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
@@ -391,8 +391,10 @@ class DeltaAnalysis(protected val session: SparkSession)
     case stmt: CDCStatementBase if stmt.functionArgs.forall(_.resolved) =>
       stmt.toTableChanges(session)
 
-    case tc: TableChanges if tc.child.resolved => tc.toReadQuery
-
+    case tc: TableChanges if tc.child.resolved &&
+        // Skip CDF over DSv2 table, this will be resolved in [[ResolveTableChangesV2]].
+        !tc.child.exists(DeltaV2TableMarker.isDeltaV2TableRelation) =>
+      tc.toReadQuery
 
     // Here we take advantage of CreateDeltaTableCommand which takes a LogicalPlan for CTAS in order
     // to perform CLONE. We do this by passing the CloneTableCommand as the query in

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -595,6 +595,17 @@ trait DeltaErrorsBase
   }
 
   /**
+   * Read-time CDC reader rejected a reader option it doesn't honor (e.g. `computeUpdates`,
+   * `deduplicationMode`, `startingBoundInclusive`, `endingBoundInclusive`). See
+   * `ResolveTableChangesV2.rejectUnsupportedOptions` for the rejected set.
+   */
+  def changelogUnsupportedOption(option: String): Throwable = {
+    new DeltaIllegalArgumentException(
+      errorClass = "DELTA_CHANGELOG_UNSUPPORTED_OPTION",
+      messageParameters = Array(option))
+  }
+
+  /**
    * Throwable used for invalid CDC 'start' and 'end' options, where end < start
    */
   def endBeforeStartVersionInCDC(start: Long, end: Long): Throwable = {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaV2TableMarker.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaV2TableMarker.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.catalog
+
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2RelationShim
+
+/**
+ * Trait allowing V1 code path to identify a V2 [[DeltaV2Table]] without taking a dependency on
+ * that class that lives in a different target.
+ */
+trait DeltaV2TableMarker
+
+object DeltaV2TableMarker {
+
+  /** Whether the given plan is a relation over a [[DeltaV2Table]]. */
+  def isDeltaV2TableRelation(child: LogicalPlan): Boolean = child match {
+    case DataSourceV2RelationShim(_: DeltaV2TableMarker, _, _, _, _) => true
+    case _ => false
+  }
+}

--- a/spark/src/test/scala-shims/spark-4.2/org/apache/spark/sql/delta/DeltaV2CDFSuite.scala
+++ b/spark/src/test/scala-shims/spark-4.2/org/apache/spark/sql/delta/DeltaV2CDFSuite.scala
@@ -1,0 +1,454 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.test.SharedSparkSession
+
+/**
+ * Coverage for reading CDF via the existing Delta APIs (table_changes(),
+ * .option("readChangeData", "true")), but going through Spark DSv2 CDC read implementation.
+ */
+class DeltaV2CDFSuite
+  extends QueryTest
+  with SharedSparkSession
+  with DeltaSQLCommandTest {
+
+  override protected def sparkConf: SparkConf = super.sparkConf
+    // CDF defaults to off so the row-tracking table exercises the read-time CDF route.
+    .set(DeltaConfigs.CHANGE_DATA_FEED.defaultTablePropertyKey, "false")
+    .set(DeltaSQLConf.DELTA_CHANGELOG_V2_ENABLED.key, "true")
+
+  private def createRowTrackingTable(tbl: String): Unit = {
+    sql(
+      s"""CREATE TABLE $tbl (id BIGINT, name STRING) USING delta TBLPROPERTIES (
+         |  'delta.enableChangeDataFeed' = 'false',
+         |  'delta.enableRowTracking' = 'true',
+         |  'delta.enableDeletionVectors' = 'false'
+         |)""".stripMargin)
+    sql(s"INSERT INTO $tbl VALUES (1, 'Alice')")   // v1
+    sql(s"INSERT INTO $tbl VALUES (2, 'Bob')")     // v2
+    sql(s"INSERT INTO $tbl VALUES (3, 'Charlie')") // v3
+  }
+
+  private def withStrictV2[T](body: => T): T = {
+    withSQLConf(DeltaSQLConf.V2_ENABLE_MODE.key -> "STRICT")(body)
+  }
+
+  test("table_changes routes to V2 read-time CDF when catalog returns DeltaV2Table") {
+    val tbl = "rt_cdf_tbl"
+    withTable(tbl) {
+      createRowTrackingTable(tbl)
+      withStrictV2 {
+        val res = sql(s"SELECT id, name, _change_type FROM table_changes('$tbl', 1, 3)")
+          .orderBy("_commit_version", "id")
+        checkAnswer(
+          res,
+          Row(1L, "Alice", "insert") ::
+          Row(2L, "Bob", "insert") ::
+          Row(3L, "Charlie", "insert") :: Nil)
+      }
+    }
+  }
+
+  test("readChangeFeed via DataFrame.table() routes to V2 read-time CDF") {
+    val tbl = "rt_cdf_opt_tbl"
+    withTable(tbl) {
+      createRowTrackingTable(tbl)
+      withStrictV2 {
+        val res = spark.read.format("delta")
+          .option("readChangeFeed", "true")
+          .option("startingVersion", "1")
+          .option("endingVersion", "3")
+          .table(tbl)
+          .select("id", "name", "_change_type")
+          .orderBy("_commit_version", "id")
+        checkAnswer(
+          res,
+          Row(1L, "Alice", "insert") ::
+          Row(2L, "Bob", "insert") ::
+          Row(3L, "Charlie", "insert") :: Nil)
+      }
+    }
+  }
+
+  test("V1 mode keeps legacy CDCReader behavior: no CDF -> CHANGE_DATA_NOT_RECORDED") {
+    val tbl = "rt_cdf_v1_tbl"
+    withTable(tbl) {
+      createRowTrackingTable(tbl)
+      // Default V2_ENABLE_MODE is NONE, so catalog returns DeltaTableV2 and the V1 toReadQuery
+      // path runs CDCReader, which throws because `delta.enableChangeDataFeed` is unset.
+      checkError(
+        intercept[DeltaAnalysisException] {
+          sql(s"SELECT * FROM table_changes('$tbl', 1, 3)").collect()
+        },
+        "DELTA_MISSING_CHANGE_DATA",
+        parameters = Map(
+          "startVersion" -> "1",
+          "endVersion" -> "3",
+          "version" -> "1",
+          "key" -> DeltaConfigs.CHANGE_DATA_FEED.key))
+    }
+  }
+
+  test("V1 mode keeps legacy CDCReader for tables that DO have CDF enabled") {
+    val tbl = "rt_cdf_v1_cdf_on"
+    withTable(tbl) {
+      sql(
+        s"""CREATE TABLE $tbl (id BIGINT) USING delta TBLPROPERTIES (
+           |  'delta.enableChangeDataFeed' = 'true'
+           |)""".stripMargin)
+      sql(s"INSERT INTO $tbl VALUES (1), (2)")
+      val res = sql(s"SELECT id, _change_type FROM table_changes('$tbl', 1, 1)")
+        .orderBy("id")
+      checkAnswer(res, Row(1L, "insert") :: Row(2L, "insert") :: Nil)
+    }
+  }
+
+  private val unsupportedOptionCases: Seq[(String, String)] = Seq(
+    "computeUpdates" -> "true",
+    "computeUpdates" -> "false",
+    "deduplicationMode" -> "dropCarryovers",
+    "deduplicationMode" -> "none",
+    "deduplicationMode" -> "netChanges",
+    "startingBoundInclusive" -> "true",
+    "startingBoundInclusive" -> "false",
+    "endingBoundInclusive" -> "true",
+    "endingBoundInclusive" -> "false")
+
+  for ((key, value) <- unsupportedOptionCases) {
+    test(s"$key=$value is rejected by the V2 CDC reader") {
+      val tbl = s"rt_cdf_${key}_$value".toLowerCase(java.util.Locale.ROOT)
+      withTable(tbl) {
+        createRowTrackingTable(tbl)
+        withStrictV2 {
+          checkError(
+            intercept[DeltaIllegalArgumentException] {
+              spark.read.format("delta")
+                .option("readChangeFeed", "true")
+                .option("startingVersion", "1")
+                .option("endingVersion", "3")
+                .option(key, value)
+                .table(tbl)
+                .collect()
+            },
+            "DELTA_CHANGELOG_UNSUPPORTED_OPTION",
+            sqlState = "0AKDC",
+            parameters = Map("option" -> key))
+        }
+      }
+    }
+  }
+
+  // TODO: Re-enable when Spark 4.2 is out. 4.2.0-preview5 doesn't yet contain post-processing
+  // for CDC in Spark that labels update pre/post images.
+  ignore("UPDATE: preimage/postimage pair emitted") {
+    val tbl = "rt_cdf_update"
+    withTable(tbl) {
+      createRowTrackingTable(tbl)
+      sql(s"UPDATE $tbl SET name = 'Robert' WHERE id = 2") // v4
+      withStrictV2 {
+        val res = sql(
+          s"SELECT id, name, _change_type FROM table_changes('$tbl', 4, 4)")
+          .orderBy("id", "_change_type")
+        checkAnswer(
+          res,
+          Row(2L, "Bob", "update_preimage") ::
+          Row(2L, "Robert", "update_postimage") :: Nil)
+      }
+    }
+  }
+
+  test("DELETE: surfaces as a `delete` row") {
+    val tbl = "rt_cdf_delete"
+    withTable(tbl) {
+      createRowTrackingTable(tbl) // v3
+      sql(s"DELETE FROM $tbl WHERE id = 2") // v4
+      withStrictV2 {
+        val res = sql(
+          s"SELECT id, name, _change_type FROM table_changes('$tbl', 4, 4)")
+          .orderBy("id")
+        checkAnswer(res, Row(2L, "Bob", "delete") :: Nil)
+      }
+    }
+  }
+
+  test("predicate filters drop non-matching change rows") {
+    val tbl = "rt_cdf_predicate"
+    withTable(tbl) {
+      createRowTrackingTable(tbl)           // v1-v3: insert id 1, 2, 3 (one file each)
+      sql(s"DELETE FROM $tbl WHERE id = 2") // v4: delete file 2
+      withStrictV2 {
+        checkAnswer(
+          sql(s"SELECT id, name, _change_type FROM table_changes('$tbl', 1, 4) WHERE id = 2"),
+          Row(2L, "Bob", "insert") ::
+          Row(2L, "Bob", "delete") :: Nil)
+        checkAnswer(
+          sql(s"SELECT id, _change_type FROM table_changes('$tbl', 1, 4) " +
+            "WHERE _change_type = 'delete'"),
+          Row(2L, "delete") :: Nil)
+      }
+    }
+  }
+
+  // TODO: Re-enable when Spark 4.2 is out. 4.2.0-preview5 doesn't yet contain post-processing
+  // for CDC in Spark that labels update pre/post images.
+  ignore("MERGE: insert/update/delete in one commit each surface with the right change_type") {
+    val src = "rt_cdf_merge_src"
+    val tgt = "rt_cdf_merge_tgt"
+    withTable(src, tgt) {
+      createRowTrackingTable(tgt)
+      sql(s"CREATE TABLE $src (id BIGINT, name STRING) USING delta")
+      sql(s"INSERT INTO $src VALUES (2, 'Robert'), (3, NULL), (4, 'Dave')")
+
+      sql(
+        s"""MERGE INTO $tgt t USING $src s ON t.id = s.id
+           |WHEN MATCHED AND s.name IS NULL THEN DELETE
+           |WHEN MATCHED THEN UPDATE SET t.name = s.name
+           |WHEN NOT MATCHED THEN INSERT (id, name) VALUES (s.id, s.name)""".stripMargin) // v4
+
+      withStrictV2 {
+        val res = sql(
+          s"SELECT id, name, _change_type FROM table_changes('$tgt', 4, 4)")
+          .orderBy("id", "_change_type")
+        checkAnswer(
+          res,
+          Row(2L, "Bob", "update_preimage") ::
+          Row(2L, "Robert", "update_postimage") ::
+          Row(3L, "Charlie", "delete") ::
+          Row(4L, "Dave", "insert") :: Nil)
+      }
+    }
+  }
+
+  // TODO: Re-enable when Spark 4.2 is out. 4.2.0-preview5 doesn't yet contain post-processing
+  // for CDC in Spark that drops carry-over rows / labels update pre/post images, both of which
+  // a multi-row base file rewritten by repeated DMLs relies on.
+  ignore("repeated DMLs touching the same base file diff to per-row changes") {
+    val tbl = "rt_cdf_repeated_dml"
+    withTable(tbl) {
+      sql(
+        s"""CREATE TABLE $tbl (id BIGINT, name STRING) USING delta TBLPROPERTIES (
+           |  'delta.enableChangeDataFeed' = 'false',
+           |  'delta.enableRowTracking' = 'true',
+           |  'delta.enableDeletionVectors' = 'false'
+           |)""".stripMargin)
+
+      sql(s"INSERT INTO $tbl VALUES (1, 'A'), (2, 'B'), (3, 'C')") // v1 writes a single file
+      sql(s"UPDATE $tbl SET name = 'B2' WHERE id = 2")             // v2 rewrites the file
+      sql(s"UPDATE $tbl SET name = 'C2' WHERE id = 3")             // v3 rewrites the file from v2
+      withStrictV2 {
+        val res = sql(s"SELECT id, name, _change_type FROM table_changes('$tbl', 2, 3)")
+        checkAnswer(
+          res,
+          Row(2L, "B", "update_preimage") ::
+          Row(2L, "B2", "update_postimage") ::
+          Row(3L, "C", "update_preimage") ::
+          Row(3L, "C2", "update_postimage") :: Nil)
+      }
+    }
+  }
+
+  // TODO: Re-enable once the V2 read-time CDF path applies deletion vectors. Today
+  // DeltaChangelogBatch reads whole data files and ignores DVs, and DeltaChangelog always
+  // reports containsCarryoverRows=true, so a DV-based DELETE (which references the same file
+  // with a DV rather than rewriting it) cancels out as a carry-over and the deleted row is
+  // never surfaced. Labeling also depends on the post-processing missing from 4.2.0-preview5.
+  ignore("deletion vectors: a DV-based DELETE surfaces the deleted row") {
+    val tbl = "rt_cdf_dv_delete"
+    withTable(tbl) {
+      sql(
+        s"""CREATE TABLE $tbl (id BIGINT, name STRING) USING delta TBLPROPERTIES (
+           |  'delta.enableChangeDataFeed' = 'false',
+           |  'delta.enableRowTracking' = 'true',
+           |  'delta.enableDeletionVectors' = 'true'
+           |)""".stripMargin)
+      sql(s"INSERT INTO $tbl VALUES (1, 'A'), (2, 'B'), (3, 'C')") // v1: one file
+      sql(s"DELETE FROM $tbl WHERE id = 2")                        // v2: writes a DV, keeps file
+      withStrictV2 {
+        val res = sql(s"SELECT id, name, _change_type FROM table_changes('$tbl', 2, 2)")
+          .orderBy("id")
+        checkAnswer(res, Row(2L, "B", "delete") :: Nil)
+      }
+    }
+  }
+
+  // TODO: Re-enable when Spark 4.2 is out. 4.2.0-preview5 doesn't yet contain post-processing
+  // for CDC in Spark that labels update pre/post images.
+  ignore("V2 mode with delta.enableChangeDataFeed=true also routes through the V2 reader") {
+    val tbl = "rt_cdf_v2_cdf_on"
+    withTable(tbl) {
+      sql(
+        s"""CREATE TABLE $tbl (id BIGINT, name STRING) USING delta TBLPROPERTIES (
+           |  'delta.enableChangeDataFeed' = 'true',
+           |  'delta.enableRowTracking' = 'true',
+           |  'delta.enableDeletionVectors' = 'false'
+           |)""".stripMargin)
+      sql(s"INSERT INTO $tbl VALUES (1, 'A'), (2, 'B')") // v1
+      sql(s"UPDATE $tbl SET name = 'b' WHERE id = 2")    // v2
+      withStrictV2 {
+        val res = sql(s"SELECT id, name, _change_type FROM table_changes('$tbl', 2, 2)")
+          .orderBy("id", "_change_type")
+        checkAnswer(
+          res,
+          Row(2L, "B", "update_preimage") ::
+          Row(2L, "b", "update_postimage") :: Nil)
+      }
+    }
+  }
+
+  test("table_changes_by_path stays on the V1 path even in V2 mode") {
+    // Path-based reads resolve through `UnresolvedPathBasedDeltaTableRelation` ->
+    // `getPathBasedDeltaTable`, which always returns a V1 `DeltaTableV2`.
+    // This test may need to be updated if/when we support DSv2 for path based access.
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      spark.range(2).toDF("id").write.format("delta")
+        .option("delta.enableRowTracking", "true")
+        .save(path)
+      withStrictV2 {
+        checkError(
+          intercept[DeltaAnalysisException] {
+            sql(s"SELECT * FROM table_changes_by_path('$path', 0, 0)").collect()
+          },
+          "DELTA_MISSING_CHANGE_DATA",
+          parameters = Map(
+            "startVersion" -> "0",
+            "endVersion" -> "0",
+            "version" -> "0",
+            "key" -> DeltaConfigs.CHANGE_DATA_FEED.key))
+      }
+    }
+  }
+
+  test("DELTA_CHANGELOG_V2_ENABLED=false leaves V2-resolved CDC plans unresolved") {
+    val tbl = "rt_cdf_changelog_v2_off"
+    withTable(tbl) {
+      createRowTrackingTable(tbl)
+      withStrictV2 {
+        withSQLConf(DeltaSQLConf.DELTA_CHANGELOG_V2_ENABLED.key -> "false") {
+          intercept[Exception] {
+            sql(s"SELECT * FROM table_changes('$tbl', 1, 3)").collect()
+          }
+        }
+      }
+    }
+  }
+
+  test("end < start range fails with a clear error") {
+    val tbl = "rt_cdf_empty_range"
+    withTable(tbl) {
+      createRowTrackingTable(tbl)
+      withStrictV2 {
+        checkError(
+          intercept[DeltaIllegalArgumentException] {
+            sql(s"SELECT * FROM table_changes('$tbl', 3, 1)").collect()
+          },
+          "DELTA_INVALID_CDC_RANGE",
+          parameters = Map("start" -> "3", "end" -> "1"))
+      }
+    }
+  }
+
+  test("start version after the latest commit fails with a clear error") {
+    val tbl = "rt_cdf_start_after_latest"
+    withTable(tbl) {
+      createRowTrackingTable(tbl) // latest is v3
+      withStrictV2 {
+        checkError(
+          intercept[DeltaIllegalArgumentException] {
+            sql(s"SELECT * FROM table_changes('$tbl', 99, 99)").collect()
+          },
+          "DELTA_CDC_START_VERSION_AFTER_LATEST",
+          parameters = Map("start" -> "99", "latest" -> "3"))
+      }
+    }
+  }
+
+  test("timestamp-range CDC read selects the right commits") {
+    val tbl = "rt_cdf_ts_range"
+    withTable(tbl) {
+      createRowTrackingTable(tbl)
+      val tsV2 = sql(s"DESCRIBE HISTORY $tbl")
+        .where("version = 2")
+        .select("timestamp")
+        .collect()
+        .head
+        .getTimestamp(0)
+        .toString
+      withStrictV2 {
+        val res = spark.read.format("delta")
+          .option("readChangeFeed", "true")
+          .option("startingTimestamp", tsV2)
+          .option("endingTimestamp", tsV2)
+          .table(tbl)
+          .select("id", "name", "_change_type")
+        checkAnswer(res, Row(2L, "Bob", "insert") :: Nil)
+      }
+    }
+  }
+
+  test("V2 CDC read on a table without row tracking fails with a clear error") {
+    val tbl = "rt_cdf_no_row_tracking"
+    withTable(tbl) {
+      sql(
+        s"""CREATE TABLE $tbl (id BIGINT) USING delta TBLPROPERTIES (
+           |  'delta.enableChangeDataFeed' = 'false',
+           |  'delta.enableRowTracking' = 'false'
+           |)""".stripMargin)
+      sql(s"INSERT INTO $tbl VALUES (1), (2)")
+      withStrictV2 {
+        checkError(
+          intercept[DeltaAnalysisException] {
+            sql(s"SELECT * FROM table_changes('$tbl', 1, 1)").collect()
+          },
+          "DELTA_CHANGELOG_REQUIRES_ROW_TRACKING",
+          parameters = Map("tableName" -> "spark_catalog.default.rt_cdf_no_row_tracking"))
+      }
+    }
+  }
+
+  test("time travel option combined with readChangeFeed is rejected") {
+    val tbl = "rt_cdf_time_travel"
+    withTable(tbl) {
+      createRowTrackingTable(tbl)
+      withStrictV2 {
+        // In V2 mode, the catalog returns DeltaV2Table from `loadTable(ident)`. The
+        // time-travel overload `loadTable(ident, version)` falls through to the parent
+        // `TableCatalog` default after `AbstractDeltaCatalog.loadTableWithTimeTravel` sees the
+        // non-DeltaTableV2 case, which throws Spark's `UNSUPPORTED_FEATURE.TIME_TRAVEL`. This
+        // also blocks `readChangeFeed` + `versionAsOf` -- the combination never reaches our
+        // V2 CDC rule.
+        checkError(
+          intercept[AnalysisException] {
+            spark.read.format("delta")
+              .option("readChangeFeed", "true")
+              .option("startingVersion", "1")
+              .option("endingVersion", "3")
+              .option("versionAsOf", "2")
+              .table(tbl)
+              .collect()
+          },
+          "UNSUPPORTED_FEATURE.TIME_TRAVEL",
+          parameters = Map("relationId" -> s"`spark_catalog`.`default`.`$tbl`"))
+      }
+    }
+  }
+}

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
@@ -66,6 +66,7 @@ import org.apache.spark.sql.delta.DeltaTableUtils;
 import org.apache.spark.sql.delta.RowCommitVersion$;
 import org.apache.spark.sql.delta.RowId$;
 import org.apache.spark.sql.delta.SparkTableShims$;
+import org.apache.spark.sql.delta.catalog.DeltaV2TableMarker;
 import org.apache.spark.sql.delta.commands.cdc.CDCReader;
 import org.apache.spark.sql.delta.sources.PersistedMetadata;
 import org.apache.spark.sql.execution.datasources.FileFormat$;
@@ -76,7 +77,8 @@ import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 
 /** DataSource V2 Table implementation for Delta Lake using the Delta Kernel API. */
-public class DeltaV2Table implements Table, SupportsRead, SupportsWrite, SupportsMetadataColumns {
+public class DeltaV2Table
+    implements Table, SupportsRead, SupportsWrite, SupportsMetadataColumns, DeltaV2TableMarker {
   private static final String METADATA_COLUMN_NAME = FileFormat$.MODULE$.METADATA_NAME();
   private static final String ROW_ID_METADATA_FIELD_NAME = RowId$.MODULE$.ROW_ID();
   private static final String ROW_COMMIT_VERSION_METADATA_FIELD_NAME =


### PR DESCRIPTION
Cherry-pick https://github.com/delta-io/delta/pull/6857 to 4.3 release branch `branch-4.3`

## Description
Builds on https://github.com/delta-io/delta/pull/6741 adding support for reading CDF using Spark new DSv2 CDC implementation shipping in Spark 4.2. This implementation computes changes at read-time without requiring enabling `delta.enableChangeDataFeed` on the table.

With https://github.com/delta-io/delta/pull/6741, the new implementation is available through a new Spark CDC API - e.g. SQL: `SELECT * FROM table CHANGES FROM VERSION 1 TO VERSION 10`


This PR now also allows querying CDF via existing Delta API (e.g. `table_changes()`). This only works if the table is resolved as a DSv2 table (`DeltaV2Table`) by the catalog, i.e. currently requires `V2_ENABLE_MODE=STRICT`.
DSv2 tables don't support reading existing Delta write-time CDF, so there's no overlap between previous capabilities on DSv1 tables and this change.

## How was this patch tested?
Added `DeltaV2CDCSuite` covering routing reads to Spark CDC implementation