### PR TITLE
[Spark] Delta exception classes conversion for Spark Connect

### DIFF
--- a/python/delta/connect/__init__.py
+++ b/python/delta/connect/__init__.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 
+import delta.connect.exceptions  # noqa: F401; installs the Spark Connect exception conversion
 from delta.connect.tables import DeltaTable
 
 __all__ = ['DeltaTable']

--- a/python/delta/connect/__init__.py
+++ b/python/delta/connect/__init__.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-import delta.connect.exceptions  # noqa: F401; installs the Spark Connect exception conversion
+import delta.connect.exceptions  # noqa: F401; registers the Spark Connect exception conversion
 from delta.connect.tables import DeltaTable
 
 __all__ = ['DeltaTable']

--- a/python/delta/connect/__init__.py
+++ b/python/delta/connect/__init__.py
@@ -14,8 +14,7 @@
 # limitations under the License.
 #
 
-# Imported for its side effect: registers the Delta exception classes in PySpark's
-# Spark Connect error conversion.
+# Side effect: registers the Delta exception classes in PySpark's Spark Connect error conversion.
 import delta.connect.exceptions  # noqa: F401
 from delta.connect.tables import DeltaTable
 

--- a/python/delta/connect/__init__.py
+++ b/python/delta/connect/__init__.py
@@ -14,7 +14,9 @@
 # limitations under the License.
 #
 
-import delta.connect.exceptions  # noqa: F401; registers the Spark Connect exception conversion
+# Imported for its side effect: registers the Delta exception classes in PySpark's
+# Spark Connect error conversion.
+import delta.connect.exceptions  # noqa: F401
 from delta.connect.tables import DeltaTable
 
 __all__ = ['DeltaTable']

--- a/python/delta/connect/__init__.py
+++ b/python/delta/connect/__init__.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-# Side effect: registers the Delta exception classes in PySpark's Spark Connect error conversion.
+# Registers Delta's exception classes in PySpark's Spark Connect error conversion on import.
 import delta.connect.exceptions  # noqa: F401
 from delta.connect.tables import DeltaTable
 

