### PR TITLE
[Spark][4.3] Enh: Support Show Partitions Command

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
@@ -84,6 +84,19 @@ class DeltaAnalysis(protected val session: SparkSession)
   extends Rule[LogicalPlan] with AnalysisHelper with DeltaInsertCastSupport {
 
   override def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperatorsDown {
+    // Intercept SHOW PARTITIONS for Delta tables
+    // Spark's ShowPartitions command requires SUPPORTS_PARTITION_MANAGEMENT capability,
+    // but Delta manages partitions through the transaction log, not the metastore.
+    // We intercept and replace with our custom command that reads from the Delta log.
+    case ShowPartitions(
+        r @ ResolvedTable(_, _, _: DeltaTableV2, _), partSpec, _) =>
+      // DeltaTableV2 does not implement SUPPORTS_PARTITION_MANAGEMENT, so the spec is still
+      // expected to be UnresolvedPartitionSpec here.
+      val partitionSpec = partSpec.collect {
+        case UnresolvedPartitionSpec(spec, _) => spec
+      }.getOrElse(Map.empty[String, String])
+      ShowDeltaPartitionsCommand(r, partitionSpec)
+
     // INSERT INTO by ordinal and df.insertInto()
     case a @ AppendDelta(r, d) if !a.isByName &&
         needsSchemaAdjustmentByOrdinal(d, a.query, r.schema, a.writeOptions) =>

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/ShowDeltaPartitionsCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/ShowDeltaPartitionsCommand.scala
@@ -1,0 +1,102 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.commands
+
+import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
+import org.apache.spark.sql.delta.{DataFrameUtils, DeltaErrors}
+import org.apache.spark.sql.delta.catalog.DeltaTableV2
+import org.apache.spark.sql.{Column, Row, SparkSession}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, EqualNullSafe, Literal}
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, UnaryNode}
+import org.apache.spark.sql.catalyst.util.quoteIfNeeded
+import org.apache.spark.sql.execution.command.RunnableCommand
+import org.apache.spark.sql.execution.datasources.LogicalRelation
+import org.apache.spark.util.Utils
+
+/**
+ * Command to show partitions for a Delta table.
+ *
+ * Unlike Spark's standard SHOW PARTITIONS output, which returns a single string column such as
+ * `year=2024/month=01`, this Delta command returns one typed output column per partition column.
+ * This matches Delta's runtime SHOW PARTITIONS behavior.
+ *
+ * The command executes through a Delta relation so that partition enumeration follows normal Delta
+ * read semantics instead of directly scanning `snapshot.allFiles`.
+ *
+ * @param child The resolved Delta table
+ * @param partitionSpec Optional partition spec to filter the returned partitions
+ */
+case class ShowDeltaPartitionsCommand(
+    child: LogicalPlan,
+    partitionSpec: Map[String, String] = Map.empty)
+  extends RunnableCommand with UnaryNode with DeltaCommand {
+
+  private lazy val deltaTable: DeltaTableV2 = getDeltaTable(child, "SHOW PARTITIONS")
+
+  private lazy val snapshot = deltaTable.update()
+
+  override def run(sparkSession: SparkSession): Seq[Row] = {
+    recordDeltaOperation(deltaTable.deltaLog, "delta.ddl.showPartitions") {
+      val partitionSchemaFields = snapshot.metadata.partitionSchema.fields.toSeq
+      val partitionColumns = partitionSchemaFields.map(_.name)
+
+      if (partitionColumns.isEmpty) {
+        throw DeltaErrors.showPartitionInNotPartitionedTable(deltaTable.name())
+      }
+
+      val partitionFilters =
+        if (partitionSpec.nonEmpty) {
+          val badColumns = partitionSpec.keySet.filterNot(partitionColumns.contains)
+          if (badColumns.nonEmpty) {
+            throw DeltaErrors.showPartitionInNotPartitionedColumn(badColumns)
+          }
+          partitionSpec.toSeq.map { case (key, value) =>
+            EqualNullSafe(UnresolvedAttribute.quoted(key), Literal(value))
+          }
+        } else {
+          Nil
+        }
+
+      val baseRelation = deltaTable.deltaLog.createRelation(
+        partitionFilters = partitionFilters,
+        snapshotToUseOpt = Some(snapshot),
+        catalogTableOpt = deltaTable.catalogTable)
+      val filteredDf = DataFrameUtils.ofRows(sparkSession, LogicalRelation(baseRelation))
+
+      val typedColumns = partitionSchemaFields.map { field =>
+        new Column(quoteIfNeeded(field.name)).cast(field.dataType)
+      }
+      filteredDf.select(typedColumns: _*)
+        .distinct()
+        .collect()
+        .toSeq
+    }
+  }
+
+  override lazy val output: Seq[Attribute] = {
+    if (snapshot == null && Utils.isTesting) {
+      Nil
+    } else {
+      snapshot.metadata.partitionSchema.fields.map { field =>
+        AttributeReference(field.name, field.dataType, nullable = field.nullable)()
+      }
+    }
+  }
+  override protected def withNewChildInternal(newChild: LogicalPlan): ShowDeltaPartitionsCommand = {
+    copy(child = newChild, partitionSpec = partitionSpec)
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/ShowDeltaPartitionsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/ShowDeltaPartitionsSuite.scala
@@ -1,0 +1,437 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import java.math.{BigDecimal => JBigDecimal}
+import java.sql.{Date, Timestamp}
+
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.test.SharedSparkSession
+
+/**
+ * Test suite for Delta's SHOW PARTITIONS support on Delta tables.
+ *
+ * This suite verifies that DeltaAnalysis rewrites SHOW PARTITIONS on Delta tables to
+ * ShowDeltaPartitionsCommand, which returns typed partition values from Delta metadata.
+ */
+class ShowDeltaPartitionsSuite extends QueryTest with SharedSparkSession with DeltaSQLCommandTest {
+
+  test("SHOW PARTITIONS on single partition column Delta table") {
+    withTable("delta_table") {
+      sql(
+        """
+          |CREATE TABLE delta_table (id INT, date STRING, value DOUBLE)
+          |USING delta
+          |PARTITIONED BY (date)
+        """.stripMargin)
+
+      // Insert data into multiple partitions
+      sql("INSERT INTO delta_table VALUES (1, '2024-01-01', 100.0)")
+      sql("INSERT INTO delta_table VALUES (2, '2024-01-02', 200.0)")
+      sql("INSERT INTO delta_table VALUES (3, '2024-01-03', 300.0)")
+
+      // Show partitions
+      val result = sql("SHOW PARTITIONS delta_table")
+
+      checkAnswer(
+        result,
+        Seq(
+          Row("2024-01-01"),
+          Row("2024-01-02"),
+          Row("2024-01-03")
+        )
+      )
+    }
+  }
+
+  test("SHOW PARTITIONS on multi-partition column Delta table") {
+    withTable("delta_table") {
+      sql(
+        """
+          |CREATE TABLE delta_table (id INT, year STRING, month STRING, value DOUBLE)
+          |USING delta
+          |PARTITIONED BY (year, month)
+        """.stripMargin)
+
+      // Insert data into multiple partitions
+      sql("INSERT INTO delta_table VALUES (1, '2024', '01', 100.0)")
+      sql("INSERT INTO delta_table VALUES (2, '2024', '02', 200.0)")
+      sql("INSERT INTO delta_table VALUES (3, '2023', '12', 300.0)")
+
+      // Show partitions
+      val result = sql("SHOW PARTITIONS delta_table")
+
+      checkAnswer(
+        result,
+        Seq(
+          Row("2023", "12"),
+          Row("2024", "01"),
+          Row("2024", "02")
+        )
+      )
+    }
+  }
+
+  test("SHOW PARTITIONS on non-partitioned Delta table should fail") {
+    withTable("delta_table") {
+      sql(
+        """
+          |CREATE TABLE delta_table (id INT, value DOUBLE)
+          |USING delta
+        """.stripMargin)
+
+      sql("INSERT INTO delta_table VALUES (1, 100.0)")
+      sql("INSERT INTO delta_table VALUES (2, 200.0)")
+
+      val e = intercept[DeltaAnalysisException] {
+        sql("SHOW PARTITIONS delta_table")
+      }
+      checkError(
+        e,
+        "DELTA_SHOW_PARTITION_IN_NON_PARTITIONED_TABLE",
+        parameters = Map("tableName" -> "spark_catalog.default.delta_table"))
+    }
+  }
+
+  test("SHOW PARTITIONS with partition spec on Delta table") {
+    withTable("delta_table") {
+      sql(
+        """
+          |CREATE TABLE delta_table (id INT, year INT, month STRING, value DOUBLE)
+          |USING delta
+          |PARTITIONED BY (year, month)
+        """.stripMargin)
+
+      sql("INSERT INTO delta_table VALUES (1, 2024, '01', 100.0)")
+      sql("INSERT INTO delta_table VALUES (2, 2024, '02', 200.0)")
+      sql("INSERT INTO delta_table VALUES (3, 2023, '12', 300.0)")
+
+      checkAnswer(
+        sql("SHOW PARTITIONS delta_table PARTITION (year = 2024)"),
+        Seq(
+          Row(2024, "01"),
+          Row(2024, "02")
+        )
+      )
+
+      checkAnswer(
+        sql("SHOW PARTITIONS delta_table PARTITION (year = 2024, month = '02')"),
+        Seq(Row(2024, "02"))
+      )
+
+      checkAnswer(
+        sql("SHOW PARTITIONS delta_table PARTITION (year = 2025)"),
+        Seq.empty
+      )
+    }
+  }
+
+  test("SHOW PARTITIONS with invalid partition column name in partition spec") {
+    withTable("delta_table") {
+      sql(
+        """
+          |CREATE TABLE delta_table (id INT, year INT, month STRING, value DOUBLE)
+          |USING delta
+          |PARTITIONED BY (year, month)
+        """.stripMargin)
+
+      sql("INSERT INTO delta_table VALUES (1, 2024, '01', 100.0)")
+
+      val e = intercept[DeltaAnalysisException] {
+        sql("SHOW PARTITIONS delta_table PARTITION (day = 1)")
+      }
+      checkError(
+        e,
+        "DELTA_SHOW_PARTITION_IN_NON_PARTITIONED_COLUMN",
+        parameters = Map("badCols" -> "[day]"))
+    }
+  }
+
+  test("SHOW PARTITIONS deduplicates partitions written across multiple inserts") {
+    withTable("delta_table") {
+      sql(
+        """
+          |CREATE TABLE delta_table (id INT, date STRING, value DOUBLE)
+          |USING delta
+          |PARTITIONED BY (date)
+        """.stripMargin)
+
+      sql("INSERT INTO delta_table VALUES (1, '2024-01-01', 100.0)")
+      sql("INSERT INTO delta_table VALUES (2, '2024-01-01', 200.0)")
+      sql("INSERT INTO delta_table VALUES (3, '2024-01-02', 300.0)")
+
+      checkAnswer(
+        sql("SHOW PARTITIONS delta_table"),
+        Seq(
+          Row("2024-01-01"),
+          Row("2024-01-02")
+        )
+      )
+    }
+  }
+
+  test("SHOW PARTITIONS on path-based Delta table") {
+    withTempDir { dir =>
+      val path = dir.getCanonicalPath
+
+      sql(
+        s"""
+          |CREATE TABLE delta.`$path` (id INT, date STRING, value DOUBLE)
+          |USING delta
+          |PARTITIONED BY (date)
+        """.stripMargin)
+
+      sql(s"INSERT INTO delta.`$path` VALUES (1, '2024-01-01', 100.0)")
+      sql(s"INSERT INTO delta.`$path` VALUES (2, '2024-01-02', 200.0)")
+
+      // Show partitions using path
+      val result = sql(s"SHOW PARTITIONS delta.`$path`")
+
+      checkAnswer(
+        result,
+        Seq(
+          Row("2024-01-01"),
+          Row("2024-01-02")
+        )
+      )
+    }
+  }
+
+  test("SHOW PARTITIONS on column-mapping-enabled Delta table") {
+    withTempDir { dir =>
+      val path = dir.getCanonicalPath
+
+      sql(
+        s"""
+           |CREATE TABLE delta.`$path` (id INT, date STRING, value DOUBLE)
+           |USING delta
+           |PARTITIONED BY (date)
+           |TBLPROPERTIES (
+           |  'delta.columnMapping.mode' = 'name',
+           |  'delta.minReaderVersion' = '2',
+           |  'delta.minWriterVersion' = '5'
+           |)
+         """.stripMargin)
+
+      sql(s"INSERT INTO delta.`$path` VALUES (1, '2024-01-01', 100.0)")
+      sql(s"INSERT INTO delta.`$path` VALUES (2, '2024-01-02', 200.0)")
+
+      checkAnswer(
+        sql(s"SHOW PARTITIONS delta.`$path`"),
+        Seq(
+          Row("2024-01-01"),
+          Row("2024-01-02")
+        )
+      )
+    }
+  }
+
+  test("SHOW PARTITIONS with special characters in partition values") {
+    withTable("delta_table") {
+      sql(
+        """
+          |CREATE TABLE delta_table (id INT, category STRING, value DOUBLE)
+          |USING delta
+          |PARTITIONED BY (category)
+        """.stripMargin)
+
+      // Insert data with special characters
+      sql("INSERT INTO delta_table VALUES (1, 'cat-1', 100.0)")
+      sql("INSERT INTO delta_table VALUES (2, 'cat_2', 200.0)")
+      sql("INSERT INTO delta_table VALUES (3, 'cat.3', 300.0)")
+
+      checkAnswer(
+        sql("SHOW PARTITIONS delta_table"),
+        Seq(
+          Row("cat-1"),
+          Row("cat.3"),
+          Row("cat_2")
+        )
+      )
+    }
+  }
+
+  test("SHOW PARTITIONS after DELETE operation") {
+    withTable("delta_table") {
+      sql(
+        """
+          |CREATE TABLE delta_table (id INT, date STRING, value DOUBLE)
+          |USING delta
+          |PARTITIONED BY (date)
+        """.stripMargin)
+
+      sql("INSERT INTO delta_table VALUES (1, '2024-01-01', 100.0)")
+      sql("INSERT INTO delta_table VALUES (2, '2024-01-02', 200.0)")
+      sql("INSERT INTO delta_table VALUES (3, '2024-01-03', 300.0)")
+
+      // Delete all data from one partition
+      sql("DELETE FROM delta_table WHERE date = '2024-01-02'")
+
+      checkAnswer(
+        sql("SHOW PARTITIONS delta_table"),
+        Seq(
+          Row("2024-01-01"),
+          Row("2024-01-03")
+        )
+      )
+    }
+  }
+
+  test("SHOW PARTITIONS with NULL partition values") {
+    withTable("delta_table") {
+      sql(
+        """
+          |CREATE TABLE delta_table (id INT, category STRING, part INT, value DOUBLE)
+          |USING delta
+          |PARTITIONED BY (category, part)
+        """.stripMargin)
+
+      sql("INSERT INTO delta_table VALUES (1, 'cat1', 1, 100.0)")
+      sql("INSERT INTO delta_table VALUES (2, NULL, 2, 200.0)")
+      sql("INSERT INTO delta_table VALUES (3, 'cat2', NULL, 300.0)")
+
+      checkAnswer(
+        sql("SHOW PARTITIONS delta_table"),
+        Seq(
+          Row("cat1", 1),
+          Row("cat2", null),
+          Row(null, 2)
+        )
+      )
+
+      checkAnswer(
+        sql("SHOW PARTITIONS delta_table PARTITION (category = 'cat1', part = 1)"),
+        Seq(Row("cat1", 1))
+      )
+
+      checkAnswer(
+        sql("SHOW PARTITIONS delta_table PARTITION (part = null)"),
+        Seq(Row("cat2", null))
+      )
+
+      checkAnswer(
+        sql("SHOW PARTITIONS delta_table PARTITION (category = null)"),
+        Seq(Row(null, 2))
+      )
+    }
+  }
+
+  test("SHOW PARTITIONS preserves typed partition values for DATE, TIMESTAMP, and DECIMAL") {
+    withTable("delta_table") {
+      sql(
+        """
+          |CREATE TABLE delta_table (
+          |  id INT,
+          |  part_date DATE,
+          |  part_ts TIMESTAMP,
+          |  part_decimal DECIMAL(10, 2),
+          |  value DOUBLE)
+          |USING delta
+          |PARTITIONED BY (part_date, part_ts, part_decimal)
+        """.stripMargin)
+
+      sql(
+        """
+          |INSERT INTO delta_table VALUES
+          |(1, DATE '2024-01-02', TIMESTAMP '2024-01-02 03:04:05', CAST(123.45 AS DECIMAL(10, 2)),
+          | 100.0)
+        """.stripMargin)
+
+      val result = sql("SHOW PARTITIONS delta_table").collect()
+      assert(result.length === 1)
+
+      val row = result.head
+      assert(row.get(0).isInstanceOf[Date], s"Expected DATE partition value, got ${row.get(0)}")
+      assert(
+        row.get(1).isInstanceOf[Timestamp],
+        s"Expected TIMESTAMP partition value, got ${row.get(1)}")
+      assert(
+        row.get(2).isInstanceOf[JBigDecimal],
+        s"Expected DECIMAL partition value, got ${row.get(2)}")
+
+      assert(row === Row(
+        Date.valueOf("2024-01-02"),
+        Timestamp.valueOf("2024-01-02 03:04:05"),
+        new JBigDecimal("123.45")))
+    }
+  }
+
+  test("SHOW PARTITIONS on table with numeric partition columns") {
+    withTable("delta_table") {
+      sql(
+        """
+          |CREATE TABLE delta_table (id INT, year INT, value DOUBLE)
+          |USING delta
+          |PARTITIONED BY (year)
+        """.stripMargin)
+
+      sql("INSERT INTO delta_table VALUES (1, 10, 100.0)")
+      sql("INSERT INTO delta_table VALUES (2, 2, 200.0)")
+      sql("INSERT INTO delta_table VALUES (3, 20, 300.0)")
+
+      checkAnswer(
+        sql("SHOW PARTITIONS delta_table"),
+        Seq(Row(2), Row(10), Row(20))
+      )
+    }
+  }
+
+  test("SHOW PARTITIONS on empty partitioned Delta table") {
+    withTable("delta_table") {
+      sql(
+        """
+          |CREATE TABLE delta_table (id INT, date STRING, value DOUBLE)
+          |USING delta
+          |PARTITIONED BY (date)
+        """.stripMargin)
+
+      // Don't insert any data
+
+      // Show partitions on empty table
+      val result = sql("SHOW PARTITIONS delta_table")
+
+      // Should return empty result
+      assert(result.isEmpty)
+    }
+  }
+
+  test("SHOW PARTITIONS works with catalog qualified table name") {
+    withTable("delta_table") {
+      sql(
+        """
+          |CREATE TABLE delta_table (id INT, region STRING, value DOUBLE)
+          |USING delta
+          |PARTITIONED BY (region)
+        """.stripMargin)
+
+      sql("INSERT INTO delta_table VALUES (1, 'us', 100.0)")
+      sql("INSERT INTO delta_table VALUES (2, 'eu', 200.0)")
+
+      // Show partitions with catalog qualified name
+      val result = sql("SHOW PARTITIONS spark_catalog.default.delta_table")
+
+      checkAnswer(
+        result,
+        Seq(
+          Row("eu"),
+          Row("us")
+        )
+      )
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description



<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Cherry-pick https://github.com/delta-io/delta/pull/6102 to 4.3 release
branch `branch-4.3`

Adds support for SHOW PARTITIONS command on Delta tables by reusing Spark's SQL parser and implementing a custom Delta command that reads partition information from the Delta transaction log.

For Delta tables, the command returns one typed output column per partition column instead of Spark’s default single Hive-style partition string.

Syntax:

SHOW PARTITIONS (db.table|'/path/to/dir'|delta./path/to/dir) [PARTITION(clause)]; 

Resolves https://github.com/delta-io/delta/issues/996

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

Tested using a local setup, by creation a Delta Lake Table, partitioned on _region_ column, and the result of `SHOW PARTITIONS` command is as follows:
```
+---+------+
| id|region|
+---+------+
|  3|    eu|
|  2|    us|
|  1|    us|
|  4|  apac|
+---+------+

Partitions for table: local_partitioned_table
+------+
|region|
+------+
|apac  |
|eu    |
|us    |
+------+
```

Additionally, `ShowDeltaPartitionsSuite` has been introduced with extensive test coverage for `SHOW PARTITIONS`.


## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, It introduces support for `SHOW PARTITION` SQL for the user
