### PR TITLE
[Spark] Allow USING INVENTORY table identifier to resolve non-Delta sources

### DIFF
--- a/spark/src/main/scala/io/delta/tables/execution/VacuumTableCommand.scala
+++ b/spark/src/main/scala/io/delta/tables/execution/VacuumTableCommand.scala
@@ -33,9 +33,13 @@ import org.apache.spark.sql.types.StringType
  * The `vacuum` command implementation for Spark SQL. Example SQL:
  * {{{
  *    VACUUM ('/path/to/dir' | delta.`/path/to/dir`)
- *    [USING INVENTORY (delta.`/path/to/dir`| ( sub_query ))]
+ *    [USING INVENTORY (<table_identifier> | ( <sub_query> ))]
  *    [RETAIN number HOURS] [DRY RUN];
  * }}}
+ *
+ * The inventory source (table identifier or subquery) is consumed as a
+ * DataFrame and validated against `VacuumCommand.INVENTORY_SCHEMA`. It does
+ * not need to be a Delta table.
  */
 case class VacuumTableCommand(
     override val child: LogicalPlan,

--- a/spark/src/main/scala/io/delta/tables/execution/VacuumTableCommand.scala
+++ b/spark/src/main/scala/io/delta/tables/execution/VacuumTableCommand.scala
@@ -16,7 +16,7 @@
 
 package io.delta.tables.execution
 
-import org.apache.spark.sql.{Row, SparkSession}
+import org.apache.spark.sql.{Dataset, Row, SparkSession}
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, UnaryNode}
 import org.apache.spark.sql.catalyst.TableIdentifier
@@ -61,8 +61,8 @@ case class VacuumTableCommand(
         DeltaTableIdentifier(path = Some(deltaTable.path.toString)))
     }
     val inventory = inventoryTable.map(sparkSession.sessionState.analyzer.execute)
-        .map(p => Some(getDeltaTable(p, "VACUUM").toDf(sparkSession)))
-        .getOrElse(inventoryQuery.map(sparkSession.sql))
+      .map(plan => Some(Dataset.ofRows(sparkSession, plan)))
+      .getOrElse(inventoryQuery.map(sparkSession.sql))
     VacuumCommand.gc(sparkSession, deltaTable, dryRun, horizonHours,
       inventory, vacuumType).collect()
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaVacuumSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaVacuumSuite.scala
@@ -759,6 +759,62 @@ class DeltaVacuumSuite extends DeltaVacuumSuiteBase with DeltaSQLCommandTest {
     }
   }
 
