### PR TITLE
[Delta][UniForm]Iceberg V3: Support Row Id

### DIFF
--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/DeltaToIcebergConvert.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/DeltaToIcebergConvert.scala
@@ -131,6 +131,11 @@ object DeltaToIcebergConvert extends DeltaLogging {
   }
 
   object RowTracking {
+    /**
+     * Set the next row-id on an Iceberg transaction so that subsequent data files written by
+     * the transaction get first-row-ids picked up from the Delta-side row-id high water mark.
+     * No-op when the Delta snapshot has no row tracking high water mark recorded.
+     */
     private[delta] def setNextRowId(snapshot: Snapshot, icebergTxn: IcebergTransaction): Unit = {
       RowId.extractHighWatermark(snapshot).foreach { highWaterMark =>
         IcebergTransactionUtils.setIcebergTxnNextRowId(icebergTxn, highWaterMark + 1)

--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConversionTransaction.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConversionTransaction.scala
@@ -26,6 +26,8 @@ import scala.jdk.OptionConverters._
 import scala.util.control.NonFatal
 
 import org.apache.spark.sql.delta.{DeltaFileProviderUtils, DummySnapshot, IcebergConstants, NoMapping, Snapshot}
+import org.apache.spark.sql.delta.IcebergCompat
+import org.apache.spark.sql.delta.RowId
 import org.apache.spark.sql.delta.actions.{AddFile, FileAction, Metadata, RemoveFile}
 import org.apache.spark.sql.delta.icebergShaded.IcebergTransactionUtils._
 import org.apache.spark.sql.delta.logging.DeltaLogKeys
@@ -83,6 +85,12 @@ class IcebergConversionTransaction(
       new java.util.ArrayList[MetadataUpdate]()
     ) extends DeltaLogging {
 
+  // Tracks the Delta version of the last commit that produced an Iceberg snapshot.
+  // Updated by TransactionHelper.commit() for non-NullHelper commits. Used to detect
+  // gaps caused by trailing non-data commits (NullHelper) so that
+  // UnityCatalogTableOperations.doCommit can validate the sequence number correctly.
+  private[delta] var lastDataDeltaVersion: Option[Long] = None
+
   ///////////////////////////
   // Nested Helper Classes //
   ///////////////////////////
@@ -134,6 +142,11 @@ class IcebergConversionTransaction(
 
     def commit(expectedSequenceNumber: Long): Unit = {
       assert(!committed, "Already committed.")
+      if (IcebergCompat.isGeqEnabled(postCommitSnapshot.metadata, 3)) {
+        // set lastSequenceNumber in TableMetadata to delta version - 1
+        // so iceberg will create snapshot/manifest at the delta version
+        IcebergTransactionUtils.setIcebergTxnLastSequenceNumber(txn, expectedSequenceNumber - 1)
+      }
       impl.commit()
       committed = true
     }
@@ -501,6 +514,13 @@ class IcebergConversionTransaction(
       case _ =>
         updateTxn.remove(IcebergConverter.BASE_DELTA_VERSION_PROPERTY)
     }
+    if (IcebergCompat.isGeqEnabled(postCommitSnapshot.metadata, 3)) {
+      updateTxn.set(
+        IcebergConverter.DELTA_HIGH_WATER_MARK_PROPERTY,
+        RowId.extractHighWatermark(postCommitSnapshot)
+          .getOrElse(RowId.MISSING_HIGH_WATER_MARK).toString
+      )
+    }
     updateTxn.commit()
 
     // We ensure the iceberg txns are serializable by only allowing them to commit against
@@ -523,6 +543,17 @@ class IcebergConversionTransaction(
       )
     }
     try {
+      // Set last sequence number in iceberg metadata to be same as Delta version, as
+      // some delta operations (eg, schema change, table property change) result in a new
+      // delta version but no new iceberg snapshot. This is needed to ensure the IRC iceberg
+      // writer sends the correct sequence number when it adds new snapshots.
+      if (IcebergCompat.isGeqEnabled(postCommitSnapshot.metadata, 3)) {
+        // Set lastSequenceNumber in TableMetadata to delta version
+        IcebergTransactionUtils.setIcebergTxnLastSequenceNumber(txn, postCommitSnapshot.version)
+        // For non-DBI tables, the post commit snapshot already contains the updated highWaterMark,
+        // so we can directly set it as the Iceberg nextRowId.
+        DeltaToIcebergConvert.RowTracking.setNextRowId(postCommitSnapshot, txn)
+      }
       txn.commitTransaction()
       recordIcebergCommit()
     } catch {

--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConverter.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConverter.scala
@@ -27,6 +27,7 @@ import scala.util.control.NonFatal
 import org.apache.spark.sql.delta.{CommittedTransaction, CurrentTransactionInfo, DeltaErrors, DeltaFileNotFoundException, DeltaFileProviderUtils, DeltaLog, DeltaOperations, DummySnapshot, IcebergCompat, IcebergConstants, Snapshot, SnapshotDescriptor, UniversalFormat, UniversalFormatConverter}
 import org.apache.spark.sql.delta.DeltaOperations.OPTIMIZE_OPERATION_NAME
 import org.apache.spark.sql.delta.RowId.RowTrackingMetadataDomain
+import org.apache.spark.sql.delta.RowTracking
 import org.apache.spark.sql.delta.actions.{Action, AddFile, CommitInfo, DomainMetadata, FileAction, InMemoryLogReplay, Metadata, Protocol, RemoveFile}
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.hooks.IcebergConverterHook
@@ -38,6 +39,7 @@ import io.delta.storage.commit.{CommitFailedException => DeltaCommitFailedExcept
 import org.apache.commons.lang3.exception.ExceptionUtils
 import org.apache.hadoop.fs.Path
 import shadedForDelta.org.apache.iceberg.{Table => IcebergTable, TableProperties}
+import shadedForDelta.org.apache.iceberg.BaseTable
 import shadedForDelta.org.apache.iceberg.exceptions.CommitFailedException
 import shadedForDelta.org.apache.iceberg.hadoop.HadoopTables
 import shadedForDelta.org.apache.iceberg.hive.{HiveCatalog, HiveTableOperations}
@@ -68,6 +70,11 @@ object IcebergConverter {
    * Indicates the base delta commit version # that the conversion started from
    */
   val BASE_DELTA_VERSION_PROPERTY = "base-delta-version"
+  /**
+   * Property to be set in translated Iceberg metadata files.
+   * Indicates the delta highWaterMark # that it corresponds to.
+   */
+  val DELTA_HIGH_WATER_MARK_PROPERTY = "delta-high-water-mark"
 
   def getLastConvertedDeltaVersion(table: Option[IcebergTable]): Option[Long] =
     table.flatMap(_.properties().asScala.get(DELTA_VERSION_PROPERTY)).map(_.toLong)
@@ -369,7 +376,11 @@ class IcebergConverter
         case _ => None
       }
 
+      val rowTrackingJustEnabled =
+        isRowTrackingJustEnabled(
+          snapshotToConvert, prevConvertedSnapshotOpt, lastConvertedIcebergTable)
       val tableOp = (lastDeltaVersionConverted, prevConvertedSnapshotOpt) match {
+        case (Some(_), _) if rowTrackingJustEnabled => REPLACE_TABLE
         case (Some(_), Some(_)) => WRITE_TABLE
         case (Some(_), None) => REPLACE_TABLE
         case (None, None) => CREATE_TABLE
@@ -381,6 +392,18 @@ class IcebergConverter
       )
 
       val convertedCommits: Seq[Option[CommitInfo]] = prevConvertedSnapshotOpt match {
+        // If `rowTrackingBackfillRequired` is enabled, the Row Tracking Backfill command
+        // will first be triggered, adding one or more ROW TRACKING BACKFILL commits
+        // to the table. After backfilling completes, here we must regenerate the entire
+        // Iceberg metadata to keep the snapshot version in sync.
+        case _ if rowTrackingJustEnabled =>
+          val commitInfos = createSnapshotsForReplaceTable(
+            snapshotToConvert, prevConvertedSnapshotOpt, icebergTxn, catalogTable,
+            snapshotToConvert.version, useRowTrackingVersion = true)
+          prevConvertedSnapshotOpt.foreach { prevSnapshot =>
+            icebergTxn.updateTableMetadata(prevSnapshot.metadata)
+          }
+          commitInfos
         case Some(prevSnapshot) =>
           // Read the actions directly from the delta json files.
           // TODO: Run this as a spark job on executors
@@ -496,12 +519,27 @@ class IcebergConverter
       txnInfo: CurrentTransactionInfo,
       deltaAttemptVersion: Long,
       catalogTable: CatalogTable): Snapshot = {
+    val rowTrackingHighWaterMark = if (IcebergCompat.isGeqEnabled(txnInfo.metadata, 3)) {
+      txnInfo.finalActionsToCommit.collectFirst {
+        case RowTrackingMetadataDomain(domain) => domain.rowIdHighWaterMark
+      }.orElse(Some(txnInfo.readRowIdHighWatermark))
+    } else {
+      None
+    }
+    val domainMetadata = if (IcebergCompat.isGeqEnabled(txnInfo.metadata, 3)) {
+      rowTrackingHighWaterMark.map { highWaterMark =>
+        Seq(RowTrackingMetadataDomain(rowIdHighWaterMark = highWaterMark).toDomainMetadata)
+      }
+    } else {
+      None
+    }
 
     new DummySnapshotWithAllFilesSupport(
       deltaLog.logPath,
       deltaLog,
       txnInfo.metadata,
       deltaAttemptVersion,
+      domainMetadata,
       Some(txnInfo.protocol),
       txnInfo,
       catalogTable
@@ -598,6 +636,89 @@ class IcebergConverter
       }
     }
   }
+
+  /**
+   * Returns true iff Row Tracking has just been turned on for this table
+   *
+   * A "just enabled" state is detected when **all** of the following hold:
+   *   1) Row Tracking is enabled on `snapshotToConvert`, and
+   *   2) IcebergCompat V3 is enabled on `snapshotToConvert.metadata`, and
+   *   3) Either:
+   *        - there is no previously converted snapshot (i.e., first time enable icebergCompat), or
+   *        - the last converted Iceberg table exists and its current Iceberg
+   *          format version is <= 2 (i.e., the table was on a lower compat version).
+   */
+  protected def isRowTrackingJustEnabled(
+      snapshotToConvert: Snapshot,
+      prevConvertedSnapshotOpt: Option[Snapshot],
+      lastConvertedIcebergTable: Option[IcebergTable]): Boolean = {
+    val rowTrackingEnabledOnSnapshotToConvert = RowTracking.isEnabled(
+      snapshotToConvert.protocol, snapshotToConvert.metadata)
+    rowTrackingEnabledOnSnapshotToConvert &&
+      IcebergCompat.isGeqEnabled(snapshotToConvert.metadata, 3) &&
+      // Either this is first time to enable Uniform or upgrade from lower version
+      (prevConvertedSnapshotOpt.isEmpty || lastConvertedIcebergTable.exists(
+        _.asInstanceOf[BaseTable].operations().current().formatVersion() <= 2))
+  }
+
+  /**
+   * Replays all AddFile actions from a Delta snapshot into Iceberg by committing
+   * them version by version within a replace table transaction.
+   *
+   * Groups all AddFile actions from snapshotToConvert by commit version and
+   * commits each group to icebergTxn at its respective version. The commit version
+   * is determined either by each file's defaultRowCommitVersion (when
+   * useRowTrackingVersion is true), or by the provided deltaVersion as a fallback.
+   *
+   * @param snapshotToConvert The Delta snapshot whose AddFiles are being replayed
+   * @param prevConvertedSnapshotOpt Optional previous converted Iceberg snapshot
+   * @param icebergTxn The Iceberg conversion transaction
+   * @param catalogTable The catalog table metadata
+   * @param fallbackVersion Fallback Delta version to use when
+   *                        file-level commit versions are missing
+   * @param useRowTrackingVersion Whether to derive commit version from each file's
+   *                              defaultRowCommitVersion (if available)
+   * @return A sequence of optional CommitInfo objects for each replayed commit
+   * @throws IllegalStateException if no actions are found for a commit version
+   */
+  protected def createSnapshotsForReplaceTable(
+      snapshotToConvert: Snapshot,
+      prevConvertedSnapshotOpt: Option[Snapshot],
+      icebergTxn: IcebergConversionTransaction,
+      catalogTable: CatalogTable,
+      fallbackVersion: Long,
+      useRowTrackingVersion: Boolean): Seq[Option[CommitInfo]] = {
+    val versionActionPairs = snapshotToConvert.allFiles.rdd.map { add =>
+      val version = if (useRowTrackingVersion) {
+        add.defaultRowCommitVersion.getOrElse(fallbackVersion)
+      } else {
+        fallbackVersion
+      }
+      val action = add.copy(dataChange = true).wrap.unwrap
+      version -> action
+    }
+    val allVersions = versionActionPairs.keys.distinct().collect().sorted
+    val groupedRdd = versionActionPairs.groupByKey().cache()
+
+    // Process one version at a time
+    val commitInfos = allVersions.toSeq.map { version =>
+      // Turn JSON back into Actions
+      val actionsToAdd: Seq[Action] =
+        groupedRdd
+          .lookup(version)
+          .headOption
+          .map(_.iterator.toSeq)
+          .getOrElse(throw new IllegalStateException(s"No actions found for version $version"))
+      runIcebergConversionForActions(
+        icebergTxn,
+        actionsToAdd,
+        prevConvertedSnapshotOpt,
+        version
+      )
+    }
+    commitInfos
+  }
+
   /**
    * Commit the set of changes into an Iceberg snapshot. Each call to this function will
    * build exactly one Iceberg Snapshot.
@@ -649,13 +770,13 @@ class IcebergConverter
    * |  Add + Remove     +---------------+---------------------+--------------------+
    * |                   |  None         |   RewriteHelper     |  OPTIMIZE          |
    * |                   +---------------+---------------------+--------------------+
-   * |                   |  Some         |   Unsupported       |  (unknown)         |
+   * |                   |  Some         |   OverwriteHelper   |  Note 3            |
    * +-------------------+---------------+---------------------+--------------------+
    * |  Add + Remove     |  All          |   RowDeltaHelper    |  UPDATE            |
    * |  with DV          +---------------+---------------------+--------------------+
    * |                   |  None         |   RewriteHelper     |  OPTIMIZE          |
    * |                   +---------------+---------------------+--------------------+
-   * |                   |  Some         |   same as All       |  Note 3            |
+   * |                   |  Some         |   RowDeltaHelper    |  Note 3            |
    * +-------------------+---------------+---------------------+--------------------+
    * Note:
    * 1. We assume a Create/Replace table operation will only contain AddFiles.
@@ -720,9 +841,7 @@ class IcebergConverter
         val dataChange = DataChange(dataChangeBits)
 
         (addFiles.nonEmpty, removeFiles.nonEmpty, dataChange) match {
-          case (true, false, DataChange.All) if !hasDv =>
-            icebergTxn.getAppendOnlyHelper
-          case (true, false, DataChange.Some) if !hasDv =>
+          case (true, false, DataChange.All | DataChange.Some) if !hasDv =>
             icebergTxn.getAppendOnlyHelper
           case (true, false, DataChange.All | DataChange.Some) if hasDv =>
             icebergTxn.getRowDeltaHelper
@@ -742,9 +861,7 @@ class IcebergConverter
             icebergTxn.getRowDeltaHelper
           case (true, true, DataChange.None) if hasDv =>
             icebergTxn.getRewriteHelper
-          case (true, true, DataChange.All) if !hasDv =>
-            icebergTxn.getOverwriteHelper
-          case (true, true, DataChange.Some) if !hasDv =>
+          case (true, true, DataChange.All | DataChange.Some) if !hasDv =>
             icebergTxn.getOverwriteHelper
           case (true, true, DataChange.None) if !hasDv =>
             icebergTxn.getRewriteHelper
@@ -836,6 +953,7 @@ class DummySnapshotWithAllFilesSupport(
     override val deltaLog: DeltaLog,
     override val metadata: Metadata,
     override val version: Long = -1,
+    val domainMetadataOpt: Option[Seq[DomainMetadata]] = None,
     val protocolOpt: Option[Protocol] = None,
     val txnInfo: CurrentTransactionInfo,
     val catalogTable: CatalogTable)
@@ -843,6 +961,7 @@ class DummySnapshotWithAllFilesSupport(
     logPath,
     deltaLog,
     metadata,
+    domainMetadataOpt,
     protocolOpt
   ) {
   override def allFiles: Dataset[AddFile] = {

--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergTransactionUtils.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergTransactionUtils.scala
@@ -162,6 +162,17 @@ object IcebergTransactionUtils
         DeltaToIcebergConvert.Partition.convertPartitionValues(
           snapshot, partitionSpec, f.partitionValues, logicalToPhysicalPartitionNames))
     }
+    f match {
+      case add: AddFile =>
+        add.baseRowId.map { rowId =>
+          builder.withFirstRowId(rowId)
+        }
+      case remove: RemoveFile =>
+        remove.baseRowId.map { rowId =>
+          builder.withFirstRowId(rowId)
+        }
+      case _ =>
+    }
     builder
   }
 

--- a/icebergShaded/src/main/java/org/apache/iceberg/unityCatalog/UnityCatalogTableOperations.java
+++ b/icebergShaded/src/main/java/org/apache/iceberg/unityCatalog/UnityCatalogTableOperations.java
@@ -52,17 +52,6 @@ public class UnityCatalogTableOperations extends BaseMetastoreTableOperations {
     public static final String DELTA_TIMESTAMP_PROPERTY = "delta-timestamp";
     public static final String BASE_DELTA_VERSION_PROPERTY = "base-delta-version";
     public static final String DELTA_HIGH_WATER_MARK_PROPERTY = "delta-high-water-mark";
-    // Always set during Iceberg conversion when at least one data commit produces a snapshot.
-    // Records the Delta version of that last data commit. When trailing non-data commits
-    // (e.g., ALTER TABLE) cause delta-version to advance beyond the Iceberg sequence number,
-    // doCommit validates against this property instead of delta-version.
-    // Not updated when all commits in a batch are non-data.
-    public static final String LAST_DATA_DELTA_VERSION_PROPERTY = "last-data-delta-version";
-
-    public static final String DELTA_SQL_CONF_BYPASS_SEQUENCE_NUMBER_CHECK =
-            "spark.databricks.delta.uniform.bypassSnapshotSequenceNumberCheck";
-    public static final String DELTA_SQL_CONF_BYPASS_FORMAT_VERSION_DOWNGRAGDE_CHECK =
-            "spark.databricks.delta.uniform.bypassFormatVersionDowngradeCheck";
 
     private final FileIO fileIO;
     private final TableIdentifier tableIdentifier;

--- a/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
@@ -939,6 +939,7 @@ class DummySnapshot(
     val logPath: Path,
     override val deltaLog: DeltaLog,
     override val metadata: Metadata,
+    domainMetadataOpt: Option[Seq[DomainMetadata]] = None,
     protocolOpt: Option[Protocol] = None)
   extends Snapshot(
     path = logPath,
@@ -966,6 +967,7 @@ class DummySnapshot(
   override def protocol: Protocol =
     protocolOpt.getOrElse(Protocol.forNewTable(spark, Some(metadata)))
 
+  override def domainMetadata: Seq[DomainMetadata] = domainMetadataOpt.getOrElse(Seq.empty)
   override protected lazy val computedState: SnapshotState = initialState(metadata, protocol)
   override protected lazy val getInCommitTimestampOpt: Option[Long] = None
   _computedStateTriggered = true


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (UniForm / Iceberg)

## Description

Adds Iceberg V3 **row-tracking (row id) support** to the UniForm Delta-to-Iceberg conversion, so converted tables carry Iceberg row-lineage metadata consistent with Delta:

- `IcebergTransactionUtils`: copy `baseRowId` / `defaultRowCommitVersion` from Delta `AddFile`/`RemoveFile` actions onto the Iceberg `DataFile`.
- `IcebergConversionTransaction`: align Iceberg sequence numbers with Delta versions for IcebergCompatV3 tables (set `lastSequenceNumber = version - 1` per helper commit so the snapshot is created at the Delta version, and `lastSequenceNumber = version` on transaction commit), write the `delta-high-water-mark` table property, and seed the Iceberg transaction's `nextRowId` from the Delta row-id high water mark (`DeltaToIcebergConvert.RowTracking.setNextRowId`).
- `IcebergConverter`: when row tracking has just been enabled (e.g. by Row Tracking Backfill), route the conversion to `REPLACE_TABLE` and regenerate all Iceberg snapshots from the table's `allFiles`, grouped by `defaultRowCommitVersion`; thread the row-tracking high water mark into the dummy snapshot used by conversion-on-commit. Also merges the `DataChange.All | DataChange.Some` helper-selection cases that pick the same commit helper and fixes the doc table accordingly.

## How was this patch tested?

Existing UniForm Iceberg conversion suites; this mirrors the row-id conversion change in the Databricks runtime, where it is covered by the UniForm Iceberg V3 row-tracking and sequence-number tests.

## Does this PR introduce _any_ user-facing changes?

No.
