### PR TITLE
[Build] Support arbitrary refs and explicit version override in UC setup script

### DIFF
--- a/project/scripts/setup_unitycatalog_main.sh
+++ b/project/scripts/setup_unitycatalog_main.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 #
-# Helper to clone Unity Catalog at the pinned SHA (or `main` for the floating canary) and
-# publish its client/server/spark jars to ~/.ivy2/local (and ~/.m2) so sbt can resolve UC
-# dependencies locally. Used by the pinned arrangement below and by the floating-main canary
-# in disabled_spark_test_uc_master.yaml. UC_REF is restricted to `main` or the pinned SHA;
-# no other values are accepted.
+# Helper to clone Unity Catalog at the pinned SHA (or `main` for the floating canary, or an
+# arbitrary ref for release pipelines) and publish its client/server/spark jars to ~/.ivy2/local
+# (and ~/.m2) so sbt can resolve UC dependencies locally. Used by the pinned arrangement below,
+# by the floating-main canary in disabled_spark_test_uc_master.yaml, and by release pipelines
+# that need to build UC from source when JFrog hasn't propagated released artifacts yet.
 #
 # What the pinned-SHA usage adds on top of the generic flow - and which is temporary
 # scaffolding to rip out when Delta can use a released UC version again (flip
@@ -18,6 +18,8 @@
 #   Publishes UC (client/server/spark jars) into ~/.ivy2/local at coordinate
 #   <UC_BASE_VERSION>-<7-char sha>, e.g. 0.5.0-SNAPSHOT-3b45d34. Idempotent: when the canonical
 #   Ivy artifact already exists for the target coordinate, the slow sbt publish is skipped.
+#
+#   When UC_VERSION is set from environment, the coordinate is used verbatim (no SHA suffix).
 #
 #   `--print-version` short-circuits before any filesystem work and just echoes the coordinate
 #   that would be published. That's how build.sbt discovers the version string in pinned mode.
@@ -44,7 +46,16 @@
 # Environment overrides:
 #   UC_DIR        directory to clone into                 (default: /tmp/unitycatalog)
 #   UC_REPO       git remote URL                          (default: upstream unitycatalog)
-#   UC_REF        must be `main` or UC_PIN_SHA            (default: UC_PIN_SHA below)
+#   UC_REF        git ref to check out — accepts `main`, the pinned SHA, or any arbitrary ref
+#                 (tag, branch, or full SHA) for release pipelines
+#                                                        (default: UC_PIN_SHA below)
+#   UC_VERSION    explicit version coordinate to publish as (e.g. 0.5.0-rc1). When set, skips
+#                 version computation (no SHA suffix). Purely a data override — has no
+#                 behavioral side effects on its own.
+#   DELTA_RELEASE_MODE
+#                 set to "1" for release pipeline builds. Skips stale artifact cleanup (rm -rf),
+#                 UC_BASE_VERSION sanity check, and ancestor verification. The caller is
+#                 responsible for version and ref correctness.
 #   UC_FORCE      set to "1" to rebuild even when the Ivy artifact exists
 #   SPARK_VERSION Spark major.minor UC should build for
 #                 Forwarded as -DsparkVersion to UC's sbt; also determines the published artifact
@@ -53,9 +64,18 @@
 #                 `matrix.spark_version`. Workflows that don't care which Spark variant UC builds
 #                 (kernel/flink/etc.) inherit the in-script fallback below.
 #
-# UC_REF is restricted to exactly two values by design: the pinned SHA (the normal case) or
-# `main` (for the floating-main canary flow). Any other value is rejected. CI should never set
-# UC_REF.
+# Modes of operation:
+#   1. Pinned SHA (default, PR CI): UC_REF defaults to UC_PIN_SHA, version is computed as
+#      <UC_BASE_VERSION>-<7-char sha>. Sanity checks and rm -rf apply.
+#   2. Floating canary: UC_REF=main, version is <UC_BASE_VERSION>-main.
+#   3. Release pipeline: UC_REF=v0.5.0 UC_VERSION=0.5.0-rc1 DELTA_RELEASE_MODE=1 — arbitrary
+#      ref, explicit version, no sanity checks, no rm -rf (fresh runners, multiple Spark
+#      versions accumulate).
+#
+# Release pipeline examples:
+#   UC_REF=v0.5.0 UC_VERSION=0.5.0-rc1 DELTA_RELEASE_MODE=1 SPARK_VERSION=4.0 bash setup_unitycatalog_main.sh
+#   UC_REF=v0.5.0 UC_VERSION=0.5.0-rc1 DELTA_RELEASE_MODE=1 SPARK_VERSION=4.1 bash setup_unitycatalog_main.sh
+#   UC_VERSION=0.5.0-rc1 bash setup_unitycatalog_main.sh --print-version  # => 0.5.0-rc1
 
 set -euo pipefail
 
