### PR TITLE
[Spark][Tests] Add Python test for Delta tables with GeoSpatial types

### DIFF
--- a/python/delta/tests/test_deltatable.py
+++ b/python/delta/tests/test_deltatable.py
@@ -1619,6 +1619,34 @@ class DeltaTableTestsMixin:
         with self.assertRaises(TypeError):
             builder.clusterBy([1])  # type: ignore[list-item]
 
+    def test_create_table_geo_types(self) -> None:
+        try:
+            from pyspark.sql.types import GeometryType, GeographyType  # type: ignore[attr-defined]
+        except ImportError:
+            self.skipTest("Geo types are not supported in this version of PySpark.")
+
+        # Geo types are gated by both Spark (encoders, expressions) and Delta (table feature).
+        self.spark.conf.set("spark.sql.geospatial.enabled", "true")
+        self.spark.conf.set("spark.databricks.delta.geo.preview.enabled", "true")
+        try:
+            with self.tempTable() as tableName:
+                deltaTable = DeltaTable.create().tableName(tableName) \
+                    .addColumn("geom", dataType="geometry(4326)") \
+                    .addColumn("geog", dataType="geography(4326)") \
+                    .execute()
+                self.__verify_table_schema(tableName,
+                                           deltaTable.toDF().schema,
+                                           ["geom", "geog"],
+                                           [GeometryType(4326), GeographyType(4326)],
+                                           nullables={"geom", "geog"})
+                self.assertEqual(
+                    DeltaTable.forName(self.spark, tableName).toDF().count(),
+                    0
+                )
+        finally:
+            self.spark.conf.unset("spark.databricks.delta.geo.preview.enabled")
+            self.spark.conf.unset("spark.sql.geospatial.enabled")
+
     def __checkAnswer(self, df: DataFrame,
                       expectedAnswer: List[Any],
                       schema: Union[StructType, List[str]] = ["key", "value"]) -> None:


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

Part of https://github.com/delta-io/delta/issues/6622.

## Description

Extended geospatial test coverage in Python.

Adds Python test coverage for the GeoSpatial table feature (`GEOMETRY`/`GEOGRAPHY` types): `test_create_table_geo_types`: creates a Delta table via `DeltaTableBuilder.addColumn` with `geometry(4326)` / `geography(4326)` DDL strings, verifies the schema round-trips back as `GeometryType(4326)` / `GeographyType(4326)`, and reads the table back.

## How was this patch tested?

Added appropriate unit tests under `test_deltatable`.

## Does this PR introduce _any_ user-facing changes?

No, test-only change.