### PR TITLE
[Spark] Allow concurrent DML transactions during catalogManaged enablement

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
@@ -32,6 +32,7 @@ import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.DeltaSparkPlanUtils.CheckDeterministicOptions
 import org.apache.spark.sql.delta.util.FileNames
 import io.delta.storage.commit.UpdatedActions
+import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorClient
 import io.delta.storage.commit.uniform.UniformMetadata
 import org.apache.hadoop.fs.FileStatus
 
@@ -770,8 +771,12 @@ private[delta] class ConflictChecker(
     val ictAllowList =
         InCommitTimestampUtils.TABLE_PROPERTY_KEYS.toSet
 
+    val catalogManagedAllowList =
+        Set(UCCommitCoordinatorClient.UC_TABLE_ID_KEY)
+
     rowTrackingAllowList ++ columnMappingAllowList ++ dvsAllowList
       .++(v2CheckpointAllowList)
+      .++(catalogManagedAllowList)
       .++(ictAllowList)
   }
 
@@ -846,6 +851,10 @@ private[delta] class ConflictChecker(
             value.toBoolean // only allow enabling, not disabling
         case DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION.key => isNew
         case DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP.key => isNew
+        // Catalog-owned enablement configuration
+        case UCCommitCoordinatorClient.UC_TABLE_ID_KEY
+            if currentTransactionInfo.protocol.isFeatureSupported(CatalogOwnedTableFeature) =>
+          isNew
         case _ => true
       }
     }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
