### PR TITLE
[SQL] Rename v2 read Batch/ReaderFactory/PartitionReader to DeltaV2*

### DIFF
--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2Batch.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2Batch.java
@@ -33,7 +33,7 @@ import org.apache.spark.sql.internal.SQLConf;
 import org.apache.spark.sql.sources.Filter;
 import org.apache.spark.sql.types.StructType;
 
-public class SparkBatch implements Batch {
+public class DeltaV2Batch implements Batch {
   private final Snapshot snapshot;
   private final StructType readDataSchema;
   private final StructType dataSchema;
@@ -51,7 +51,7 @@ public class SparkBatch implements Batch {
   private scala.collection.immutable.Map<String, String> scalaOptions;
   private final List<PartitionedFile> partitionedFiles;
 
-  public SparkBatch(
+  public DeltaV2Batch(
       Snapshot snapshot,
       StructType dataSchema,
       StructType partitionSchema,
@@ -109,9 +109,9 @@ public class SparkBatch implements Batch {
   @Override
   public boolean equals(Object obj) {
     if (this == obj) return true;
-    if (!(obj instanceof SparkBatch)) return false;
+    if (!(obj instanceof DeltaV2Batch)) return false;
 
-    SparkBatch that = (SparkBatch) obj;
+    DeltaV2Batch that = (DeltaV2Batch) obj;
     return Objects.equals(this.snapshot, that.snapshot)
         && Objects.equals(this.readDataSchema, that.readDataSchema)
         && Objects.equals(this.dataSchema, that.dataSchema)

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2Batch.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2Batch.java
@@ -33,7 +33,13 @@ import org.apache.spark.sql.internal.SQLConf;
 import org.apache.spark.sql.sources.Filter;
 import org.apache.spark.sql.types.StructType;
 
-public class DeltaV2Batch implements Batch {
+/**
+ * Package-private batch implementation for Delta's Spark DataSource V2 read path.
+ *
+ * <p>This class must remain package-private so callers outside {@code v2.read} depend only on
+ * Spark's public connector interfaces instead of coupling to Delta's internal V2 implementation.
+ */
+class DeltaV2Batch implements Batch {
   private final Snapshot snapshot;
   private final StructType readDataSchema;
   private final StructType dataSchema;

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2PartitionReader.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2PartitionReader.java
@@ -24,7 +24,7 @@ import org.apache.spark.sql.execution.datasources.PartitionedFile;
 import scala.Function1;
 import scala.collection.Iterator;
 
-public class SparkPartitionReader<T> implements PartitionReader<T> {
+public class DeltaV2PartitionReader<T> implements PartitionReader<T> {
   // Function that produces an Iterator for a given file.
   private final Function1<PartitionedFile, Iterator<InternalRow>> readFunc;
   private final FilePartition partition;
@@ -35,7 +35,7 @@ public class SparkPartitionReader<T> implements PartitionReader<T> {
   // Current iterator for the file being read.
   private Iterator<T> currentIterator = null;
 
-  public SparkPartitionReader(
+  public DeltaV2PartitionReader(
       Function1<PartitionedFile, Iterator<InternalRow>> readFunc, FilePartition partition) {
     this.readFunc = java.util.Objects.requireNonNull(readFunc, "readFunc");
     this.partition = java.util.Objects.requireNonNull(partition, "partition");

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2PartitionReader.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2PartitionReader.java
@@ -24,7 +24,13 @@ import org.apache.spark.sql.execution.datasources.PartitionedFile;
 import scala.Function1;
 import scala.collection.Iterator;
 
-public class DeltaV2PartitionReader<T> implements PartitionReader<T> {
+/**
+ * Package-private partition reader for Delta's Spark DataSource V2 read path.
+ *
+ * <p>This class must remain package-private so callers outside {@code v2.read} depend only on
+ * Spark's public connector interfaces instead of coupling to Delta's internal V2 implementation.
+ */
+class DeltaV2PartitionReader<T> implements PartitionReader<T> {
   // Function that produces an Iterator for a given file.
   private final Function1<PartitionedFile, Iterator<InternalRow>> readFunc;
   private final FilePartition partition;

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2ReaderFactory.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2ReaderFactory.java
@@ -25,7 +25,13 @@ import org.apache.spark.sql.vectorized.ColumnarBatch;
 import scala.Function1;
 import scala.collection.Iterator;
 
-public class DeltaV2ReaderFactory implements PartitionReaderFactory {
+/**
+ * Package-private reader factory for Delta's Spark DataSource V2 read path.
+ *
+ * <p>This class must remain package-private so callers outside {@code v2.read} depend only on
+ * Spark's public connector interfaces instead of coupling to Delta's internal V2 implementation.
+ */
+class DeltaV2ReaderFactory implements PartitionReaderFactory {
   private Function1<PartitionedFile, Iterator<InternalRow>> readFunc;
   private boolean supportsColumnar;
 

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2ReaderFactory.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2ReaderFactory.java
@@ -25,11 +25,11 @@ import org.apache.spark.sql.vectorized.ColumnarBatch;
 import scala.Function1;
 import scala.collection.Iterator;
 
-public class SparkReaderFactory implements PartitionReaderFactory {
+public class DeltaV2ReaderFactory implements PartitionReaderFactory {
   private Function1<PartitionedFile, Iterator<InternalRow>> readFunc;
   private boolean supportsColumnar;
 
-  public SparkReaderFactory(
+  public DeltaV2ReaderFactory(
       Function1<PartitionedFile, Iterator<InternalRow>> readFunc, boolean supportsColumnar) {
     this.readFunc = readFunc;
     this.supportsColumnar = supportsColumnar;
@@ -37,7 +37,7 @@ public class SparkReaderFactory implements PartitionReaderFactory {
 
   @Override
   public PartitionReader<ColumnarBatch> createColumnarReader(InputPartition partition) {
-    return new SparkPartitionReader<ColumnarBatch>(readFunc, (FilePartition) partition);
+    return new DeltaV2PartitionReader<ColumnarBatch>(readFunc, (FilePartition) partition);
   }
 
   @Override
@@ -47,6 +47,6 @@ public class SparkReaderFactory implements PartitionReaderFactory {
 
   @Override
   public PartitionReader<InternalRow> createReader(InputPartition partition) {
-    return new SparkPartitionReader<InternalRow>(readFunc, (FilePartition) partition);
+    return new DeltaV2PartitionReader<InternalRow>(readFunc, (FilePartition) partition);
   }
 }

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2Reads.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2Reads.java
@@ -30,4 +30,5 @@ public final class DeltaV2Reads {
       Function1<PartitionedFile, Iterator<InternalRow>> readFunc, boolean supportsColumnar) {
     return new DeltaV2ReaderFactory(readFunc, supportsColumnar);
   }
+
 }

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2Reads.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2Reads.java
@@ -30,5 +30,4 @@ public final class DeltaV2Reads {
       Function1<PartitionedFile, Iterator<InternalRow>> readFunc, boolean supportsColumnar) {
     return new DeltaV2ReaderFactory(readFunc, supportsColumnar);
   }
-
 }

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2Reads.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2Reads.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.read;
+
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.connector.read.PartitionReaderFactory;
+import org.apache.spark.sql.execution.datasources.PartitionedFile;
+import scala.Function1;
+import scala.collection.Iterator;
+
+/** Public factory methods for Delta's package-private Spark DataSource V2 read internals. */
+public final class DeltaV2Reads {
+
+  private DeltaV2Reads() {}
+
+  public static PartitionReaderFactory newReaderFactory(
+      Function1<PartitionedFile, Iterator<InternalRow>> readFunc, boolean supportsColumnar) {
+    return new DeltaV2ReaderFactory(readFunc, supportsColumnar);
+  }
+}

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkScan.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkScan.java
@@ -200,7 +200,7 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
               + "connector. Either remove the CDC read option or use a streaming read.");
     }
     ensurePlanned();
-    return new SparkBatch(
+    return new DeltaV2Batch(
         initialSnapshot,
         dataSchema,
         partitionSchema,

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/PartitionUtils.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/PartitionUtils.java
@@ -25,7 +25,7 @@ import io.delta.kernel.internal.actions.Protocol;
 import io.delta.kernel.internal.tablefeatures.TableFeatures;
 import io.delta.spark.internal.v2.read.ColumnReorderReadFunction;
 import io.delta.spark.internal.v2.read.DeltaParquetFileFormatV2;
-import io.delta.spark.internal.v2.read.DeltaV2ReaderFactory;
+import io.delta.spark.internal.v2.read.DeltaV2Reads;
 import io.delta.spark.internal.v2.read.cdc.CDCReadFunction;
 import io.delta.spark.internal.v2.read.cdc.CDCSchemaContext;
 import io.delta.spark.internal.v2.read.deletionvector.DeletionVectorReadFunction;
@@ -453,7 +453,7 @@ public class PartitionUtils {
             partitionSchema,
             ddlOrderedReadOutputSchema);
 
-    return new DeltaV2ReaderFactory(readFunc, enableVectorizedReader);
+    return DeltaV2Reads.newReaderFactory(readFunc, enableVectorizedReader);
   }
 
   /**

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/PartitionUtils.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/PartitionUtils.java
@@ -25,7 +25,7 @@ import io.delta.kernel.internal.actions.Protocol;
 import io.delta.kernel.internal.tablefeatures.TableFeatures;
 import io.delta.spark.internal.v2.read.ColumnReorderReadFunction;
 import io.delta.spark.internal.v2.read.DeltaParquetFileFormatV2;
-import io.delta.spark.internal.v2.read.SparkReaderFactory;
+import io.delta.spark.internal.v2.read.DeltaV2ReaderFactory;
 import io.delta.spark.internal.v2.read.cdc.CDCReadFunction;
 import io.delta.spark.internal.v2.read.cdc.CDCSchemaContext;
 import io.delta.spark.internal.v2.read.deletionvector.DeletionVectorReadFunction;
@@ -453,7 +453,7 @@ public class PartitionUtils {
             partitionSchema,
             ddlOrderedReadOutputSchema);
 
-    return new SparkReaderFactory(readFunc, enableVectorizedReader);
+    return new DeltaV2ReaderFactory(readFunc, enableVectorizedReader);
   }
 
   /**

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2BatchTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2BatchTest.java
@@ -37,7 +37,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-public class SparkBatchTest extends DeltaV2TestBase {
+public class DeltaV2BatchTest extends DeltaV2TestBase {
 
   private static String tablePath;
   private static final String tableName = "deltatbl_partitioned_batch";
@@ -58,7 +58,7 @@ public class SparkBatchTest extends DeltaV2TestBase {
   // Cases where two batches built from the same table must be equal. city/date are partition
   // columns (exercise pushedToKernelFiltersSet); name/cnt are data columns and per
   // ExpressionUtils.classifyFilter have isDataFilter=true, so they flow into
-  // SparkBatch.dataFilters and exercise the dataFiltersSet branch of equals/hashCode.
+  // DeltaV2Batch.dataFilters and exercise the dataFiltersSet branch of equals/hashCode.
   static Stream<Arguments> equalBatchCasesProvider() {
     Filter cityEq = new EqualTo("city", "hz");
     Filter dateEq = new EqualTo("date", "20180520");


### PR DESCRIPTION
## Description

Rename the Delta Kernel DSv2 batch read-execution classes in
`io.delta.spark.internal.v2.read` to the `DeltaV2*` convention, matching the
`DeltaV2Table` and `DeltaV2WriteBuilder` classes already in the package:

- `SparkBatch` -> `DeltaV2Batch`
- `SparkReaderFactory` -> `DeltaV2ReaderFactory`
- `SparkPartitionReader` -> `DeltaV2PartitionReader`

Identifiers only (class files, class names, references, and the corresponding
test class). No behavior change.

## How was this patch tested?

Existing tests, with all class references updated to the new names.

## Does this PR introduce _any_ user-facing change?

No.