### PR TITLE
[Delta][UniForm]Iceberg V3: variant and def value

### DIFF
--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergSchemaUtils.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergSchemaUtils.scala
@@ -85,6 +85,8 @@ trait IcebergSchemaUtils extends DeltaLogging {
             DeltaToIcebergConvert.Schema.extractLiteralDefault(f) match {
               case Left(errorMsg) =>
                 throw new UnsupportedOperationException(errorMsg)
+              case Right(Some(defaultLiteral)) =>
+                IcebergTypes.NestedField.from(icebergField).withWriteDefault(defaultLiteral).build()
               case _ => icebergField
             }
           } else {
@@ -122,6 +124,7 @@ trait IcebergSchemaUtils extends DeltaLogging {
           )
         }
 
+      case variantType: VariantType => IcebergTypes.VariantType.get()
       case atomicType: AtomicType => convertAtomic(atomicType)
 
       case other =>

--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergStatsConverter.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergStatsConverter.scala
@@ -105,6 +105,14 @@ case class IcebergStatsConverter(statsRow: InternalRow, statsSchema: StructType)
         // If the stats schema contains a struct type, there is a corresponding struct in the data
         // schema. The struct's per-field stats are also stored in the Delta stats struct. See the
         // `StatisticsCollection` trait comment for more.
+        // Variant stats are encoded as the concatenation of the variant's metadata bytes
+        // followed by its value bytes, matching the Iceberg variant binary format.
+        case _: VariantType =>
+          val variantVal = stats.getVariant(idx)
+          val variantBytes = ByteBuffer.wrap(variantVal.getMetadata ++
+            variantVal.getValue)
+          Map[Integer, ByteBuffer](Integer.valueOf(DeltaColumnMapping.getColumnId(field)) ->
+            variantBytes)
         case st: StructType =>
           generateIcebergByteBufferMetricMap(stats.getStruct(idx, st.fields.length), st)
         // Ignore the Delta statistic if the conversion doesn't support the given data type or the


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (UniForm — Delta → Iceberg conversion)

## Description

Extends the Delta → Iceberg (UniForm) conversion to cover two cases that were previously dropped:

**1. Variant type.**
- `IcebergSchemaUtils`: map Delta `VariantType` to Iceberg's native `IcebergTypes.VariantType` during schema conversion. Previously a Variant column fell through to the unsupported-type path.
- `IcebergStatsConverter`: convert Variant column statistics into Iceberg's variant binary format — the concatenation of the variant's metadata bytes followed by its value bytes — keyed by the column's Delta column-mapping id.

**2. Column default (write default).**
- `IcebergSchemaUtils`: when a field carries a literal default (`DeltaToIcebergConvert.Schema.extractLiteralDefault` returns `Right(Some(literal))`), attach it to the generated Iceberg field via `NestedField.withWriteDefault(...)`. Previously the extracted default was ignored and the field was emitted without it.

## How was this patch tested?

<!-- TODO: confirm before merge. No test files are included in this diff. -->
Exercised through the existing UniForm Delta → Iceberg conversion path. Recommend adding/confirming coverage in the Iceberg conversion suites (schema mapping for Variant + default, and the Variant stats encoding) before merge.

## Does this PR introduce _any_ user-facing changes?

No