--- a/python/delta/connect/exceptions.py
+++ b/python/delta/connect/exceptions.py
@@ -116,7 +116,7 @@ class ConcurrentTransactionException(SparkConnectGrpcException, BaseConcurrentTr
     """
 
 
-_delta_exceptions_registered = False
+_delta_exception_registered = False
 
 
 def _register_exception_class_mappings() -> None:
@@ -165,6 +165,6 @@ def _register_exception_class_mappings() -> None:
     )
 
 
-if not _delta_exceptions_registered:
+if not _delta_exception_registered:
     _register_exception_class_mappings()
-    _delta_exceptions_registered = True
+    _delta_exception_registered = True

--- a/python/delta/connect/exceptions.py
+++ b/python/delta/connect/exceptions.py
@@ -15,9 +15,11 @@
 #
 
 import json
-from typing import TYPE_CHECKING
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
 
-from pyspark.errors.exceptions.connect import SparkConnectException
+import pyspark.errors.exceptions.connect
+import pyspark.sql.connect.client.core
+from pyspark.errors.exceptions.connect import SparkConnectException, SparkConnectGrpcException
 
 from delta.exceptions.base import (
     DeltaConcurrentModificationException as BaseDeltaConcurrentModificationException,
@@ -32,9 +34,12 @@ from delta.exceptions.base import (
 
 if TYPE_CHECKING:
     from google.rpc.error_details_pb2 import ErrorInfo
+    from pyspark.sql.connect.proto import FetchErrorDetailsResponse
 
 
-class DeltaConcurrentModificationException(SparkConnectException, BaseDeltaConcurrentModificationException):
+class DeltaConcurrentModificationException(
+    SparkConnectGrpcException, BaseDeltaConcurrentModificationException
+):
     """
     The basic class for all Delta commit conflict exceptions.
 
@@ -44,7 +49,7 @@ class DeltaConcurrentModificationException(SparkConnectException, BaseDeltaConcu
     """
 
 
-class ConcurrentWriteException(SparkConnectException, BaseConcurrentWriteException):
+class ConcurrentWriteException(SparkConnectGrpcException, BaseConcurrentWriteException):
     """
     Thrown when a concurrent transaction has written data after the current transaction read the
     table.
@@ -55,7 +60,7 @@ class ConcurrentWriteException(SparkConnectException, BaseConcurrentWriteExcepti
     """
 
 
-class MetadataChangedException(SparkConnectException, BaseMetadataChangedException):
+class MetadataChangedException(SparkConnectGrpcException, BaseMetadataChangedException):
     """
     Thrown when the metadata of the Delta table has changed between the time of read
     and the time of commit.
@@ -66,7 +71,7 @@ class MetadataChangedException(SparkConnectException, BaseMetadataChangedExcepti
     """
 
 
-class ProtocolChangedException(SparkConnectException, BaseProtocolChangedException):
+class ProtocolChangedException(SparkConnectGrpcException, BaseProtocolChangedException):
     """
     Thrown when the protocol version has changed between the time of read
     and the time of commit.
@@ -77,7 +82,7 @@ class ProtocolChangedException(SparkConnectException, BaseProtocolChangedExcepti
     """
 
 
-class ConcurrentAppendException(SparkConnectException, BaseConcurrentAppendException):
+class ConcurrentAppendException(SparkConnectGrpcException, BaseConcurrentAppendException):
     """
     Thrown when files are added that would have been read by the current transaction.
 
@@ -87,7 +92,7 @@ class ConcurrentAppendException(SparkConnectException, BaseConcurrentAppendExcep
     """
 
 
-class ConcurrentDeleteReadException(SparkConnectException, BaseConcurrentDeleteReadException):
+class ConcurrentDeleteReadException(SparkConnectGrpcException, BaseConcurrentDeleteReadException):
     """
     Thrown when the current transaction reads data that was deleted by a concurrent transaction.
 
@@ -97,7 +102,9 @@ class ConcurrentDeleteReadException(SparkConnectException, BaseConcurrentDeleteR
     """
 
 
-class ConcurrentDeleteDeleteException(SparkConnectException, BaseConcurrentDeleteDeleteException):
+class ConcurrentDeleteDeleteException(
+    SparkConnectGrpcException, BaseConcurrentDeleteDeleteException
+):
     """
     Thrown when the current transaction deletes data that was deleted by a concurrent transaction.
 
@@ -107,7 +114,7 @@ class ConcurrentDeleteDeleteException(SparkConnectException, BaseConcurrentDelet
     """
 
 
-class ConcurrentTransactionException(SparkConnectException, BaseConcurrentTransactionException):
+class ConcurrentTransactionException(SparkConnectGrpcException, BaseConcurrentTransactionException):
     """
     Thrown when concurrent transaction both attempt to update the same idempotent transaction.
 
@@ -117,25 +124,97 @@ class ConcurrentTransactionException(SparkConnectException, BaseConcurrentTransa
     """
 
 
-def _convert_delta_exception(info: "ErrorInfo", message: str):
-    classes = []
-    if "classes" in info.metadata:
-        classes = json.loads(info.metadata["classes"])
+def _convert_delta_exception(classes: List[str], message: str, **kwargs: Any):
+    """
+    Maps a server-side Delta concurrency exception to its Delta-specific Python class.
 
+    kwargs carry the structured error metadata (errorClass, sql_state, server_stacktrace, ...)
+    accepted by SparkConnectGrpcException, so that the converted exception keeps the same
+    metadata as exceptions built through the generic conversion in
+    pyspark.errors.exceptions.connect.
+    """
     if "io.delta.exceptions.ConcurrentWriteException" in classes:
-        return ConcurrentWriteException(message)
+        return ConcurrentWriteException(message, **kwargs)
     if "io.delta.exceptions.MetadataChangedException" in classes:
-        return MetadataChangedException(message)
+        return MetadataChangedException(message, **kwargs)
     if "io.delta.exceptions.ProtocolChangedException" in classes:
-        return ProtocolChangedException(message)
+        return ProtocolChangedException(message, **kwargs)
     if "io.delta.exceptions.ConcurrentAppendException" in classes:
-        return ConcurrentAppendException(message)
+        return ConcurrentAppendException(message, **kwargs)
     if "io.delta.exceptions.ConcurrentDeleteReadException" in classes:
-        return ConcurrentDeleteReadException(message)
+        return ConcurrentDeleteReadException(message, **kwargs)
     if "io.delta.exceptions.ConcurrentDeleteDeleteException" in classes:
-        return ConcurrentDeleteDeleteException(message)
+        return ConcurrentDeleteDeleteException(message, **kwargs)
     if "io.delta.exceptions.ConcurrentTransactionException" in classes:
-        return ConcurrentTransactionException(message)
+        return ConcurrentTransactionException(message, **kwargs)
     if "io.delta.exceptions.DeltaConcurrentModificationException" in classes:
-        return DeltaConcurrentModificationException(message)
+        return DeltaConcurrentModificationException(message, **kwargs)
     return None
+
+
+_delta_exception_patched = False
+
+
+def _patch_convert_exception() -> None:
+    """
+    Patch PySpark's Spark Connect error conversion so that Delta concurrent-modification
+    exceptions raised by the server surface as their Delta-specific Python classes instead of
+    a generic SparkConnectGrpcException, keeping the structured error metadata intact.
+
+    This mirrors the patching delta.exceptions.captured does for the classic (py4j) client.
+    """
+    original_convert_exception = pyspark.errors.exceptions.connect.convert_exception
+
+    def convert_delta_exception(
+        info: "ErrorInfo",
+        truncated_message: str,
+        resp: Optional["FetchErrorDetailsResponse"] = None,
+        *args: Any,
+        **kwargs: Any,
+    ) -> SparkConnectException:
+        converted = original_convert_exception(info, truncated_message, resp, *args, **kwargs)
+        if not isinstance(converted, SparkConnectGrpcException):
+            return converted
+
+        classes: List[str] = []
+        if "classes" in info.metadata:
+            classes = json.loads(info.metadata["classes"])
+
+        # The raw server-side message, mirroring pyspark's _convert_exception. The converted
+        # exception's message cannot be reused: the UnknownException branch of the generic
+        # conversion prefixes it with "(<reason>) ".
+        if resp is not None and resp.HasField("root_error_idx"):
+            message = resp.errors[resp.root_error_idx].message
+        else:
+            message = truncated_message
+
+        # Rebuild the structured error metadata that the generic conversion attached to the
+        # converted exception. _display_stacktrace and _sql_state have no public accessors
+        # returning the raw values (getSqlState falls back to an error-class lookup);
+        # getGrpcStatusCode and the matching constructor kwarg only exist on newer PySpark
+        # versions.
+        metadata_kwargs: Dict[str, Any] = {
+            "errorClass": converted.getCondition(),
+            "messageParameters": converted.getMessageParameters(),
+            "sql_state": converted._sql_state,
+            "server_stacktrace": converted.getStackTrace(),
+            "display_server_stacktrace": converted._display_stacktrace,
+            "contexts": converted.getQueryContext(),
+        }
+        if hasattr(converted, "getGrpcStatusCode"):
+            metadata_kwargs["grpc_status_code"] = converted.getGrpcStatusCode()
+
+        delta_exception = _convert_delta_exception(classes, message, **metadata_kwargs)
+        if delta_exception is not None:
+            return delta_exception
+        return converted
+
+    pyspark.errors.exceptions.connect.convert_exception = convert_delta_exception
+    # SparkConnectClient binds convert_exception by name at import time, so the binding in
+    # pyspark.sql.connect.client.core must be replaced as well.
+    pyspark.sql.connect.client.core.convert_exception = convert_delta_exception
+
+
+if not _delta_exception_patched:
+    _patch_convert_exception()
+    _delta_exception_patched = True

--- a/python/delta/connect/exceptions.py
+++ b/python/delta/connect/exceptions.py
@@ -119,6 +119,23 @@ class ConcurrentTransactionException(SparkConnectGrpcException, BaseConcurrentTr
 _delta_exception_registered = False
 
 
+# Server-side Delta exception class name -> Python Delta exception class. We register only the
+# io.delta.exceptions.* names because those are the public API; org.apache.spark.sql.delta.* are
+# their internal Scala superclasses (returned in the class hierarchy at runtime) and are not part
+# of the contract user code catches. See _register_exception_class_mappings for how this is used.
+_DELTA_EXCEPTION_CLASS_MAPPING = {
+    "io.delta.exceptions.DeltaConcurrentModificationException":
+        DeltaConcurrentModificationException,
+    "io.delta.exceptions.ConcurrentWriteException": ConcurrentWriteException,
+    "io.delta.exceptions.MetadataChangedException": MetadataChangedException,
+    "io.delta.exceptions.ProtocolChangedException": ProtocolChangedException,
+    "io.delta.exceptions.ConcurrentAppendException": ConcurrentAppendException,
+    "io.delta.exceptions.ConcurrentDeleteReadException": ConcurrentDeleteReadException,
+    "io.delta.exceptions.ConcurrentDeleteDeleteException": ConcurrentDeleteDeleteException,
+    "io.delta.exceptions.ConcurrentTransactionException": ConcurrentTransactionException,
+}
+
+
 def _register_exception_class_mappings() -> None:
     """
     Register the Delta-specific exception classes in PySpark's Spark Connect error conversion.
@@ -130,39 +147,30 @@ def _register_exception_class_mappings() -> None:
     server-side stacktrace, message parameters, query contexts) the same way it does for its own
     exceptions.
 
-    The conversion iterates the server-sent class hierarchy (ordered most-derived first) and
-    returns the first name found in EXCEPTION_CLASS_MAPPING. Only the io.delta.exceptions.*
-    names are registered, and both a concrete exception and the base
-    DeltaConcurrentModificationException are, so the most-derived one wins. For example a
-    ConcurrentAppendException arrives as
+    The lookup iterates the server-sent class hierarchy (ordered most-derived first) and returns
+    on the first name found in EXCEPTION_CLASS_MAPPING. We register only io.delta.exceptions.*
+    names - both the concrete exceptions and their base DeltaConcurrentModificationException - so
+    the most-derived registered class wins over the base. For example a ConcurrentAppendException
+    arrives as
 
-        ["io.delta.exceptions.ConcurrentAppendException",  # registered, picked
-         "org.apache.spark.sql.delta.ConcurrentAppendException",  # not registered, skipped
-         "io.delta.exceptions.DeltaConcurrentModificationException",  # registered (base)
+        ["io.delta.exceptions.ConcurrentAppendException",              # <- picked (registered)
+         "org.apache.spark.sql.delta.ConcurrentAppendException",       # <- skipped (legacy alias,
+                                                                       #    not registered)
+         "io.delta.exceptions.DeltaConcurrentModificationException",   # <- would match, but the
+                                                                       #    earlier hit wins
          ...]
 
-    so it matches the io.delta.exceptions.ConcurrentAppendException entry and maps to the Delta
-    ConcurrentAppendException class, rather than the base DeltaConcurrentModificationException.
+    and maps to the concrete ConcurrentAppendException, not the base.
+
+    The org.apache.spark.sql.delta.* entries are internal Scala superclasses of the
+    io.delta.exceptions.* classes; they appear in the hierarchy at runtime but are not part of the
+    user-facing catch contract, so we deliberately don't register them.
 
     This mirrors, for Spark Connect, the conversion that delta.exceptions.captured installs for
     the classic (py4j) client.
     """
     pyspark.errors.exceptions.connect.EXCEPTION_CLASS_MAPPING.update(
-        {
-            "io.delta.exceptions.DeltaConcurrentModificationException":
-                DeltaConcurrentModificationException,
-            "io.delta.exceptions.ConcurrentWriteException": ConcurrentWriteException,
-            "io.delta.exceptions.MetadataChangedException": MetadataChangedException,
-            "io.delta.exceptions.ProtocolChangedException": ProtocolChangedException,
-            "io.delta.exceptions.ConcurrentAppendException": ConcurrentAppendException,
-            "io.delta.exceptions.ConcurrentDeleteReadException":
-                ConcurrentDeleteReadException,
-            "io.delta.exceptions.ConcurrentDeleteDeleteException":
-                ConcurrentDeleteDeleteException,
-            "io.delta.exceptions.ConcurrentTransactionException":
-                ConcurrentTransactionException,
-        }
-    )
+        _DELTA_EXCEPTION_CLASS_MAPPING)
 
 
 if not _delta_exception_registered:

--- a/python/delta/connect/exceptions.py
+++ b/python/delta/connect/exceptions.py
@@ -131,15 +131,18 @@ def _register_exception_class_mappings() -> None:
     exceptions.
 
     The conversion iterates the server-sent class hierarchy (ordered most-derived first) and
-    returns the first registered match. A Delta exception's hierarchy contains both its concrete
-    class and the base DeltaConcurrentModificationException, both registered here, so the order
-    decides which wins. For example a ConcurrentAppendException arrives as
+    returns the first name found in EXCEPTION_CLASS_MAPPING. Only the io.delta.exceptions.*
+    names are registered, and both a concrete exception and the base
+    DeltaConcurrentModificationException are, so the most-derived one wins. For example a
+    ConcurrentAppendException arrives as
 
-        ["io.delta.exceptions.ConcurrentAppendException",
-         "org.apache.spark.sql.delta.ConcurrentAppendException",
-         "io.delta.exceptions.DeltaConcurrentModificationException", ...]
+        ["io.delta.exceptions.ConcurrentAppendException",  # registered, picked
+         "org.apache.spark.sql.delta.ConcurrentAppendException",  # not registered, skipped
+         "io.delta.exceptions.DeltaConcurrentModificationException",  # registered (base)
+         ...]
 
-    and maps to ConcurrentAppendException, not the base DeltaConcurrentModificationException.
+    so it matches the io.delta.exceptions.ConcurrentAppendException entry and maps to the Delta
+    ConcurrentAppendException class, rather than the base DeltaConcurrentModificationException.
 
     This mirrors, for Spark Connect, the conversion that delta.exceptions.captured installs for
     the classic (py4j) client.

--- a/python/delta/connect/exceptions.py
+++ b/python/delta/connect/exceptions.py
@@ -14,12 +14,8 @@
 # limitations under the License.
 #
 
-import json
-from typing import Any, Dict, List, Optional, TYPE_CHECKING
-
 import pyspark.errors.exceptions.connect
-import pyspark.sql.connect.client.core
-from pyspark.errors.exceptions.connect import SparkConnectException, SparkConnectGrpcException
+from pyspark.errors.exceptions.connect import SparkConnectGrpcException
 
 from delta.exceptions.base import (
     DeltaConcurrentModificationException as BaseDeltaConcurrentModificationException,
@@ -31,10 +27,6 @@ from delta.exceptions.base import (
     ConcurrentDeleteDeleteException as BaseConcurrentDeleteDeleteException,
     ConcurrentTransactionException as BaseConcurrentTransactionException,
 )
-
-if TYPE_CHECKING:
-    from google.rpc.error_details_pb2 import ErrorInfo
-    from pyspark.sql.connect.proto import FetchErrorDetailsResponse
 
 
 class DeltaConcurrentModificationException(
@@ -124,97 +116,41 @@ class ConcurrentTransactionException(SparkConnectGrpcException, BaseConcurrentTr
     """
 
 
-def _convert_delta_exception(classes: List[str], message: str, **kwargs: Any):
+_delta_exceptions_registered = False
+
+
+def _register_exception_class_mappings() -> None:
     """
-    Maps a server-side Delta concurrency exception to its Delta-specific Python class.
+    Register the Delta-specific exception classes in PySpark's Spark Connect error conversion
+    (EXCEPTION_CLASS_MAPPING maps server-side exception class names to Python exception
+    classes), so that Delta concurrent-modification exceptions raised by the server surface as
+    these classes instead of a generic SparkConnectGrpcException. The generic conversion
+    attaches the structured error metadata (error class, SQL state, server-side stacktrace,
+    message parameters, query contexts) to the registered classes the same way as to PySpark's
+    own exceptions. The conversion walks the server-sent class hierarchy from the most derived
+    class, so the most specific registered class wins.
 
-    kwargs carry the structured error metadata (errorClass, sql_state, server_stacktrace, ...)
-    accepted by SparkConnectGrpcException, so that the converted exception keeps the same
-    metadata as exceptions built through the generic conversion in
-    pyspark.errors.exceptions.connect.
+    This mirrors, for Spark Connect, the conversion patch that delta.exceptions.captured
+    installs for the classic (py4j) client.
     """
-    if "io.delta.exceptions.ConcurrentWriteException" in classes:
-        return ConcurrentWriteException(message, **kwargs)
-    if "io.delta.exceptions.MetadataChangedException" in classes:
-        return MetadataChangedException(message, **kwargs)
-    if "io.delta.exceptions.ProtocolChangedException" in classes:
-        return ProtocolChangedException(message, **kwargs)
-    if "io.delta.exceptions.ConcurrentAppendException" in classes:
-        return ConcurrentAppendException(message, **kwargs)
-    if "io.delta.exceptions.ConcurrentDeleteReadException" in classes:
-        return ConcurrentDeleteReadException(message, **kwargs)
-    if "io.delta.exceptions.ConcurrentDeleteDeleteException" in classes:
-        return ConcurrentDeleteDeleteException(message, **kwargs)
-    if "io.delta.exceptions.ConcurrentTransactionException" in classes:
-        return ConcurrentTransactionException(message, **kwargs)
-    if "io.delta.exceptions.DeltaConcurrentModificationException" in classes:
-        return DeltaConcurrentModificationException(message, **kwargs)
-    return None
-
-
-_delta_exception_patched = False
-
-
-def _patch_convert_exception() -> None:
-    """
-    Patch PySpark's Spark Connect error conversion so that Delta concurrent-modification
-    exceptions raised by the server surface as their Delta-specific Python classes instead of
-    a generic SparkConnectGrpcException, keeping the structured error metadata intact.
-
-    This mirrors the patching delta.exceptions.captured does for the classic (py4j) client.
-    """
-    original_convert_exception = pyspark.errors.exceptions.connect.convert_exception
-
-    def convert_delta_exception(
-        info: "ErrorInfo",
-        truncated_message: str,
-        resp: Optional["FetchErrorDetailsResponse"] = None,
-        *args: Any,
-        **kwargs: Any,
-    ) -> SparkConnectException:
-        converted = original_convert_exception(info, truncated_message, resp, *args, **kwargs)
-        if not isinstance(converted, SparkConnectGrpcException):
-            return converted
-
-        classes: List[str] = []
-        if "classes" in info.metadata:
-            classes = json.loads(info.metadata["classes"])
-
-        # The raw server-side message, mirroring pyspark's _convert_exception. The converted
-        # exception's message cannot be reused: the UnknownException branch of the generic
-        # conversion prefixes it with "(<reason>) ".
-        if resp is not None and resp.HasField("root_error_idx"):
-            message = resp.errors[resp.root_error_idx].message
-        else:
-            message = truncated_message
-
-        # Rebuild the structured error metadata that the generic conversion attached to the
-        # converted exception. _display_stacktrace and _sql_state have no public accessors
-        # returning the raw values (getSqlState falls back to an error-class lookup);
-        # getGrpcStatusCode and the matching constructor kwarg only exist on newer PySpark
-        # versions.
-        metadata_kwargs: Dict[str, Any] = {
-            "errorClass": converted.getCondition(),
-            "messageParameters": converted.getMessageParameters(),
-            "sql_state": converted._sql_state,
-            "server_stacktrace": converted.getStackTrace(),
-            "display_server_stacktrace": converted._display_stacktrace,
-            "contexts": converted.getQueryContext(),
+    pyspark.errors.exceptions.connect.EXCEPTION_CLASS_MAPPING.update(
+        {
+            "io.delta.exceptions.DeltaConcurrentModificationException":
+                DeltaConcurrentModificationException,
+            "io.delta.exceptions.ConcurrentWriteException": ConcurrentWriteException,
+            "io.delta.exceptions.MetadataChangedException": MetadataChangedException,
+            "io.delta.exceptions.ProtocolChangedException": ProtocolChangedException,
+            "io.delta.exceptions.ConcurrentAppendException": ConcurrentAppendException,
+            "io.delta.exceptions.ConcurrentDeleteReadException":
+                ConcurrentDeleteReadException,
+            "io.delta.exceptions.ConcurrentDeleteDeleteException":
+                ConcurrentDeleteDeleteException,
+            "io.delta.exceptions.ConcurrentTransactionException":
+                ConcurrentTransactionException,
         }
-        if hasattr(converted, "getGrpcStatusCode"):
-            metadata_kwargs["grpc_status_code"] = converted.getGrpcStatusCode()
-
-        delta_exception = _convert_delta_exception(classes, message, **metadata_kwargs)
-        if delta_exception is not None:
-            return delta_exception
-        return converted
-
-    pyspark.errors.exceptions.connect.convert_exception = convert_delta_exception
-    # SparkConnectClient binds convert_exception by name at import time, so the binding in
-    # pyspark.sql.connect.client.core must be replaced as well.
-    pyspark.sql.connect.client.core.convert_exception = convert_delta_exception
+    )
 
 
-if not _delta_exception_patched:
-    _patch_convert_exception()
-    _delta_exception_patched = True
+if not _delta_exceptions_registered:
+    _register_exception_class_mappings()
+    _delta_exceptions_registered = True

--- a/python/delta/connect/exceptions.py
+++ b/python/delta/connect/exceptions.py
@@ -121,17 +121,28 @@ _delta_exceptions_registered = False
 
 def _register_exception_class_mappings() -> None:
     """
-    Register the Delta-specific exception classes in PySpark's Spark Connect error conversion
-    (EXCEPTION_CLASS_MAPPING maps server-side exception class names to Python exception
-    classes), so that Delta concurrent-modification exceptions raised by the server surface as
-    these classes instead of a generic SparkConnectGrpcException. The generic conversion
-    attaches the structured error metadata (error class, SQL state, server-side stacktrace,
-    message parameters, query contexts) to the registered classes the same way as to PySpark's
-    own exceptions. The conversion walks the server-sent class hierarchy from the most derived
-    class, so the most specific registered class wins.
+    Register the Delta-specific exception classes in PySpark's Spark Connect error conversion.
 
-    This mirrors, for Spark Connect, the conversion patch that delta.exceptions.captured
-    installs for the classic (py4j) client.
+    PySpark converts a server error by looking up the server-side exception class names in
+    EXCEPTION_CLASS_MAPPING. Registering the Delta classes there makes Delta commit-conflict
+    exceptions surface as these classes instead of a generic SparkConnectGrpcException, and lets
+    PySpark's generic conversion attach the structured error metadata (error class, SQL state,
+    server-side stacktrace, message parameters, query contexts) the same way it does for its own
+    exceptions.
+
+    The conversion iterates the server-sent class hierarchy (ordered most-derived first) and
+    returns the first registered match. A Delta exception's hierarchy contains both its concrete
+    class and the base DeltaConcurrentModificationException, both registered here, so the order
+    decides which wins. For example a ConcurrentAppendException arrives as
+
+        ["io.delta.exceptions.ConcurrentAppendException",
+         "org.apache.spark.sql.delta.ConcurrentAppendException",
+         "io.delta.exceptions.DeltaConcurrentModificationException", ...]
+
+    and maps to ConcurrentAppendException, not the base DeltaConcurrentModificationException.
+
+    This mirrors, for Spark Connect, the conversion that delta.exceptions.captured installs for
+    the classic (py4j) client.
     """
     pyspark.errors.exceptions.connect.EXCEPTION_CLASS_MAPPING.update(
         {

--- a/python/delta/connect/tests/test_exceptions.py
+++ b/python/delta/connect/tests/test_exceptions.py
@@ -19,7 +19,8 @@ import unittest
 
 from google.rpc.error_details_pb2 import ErrorInfo
 
-import delta.connect.exceptions  # noqa: F401; installs the conversion patch under test
+# Imported for its side effect: registers the exception class mappings under test.
+import delta.connect.exceptions  # noqa: F401
 import delta.exceptions
 from delta.connect.exceptions import ConcurrentAppendException
 

--- a/python/delta/connect/tests/test_exceptions.py
+++ b/python/delta/connect/tests/test_exceptions.py
@@ -1,0 +1,119 @@
+#
+# Copyright (2024) The Delta Lake Project Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import json
+import unittest
+
+from google.rpc.error_details_pb2 import ErrorInfo
+
+import delta.connect.exceptions  # noqa: F401; installs the conversion patch under test
+import delta.exceptions
+from delta.connect.exceptions import ConcurrentAppendException
+
+import pyspark.sql.connect.client.core
+import pyspark.sql.connect.proto as pb2
+from pyspark.errors.exceptions.connect import AnalysisException
+
+
+class DeltaConnectExceptionConversionTests(unittest.TestCase):
+    """
+    Tests for the Spark Connect error conversion patch installed by delta.connect.exceptions.
+    These tests exercise the conversion directly from constructed gRPC error payloads and do
+    not need a Spark Connect server.
+    """
+
+    def _convert(self, info, truncated_message, resp=None):
+        # Conversion goes through the patched binding used by SparkConnectClient.
+        return pyspark.sql.connect.client.core.convert_exception(info, truncated_message, resp)
+
+    def test_delta_exception_from_error_info(self):
+        info = ErrorInfo()
+        info.reason = "io.delta.exceptions.ConcurrentAppendException"
+        info.metadata["classes"] = json.dumps([
+            "io.delta.exceptions.ConcurrentAppendException",
+            "io.delta.exceptions.DeltaConcurrentModificationException",
+        ])
+        info.metadata["errorClass"] = "DELTA_CONCURRENT_APPEND"
+        info.metadata["sqlState"] = "2D521"
+        info.metadata["messageParameters"] = json.dumps({"partition": "the root of the table"})
+
+        exception = self._convert(info, "Files were added by a concurrent update.")
+
+        self.assertIsInstance(exception, ConcurrentAppendException)
+        # User code catching the documented delta.exceptions types must keep working.
+        self.assertIsInstance(exception, delta.exceptions.ConcurrentAppendException)
+        self.assertEqual(exception.getCondition(), "DELTA_CONCURRENT_APPEND")
+        self.assertEqual(exception.getSqlState(), "2D521")
+        self.assertEqual(
+            exception.getMessageParameters(), {"partition": "the root of the table"})
+        # The "(<reason>) " prefix added by the generic conversion must not leak in.
+        self.assertEqual(exception.getMessage(), "Files were added by a concurrent update.")
+
+    def test_delta_exception_with_fetch_error_details(self):
+        # With an enriched error (FetchErrorDetailsResponse), the full message, the server-side
+        # stacktrace and the message parameters come from the response and must be preserved on
+        # the Delta-specific exception.
+        resp = pb2.FetchErrorDetailsResponse()
+        resp.root_error_idx = 0
+        error = resp.errors.add()
+        error.message = "Files were added by a concurrent update."
+        error.error_type_hierarchy.append("io.delta.exceptions.ConcurrentAppendException")
+        stack_frame = error.stack_trace.add()
+        stack_frame.declaring_class = "org.apache.spark.sql.delta.ConflictChecker"
+        stack_frame.method_name = "checkConflicts"
+        stack_frame.file_name = "ConflictChecker.scala"
+        stack_frame.line_number = 42
+        error.spark_throwable.error_class = "DELTA_CONCURRENT_APPEND"
+        error.spark_throwable.message_parameters["partition"] = "the root of the table"
+
+        info = ErrorInfo()
+        info.reason = "io.delta.exceptions.ConcurrentAppendException"
+        info.metadata["classes"] = json.dumps(["io.delta.exceptions.ConcurrentAppendException"])
+        info.metadata["errorClass"] = "DELTA_CONCURRENT_APPEND"
+
+        exception = self._convert(info, "Truncated message", resp)
+
+        self.assertIsInstance(exception, ConcurrentAppendException)
+        self.assertEqual(exception.getCondition(), "DELTA_CONCURRENT_APPEND")
+        self.assertEqual(
+            exception.getMessageParameters(), {"partition": "the root of the table"})
+        self.assertIn("ConflictChecker", exception.getStackTrace())
+        self.assertEqual(exception.getMessage(), "Files were added by a concurrent update.")
+
+    def test_non_delta_exception_is_unaffected(self):
+        info = ErrorInfo()
+        info.reason = "org.apache.spark.sql.AnalysisException"
+        info.metadata["classes"] = json.dumps(["org.apache.spark.sql.AnalysisException"])
+        info.metadata["errorClass"] = "TABLE_OR_VIEW_NOT_FOUND"
+        info.metadata["sqlState"] = "42P01"
+        info.metadata["messageParameters"] = json.dumps({"relationName": "`t`"})
+
+        exception = self._convert(
+            info, "[TABLE_OR_VIEW_NOT_FOUND] The table or view `t` cannot be found.")
+
+        self.assertIsInstance(exception, AnalysisException)
+        self.assertNotIsInstance(
+            exception, delta.exceptions.DeltaConcurrentModificationException)
+        self.assertEqual(exception.getCondition(), "TABLE_OR_VIEW_NOT_FOUND")
+
+
+if __name__ == "__main__":
+    try:
+        import xmlrunner
+        testRunner = xmlrunner.XMLTestRunner(output='target/test-reports', verbosity=4)
+    except ImportError:
+        testRunner = None
+    unittest.main(testRunner=testRunner, verbosity=4)

--- a/python/delta/connect/tests/test_exceptions.py
+++ b/python/delta/connect/tests/test_exceptions.py
@@ -62,14 +62,17 @@ class DeltaConnectExceptionConversionTests(unittest.TestCase):
         # User code catching the documented delta.exceptions types must keep working.
         self.assertIsInstance(exception, delta.exceptions.ConcurrentAppendException)
         # The base class is registered and present in the hierarchy too; the most-derived class
-        # must win. The Python exception classes are flat siblings, so this fails if the base
-        # were picked instead.
+        # must win. In Python, ConcurrentAppendException and DeltaConcurrentModificationException
+        # do not inherit from each other (unlike the Scala side), so isinstance returning False
+        # for the base is proof that the conversion picked the concrete class, not the base.
         self.assertNotIsInstance(exception, delta.exceptions.DeltaConcurrentModificationException)
         self.assertEqual(exception.getCondition(), "DELTA_CONCURRENT_APPEND")
         self.assertEqual(exception.getSqlState(), "2D521")
         self.assertEqual(
             exception.getMessageParameters(), {"partition": "the root of the table"})
-        # The "(<reason>) " prefix added by the generic conversion must not leak in.
+        # When no mapping matches, pyspark's fallback wraps the message as "(<reason>) <message>"
+        # on a SparkConnectGrpcException. Asserting the plain message here proves we hit the
+        # mapped Delta path, not the fallback.
         self.assertEqual(exception.getMessage(), "Files were added by a concurrent update.")
 
     def test_delta_base_exception_maps_to_base_class(self):

--- a/python/delta/connect/tests/test_exceptions.py
+++ b/python/delta/connect/tests/test_exceptions.py
@@ -30,13 +30,13 @@ from pyspark.errors.exceptions.connect import AnalysisException
 
 class DeltaConnectExceptionConversionTests(unittest.TestCase):
     """
-    Tests for the Spark Connect error conversion patch installed by delta.connect.exceptions.
-    These tests exercise the conversion directly from constructed gRPC error payloads and do
-    not need a Spark Connect server.
+    Tests for the exception class mappings registered by delta.connect.exceptions in PySpark's
+    Spark Connect error conversion. These tests exercise the conversion directly from
+    constructed gRPC error payloads and do not need a Spark Connect server.
     """
 
     def _convert(self, info, truncated_message, resp=None):
-        # Conversion goes through the patched binding used by SparkConnectClient.
+        # Conversion goes through the binding used by SparkConnectClient.
         return pyspark.sql.connect.client.core.convert_exception(info, truncated_message, resp)
 
     def test_delta_exception_from_error_info(self):

--- a/python/delta/connect/tests/test_exceptions.py
+++ b/python/delta/connect/tests/test_exceptions.py
@@ -19,7 +19,7 @@ import unittest
 
 from google.rpc.error_details_pb2 import ErrorInfo
 
-# Imported for its side effect: registers the exception class mappings under test.
+# Registers the exception class mappings under test (on import).
 import delta.connect.exceptions  # noqa: F401
 import delta.exceptions
 from delta.connect.exceptions import ConcurrentAppendException
@@ -43,8 +43,13 @@ class DeltaConnectExceptionConversionTests(unittest.TestCase):
     def test_delta_exception_from_error_info(self):
         info = ErrorInfo()
         info.reason = "io.delta.exceptions.ConcurrentAppendException"
+        # Realistic server-sent hierarchy, ordered most-derived first: the concrete class, its
+        # org.apache.spark.sql.delta parent (not registered), then the registered base class.
+        # Both io.delta.exceptions classes are registered, so the conversion must return the
+        # most-derived one.
         info.metadata["classes"] = json.dumps([
             "io.delta.exceptions.ConcurrentAppendException",
+            "org.apache.spark.sql.delta.ConcurrentAppendException",
             "io.delta.exceptions.DeltaConcurrentModificationException",
         ])
         info.metadata["errorClass"] = "DELTA_CONCURRENT_APPEND"
@@ -56,12 +61,30 @@ class DeltaConnectExceptionConversionTests(unittest.TestCase):
         self.assertIsInstance(exception, ConcurrentAppendException)
         # User code catching the documented delta.exceptions types must keep working.
         self.assertIsInstance(exception, delta.exceptions.ConcurrentAppendException)
+        # The base class is registered and present in the hierarchy too; the most-derived class
+        # must win. The Python exception classes are flat siblings, so this fails if the base
+        # were picked instead.
+        self.assertNotIsInstance(exception, delta.exceptions.DeltaConcurrentModificationException)
         self.assertEqual(exception.getCondition(), "DELTA_CONCURRENT_APPEND")
         self.assertEqual(exception.getSqlState(), "2D521")
         self.assertEqual(
             exception.getMessageParameters(), {"partition": "the root of the table"})
         # The "(<reason>) " prefix added by the generic conversion must not leak in.
         self.assertEqual(exception.getMessage(), "Files were added by a concurrent update.")
+
+    def test_delta_base_exception_maps_to_base_class(self):
+        # A payload whose only registered class is the abstract base maps to the base Delta
+        # exception (the catch-all for commit conflicts), not a generic SparkConnectGrpcException.
+        info = ErrorInfo()
+        info.reason = "io.delta.exceptions.DeltaConcurrentModificationException"
+        info.metadata["classes"] = json.dumps([
+            "io.delta.exceptions.DeltaConcurrentModificationException",
+        ])
+
+        exception = self._convert(info, "A concurrent modification occurred.")
+
+        self.assertIsInstance(
+            exception, delta.exceptions.DeltaConcurrentModificationException)
 
     def test_delta_exception_with_fetch_error_details(self):
         # With an enriched error (FetchErrorDetailsResponse), the full message, the server-side

--- a/python/delta/connect/tests/test_exceptions_init.py
+++ b/python/delta/connect/tests/test_exceptions_init.py
@@ -36,24 +36,11 @@ class DeltaConnectExceptionConversionInstalledTests(unittest.TestCase):
         # Each Delta concurrency exception must be registered in PySpark's conversion mapping,
         # keyed by its server-side class name and mapped to the matching delta.connect class.
         from pyspark.errors.exceptions.connect import EXCEPTION_CLASS_MAPPING
-        module = sys.modules.get("delta.connect.exceptions")
-        self.assertIsNotNone(
-            module, "import delta.connect did not import delta.connect.exceptions")
-        names = [
-            "DeltaConcurrentModificationException",
-            "ConcurrentWriteException",
-            "MetadataChangedException",
-            "ProtocolChangedException",
-            "ConcurrentAppendException",
-            "ConcurrentDeleteReadException",
-            "ConcurrentDeleteDeleteException",
-            "ConcurrentTransactionException",
-        ]
-        for name in names:
-            class_name = "io.delta.exceptions." + name
+        from delta.connect.exceptions import _DELTA_EXCEPTION_CLASS_MAPPING
+        for class_name, cls in _DELTA_EXCEPTION_CLASS_MAPPING.items():
             self.assertIs(
-                EXCEPTION_CLASS_MAPPING.get(class_name), getattr(module, name),
-                "%s is not registered to the Delta %s" % (class_name, name))
+                EXCEPTION_CLASS_MAPPING.get(class_name), cls,
+                "%s is not registered to %s" % (class_name, cls.__name__))
 
 
 if __name__ == "__main__":

--- a/python/delta/connect/tests/test_exceptions_init.py
+++ b/python/delta/connect/tests/test_exceptions_init.py
@@ -1,0 +1,65 @@
+#
+# Copyright (2024) The Delta Lake Project Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import sys
+import unittest
+
+# Import the package, not delta.connect.exceptions - run-tests.py runs this file in its own
+# process, and delta.connect.exceptions is imported only by delta/connect/__init__.py, so this
+# verifies that wiring installs the registration.
+import delta.connect  # noqa: F401
+
+
+class DeltaConnectExceptionConversionInstalledTests(unittest.TestCase):
+    def test_importing_delta_connect_installs_conversion(self):
+        # Inspect sys.modules rather than importing delta.connect.exceptions ourselves (which would
+        # set the flag regardless), so a missing import in delta/connect/__init__.py is caught.
+        module = sys.modules.get("delta.connect.exceptions")
+        self.assertIsNotNone(
+            module, "import delta.connect did not import delta.connect.exceptions")
+        self.assertTrue(module._delta_exception_registered)
+
+    def test_delta_exceptions_registered_in_mapping(self):
+        # Each Delta concurrency exception must be registered in PySpark's conversion mapping,
+        # keyed by its server-side class name and mapped to the matching delta.connect class.
+        from pyspark.errors.exceptions.connect import EXCEPTION_CLASS_MAPPING
+        module = sys.modules.get("delta.connect.exceptions")
+        self.assertIsNotNone(
+            module, "import delta.connect did not import delta.connect.exceptions")
+        names = [
+            "DeltaConcurrentModificationException",
+            "ConcurrentWriteException",
+            "MetadataChangedException",
+            "ProtocolChangedException",
+            "ConcurrentAppendException",
+            "ConcurrentDeleteReadException",
+            "ConcurrentDeleteDeleteException",
+            "ConcurrentTransactionException",
+        ]
+        for name in names:
+            class_name = "io.delta.exceptions." + name
+            self.assertIs(
+                EXCEPTION_CLASS_MAPPING.get(class_name), getattr(module, name),
+                "%s is not registered to the Delta %s" % (class_name, name))
+
+
+if __name__ == "__main__":
+    try:
+        import xmlrunner
+        testRunner = xmlrunner.XMLTestRunner(output='target/test-reports', verbosity=4)
+    except ImportError:
+        testRunner = None
+    unittest.main(testRunner=testRunner, verbosity=4)

--- a/python/delta/exceptions/__init__.py
+++ b/python/delta/exceptions/__init__.py
@@ -14,16 +14,12 @@
 # limitations under the License.
 #
 
-# Importing delta.exceptions.captured installs the conversion that makes the classic (py4j)
-# PySpark client raise the Delta-specific exceptions exported below. In a Spark Connect-only
-# install (pyspark-connect) there is no py4j and pyspark does not export SparkContext, so
-# captured's "from pyspark import SparkContext" raises ImportError; guard it so that importing
-# delta still works there. On that path the equivalent conversion is registered instead by
-# delta.connect.exceptions.
-try:
+from pyspark.util import is_remote_only
+
+# Installs the conversion for the classic (py4j) client; needs SparkContext, hence the
+# is_remote_only() guard. Spark Connect-only installs do this in delta/connect/__init__.py.
+if not is_remote_only():
     import delta.exceptions.captured  # noqa: F401
-except ImportError:
-    pass
 
 from delta.exceptions.base import (
     DeltaConcurrentModificationException,

--- a/python/delta/exceptions/__init__.py
+++ b/python/delta/exceptions/__init__.py
@@ -14,6 +14,15 @@
 # limitations under the License.
 #
 
+# Importing delta.exceptions.captured installs the conversion patch that makes the classic
+# (py4j) PySpark client raise the Delta-specific exceptions exported below. It cannot be
+# imported in Spark Connect-only environments, where pyspark ships without py4j; there the
+# equivalent patch is installed by delta.connect.exceptions.
+try:
+    import delta.exceptions.captured  # noqa: F401
+except ImportError:
+    pass
+
 from delta.exceptions.base import (
     DeltaConcurrentModificationException,
     ConcurrentWriteException,

--- a/python/delta/exceptions/__init__.py
+++ b/python/delta/exceptions/__init__.py
@@ -17,7 +17,7 @@
 # Importing delta.exceptions.captured installs the conversion patch that makes the classic
 # (py4j) PySpark client raise the Delta-specific exceptions exported below. It cannot be
 # imported in Spark Connect-only environments, where pyspark ships without py4j; there the
-# equivalent patch is installed by delta.connect.exceptions.
+# equivalent conversion is registered by delta.connect.exceptions.
 try:
     import delta.exceptions.captured  # noqa: F401
 except ImportError:

--- a/python/delta/exceptions/__init__.py
+++ b/python/delta/exceptions/__init__.py
@@ -17,7 +17,7 @@
 from pyspark.util import is_remote_only
 
 # Installs the conversion for the classic (py4j) client; needs SparkContext, hence the
-# is_remote_only() guard. Spark Connect-only installs do this in delta/connect/__init__.py.
+# is_remote_only() guard. The Spark connect-specific installs do this in delta/connect/__init__.py.
 if not is_remote_only():
     import delta.exceptions.captured  # noqa: F401
 

--- a/python/delta/exceptions/__init__.py
+++ b/python/delta/exceptions/__init__.py
@@ -14,10 +14,12 @@
 # limitations under the License.
 #
 
-# Importing delta.exceptions.captured installs the conversion patch that makes the classic
-# (py4j) PySpark client raise the Delta-specific exceptions exported below. It cannot be
-# imported in Spark Connect-only environments, where pyspark ships without py4j; there the
-# equivalent conversion is registered by delta.connect.exceptions.
+# Importing delta.exceptions.captured installs the conversion that makes the classic (py4j)
+# PySpark client raise the Delta-specific exceptions exported below. In a Spark Connect-only
+# install (pyspark-connect) there is no py4j and pyspark does not export SparkContext, so
+# captured's "from pyspark import SparkContext" raises ImportError; guard it so that importing
+# delta still works there. On that path the equivalent conversion is registered instead by
+# delta.connect.exceptions.
 try:
     import delta.exceptions.captured  # noqa: F401
 except ImportError:

--- a/python/delta/tables.py
+++ b/python/delta/tables.py
@@ -19,6 +19,7 @@ from typing import (
     TYPE_CHECKING, cast, overload, Any, Dict, Iterable, Optional, Union, NoReturn, List, Tuple
 )
 
+# Installs the Delta exception conversion on `import delta` (see delta.exceptions).
 import delta.exceptions  # noqa: F401; pylint: disable=unused-variable
 from delta._typing import (
     ColumnMapping, OptionalColumnMapping, ExpressionOrColumn, OptionalExpressionOrColumn

--- a/python/delta/tables.py
+++ b/python/delta/tables.py
@@ -19,6 +19,7 @@ from typing import (
     TYPE_CHECKING, cast, overload, Any, Dict, Iterable, Optional, Union, NoReturn, List, Tuple
 )
 
+import delta.exceptions  # noqa: F401; pylint: disable=unused-variable
 from delta._typing import (
     ColumnMapping, OptionalColumnMapping, ExpressionOrColumn, OptionalExpressionOrColumn
 )

--- a/python/delta/tests/test_exceptions.py
+++ b/python/delta/tests/test_exceptions.py
@@ -17,8 +17,6 @@
 from typing import Any, Callable, TYPE_CHECKING
 import unittest
 
-# Import the documented module (not delta.exceptions.captured directly) so this test also
-# verifies that importing delta.exceptions installs the exception conversion patch.
 import delta.exceptions as exceptions
 
 from delta.testing.utils import DeltaTestCase

--- a/python/delta/tests/test_exceptions.py
+++ b/python/delta/tests/test_exceptions.py
@@ -17,7 +17,9 @@
 from typing import Any, Callable, TYPE_CHECKING
 import unittest
 
-import delta.exceptions.captured as exceptions
+# Import the documented module (not delta.exceptions.captured directly) so this test also
+# verifies that importing delta.exceptions installs the exception conversion patch.
+import delta.exceptions as exceptions
 
 from delta.testing.utils import DeltaTestCase
 from pyspark.sql.utils import AnalysisException, IllegalArgumentException

--- a/python/delta/tests/test_exceptions_init.py
+++ b/python/delta/tests/test_exceptions_init.py
@@ -31,7 +31,7 @@ class DeltaClassicExceptionConversionInstalledTests(unittest.TestCase):
         # Inspect sys.modules rather than importing delta.exceptions.captured ourselves (which would
         # set the flag regardless), so a missing import in the chain is caught.
         module = sys.modules.get("delta.exceptions.captured")
-        self.assertIsNotNone(module, "import delta did not import delta.exceptions.captured")
+        assert module is not None, "import delta did not import delta.exceptions.captured"
         self.assertTrue(module._delta_exception_patched)
 
     @unittest.skipIf(is_remote_only(), "classic conversion needs py4j/SparkContext")

--- a/python/delta/tests/test_exceptions_init.py
+++ b/python/delta/tests/test_exceptions_init.py
@@ -1,0 +1,52 @@
+#
+# Copyright (2021) The Delta Lake Project Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import sys
+import unittest
+
+from pyspark.util import is_remote_only
+
+# Import delta, not delta.exceptions / delta.exceptions.captured - run-tests.py runs this file in
+# its own process, and captured is imported only via the import delta -> tables -> delta.exceptions
+# chain, so this verifies that wiring installs the conversion.
+import delta  # noqa: F401
+
+
+class DeltaClassicExceptionConversionInstalledTests(unittest.TestCase):
+    @unittest.skipIf(is_remote_only(), "classic conversion needs py4j/SparkContext")
+    def test_importing_delta_installs_conversion(self):
+        # Inspect sys.modules rather than importing delta.exceptions.captured ourselves (which would
+        # set the flag regardless), so a missing import in the chain is caught.
+        module = sys.modules.get("delta.exceptions.captured")
+        self.assertIsNotNone(module, "import delta did not import delta.exceptions.captured")
+        self.assertTrue(module._delta_exception_patched)
+
+    @unittest.skipIf(is_remote_only(), "classic conversion needs py4j/SparkContext")
+    def test_convert_exception_is_patched(self):
+        # delta replaces pyspark's classic convert_exception with its own wrapper; assert the
+        # installed function comes from delta (see delta/exceptions/captured.py).
+        import pyspark.errors.exceptions.captured as pyspark_captured
+        self.assertEqual(
+            pyspark_captured.convert_exception.__module__, "delta.exceptions.captured")
+
+
+if __name__ == "__main__":
+    try:
+        import xmlrunner
+        testRunner = xmlrunner.XMLTestRunner(output='target/test-reports', verbosity=4)
+    except ImportError:
+        testRunner = None
+    unittest.main(testRunner=testRunner, verbosity=4)

--- a/python/delta/tests/test_exceptions_init.py
+++ b/python/delta/tests/test_exceptions_init.py
@@ -27,7 +27,7 @@ import delta  # noqa: F401
 
 class DeltaClassicExceptionConversionInstalledTests(unittest.TestCase):
     @unittest.skipIf(is_remote_only(), "classic conversion needs py4j/SparkContext")
-    def test_importing_delta_installs_conversion(self):
+    def test_importing_delta_installs_conversion(self) -> None:
         # Inspect sys.modules rather than importing delta.exceptions.captured ourselves (which would
         # set the flag regardless), so a missing import in the chain is caught.
         module = sys.modules.get("delta.exceptions.captured")
@@ -35,7 +35,7 @@ class DeltaClassicExceptionConversionInstalledTests(unittest.TestCase):
         self.assertTrue(module._delta_exception_patched)
 
     @unittest.skipIf(is_remote_only(), "classic conversion needs py4j/SparkContext")
-    def test_convert_exception_is_patched(self):
+    def test_convert_exception_is_patched(self) -> None:
         # delta replaces pyspark's classic convert_exception with its own wrapper; assert the
         # installed function comes from delta (see delta/exceptions/captured.py).
         import pyspark.errors.exceptions.captured as pyspark_captured


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR fixes **two** problems with Delta's Python exception conversion, so that Delta commit
conflicts surface as the documented Delta-specific exception types (with their structured error
metadata) on both the Spark Connect and classic clients.

**1. Spark Connect: Delta commit conflicts were not converted, and would have lost their error
metadata.** The Delta-specific Spark Connect exception classes added in #4569
(`python/delta/connect/exceptions.py`) are dead code: their `_convert_delta_exception` hook has
no caller, so a Delta commit conflict surfaces as a generic
`SparkConnectGrpcException`/`UnknownException` and
`except delta.exceptions.ConcurrentAppendException` never matches. This PR wires the conversion by
registering the Delta classes in PySpark's
`EXCEPTION_CLASS_MAPPING` — the server-class-name to Python-exception table that drives
`pyspark.errors.exceptions.connect._convert_exception`; the unused `_convert_delta_exception`
hook is removed. Registration is installed on `import delta.connect` (e.g. when `DeltaTable`
dispatches to the Spark Connect implementation). The classes are now based on
`SparkConnectGrpcException` — the same base PySpark uses for its own mapped exceptions such as
`AnalysisException` — so the generic conversion constructs them with the full metadata, and
`getCondition()`, `getSqlState()`, `getStackTrace()` and `getMessageParameters()` work the same
as for any other Connect exception (matching classic py4j behavior). The conversion walks the
server-sent class hierarchy most-derived-first, so the specific Delta type wins over the base.

**2. Classic (py4j): the conversion was no longer installed automatically.** #4569 split
`delta/exceptions.py` into a package and dropped the `import delta.exceptions` side effect from
`delta/tables.py`, while `delta.exceptions.__init__` only re-exports the base classes — so the
patch that converts JVM Delta exceptions to the Delta-specific Python types was only installed if
user code imported `delta.exceptions.captured` directly (the test was changed to do exactly that,
which is why CI did not catch it). This PR restores the activation: `delta/tables.py` again
imports `delta.exceptions`, and `delta.exceptions` imports the captured module — gated by
`if not is_remote_only()`, the same predicate PySpark uses to decide whether `SparkContext`
exists, since captured depends on it and a Spark Connect-only install (`pyspark-connect`) does
not provide it. (On Spark Connect, conversion is handled by fix 1, not captured.)

## How was this patch tested?

New unit tests in `python/delta/connect/tests/test_exceptions.py` exercise the conversion with
the registered mappings directly from constructed gRPC error payloads (no Spark Connect server
needed):

- a Delta concurrency error converts to `delta.connect.exceptions.ConcurrentAppendException`,
  remains catchable as the documented `delta.exceptions.ConcurrentAppendException`, and keeps
  `getCondition()`, `getSqlState()`, `getMessageParameters()` and the raw message (no
  `"(<reason>) "` prefix leaking from the generic conversion);
- with an enriched error (`FetchErrorDetailsResponse`), the full message, the server-side
  stacktrace and the message parameters from the response are preserved;
- non-Delta exceptions (e.g. `AnalysisException`) are unaffected by the patch.

The existing `python/delta/tests/test_exceptions.py` now imports `delta.exceptions` (the
documented module) instead of `delta.exceptions.captured`, so it also verifies the restored
automatic patch activation on the classic path.

Two new `test_exceptions_init.py` suites (under `python/delta/connect/tests/` and
`python/delta/tests/`) guard the install wiring itself. `run-tests.py` runs each test file in its
own process, and they inspect `sys.modules` rather than importing the conversion module directly,
so the conversion can only have been installed by the package import under test:

- connect: `import delta.connect` registers all eight Delta concurrency classes in
  `EXCEPTION_CLASS_MAPPING`;
- classic: `import delta` patches PySpark's `convert_exception` (skipped under `is_remote_only()`,
  where the classic path does not apply).

## Does this PR introduce _any_ user-facing changes?

Yes:

- On Spark Connect, Delta commit conflicts now raise the documented Delta-specific exception
  types (`ConcurrentAppendException`, `ConcurrentWriteException`, `MetadataChangedException`,
  `ProtocolChangedException`, `ConcurrentDeleteReadException`, `ConcurrentDeleteDeleteException`,
  `ConcurrentTransactionException`, `DeltaConcurrentModificationException`) instead of a generic
  `SparkConnectGrpcException`/`UnknownException`, and these exceptions expose the structured
  error metadata (`getCondition()`, `getSqlState()`, `getStackTrace()`,
  `getMessageParameters()`). Code catching `SparkConnectGrpcException` keeps working, since the
  Delta classes now extend it.
- On classic clusters, importing `delta` (or `delta.exceptions`) again installs the exception
  conversion automatically, so Delta commit conflicts raise the Delta-specific exception types
  as documented — without requiring a direct import of the internal
  `delta.exceptions.captured` module.

## Not addressed here: the Scala Spark Connect client

This PR is Python-only. The classic Scala/JVM path needs no change — Delta throws
`io.delta.exceptions.*` directly and callers catch them natively, with no client-side
reconstruction. The Scala *Spark Connect* client, however, has the analogue of the gap this PR
fixes for Python: it does not convert Delta commit conflicts to the typed `io.delta.exceptions.*`
classes, so they surface as a generic `SparkException`. Unlike the Python connect path — whose
`EXCEPTION_CLASS_MAPPING` is a module global Delta can register into — Spark's Scala
`GrpcExceptionConverter` exposes no third-party registration hook (its mapping is
`private[client]`), so closing that gap would require an upstream Spark change. Left as a
follow-up.