### PR TITLE
[Spark] Extend GeoTypesShim with geometry/geography predicates and CRS extractors

### DIFF
--- a/spark/src/main/scala-shims/spark-4.0/GeoTypesShim.scala
+++ b/spark/src/main/scala-shims/spark-4.0/GeoTypesShim.scala
@@ -28,6 +28,12 @@ object GeoTypesShim {
   /** Returns true if `dt` is `GeometryType` or `GeographyType`. */
   def isGeoSpatialType(dt: DataType): Boolean = false
 
+  /** Returns true if `dt` is `GeometryType`. */
+  def isGeometryType(dt: DataType): Boolean = false
+
+  /** Returns true if `dt` is `GeographyType`. */
+  def isGeographyType(dt: DataType): Boolean = false
+
   /**
    * If `dt` is a geospatial type with an unsupported SRID, returns `Some(srid)`. Returns
    * `None` for non-geospatial types or geospatial types with supported SRIDs.
@@ -39,4 +45,15 @@ object GeoTypesShim {
    * (e.g. generated columns, check constraints).
    */
   val geoExpressions: Set[Class[_]] = Set.empty[Class[_]]
+
+  /** Returns the CRS of a `GeometryType`. Only valid when `isGeometryType(dt)` is true. */
+  def geometryCrs(dt: DataType): String =
+    throw new IllegalArgumentException(s"Not a geometry type: $dt")
+
+  /**
+   * Returns the CRS and edge interpolation algorithm name (e.g. "SPHERICAL") of a
+   * `GeographyType`. Only valid when `isGeographyType(dt)` is true.
+   */
+  def geographyCrsAndAlgorithm(dt: DataType): (String, String) =
+    throw new IllegalArgumentException(s"Not a geography type: $dt")
 }

--- a/spark/src/main/scala-shims/spark-4.2/GeoTypesShim.scala
+++ b/spark/src/main/scala-shims/spark-4.2/GeoTypesShim.scala
@@ -27,8 +27,17 @@ import org.apache.spark.sql.types.{DataType, GeographyType, GeometryType}
  */
 object GeoTypesShim {
   /** Returns true if `dt` is `GeometryType` or `GeographyType`. */
-  def isGeoSpatialType(dt: DataType): Boolean = dt match {
-    case _: GeometryType | _: GeographyType => true
+  def isGeoSpatialType(dt: DataType): Boolean = isGeometryType(dt) || isGeographyType(dt)
+
+  /** Returns true if `dt` is `GeometryType`. */
+  def isGeometryType(dt: DataType): Boolean = dt match {
+    case _: GeometryType => true
+    case _ => false
+  }
+
+  /** Returns true if `dt` is `GeographyType`. */
+  def isGeographyType(dt: DataType): Boolean = dt match {
+    case _: GeographyType => true
     case _ => false
   }
 
@@ -52,4 +61,19 @@ object GeoTypesShim {
     classOf[ST_GeomFromWKB],
     classOf[ST_SetSrid],
     classOf[ST_Srid])
+
+  /** Returns the CRS of a `GeometryType`. Only valid when `isGeometryType(dt)` is true. */
+  def geometryCrs(dt: DataType): String = dt match {
+    case g: GeometryType => g.crs
+    case _ => throw new IllegalArgumentException(s"Not a geometry type: $dt")
+  }
+
+  /**
+   * Returns the CRS and edge interpolation algorithm name (e.g. "SPHERICAL") of a
+   * `GeographyType`. Only valid when `isGeographyType(dt)` is true.
+   */
+  def geographyCrsAndAlgorithm(dt: DataType): (String, String) = dt match {
+    case g: GeographyType => (g.crs, g.algorithm.toString)
+    case _ => throw new IllegalArgumentException(s"Not a geography type: $dt")
+  }
 }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Extends `GeoTypesShim` with geometry/geography type predicates and CRS extractors across the supported Spark versions:

- `isGeometryType(dt)` / `isGeographyType(dt)` — separate predicates for the two geo types (`isGeoSpatialType` is now their disjunction).
- `geometryCrs(dt)` — returns the CRS of a `GeometryType`; only valid when `isGeometryType(dt)` is true.
- `geographyCrsAndAlgorithm(dt)` — returns the CRS and edge interpolation algorithm name (e.g. `"SPHERICAL"`) of a `GeographyType`; only valid when `isGeographyType(dt)` is true.

This PR only touches the GeoTypesShim copies that are maintained in this repo: the Spark 4.2 shim gets the real implementations, and the Spark 4.0 shim stubs the predicates to `false` (the geo types do not exist on Spark 4.0, see SPARK-53760), making the extractors unreachable there. The Spark 4.1 shim is synced from Databricks runtime via Copybara and will receive the same methods through that channel, so it is intentionally not modified here.

This prepares for the upcoming Delta UniForm Delta-to-Iceberg geospatial schema conversion (Iceberg V3 `geometry` / `geography` types), which needs to obtain a geo column's CRS and edge interpolation algorithm without referencing the Spark geo classes directly, so the shared converter code stays compilable on Spark 4.0.

## How was this patch tested?

Existing build/compilation across the Spark version matrix; the new methods are pure type dispatch on `DataType` with no behavior change to existing callers. They are exercised by the follow-up Delta-to-Iceberg geospatial conversion change.

## Does this PR introduce _any_ user-facing changes?

No.
