### PR TITLE
Fix incorrect metric counting in changesToDF usage log

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/cdc/CDCReader.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/cdc/CDCReader.scala
@@ -268,7 +268,7 @@ trait CDCReaderImpl extends CDCReaderBase {
     )
 
     var totalBytes = 0L
-    var numAddFiles, numRemoveFiles, numAddCRCFiles = 0L
+    var numAddFiles, numRemoveFiles, numAddCDCFiles = 0L
 
     changes.foreach {
       case (v, actions) =>
@@ -311,16 +311,7 @@ trait CDCReaderImpl extends CDCReaderBase {
         // extracted here cannot be relied on for correctness.
         var commitInfo: Option[CommitInfo] = None
         actions.foreach {
-          case c: AddCDCFile =>
-            cdcActions.append(c)
-            numAddCRCFiles += 1L
-            totalBytes += c.size
-          case a: AddFile =>
-            numAddFiles += 1L
-            totalBytes += a.size
-          case r: RemoveFile =>
-            numRemoveFiles += 1L
-            totalBytes += r.size.getOrElse(0L)
+          case c: AddCDCFile => cdcActions.append(c)
           case i: CommitInfo => commitInfo = Some(i)
           case _ => // do nothing
         }
@@ -340,6 +331,8 @@ trait CDCReaderImpl extends CDCReaderBase {
         // If there are CDC actions, we read them exclusively if we should not use the
         // Add and RemoveFiles.
         if (cdcActions.nonEmpty && !useCoarseGrainedCDC) {
+          numAddCDCFiles += cdcActions.size
+          totalBytes += cdcActions.map(_.size).sum
           changeFiles.append(CDCDataSpec(v, ts, cdcActions.toSeq, commitInfo))
         } else {
           val shouldSkipIndexedFile = commitInfo.exists(CDCReader.shouldSkipFileActionsInCommit)
@@ -353,6 +346,10 @@ trait CDCReaderImpl extends CDCReaderBase {
             // infer CDC from them.
             val addActions = actions.collect { case a: AddFile if a.dataChange => a }
             val removeActions = actions.collect { case r: RemoveFile if r.dataChange => r }
+            numAddFiles += addActions.size
+            numRemoveFiles += removeActions.size
+            totalBytes += addActions.map(_.size).sum
+            totalBytes += removeActions.map(_.size.getOrElse(0L)).sum
             addFiles.append(
               CDCDataSpec(
                 version = v,
@@ -418,12 +415,13 @@ trait CDCReaderImpl extends CDCReaderBase {
         "useCoarseGrainedCDC" -> useCoarseGrainedCDC,
         "numAddFiles" -> numAddFiles,
         "numRemoveFiles" -> numRemoveFiles,
-        "numAddCRCFiles" -> numAddCRCFiles,
+        // numAddCRCFiles is a typo, kept for backwards compatability.
+        "numAddCRCFiles" -> numAddCDCFiles,
         "totalBytes" -> totalBytes,
         "isStreaming" -> isStreaming
       )
     )
-    val totalFiles = numAddFiles + numRemoveFiles + numAddCRCFiles
+    val totalFiles = numAddFiles + numRemoveFiles + numAddCDCFiles
     CDCVersionDiffInfo(
       (emptyDf +: dfs).reduce((df1, df2) => df1.union(
         df2

--- a/spark/src/test/scala/org/apache/spark/sql/delta/cdc/CDCReaderSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/cdc/CDCReaderSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.delta.cdc
 // scalastyle:off import.ordering.noEmptyLine
 import java.io.File
 
-import com.databricks.spark.util.Log4jUsageLogger
+import com.databricks.spark.util.{Log4jUsageLogger, UsageRecord}
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.DeltaOperations.Delete
 import org.apache.spark.sql.delta.DeltaTestUtils.BOOLEAN_DOMAIN
@@ -30,6 +30,7 @@ import org.apache.spark.sql.delta.files.DelayedCommitProtocol
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
+import org.apache.spark.sql.delta.util.JsonUtils
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.SparkConf
@@ -471,6 +472,84 @@ class CDCReaderSuite
 
       assert(events.exists(event => event.metric == "tahoeEvent" &&
         event.tags.get("opType") == Option("delta.changeDataFeed.changesToDF")))
+    }
+  }
+
+  /** Collect and parse the `delta.changeDataFeed.changesToDF` usage logs among the events. */
+  private def findChangesToDFEvents(events: Seq[UsageRecord]): Seq[Map[String, Any]] = {
+    events.collect {
+      case event if event.metric == "tahoeEvent" &&
+        event.tags.get("opType").contains("delta.changeDataFeed.changesToDF") =>
+        JsonUtils.fromJson[Map[String, Any]](event.blob)
+    }
+  }
+
+  /** Parse the single `delta.changeDataFeed.changesToDF` usage log emitted by the events. */
+  private def getChangesToDFMetrics(events: Seq[UsageRecord]): Map[String, Any] = {
+    findChangesToDFEvents(events) match {
+      case Seq(metrics) => metrics
+      case other => fail("Expected exactly one delta.changeDataFeed.changesToDF usage event, " +
+        s"got ${other.size} with opTypes: " + events.flatMap(_.tags.get("opType")).mkString(", "))
+    }
+  }
+
+  /** Extract a non-negative numeric metric emitted in a parsed usage log. */
+  private def getMetric(metrics: Map[String, Any], key: String): Long = {
+    metrics.get(key)
+      .map(_.asInstanceOf[Number].longValue())
+      .getOrElse(fail(s"Metric '$key' not found in usage log: $metrics"))
+  }
+
+  test("changesToDF metrics count only AddCDCFiles when a commit has CDC actions") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      val log = DeltaLog.forTable(spark, path)
+
+      spark.range(10).write.format("delta").save(path)
+      sql(s"UPDATE delta.`$path` SET id = id + 100 WHERE id < 5")
+
+      val events = Log4jUsageLogger.track {
+        CDCReader.changesToBatchDF(log, 1, 1, spark)
+      }
+      val metrics = getChangesToDFMetrics(events)
+
+      assert(getMetric(metrics, "numAddCRCFiles") >= 1L,
+        s"Expected the AddCDCFile actions to be counted: $metrics")
+      assert(getMetric(metrics, "numAddFiles") == 0L,
+        s"AddFile actions ignored when serving CDC must not be counted: $metrics")
+      assert(getMetric(metrics, "numRemoveFiles") == 0L,
+        s"RemoveFile actions ignored when serving CDC must not be counted: $metrics")
+      assert(getMetric(metrics, "totalBytes") >= 1L,
+        s"Expected the AddCDCFile sizes to contribute to totalBytes: $metrics")
+    }
+  }
+
+  test("changesToDF metrics exclude dataChange = false file actions") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      val log = DeltaLog.forTable(spark, path)
+
+      spark.range(0, 50).write.format("delta").save(path)
+      spark.range(50, 100).write.format("delta").mode("append").save(path)
+      sql(s"OPTIMIZE delta.`$path`")
+
+      val optimizeVersion = log.update().version
+      assert(optimizeVersion == 2L,
+        s"Expected OPTIMIZE to commit version 2, but the latest version is $optimizeVersion")
+
+      val events = Log4jUsageLogger.track {
+        CDCReader.changesToBatchDF(log, optimizeVersion, optimizeVersion, spark)
+      }
+      val metrics = getChangesToDFMetrics(events)
+
+      assert(getMetric(metrics, "numAddFiles") == 0L,
+        s"dataChange = false AddFile actions must not be counted: $metrics")
+      assert(getMetric(metrics, "numRemoveFiles") == 0L,
+        s"dataChange = false RemoveFile actions must not be counted: $metrics")
+      assert(getMetric(metrics, "numAddCRCFiles") == 0L,
+        s"OPTIMIZE produces no CDC actions: $metrics")
+      assert(getMetric(metrics, "totalBytes") == 0L,
+        s"No files are read for this commit, so totalBytes must be 0: $metrics")
     }
   }
 }


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
Tighten the metric counting around Add/Remove file counting to only consider actions that will always make the final scan.

<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
UTs
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
