### PR TITLE
[Spark] Support loading a DSv2 (Kernel) table at a specific version

### DIFF
--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
@@ -41,6 +41,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.Set;
 import java.util.function.Supplier;
 import org.apache.hadoop.conf.Configuration;
@@ -123,7 +124,7 @@ public class DeltaV2Table
    * @throws NullPointerException if identifier or tablePath is null
    */
   public DeltaV2Table(Identifier identifier, String tablePath) {
-    this(identifier, tablePath, Collections.emptyMap(), Optional.empty());
+    this(identifier, tablePath, Collections.emptyMap(), Optional.empty(), OptionalLong.empty());
   }
 
   /**
@@ -135,7 +136,23 @@ public class DeltaV2Table
    * @throws NullPointerException if identifier or tablePath is null
    */
   public DeltaV2Table(Identifier identifier, String tablePath, Map<String, String> options) {
-    this(identifier, tablePath, options, Optional.empty());
+    this(identifier, tablePath, options, Optional.empty(), OptionalLong.empty());
+  }
+
+  /**
+   * Path-based constructor pinned to an explicit time travel version (if present).
+   *
+   * @param identifier logical table identifier used by Spark's catalog
+   * @param tablePath filesystem path to the Delta table root
+   * @param options table options used to configure the Hadoop conf, table reads and writes
+   * @param timeTravelVersion the table version to pin the initial snapshot to
+   */
+  public DeltaV2Table(
+      Identifier identifier,
+      String tablePath,
+      Map<String, String> options,
+      OptionalLong timeTravelVersion) {
+    this(identifier, tablePath, options, Optional.empty(), timeTravelVersion);
   }
 
   /**
@@ -149,11 +166,28 @@ public class DeltaV2Table
    */
   public DeltaV2Table(
       Identifier identifier, CatalogTable catalogTable, Map<String, String> options) {
+    this(identifier, catalogTable, options, OptionalLong.empty());
+  }
+
+  /**
+   * Catalog-table constructor pinned to an explicit time travel version (if present).
+   *
+   * @param identifier logical table identifier used by Spark's catalog
+   * @param catalogTable the Spark CatalogTable containing table metadata including location
+   * @param options user-provided options to override catalog properties
+   * @param timeTravelVersion the table version to pin the initial snapshot to
+   */
+  public DeltaV2Table(
+      Identifier identifier,
+      CatalogTable catalogTable,
+      Map<String, String> options,
+      OptionalLong timeTravelVersion) {
     this(
         identifier,
         getDecodedPath(requireNonNull(catalogTable, "catalogTable is null").location()),
         options,
-        Optional.of(catalogTable));
+        Optional.of(catalogTable),
+        timeTravelVersion);
   }
 
   /**
@@ -172,7 +206,8 @@ public class DeltaV2Table
       Identifier identifier,
       String tablePath,
       Map<String, String> userOptions,
-      Optional<CatalogTable> catalogTable) {
+      Optional<CatalogTable> catalogTable,
+      OptionalLong timeTravelVersion) {
     this.identifier = requireNonNull(identifier, "identifier is null");
     this.tablePath = requireNonNull(tablePath, "tablePath is null");
     this.catalogTable = catalogTable;
@@ -198,8 +233,10 @@ public class DeltaV2Table
         SparkSession.active().sessionState().newHadoopConfWithOptions(toScalaMap(options));
     this.kernelEngine = DefaultEngine.create(this.hadoopConf);
     this.snapshotManager = SnapshotManagerFactory.create(tablePath, kernelEngine, catalogTable);
-    // Load the initial snapshot through the manager
-    this.initialSnapshot = snapshotManager.loadLatestSnapshot();
+    this.initialSnapshot =
+        timeTravelVersion.isPresent()
+            ? loadSnapshotAtCheckedVersion(snapshotManager, timeTravelVersion.getAsLong())
+            : snapshotManager.loadLatestSnapshot();
 
     this.isCDCRead = CDCReader.isCDCRead(new CaseInsensitiveStringMap(this.options));
 
@@ -287,6 +324,13 @@ public class DeltaV2Table
    */
   public DeltaSnapshotManager getSnapshotManager() {
     return snapshotManager;
+  }
+
+  /** Returns a copy of this table pinned to {@code version}. */
+  public DeltaV2Table withVersion(long version) {
+    return catalogTable.isPresent()
+        ? new DeltaV2Table(identifier, catalogTable.get(), options, OptionalLong.of(version))
+        : new DeltaV2Table(identifier, tablePath, options, OptionalLong.of(version));
   }
 
   /**
@@ -411,6 +455,15 @@ public class DeltaV2Table
         schemaProvider.getRawSchema(),
         catalogStats,
         merged);
+  }
+
+  /**
+   * Validates that {@code version} exists in the Delta log, then loads the snapshot pinned to it.
+   */
+  private static Snapshot loadSnapshotAtCheckedVersion(DeltaSnapshotManager manager, long version) {
+    manager.checkVersionExists(
+        version, /* mustBeRecreatable = */ true, /* allowOutOfRange = */ false);
+    return manager.loadSnapshotAt(version);
   }
 
   @Override

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/catalog/DeltaV2TableTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/catalog/DeltaV2TableTest.java
@@ -902,4 +902,45 @@ public class DeltaV2TableTest extends DeltaV2TestBase {
               ex.getMessage());
         });
   }
