### PR TITLE
[SQL] Rename v2 read MicroBatchStream to DeltaV2MicroBatchStream

### DIFF
--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/V1V2SourceSchemaLogCompatibilitySuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/V1V2SourceSchemaLogCompatibilitySuite.scala
@@ -34,7 +34,7 @@ import org.apache.spark.sql.{DataFrame, Row}
 
 /**
  * Verifies that a single stream's schema tracking log is interchangeable between the V1 (legacy
- * DeltaSource) and V2 (Kernel-based SparkMicroBatchStream) connectors. Each test alternates the
+ * DeltaSource) and V2 (Kernel-based DeltaV2MicroBatchStream) connectors. Each test alternates the
  * connector across stream restarts that share the same checkpoint and schema location, exercising
  * schema log initialization, non-additive evolution, and additive-then-non-additive sequences.
  */

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
@@ -1569,7 +1569,7 @@ object DeltaSource extends DeltaLogging {
   /**
    * Build the latest offset based on the last indexedFile. The function also checks if latest
    * version is valid by comparing with previous version.
-   * Public for use by SparkMicroBatchStream.
+   * Public for use by DeltaV2MicroBatchStream.
    * @param tableId The table ID
    * @param fileVersion The version of the last indexed file.
    * @param fileIndex The index of the last indexed file.

--- a/spark/v2/src/main/java-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogScan.java
+++ b/spark/v2/src/main/java-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogScan.java
@@ -55,7 +55,7 @@ public class DeltaChangelogScan implements Scan {
 
   // TODO: implement toMicroBatchStream() so spark.readStream...loadChangelog(...) can drive a
   // streaming CDC read through this Changelog. The existing streaming-CDC entrypoint
-  // (SparkMicroBatchStream + readChangeFeed=true) provides the wire format today, but it bypasses
+  // (DeltaV2MicroBatchStream + readChangeFeed=true) provides the wire format today, but it bypasses
   // the catalog-driven Changelog API that SPARK-56687 (PR apache/spark#55637) builds on for
   // streaming netChanges post-processing.
 }

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2Batch.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2Batch.java
@@ -99,7 +99,7 @@ class DeltaV2Batch implements Batch {
   @Override
   public PartitionReaderFactory createReaderFactory() {
     // Non-CDC plain table scan. Write-time CDF streaming reads route through
-    // SparkMicroBatchStream; read-time CDF batch reads route through DeltaChangelogBatch.
+    // DeltaV2MicroBatchStream; read-time CDF batch reads route through DeltaChangelogBatch.
     return PartitionUtils.createDeltaParquetReaderFactory(
         snapshot,
         dataSchema,

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2MicroBatchStream.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2MicroBatchStream.java
@@ -110,10 +110,10 @@ import scala.runtime.AbstractFunction2;
 import scala.util.matching.Regex;
 
 // TODO(#5318): Use DeltaErrors error framework for consistent error handling.
-public class SparkMicroBatchStream
+public class DeltaV2MicroBatchStream
     implements MicroBatchStream, SupportsAdmissionControl, SupportsTriggerAvailableNow {
 
-  private static final Logger logger = LoggerFactory.getLogger(SparkMicroBatchStream.class);
+  private static final Logger logger = LoggerFactory.getLogger(DeltaV2MicroBatchStream.class);
 
   private static final String FILE_IDX_COL = "_file_idx";
 
@@ -226,7 +226,7 @@ public class SparkMicroBatchStream
   private final boolean useDistributedInitialSnapshot;
   private final StorageLevel snapshotCacheStorageLevel;
 
-  public SparkMicroBatchStream(
+  public DeltaV2MicroBatchStream(
       DeltaSnapshotManager snapshotManager,
       Snapshot snapshotAtSourceInit,
       Configuration hadoopConf,

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2MicroBatchStream.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2MicroBatchStream.java
@@ -110,7 +110,13 @@ import scala.runtime.AbstractFunction2;
 import scala.util.matching.Regex;
 
 // TODO(#5318): Use DeltaErrors error framework for consistent error handling.
-public class DeltaV2MicroBatchStream
+/**
+ * Package-private micro-batch stream implementation for Delta's Spark DataSource V2 read path.
+ *
+ * <p>This class must remain package-private so callers outside {@code v2.read} depend only on
+ * Spark's public connector interfaces instead of coupling to Delta's internal V2 implementation.
+ */
+class DeltaV2MicroBatchStream
     implements MicroBatchStream, SupportsAdmissionControl, SupportsTriggerAvailableNow {
 
   private static final Logger logger = LoggerFactory.getLogger(DeltaV2MicroBatchStream.class);

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2MicroBatchStream.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2MicroBatchStream.java
@@ -831,7 +831,7 @@ class DeltaV2MicroBatchStream
           new DeltaTimeTravelSpec(
                   /* timestamp= */ options.startingTimestamp().map(Literal$.MODULE$::apply),
                   /* version= */ Option.empty(),
-                  /* creationSource= */ Some.apply("sparkMicroBatchStream"),
+                  /* creationSource= */ Some.apply("deltaV2MicroBatchStream"),
                   /* enforceRetention= */ true)
               .getTimestamp(spark.sessionState().conf());
       long startingVersion =

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2Scan.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2Scan.java
@@ -242,7 +242,7 @@ class DeltaV2Scan implements Scan, SupportsReportStatistics, SupportsRuntimeV2Fi
             Option.apply(checkpointLocation),
             /* mergeConsecutiveSchemaChanges= */ false);
 
-    return new SparkMicroBatchStream(
+    return new DeltaV2MicroBatchStream(
         snapshotManager,
         latestSnapshot,
         hadoopConf,

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/MetadataEvolutionHandler.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/MetadataEvolutionHandler.java
@@ -505,7 +505,7 @@ public class MetadataEvolutionHandler {
    * <p>The persisted metadata is the source of truth for the analyzed schema. With {@code
    * mergeConsecutiveSchemaChanges=true}, the merger folds consecutive metadata-only commits and
    * writes the merged entry back to the durable schema log; the execution-time {@link
-   * SparkMicroBatchStream} then re-reads the same merged entry via {@link
+   * DeltaV2MicroBatchStream} then re-reads the same merged entry via {@link
    * DeltaSourceMetadataTrackingLog#getCurrentTrackedMetadata}.
    */
   public static Optional<PersistedMetadata> getPersistedMetadataForMicroBatchStream(
@@ -722,7 +722,7 @@ public class MetadataEvolutionHandler {
     try (CloseableIterator<CommitActions> commitsIter =
         // Always include CDC: the merger must stop on any file action
         StreamingHelper.getCommitActionsFromRangeUnsafe(
-            engine, commitRange, tablePath, SparkMicroBatchStream.CDC_ACTION_SET)) {
+            engine, commitRange, tablePath, DeltaV2MicroBatchStream.CDC_ACTION_SET)) {
       while (commitsIter.hasNext()) {
         try (CommitActions commit = commitsIter.next()) {
           long version = commit.getVersion();

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/V2StreamingReadTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/V2StreamingReadTest.java
@@ -241,8 +241,8 @@ public class V2StreamingReadTest extends V2TestBase {
    * thread. If that thread is blocked inside Kernel's {@code DefaultJsonHandler} reading delta log
    * JSON files via NIO channels, the interrupt causes a {@link
    * java.nio.channels.ClosedByInterruptException} wrapped in a {@code KernelEngineException}. The
-   * fix in {@code SparkMicroBatchStream.latestOffset()} and {@code
-   * SparkMicroBatchStream.planInputPartitions()} re-wraps this as an {@link
+   * fix in {@code DeltaV2MicroBatchStream.latestOffset()} and {@code
+   * DeltaV2MicroBatchStream.planInputPartitions()} re-wraps this as an {@link
    * java.io.UncheckedIOException} so Spark's {@code isInterruptedByStop} recognizes it as a clean
    * shutdown.
    */

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2MicroBatchStreamCDCTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2MicroBatchStreamCDCTest.java
@@ -57,8 +57,8 @@ import scala.collection.JavaConverters;
 import scala.collection.immutable.Map$;
 import scala.collection.immutable.Seq;
 
-/** Tests for SparkMicroBatchStream CDC (Change Data Capture) support and DSv1/DSv2 parity. */
-public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
+/** Tests for DeltaV2MicroBatchStream CDC (Change Data Capture) support and DSv1/DSv2 parity. */
+public class DeltaV2MicroBatchStreamCDCTest extends DeltaV2TestBase {
 
   // TODO(cdf3): Add test for CDF enabled in initial snapshot but disabled in a later commit.
 
@@ -71,7 +71,7 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
 
     Configuration hadoopConf = new Configuration();
     PathBasedSnapshotManager snapshotManager = new PathBasedSnapshotManager(tablePath, hadoopConf);
-    SparkMicroBatchStream stream =
+    DeltaV2MicroBatchStream stream =
         createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
 
     RuntimeException exception =
@@ -108,7 +108,7 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
 
     Configuration hadoopConf = new Configuration();
     PathBasedSnapshotManager snapshotManager = new PathBasedSnapshotManager(tablePath, hadoopConf);
-    SparkMicroBatchStream stream =
+    DeltaV2MicroBatchStream stream =
         createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
 
     long initVersion = snapshotManager.loadLatestSnapshot().getVersion();
@@ -128,7 +128,7 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
 
     Configuration hadoopConf = new Configuration();
     PathBasedSnapshotManager snapshotManager = new PathBasedSnapshotManager(tablePath, hadoopConf);
-    SparkMicroBatchStream stream =
+    DeltaV2MicroBatchStream stream =
         createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
 
     // Init snapshot has CDF=on (v3), but startVersion=0 had CDF=off. The check must use the
@@ -150,7 +150,7 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
 
     Configuration hadoopConf = new Configuration();
     PathBasedSnapshotManager snapshotManager = new PathBasedSnapshotManager(tablePath, hadoopConf);
-    SparkMicroBatchStream stream =
+    DeltaV2MicroBatchStream stream =
         createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
     long latestVersion = snapshotManager.loadLatestSnapshot().getVersion();
 
@@ -159,7 +159,7 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
     assertDoesNotThrow(() -> stream.validateCDFEnabledOnTable(latestVersion + 1));
   }
 
-  private static final SparkMicroBatchStreamTest.ScenarioSetup CDC_TWO_INSERT_SETUP =
+  private static final DeltaV2MicroBatchStreamTest.ScenarioSetup CDC_TWO_INSERT_SETUP =
       (tableName, tempDir) -> {
         sql("INSERT INTO %s VALUES (1, 'User1'), (2, 'User2')", tableName);
         sql("INSERT INTO %s VALUES (3, 'User3')", tableName);
@@ -179,13 +179,13 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
             noMaxBytes),
         Arguments.of(
             "Empty table (no data files)",
-            (SparkMicroBatchStreamTest.ScenarioSetup) (t, d) -> {},
+            (DeltaV2MicroBatchStreamTest.ScenarioSetup) (t, d) -> {},
             /* isInitialSnapshot= */ true,
             noMaxFiles,
             noMaxBytes),
         Arguments.of(
             "Multiple inserts (5 versions)",
-            (SparkMicroBatchStreamTest.ScenarioSetup)
+            (DeltaV2MicroBatchStreamTest.ScenarioSetup)
                 (t, d) -> {
                   for (int i = 1; i <= 5; i++) {
                     sql("INSERT INTO %s VALUES (%d, 'V%d')", t, i, i);
@@ -231,7 +231,7 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
   @MethodSource("cdcFileChangesParameters")
   public void testGetFileChangesForCDC(
       String testDescription,
-      SparkMicroBatchStreamTest.ScenarioSetup setup,
+      DeltaV2MicroBatchStreamTest.ScenarioSetup setup,
       boolean isInitialSnapshot,
       Optional<Integer> maxFiles,
       Optional<Long> maxBytes,
@@ -267,7 +267,7 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
     // DSv2
     Configuration hadoopConf = new Configuration();
     PathBasedSnapshotManager snapshotManager = new PathBasedSnapshotManager(tablePath, hadoopConf);
-    SparkMicroBatchStream stream =
+    DeltaV2MicroBatchStream stream =
         createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
     List<IndexedFile> dsv2Files = new ArrayList<>();
     try (CloseableIterator<IndexedFile> iter =
@@ -283,7 +283,7 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
     if (isInitialSnapshot) {
       assertCDCFileChangesMatch(dsv1Files, dsv2Files);
     } else {
-      SparkMicroBatchStreamTest.compareFileChanges(dsv1Files, dsv2Files);
+      DeltaV2MicroBatchStreamTest.compareFileChanges(dsv1Files, dsv2Files);
     }
   }
 
@@ -322,7 +322,7 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
             /* isInitialSnapshot= */ false,
             /* maxFiles= */ Optional.empty(),
             /* maxBytes= */ Optional.empty());
-    SparkMicroBatchStreamTest.compareFileChanges(dsv1Unlimited, dsv2Unlimited);
+    DeltaV2MicroBatchStreamTest.compareFileChanges(dsv1Unlimited, dsv2Unlimited);
 
     Set<Long> unlimitedVersions = new HashSet<>();
     for (IndexedFile f : dsv2Unlimited) {
@@ -350,7 +350,7 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
             /* isInitialSnapshot= */ false,
             /* maxFiles= */ Optional.of(1),
             /* maxBytes= */ Optional.empty());
-    SparkMicroBatchStreamTest.compareFileChanges(dsv1Limited, dsv2Limited);
+    DeltaV2MicroBatchStreamTest.compareFileChanges(dsv1Limited, dsv2Limited);
 
     Set<Long> limitedVersions = new HashSet<>();
     for (IndexedFile f : dsv2Limited) {
@@ -413,7 +413,7 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
             /* isInitialSnapshot= */ false,
             /* maxFiles= */ Optional.of(1),
             /* maxBytes= */ Optional.empty());
-    SparkMicroBatchStreamTest.compareFileChanges(dsv1Call1, dsv2Call1);
+    DeltaV2MicroBatchStreamTest.compareFileChanges(dsv1Call1, dsv2Call1);
 
     // Verify no END sentinel in partial result
     boolean dsv2HasEnd =
@@ -479,7 +479,7 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
             /* isInitialSnapshot= */ false,
             /* maxFiles= */ Optional.empty(),
             /* maxBytes= */ Optional.of(maxBytes));
-    SparkMicroBatchStreamTest.compareFileChanges(dsv1Files, dsv2Files);
+    DeltaV2MicroBatchStreamTest.compareFileChanges(dsv1Files, dsv2Files);
 
     long v2DataFiles =
         dsv2Files.stream().filter(f -> f.getVersion() == 2 && f.hasFileAction()).count();
@@ -511,7 +511,7 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
     sql("INSERT INTO %s VALUES (1, 'User1'), (2, 'User2')", tableName);
 
     long commitVersion = 2;
-    SparkMicroBatchStream stream = createStream(tablePath);
+    DeltaV2MicroBatchStream stream = createStream(tablePath);
     CommitActions commit = getCommitActions(tablePath, commitVersion);
 
     List<IndexedFile> files;
@@ -557,7 +557,7 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
     sql("DELETE FROM %s WHERE id = 1", tableName);
 
     long commitVersion = 3;
-    SparkMicroBatchStream stream = createStream(tablePath);
+    DeltaV2MicroBatchStream stream = createStream(tablePath);
     CommitActions commit = getCommitActions(tablePath, commitVersion);
 
     List<IndexedFile> files;
@@ -603,7 +603,7 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
     long commitVersion = 3;
     writeSyntheticNoopMergeCommit(tablePath, commitVersion);
 
-    SparkMicroBatchStream stream = createStream(tablePath);
+    DeltaV2MicroBatchStream stream = createStream(tablePath);
 
     // Verify the commit has file actions (the synthetic commit has Add + Remove).
     CommitActions rawCommit = getCommitActions(tablePath, commitVersion);
@@ -684,7 +684,7 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
             /* isInitialSnapshot= */ false,
             /* maxFiles= */ Optional.empty(),
             /* maxBytes= */ Optional.empty());
-    SparkMicroBatchStreamTest.compareFileChanges(dsv1Files, dsv2Files);
+    DeltaV2MicroBatchStreamTest.compareFileChanges(dsv1Files, dsv2Files);
 
     // Verify ordering: RemoveFile (delete) before AddFile (insert) in delta log
     List<IndexedFile> dataFiles = new ArrayList<>();
@@ -711,7 +711,7 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
     sql("INSERT INTO %s VALUES (1, 'User1')", tableName);
 
     long commitVersion = 2;
-    SparkMicroBatchStream stream = createStream(tablePath);
+    DeltaV2MicroBatchStream stream = createStream(tablePath);
     CommitActions commit = getCommitActions(tablePath, commitVersion);
 
     DeltaSourceOffset endOffset =
@@ -830,7 +830,7 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
     sql("ALTER TABLE %s ADD COLUMNS (c3 INT)", tableName); // v3 metadata-only
 
     String schemaLogPath = new File(tempDir, "schema_log").getAbsolutePath();
-    SparkMicroBatchStream stream =
+    DeltaV2MicroBatchStream stream =
         createStreamWithSeededTrackingLog(tablePath, schemaLogPath, /* seededVersion= */ 2L);
 
     long commitVersion = 3L;
@@ -889,7 +889,7 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
     sql("INSERT INTO %s VALUES (2, 'b', 99)", tableName); // v4 post-barrier
 
     String schemaLogPath = new File(tempDir, "schema_log").getAbsolutePath();
-    SparkMicroBatchStream stream =
+    DeltaV2MicroBatchStream stream =
         createStreamWithSeededTrackingLog(tablePath, schemaLogPath, /* seededVersion= */ 2L);
 
     // Drive the stream from v2 (inclusive). Expected output structure:
@@ -942,7 +942,7 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
         tableName); // v3 protocol-only
 
     String schemaLogPath = new File(tempDir, "schema_log").getAbsolutePath();
-    SparkMicroBatchStream stream =
+    DeltaV2MicroBatchStream stream =
         createStreamWithSeededTrackingLog(tablePath, schemaLogPath, /* seededVersion= */ 2L);
 
     long commitVersion = 3L;
@@ -985,7 +985,7 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
     sql("ALTER TABLE %s ADD COLUMNS (c3 INT)", tableName); // v3 metadata-only
 
     String schemaLogPath = new File(tempDir, "schema_log").getAbsolutePath();
-    SparkMicroBatchStream stream =
+    DeltaV2MicroBatchStream stream =
         createStreamWithSeededTrackingLog(tablePath, schemaLogPath, /* seededVersion= */ 2L);
 
     long commitVersion = 3L;
@@ -1022,7 +1022,7 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
    * {@code seededVersion}. {@code mergeConsecutiveSchemaChanges=false} so the merger doesn't fold
    * later metadata into the seeded entry — useful when the test wants a specific divergence point.
    */
-  private SparkMicroBatchStream createStreamWithSeededTrackingLog(
+  private DeltaV2MicroBatchStream createStreamWithSeededTrackingLog(
       String tablePath, String schemaLogPath, long seededVersion) {
     Configuration hadoopConf = new Configuration();
     PathBasedSnapshotManager snapshotManager = new PathBasedSnapshotManager(tablePath, hadoopConf);
@@ -1064,7 +1064,7 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
     StructType tableSchema =
         io.delta.spark.internal.v2.utils.SchemaUtils.convertKernelSchemaToSparkSchema(
             seededSnapshot.getSchema());
-    return new SparkMicroBatchStream(
+    return new DeltaV2MicroBatchStream(
         snapshotManager,
         latestSnapshot,
         hadoopConf,
@@ -1124,7 +1124,7 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
       throws Exception {
     Configuration hadoopConf = new Configuration();
     PathBasedSnapshotManager snapshotManager = new PathBasedSnapshotManager(tablePath, hadoopConf);
-    SparkMicroBatchStream stream =
+    DeltaV2MicroBatchStream stream =
         createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
     List<IndexedFile> files = new ArrayList<>();
     try (CloseableIterator<IndexedFile> iter =
@@ -1180,13 +1180,13 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
         /* filters= */ emptySeq);
   }
 
-  private SparkMicroBatchStream createTestStreamWithDefaults(
+  private DeltaV2MicroBatchStream createTestStreamWithDefaults(
       PathBasedSnapshotManager snapshotManager, Configuration hadoopConf, DeltaOptions options) {
     io.delta.kernel.Snapshot snapshot = snapshotManager.loadLatestSnapshot();
     StructType tableSchema =
         io.delta.spark.internal.v2.utils.SchemaUtils.convertKernelSchemaToSparkSchema(
             snapshot.getSchema());
-    return new SparkMicroBatchStream(
+    return new DeltaV2MicroBatchStream(
         snapshotManager,
         snapshot,
         hadoopConf,
@@ -1203,7 +1203,7 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
         /* metadataPath= */ "");
   }
 
-  private SparkMicroBatchStream createStream(String tablePath) {
+  private DeltaV2MicroBatchStream createStream(String tablePath) {
     Configuration hadoopConf = new Configuration();
     PathBasedSnapshotManager snapshotManager = new PathBasedSnapshotManager(tablePath, hadoopConf);
     return createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
@@ -1351,7 +1351,7 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
     DeltaLog deltaLog = DeltaLog.forTable(spark, new Path(tablePath));
     deltaLog.update(false, Option.empty(), Option.empty());
 
-    SparkMicroBatchStream stream = createStream(tablePath);
+    DeltaV2MicroBatchStream stream = createStream(tablePath);
     CommitActions commit = getCommitActions(tablePath, commitVersion);
 
     List<IndexedFile> files;
@@ -1445,7 +1445,7 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
     createEmptyTestTable(tablePath, tableName);
     sql("INSERT INTO %s VALUES (1, 'A')", tableName);
 
-    SparkMicroBatchStream stream = createStream(tablePath);
+    DeltaV2MicroBatchStream stream = createStream(tablePath);
 
     // Simulate a "Some+None" DV-diff result: the CDCDataFile is from fromDVDiff but the backing
     // AddFile has NO deletion vector (restore case). hasDeletionVector() returns false.
@@ -1497,7 +1497,7 @@ public class SparkMicroBatchStreamCDCTest extends DeltaV2TestBase {
 
   private void assertCDCFileChangesMatch(
       List<org.apache.spark.sql.delta.sources.IndexedFile> dsv1Files, List<IndexedFile> dsv2Files) {
-    SparkMicroBatchStreamTest.compareFileChanges(dsv1Files, dsv2Files);
+    DeltaV2MicroBatchStreamTest.compareFileChanges(dsv1Files, dsv2Files);
 
     // CDC metadata (only on DSv2 data files, not sentinels)
     for (int i = 0; i < dsv2Files.size(); i++) {

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2MicroBatchStreamCDCTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2MicroBatchStreamCDCTest.java
@@ -58,7 +58,7 @@ import scala.collection.immutable.Map$;
 import scala.collection.immutable.Seq;
 
 /** Tests for DeltaV2MicroBatchStream CDC (Change Data Capture) support and DSv1/DSv2 parity. */
-public class DeltaV2MicroBatchStreamCDCTest extends DeltaV2TestBase {
+class DeltaV2MicroBatchStreamCDCTest extends DeltaV2TestBase {
 
   // TODO(cdf3): Add test for CDF enabled in initial snapshot but disabled in a later commit.
 

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2MicroBatchStreamTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2MicroBatchStreamTest.java
@@ -363,7 +363,7 @@ public class DeltaV2MicroBatchStreamTest extends DeltaV2TestBase {
     }
     deltaChanges.close();
 
-    // dsv2 DeltaV2MicroBatchStream
+    // Delta V2 micro-batch stream
     Configuration hadoopConf = new Configuration();
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(testTablePath, hadoopConf);
@@ -541,7 +541,7 @@ public class DeltaV2MicroBatchStreamTest extends DeltaV2TestBase {
     }
     deltaChanges.close();
 
-    // dsv2 DeltaV2MicroBatchStream
+    // Delta V2 micro-batch stream
     Configuration hadoopConf = new Configuration();
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(testTablePath, hadoopConf);
@@ -724,7 +724,7 @@ public class DeltaV2MicroBatchStreamTest extends DeltaV2TestBase {
     }
     deltaChanges.close();
 
-    // Test DSv2 DeltaV2MicroBatchStream
+    // Test Delta V2 micro-batch stream
     Configuration hadoopConf = new Configuration();
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(testTablePath, hadoopConf);
@@ -893,7 +893,7 @@ public class DeltaV2MicroBatchStreamTest extends DeltaV2TestBase {
             },
             String.format("DSv1 should throw on REMOVE for scenario: %s", testDescription));
 
-    // Test DSv2 DeltaV2MicroBatchStream
+    // Test Delta V2 micro-batch stream
     Configuration hadoopConf = new Configuration();
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(testTablePath, hadoopConf);
@@ -2823,7 +2823,7 @@ public class DeltaV2MicroBatchStreamTest extends DeltaV2TestBase {
       DeltaLog deltaLog = DeltaLog.forTable(spark, new Path(testTablePath));
       DeltaSource deltaSource = createDeltaSource(deltaLog, testTablePath);
 
-      // Create DSv2 DeltaV2MicroBatchStream
+      // Create Delta V2 micro-batch stream
       Configuration hadoopConf = new Configuration();
       PathBasedSnapshotManager snapshotManager =
           new PathBasedSnapshotManager(testTablePath, hadoopConf);
@@ -2944,7 +2944,7 @@ public class DeltaV2MicroBatchStreamTest extends DeltaV2TestBase {
       }
       deltaChanges.close();
 
-      // Test DSv2 DeltaV2MicroBatchStream
+      // Test Delta V2 micro-batch stream
       Configuration hadoopConf = new Configuration();
       PathBasedSnapshotManager snapshotManager =
           new PathBasedSnapshotManager(testTablePath, hadoopConf);
@@ -3000,7 +3000,7 @@ public class DeltaV2MicroBatchStreamTest extends DeltaV2TestBase {
       DeltaLog deltaLog = DeltaLog.forTable(spark, new Path(testTablePath));
       DeltaSource deltaSource = createDeltaSource(deltaLog, testTablePath);
 
-      // Create DSv2 DeltaV2MicroBatchStream
+      // Create Delta V2 micro-batch stream
       Configuration hadoopConf = new Configuration();
       PathBasedSnapshotManager snapshotManager =
           new PathBasedSnapshotManager(testTablePath, hadoopConf);
@@ -3109,7 +3109,7 @@ public class DeltaV2MicroBatchStreamTest extends DeltaV2TestBase {
       DeltaLog deltaLog = DeltaLog.forTable(spark, new Path(testTablePath));
       DeltaSource deltaSource = createDeltaSource(deltaLog, testTablePath);
 
-      // Create DSv2 DeltaV2MicroBatchStream
+      // Create Delta V2 micro-batch stream
       Configuration hadoopConf = new Configuration();
       PathBasedSnapshotManager snapshotManager =
           new PathBasedSnapshotManager(testTablePath, hadoopConf);
@@ -3241,7 +3241,7 @@ public class DeltaV2MicroBatchStreamTest extends DeltaV2TestBase {
             element ->
                 element.toString().contains("checkReadIncompatibleSchemaChangeOnStreamStartOnce"));
 
-    // Test DSv2 DeltaV2MicroBatchStream
+    // Test Delta V2 micro-batch stream
     Configuration hadoopConf = new Configuration();
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(testTablePath, hadoopConf);

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2MicroBatchStreamTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2MicroBatchStreamTest.java
@@ -75,13 +75,13 @@ import scala.collection.JavaConverters;
 import scala.collection.immutable.Map$;
 import scala.collection.immutable.Seq;
 
-public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
+public class DeltaV2MicroBatchStreamTest extends DeltaV2TestBase {
 
   /**
-   * Helper method to create a minimal SparkMicroBatchStream instance for tests that only check for
-   * UnsupportedOperationException.
+   * Helper method to create a minimal DeltaV2MicroBatchStream instance for tests that only check
+   * for UnsupportedOperationException.
    */
-  private SparkMicroBatchStream createTestStream(File tempDir) {
+  private DeltaV2MicroBatchStream createTestStream(File tempDir) {
     String tablePath = tempDir.getAbsolutePath();
     String tableName = "test_unsupported_" + System.nanoTime();
     createEmptyTestTable(tablePath, tableName);
@@ -96,7 +96,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
 
   @Test
   public void testLatestOffset_throwsUnsupportedOperationException(@TempDir File tempDir) {
-    SparkMicroBatchStream microBatchStream = createTestStream(tempDir);
+    DeltaV2MicroBatchStream microBatchStream = createTestStream(tempDir);
     IllegalStateException exception =
         assertThrows(IllegalStateException.class, () -> microBatchStream.latestOffset());
   }
@@ -118,7 +118,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
     Configuration hadoopConf = new Configuration();
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(testTablePath, hadoopConf);
-    SparkMicroBatchStream stream =
+    DeltaV2MicroBatchStream stream =
         createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
 
     // Get the latest version
@@ -145,7 +145,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
   @Test
   public void testDeserializeOffset_ValidJson(@TempDir File tempDir) throws Exception {
     String tablePath = tempDir.getAbsolutePath();
-    SparkMicroBatchStream stream = createTestStream(tempDir);
+    DeltaV2MicroBatchStream stream = createTestStream(tempDir);
 
     DeltaLog deltaLog = DeltaLog.forTable(spark, new Path(tablePath));
     String tableId = deltaLog.tableId();
@@ -163,7 +163,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
 
   @Test
   public void testDeserializeOffset_MismatchedTableId(@TempDir File tempDir) throws Exception {
-    SparkMicroBatchStream stream = createTestStream(tempDir);
+    DeltaV2MicroBatchStream stream = createTestStream(tempDir);
 
     // Create offset with wrong tableId
     String wrongTableId = "wrong-table-id";
@@ -185,7 +185,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
 
   @Test
   public void testDeserializeOffset_InvalidJson(@TempDir File tempDir) {
-    SparkMicroBatchStream stream = createTestStream(tempDir);
+    DeltaV2MicroBatchStream stream = createTestStream(tempDir);
     String invalidJson = "{this is not valid json}";
     assertThrows(RuntimeException.class, () -> stream.deserializeOffset(invalidJson));
   }
@@ -193,7 +193,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
   @Test
   public void testDeserializeOffset_WithInitialSnapshot(@TempDir File tempDir) throws Exception {
     String tablePath = tempDir.getAbsolutePath();
-    SparkMicroBatchStream stream = createTestStream(tempDir);
+    DeltaV2MicroBatchStream stream = createTestStream(tempDir);
 
     DeltaLog deltaLog = DeltaLog.forTable(spark, new Path(tablePath));
     String tableId = deltaLog.tableId();
@@ -214,7 +214,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
   @Test
   public void testCommit_NoOp(@TempDir File tempDir) throws Exception {
     String tablePath = tempDir.getAbsolutePath();
-    SparkMicroBatchStream stream = createTestStream(tempDir);
+    DeltaV2MicroBatchStream stream = createTestStream(tempDir);
 
     DeltaLog deltaLog = DeltaLog.forTable(spark, new Path(tablePath));
     String tableId = deltaLog.tableId();
@@ -225,7 +225,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
 
   @Test
   public void testStop_NoOp(@TempDir File tempDir) {
-    SparkMicroBatchStream stream = createTestStream(tempDir);
+    DeltaV2MicroBatchStream stream = createTestStream(tempDir);
     assertDoesNotThrow(() -> stream.stop());
   }
 
@@ -271,7 +271,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
     Configuration hadoopConf = new Configuration();
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(testTablePath, hadoopConf);
-    SparkMicroBatchStream stream =
+    DeltaV2MicroBatchStream stream =
         createTestStreamWithDefaults(snapshotManager, hadoopConf, options);
     Offset initialOffset = stream.initialOffset();
     Offset dsv2Offset = stream.latestOffset(initialOffset, readLimit);
@@ -305,7 +305,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
 
   /**
    * Parameterized test that verifies parity between DSv1 DeltaSource.getFileChanges and DSv2
-   * SparkMicroBatchStream.getFileChanges using Delta Kernel APIs.
+   * DeltaV2MicroBatchStream.getFileChanges using Delta Kernel APIs.
    *
    * <p>Tests both regular delta log streaming and initial snapshot scenarios.
    *
@@ -363,11 +363,11 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
     }
     deltaChanges.close();
 
-    // dsv2 SparkMicroBatchStream
+    // dsv2 DeltaV2MicroBatchStream
     Configuration hadoopConf = new Configuration();
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(testTablePath, hadoopConf);
-    SparkMicroBatchStream stream =
+    DeltaV2MicroBatchStream stream =
         createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
     Optional<DeltaSourceOffset> endOffsetOption = ScalaUtils.toJavaOptional(scalaEndOffset);
     try (CloseableIterator<IndexedFile> kernelChanges =
@@ -495,7 +495,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
 
   /**
    * Test that verifies parity between DSv1 DeltaSource.getFileChangesWithRateLimit and DSv2
-   * SparkMicroBatchStream.getFileChangesWithRateLimit.
+   * DeltaV2MicroBatchStream.getFileChangesWithRateLimit.
    *
    * <p>Tests both regular delta log streaming and initial snapshot scenarios with rate limiting.
    */
@@ -541,11 +541,11 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
     }
     deltaChanges.close();
 
-    // dsv2 SparkMicroBatchStream
+    // dsv2 DeltaV2MicroBatchStream
     Configuration hadoopConf = new Configuration();
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(testTablePath, hadoopConf);
-    SparkMicroBatchStream stream =
+    DeltaV2MicroBatchStream stream =
         createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
     // We need a separate AdmissionLimits object for DSv2 because the method is stateful.
     Optional<DeltaSource.AdmissionLimits> dsv2Limits =
@@ -724,11 +724,11 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
     }
     deltaChanges.close();
 
-    // Test DSv2 SparkMicroBatchStream
+    // Test DSv2 DeltaV2MicroBatchStream
     Configuration hadoopConf = new Configuration();
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(testTablePath, hadoopConf);
-    SparkMicroBatchStream stream =
+    DeltaV2MicroBatchStream stream =
         createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
     try (CloseableIterator<IndexedFile> kernelChanges =
         stream.getFileChanges(
@@ -784,7 +784,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
     Configuration hadoopConf = new Configuration();
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(testTablePath, hadoopConf);
-    SparkMicroBatchStream stream =
+    DeltaV2MicroBatchStream stream =
         createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
 
     // Get file changes from version 0 (which will include versions 1-4)
@@ -893,11 +893,11 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
             },
             String.format("DSv1 should throw on REMOVE for scenario: %s", testDescription));
 
-    // Test DSv2 SparkMicroBatchStream
+    // Test DSv2 DeltaV2MicroBatchStream
     Configuration hadoopConf = new Configuration();
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(testTablePath, hadoopConf);
-    SparkMicroBatchStream stream =
+    DeltaV2MicroBatchStream stream =
         createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
 
     AtomicInteger dsv2SuccessfulCalls = new AtomicInteger(0);
@@ -1081,7 +1081,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
     Configuration hadoopConf = new Configuration();
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(testTablePath, hadoopConf);
-    SparkMicroBatchStream stream =
+    DeltaV2MicroBatchStream stream =
         createTestStreamWithDefaults(snapshotManager, hadoopConf, options);
     try (CloseableIterator<IndexedFile> kernelChanges =
         stream.getFileChanges(fromVersion, fromIndex, isInitialSnapshot, Optional.empty())) {
@@ -1148,7 +1148,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
     Configuration hadoopConf = new Configuration();
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(testTablePath, hadoopConf);
-    SparkMicroBatchStream stream =
+    DeltaV2MicroBatchStream stream =
         createTestStreamWithDefaults(snapshotManager, hadoopConf, options);
 
     AtomicInteger dsv2SuccessfulCalls = new AtomicInteger(0);
@@ -1496,7 +1496,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
     Configuration hadoopConf = spark.sessionState().newHadoopConf();
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(testTablePath, hadoopConf);
-    SparkMicroBatchStream stream =
+    DeltaV2MicroBatchStream stream =
         createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
 
     // Get file changes from version 1 onwards
@@ -1529,7 +1529,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
 
   /**
    * Parameterized test that verifies parity between DSv1 DeltaSource.latestOffset and DSv2
-   * SparkMicroBatchStream.latestOffset.
+   * DeltaV2MicroBatchStream.latestOffset.
    */
   @ParameterizedTest
   @MethodSource("latestOffsetParameters")
@@ -1564,7 +1564,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
     Configuration hadoopConf = new Configuration();
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(testTablePath, hadoopConf);
-    SparkMicroBatchStream stream =
+    DeltaV2MicroBatchStream stream =
         createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
     Offset v2EndOffset = stream.latestOffset(startOffset, readLimit);
 
@@ -1683,7 +1683,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
     Configuration hadoopConf = new Configuration();
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(testTablePath, hadoopConf);
-    SparkMicroBatchStream stream =
+    DeltaV2MicroBatchStream stream =
         createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
     List<Offset> dsv2Offsets =
         advanceOffsetSequenceDsv2(stream, startOffset, numIterations, readLimit);
@@ -1809,7 +1809,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
     Configuration hadoopConf = new Configuration();
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(testTablePath, hadoopConf);
-    SparkMicroBatchStream stream =
+    DeltaV2MicroBatchStream stream =
         createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
     Offset dsv2Offset = stream.latestOffset(startOffset, readLimit);
 
@@ -1900,7 +1900,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
     Configuration hadoopConf = new Configuration();
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(testTablePath, hadoopConf);
-    SparkMicroBatchStream stream =
+    DeltaV2MicroBatchStream stream =
         createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
     // Enable availableNow
     stream.prepareForTriggerAvailableNow();
@@ -2048,8 +2048,8 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
     StructType dataSchema = deltaSnapshot.metadata().schema();
     StructType partitionSchema = deltaSnapshot.metadata().partitionSchema();
 
-    SparkMicroBatchStream stream =
-        new SparkMicroBatchStream(
+    DeltaV2MicroBatchStream stream =
+        new DeltaV2MicroBatchStream(
             snapshotManager,
             snapshotManager.loadLatestSnapshot(),
             spark.sessionState().newHadoopConf(),
@@ -2236,8 +2236,8 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
                 .filter(f -> !partitionColNames.contains(f.name()))
                 .toArray(StructField[]::new));
 
-    SparkMicroBatchStream stream =
-        new SparkMicroBatchStream(
+    DeltaV2MicroBatchStream stream =
+        new DeltaV2MicroBatchStream(
             snapshotManager,
             snapshotManager.loadLatestSnapshot(),
             spark.sessionState().newHadoopConf(),
@@ -2456,7 +2456,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
 
   /**
    * Parameterized test that verifies parity between DSv1 DeltaSource.getStartingVersion and DSv2
-   * SparkMicroBatchStream.getStartingVersion.
+   * DeltaV2MicroBatchStream.getStartingVersion.
    */
   @ParameterizedTest
   @MethodSource("getStartingVersionParameters")
@@ -2516,7 +2516,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
     // dsv2
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(testTablePath, new Configuration());
-    SparkMicroBatchStream dsv2Stream =
+    DeltaV2MicroBatchStream dsv2Stream =
         createTestStreamWithDefaults(snapshotManager, new Configuration(), emptyDeltaOptions());
     Optional<Long> dsv2Result = dsv2Stream.getStartingVersion();
 
@@ -2646,7 +2646,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
     // dsv2
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(testTablePath, new Configuration());
-    SparkMicroBatchStream dsv2Stream =
+    DeltaV2MicroBatchStream dsv2Stream =
         createTestStreamWithDefaults(
             snapshotManager,
             new Configuration(),
@@ -2662,7 +2662,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
 
   /**
    * Test that verifies parity between DSv1 DeltaSource.getStartingVersion and DSv2
-   * SparkMicroBatchStream.getStartingVersion when using startingTimestamp option.
+   * DeltaV2MicroBatchStream.getStartingVersion when using startingTimestamp option.
    *
    * <p>Uses ICT (In-Commit Timestamps) so we can read exact commit timestamps from the delta log
    * and test the boundary case where startingTimestamp exactly equals a commit time.
@@ -2737,7 +2737,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
       // dsv2
       PathBasedSnapshotManager snapshotManager =
           new PathBasedSnapshotManager(testTablePath, new Configuration());
-      SparkMicroBatchStream dsv2Stream =
+      DeltaV2MicroBatchStream dsv2Stream =
           createTestStreamWithDefaults(
               snapshotManager,
               new Configuration(),
@@ -2761,7 +2761,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
     // dsv2
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(testTablePath, new Configuration());
-    SparkMicroBatchStream dsv2Stream =
+    DeltaV2MicroBatchStream dsv2Stream =
         createTestStreamWithDefaults(
             snapshotManager,
             new Configuration(),
@@ -2823,11 +2823,11 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
       DeltaLog deltaLog = DeltaLog.forTable(spark, new Path(testTablePath));
       DeltaSource deltaSource = createDeltaSource(deltaLog, testTablePath);
 
-      // Create DSv2 SparkMicroBatchStream
+      // Create DSv2 DeltaV2MicroBatchStream
       Configuration hadoopConf = new Configuration();
       PathBasedSnapshotManager snapshotManager =
           new PathBasedSnapshotManager(testTablePath, hadoopConf);
-      SparkMicroBatchStream stream =
+      DeltaV2MicroBatchStream stream =
           createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
 
       // Execute schema change after source initialization to ensure forward change
@@ -2944,11 +2944,11 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
       }
       deltaChanges.close();
 
-      // Test DSv2 SparkMicroBatchStream
+      // Test DSv2 DeltaV2MicroBatchStream
       Configuration hadoopConf = new Configuration();
       PathBasedSnapshotManager snapshotManager =
           new PathBasedSnapshotManager(testTablePath, hadoopConf);
-      SparkMicroBatchStream stream =
+      DeltaV2MicroBatchStream stream =
           createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
       try (CloseableIterator<IndexedFile> kernelChanges =
           stream.getFileChanges(
@@ -3000,11 +3000,11 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
       DeltaLog deltaLog = DeltaLog.forTable(spark, new Path(testTablePath));
       DeltaSource deltaSource = createDeltaSource(deltaLog, testTablePath);
 
-      // Create DSv2 SparkMicroBatchStream
+      // Create DSv2 DeltaV2MicroBatchStream
       Configuration hadoopConf = new Configuration();
       PathBasedSnapshotManager snapshotManager =
           new PathBasedSnapshotManager(testTablePath, hadoopConf);
-      SparkMicroBatchStream stream =
+      DeltaV2MicroBatchStream stream =
           createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
 
       // Execute schema change after source initialization to ensure forward change
@@ -3109,11 +3109,11 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
       DeltaLog deltaLog = DeltaLog.forTable(spark, new Path(testTablePath));
       DeltaSource deltaSource = createDeltaSource(deltaLog, testTablePath);
 
-      // Create DSv2 SparkMicroBatchStream
+      // Create DSv2 DeltaV2MicroBatchStream
       Configuration hadoopConf = new Configuration();
       PathBasedSnapshotManager snapshotManager =
           new PathBasedSnapshotManager(testTablePath, hadoopConf);
-      SparkMicroBatchStream stream =
+      DeltaV2MicroBatchStream stream =
           createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
 
       DeltaUnsupportedOperationException dsv1Exception =
@@ -3241,11 +3241,11 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
             element ->
                 element.toString().contains("checkReadIncompatibleSchemaChangeOnStreamStartOnce"));
 
-    // Test DSv2 SparkMicroBatchStream
+    // Test DSv2 DeltaV2MicroBatchStream
     Configuration hadoopConf = new Configuration();
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(testTablePath, hadoopConf);
-    SparkMicroBatchStream stream =
+    DeltaV2MicroBatchStream stream =
         createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
     DeltaUnsupportedOperationException dsv2Exception =
         assertThrows(
@@ -3320,7 +3320,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
 
       // Stream constructed BEFORE the schema change — pre-change snapshot is still the latest.
       StructType preChangeSchema = loadSparkSchemaAtVersion(snapshotManager, startVersion);
-      SparkMicroBatchStream streamPreChange =
+      DeltaV2MicroBatchStream streamPreChange =
           createSchemaTrackingTestStream(
               snapshotManager,
               hadoopConf,
@@ -3365,7 +3365,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
       StructType postChangeSchema =
           io.delta.spark.internal.v2.utils.SchemaUtils.convertKernelSchemaToSparkSchema(
               snapshotManager.loadLatestSnapshot().getSchema());
-      SparkMicroBatchStream streamPostChange =
+      DeltaV2MicroBatchStream streamPostChange =
           createSchemaTrackingTestStream(
               snapshotManager,
               hadoopConf,
@@ -3464,7 +3464,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
 
       // Round 1: post-change schema (analysis would bind to the latest snapshot since the log
       // is empty). First latestOffset runs eager-init and throws.
-      SparkMicroBatchStream streamForEagerInit =
+      DeltaV2MicroBatchStream streamForEagerInit =
           createSchemaTrackingTestStream(
               snapshotManager,
               hadoopConf,
@@ -3485,7 +3485,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
       assertEquals(startVersion, afterInit.deltaCommitVersion());
 
       // Round 2: pre-change schema (the log entry now carries it).
-      SparkMicroBatchStream streamForBarrier =
+      DeltaV2MicroBatchStream streamForBarrier =
           createSchemaTrackingTestStream(
               snapshotManager,
               hadoopConf,
@@ -3519,7 +3519,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
       assertPostChangeSchema.accept(evolved.dataSchema());
 
       // Round 3: post-change schema. Advance barrier → POST_BARRIER, commit succeeds.
-      SparkMicroBatchStream streamForPostBarrier =
+      DeltaV2MicroBatchStream streamForPostBarrier =
           createSchemaTrackingTestStream(
               snapshotManager,
               hadoopConf,
@@ -3583,7 +3583,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
 
     // Populate the tracking log via eager init on a default-options stream so that
     // shouldTrackMetadataChange() returns true on the next stream.
-    SparkMicroBatchStream streamForInit =
+    DeltaV2MicroBatchStream streamForInit =
         createSchemaTrackingTestStream(
             snapshotManager,
             hadoopConf,
@@ -3600,7 +3600,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
     // With the log populated, a stream configured with failOnDataLoss=false must reject the first
     // change-log scan.
     DeltaOptions failOnDataLossFalse = createDeltaOptions("failOnDataLoss", "false");
-    SparkMicroBatchStream stream =
+    DeltaV2MicroBatchStream stream =
         createSchemaTrackingTestStream(
             snapshotManager,
             hadoopConf,
@@ -3943,7 +3943,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
     Configuration hadoopConf = new Configuration();
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(testTablePath, hadoopConf);
-    SparkMicroBatchStream stream =
+    DeltaV2MicroBatchStream stream =
         createTestStreamWithDefaults(snapshotManager, hadoopConf, options);
     try (CloseableIterator<IndexedFile> dsv2Changes =
         stream.getFileChanges(
@@ -4006,7 +4006,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
     Configuration hadoopConf = new Configuration();
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(testTablePath, hadoopConf);
-    SparkMicroBatchStream stream =
+    DeltaV2MicroBatchStream stream =
         createTestStreamWithDefaults(snapshotManager, hadoopConf, defaultOptions);
     io.delta.kernel.exceptions.StartVersionNotFoundException dsv2Exception =
         assertThrows(
@@ -4053,7 +4053,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(testTablePath, hadoopConf);
     DeltaOptions options = createDeltaOptions("failOnDataLoss", "false");
-    SparkMicroBatchStream stream =
+    DeltaV2MicroBatchStream stream =
         createTestStreamWithDefaults(snapshotManager, hadoopConf, options);
 
     // Reading from version 1 (which exists) should throw InvalidTableException because
@@ -4240,7 +4240,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
   }
 
   private List<Offset> advanceOffsetSequenceDsv2(
-      SparkMicroBatchStream stream, Offset startOffset, int numIterations, ReadLimit limit) {
+      DeltaV2MicroBatchStream stream, Offset startOffset, int numIterations, ReadLimit limit) {
     List<Offset> offsets = new ArrayList<>();
     offsets.add(startOffset);
 
@@ -4289,15 +4289,15 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
         /* filters= */ emptySeq);
   }
 
-  /** Helper method to create a SparkMicroBatchStream with default values for testing. */
-  private SparkMicroBatchStream createTestStreamWithDefaults(
+  /** Helper method to create a DeltaV2MicroBatchStream with default values for testing. */
+  private DeltaV2MicroBatchStream createTestStreamWithDefaults(
       PathBasedSnapshotManager snapshotManager, Configuration hadoopConf, DeltaOptions options) {
     io.delta.kernel.Snapshot snapshot = snapshotManager.loadLatestSnapshot();
     String tablePath = ((io.delta.kernel.internal.SnapshotImpl) snapshot).getPath();
     StructType tableSchema =
         io.delta.spark.internal.v2.utils.SchemaUtils.convertKernelSchemaToSparkSchema(
             snapshot.getSchema());
-    return new SparkMicroBatchStream(
+    return new DeltaV2MicroBatchStream(
         snapshotManager,
         snapshot,
         hadoopConf,
@@ -4314,7 +4314,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
         /* metadataPath= */ tablePath + "/_checkpoint");
   }
 
-  private SparkMicroBatchStream createSchemaTrackingTestStream(
+  private DeltaV2MicroBatchStream createSchemaTrackingTestStream(
       PathBasedSnapshotManager snapshotManager,
       Configuration hadoopConf,
       DeltaOptions options,
@@ -4323,7 +4323,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
       Option<DeltaSourceMetadataTrackingLog> metadataTrackingLog,
       String metadataPath) {
     io.delta.kernel.Snapshot snapshot = snapshotManager.loadLatestSnapshot();
-    return new SparkMicroBatchStream(
+    return new DeltaV2MicroBatchStream(
         snapshotManager,
         snapshot,
         hadoopConf,
@@ -4370,7 +4370,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
   }
 
   private List<Integer> readIdsBetweenOffsets(
-      SparkMicroBatchStream stream, Offset startOffset, Offset endOffset) throws Exception {
+      DeltaV2MicroBatchStream stream, Offset startOffset, Offset endOffset) throws Exception {
     InputPartition[] partitions = stream.planInputPartitions(startOffset, endOffset);
     PartitionReaderFactory readerFactory = stream.createReaderFactory();
     List<Integer> ids = new ArrayList<>();
@@ -4409,7 +4409,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
    * reader is closed.
    */
   private List<InternalRow> readRowsBetweenOffsets(
-      SparkMicroBatchStream stream, Offset startOffset, Offset endOffset) throws Exception {
+      DeltaV2MicroBatchStream stream, Offset startOffset, Offset endOffset) throws Exception {
     InputPartition[] partitions = stream.planInputPartitions(startOffset, endOffset);
     PartitionReaderFactory readerFactory = stream.createReaderFactory();
     List<InternalRow> rows = new ArrayList<>();
@@ -4447,7 +4447,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
    * scenarios that drop or rename the leading column.
    */
   private long countRowsBetweenOffsets(
-      SparkMicroBatchStream stream, Offset startOffset, Offset endOffset) throws Exception {
+      DeltaV2MicroBatchStream stream, Offset startOffset, Offset endOffset) throws Exception {
     InputPartition[] partitions = stream.planInputPartitions(startOffset, endOffset);
     PartitionReaderFactory readerFactory = stream.createReaderFactory();
     long count = 0L;
@@ -4521,10 +4521,10 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
             deltaLog, testTablePath, createDeltaOptions("startingVersion", startingVersion));
     scala.Option<Object> dsv1Result = deltaSource.getStartingVersion();
 
-    // DSv2: Create SparkMicroBatchStream and get starting version
+    // DSv2: Create DeltaV2MicroBatchStream and get starting version
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(testTablePath, new Configuration());
-    SparkMicroBatchStream dsv2Stream =
+    DeltaV2MicroBatchStream dsv2Stream =
         createTestStreamWithDefaults(
             snapshotManager,
             new Configuration(),
@@ -4579,7 +4579,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
       Configuration hadoopConf = new Configuration();
       PathBasedSnapshotManager snapshotManager =
           new PathBasedSnapshotManager(testTablePath, hadoopConf);
-      SparkMicroBatchStream stream =
+      DeltaV2MicroBatchStream stream =
           createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
 
       long version = 5L;
@@ -4620,18 +4620,19 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
     // KernelEngineException wrapping ClosedByInterruptException -> present
     ClosedByInterruptException cbie = new ClosedByInterruptException();
     assertThat(
-            SparkMicroBatchStream.findClosedByInterruptCause(
+            DeltaV2MicroBatchStream.findClosedByInterruptCause(
                 new io.delta.kernel.exceptions.KernelEngineException("readJsonFile", cbie)))
         .isPresent()
         .contains(cbie);
 
     // Plain RuntimeException -> empty
-    assertThat(SparkMicroBatchStream.findClosedByInterruptCause(new RuntimeException("unrelated")))
+    assertThat(
+            DeltaV2MicroBatchStream.findClosedByInterruptCause(new RuntimeException("unrelated")))
         .isEmpty();
 
     // KernelEngineException wrapping a different IOException -> empty
     assertThat(
-            SparkMicroBatchStream.findClosedByInterruptCause(
+            DeltaV2MicroBatchStream.findClosedByInterruptCause(
                 new io.delta.kernel.exceptions.KernelEngineException(
                     "readJsonFile", new java.io.FileNotFoundException("missing"))))
         .isEmpty();
@@ -4665,7 +4666,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
         };
 
     try (CloseableIterator<IndexedFile> wrapped =
-        SparkMicroBatchStream.wrapIteratorWithCommitClose(
+        DeltaV2MicroBatchStream.wrapIteratorWithCommitClose(
             inner, newTrackingCommitActions(commitClosed))) {
       while (wrapped.hasNext()) {
         wrapped.next();
@@ -4701,7 +4702,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
         };
 
     try (CloseableIterator<IndexedFile> wrapped =
-        SparkMicroBatchStream.wrapIteratorWithCommitClose(
+        DeltaV2MicroBatchStream.wrapIteratorWithCommitClose(
             inner, newTrackingCommitActions(commitClosed))) {
       assertTrue(wrapped.hasNext());
       wrapped.next();
@@ -4736,7 +4737,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
         };
 
     CloseableIterator<IndexedFile> wrapped =
-        SparkMicroBatchStream.wrapIteratorWithCommitClose(
+        DeltaV2MicroBatchStream.wrapIteratorWithCommitClose(
             inner, newTrackingCommitActions(commitClosed));
     try {
       wrapped.close();
@@ -4791,7 +4792,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
 
     assertDoesNotThrow(
         () ->
-            SparkMicroBatchStream.validateSchemaCompatibilityOnStartup(
+            DeltaV2MicroBatchStream.validateSchemaCompatibilityOnStartup(
                 dataSchema, partitionSchema, snapshotSchema));
   }
 
@@ -4808,7 +4809,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
 
     assertDoesNotThrow(
         () ->
-            SparkMicroBatchStream.validateSchemaCompatibilityOnStartup(
+            DeltaV2MicroBatchStream.validateSchemaCompatibilityOnStartup(
                 dataSchema, partitionSchema, snapshotSchema));
   }
 
@@ -4830,7 +4831,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
         assertThrows(
             DeltaIllegalStateException.class,
             () ->
-                SparkMicroBatchStream.validateSchemaCompatibilityOnStartup(
+                DeltaV2MicroBatchStream.validateSchemaCompatibilityOnStartup(
                     dataSchema, partitionSchema, snapshotSchema));
     assertTrue(ex.getMessage().contains("DELTA_STREAMING_SCHEMA_MISMATCH_ON_RESTART"));
   }
@@ -4851,7 +4852,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
         assertThrows(
             DeltaIllegalStateException.class,
             () ->
-                SparkMicroBatchStream.validateSchemaCompatibilityOnStartup(
+                DeltaV2MicroBatchStream.validateSchemaCompatibilityOnStartup(
                     dataSchema, partitionSchema, snapshotSchema));
     assertTrue(ex.getMessage().contains("DELTA_STREAMING_SCHEMA_MISMATCH_ON_RESTART"));
   }
@@ -4871,7 +4872,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
         assertThrows(
             DeltaIllegalStateException.class,
             () ->
-                SparkMicroBatchStream.validateSchemaCompatibilityOnStartup(
+                DeltaV2MicroBatchStream.validateSchemaCompatibilityOnStartup(
                     dataSchema, partitionSchema, snapshotSchema));
     assertTrue(ex.getMessage().contains("DELTA_STREAMING_SCHEMA_MISMATCH_ON_RESTART"));
   }
@@ -4885,7 +4886,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
 
     assertDoesNotThrow(
         () ->
-            SparkMicroBatchStream.validateSchemaCompatibilityOnStartup(
+            DeltaV2MicroBatchStream.validateSchemaCompatibilityOnStartup(
                 dataSchema, partitionSchema, snapshotSchema));
   }
 
@@ -4899,7 +4900,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
         assertThrows(
             DeltaIllegalStateException.class,
             () ->
-                SparkMicroBatchStream.validateSchemaCompatibilityOnStartup(
+                DeltaV2MicroBatchStream.validateSchemaCompatibilityOnStartup(
                     dataSchema, partitionSchema, snapshotSchema));
     assertTrue(ex.getMessage().contains("DELTA_STREAMING_SCHEMA_MISMATCH_ON_RESTART"));
   }
@@ -4912,7 +4913,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
 
     assertDoesNotThrow(
         () ->
-            SparkMicroBatchStream.validateSchemaCompatibilityOnStartup(
+            DeltaV2MicroBatchStream.validateSchemaCompatibilityOnStartup(
                 dataSchema, partitionSchema, snapshotSchema));
   }
 
@@ -4938,7 +4939,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
       Configuration hadoopConf = spark.sessionState().newHadoopConf();
       PathBasedSnapshotManager snapshotManager =
           new PathBasedSnapshotManager(testTablePath, hadoopConf);
-      SparkMicroBatchStream stream =
+      DeltaV2MicroBatchStream stream =
           createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
 
       long version = snapshotManager.loadLatestSnapshot().getVersion();
@@ -5000,7 +5001,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
       Configuration hadoopConf = spark.sessionState().newHadoopConf();
       PathBasedSnapshotManager snapshotManager =
           new PathBasedSnapshotManager(testTablePath, hadoopConf);
-      SparkMicroBatchStream stream =
+      DeltaV2MicroBatchStream stream =
           createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
 
       long version = snapshotManager.loadLatestSnapshot().getVersion();
@@ -5080,14 +5081,14 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
       Configuration hadoopConf = spark.sessionState().newHadoopConf();
       PathBasedSnapshotManager snapshotManager =
           new PathBasedSnapshotManager(testTablePath, hadoopConf);
-      SparkMicroBatchStream stream =
+      DeltaV2MicroBatchStream stream =
           createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
 
       long version = snapshotManager.loadLatestSnapshot().getVersion();
 
       // Access the internal AtomicReference via reflection
       java.lang.reflect.Field cacheField =
-          SparkMicroBatchStream.class.getDeclaredField("cachedDataFrameSnapshot");
+          DeltaV2MicroBatchStream.class.getDeclaredField("cachedDataFrameSnapshot");
       cacheField.setAccessible(true);
       @SuppressWarnings("unchecked")
       java.util.concurrent.atomic.AtomicReference<DataFrameSnapshotCache> cacheRef =
@@ -5133,7 +5134,7 @@ public class SparkMicroBatchStreamTest extends DeltaV2TestBase {
       Configuration hadoopConf = spark.sessionState().newHadoopConf();
       PathBasedSnapshotManager snapshotManager =
           new PathBasedSnapshotManager(testTablePath, hadoopConf);
-      SparkMicroBatchStream stream =
+      DeltaV2MicroBatchStream stream =
           createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
 
       long version = snapshotManager.loadLatestSnapshot().getVersion();

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2ScanBuilderTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2ScanBuilderTest.java
@@ -200,8 +200,8 @@ public class DeltaV2ScanBuilderTest extends DeltaV2TestBase {
 
     assertNotNull(microBatchStream, "MicroBatchStream should not be null");
     assertTrue(
-        microBatchStream instanceof SparkMicroBatchStream,
-        "MicroBatchStream should be an instance of SparkMicroBatchStream");
+        microBatchStream instanceof DeltaV2MicroBatchStream,
+        "MicroBatchStream should be an instance of DeltaV2MicroBatchStream");
   }
 
   @Test

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2ScanBuilderTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2ScanBuilderTest.java
@@ -157,7 +157,7 @@ public class DeltaV2ScanBuilderTest extends DeltaV2TestBase {
   }
 
   @Test
-  public void testToMicroBatchStream_returnsSparkMicroBatchStream(@TempDir File tempDir) {
+  public void testToMicroBatchStream_returnsDeltaV2MicroBatchStream(@TempDir File tempDir) {
     String path = tempDir.getAbsolutePath();
     String tableName = "microbatch_test";
     spark.sql(


### PR DESCRIPTION
## Description

Rename the Delta Kernel DSv2 streaming read class in
`io.delta.spark.internal.v2.read` to the `DeltaV2*` convention, matching the
`DeltaV2Table` and `DeltaV2WriteBuilder` classes already in the package:

- `SparkMicroBatchStream` -> `DeltaV2MicroBatchStream`

Identifiers only (class file, class name, references, and the corresponding
test classes). No behavior change.

## How was this patch tested?

Existing tests, with all class references updated to the new name.

## Does this PR introduce _any_ user-facing change?

No.