### PR TITLE
[Spark] Fix URI path parsing

### DIFF
--- a/spark-unified/src/test/scala-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogCatalogIntegrationTest.java
+++ b/spark-unified/src/test/scala-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogCatalogIntegrationTest.java
@@ -181,6 +181,69 @@ public class DeltaChangelogCatalogIntegrationTest extends DeltaChangelogTestBase
   }
 
   // ===========================================================================================
+  // Reserved characters in file paths (URI encoding)
+  // ===========================================================================================
+
+  /**
+   * Regression test for URI parsing of file paths that contain reserved characters. The table path
+   * contains a space, and data file names carry '%' via the default {@code
+   * testOnly.dataFileNamePrefix} ("test%file%prefix-").
+   *
+   * <p>Before the fix the changelog read built file paths with {@code new Path(tablePath,
+   * child).toString()} (re-encoding the already-encoded child) and {@code
+   * SparkPath.fromUrlString(...)} (assuming a fully encoded URI), so reading the changes threw
+   * {@code java.net.URISyntaxException}. With {@code PartitionUtils.resolveTableRelativePath} /
+   * {@code SparkPath.fromPath} the paths resolve correctly and the read returns the changes.
+   */
+  @Test
+  public void testChangesReadWithReservedCharsInPath() throws Exception {
+    String tableName = "dsv2_cdc_reserved_" + System.nanoTime();
+    // The space in the path exercises URL-encoding of reserved characters.
+    String tablePath = System.getProperty("java.io.tmpdir") + "/spark test-" + System.nanoTime();
+    withTable(
+        tablePath,
+        () ->
+            withTable(
+                new String[] {tableName},
+                () -> {
+                  spark.sql(
+                      String.format(
+                          "CREATE TABLE %s (id BIGINT, name STRING) USING delta LOCATION '%s' "
+                              + "TBLPROPERTIES ('delta.enableDeletionVectors'='false', "
+                              + "'delta.enableRowTracking'='true')",
+                          tableName, tablePath));
+                  spark.sql(
+                      String.format("INSERT INTO %s VALUES (1, 'Alice'), (2, 'Bob')", tableName));
+                  spark.sql(String.format("DELETE FROM %s WHERE id = 1", tableName));
+
+                  // CHANGES read needs the V2 connector; see withHistoryTable for the rationale.
+                  withSQLConf(
+                      "spark.databricks.delta.v2.enableMode",
+                      "STRICT",
+                      () -> {
+                        // Without the fix, collecting throws java.net.URISyntaxException because
+                        // the file path under the space-containing table path is double-encoded.
+                        List<Row> rows =
+                            spark
+                                .sql(
+                                    String.format(
+                                        "SELECT id, name, _change_type, _commit_version "
+                                            + "FROM %s CHANGES FROM VERSION 1 TO VERSION 2",
+                                        tableName))
+                                .orderBy("_commit_version", "id", "_change_type")
+                                .collectAsList();
+
+                        // v1: insert (1, Alice), (2, Bob); v2: delete (1, Alice).
+                        assertEquals(
+                            3,
+                            rows.size(),
+                            "Expected 3 change rows; a URISyntaxException here means the "
+                                + "reserved-character path was not resolved correctly");
+                      });
+                }));
+  }
+
+  // ===========================================================================================
   // Bounds inclusivity/exclusivity testing
   // ===========================================================================================
 

--- a/spark/v2/src/main/java-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogBatch.java
+++ b/spark/v2/src/main/java-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogBatch.java
@@ -23,7 +23,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.Path;
 import org.apache.spark.paths.SparkPath;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