+
+  // ---------------------------------------------------------------------------
+  // Time travel: withVersion(long)
+  // ---------------------------------------------------------------------------
+
+  /** withVersion(N) returns a copy pinned to the snapshot at version N. */
+  @Test
+  public void testWithVersionPinsToHistoricalSnapshot(@TempDir File tempDir) {
+    String path = tempDir.getAbsolutePath();
+    spark.sql(
+        String.format("CREATE TABLE test_with_version (id INT) USING delta LOCATION '%s'", path));
+    spark.sql("ALTER TABLE test_with_version ADD COLUMNS (name STRING)");
+
+    Identifier identifier = Identifier.of(new String[] {"default"}, "test_with_version");
+    DeltaV2Table latest = new DeltaV2Table(identifier, path);
+    assertEquals(2, latest.schema().fields().length);
+
+    // withVersion(0) pins to the historical snapshot.
+    DeltaV2Table pinned = latest.withVersion(0L);
+    assertEquals(1, pinned.schema().fields().length, "pinned table should see the v0 schema");
+    assertEquals("id", pinned.schema().fields()[0].name());
+
+    // The original table is unaffected.
+    assertEquals(2, latest.schema().fields().length);
+    assertNotEquals(latest, pinned);
+  }
+
+  /** withVersion fails when the requested version is out of range. */
+  @Test
+  public void testWithVersionRejectsOutOfRangeVersion(@TempDir File tempDir) {
+    String path = tempDir.getAbsolutePath();
+    spark.sql(
+        String.format(
+            "CREATE TABLE test_with_version_oor (id INT) USING delta LOCATION '%s'", path));
+
+    Identifier identifier = Identifier.of(new String[] {"default"}, "test_with_version_oor");
+    DeltaV2Table table = new DeltaV2Table(identifier, path);
+
+    assertThrows(RuntimeException.class, () -> table.withVersion(5L));
+    assertThrows(RuntimeException.class, () -> table.withVersion(-1L));
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Adds the ability to pin a `DeltaV2Table` to a specific table version:

- New `OptionalLong timeTravelVersion` in the constructor plus a `withVersion(long)` method return a table whose initial snapshot is loaded at the requested version.
- Version resolution goes through `loadSnapshotAtCheckedVersion`, which validates the version with `checkVersionExists` before loading.
- When no version is supplied, behavior is unchanged (latest snapshot).

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

Added `withVersion` tests in `DeltaV2TableTest.java`, additionally tested through the DSv2 connector's existing read paths.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No