### PR TITLE
[Spark] Use the snapshot's own metadata id at snapshot-scoped callsites

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/MaterializedRowTrackingColumn.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/MaterializedRowTrackingColumn.scala
@@ -123,7 +123,7 @@ abstract class MaterializedRowTrackingColumn {
     }
 
     val materializedColumnName = getMaterializedColumnNameOrThrow(
-      snapshot.protocol, snapshot.metadata, snapshot.deltaLog.unsafeVolatileTableId)
+      snapshot.protocol, snapshot.metadata, snapshot.unsafeVolatileTableId)
 
     val analyzedPlan = dataFrame.queryExecution.analyzed
     analyzedPlan.outputSet.view.find(attr => materializedColumnName == attr.name)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/MaterializedRowTrackingColumn.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/MaterializedRowTrackingColumn.scala
@@ -123,7 +123,7 @@ abstract class MaterializedRowTrackingColumn {
     }
 
     val materializedColumnName = getMaterializedColumnNameOrThrow(
-      snapshot.protocol, snapshot.metadata, snapshot.unsafeVolatileTableId)
+      snapshot.protocol, snapshot.metadata, snapshot.metadata.id)
 
     val analyzedPlan = dataFrame.queryExecution.analyzed
     analyzedPlan.outputSet.view.find(attr => materializedColumnName == attr.name)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/RowCommitVersion.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/RowCommitVersion.scala
@@ -54,7 +54,7 @@ object RowCommitVersion {
     }
 
     val materializedColumnName = MaterializedRowCommitVersion.getMaterializedColumnNameOrThrow(
-      snapshot.protocol, snapshot.metadata, snapshot.deltaLog.unsafeVolatileTableId)
+      snapshot.protocol, snapshot.metadata, snapshot.unsafeVolatileTableId)
 
     val rowCommitVersionColumn =
       DeltaTableUtils.getFileMetadataColumn(dataFrame).getField(METADATA_STRUCT_FIELD_NAME)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/RowCommitVersion.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/RowCommitVersion.scala
@@ -54,7 +54,7 @@ object RowCommitVersion {
     }
 
     val materializedColumnName = MaterializedRowCommitVersion.getMaterializedColumnNameOrThrow(
-      snapshot.protocol, snapshot.metadata, snapshot.unsafeVolatileTableId)
+      snapshot.protocol, snapshot.metadata, snapshot.metadata.id)
 
     val rowCommitVersionColumn =
       DeltaTableUtils.getFileMetadataColumn(dataFrame).getField(METADATA_STRUCT_FIELD_NAME)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/RowId.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/RowId.scala
@@ -341,7 +341,7 @@ object RowId {
     }
 
     val materializedColumnName = MaterializedRowId.getMaterializedColumnNameOrThrow(
-      snapshot.protocol, snapshot.metadata, snapshot.unsafeVolatileTableId)
+      snapshot.protocol, snapshot.metadata, snapshot.metadata.id)
 
     val rowIdColumn = DeltaTableUtils.getFileMetadataColumn(dataFrame).getField(ROW_ID)
     val shouldSetIcebergReservedFieldId = IcebergCompat.isGeqEnabled(snapshot.metadata, 3)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/RowId.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/RowId.scala
@@ -341,7 +341,7 @@ object RowId {
     }
 
     val materializedColumnName = MaterializedRowId.getMaterializedColumnNameOrThrow(
-      snapshot.protocol, snapshot.metadata, snapshot.deltaLog.unsafeVolatileTableId)
+      snapshot.protocol, snapshot.metadata, snapshot.unsafeVolatileTableId)
 
     val rowIdColumn = DeltaTableUtils.getFileMetadataColumn(dataFrame).getField(ROW_ID)
     val shouldSetIcebergReservedFieldId = IcebergCompat.isGeqEnabled(snapshot.metadata, 3)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