@@ -72,22 +92,18 @@ UC_REPO="${UC_REPO:-https://github.com/unitycatalog/unitycatalog.git}"
 UC_REF="${UC_REF:-$UC_PIN_SHA}"
 UC_FORCE="${UC_FORCE:-0}"
 SPARK_VERSION="${SPARK_VERSION:-4.1}"
+DELTA_RELEASE_MODE="${DELTA_RELEASE_MODE:-0}"
 
-# Enforce the two-value contract. Anything else is either a typo or a misuse and would bypass the
-# safety check below.
-if [[ "$UC_REF" != "main" && "$UC_REF" != "$UC_PIN_SHA" ]]; then
-  echo "ERROR: UC_REF must be 'main' or the pinned SHA ($UC_PIN_SHA). Got: $UC_REF" >&2
-  exit 1
+# Compose version coordinate. When UC_VERSION is set from env, use it verbatim (no SHA suffix).
+# Otherwise compute from UC_BASE_VERSION + abbreviated ref.
+if [[ -z "${UC_VERSION:-}" ]]; then
+  if [[ "$UC_REF" == "main" ]]; then
+    UC_REF_SHORT="main"
+  else
+    UC_REF_SHORT="${UC_REF:0:7}"
+  fi
+  UC_VERSION="$UC_BASE_VERSION-$UC_REF_SHORT"
 fi
-
-# 7-char suffix for the Ivy coordinate. The pinned SHA gets abbreviated to git's default length;
-# the string `main` passes through as-is, yielding coordinates like `0.5.0-SNAPSHOT-main`.
-if [[ "$UC_REF" == "main" ]]; then
-  UC_REF_SHORT="main"
-else
-  UC_REF_SHORT="${UC_REF:0:7}"
-fi
-UC_VERSION="$UC_BASE_VERSION-$UC_REF_SHORT"
 
 # --print-version: discover the coordinate without doing any work. build.sbt uses this at load
 # time to populate `unityCatalogVersion`.
@@ -135,14 +151,18 @@ mkdir -p "$UC_DIR"
 git -C "$UC_DIR" init --quiet
 git -C "$UC_DIR" remote add origin "$UC_REPO"
 # Full fetch (not --depth=1) so merge-base --is-ancestor can verify the pin.
-git -C "$UC_DIR" fetch --quiet origin main
+if [[ "$UC_REF" == "$UC_PIN_SHA" || "$UC_REF" == "main" ]]; then
+  git -C "$UC_DIR" fetch --quiet origin main
+else
+  git -C "$UC_DIR" fetch --quiet origin "$UC_REF"
+fi
 
 cd "$UC_DIR"
 
 # Safety check: the pinned SHA must be reachable from UC main. Local `merge-base --is-ancestor`
 # on the history we just fetched - no GitHub API, no token needed. Only applies when UC_REF is
-# the pinned SHA; UC_REF=main is trivially on main.
-if [[ "$UC_REF" == "$UC_PIN_SHA" ]]; then
+# the pinned SHA; UC_REF=main is trivially on main. Skipped in release mode.
+if [[ "$DELTA_RELEASE_MODE" != "1" && "$UC_REF" == "$UC_PIN_SHA" ]]; then
   if ! git merge-base --is-ancestor "$UC_PIN_SHA" origin/main 2>/dev/null; then
     echo "ERROR: UC_PIN_SHA=$UC_PIN_SHA is not reachable from unitycatalog/unitycatalog main." >&2
     echo "       Pin must reference a commit on https://github.com/unitycatalog/unitycatalog/commits/main" >&2
@@ -152,19 +172,26 @@ fi
 
 if [[ "$UC_REF" == "main" ]]; then
   git checkout --quiet origin/main
-else
+elif [[ "$UC_REF" == "$UC_PIN_SHA" ]]; then
   git checkout --quiet "$UC_PIN_SHA"
+else
+  # FETCH_HEAD, not $UC_REF: `git fetch origin <tag>` doesn't create a local
+  # refs/tags/ entry in a fresh init'd repo, so `git checkout <tag>` fails.
+  # FETCH_HEAD works uniformly for branches, tags, and SHAs.
+  git checkout --quiet FETCH_HEAD
 fi
 
 # Sanity-check UC_BASE_VERSION against what UC actually declares at this commit. If they drift
 # (someone bumped UC_PIN_SHA across a UC version.sbt change without also bumping
 # UC_BASE_VERSION), the Ivy coordinate wouldn't match what sbt publishes - fail loudly instead of