+  test("vacuum using inventory non-delta table identifier") {
+    withSQLConf(DeltaSQLConf.DELTA_VACUUM_RETENTION_CHECK_ENABLED.key -> "false") {
+      withEnvironment { (tempDir, clock) =>
+        import testImplicits._
+        val path = s"""${tempDir.getCanonicalPath}_data"""
+        val inventoryTable = "inventory_non_delta"
+
+        // Define test delta table
+        val data = Seq(
+          (10, 1, "a"),
+          (10, 2, "a"),
+          (10, 3, "a"),
+          (10, 4, "a"),
+          (10, 5, "a")
+        )
+        data.toDF("v1", "v2", "v3")
+          .write
+          .partitionBy("v1", "v2")
+          .format("delta")
+          .save(path)
+        val table = DeltaTableV2(spark, new File(path), clock)
+        val dataPath = table.deltaLog.dataPath
+        val inventoryData = Seq(
+          Row(s"${dataPath}/file1.txt", 300000L, false, 0L),
+          Row(s"${dataPath}/file2.txt", 300000L, false, 0L),
+          Row(s"${dataPath}/_underscore_col_=10/test.txt", 300000L, false, 0L),
+          Row(s"${dataPath}/_underscore_col_=10/test2.txt", 300000L, false, 0L)
+        )
+
+        withTable(inventoryTable) {
+          spark.createDataFrame(
+            spark.sparkContext.parallelize(inventoryData), VacuumCommand.INVENTORY_SCHEMA)
+            .write
+            .format("parquet")
+            .saveAsTable(inventoryTable)
+
+          gcTest(table, clock)(
+            CreateFile("file1.txt", commitToActionLog = false),
+            CreateFile("file2.txt", commitToActionLog = false),
+            // Delta marks dirs starting with `_` as hidden unless specified as partition folder
+            CreateFile("_underscore_col_=10/test.txt", false),
+            CreateFile("_underscore_col_=10/test2.txt", false),
+            AdvanceClock(defaultTombstoneInterval + 1000)
+          )
+
+          sql(s"vacuum delta.`$path` using inventory $inventoryTable retain 0 hours")
+          gcTest(table, clock)(
+            CheckFiles(Seq("file1.txt", "file2.txt"), exist = false),
+            // hidden files must not be dropped
+            CheckFiles(Seq("_underscore_col_=10/test.txt", "_underscore_col_=10/test2.txt"))
+          )
+        }
+      }
+    }
+  }
+
   test("vacuum using inventory query and should not touch hidden files") {
     withSQLConf(DeltaSQLConf.DELTA_VACUUM_RETENTION_CHECK_ENABLED.key -> "false") {
       withEnvironment { (tempDir, clock) =>

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaVacuumSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaVacuumSuite.scala
@@ -759,12 +759,12 @@ class DeltaVacuumSuite extends DeltaVacuumSuiteBase with DeltaSQLCommandTest {
     }
   }
 
-  test("vacuum using inventory non-delta table identifier") {
+  test("vacuum using inventory non-Delta table identifier") {
     withSQLConf(DeltaSQLConf.DELTA_VACUUM_RETENTION_CHECK_ENABLED.key -> "false") {
       withEnvironment { (tempDir, clock) =>
         import testImplicits._
         val path = s"""${tempDir.getCanonicalPath}_data"""
-        val inventoryTable = "inventory_non_delta"
+        val inventoryTableName = "inventory_non_delta"
 
         // Define test delta table
         val data = Seq(
@@ -783,32 +783,23 @@ class DeltaVacuumSuite extends DeltaVacuumSuiteBase with DeltaSQLCommandTest {
         val dataPath = table.deltaLog.dataPath
         val inventoryData = Seq(
           Row(s"${dataPath}/file1.txt", 300000L, false, 0L),
-          Row(s"${dataPath}/file2.txt", 300000L, false, 0L),
-          Row(s"${dataPath}/_underscore_col_=10/test.txt", 300000L, false, 0L),
-          Row(s"${dataPath}/_underscore_col_=10/test2.txt", 300000L, false, 0L)
+          Row(s"${dataPath}/file2.txt", 300000L, false, 0L)
         )
-
-        withTable(inventoryTable) {
+        withTable(inventoryTableName) {
+          // Inventory source is a managed Parquet table (non-Delta).
           spark.createDataFrame(
             spark.sparkContext.parallelize(inventoryData), VacuumCommand.INVENTORY_SCHEMA)
             .write
             .format("parquet")
-            .saveAsTable(inventoryTable)
-
+            .saveAsTable(inventoryTableName)
           gcTest(table, clock)(
             CreateFile("file1.txt", commitToActionLog = false),
             CreateFile("file2.txt", commitToActionLog = false),
-            // Delta marks dirs starting with `_` as hidden unless specified as partition folder
-            CreateFile("_underscore_col_=10/test.txt", false),
-            CreateFile("_underscore_col_=10/test2.txt", false),
             AdvanceClock(defaultTombstoneInterval + 1000)
           )
-
-          sql(s"vacuum delta.`$path` using inventory $inventoryTable retain 0 hours")
+          sql(s"vacuum delta.`$path` using inventory $inventoryTableName retain 0 hours")
           gcTest(table, clock)(
-            CheckFiles(Seq("file1.txt", "file2.txt"), exist = false),
-            // hidden files must not be dropped
-            CheckFiles(Seq("_underscore_col_=10/test.txt", "_underscore_col_=10/test2.txt"))
+            CheckFiles(Seq("file1.txt", "file2.txt"), exist = false)
           )
         }
       }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Resolves #7036.

`VACUUM ... USING INVENTORY <table_identifier>` previously called `getDeltaTable(p, "VACUUM").toDf(sparkSession)` on the resolved identifier plan, requiring the inventory source to be a Delta table. The downstream consumer `VacuumCommand.getFilesFromInventory` only needs a `DataFrame` matching `INVENTORY_SCHEMA`. The subquery path already accepts any analyzable relation, so the identifier-only Delta restriction is unnecessary and inconsistent.

This PR resolves the analyzed plan via `Dataset.ofRows(...)` so identifier and subquery paths behave the same way. Schema validation in `getFilesFromInventory` continues to reject malformed sources.

Target-table controls are unchanged; the VACUUM target still goes through Delta-specific safety and protocol checks.

## How was this patch tested?

Added `vacuum using inventory non-Delta table identifier` in `DeltaVacuumSuite`, which covers a Parquet inventory source registered as a managed table. Existing inventory tests provide regression coverage for the unchanged paths.

## Does this PR introduce _any_ user-facing changes?

Yes (relaxation only). `VACUUM ... USING INVENTORY <identifier>` no longer requires the inventory source to be a Delta table. Sources with a wrong schema still fail with `DELTA_INVALID_INVENTORY_SCHEMA`. Non-breaking change.