@@ -339,7 +338,7 @@ public class DeltaChangelogBatch implements Batch {
       CDCInputPartition cdcPartition = (CDCInputPartition) partition;
       InternalRow partitionValues = new GenericInternalRow(0);
       SparkPath sparkPath =
-          SparkPath.fromUrlString(new Path(tablePath, cdcPartition.getFilePath()).toString());
+          PartitionUtils.resolveTableRelativePath(tablePath, cdcPartition.getFilePath());
       scala.collection.immutable.Map<String, Object> constantMetadata =
           (scala.collection.immutable.Map<String, Object>)
               (scala.collection.immutable.Map<?, ?>)

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/PartitionUtils.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/PartitionUtils.java
@@ -271,10 +271,10 @@ public class PartitionUtils {
    * <p>Delta stores file paths URL-encoded per the protocol. Building the absolute path with {@code
    * new Path(parent, child)} re-encodes the already-encoded child (e.g. '%' -> '%25'), and {@code
    * SparkPath.fromUrlString(Path.toString())} then assumes a fully URL-encoded URI that {@code
-   * Path.toString()} does not produce. Reserved characters in the path (spaces, '%') therefore raise
-   * {@link URISyntaxException} or resolve to the wrong (double-encoded) file. Wrapping the child in
-   * {@code new URI(child)} accepts the already-encoded form verbatim, and {@link SparkPath#fromPath}
-   * routes through Hadoop's URI builder instead of assuming an encoded string.
+   * Path.toString()} does not produce. Reserved characters in the path (spaces, '%') therefore
+   * raise {@link URISyntaxException} or resolve to the wrong (double-encoded) file. Wrapping the
+   * child in {@code new URI(child)} accepts the already-encoded form verbatim, and {@link
+   * SparkPath#fromPath} routes through Hadoop's URI builder instead of assuming an encoded string.
    */
   public static SparkPath resolveTableRelativePath(String tablePath, String relativeOrAbsolute) {
     try {

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/PartitionUtils.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/PartitionUtils.java
@@ -32,8 +32,6 @@ import io.delta.spark.internal.v2.read.deletionvector.DeletionVectorReadFunction
 import io.delta.spark.internal.v2.read.deletionvector.DeletionVectorSchemaContext;
 import io.delta.spark.internal.v2.read.metadata.MetadataStructReadFunction;
 import io.delta.spark.internal.v2.read.metadata.MetadataStructSchemaContext;
-import io.delta.spark.internal.v2.read.rowtracking.RowTrackingReadFunction;
-import io.delta.spark.internal.v2.read.rowtracking.RowTrackingSchemaContext;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.ZoneId;

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/PartitionUtils.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/PartitionUtils.java
@@ -32,6 +32,10 @@ import io.delta.spark.internal.v2.read.deletionvector.DeletionVectorReadFunction
 import io.delta.spark.internal.v2.read.deletionvector.DeletionVectorSchemaContext;
 import io.delta.spark.internal.v2.read.metadata.MetadataStructReadFunction;
 import io.delta.spark.internal.v2.read.metadata.MetadataStructSchemaContext;
+import io.delta.spark.internal.v2.read.rowtracking.RowTrackingReadFunction;
+import io.delta.spark.internal.v2.read.rowtracking.RowTrackingSchemaContext;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -201,7 +205,7 @@ public class PartitionUtils {
             buildDvMetadataScala(addFile.getDeletionVector()),
             buildRowTrackingMetadata(addFile.getBaseRowId(), addFile.getDefaultRowCommitVersion()));
     return makePartitionedFile(
-        new Path(tablePath, addFile.getPath()).toString(),
+        resolveTableRelativePath(tablePath, addFile.getPath()),
         addFile.getSize(),
         addFile.getModificationTime(),
         getPartitionRow(addFile.getPartitionValues(), partitionSchema, zoneId),
@@ -253,22 +257,45 @@ public class PartitionUtils {
             ? cdcFile.getAddFile().getModificationTime()
             : cdcFile.getCommitTimestamp();
     return makePartitionedFile(
-        new Path(tablePath, cdcFile.getPath()).toString(),
+        resolveTableRelativePath(tablePath, cdcFile.getPath()),
         cdcFile.getFileSize(),
         modificationTime,
         partitionRow,
         metadata);
   }
 
+  /**
+   * Resolves a Delta-log-stored relative path against the table root and returns its {@link
+   * SparkPath}.
+   *
+   * <p>Delta stores file paths URL-encoded per the protocol. Building the absolute path with {@code
+   * new Path(parent, child)} re-encodes the already-encoded child (e.g. '%' -> '%25'), and {@code
+   * SparkPath.fromUrlString(Path.toString())} then assumes a fully URL-encoded URI that {@code
+   * Path.toString()} does not produce. Reserved characters in the path (spaces, '%') therefore raise
+   * {@link URISyntaxException} or resolve to the wrong (double-encoded) file. Wrapping the child in
+   * {@code new URI(child)} accepts the already-encoded form verbatim, and {@link SparkPath#fromPath}
+   * routes through Hadoop's URI builder instead of assuming an encoded string.
+   */
+  public static SparkPath resolveTableRelativePath(String tablePath, String relativeOrAbsolute) {
+    try {
+      Path child = new Path(new URI(relativeOrAbsolute));
+      Path absolute = child.isAbsolute() ? child : new Path(new Path(tablePath), child);
+      return SparkPath.fromPath(absolute);
+    } catch (URISyntaxException e) {
+      throw new IllegalArgumentException(
+          "Could not parse Delta-log file path as URI: " + relativeOrAbsolute, e);
+    }
+  }
+
   private static PartitionedFile makePartitionedFile(
-      String path,
+      SparkPath path,
       long size,
       long modificationTime,
       InternalRow partitionRow,
       scala.collection.immutable.Map<String, Object> metadata) {
     return new PartitionedFile(
         partitionRow,
-        SparkPath.fromUrlString(path),
+        path,
         /* start= */ 0L,
         /* length= */ size,
         /* preferredLocations= */ new String[0],


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Fixes URI / file-path parsing in the DSv2 changelog read path for paths that contain reserved characters (spaces, `%`), e.g. tables under a path with a space or partition values that Delta URL-encodes (`country=United%20States/...`).

Two latent defects on the read path:
1. `new Path(tablePath, child)` re-encodes the already-encoded relative path (`%` -> `%25`), producing a double-encoded path.
2. `SparkPath.fromUrlString(Path.toString())` assumes a fully URL-encoded URI string, but `Path.toString()` does not produce one, so reserved characters raise `java.net.URISyntaxException`.

The fix follows the `SparkPath` design intent: a helper `PartitionUtils.resolveTableRelativePath(...)` returns a `SparkPath`, wrapping the child in `new URI(child)` (accepts the already-encoded form verbatim) and using `SparkPath.fromPath(Path)` instead of `fromUrlString(Path.toString())`. `makePartitionedFile` now accepts a `SparkPath` directly, so call sites no longer construct paths or convert encodings.

Affected: `PartitionUtils.java` (helper + `makePartitionedFile` signature + 2 call sites) and `DeltaChangelogBatch.java` (uses the helper; `Path` import removed).



## How was this patch tested?
Local test run.
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