@@ -65,6 +65,11 @@ trait SnapshotDescriptor extends DeltaLoggingProvider {
   def metadata: Metadata
   def protocol: Protocol
 
+  // Named "unsafeVolatile" because `Snapshot` overrides this with the DeltaLog's volatile cached
+  // id (see the override there for why), so the value may not match this descriptor's
+  // `metadata.id`.
+  def unsafeVolatileTableId: String = metadata.id
+
   def schema: StructType = metadata.schema
 
   def dataPath: Path
@@ -409,6 +414,16 @@ class Snapshot(
 
   override def protocol: Protocol = _reconstructedProtocolMetadataAndICT.protocol
 
+  // Use the DeltaLog's cached (volatile) table id rather than `metadata.id`. The base
+  // `SnapshotDescriptor.unsafeVolatileTableId` reads `metadata.id`, but for a `Snapshot`
+  // accessing `metadata` forces state reconstruction (`_reconstructedProtocolMetadataAndICT`).
+  // `unsafeVolatileTableId` is used by the logging methods below, and those are invoked *during*
+  // reconstruction itself (e.g. the usage log on the incremental-checksum path) and during
+  // snapshot construction. Reading `metadata.id` there would re-enter the reconstruction lazy
+  // val on the same thread and overflow the stack, so we read the always-available cached id
+  // instead.
+  override def unsafeVolatileTableId: String = deltaLog.unsafeVolatileTableId
+
   /**
    * Tries to retrieve the protocol, metadata, and in-commit-timestamp (if needed) from the
    * checksum file. If the checksum file is not present or if the protocol or metadata is missing
@@ -737,28 +752,25 @@ class Snapshot(
 
 
   def logInfo(msg: MessageWithContext): Unit = {
-    val tableId = deltaLog.unsafeVolatileTableId
-    super.logInfo(log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, tableId)}] " + msg)
+    super.logInfo(log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, unsafeVolatileTableId)}] " + msg)
   }
 
   def logWarning(msg: MessageWithContext): Unit = {
-    val tableId = deltaLog.unsafeVolatileTableId
-    super.logWarning(log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, tableId)}] " + msg)
+    super.logWarning(log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, unsafeVolatileTableId)}] " + msg)
   }
 
   def logWarning(msg: MessageWithContext, throwable: Throwable): Unit = {
-    val tableId = deltaLog.unsafeVolatileTableId
-    super.logWarning(log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, tableId)}] " + msg, throwable)
+    super.logWarning(
+      log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, unsafeVolatileTableId)}] " + msg, throwable)
   }
 
   def logError(msg: MessageWithContext): Unit = {
-    val tableId = deltaLog.unsafeVolatileTableId
-    super.logError(log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, tableId)}] " + msg)
+    super.logError(log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, unsafeVolatileTableId)}] " + msg)
   }
 
   def logError(msg: MessageWithContext, throwable: Throwable): Unit = {
-    val tableId = deltaLog.unsafeVolatileTableId
-    super.logError(log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, tableId)}] " + msg, throwable)
+    super.logError(
+      log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, unsafeVolatileTableId)}] " + msg, throwable)
   }
 
   override def toString: String =

--- a/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
@@ -65,11 +65,6 @@ trait SnapshotDescriptor extends DeltaLoggingProvider {
   def metadata: Metadata
   def protocol: Protocol
 
-  // Named "unsafeVolatile" because `Snapshot` overrides this with the DeltaLog's volatile cached
-  // id (see the override there for why), so the value may not match this descriptor's
-  // `metadata.id`.
-  def unsafeVolatileTableId: String = metadata.id
-
   def schema: StructType = metadata.schema
 
   def dataPath: Path
@@ -414,16 +409,6 @@ class Snapshot(
 
   override def protocol: Protocol = _reconstructedProtocolMetadataAndICT.protocol
 
-  // Use the DeltaLog's cached (volatile) table id rather than `metadata.id`. The base
-  // `SnapshotDescriptor.unsafeVolatileTableId` reads `metadata.id`, but for a `Snapshot`
-  // accessing `metadata` forces state reconstruction (`_reconstructedProtocolMetadataAndICT`).
-  // `unsafeVolatileTableId` is used by the logging methods below, and those are invoked *during*
-  // reconstruction itself (e.g. the usage log on the incremental-checksum path) and during
-  // snapshot construction. Reading `metadata.id` there would re-enter the reconstruction lazy
-  // val on the same thread and overflow the stack, so we read the always-available cached id
-  // instead.
-  override def unsafeVolatileTableId: String = deltaLog.unsafeVolatileTableId
-
   /**
    * Tries to retrieve the protocol, metadata, and in-commit-timestamp (if needed) from the
    * checksum file. If the checksum file is not present or if the protocol or metadata is missing
@@ -751,26 +736,33 @@ class Snapshot(
     spark.createDataFrame(spark.sparkContext.emptyRDD[Row], logSchema)
 
 
+  // These logging methods must NOT read `this.metadata`: they are invoked *during* P&M
+  // reconstruction (e.g. the usage log on the incremental-checksum path) and during snapshot
+  // construction, where reading `metadata` re-enters the `_reconstructedProtocolMetadataAndICT`
+  // lazy val on the same thread and overflows the stack. Use the DeltaLog's cached id instead.
   def logInfo(msg: MessageWithContext): Unit = {
-    super.logInfo(log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, unsafeVolatileTableId)}] " + msg)
+    val tableId = deltaLog.unsafeVolatileTableId
+    super.logInfo(log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, tableId)}] " + msg)
   }
 
   def logWarning(msg: MessageWithContext): Unit = {
-    super.logWarning(log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, unsafeVolatileTableId)}] " + msg)
+    val tableId = deltaLog.unsafeVolatileTableId
+    super.logWarning(log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, tableId)}] " + msg)
   }
 
   def logWarning(msg: MessageWithContext, throwable: Throwable): Unit = {
-    super.logWarning(
-      log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, unsafeVolatileTableId)}] " + msg, throwable)
+    val tableId = deltaLog.unsafeVolatileTableId
+    super.logWarning(log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, tableId)}] " + msg, throwable)
   }
 
   def logError(msg: MessageWithContext): Unit = {
-    super.logError(log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, unsafeVolatileTableId)}] " + msg)
+    val tableId = deltaLog.unsafeVolatileTableId
+    super.logError(log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, tableId)}] " + msg)
   }
 
   def logError(msg: MessageWithContext, throwable: Throwable): Unit = {
-    super.logError(
-      log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, unsafeVolatileTableId)}] " + msg, throwable)
+    val tableId = deltaLog.unsafeVolatileTableId
+    super.logError(log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, tableId)}] " + msg, throwable)
   }
 
   override def toString: String =

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaDataSource.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaDataSource.scala
@@ -537,7 +537,7 @@ object DeltaDataSource extends DatabricksLogging {
         DeltaSourceMetadataTrackingLog.create(
           spark,
           schemaTrackingLocation,
-          sourceSnapshot.deltaLog.unsafeVolatileTableId,
+          sourceSnapshot.unsafeVolatileTableId,
           sourceSnapshot.dataPath.toString,
           parameters,
           sourceMetadataPathOpt,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaDataSource.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaDataSource.scala
@@ -537,7 +537,7 @@ object DeltaDataSource extends DatabricksLogging {
         DeltaSourceMetadataTrackingLog.create(
           spark,
           schemaTrackingLocation,
-          sourceSnapshot.unsafeVolatileTableId,
+          sourceSnapshot.metadata.id,
           sourceSnapshot.dataPath.toString,
           parameters,
           sourceMetadataPathOpt,


### PR DESCRIPTION
## Description

Read `snapshot.metadata.id` directly at callsites that operate on a specific snapshot (`MaterializedRowTrackingColumn`, `RowCommitVersion`, `RowId`, `DeltaDataSource`). It is the id pinned to the snapshot in hand -- immutable and consistent with everything else read from that snapshot -- whereas `deltaLog.unsafeVolatileTableId` returns the id of whatever snapshot the `DeltaLog` happens to have cached at that moment, which can change between adjacent reads and falls back to a fresh random UUID when no snapshot is cached yet.

`Snapshot`'s own logging methods keep reading the cached volatile id, with a new comment explaining why: they run during P&M reconstruction and snapshot construction, where reading `this.metadata` would re-enter the `_reconstructedProtocolMetadataAndICT` lazy val on the same thread and overflow the stack.

## How was this patch tested?

Existing tests cover the touched paths; this does not change behavior for tables whose cached snapshot matches the scanned snapshot.

## Does this PR introduce _any_ user-facing changes?

No.
