### PR TITLE
[Spark] Thread committed transaction info through commit

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/CommittedTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/CommittedTransaction.scala
@@ -32,8 +32,10 @@ import org.apache.spark.sql.catalyst.catalog.CatalogTable
  * @param txnId                 the unique identifier of the committed transaction.
  * @param deltaLog              the [[DeltaLog]] instance for the table the transaction
  *                              committed on.
- * @param catalogTable          the catalog table at the start of the transaction for the
- *                              committed table.
+ * @param catalogTable          the catalog table exposed to post-commit hooks.
+ *                              Normal commits use the transaction's construction-time table.
+ *                              UC retry and migration paths may pass the refreshed table.
+ *                              That table comes from the successful commit attempt.
  * @param readSnapshot          the snapshot of the table at the time of the transaction's read.
  * @param committedVersion      the version of the table after the txn committed.
  * @param committedActions      the actions that were committed in this transaction.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -1852,10 +1852,10 @@ trait OptimisticTransactionImpl extends TransactionHelper
 
       val (commitVersion, postCommitSnapshot, updatedCurrentTransactionInfo) =
         doCommitRetryIteratively(firstAttemptVersion, currentTransactionInfo, isolationLevelToUse)
-      // committedActions mirrors the committed log JSON (CommitInfo first),
-      // so post-commit hooks can read operationMetrics without re-parsing.
-      setCommitted(commitVersion, postCommitSnapshot,
-        updatedCurrentTransactionInfo.finalActionsToCommit)
+      setCommitted(
+        commitVersion,
+        postCommitSnapshot,
+        Some(updatedCurrentTransactionInfo))
       logInfo(log"Committed delta #${MDC(DeltaLogKeys.VERSION, commitVersion)} to " +
         log"${MDC(DeltaLogKeys.PATH, deltaLog.logPath)}")
       commitVersion
@@ -2130,7 +2130,10 @@ trait OptimisticTransactionImpl extends TransactionHelper
         attemptVersion,
         commitResponse.getCommit,
         txnId)
