### PR TITLE
[Flink] Fix normalize() dropping bucket names containing underscores

### DIFF
--- a/flink/src/main/java/io/delta/flink/table/AbstractKernelTable.java
+++ b/flink/src/main/java/io/delta/flink/table/AbstractKernelTable.java
@@ -113,8 +113,9 @@ public abstract class AbstractKernelTable implements DeltaTable {
         target =
             new URI(
                 target.getScheme(),
-                Optional.ofNullable(target.getHost()).orElse(""),
+                Optional.ofNullable(target.getAuthority()).orElse(""),
                 target.getPath() + "/",
+                target.getQuery(),
                 target.getFragment());
       }
     } catch (URISyntaxException e) {

--- a/flink/src/test/java/io/delta/flink/table/AbstractKernelTableTest.java
+++ b/flink/src/test/java/io/delta/flink/table/AbstractKernelTableTest.java
@@ -100,6 +100,14 @@ class AbstractKernelTableTest extends TestHelper {
         AbstractKernelTable.normalize(URI.create("file:///var/char/good")).toString());
     assertEquals(
         "s3://host/var/", AbstractKernelTable.normalize(URI.create("s3://host/var")).toString());
+    assertEquals(
+        "s3://my_bucket/var/",
+        AbstractKernelTable.normalize(URI.create("s3://my_bucket/var")).toString());
+    assertEquals(
+        "abfss://container@account.dfs.core.windows.net/path/",
+        AbstractKernelTable.normalize(
+                URI.create("abfss://container@account.dfs.core.windows.net/path"))
+            .toString());
   }
 
   @Test


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [x] Flink
- [ ] Kernel
- [ ] Other

## Description

`AbstractKernelTable.normalize(URI)` rebuilt the URI using `getHost()`:

```java
new URI(
    target.getScheme(),
    Optional.ofNullable(target.getHost()).orElse(""),
    target.getPath() + "/",
    target.getFragment());
```

`java.net.URI.getHost()` returns `null` when the authority is not RFC 2396
server-based. An underscore is illegal in a hostname, so a bucket name like
`my_bucket` makes the authority registry-based and `getHost()` returns `null`.
The `null` was then replaced with `""`, so:

```
s3://my_bucket/path  ->  s3:///path/      (bucket dropped, path wrong)
```

Switching to `getAuthority()` (the raw authority component) preserves the
bucket verbatim. It also preserves userinfo for authorities such as
`container@account.dfs.core.windows.net`, and the query component is now
carried through the rebuild:

```
s3://my_bucket/path                                  -> s3://my_bucket/path/
abfss://container@account.dfs.core.windows.net/path  -> abfss://container@account.dfs.core.windows.net/path/
file:///var/char/good                                -> file:///var/char/good/   (unchanged)
```

Reported by a user testing `DeltaSink` against a bucket whose name contains
an underscore.

## How was this patch tested?

- New assertions in `AbstractKernelTableTest#testNormalizeURI` cover the
  underscore-bucket and `abfss` userinfo cases; existing `file:` / `s3://host`
  cases are retained to guard against regression.
- `build/sbt "flink/testOnly io.delta.flink.table.AbstractKernelTableTest"`.

## Does this PR introduce _any_ user-facing changes?

No