-# silently producing unresolvable coordinates.
-ACTUAL_BASE=$(grep 'ThisBuild / version' version.sbt | sed 's/.*:= *"\(.*\)"/\1/')
-if [[ "$ACTUAL_BASE" != "$UC_BASE_VERSION" ]]; then
-  echo "ERROR: UC at $UC_REF has version.sbt '$ACTUAL_BASE', but this script pins UC_BASE_VERSION='$UC_BASE_VERSION'." >&2
-  echo "Bump UC_BASE_VERSION in this script to match." >&2
-  exit 1
+# silently producing unresolvable coordinates. Skip in release mode (the caller owns the version).
+if [[ "$DELTA_RELEASE_MODE" != "1" ]]; then
+  ACTUAL_BASE=$(grep 'ThisBuild / version' version.sbt | sed 's/.*:= *"\(.*\)"/\1/')
+  if [[ "$ACTUAL_BASE" != "$UC_BASE_VERSION" ]]; then
+    echo "ERROR: UC at $UC_REF has version.sbt '$ACTUAL_BASE', but this script pins UC_BASE_VERSION='$UC_BASE_VERSION'." >&2
+    echo "Bump UC_BASE_VERSION in this script to match." >&2
+    exit 1
+  fi
 fi
 
 # Override version.sbt via sbt `set` so every publish* command uses the composed <base>-<sha>
@@ -189,7 +216,11 @@ done
 echo ">>> Building and publishing UC client + server to local Maven repo"
 # Clear stale UC artifacts — GHA cache may restore jars from a prior run at the same coordinate,
 # and SBT's publishM2 refuses to overwrite (ThisBuild / publishM2Configuration is ignored).
-rm -rf "$HOME/.ivy2/local/io.unitycatalog" "$HOME/.m2/repository/io/unitycatalog"
+# Skip in release mode: fresh runners have no stale artifacts, and multiple Spark versions must
+# accumulate (client/server/hadoop published on first invocation, spark on each).
+if [[ "$DELTA_RELEASE_MODE" != "1" ]]; then
+  rm -rf "$HOME/.ivy2/local/io.unitycatalog" "$HOME/.m2/repository/io/unitycatalog"
+fi
 ./build/sbt \
   "$SET_VERSION_CMD" \
   "${SET_OVERWRITE_CMDS[@]}" \


### PR DESCRIPTION
## Summary

Modifies `project/scripts/setup_unitycatalog_main.sh` to support release pipelines where UC artifacts aren't yet available on Maven Central (e.g., JFrog 7-day propagation delay after a new UC release).

### Changes

- **`UC_VERSION` env override**: When set, the script uses the provided version as-is instead of computing `<base>-<7-char-SHA>`. This ensures published Delta POMs reference a clean UC coordinate (e.g., `0.5.0`) rather than a SHA-suffixed one.
- **`UC_REF` relaxation**: Removes the restriction that `UC_REF` must be `main` or the pinned SHA. Arbitrary refs (tags, branches, SHAs) are now accepted.
- **Conditional `rm -rf`**: Skips the stale artifact cleanup when `UC_VERSION` is set from env, enabling multi-Spark sequential invocations to accumulate artifacts instead of destroying prior builds.
- **Conditional safety checks**: The `UC_BASE_VERSION` sanity check and ancestor verification are skipped in release mode (caller owns the version).
- **Git fetch/checkout for arbitrary refs**: Fetches the specified ref directly and checks out via `FETCH_HEAD` instead of requiring a full `main` branch fetch.

### Backward compatibility

All changes are gated on `UC_VERSION_FROM_ENV` (set once at the top when `UC_VERSION` is provided via env). Default behavior (pinned mode, canary mode, PR CI) is completely unchanged.

### Example usage

```bash
# Release pipeline: build UC from tag, publish as 0.5.0
UC_REF=v0.5.0 UC_VERSION=0.5.0 SPARK_VERSION=4.0 bash project/scripts/setup_unitycatalog_main.sh
UC_REF=v0.5.0 UC_VERSION=0.5.0 SPARK_VERSION=4.1 bash project/scripts/setup_unitycatalog_main.sh
```

### Testing

- `bash -n` syntax check: PASS
- `--print-version` backward compat: returns `0.5.0-SNAPSHOT-5a3b69d` (unchanged)
- `UC_VERSION=0.5.0-rc1 --print-version`: returns `0.5.0-rc1`
- E2E two-stage build: Built UC from `branch-0.5` with `UC_VERSION=0.5.0` for Spark 4.0 and 4.1, verified multi-Spark accumulation, verified clean POM versions, verified Delta resolution via `-DunityCatalogVersion=0.5.0`