### PR TITLE
[Spark][4.3] Fix Parquet schema converter compatibility across Spark patches

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
@@ -903,15 +903,12 @@ object Snapshot extends DeltaLogging {
       spark: SparkSession,
       deltaLog: DeltaLog,
       file: FileStatus): (StructType, Long) = {
-    // Converter used to convert Parquet `MessageType` to Spark SQL `StructType`
-    val converter = new ParquetToSparkSchemaConverter(
-      assumeBinaryIsString = spark.sessionState.conf.isParquetBinaryAsString,
-      assumeInt96IsTimestamp = spark.sessionState.conf.isParquetINT96AsTimestamp)
-
     val conf = deltaLog.newDeltaHadoopConf()
+    // Converter used to convert Parquet `MessageType` to Spark SQL `StructType`
+    val converter = new ParquetToSparkSchemaConverter(spark.sessionState.conf)
 
     val parquetMetadata = {
-      ParquetFileReader.readFooter(deltaLog.newDeltaHadoopConf(), file.getPath)
+      ParquetFileReader.readFooter(conf, file.getPath)
     }
     val rowCount = parquetMetadata.getBlocks.asScala.map(_.getRowCount).sum
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/convert/ConvertUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/convert/ConvertUtils.scala
@@ -334,14 +334,7 @@ trait ConvertUtilsBase extends DeltaLogging {
 /**
  * Configuration for fetching Parquet schema.
  *
- * @param assumeBinaryIsString: whether unannotated BINARY fields should be assumed to be Spark
- *                              SQL [[StringType]] fields.
- * @param assumeInt96IsTimestamp: whether unannotated INT96 fields should be assumed to be Spark
- *                                SQL [[TimestampType]] fields.
  * @param ignoreCorruptFiles: a boolean indicating whether corrupt files should be ignored during
  *                            schema retrieval.
  */
-case class ParquetSchemaFetchConfig(
-  assumeBinaryIsString: Boolean,
-  assumeInt96IsTimestamp: Boolean,
-  ignoreCorruptFiles: Boolean)
+case class ParquetSchemaFetchConfig(ignoreCorruptFiles: Boolean)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/convert/ParquetFileManifest.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/convert/ParquetFileManifest.scala
@@ -57,10 +57,7 @@ class ManualListingFileManifest(
       }.toMap
       val footerSeq = DeltaFileOperations.readParquetFootersInParallel(
         conf.value.value, fileStatuses.map(_.toFileStatus), fetchConfig.ignoreCorruptFiles)
-      val schemaConverter = new ParquetToSparkSchemaConverter(
-        assumeBinaryIsString = fetchConfig.assumeBinaryIsString,
-        assumeInt96IsTimestamp = fetchConfig.assumeInt96IsTimestamp
-      )
+      val schemaConverter = new ParquetToSparkSchemaConverter(conf.value.value)
       footerSeq.map { footer =>
         val fileStatus = pathToStatusMapping(footer.getFile.toString)
         val schema = ParquetFileFormat.readSchemaFromFooter(footer, schemaConverter)
@@ -138,10 +135,7 @@ class CatalogFileManifest(
           conf.value.value,
           fileStatuses.map(_.toFileStatus),
           fetchConfig.ignoreCorruptFiles)
-        val schemaConverter = new ParquetToSparkSchemaConverter(
-          assumeBinaryIsString = fetchConfig.assumeBinaryIsString,
-          assumeInt96IsTimestamp = fetchConfig.assumeInt96IsTimestamp
-        )
+        val schemaConverter = new ParquetToSparkSchemaConverter(conf.value.value)
         footerSeq.map { footer =>
           val schema = ParquetFileFormat.readSchemaFromFooter(footer, schemaConverter)
           val fileStatus = pathToFile(footer.getFile.toString)
@@ -211,10 +205,7 @@ class MetadataLogFileManifest(
       }.toMap
       val footerSeq = DeltaFileOperations.readParquetFootersInParallel(
         conf.value.value, fileStatuses.map(_.toFileStatus), fetchConfig.ignoreCorruptFiles)
-      val schemaConverter = new ParquetToSparkSchemaConverter(
-        assumeBinaryIsString = fetchConfig.assumeBinaryIsString,
-        assumeInt96IsTimestamp = fetchConfig.assumeInt96IsTimestamp
-      )
+      val schemaConverter = new ParquetToSparkSchemaConverter(conf.value.value)
       footerSeq.map { footer =>
         val fileStatus = pathToStatusMapping(footer.getFile.toString)
         val schema = ParquetFileFormat.readSchemaFromFooter(footer, schemaConverter)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/convert/ParquetTable.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/convert/ParquetTable.scala
@@ -54,9 +54,14 @@ class ParquetTable(
   }
 
   protected lazy val serializableConf: SerializableConfiguration = {
-    // scalastyle:off deltahadoopconfiguration
     val sqlConf = spark.sessionState.conf
+    // scalastyle:off deltahadoopconfiguration
     val hadoopConf = spark.sessionState.newHadoopConf()
+    // scalastyle:on deltahadoopconfiguration
+
+    // ParquetToSparkSchemaConverter(Configuration) requires these SQLConf values to be
+    // present in the Hadoop conf. newHadoopConf only includes SQL configs explicitly set
+    // by the user, so copy the required values here just like Spark's Parquet reader does.
     hadoopConf.setBoolean(SQLConf.PARQUET_BINARY_AS_STRING.key, sqlConf.isParquetBinaryAsString)
     hadoopConf.setBoolean(SQLConf.PARQUET_INT96_AS_TIMESTAMP.key, sqlConf.isParquetINT96AsTimestamp)
     hadoopConf.setBoolean(SQLConf.CASE_SENSITIVE.key, sqlConf.caseSensitiveAnalysis)
@@ -66,11 +71,7 @@ class ParquetTable(
     hadoopConf.setBoolean(
       SQLConf.LEGACY_PARQUET_NANOS_AS_LONG.key,
       sqlConf.legacyParquetNanosAsLong)
-    hadoopConf.setBoolean(
-      SQLConf.PARQUET_FIELD_ID_READ_ENABLED.key,
-      sqlConf.parquetFieldIdReadEnabled)
     new SerializableConfiguration(hadoopConf)
-    // scalastyle:on deltahadoopconfiguration
   }
 
   override val partitionSchema: StructType = {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/convert/ParquetTable.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/convert/ParquetTable.scala
@@ -28,6 +28,7 @@ import org.apache.spark.sql.{AnalysisException, SparkSession}
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.execution.datasources.PartitioningUtils
 import org.apache.spark.sql.execution.datasources.parquet.{ParquetFileFormat, ParquetToSparkSchemaConverter}
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.SerializableConfiguration
 
@@ -54,7 +55,21 @@ class ParquetTable(
 
   protected lazy val serializableConf: SerializableConfiguration = {
     // scalastyle:off deltahadoopconfiguration
-    new SerializableConfiguration(spark.sessionState.newHadoopConf())
+    val sqlConf = spark.sessionState.conf
+    val hadoopConf = spark.sessionState.newHadoopConf()
+    hadoopConf.setBoolean(SQLConf.PARQUET_BINARY_AS_STRING.key, sqlConf.isParquetBinaryAsString)
+    hadoopConf.setBoolean(SQLConf.PARQUET_INT96_AS_TIMESTAMP.key, sqlConf.isParquetINT96AsTimestamp)
+    hadoopConf.setBoolean(SQLConf.CASE_SENSITIVE.key, sqlConf.caseSensitiveAnalysis)
+    hadoopConf.setBoolean(
+      SQLConf.PARQUET_INFER_TIMESTAMP_NTZ_ENABLED.key,
+      sqlConf.parquetInferTimestampNTZEnabled)
+    hadoopConf.setBoolean(
+      SQLConf.LEGACY_PARQUET_NANOS_AS_LONG.key,
+      sqlConf.legacyParquetNanosAsLong)
+    hadoopConf.setBoolean(
+      SQLConf.PARQUET_FIELD_ID_READ_ENABLED.key,
+      sqlConf.parquetFieldIdReadEnabled)
+    new SerializableConfiguration(hadoopConf)
     // scalastyle:on deltahadoopconfiguration
   }
 
@@ -71,11 +86,7 @@ class ParquetTable(
   override val format: String = "parquet"
 
   val fileManifest: ConvertTargetFileManifest = {
-    val fetchConfig = ParquetSchemaFetchConfig(
-      spark.sessionState.conf.isParquetBinaryAsString,
-      spark.sessionState.conf.isParquetINT96AsTimestamp,
-      spark.sessionState.conf.ignoreCorruptFiles
-    )
+    val fetchConfig = ParquetSchemaFetchConfig(spark.sessionState.conf.ignoreCorruptFiles)
     if (spark.sessionState.conf.getConf(DeltaSQLConf.DELTA_CONVERT_USE_METADATA_LOG) &&
       FileStreamSink.hasMetadata(Seq(basePath), serializableConf.value, spark.sessionState.conf)) {
       new MetadataLogFileManifest(spark, basePath, partitionSchema, fetchConfig, serializableConf)


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This is the `branch-4.3` backport of https://github.com/delta-io/delta/pull/6999.

This PR fixes a runtime failure with Spark 4.1.2.

Delta was creating Spark's `ParquetToSparkSchemaConverter` by calling a constructor with several `Boolean` arguments. That constructor belongs to Spark, not Delta. Spark changed the number of `Boolean` arguments between Spark versions: the Spark version Delta was compiled with had 7 booleans, but Spark 4.1.2 has 8.

So this can happen:

1. Delta is compiled against one Spark version.
2. The same Delta artifact is run with another Spark patch version.
3. The JVM looks for the exact constructor Delta was compiled with.
4. That constructor does not exist in the Spark jar being used at runtime.
5. The query fails with `NoSuchMethodError`.

The fix is to stop calling the constructor that takes many `Boolean` arguments. Instead, Delta now uses constructors that take Spark configuration objects:

- `SQLConf` when the code has access to the `SparkSession`
- Hadoop `Configuration` when the code runs from serialized Hadoop configuration

This keeps Delta from depending on one exact Spark constructor shape. Spark can decide how to read its own config values for that Spark version.

For `CONVERT TO DELTA`, some schema reading happens using a serialized Hadoop configuration. For that path, this PR copies the Parquet SQL config values that Spark's `Configuration` constructor requires into the Hadoop configuration before sending it to workers. Without that copy, the config-based constructor may not see the same values that were set in `SQLConf`, and some Spark versions can fail because the required keys are missing.

## How was this patch tested?

```bash
build/sbt "spark/compile"
```

I also checked that Delta no longer directly passes named `assumeBinaryIsString` or `assumeInt96IsTimestamp` arguments to `ParquetToSparkSchemaConverter` in production code.

## Does this PR introduce _any_ user-facing changes?

No API change. This fixes a runtime crash and makes these Parquet schema conversion paths honor the same Parquet SQL config values as Spark's normal Parquet reader.