-      setCommitted(attemptVersion, postCommitSnapshot, committedActions = Seq.empty)
+      setCommitted(
+        attemptVersion,
+        postCommitSnapshot,
+        committedTransactionInfoOpt = None)
       val postCommitReconstructionTime = System.nanoTime()
       commitStatsComputer.finalizeAndEmitCommitStats(
         spark,
@@ -2636,7 +2639,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
 
       for (attemptNumber <- 0 to maxRetryAttempts) {
         try {
-          val postCommitSnapshot = if (!shouldCheckForConflicts) {
+          val (postCommitSnapshot, committedTransactionInfo) = if (!shouldCheckForConflicts) {
             doCommit(commitVersion, updatedCurrentTransactionInfo, attemptNumber, isolationLevel)
           } else recordDeltaOperation(deltaLog, "delta.commit.retry") {
             val (newCommitVersion, newCurrentTransactionInfo) = checkForConflicts(
@@ -2691,13 +2694,13 @@ trait OptimisticTransactionImpl extends TransactionHelper
    * Commit `actions` using `attemptVersion` version number. Throws a FileAlreadyExistsException
    * if any conflicts are detected.
    *
-   * @return the post-commit snapshot of the deltaLog
+   * @return the post-commit snapshot and transaction info used by the successful commit.
    */
   protected def doCommit(
       attemptVersion: Long,
       currentTransactionInfo: CurrentTransactionInfo,
       attemptNumber: Int,
-      isolationLevel: IsolationLevel): Snapshot = {
+      isolationLevel: IsolationLevel): (Snapshot, CurrentTransactionInfo) = {
     val targetCatalogTable = catalogTable
     // If the table requires atomic Iceberg metadata generation
     // , generate iceberg metadata and update the transaction info.
@@ -2743,7 +2746,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
     val fsWriteStartNano = System.nanoTime()
     val jsonActions = actions.map(_.json)
 
-    val (newChecksumOpt, commit) =
+    val (newChecksumOpt, commit, committedTransactionInfo) =
       writeCommitFile(attemptVersion, jsonActions.toIterator, updatedCurrentTransactionInfo)
 
     spark.sessionState.conf.setConf(
@@ -2786,7 +2789,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
       commitSizeBytes = commitSizeBytes
     )
 
-    postCommitSnapshot
+    (postCommitSnapshot, committedTransactionInfo)
   }
 
   class FileSystemBasedCommitCoordinatorClient(val deltaLog: DeltaLog)
@@ -2875,7 +2878,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
       attemptVersion: Long,
       jsonActions: Iterator[String],
       currentTransactionInfo: CurrentTransactionInfo)
-      : (Option[VersionChecksum], Commit) = {
+      : (Option[VersionChecksum], Commit, CurrentTransactionInfo) = {
     val commitCoordinatorClient = readSnapshotTableCommitCoordinatorClientOpt.getOrElse {
       TableCommitCoordinatorClient(
         new FileSystemBasedCommitCoordinatorClient(deltaLog),
@@ -2883,10 +2886,15 @@ trait OptimisticTransactionImpl extends TransactionHelper
         snapshot.metadata.coordinatedCommitsTableConf
       )
     }
-    val commitFile = writeCommitFileImpl(
+    val (commitFile, committedTransactionInfo) = writeCommitFileImpl(
       attemptVersion, jsonActions, commitCoordinatorClient, currentTransactionInfo)
+    // Derive the checksum from currentTransactionInfo, not committedTransactionInfo.
+    // The checksum uses Delta log inputs.
+    // Those inputs are actions, metadata, protocol, operation name, and txn id.
+    // committedTransactionInfo may carry a refreshed CatalogTable for UC commit metadata.
+    // CatalogTable is not a checksum input.
     val newChecksumOpt = incrementallyDeriveChecksum(attemptVersion, currentTransactionInfo)
-    (newChecksumOpt, commitFile)
+    (newChecksumOpt, commitFile, committedTransactionInfo)
   }
 
   protected def writeCommitFileImpl(
@@ -2894,18 +2902,22 @@ trait OptimisticTransactionImpl extends TransactionHelper
     jsonActions: Iterator[String],
     tableCommitCoordinatorClient: TableCommitCoordinatorClient,
     currentTransactionInfo: CurrentTransactionInfo
-  ): Commit = {
+  ): (Commit, CurrentTransactionInfo) = {
     val updatedActions =
       currentTransactionInfo.getUpdatedActions(snapshot.metadata, snapshot.protocol)
-    val commitResponse = TransactionExecutionObserver.withObserver(executionObserver) {
-      tableCommitCoordinatorClient.commit(
-        attemptVersion,
-        jsonActions,
-        updatedActions,
-        catalogTable.map(_.identifier),
-        new CatalogTrackedInfo(
-          currentTransactionInfo.convertedIcebergMetadata.toJava,
-          currentTransactionInfo.domainMetadata.map(dm => dm: AbstractDomainMetadata).asJava)
+    val (commitResponse, committedTransactionInfo) =
+      TransactionExecutionObserver.withObserver(executionObserver) {
+      (
+        tableCommitCoordinatorClient.commit(
+          attemptVersion,
+          jsonActions,
+          updatedActions,
+          catalogTable.map(_.identifier),
+          new CatalogTrackedInfo(
+            currentTransactionInfo.convertedIcebergMetadata.toJava,
+            currentTransactionInfo.domainMetadata.map(dm => dm: AbstractDomainMetadata).asJava)
+        ),
+        currentTransactionInfo
       )
     }
     if (attemptVersion == 0L) {
@@ -2916,7 +2928,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
           s"$expectedPathForCommitZero but was written to $actualCommitPath")
       }
     }
-    commitResponse.getCommit
+    (commitResponse.getCommit, committedTransactionInfo)
   }
 
 
@@ -3082,14 +3094,20 @@ trait OptimisticTransactionImpl extends TransactionHelper
   protected def setCommitted(
       committedVersion: Long,
       postCommitSnapshot: Snapshot,
-      committedActions: Seq[Action]): Unit =
+      committedTransactionInfoOpt: Option[CurrentTransactionInfo]): Unit = {
+    // Normal commit paths carry CurrentTransactionInfo with refreshed catalog state and actions.
+    // commitLarge passes None because it streams the payload and records no committed actions.
+    val actionsForCommittedTransaction =
+      committedTransactionInfoOpt.map(_.finalActionsToCommit).getOrElse(Seq.empty)
+    val catalogTableForCommittedTransaction =
+      committedTransactionInfoOpt.flatMap(_.catalogTable).orElse(catalogTable)
     committed = Some(CommittedTransaction(
       txnId = txnId,
       deltaLog = deltaLog,
       catalogTable = catalogTable,
       readSnapshot = snapshot,
       committedVersion = committedVersion,
-      committedActions = committedActions,
+      committedActions = actionsForCommittedTransaction,
       postCommitSnapshot = postCommitSnapshot,
       postCommitHooks = postCommitHooks.toSeq,
       txnExecutionTimeMs = txnExecutionTimeMs.get,
@@ -3097,6 +3115,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
       partitionsAddedToOpt = partitionsAddedToOpt,
       isBlindAppend = isBlindAppend
     ))
+  }
 
   /** Register a hook that will be executed once a commit is successful. */
   def registerPostCommitHook(hook: PostCommitHook): Unit = {


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

`doCommit` may update the transaction info it was given before writing the commit file, for example when generating Iceberg conversion metadata for UniForm tables, but it previously returned only the post-commit snapshot. The `CurrentTransactionInfo` actually used to build the commit payload was invisible to callers; `doCommitRetryIteratively` and `setCommitted` only ever saw the caller-side copy.

This PR threads that info through the return values. `writeCommitFileImpl` returns the `CurrentTransactionInfo` used for the commit payload alongside the `Commit`, `writeCommitFile` forwards it next to the incrementally derived checksum, and `doCommit` returns it with the post-commit snapshot. The checksum still derives from the input `currentTransactionInfo`: checksum inputs are Delta log state (actions, metadata, protocol, operation name, transaction id), and catalog state possibly refreshed during the commit is not part of that input.

`setCommitted` now takes `Option[CurrentTransactionInfo]` instead of a pre-extracted `Seq[Action]`. Normal commits pass the transaction info and derive `committedActions` from `finalActionsToCommit`; `commitLarge` passes `None` because it streams the payload and records no committed actions. Behavior in this repo is unchanged: `commit()` passes the same transaction info whose `finalActionsToCommit` it previously extracted, and `CommittedTransaction.catalogTable` continues to receive the transaction's construction-time catalog table. The new return values let commit implementations that refresh catalog state or generate additional actions inside `doCommit` surface the state used by the successful attempt to `setCommitted` and post-commit hooks, rather than passing it through side channels.

## How was this patch tested?

Existing unit tests. This is a signature-level refactor of the commit path with no behavior change in this repo; every existing commit exercises `doCommit`, `writeCommitFile`, and `setCommitted`.

## Does this PR introduce _any_ user-facing changes?

No.
