### PR TITLE
[SQL] Rename v2 read Scan/ScanBuilder to DeltaV2*

### DIFF
--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
@@ -27,8 +27,8 @@ import io.delta.kernel.internal.DeltaHistoryManager;
 import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.internal.rowtracking.RowTracking;
 import io.delta.spark.internal.v2.exception.TimestampOutOfRangeException;
+import io.delta.spark.internal.v2.read.DeltaV2ScanUtils;
 import io.delta.spark.internal.v2.read.MetadataEvolutionHandler;
-import io.delta.spark.internal.v2.read.SparkScanBuilder;
 import io.delta.spark.internal.v2.read.cdc.CDCSchemaContext;
 import io.delta.spark.internal.v2.snapshot.DeltaSnapshotManager;
 import io.delta.spark.internal.v2.snapshot.SnapshotManagerFactory;
@@ -492,7 +492,7 @@ public class DeltaV2Table
                         stats,
                         schemaProvider.getDataSchema(),
                         schemaProvider.getPartitionSchema()));
-    return new SparkScanBuilder(
+    return DeltaV2ScanUtils.newScanBuilder(
         name(),
         initialSnapshot,
         snapshotManager,

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/ColumnReorderReadFunction.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/ColumnReorderReadFunction.java
@@ -36,7 +36,7 @@ import scala.runtime.AbstractFunction1;
 
 /**
  * Reorders a Parquet reader's {@code readDataSchema ++ partitionSchema} output into the DDL field
- * order declared by {@link SparkScan#readSchema()}.
+ * order declared by {@link DeltaV2Scan#readSchema()}.
  */
 public class ColumnReorderReadFunction
     extends AbstractFunction1<PartitionedFile, Iterator<InternalRow>> implements Serializable {

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2Scan.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2Scan.java
@@ -59,8 +59,13 @@ import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 import scala.Option;
 
-/** Spark DSV2 Scan implementation backed by Delta Kernel. */
-public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntimeV2Filtering {
+/**
+ * Package-private scan implementation for Delta's Spark DataSource V2 read path.
+ *
+ * <p>This class must remain package-private so callers outside {@code v2.read} depend only on
+ * Spark's public connector interfaces instead of coupling to Delta's internal V2 implementation.
+ */
+class DeltaV2Scan implements Scan, SupportsReportStatistics, SupportsRuntimeV2Filtering {
 
   private final DeltaSnapshotManager snapshotManager;
   private final Snapshot initialSnapshot;
@@ -106,7 +111,7 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
       appliedRuntimePredicates = new HashSet<>();
 
   // TODO(#6743): bundle scan-level schemas into a single ScanSchemaContext.
-  public SparkScan(
+  public DeltaV2Scan(
       DeltaSnapshotManager snapshotManager,
       Snapshot initialSnapshot,
       StructType tableSchema,
@@ -218,7 +223,7 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
   @Override
   public MicroBatchStream toMicroBatchStream(String checkpointLocation) {
     // Loads a fresh snapshot as the baseline for schema change detection and table identity
-    // checks. SparkScan's initialSnapshot is from analysis time and may be stale by stream
+    // checks. DeltaV2Scan's initialSnapshot is from analysis time and may be stale by stream
     // start/restart.
     // Matches V1's DeltaDataSource.createSource() behavior.
     Snapshot latestSnapshot = snapshotManager.loadLatestSnapshot();
@@ -649,7 +654,7 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    SparkScan that = (SparkScan) o;
+    DeltaV2Scan that = (DeltaV2Scan) o;
     return Objects.equals(initialSnapshot.getPath(), that.initialSnapshot.getPath())
         && initialSnapshot.getVersion() == that.initialSnapshot.getVersion()
         && Objects.equals(dataSchema, that.dataSchema)

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2ScanBuilder.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2ScanBuilder.java
@@ -35,10 +35,12 @@ import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 
 /**
- * A Spark ScanBuilder implementation that wraps Delta Kernel's ScanBuilder. This allows Spark to
- * use Delta Kernel for reading Delta tables.
+ * Package-private scan builder implementation for Delta's Spark DataSource V2 read path.
+ *
+ * <p>This class must remain package-private so callers outside {@code v2.read} depend only on
+ * Spark's public connector interfaces instead of coupling to Delta's internal V2 implementation.
  */
-public class SparkScanBuilder
+class DeltaV2ScanBuilder
     implements ScanBuilder, SupportsPushDownRequiredColumns, SupportsPushDownFilters {
 
   private io.delta.kernel.ScanBuilder kernelScanBuilder;
@@ -60,7 +62,7 @@ public class SparkScanBuilder
   private Filter[] dataFilters;
 
   /**
-   * Creates a SparkScanBuilder with the given snapshot and configuration.
+   * Creates a DeltaV2ScanBuilder with the given snapshot and configuration.
    *
    * @param tableName the name of the table
    * @param initialSnapshot Snapshot created during connector setup
@@ -71,7 +73,7 @@ public class SparkScanBuilder
    * @param catalogStats optional V2 Statistics converted from catalog stats
    * @param options scan options
    */
-  public SparkScanBuilder(
+  public DeltaV2ScanBuilder(
       String tableName,
       io.delta.kernel.Snapshot initialSnapshot,
       DeltaSnapshotManager snapshotManager,
@@ -174,7 +176,7 @@ public class SparkScanBuilder
 
   @Override
   public org.apache.spark.sql.connector.read.Scan build() {
-    return new SparkScan(
+    return new DeltaV2Scan(
         snapshotManager,
         initialSnapshot,
         tableSchema,

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2ScanUtils.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2ScanUtils.java
@@ -15,19 +15,46 @@
  */
 package io.delta.spark.internal.v2.read;
 
+import io.delta.kernel.Snapshot;
+import io.delta.spark.internal.v2.snapshot.DeltaSnapshotManager;
+import java.util.Optional;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.read.PartitionReaderFactory;
+import org.apache.spark.sql.connector.read.ScanBuilder;
+import org.apache.spark.sql.connector.read.Statistics;
 import org.apache.spark.sql.execution.datasources.PartitionedFile;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 import scala.Function1;
 import scala.collection.Iterator;
 
-/** Public factory methods for Delta's package-private Spark DataSource V2 read internals. */
-public final class DeltaV2Reads {
+/** Public factory methods for Delta's package-private Spark DataSource V2 scan internals. */
+public final class DeltaV2ScanUtils {
 
-  private DeltaV2Reads() {}
+  private DeltaV2ScanUtils() {}
 
   public static PartitionReaderFactory newReaderFactory(
       Function1<PartitionedFile, Iterator<InternalRow>> readFunc, boolean supportsColumnar) {
     return new DeltaV2ReaderFactory(readFunc, supportsColumnar);
+  }
+
+  public static ScanBuilder newScanBuilder(
+      String tableName,
+      Snapshot initialSnapshot,
+      DeltaSnapshotManager snapshotManager,
+      StructType dataSchema,
+      StructType partitionSchema,
+      StructType tableSchema,
+      Optional<Statistics> catalogStats,
+      CaseInsensitiveStringMap options) {
+    return new DeltaV2ScanBuilder(
+        tableName,
+        initialSnapshot,
+        snapshotManager,
+        dataSchema,
+        partitionSchema,
+        tableSchema,
+        catalogStats,
+        options);
   }
 }

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/PartitionUtils.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/PartitionUtils.java
@@ -25,7 +25,7 @@ import io.delta.kernel.internal.actions.Protocol;
 import io.delta.kernel.internal.tablefeatures.TableFeatures;
 import io.delta.spark.internal.v2.read.ColumnReorderReadFunction;
 import io.delta.spark.internal.v2.read.DeltaParquetFileFormatV2;
-import io.delta.spark.internal.v2.read.DeltaV2Reads;
+import io.delta.spark.internal.v2.read.DeltaV2ScanUtils;
 import io.delta.spark.internal.v2.read.cdc.CDCReadFunction;
 import io.delta.spark.internal.v2.read.cdc.CDCSchemaContext;
 import io.delta.spark.internal.v2.read.deletionvector.DeletionVectorReadFunction;
@@ -467,7 +467,7 @@ public class PartitionUtils {
             partitionSchema,
             ddlOrderedReadOutputSchema);
 
-    return DeltaV2Reads.newReaderFactory(readFunc, enableVectorizedReader);
+    return DeltaV2ScanUtils.newReaderFactory(readFunc, enableVectorizedReader);
   }
 
   /**

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2BatchTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2BatchTest.java
@@ -80,17 +80,17 @@ public class DeltaV2BatchTest extends DeltaV2TestBase {
   @ParameterizedTest(name = "{0}: batches should be equal")
   @MethodSource("equalBatchCasesProvider")
   public void testEqualsAndHashCode(String description, Filter[] filters1, Filter[] filters2) {
-    SparkScanBuilder builder1 = (SparkScanBuilder) table.newScanBuilder(options);
+    DeltaV2ScanBuilder builder1 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
     if (filters1.length > 0) {
       builder1.pushFilters(filters1);
     }
-    Batch batch1 = ((SparkScan) builder1.build()).toBatch();
+    Batch batch1 = ((DeltaV2Scan) builder1.build()).toBatch();
 
-    SparkScanBuilder builder2 = (SparkScanBuilder) table.newScanBuilder(options);
+    DeltaV2ScanBuilder builder2 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
     if (filters2.length > 0) {
       builder2.pushFilters(filters2);
     }
-    Batch batch2 = ((SparkScan) builder2.build()).toBatch();
+    Batch batch2 = ((DeltaV2Scan) builder2.build()).toBatch();
 
     assertEquals(batch1, batch2);
     assertEquals(batch1.hashCode(), batch2.hashCode());
@@ -98,12 +98,12 @@ public class DeltaV2BatchTest extends DeltaV2TestBase {
 
   @Test
   public void testEqualsWithDifferentPushedFilters() {
-    SparkScanBuilder builder1 = (SparkScanBuilder) table.newScanBuilder(options);
-    Batch batch1 = ((SparkScan) builder1.build()).toBatch();
+    DeltaV2ScanBuilder builder1 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    Batch batch1 = ((DeltaV2Scan) builder1.build()).toBatch();
 
-    SparkScanBuilder builder2 = (SparkScanBuilder) table.newScanBuilder(options);
+    DeltaV2ScanBuilder builder2 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
     builder2.pushFilters(new Filter[] {new EqualTo("city", "hz")});
-    Batch batch2 = ((SparkScan) builder2.build()).toBatch();
+    Batch batch2 = ((DeltaV2Scan) builder2.build()).toBatch();
 
     assertNotEquals(batch1, batch2);
     assertNotEquals(batch1.hashCode(), batch2.hashCode());

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2ScanBuilderTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2ScanBuilderTest.java
@@ -42,7 +42,7 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-public class SparkScanBuilderTest extends DeltaV2TestBase {
+public class DeltaV2ScanBuilderTest extends DeltaV2TestBase {
 
   @Test
   public void testBuild_returnsScanWithExpectedSchema(@TempDir File tempDir) {
@@ -71,8 +71,8 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
               DataTypes.createStructField("name", DataTypes.StringType, true),
               DataTypes.createStructField("dep_id", DataTypes.IntegerType, true)
             });
-    SparkScanBuilder builder =
-        new SparkScanBuilder(
+    DeltaV2ScanBuilder builder =
+        new DeltaV2ScanBuilder(
             tableName,
             snapshot,
             snapshotManager,
@@ -92,7 +92,7 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
     builder.pruneColumns(expectedSparkSchema);
     Scan scan = builder.build();
 
-    assertTrue(scan instanceof SparkScan);
+    assertTrue(scan instanceof DeltaV2Scan);
     assertEquals(expectedSparkSchema, scan.readSchema());
   }
 
@@ -123,8 +123,8 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
               DataTypes.createStructField("name", DataTypes.StringType, true),
               DataTypes.createStructField("dep_id", DataTypes.IntegerType, true)
             });
-    SparkScanBuilder builder =
-        new SparkScanBuilder(
+    DeltaV2ScanBuilder builder =
+        new DeltaV2ScanBuilder(
             tableName,
             snapshot,
             snapshotManager,
@@ -150,8 +150,8 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
     }
   }
 
-  private StructType getRequiredDataSchema(SparkScanBuilder builder) throws Exception {
-    Field field = SparkScanBuilder.class.getDeclaredField("requiredDataSchema");
+  private StructType getRequiredDataSchema(DeltaV2ScanBuilder builder) throws Exception {
+    Field field = DeltaV2ScanBuilder.class.getDeclaredField("requiredDataSchema");
     field.setAccessible(true);
     return (StructType) field.get(builder);
   }
@@ -183,8 +183,8 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
               DataTypes.createStructField("name", DataTypes.StringType, true),
               DataTypes.createStructField("dep_id", DataTypes.IntegerType, true)
             });
-    SparkScanBuilder builder =
-        new SparkScanBuilder(
+    DeltaV2ScanBuilder builder =
+        new DeltaV2ScanBuilder(
             tableName,
             snapshot,
             snapshotManager,
@@ -206,7 +206,7 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
 
   @Test
   public void testPushFilters_singleSupportedDataFilter(@TempDir File tempDir) throws Exception {
-    SparkScanBuilder builder = createTestScanBuilder(tempDir);
+    DeltaV2ScanBuilder builder = createTestScanBuilder(tempDir);
 
     checkSupportsPushDownFilters(
         builder,
@@ -226,7 +226,7 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
 
   @Test
   public void testPushFilters_singleUnsupportedDataFilter(@TempDir File tempDir) throws Exception {
-    SparkScanBuilder builder = createTestScanBuilder(tempDir);
+    DeltaV2ScanBuilder builder = createTestScanBuilder(tempDir);
 
     checkSupportsPushDownFilters(
         builder,
@@ -244,7 +244,7 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
   @Test
   public void testPushFilters_singleSupportedDataFilter_StringStartsWith(@TempDir File tempDir)
       throws Exception {
-    SparkScanBuilder builder = createTestScanBuilder(tempDir);
+    DeltaV2ScanBuilder builder = createTestScanBuilder(tempDir);
 
     checkSupportsPushDownFilters(
         builder,
@@ -267,7 +267,7 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
 
   @Test
   public void testPushFilters_multiSupportedDataFilters(@TempDir File tempDir) throws Exception {
-    SparkScanBuilder builder = createTestScanBuilder(tempDir);
+    DeltaV2ScanBuilder builder = createTestScanBuilder(tempDir);
 
     checkSupportsPushDownFilters(
         builder,
@@ -296,7 +296,7 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
   @Test
   public void testPushFilters_mixedSupportedAndUnsupportedDataFilters(@TempDir File tempDir)
       throws Exception {
-    SparkScanBuilder builder = createTestScanBuilder(tempDir);
+    DeltaV2ScanBuilder builder = createTestScanBuilder(tempDir);
 
     checkSupportsPushDownFilters(
         builder,
@@ -320,7 +320,7 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
   @Test
   public void testPushFilters_singleSupportedPartitionFilter(@TempDir File tempDir)
       throws Exception {
-    SparkScanBuilder builder = createTestScanBuilder(tempDir);
+    DeltaV2ScanBuilder builder = createTestScanBuilder(tempDir);
 
     checkSupportsPushDownFilters(
         builder,
@@ -341,7 +341,7 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
   @Test
   public void testPushFilters_singleUnsupportedPartitionFilter(@TempDir File tempDir)
       throws Exception {
-    SparkScanBuilder builder = createTestScanBuilder(tempDir);
+    DeltaV2ScanBuilder builder = createTestScanBuilder(tempDir);
 
     checkSupportsPushDownFilters(
         builder,
@@ -363,7 +363,7 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
   @Test
   public void testPushFilters_multiSupportedPartitionFilters(@TempDir File tempDir)
       throws Exception {
-    SparkScanBuilder builder = createTestScanBuilder(tempDir);
+    DeltaV2ScanBuilder builder = createTestScanBuilder(tempDir);
 
     checkSupportsPushDownFilters(
         builder,
@@ -392,7 +392,7 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
   @Test
   public void testPushFilters_mixedSupportedAndUnsupportedPartitionFilters(@TempDir File tempDir)
       throws Exception {
-    SparkScanBuilder builder = createTestScanBuilder(tempDir);
+    DeltaV2ScanBuilder builder = createTestScanBuilder(tempDir);
 
     checkSupportsPushDownFilters(
         builder,
@@ -422,7 +422,7 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
 
   @Test
   public void testPushFilters_mixedFilters(@TempDir File tempDir) throws Exception {
-    SparkScanBuilder builder = createTestScanBuilder(tempDir);
+    DeltaV2ScanBuilder builder = createTestScanBuilder(tempDir);
 
     checkSupportsPushDownFilters(
         builder,
@@ -469,7 +469,7 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
 
   @Test
   public void testPushFilters_ORFilters(@TempDir File tempDir) throws Exception {
-    SparkScanBuilder builder = createTestScanBuilder(tempDir);
+    DeltaV2ScanBuilder builder = createTestScanBuilder(tempDir);
 
     checkSupportsPushDownFilters(
         builder,
@@ -501,7 +501,7 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
   @Test
   public void testPushFilters_ORSupportedAndUnsupportedDataFilters(@TempDir File tempDir)
       throws Exception {
-    SparkScanBuilder builder = createTestScanBuilder(tempDir);
+    DeltaV2ScanBuilder builder = createTestScanBuilder(tempDir);
 
     // OR(supported, unsupported) cannot be partially pushed: if one branch is unsupported,
     // the whole OR must remain for post-scan evaluation and nothing is pushed to the kernel.
@@ -524,7 +524,7 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
   @Test
   public void testPushFilters_ORSupportedDataAndPartitionFilters(@TempDir File tempDir)
       throws Exception {
-    SparkScanBuilder builder = createTestScanBuilder(tempDir);
+    DeltaV2ScanBuilder builder = createTestScanBuilder(tempDir);
 
     checkSupportsPushDownFilters(
         builder,
@@ -568,7 +568,7 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
    */
   @Test
   public void testPushFilters_mixedORandAND(@TempDir File tempDir) throws Exception {
-    SparkScanBuilder builder = createTestScanBuilder(tempDir);
+    DeltaV2ScanBuilder builder = createTestScanBuilder(tempDir);
 
     checkSupportsPushDownFilters(
         builder,
@@ -617,7 +617,7 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
 
   @Test
   public void testPushFilters_NOTFilters(@TempDir File tempDir) throws Exception {
-    SparkScanBuilder builder = createTestScanBuilder(tempDir);
+    DeltaV2ScanBuilder builder = createTestScanBuilder(tempDir);
 
     checkSupportsPushDownFilters(
         builder,
@@ -641,7 +641,7 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
   @Test
   public void testPushFilters_NOTSupportedDataANDSupportedPartitionFilters(@TempDir File tempDir)
       throws Exception {
-    SparkScanBuilder builder = createTestScanBuilder(tempDir);
+    DeltaV2ScanBuilder builder = createTestScanBuilder(tempDir);
 
     checkSupportsPushDownFilters(
         builder,
@@ -685,7 +685,7 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
   @Test
   public void testPushFilters_NOTSupportedDataANDUnsupportedDataFilters(@TempDir File tempDir)
       throws Exception {
-    SparkScanBuilder builder = createTestScanBuilder(tempDir);
+    DeltaV2ScanBuilder builder = createTestScanBuilder(tempDir);
 
     checkSupportsPushDownFilters(
         builder,
@@ -706,7 +706,7 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
   @Test
   public void testPushFilters_NOTSupportedDataORSupportedPartitionFilters(@TempDir File tempDir)
       throws Exception {
-    SparkScanBuilder builder = createTestScanBuilder(tempDir);
+    DeltaV2ScanBuilder builder = createTestScanBuilder(tempDir);
 
     checkSupportsPushDownFilters(
         builder,
@@ -744,7 +744,7 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
   @Test
   public void testPushFilters_NOTSupportedDataORUnsupportedDataFilters(@TempDir File tempDir)
       throws Exception {
-    SparkScanBuilder builder = createTestScanBuilder(tempDir);
+    DeltaV2ScanBuilder builder = createTestScanBuilder(tempDir);
 
     // NOT(OR(supported, unsupported)): the OR branch contains an unsupported filter
     // (StringEndsWith),
@@ -768,7 +768,7 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
   }
 
   private void checkSupportsPushDownFilters(
-      SparkScanBuilder builder,
+      DeltaV2ScanBuilder builder,
       Filter[] inputFilters,
       Filter[] expectedPostScanFilters,
       Filter[] expectedPushedFilters,
@@ -800,7 +800,7 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
     assertEquals(expectedKernelScanBuilderPredicate, predicateOpt);
   }
 
-  private SparkScanBuilder createTestScanBuilder(File tempDir) {
+  private DeltaV2ScanBuilder createTestScanBuilder(File tempDir) {
     StructType dataSchema =
         DataTypes.createStructType(
             new StructField[] {
@@ -827,7 +827,7 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
    */
   @Test
   public void testPushFilters_decimalWideningEndToEnd(@TempDir File tempDir) throws Exception {
-    SparkScanBuilder builder = createDecimalTestScanBuilder(tempDir);
+    DeltaV2ScanBuilder builder = createDecimalTestScanBuilder(tempDir);
 
     // price = 100.00 where literal is Decimal(5,2) and column is Decimal(7,2)
     Filter[] sparkFilter = new Filter[] {new EqualTo("price", new BigDecimal("100.00"))};
@@ -852,7 +852,7 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
   @Test
   public void testPushFilters_decimalRejectionPartialPushDown(@TempDir File tempDir)
       throws Exception {
-    SparkScanBuilder builder = createDecimalTestScanBuilder(tempDir);
+    DeltaV2ScanBuilder builder = createDecimalTestScanBuilder(tempDir);
 
     // AND(price > 99.999, price < 200.00): left side has scale=3 exceeding column's scale=2
     Filter[] sparkFilter =
@@ -875,7 +875,7 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
         Optional.of(kernelPredicate)); // expected kernelScanBuilder.predicate
   }
 
-  private SparkScanBuilder createDecimalTestScanBuilder(File tempDir) {
+  private DeltaV2ScanBuilder createDecimalTestScanBuilder(File tempDir) {
     StructType dataSchema =
         DataTypes.createStructType(
             new StructField[] {
@@ -896,11 +896,11 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
   }
 
   /**
-   * Shared helper for creating a SparkScanBuilder with the given schemas. Both
+   * Shared helper for creating a DeltaV2ScanBuilder with the given schemas. Both
    * createTestScanBuilder and createDecimalTestScanBuilder delegate to this method to avoid
    * duplicating snapshot loading and builder instantiation logic.
    */
-  private SparkScanBuilder createScanBuilder(
+  private DeltaV2ScanBuilder createScanBuilder(
       File tempDir, StructType dataSchema, StructType partitionSchema, StructType tableSchema) {
     String path = tempDir.getAbsolutePath();
     String tableName = String.format("test_%d", System.currentTimeMillis());
@@ -922,7 +922,7 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(path, spark.sessionState().newHadoopConf());
     Snapshot snapshot = snapshotManager.loadLatestSnapshot();
-    return new SparkScanBuilder(
+    return new DeltaV2ScanBuilder(
         tableName,
         snapshot,
         snapshotManager,
@@ -933,24 +933,24 @@ public class SparkScanBuilderTest extends DeltaV2TestBase {
         CaseInsensitiveStringMap.empty());
   }
 
-  private Predicate[] getPushedKernelPredicates(SparkScanBuilder builder) throws Exception {
+  private Predicate[] getPushedKernelPredicates(DeltaV2ScanBuilder builder) throws Exception {
     // TODO: replace reflection with other testing manners, possibly Mockito ArgumentCaptor
-    Field field = SparkScanBuilder.class.getDeclaredField("pushedKernelPredicates");
+    Field field = DeltaV2ScanBuilder.class.getDeclaredField("pushedKernelPredicates");
     field.setAccessible(true);
     return (Predicate[]) field.get(builder);
   }
 
-  private Filter[] getDataFilters(SparkScanBuilder builder) throws Exception {
+  private Filter[] getDataFilters(DeltaV2ScanBuilder builder) throws Exception {
     // TODO: replace reflection with other testing manners, possibly Mockito ArgumentCaptor
-    Field field = SparkScanBuilder.class.getDeclaredField("dataFilters");
+    Field field = DeltaV2ScanBuilder.class.getDeclaredField("dataFilters");
     field.setAccessible(true);
     return (Filter[]) field.get(builder);
   }
 
-  private Optional<Predicate> getKernelScanBuilderPredicate(SparkScanBuilder builder)
+  private Optional<Predicate> getKernelScanBuilderPredicate(DeltaV2ScanBuilder builder)
       throws Exception {
     // TODO: replace reflection with other testing manners, possibly Mockito ArgumentCaptor
-    Field field = SparkScanBuilder.class.getDeclaredField("kernelScanBuilder");
+    Field field = DeltaV2ScanBuilder.class.getDeclaredField("kernelScanBuilder");
     field.setAccessible(true);
     Object kernelScanBuilder = field.get(builder);
 

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2ScanTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2ScanTest.java
@@ -37,7 +37,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-public class SparkScanTest extends DeltaV2TestBase {
+public class DeltaV2ScanTest extends DeltaV2TestBase {
 
   private static String tablePath;
   private static final String tableName = "deltatbl_partitioned";
@@ -109,8 +109,8 @@ public class SparkScanTest extends DeltaV2TestBase {
   @Test
   public void testColumnarSupportModeReturnsSupported() {
     // Table schema uses simple types (INT, STRING) which are batch-read-compatible
-    SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan = (SparkScan) builder.build();
+    DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
     assertEquals(
         Scan.ColumnarSupportMode.SUPPORTED,
@@ -122,14 +122,14 @@ public class SparkScanTest extends DeltaV2TestBase {
   public void testColumnarSupportModeDoesNotTriggerPlanning() throws Exception {
     // Calling columnarSupportMode() must NOT trigger file planning (the whole point of the
     // override is to avoid the early planInputPartitions() call that PARTITION_DEFINED causes).
-    SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan = (SparkScan) builder.build();
+    DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
     // Call columnarSupportMode before any planning
     scan.columnarSupportMode();
 
     // Verify the scan has not been planned yet
-    Field plannedField = SparkScan.class.getDeclaredField("planned");
+    Field plannedField = DeltaV2Scan.class.getDeclaredField("planned");
     plannedField.setAccessible(true);
     assertFalse(
         (boolean) plannedField.get(scan), "columnarSupportMode() should not trigger file planning");
@@ -160,8 +160,8 @@ public class SparkScanTest extends DeltaV2TestBase {
                         Identifier.of(new String[] {"spark_catalog", "default"}, mapTableName),
                         path,
                         options);
-                SparkScanBuilder builder = (SparkScanBuilder) mapTable.newScanBuilder(options);
-                SparkScan scan = (SparkScan) builder.build();
+                DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) mapTable.newScanBuilder(options);
+                DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
                 assertEquals(
                     Scan.ColumnarSupportMode.UNSUPPORTED,
@@ -180,8 +180,8 @@ public class SparkScanTest extends DeltaV2TestBase {
         "spark.sql.parquet.enableVectorizedReader",
         "false",
         () -> {
-          SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(options);
-          SparkScan scan = (SparkScan) builder.build();
+          DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+          DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
           assertEquals(
               Scan.ColumnarSupportMode.UNSUPPORTED,
@@ -192,7 +192,7 @@ public class SparkScanTest extends DeltaV2TestBase {
 
   @Test
   public void testColumnarSupportModeWithMetadataColumnPruned() {
-    SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(options);
+    DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) table.newScanBuilder(options);
     StructType prunedSchema =
         new StructType()
             .add("name", DataTypes.StringType)
@@ -202,7 +202,7 @@ public class SparkScanTest extends DeltaV2TestBase {
             .add("part", DataTypes.IntegerType);
     builder.pruneColumns(prunedSchema);
 
-    SparkScan scan = (SparkScan) builder.build();
+    DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
     assertEquals(
         Scan.ColumnarSupportMode.UNSUPPORTED,
@@ -234,8 +234,8 @@ public class SparkScanTest extends DeltaV2TestBase {
                   Identifier.of(new String[] {"spark_catalog", "default"}, dvTableName),
                   dvPath,
                   options);
-          SparkScanBuilder builder = (SparkScanBuilder) dvTable.newScanBuilder(options);
-          SparkScan scan = (SparkScan) builder.build();
+          DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) dvTable.newScanBuilder(options);
+          DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
           // DV-enabled table with simple types should still return SUPPORTED because the
           // DV column (ByteType) is batch-compatible
@@ -253,8 +253,8 @@ public class SparkScanTest extends DeltaV2TestBase {
 
   @Test
   public void testGetDataSchemaPartitionSchemaReadDataSchemaOptionsConfiguration() {
-    SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan = (SparkScan) builder.build();
+    DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
     // Table schema: (part INT, date STRING, city STRING, name STRING, cnt INT)
     // Partition columns: (date STRING, city STRING, part INT)
@@ -304,8 +304,8 @@ public class SparkScanTest extends DeltaV2TestBase {
 
   @Test
   public void testGetTablePathReturnsTablePath() {
-    SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan = (SparkScan) builder.build();
+    DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
     String retrievedPath = scan.getTablePath();
     assertNotNull(retrievedPath, "getTablePath should not return null");
@@ -326,8 +326,8 @@ public class SparkScanTest extends DeltaV2TestBase {
     optionsWithHadoop.put("dfs.replication", "2");
     CaseInsensitiveStringMap optionsWithHadoopMap = new CaseInsensitiveStringMap(optionsWithHadoop);
 
-    SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(optionsWithHadoopMap);
-    SparkScan scan = (SparkScan) builder.build();
+    DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) table.newScanBuilder(optionsWithHadoopMap);
+    DeltaV2Scan scan = (DeltaV2Scan) builder.build();
     Configuration configuration = scan.getConfiguration();
 
     assertEquals(
@@ -342,7 +342,7 @@ public class SparkScanTest extends DeltaV2TestBase {
 
   @Test
   public void testGetReadDataSchemaWithColumnPruning() {
-    SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(options);
+    DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) table.newScanBuilder(options);
 
     StructType prunedSchema =
         new StructType()
@@ -352,7 +352,7 @@ public class SparkScanTest extends DeltaV2TestBase {
             .add("part", DataTypes.IntegerType);
     builder.pruneColumns(prunedSchema);
 
-    SparkScan scan = (SparkScan) builder.build();
+    DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
     StructType dataSchema = scan.getDataSchema();
     StructType readDataSchema = scan.getReadDataSchema();
@@ -492,9 +492,9 @@ public class SparkScanTest extends DeltaV2TestBase {
       List<String> remainingPartitionValueAfterDpp)
       throws Exception {
     ScanBuilder newBuilder = table.newScanBuilder(scanOptions);
-    SparkScanBuilder builder = (SparkScanBuilder) newBuilder;
+    DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) newBuilder;
     Scan scan = builder.build();
-    SparkScan sparkScan = (SparkScan) scan;
+    DeltaV2Scan sparkScan = (DeltaV2Scan) scan;
 
     List<PartitionedFile> beforeDppFiles = getPartitionedFiles(sparkScan);
     // make a copy for comparison after DPP
@@ -531,17 +531,17 @@ public class SparkScanTest extends DeltaV2TestBase {
     assertEquals(afterDppTotalBytes, afterDppEstimatedSize);
   }
 
-  private static List<PartitionedFile> getPartitionedFiles(SparkScan scan) throws Exception {
+  private static List<PartitionedFile> getPartitionedFiles(DeltaV2Scan scan) throws Exception {
     scan.estimateStatistics(); // ensurePlanned
-    Field field = SparkScan.class.getDeclaredField("partitionedFiles");
+    Field field = DeltaV2Scan.class.getDeclaredField("partitionedFiles");
     field.setAccessible(true);
     return (List<PartitionedFile>) field.get(scan);
   }
 
   @Test
   public void testSelectedFilesTracksPlannedAndRuntimeFilteredFiles() throws Exception {
-    SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan = (SparkScan) builder.build();
+    DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
     List<PartitionedFile> plannedFiles = getPartitionedFiles(scan);
     List<DeltaScanFile> selectedFiles = scan.getSelectedFiles();
@@ -565,37 +565,37 @@ public class SparkScanTest extends DeltaV2TestBase {
         "selected files should be pruned with runtime partition filters");
   }
 
-  private static long getTotalBytes(SparkScan scan) throws Exception {
+  private static long getTotalBytes(DeltaV2Scan scan) throws Exception {
     scan.estimateStatistics(); // ensurePlanned
-    Field field = SparkScan.class.getDeclaredField("totalBytes");
+    Field field = DeltaV2Scan.class.getDeclaredField("totalBytes");
     field.setAccessible(true);
     return (long) field.get(scan);
   }
 
-  private static long getEstimatedSizeInBytes(SparkScan scan) throws Exception {
+  private static long getEstimatedSizeInBytes(DeltaV2Scan scan) throws Exception {
     scan.estimateStatistics(); // ensurePlanned
-    Field field = SparkScan.class.getDeclaredField("estimatedSizeInBytes");
+    Field field = DeltaV2Scan.class.getDeclaredField("estimatedSizeInBytes");
     field.setAccessible(true);
     return (long) field.get(scan);
   }
 
-  private static org.apache.spark.sql.sources.Filter[] getDataFilters(SparkScan scan)
+  private static org.apache.spark.sql.sources.Filter[] getDataFilters(DeltaV2Scan scan)
       throws Exception {
-    Field field = SparkScan.class.getDeclaredField("dataFilters");
+    Field field = DeltaV2Scan.class.getDeclaredField("dataFilters");
     field.setAccessible(true);
     return (org.apache.spark.sql.sources.Filter[]) field.get(scan);
   }
 
-  private static long getTotalRows(SparkScan scan) throws Exception {
+  private static long getTotalRows(DeltaV2Scan scan) throws Exception {
     scan.estimateStatistics(); // ensurePlanned
-    Field field = SparkScan.class.getDeclaredField("totalRows");
+    Field field = DeltaV2Scan.class.getDeclaredField("totalRows");
     field.setAccessible(true);
     return (long) field.get(scan);
   }
 
-  private static boolean isRowCountKnown(SparkScan scan) throws Exception {
+  private static boolean isRowCountKnown(DeltaV2Scan scan) throws Exception {
     scan.estimateStatistics(); // ensurePlanned
-    Field field = SparkScan.class.getDeclaredField("rowCountKnown");
+    Field field = DeltaV2Scan.class.getDeclaredField("rowCountKnown");
     field.setAccessible(true);
     return (boolean) field.get(scan);
   }
@@ -608,8 +608,8 @@ public class SparkScanTest extends DeltaV2TestBase {
   public void testNumRowsEmptyWhenStatsDisabled() throws Exception {
     // With CBO and planStats disabled (the default), numRows() should return empty even when all
     // files have stats, matching V1 behavior (LogicalRelation.computeStats()).
-    SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan = (SparkScan) builder.build();
+    DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
     assertFalse(
         isRowCountKnown(scan), "rowCountKnown should be false when CBO and planStats are disabled");
@@ -625,8 +625,8 @@ public class SparkScanTest extends DeltaV2TestBase {
         "spark.sql.cbo.planStats.enabled",
         "true",
         () -> {
-          SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(options);
-          SparkScan scan = (SparkScan) builder.build();
+          DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+          DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
           assertTrue(isRowCountKnown(scan), "Row count should be known when all files have stats");
           assertEquals(5L, getTotalRows(scan), "Total rows should match the 5 inserted rows");
@@ -644,8 +644,8 @@ public class SparkScanTest extends DeltaV2TestBase {
         "spark.sql.cbo.planStats.enabled",
         "true",
         () -> {
-          SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(options);
-          SparkScan scan = (SparkScan) builder.build();
+          DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+          DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
           assertEquals(
               5L, scan.estimateStatistics().numRows().getAsLong(), "5 rows before filtering");
@@ -671,8 +671,8 @@ public class SparkScanTest extends DeltaV2TestBase {
         "spark.sql.cbo.planStats.enabled",
         "true",
         () -> {
-          SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(options);
-          SparkScan scan = (SparkScan) builder.build();
+          DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+          DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
           scan.filter(new Predicate[] {negativeCityPredicate}); // city=zz doesn't exist
 
@@ -714,8 +714,9 @@ public class SparkScanTest extends DeltaV2TestBase {
           "spark.sql.cbo.planStats.enabled",
           "true",
           () -> {
-            SparkScanBuilder builder = (SparkScanBuilder) mixedStatsTable.newScanBuilder(options);
-            SparkScan scan = (SparkScan) builder.build();
+            DeltaV2ScanBuilder builder =
+                (DeltaV2ScanBuilder) mixedStatsTable.newScanBuilder(options);
+            DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
             assertFalse(
                 isRowCountKnown(scan), "rowCountKnown should be false when some files lack stats");
@@ -737,8 +738,8 @@ public class SparkScanTest extends DeltaV2TestBase {
     cdcOptions.put("readChangeFeed", "true");
     CaseInsensitiveStringMap cdcOptionsMap = new CaseInsensitiveStringMap(cdcOptions);
 
-    SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(cdcOptionsMap);
-    SparkScan scan = (SparkScan) builder.build();
+    DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) table.newScanBuilder(cdcOptionsMap);
+    DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
     StructType schema = scan.readSchema();
 
@@ -763,8 +764,8 @@ public class SparkScanTest extends DeltaV2TestBase {
   @Test
   public void testReadSchema_nonCdcRead_returnsDataAndPartitionSchema() {
     // Without readChangeFeed, readSchema() returns readDataSchema + partitionSchema.
-    SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan = (SparkScan) builder.build();
+    DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
     StructType schema = scan.readSchema();
 
@@ -788,7 +789,7 @@ public class SparkScanTest extends DeltaV2TestBase {
     cdcOptions.put("readChangeFeed", "true");
     CaseInsensitiveStringMap cdcOptionsMap = new CaseInsensitiveStringMap(cdcOptions);
 
-    SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(cdcOptionsMap);
+    DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) table.newScanBuilder(cdcOptionsMap);
     StructType requiredSchema =
         new StructType()
             .add("name", DataTypes.StringType)
@@ -798,7 +799,7 @@ public class SparkScanTest extends DeltaV2TestBase {
             .add("date", DataTypes.StringType);
     builder.pruneColumns(requiredSchema);
 
-    SparkScan scan = (SparkScan) builder.build();
+    DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
     // readDataSchema reflects pruning: only "name" remains (cnt dropped, partition + CDC filtered)
     StructType readDataSchema = scan.getReadDataSchema();
@@ -822,8 +823,8 @@ public class SparkScanTest extends DeltaV2TestBase {
     cdcOptions.put("readChangeFeed", "true");
     CaseInsensitiveStringMap cdcOptionsMap = new CaseInsensitiveStringMap(cdcOptions);
 
-    SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(cdcOptionsMap);
-    SparkScan scan = (SparkScan) builder.build();
+    DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) table.newScanBuilder(cdcOptionsMap);
+    DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
     // Sanity: scan still advertises the CDC schema (this is needed for the streaming path).
     StructType advertised = scan.readSchema();
@@ -843,8 +844,8 @@ public class SparkScanTest extends DeltaV2TestBase {
     cdcOptions.put("readChangeData", "true");
     CaseInsensitiveStringMap cdcOptionsMap = new CaseInsensitiveStringMap(cdcOptions);
 
-    SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(cdcOptionsMap);
-    SparkScan scan = (SparkScan) builder.build();
+    DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) table.newScanBuilder(cdcOptionsMap);
+    DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
     assertEquals(8, scan.readSchema().fields().length);
     UnsupportedOperationException e =
@@ -860,7 +861,7 @@ public class SparkScanTest extends DeltaV2TestBase {
 
     assertThrows(
         IllegalArgumentException.class,
-        () -> ((SparkScanBuilder) table.newScanBuilder(cdcOptionsMap)).build());
+        () -> ((DeltaV2ScanBuilder) table.newScanBuilder(cdcOptionsMap)).build());
   }
 
   @Test
@@ -869,8 +870,8 @@ public class SparkScanTest extends DeltaV2TestBase {
     nonCdcOptions.put("readChangeFeed", "false");
     CaseInsensitiveStringMap nonCdcOptionsMap = new CaseInsensitiveStringMap(nonCdcOptions);
 
-    SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(nonCdcOptionsMap);
-    SparkScan scan = (SparkScan) builder.build();
+    DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) table.newScanBuilder(nonCdcOptionsMap);
+    DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
     StructType schema = scan.readSchema();
     assertThrows(IllegalArgumentException.class, () -> schema.fieldIndex("_change_type"));
@@ -884,11 +885,11 @@ public class SparkScanTest extends DeltaV2TestBase {
   @Test
   public void testEqualsAndHashCode() {
     // Create two scans from the same table with same options
-    SparkScanBuilder builder1 = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan1 = (SparkScan) builder1.build();
+    DeltaV2ScanBuilder builder1 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan1 = (DeltaV2Scan) builder1.build();
 
-    SparkScanBuilder builder2 = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan2 = (SparkScan) builder2.build();
+    DeltaV2ScanBuilder builder2 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan2 = (DeltaV2Scan) builder2.build();
 
     // Same table, same options should be equal
     assertEquals(scan1, scan2);
@@ -897,14 +898,14 @@ public class SparkScanTest extends DeltaV2TestBase {
 
   @Test
   public void testEqualsWithDifferentOptions() {
-    SparkScanBuilder builder1 = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan1 = (SparkScan) builder1.build();
+    DeltaV2ScanBuilder builder1 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan1 = (DeltaV2Scan) builder1.build();
 
     Map<String, String> differentOptions = new HashMap<>();
     differentOptions.put("customOption", "value");
     CaseInsensitiveStringMap optionsMap = new CaseInsensitiveStringMap(differentOptions);
-    SparkScanBuilder builder2 = (SparkScanBuilder) table.newScanBuilder(optionsMap);
-    SparkScan scan2 = (SparkScan) builder2.build();
+    DeltaV2ScanBuilder builder2 = (DeltaV2ScanBuilder) table.newScanBuilder(optionsMap);
+    DeltaV2Scan scan2 = (DeltaV2Scan) builder2.build();
 
     // Different options should not be equal and hashCodes should differ
     assertNotEquals(scan1, scan2);
@@ -914,19 +915,19 @@ public class SparkScanTest extends DeltaV2TestBase {
   @Test
   public void testEqualsWithSameFilters() {
     // Both scans with equivalent filters created separately (not same instance)
-    SparkScanBuilder builder1 = (SparkScanBuilder) table.newScanBuilder(options);
+    DeltaV2ScanBuilder builder1 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
     builder1.pushFilters(
         new org.apache.spark.sql.sources.Filter[] {
           new org.apache.spark.sql.sources.EqualTo("city", "hz")
         });
-    SparkScan scan1 = (SparkScan) builder1.build();
+    DeltaV2Scan scan1 = (DeltaV2Scan) builder1.build();
 
-    SparkScanBuilder builder2 = (SparkScanBuilder) table.newScanBuilder(options);
+    DeltaV2ScanBuilder builder2 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
     builder2.pushFilters(
         new org.apache.spark.sql.sources.Filter[] {
           new org.apache.spark.sql.sources.EqualTo("city", "hz")
         });
-    SparkScan scan2 = (SparkScan) builder2.build();
+    DeltaV2Scan scan2 = (DeltaV2Scan) builder2.build();
 
     // Same options and equivalent filters should be equal
     assertEquals(scan1, scan2);
@@ -936,16 +937,16 @@ public class SparkScanTest extends DeltaV2TestBase {
   @Test
   public void testEqualsWithDifferentFilters() {
     // Scan without filters
-    SparkScanBuilder builder1 = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan1 = (SparkScan) builder1.build();
+    DeltaV2ScanBuilder builder1 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan1 = (DeltaV2Scan) builder1.build();
 
     // Scan with filters pushed
-    SparkScanBuilder builder2 = (SparkScanBuilder) table.newScanBuilder(options);
+    DeltaV2ScanBuilder builder2 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
     builder2.pushFilters(
         new org.apache.spark.sql.sources.Filter[] {
           new org.apache.spark.sql.sources.EqualTo("city", "hz")
         });
-    SparkScan scan2 = (SparkScan) builder2.build();
+    DeltaV2Scan scan2 = (DeltaV2Scan) builder2.build();
 
     // Same options but different filters should not be equal and hashCodes should differ
     assertNotEquals(scan1, scan2);
@@ -959,13 +960,13 @@ public class SparkScanTest extends DeltaV2TestBase {
     org.apache.spark.sql.sources.Filter dateEq =
         new org.apache.spark.sql.sources.EqualTo("date", "20180520");
 
-    SparkScanBuilder builder1 = (SparkScanBuilder) table.newScanBuilder(options);
+    DeltaV2ScanBuilder builder1 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
     builder1.pushFilters(new org.apache.spark.sql.sources.Filter[] {cityEq, dateEq});
-    SparkScan scan1 = (SparkScan) builder1.build();
+    DeltaV2Scan scan1 = (DeltaV2Scan) builder1.build();
 
-    SparkScanBuilder builder2 = (SparkScanBuilder) table.newScanBuilder(options);
+    DeltaV2ScanBuilder builder2 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
     builder2.pushFilters(new org.apache.spark.sql.sources.Filter[] {dateEq, cityEq});
-    SparkScan scan2 = (SparkScan) builder2.build();
+    DeltaV2Scan scan2 = (DeltaV2Scan) builder2.build();
 
     assertEquals(scan1, scan2);
     assertEquals(scan1.hashCode(), scan2.hashCode());
@@ -976,19 +977,19 @@ public class SparkScanTest extends DeltaV2TestBase {
     // city/date are partition columns, so the test above only exercises pushedToKernelFiltersSet.
     // name and cnt are data columns (per the partitioned table schema), so per
     // ExpressionUtils.classifyFilter these filters have isDataFilter=true and flow into
-    // SparkScan.dataFilters, exercising the dataFiltersSet branch of equals/hashCode.
+    // DeltaV2Scan.dataFilters, exercising the dataFiltersSet branch of equals/hashCode.
     org.apache.spark.sql.sources.Filter nameEq =
         new org.apache.spark.sql.sources.EqualTo("name", "x");
     org.apache.spark.sql.sources.Filter cntGt =
         new org.apache.spark.sql.sources.GreaterThan("cnt", 10);
 
-    SparkScanBuilder builder1 = (SparkScanBuilder) table.newScanBuilder(options);
+    DeltaV2ScanBuilder builder1 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
     builder1.pushFilters(new org.apache.spark.sql.sources.Filter[] {nameEq, cntGt});
-    SparkScan scan1 = (SparkScan) builder1.build();
+    DeltaV2Scan scan1 = (DeltaV2Scan) builder1.build();
 
-    SparkScanBuilder builder2 = (SparkScanBuilder) table.newScanBuilder(options);
+    DeltaV2ScanBuilder builder2 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
     builder2.pushFilters(new org.apache.spark.sql.sources.Filter[] {cntGt, nameEq});
-    SparkScan scan2 = (SparkScan) builder2.build();
+    DeltaV2Scan scan2 = (DeltaV2Scan) builder2.build();
 
     // Sanity check that dataFilters is actually populated, otherwise this test would trivially
     // pass without exercising the dataFiltersSet path it's intended to cover.
@@ -1006,8 +1007,8 @@ public class SparkScanTest extends DeltaV2TestBase {
   @Test
   public void testEstimatedSizeMatchesStatistics() throws Exception {
     // Test that estimateStatistics().sizeInBytes() returns the estimatedSizeInBytes field
-    SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan = (SparkScan) builder.build();
+    DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
     long estimatedSizeFromStats = scan.estimateStatistics().sizeInBytes().getAsLong();
     long estimatedSizeFromField = getEstimatedSizeInBytes(scan);
@@ -1034,7 +1035,7 @@ public class SparkScanTest extends DeltaV2TestBase {
     //   readSchema().defaultSize() = 20 + 44 = 64
     //   outputRowSize = 8 + 64 = 72
     //   estimatedBytes = (totalBytes * 72) / 76
-    SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(options);
+    DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) table.newScanBuilder(options);
 
     // Prune columns to only include 'name' (a data column) and partition columns
     // This simulates: SELECT name, date, city, part FROM table
@@ -1046,7 +1047,7 @@ public class SparkScanTest extends DeltaV2TestBase {
             .add("part", DataTypes.IntegerType);
     builder.pruneColumns(prunedSchema);
 
-    SparkScan scan = (SparkScan) builder.build();
+    DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
     long totalBytes = getTotalBytes(scan);
     long estimatedSize = getEstimatedSizeInBytes(scan);
@@ -1071,7 +1072,7 @@ public class SparkScanTest extends DeltaV2TestBase {
     // Test that column pruning and runtime filtering work together correctly
     // Using same formula as testEstimatedSizeWithColumnPruning:
     //   estimatedBytes = (totalBytes * 72) / 76
-    SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(options);
+    DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) table.newScanBuilder(options);
 
     // Prune columns to only include 'name' column
     StructType prunedSchema =
@@ -1082,7 +1083,7 @@ public class SparkScanTest extends DeltaV2TestBase {
             .add("part", DataTypes.IntegerType);
     builder.pruneColumns(prunedSchema);
 
-    SparkScan scan = (SparkScan) builder.build();
+    DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
     // Get initial stats with column pruning
     long initialTotalBytes = getTotalBytes(scan);
@@ -1118,8 +1119,8 @@ public class SparkScanTest extends DeltaV2TestBase {
   @Test
   public void testEstimatedSizeZeroAfterFilteringOutAllFiles() throws Exception {
     // Test that filtering out all files results in zero for both sizes
-    SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan = (SparkScan) builder.build();
+    DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
     // Apply filter that matches nothing
     scan.filter(new Predicate[] {negativeCityPredicate}); // city=zz doesn't exist
@@ -1143,10 +1144,10 @@ public class SparkScanTest extends DeltaV2TestBase {
   @Test
   public void testEqualsAndHashCodeWithSameRuntimeFilter() {
     // Same filter applied to both scans (same instance)
-    SparkScanBuilder builder1 = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan1 = (SparkScan) builder1.build();
-    SparkScanBuilder builder2 = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan2 = (SparkScan) builder2.build();
+    DeltaV2ScanBuilder builder1 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan1 = (DeltaV2Scan) builder1.build();
+    DeltaV2ScanBuilder builder2 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan2 = (DeltaV2Scan) builder2.build();
 
     scan1.filter(new Predicate[] {cityPredicate});
     scan2.filter(new Predicate[] {cityPredicate});
@@ -1158,10 +1159,10 @@ public class SparkScanTest extends DeltaV2TestBase {
   @Test
   public void testEqualsAndHashCodeWithEquivalentRuntimeFilters() {
     // Equivalent filters (different instances)
-    SparkScanBuilder builder1 = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan1 = (SparkScan) builder1.build();
-    SparkScanBuilder builder2 = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan2 = (SparkScan) builder2.build();
+    DeltaV2ScanBuilder builder1 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan1 = (DeltaV2Scan) builder1.build();
+    DeltaV2ScanBuilder builder2 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan2 = (DeltaV2Scan) builder2.build();
 
     scan1.filter(new Predicate[] {cityPredicate});
 
@@ -1180,10 +1181,10 @@ public class SparkScanTest extends DeltaV2TestBase {
   @Test
   public void testEqualsAndHashCodeWithMultipleRuntimeFiltersInSameOrder() {
     // Multiple filters in same order
-    SparkScanBuilder builder1 = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan1 = (SparkScan) builder1.build();
-    SparkScanBuilder builder2 = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan2 = (SparkScan) builder2.build();
+    DeltaV2ScanBuilder builder1 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan1 = (DeltaV2Scan) builder1.build();
+    DeltaV2ScanBuilder builder2 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan2 = (DeltaV2Scan) builder2.build();
 
     scan1.filter(new Predicate[] {cityPredicate, datePredicate});
     scan2.filter(new Predicate[] {cityPredicate, datePredicate});
@@ -1195,10 +1196,10 @@ public class SparkScanTest extends DeltaV2TestBase {
   @Test
   public void testEqualsAndHashCodeWithIdempotentRuntimeFilters() {
     // Filter idempotency - applying same filter once vs twice
-    SparkScanBuilder builder1 = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan1 = (SparkScan) builder1.build();
-    SparkScanBuilder builder2 = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan2 = (SparkScan) builder2.build();
+    DeltaV2ScanBuilder builder1 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan1 = (DeltaV2Scan) builder1.build();
+    DeltaV2ScanBuilder builder2 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan2 = (DeltaV2Scan) builder2.build();
 
     scan1.filter(new Predicate[] {cityPredicate});
     scan2.filter(new Predicate[] {cityPredicate});
@@ -1211,10 +1212,10 @@ public class SparkScanTest extends DeltaV2TestBase {
   @Test
   public void testEqualsAndHashCodeWithSeparateRuntimeFilterCalls() {
     // Multiple separate filter() calls vs single call with multiple filters
-    SparkScanBuilder builder1 = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan1 = (SparkScan) builder1.build();
-    SparkScanBuilder builder2 = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan2 = (SparkScan) builder2.build();
+    DeltaV2ScanBuilder builder1 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan1 = (DeltaV2Scan) builder1.build();
+    DeltaV2ScanBuilder builder2 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan2 = (DeltaV2Scan) builder2.build();
 
     scan1.filter(new Predicate[] {cityPredicate});
     scan1.filter(new Predicate[] {datePredicate});
@@ -1227,10 +1228,10 @@ public class SparkScanTest extends DeltaV2TestBase {
   @Test
   public void testEqualsAndHashCodeWithRuntimeFiltersInDifferentOrder() {
     // Same filters in different order (order-independent)
-    SparkScanBuilder builder1 = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan1 = (SparkScan) builder1.build();
-    SparkScanBuilder builder2 = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan2 = (SparkScan) builder2.build();
+    DeltaV2ScanBuilder builder1 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan1 = (DeltaV2Scan) builder1.build();
+    DeltaV2ScanBuilder builder2 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan2 = (DeltaV2Scan) builder2.build();
 
     scan1.filter(new Predicate[] {cityPredicate, datePredicate});
     scan2.filter(new Predicate[] {datePredicate, cityPredicate});
@@ -1243,10 +1244,10 @@ public class SparkScanTest extends DeltaV2TestBase {
   public void testEqualsAndHashCodeWithNonPartitionColumnRuntimeFilters() {
     // Non-partition column predicates should not affect equality
     // Only partition column predicates should be tracked
-    SparkScanBuilder builder1 = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan1 = (SparkScan) builder1.build();
-    SparkScanBuilder builder2 = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan2 = (SparkScan) builder2.build();
+    DeltaV2ScanBuilder builder1 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan1 = (DeltaV2Scan) builder1.build();
+    DeltaV2ScanBuilder builder2 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan2 = (DeltaV2Scan) builder2.build();
 
     // cityPredicate is on partition column, dataPredicate is on non-partition column (cnt)
     scan1.filter(new Predicate[] {cityPredicate});
@@ -1260,10 +1261,10 @@ public class SparkScanTest extends DeltaV2TestBase {
   @Test
   public void testNotEqualsWithDifferentRuntimeFilters() {
     // Different filters
-    SparkScanBuilder builder1 = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan1 = (SparkScan) builder1.build();
-    SparkScanBuilder builder2 = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan2 = (SparkScan) builder2.build();
+    DeltaV2ScanBuilder builder1 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan1 = (DeltaV2Scan) builder1.build();
+    DeltaV2ScanBuilder builder2 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan2 = (DeltaV2Scan) builder2.build();
 
     scan1.filter(new Predicate[] {cityPredicate});
     scan2.filter(new Predicate[] {datePredicate});
@@ -1275,10 +1276,10 @@ public class SparkScanTest extends DeltaV2TestBase {
   @Test
   public void testNotEqualsWithAndWithoutRuntimeFilter() {
     // One with filter, one without
-    SparkScanBuilder builder1 = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan1 = (SparkScan) builder1.build();
-    SparkScanBuilder builder2 = (SparkScanBuilder) table.newScanBuilder(options);
-    SparkScan scan2 = (SparkScan) builder2.build();
+    DeltaV2ScanBuilder builder1 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan1 = (DeltaV2Scan) builder1.build();
+    DeltaV2ScanBuilder builder2 = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan2 = (DeltaV2Scan) builder2.build();
 
     scan2.filter(new Predicate[] {cityPredicate});
 
@@ -1339,10 +1340,10 @@ public class SparkScanTest extends DeltaV2TestBase {
           Identifier id = Identifier.of(new String[] {"default"}, tblName);
           DeltaV2Table sparkTable = new DeltaV2Table(id, catalogTable, Collections.emptyMap());
 
-          SparkScanBuilder builder =
-              (SparkScanBuilder)
+          DeltaV2ScanBuilder builder =
+              (DeltaV2ScanBuilder)
                   sparkTable.newScanBuilder(new CaseInsensitiveStringMap(new HashMap<>()));
-          SparkScan scan = (SparkScan) builder.build();
+          DeltaV2Scan scan = (DeltaV2Scan) builder.build();
           Statistics stats = scan.estimateStatistics();
 
           // numRows comes from per-file (post-prune) stats
@@ -1396,10 +1397,10 @@ public class SparkScanTest extends DeltaV2TestBase {
         () -> {
           Identifier id = Identifier.of(new String[] {"default"}, tblName);
           DeltaV2Table sparkTable = new DeltaV2Table(id, catalogTable, Collections.emptyMap());
-          SparkScanBuilder builder =
-              (SparkScanBuilder)
+          DeltaV2ScanBuilder builder =
+              (DeltaV2ScanBuilder)
                   sparkTable.newScanBuilder(new CaseInsensitiveStringMap(new HashMap<>()));
-          SparkScan scan = (SparkScan) builder.build();
+          DeltaV2Scan scan = (DeltaV2Scan) builder.build();
           Statistics stats = scan.estimateStatistics();
 
           // Per-file numRows wins over catalog stats.
@@ -1444,10 +1445,10 @@ public class SparkScanTest extends DeltaV2TestBase {
           () -> {
             Identifier id = Identifier.of(new String[] {"default"}, tblName);
             DeltaV2Table sparkTable = new DeltaV2Table(id, catalogTable, Collections.emptyMap());
-            SparkScanBuilder builder =
-                (SparkScanBuilder)
+            DeltaV2ScanBuilder builder =
+                (DeltaV2ScanBuilder)
                     sparkTable.newScanBuilder(new CaseInsensitiveStringMap(new HashMap<>()));
-            SparkScan scan = (SparkScan) builder.build();
+            DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
             assertFalse(
                 isRowCountKnown(scan),
@@ -1493,10 +1494,10 @@ public class SparkScanTest extends DeltaV2TestBase {
           Identifier id = Identifier.of(new String[] {"default"}, tblName);
           DeltaV2Table sparkTable = new DeltaV2Table(id, catalogTable, Collections.emptyMap());
 
-          SparkScanBuilder builder =
-              (SparkScanBuilder)
+          DeltaV2ScanBuilder builder =
+              (DeltaV2ScanBuilder)
                   sparkTable.newScanBuilder(new CaseInsensitiveStringMap(new HashMap<>()));
-          SparkScan scan = (SparkScan) builder.build();
+          DeltaV2Scan scan = (DeltaV2Scan) builder.build();
           Statistics stats = scan.estimateStatistics();
 
           // With CBO disabled, numRows should be empty (matching V1 behavior)
@@ -1540,10 +1541,10 @@ public class SparkScanTest extends DeltaV2TestBase {
                 DeltaV2Table sparkTable =
                     new DeltaV2Table(id, catalogTable, Collections.emptyMap());
 
-                SparkScanBuilder builder =
-                    (SparkScanBuilder)
+                DeltaV2ScanBuilder builder =
+                    (DeltaV2ScanBuilder)
                         sparkTable.newScanBuilder(new CaseInsensitiveStringMap(new HashMap<>()));
-                SparkScan scan = (SparkScan) builder.build();
+                DeltaV2Scan scan = (DeltaV2Scan) builder.build();
                 Statistics stats = scan.estimateStatistics();
 
                 // With planStatsEnabled, numRows should be present (from per-file stats)
@@ -1576,10 +1577,10 @@ public class SparkScanTest extends DeltaV2TestBase {
           Identifier id = Identifier.of(new String[] {"default"}, tblName);
           DeltaV2Table sparkTable = new DeltaV2Table(id, path);
 
-          SparkScanBuilder builder =
-              (SparkScanBuilder)
+          DeltaV2ScanBuilder builder =
+              (DeltaV2ScanBuilder)
                   sparkTable.newScanBuilder(new CaseInsensitiveStringMap(new HashMap<>()));
-          SparkScan scan = (SparkScan) builder.build();
+          DeltaV2Scan scan = (DeltaV2Scan) builder.build();
           Statistics stats = scan.estimateStatistics();
 
           // Per-file Delta stats (numRecords in the transaction log) are available even without
@@ -1644,10 +1645,10 @@ public class SparkScanTest extends DeltaV2TestBase {
           Identifier id = Identifier.of(new String[] {"default"}, tblName);
           DeltaV2Table sparkTable = new DeltaV2Table(id, catalogTable, Collections.emptyMap());
 
-          SparkScanBuilder builder =
-              (SparkScanBuilder)
+          DeltaV2ScanBuilder builder =
+              (DeltaV2ScanBuilder)
                   sparkTable.newScanBuilder(new CaseInsensitiveStringMap(new HashMap<>()));
-          SparkScan scan = (SparkScan) builder.build();
+          DeltaV2Scan scan = (DeltaV2Scan) builder.build();
           Statistics stats = scan.estimateStatistics();
 
           assertTrue(stats.numRows().isPresent(), "numRows should be present");
@@ -1711,15 +1712,15 @@ public class SparkScanTest extends DeltaV2TestBase {
                 DeltaV2Table sparkTable =
                     new DeltaV2Table(id, catalogTable, Collections.emptyMap());
 
-                SparkScanBuilder builder =
-                    (SparkScanBuilder)
+                DeltaV2ScanBuilder builder =
+                    (DeltaV2ScanBuilder)
                         sparkTable.newScanBuilder(new CaseInsensitiveStringMap(new HashMap<>()));
 
                 // Prune to only 'name' column to trigger column projection estimation
                 StructType prunedSchema = new StructType().add("name", DataTypes.StringType);
                 builder.pruneColumns(prunedSchema);
 
-                SparkScan scan = (SparkScan) builder.build();
+                DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
                 long totalBytes = getTotalBytes(scan);
                 long estimatedSize = getEstimatedSizeInBytes(scan);
@@ -1771,10 +1772,10 @@ public class SparkScanTest extends DeltaV2TestBase {
           Identifier id = Identifier.of(new String[] {"default"}, tblName);
           DeltaV2Table sparkTable = new DeltaV2Table(id, catalogTable, Collections.emptyMap());
 
-          SparkScanBuilder builder =
-              (SparkScanBuilder)
+          DeltaV2ScanBuilder builder =
+              (DeltaV2ScanBuilder)
                   sparkTable.newScanBuilder(new CaseInsensitiveStringMap(new HashMap<>()));
-          SparkScan scan = (SparkScan) builder.build();
+          DeltaV2Scan scan = (DeltaV2Scan) builder.build();
           Statistics stats = scan.estimateStatistics();
 
           // Per-file Delta stats (numRecords in the transaction log) provide numRows even when
@@ -1816,10 +1817,10 @@ public class SparkScanTest extends DeltaV2TestBase {
           Identifier id = Identifier.of(new String[] {"default"}, tblName);
           DeltaV2Table sparkTable = new DeltaV2Table(id, catalogTable, Collections.emptyMap());
 
-          SparkScanBuilder builder =
-              (SparkScanBuilder)
+          DeltaV2ScanBuilder builder =
+              (DeltaV2ScanBuilder)
                   sparkTable.newScanBuilder(new CaseInsensitiveStringMap(new HashMap<>()));
-          SparkScan scan = (SparkScan) builder.build();
+          DeltaV2Scan scan = (DeltaV2Scan) builder.build();
           Statistics stats = scan.estimateStatistics();
 
           // Per-file stats provide numRows even when catalog stats lack it

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2ScanTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2ScanTest.java
@@ -494,21 +494,21 @@ public class DeltaV2ScanTest extends DeltaV2TestBase {
     ScanBuilder newBuilder = table.newScanBuilder(scanOptions);
     DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) newBuilder;
     Scan scan = builder.build();
-    DeltaV2Scan sparkScan = (DeltaV2Scan) scan;
+    DeltaV2Scan deltaV2Scan = (DeltaV2Scan) scan;
 
-    List<PartitionedFile> beforeDppFiles = getPartitionedFiles(sparkScan);
+    List<PartitionedFile> beforeDppFiles = getPartitionedFiles(deltaV2Scan);
     // make a copy for comparison after DPP
     beforeDppFiles = new ArrayList<>(beforeDppFiles);
-    long beforeDppTotalBytes = getTotalBytes(sparkScan);
-    long beforeDppEstimatedSize = getEstimatedSizeInBytes(sparkScan);
+    long beforeDppTotalBytes = getTotalBytes(deltaV2Scan);
+    long beforeDppEstimatedSize = getEstimatedSizeInBytes(deltaV2Scan);
     assert (beforeDppFiles.size() == 5);
     // Without column pruning, estimatedSizeInBytes should equal totalBytes
     assertEquals(beforeDppTotalBytes, beforeDppEstimatedSize);
 
-    sparkScan.filter(runtimeFilters);
-    List<PartitionedFile> afterDppFiles = getPartitionedFiles(sparkScan);
-    long afterDppTotalBytes = getTotalBytes(sparkScan);
-    long afterDppEstimatedSize = getEstimatedSizeInBytes(sparkScan);
+    deltaV2Scan.filter(runtimeFilters);
+    List<PartitionedFile> afterDppFiles = getPartitionedFiles(deltaV2Scan);
+    long afterDppTotalBytes = getTotalBytes(deltaV2Scan);
+    long afterDppEstimatedSize = getEstimatedSizeInBytes(deltaV2Scan);
     assert (beforeDppFiles.containsAll(afterDppFiles));
     assert (beforeDppTotalBytes >= afterDppTotalBytes);
 

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkGoldenTableTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkGoldenTableTest.java
@@ -145,8 +145,8 @@ public class SparkGoldenTableTest {
               }
             });
     ScanBuilder builder = table.newScanBuilder(scanOptions);
-    assertTrue((builder instanceof SparkScanBuilder));
-    SparkScanBuilder scanBuilder = (SparkScanBuilder) builder;
+    assertTrue((builder instanceof DeltaV2ScanBuilder));
+    DeltaV2ScanBuilder scanBuilder = (DeltaV2ScanBuilder) builder;
     assertEquals(expectedDataSchema, scanBuilder.getDataSchema());
     assertEquals(expectedPartitionSchema, scanBuilder.getPartitionSchema());
     CaseInsensitiveStringMap combinedOptions =
@@ -161,8 +161,8 @@ public class SparkGoldenTableTest {
     assertEquals(combinedOptions, scanBuilder.getOptions());
 
     Scan scan1 = scanBuilder.build();
-    assertTrue(scan1 instanceof SparkScan);
-    SparkScan sparkScan1 = (SparkScan) scan1;
+    assertTrue(scan1 instanceof DeltaV2Scan);
+    DeltaV2Scan sparkScan1 = (DeltaV2Scan) scan1;
     assertEquals(expectedDataSchema, sparkScan1.getDataSchema());
     assertEquals(expectedDataSchema, sparkScan1.getReadDataSchema());
     assertEquals(expectedPartitionSchema, sparkScan1.getPartitionSchema());
@@ -177,8 +177,8 @@ public class SparkGoldenTableTest {
             });
     scanBuilder.pruneColumns(prunedSchema);
     Scan scan2 = scanBuilder.build();
-    assertTrue(scan2 instanceof SparkScan);
-    SparkScan sparkScan2 = (SparkScan) scan2;
+    assertTrue(scan2 instanceof DeltaV2Scan);
+    DeltaV2Scan sparkScan2 = (DeltaV2Scan) scan2;
     assertEquals(expectedDataSchema, sparkScan2.getDataSchema());
     StructType expectedReadDataSchemaAfterPrune =
         DataTypes.createStructType(new StructField[] {expectedDataSchema.fields()[0]});
@@ -322,8 +322,8 @@ public class SparkGoldenTableTest {
     // city = 'hz' AND date = '20180520'
     org.apache.spark.sql.connector.expressions.filter.Predicate andPredicate =
         new org.apache.spark.sql.connector.expressions.filter.Predicate(
-            "AND", new Expression[] {SparkScanTest.cityPredicate, SparkScanTest.datePredicate});
-    SparkScanTest.checkSupportsRuntimeFilters(
+            "AND", new Expression[] {DeltaV2ScanTest.cityPredicate, DeltaV2ScanTest.datePredicate});
+    DeltaV2ScanTest.checkSupportsRuntimeFilters(
         table,
         options,
         new org.apache.spark.sql.connector.expressions.filter.Predicate[] {andPredicate},
@@ -332,49 +332,49 @@ public class SparkGoldenTableTest {
     // city = 'hz' OR date = '20180520'
     org.apache.spark.sql.connector.expressions.filter.Predicate orPredicate =
         new org.apache.spark.sql.connector.expressions.filter.Predicate(
-            "OR", new Expression[] {SparkScanTest.cityPredicate, SparkScanTest.datePredicate});
-    SparkScanTest.checkSupportsRuntimeFilters(
+            "OR", new Expression[] {DeltaV2ScanTest.cityPredicate, DeltaV2ScanTest.datePredicate});
+    DeltaV2ScanTest.checkSupportsRuntimeFilters(
         table,
         scanOptions,
         new org.apache.spark.sql.connector.expressions.filter.Predicate[] {orPredicate},
         Arrays.asList("city=hz", "date=20180520"));
 
     //  city = 'hz', cnt > 10
-    SparkScanTest.checkSupportsRuntimeFilters(
+    DeltaV2ScanTest.checkSupportsRuntimeFilters(
         table,
         options,
         new org.apache.spark.sql.connector.expressions.filter.Predicate[] {
-          SparkScanTest.cityPredicate, SparkScanTest.dataPredicate
+          DeltaV2ScanTest.cityPredicate, DeltaV2ScanTest.dataPredicate
         },
         Arrays.asList("city=hz"));
 
     //  city = 'hz' OR cnt > 10
     org.apache.spark.sql.connector.expressions.filter.Predicate orDataPredicate =
         new org.apache.spark.sql.connector.expressions.filter.Predicate(
-            "OR", new Expression[] {SparkScanTest.cityPredicate, SparkScanTest.dataPredicate});
-    SparkScanTest.checkSupportsRuntimeFilters(
+            "OR", new Expression[] {DeltaV2ScanTest.cityPredicate, DeltaV2ScanTest.dataPredicate});
+    DeltaV2ScanTest.checkSupportsRuntimeFilters(
         table,
         options,
         new org.apache.spark.sql.connector.expressions.filter.Predicate[] {orDataPredicate},
-        SparkScanTest.allCities);
+        DeltaV2ScanTest.allCities);
 
     // city = date
-    SparkScanTest.checkSupportsRuntimeFilters(
+    DeltaV2ScanTest.checkSupportsRuntimeFilters(
         table,
         options,
         new org.apache.spark.sql.connector.expressions.filter.Predicate[] {
-          SparkScanTest.negativeInterColPredicate
+          DeltaV2ScanTest.negativeInterColPredicate
         },
         Arrays.asList());
 
     // city <> date
-    SparkScanTest.checkSupportsRuntimeFilters(
+    DeltaV2ScanTest.checkSupportsRuntimeFilters(
         table,
         options,
         new org.apache.spark.sql.connector.expressions.filter.Predicate[] {
-          SparkScanTest.interColPredicate
+          DeltaV2ScanTest.interColPredicate
         },
-        SparkScanTest.allCities);
+        DeltaV2ScanTest.allCities);
   }
 
   private void checkSupportsPushDownFilters(
@@ -388,7 +388,7 @@ public class SparkGoldenTableTest {
       Optional<Predicate> expectedKernelScanBuilderPredicate)
       throws Exception {
     ScanBuilder newBuilder = table.newScanBuilder(scanOptions);
-    SparkScanBuilder builder = (SparkScanBuilder) newBuilder;
+    DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) newBuilder;
 
     Filter[] postScanFilters = builder.pushFilters(inputFilters);
 
@@ -414,21 +414,21 @@ public class SparkGoldenTableTest {
     assertEquals(expectedKernelScanBuilderPredicate, predicateOpt);
   }
 
-  private Predicate[] getPushedKernelPredicates(SparkScanBuilder builder) throws Exception {
-    Field field = SparkScanBuilder.class.getDeclaredField("pushedKernelPredicates");
+  private Predicate[] getPushedKernelPredicates(DeltaV2ScanBuilder builder) throws Exception {
+    Field field = DeltaV2ScanBuilder.class.getDeclaredField("pushedKernelPredicates");
     field.setAccessible(true);
     return (Predicate[]) field.get(builder);
   }
 
-  private Filter[] getDataFilters(SparkScanBuilder builder) throws Exception {
-    Field field = SparkScanBuilder.class.getDeclaredField("dataFilters");
+  private Filter[] getDataFilters(DeltaV2ScanBuilder builder) throws Exception {
+    Field field = DeltaV2ScanBuilder.class.getDeclaredField("dataFilters");
     field.setAccessible(true);
     return (Filter[]) field.get(builder);
   }
 
-  private Optional<Predicate> getKernelScanBuilderPredicate(SparkScanBuilder builder)
+  private Optional<Predicate> getKernelScanBuilderPredicate(DeltaV2ScanBuilder builder)
       throws Exception {
-    Field field = SparkScanBuilder.class.getDeclaredField("kernelScanBuilder");
+    Field field = DeltaV2ScanBuilder.class.getDeclaredField("kernelScanBuilder");
     field.setAccessible(true);
     Object kernelScanBuilder = field.get(builder);
     Field predicateField = kernelScanBuilder.getClass().getDeclaredField("predicate");
@@ -461,8 +461,8 @@ public class SparkGoldenTableTest {
         new CaseInsensitiveStringMap(
             java.util.Collections.singletonMap("another_option_key", "another_option_value"));
     ScanBuilder builder = table.newScanBuilder(options);
-    assertTrue((builder instanceof SparkScanBuilder));
-    SparkScanBuilder scanBuilder = (SparkScanBuilder) builder;
+    assertTrue((builder instanceof DeltaV2ScanBuilder));
+    DeltaV2ScanBuilder scanBuilder = (DeltaV2ScanBuilder) builder;
 
     assertEquals(expectedSchema, scanBuilder.getDataSchema());
     assertTrue(scanBuilder.getPartitionSchema().isEmpty());
@@ -470,8 +470,8 @@ public class SparkGoldenTableTest {
 
     // Initial scan (no pruning)
     Scan scan1 = scanBuilder.build();
-    assertTrue(scan1 instanceof SparkScan);
-    SparkScan sparkScan1 = (SparkScan) scan1;
+    assertTrue(scan1 instanceof DeltaV2Scan);
+    DeltaV2Scan sparkScan1 = (DeltaV2Scan) scan1;
     assertEquals(expectedSchema, sparkScan1.getDataSchema());
     assertEquals(expectedSchema, sparkScan1.getReadDataSchema());
     assertTrue(sparkScan1.getPartitionSchema().isEmpty());
@@ -481,8 +481,8 @@ public class SparkGoldenTableTest {
     scanBuilder.pruneColumns(prunedSchema);
 
     Scan scan2 = scanBuilder.build();
-    assertTrue(scan2 instanceof SparkScan);
-    SparkScan sparkScan2 = (SparkScan) scan2;
+    assertTrue(scan2 instanceof DeltaV2Scan);
+    DeltaV2Scan sparkScan2 = (DeltaV2Scan) scan2;
     assertEquals(expectedSchema, sparkScan2.getDataSchema());
     assertEquals(prunedSchema, sparkScan2.getReadDataSchema());
     assertTrue(sparkScan2.getPartitionSchema().isEmpty());

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/write/DeltaRowLevelOperationBuilderTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/write/DeltaRowLevelOperationBuilderTest.java
@@ -88,7 +88,7 @@ public class DeltaRowLevelOperationBuilderTest extends DeltaV2TestBase {
     Scan scan = scanBuilder.build();
 
     assertNotNull(scan);
-    assertTrue(scan instanceof io.delta.spark.internal.v2.read.SparkScan);
+    assertEquals("DeltaV2Scan", scan.getClass().getSimpleName());
   }
 
   @Test


### PR DESCRIPTION
## Description

Rename the Delta Kernel DSv2 scan-planning classes in
`io.delta.spark.internal.v2.read` to the `DeltaV2*` convention, matching the
`DeltaV2Table` and `DeltaV2WriteBuilder` classes already in the package:

- `SparkScan` -> `DeltaV2Scan`
- `SparkScanBuilder` -> `DeltaV2ScanBuilder`

Identifiers only (class files, class names, references, and the corresponding
test classes). No behavior change.

## How was this patch tested?

Existing tests, with all class references updated to the new names.

## Does this PR introduce _any_ user-facing change?

No.