@@ -1256,6 +1256,8 @@ object CatalogOwnedTableFeature
   extends ReaderWriterFeature(name = "catalogManaged")
   with RemovableFeature {
 
+  override def failConcurrentTransactionsAtUpgrade: Boolean = false
+
   override def requiredFeatures: Set[TableFeature] =
     Set(InCommitTimestampTableFeature, VacuumProtocolCheckTableFeature)
 
@@ -1382,6 +1384,13 @@ object InCommitTimestampTableFeature
 object VacuumProtocolCheckTableFeature
   extends ReaderWriterFeature(name = "vacuumProtocolCheck")
   with RemovableFeature {
+
+  // Allowing concurrent transactions to rebase over this feature's enablement is safe:
+  // VACUUM already performs the writer-side protocol check at transaction start regardless
+  // of whether VacuumProtocolCheckTableFeature is in the protocol. So a rebased commit
+  // acquiring this feature mid-flight gains no new check at commit time -- the protection
+  // is already in place.
+  override def failConcurrentTransactionsAtUpgrade: Boolean = false
 
   override def preDowngradeCommand(table: DeltaTableV2): PreDowngradeTableFeatureCommand = {
     VacuumProtocolCheckPreDowngradeCommand(table)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/ConflictResolutionTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/ConflictResolutionTestUtils.scala
@@ -48,6 +48,9 @@ trait ConflictResolutionTestUtils
 
   override val timeout: FiniteDuration = 120.seconds
 
+  /** Wraps `executeImpl`. Default is pass-through; suites may override for setup/cleanup. */
+  def wrapExecution[T](thunk: => T): T = thunk
+
   def abbreviate(str: String, abbrevMarker: String, len: Int): String = {
     if (str == null || abbrevMarker == null) {
       null
@@ -67,7 +70,9 @@ trait ConflictResolutionTestUtils
     def execute(ctx: TestContext): Unit = {
       ctx.trackTransaction(this) {
         withSQLConf(sqlConf.toSeq: _*) {
-          executeImpl(ctx)
+          wrapExecution {
+            executeImpl(ctx)
+          }
         }
       }
     }
@@ -98,7 +103,9 @@ trait ConflictResolutionTestUtils
       withSQLConf(sqlConf.toSeq: _*) {
         val (observer_, future_) = runFunctionWithObserver(name, executor,
           fn = () => {
-            executeImpl(ctx)
+            wrapExecution {
+              executeImpl(ctx)
+            }
             // DV tests do not use the results. We just return an empty array to conform with
             // function's signature.
             Array.empty[Row]

--- a/spark/src/test/scala/org/apache/spark/sql/delta/FeatureEnablementConcurrencySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/FeatureEnablementConcurrencySuite.scala
@@ -22,6 +22,7 @@ import org.apache.spark.sql.delta.fuzzer.{OptimisticTransactionPhases, PhaseLock
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.util.{DeltaFileOperations, FileNames}
+import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorClient
 import org.apache.hadoop.conf.Configuration
 import org.apache.parquet.hadoop.ParquetFileReader
 import org.apache.parquet.hadoop.metadata.ParquetMetadata
@@ -357,6 +358,47 @@ class FeatureEnablementConcurrencySuite
       allowList = ictAllowList)
     assert(!result13.areValid)
 
+    // Tests 14-16: UC_TABLE_ID_KEY per-key validator. Mirroring the rebase path,
+    // currentTransactionInfo.protocol reflects the winning commit's enabled
+    // CatalogOwnedTableFeature, so we construct a conflict checker with CO in protocol.
+    val coProtocol = Protocol.forTableFeature(CatalogOwnedTableFeature)
+    val conflictCheckerWithCO = new ConflictChecker(
+      spark,
+      initialCurrentTransactionInfo = dummyTransactionInfo.copy(protocol = coProtocol),
+      winningCommitSummary = dummySummary,
+      isolationLevel = WriteSerializable)
+
+    // Test 14: Adding UC_TABLE_ID_KEY is valid (the key injected during catalogManaged
+    // enablement).
+    val tableId = "f0cfe1ee-1b65-448c-9136-ebcbfd3b7593"
+    val result14 = conflictCheckerWithCO.checkConfigurationChangesForConflicts(
+      currentMetadata = Metadata(configuration = Map.empty),
+      winningMetadata = Metadata(configuration =
+        Map(UCCommitCoordinatorClient.UC_TABLE_ID_KEY -> tableId)))
+    assert(result14.areValid)
+    assert(result14.added == Map(UCCommitCoordinatorClient.UC_TABLE_ID_KEY -> tableId))
+
+    // Test 15: Changing UC_TABLE_ID_KEY is invalid (add-only per-key validator).
+    val result15 = conflictCheckerWithCO.checkConfigurationChangesForConflicts(
+      currentMetadata = Metadata(configuration =
+        Map(UCCommitCoordinatorClient.UC_TABLE_ID_KEY -> "old-uuid")),
+      winningMetadata = Metadata(configuration =
+        Map(UCCommitCoordinatorClient.UC_TABLE_ID_KEY -> "new-uuid")))
+    assert(!result15.areValid)
+
+    // Test 16: UC_TABLE_ID_KEY added alongside a non-allowlisted key is invalid.
+    // The allowlist only covers UC_TABLE_ID_KEY; the extra key must block resolution.
+    val result16 = conflictCheckerWithCO.checkConfigurationChangesForConflicts(
+      currentMetadata = Metadata(configuration = Map.empty),
+      winningMetadata = Metadata(configuration = Map(
+        UCCommitCoordinatorClient.UC_TABLE_ID_KEY -> tableId,
+        DeltaConfigs.CHECKPOINT_INTERVAL.key -> "20")))
+    assert(!result16.areValid)
+  }
+
+  test("CatalogOwned and VacuumProtocolCheck features allow concurrent txns at upgrade") {
+    assert(!CatalogOwnedTableFeature.failConcurrentTransactionsAtUpgrade)
+    assert(!VacuumProtocolCheckTableFeature.failConcurrentTransactionsAtUpgrade)
   }
 
   def testFeatureDisablement(property: String, withUnset: Boolean): Unit = {


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Allows concurrent transactions to resolve conflicts against a commit that enables the `catalogManaged` table feature, instead of failing. This follows the conflict-free enablement pattern used by other table features (e.g. #6922):

- Override `failConcurrentTransactionsAtUpgrade = false` on `CatalogOwnedTableFeature` and `VacuumProtocolCheckTableFeature`
- Allow-list the catalog table id key in conflict resolution, with an add-only validator

## How was this patch tested?

New unit tests in `FeatureEnablementConcurrencySuite`.

## Does this PR introduce _any_ user-facing changes?

No.