### PR TITLE
Throttle AddFile sanity-check usage logs per commit

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -49,7 +49,7 @@ import org.apache.spark.sql.delta.hooks.metrics.UpdateMetricsHook
 import org.apache.spark.sql.delta.util.CatalogTableUtils
 import org.apache.spark.sql.delta.implicits.addFileEncoder
 import org.apache.spark.sql.delta.logging.DeltaLogKeys
-import org.apache.spark.sql.delta.metering.{DeltaLogging, DeltaLoggingProvider}
+import org.apache.spark.sql.delta.metering.{DeltaLogging, DeltaLoggingProvider, ThrottledEventLogger}
 import org.apache.spark.sql.delta.redirect.{RedirectFeature, TableRedirectConfiguration}
 import org.apache.spark.sql.delta.schema.{SchemaMergingUtils, SchemaUtils, UnsupportedDataTypeInfo}
 import org.apache.spark.sql.delta.sources.{DeltaSourceUtils, DeltaSQLConf}
@@ -1389,13 +1389,24 @@ trait OptimisticTransactionImpl extends TransactionHelper
   }
 
   /**
+   * Per-commit usage-log throttlers for the AddFile sanity checks. A single commit can contain
+   * many invalid AddFiles; in logging-only mode that would emit one event per invalid action and
+   * flood usage logs, so we cap each check to [[maxSanityCheckEventsToLog]] events per commit.
+   * These are instance fields, so each [[OptimisticTransaction]] (i.e. each commit) gets a fresh
+   * count.
+   */
+  private val maxSanityCheckEventsToLog = 2
+  private val emptyFileCheckEventLogger = new ThrottledEventLogger(maxSanityCheckEventsToLog)
+  private val nullPartitionCheckEventLogger = new ThrottledEventLogger(maxSanityCheckEventsToLog)
+
+  /**
    * Validates that an AddFile does not reference a zero-byte parquet file.
    * Logs a delta event regardless of the flag; throws only when
    * [[DeltaSQLConf.DELTA_EMPTY_FILE_CHECK_THROW_ENABLED]] is set.
    */
   protected def validateAddFileNotEmpty(addFile: AddFile): Unit = {
     if (addFile.size == 0) {
-      recordDeltaEvent(
+      emptyFileCheckEventLogger.recordThrottledDeltaEvent(
         deltaLog,
         "delta.sanityCheck.emptyParquetFile",
         data = Map(
@@ -1422,7 +1433,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
     notNullPartitionCols.foreach { col =>
       addFile.partitionValues.get(col) match {
         case None | Some(null) =>
-          recordDeltaEvent(
+          nullPartitionCheckEventLogger.recordThrottledDeltaEvent(
             deltaLog,
             "delta.constraints.nullPartitionViolation",
             data = Map(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/metering/DeltaLogging.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/metering/DeltaLogging.scala
@@ -227,6 +227,48 @@ object DeltaLogging {
 }
 
 /**
+ * A thread-safe, count-based throttler for usage-log emission via [[recordThrottledDeltaEvent]].
+ *
+ * Unlike [[LogThrottler]], which throttles by rate using a token bucket, this throttles purely by
+ * count: it records at most `maxEventsToLog` delta events and silently drops the rest. Each
+ * instance must be shared across all call sites it should throttle together, and its lifetime
+ * defines the throttling scope (for example, a field of an [[OptimisticTransaction]] gives
+ * per-commit throttling).
+ *
+ * @param maxEventsToLog Maximum number of events to log before throttling kicks in.
+ */
+class ThrottledEventLogger(val maxEventsToLog: Long) extends DeltaLogging {
+
+  private var numLogged: Long = 0
+
+  /**
+   * Records a delta event via [[recordDeltaEvent]] while fewer than `maxEventsToLog` events have
+   * been recorded; once the cap is reached further events are silently dropped.
+   *
+   * The counter is claimed under a lock but the (heavier) recording happens outside it, so
+   * concurrent callers serialize only on the cap check and not on event serialization.
+   */
+  def recordThrottledDeltaEvent(
+      provider: DeltaLoggingProvider,
+      opType: String,
+      tags: Map[TagDefinition, String] = Map.empty,
+      data: AnyRef = null,
+      path: Option[Path] = None): Unit = {
+    val shouldLog = this.synchronized {
+      if (numLogged < maxEventsToLog) {
+        numLogged += 1
+        true
+      } else {
+        false
+      }
+    }
+    if (shouldLog) {
+      recordDeltaEvent(provider, opType, tags, data, path)
+    }
+  }
+}
+
+/**
  * A thread-safe token bucket-based throttler implementation with nanosecond accuracy.
  *
  * Each instance must be shared across all scopes it should throttle.

--- a/spark/src/test/scala/org/apache/spark/sql/delta/CommitSanityCheckSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CommitSanityCheckSuite.scala
@@ -62,18 +62,23 @@ class CommitSanityCheckSuite extends QueryTest
 
   private def commit(
     deltaLog: DeltaLog, addFile: AddFile, isCommitLarge: Boolean): Unit = {
+    commit(deltaLog, Seq(addFile), isCommitLarge)
+  }
+
+  private def commit(
+    deltaLog: DeltaLog, addFiles: Seq[AddFile], isCommitLarge: Boolean): Unit = {
     val txn = deltaLog.startTransaction()
     if (isCommitLarge) {
       txn.commitLarge(
         spark,
-        Seq(addFile).toIterator,
+        addFiles.toIterator,
         newProtocolOpt = None,
         op = DeltaOperations.ManualUpdate,
         context = Map.empty,
         metrics = Map.empty
       )
     } else {
-      txn.commit(Seq(addFile), DeltaOperations.ManualUpdate)
+      txn.commit(addFiles, DeltaOperations.ManualUpdate)
     }
   }
 
@@ -254,6 +259,98 @@ class CommitSanityCheckSuite extends QueryTest
           assert(eventBlob.contains("notNullPartitionCols"))
           assert(eventBlob("notNullPartitionCols").toString == "part")
           assert(eventBlob.contains("stackTrace"))
+        }
+      }
+    }
+
+    // ---------------------------------------------------------------------------
+    // Per-commit usage-log throttling
+    // ---------------------------------------------------------------------------
+
+    test(s"empty file check - logs are throttled to 2 events per commit " +
+        s"[isCommitLarge: $isCommitLarge]") {
+      withTempDir { tempDir =>
+        withSQLConf(DeltaSQLConf.DELTA_EMPTY_FILE_CHECK_THROW_ENABLED.key -> "false") {
+          val deltaLog = createTable(tempDir)
+
+          val addFiles = (0 until 5).map { i =>
+            AddFile(
+              path = s"part-0000$i.parquet",
+              partitionValues = Map.empty,
+              size = 0,
+              modificationTime = System.currentTimeMillis(),
+              dataChange = true,
+              stats = """{"numRecords": 0}"""
+            )
+          }
+
+          val events = Log4jUsageLogger.track {
+            commit(deltaLog, addFiles, isCommitLarge)
+          }
+
+          val violationEvents =
+            filterUsageRecords(events, "delta.sanityCheck.emptyParquetFile")
+          assert(violationEvents.size == 2)
+        }
+      }
+    }
+
+    test(s"null partition check - logs are throttled to 2 events per commit " +
+        s"[isCommitLarge: $isCommitLarge]") {
+      withTempDir { tempDir =>
+        withSQLConf(DeltaSQLConf.DELTA_NULL_PARTITION_CHECK_THROW_ENABLED.key -> "false") {
+          val deltaLog = createPartitionedTableWithNotNullColumn(tempDir)
+
+          val addFiles = (0 until 5).map { i =>
+            AddFile(
+              path = s"part=__HIVE_DEFAULT_PARTITION__/file-$i.parquet",
+              partitionValues = Map("part" -> null),
+              size = 100,
+              modificationTime = System.currentTimeMillis(),
+              dataChange = true,
+              stats = """{"numRecords": 1}"""
+            )
+          }
+
+          val events = Log4jUsageLogger.track {
+            commit(deltaLog, addFiles, isCommitLarge)
+          }
+
+          val violationEvents =
+            filterUsageRecords(events, "delta.constraints.nullPartitionViolation")
+          assert(violationEvents.size == 2)
+        }
+      }
+    }
+
+    test(s"throttling is per-commit: a fresh commit re-allows 2 events " +
+        s"[isCommitLarge: $isCommitLarge]") {
+      withTempDir { tempDir =>
+        withSQLConf(DeltaSQLConf.DELTA_EMPTY_FILE_CHECK_THROW_ENABLED.key -> "false") {
+          val deltaLog = createTable(tempDir)
+
+          def invalidFiles(prefix: String): Seq[AddFile] = (0 until 5).map { i =>
+            AddFile(
+              path = s"$prefix-0000$i.parquet",
+              partitionValues = Map.empty,
+              size = 0,
+              modificationTime = System.currentTimeMillis(),
+              dataChange = true,
+              stats = """{"numRecords": 0}"""
+            )
+          }
+
+          val firstCommitEvents = Log4jUsageLogger.track {
+            commit(deltaLog, invalidFiles("first"), isCommitLarge)
+          }
+          val secondCommitEvents = Log4jUsageLogger.track {
+            commit(deltaLog, invalidFiles("second"), isCommitLarge)
+          }
+
+          assert(
+            filterUsageRecords(firstCommitEvents, "delta.sanityCheck.emptyParquetFile").size == 2)
+          assert(
+            filterUsageRecords(secondCommitEvents, "delta.sanityCheck.emptyParquetFile").size == 2)
         }
       }
     }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

The `validateAddFileNotEmpty` and `validateAddFileForNullPartitions` AddFile sanity checks emit a usage-log event for every invalid `AddFile`. In logging-only mode, a single commit containing many invalid `AddFile`s emits one event per invalid action, which can flood usage logs.

This PR adds `ThrottledEventLogger`, a small thread-safe count-based throttler — the count-based counterpart to the existing rate-based `LogThrottler`. It records at most `maxEventsToLog` events and silently drops the rest, claiming the counter under a lock while performing the (heavier) recording outside it. `OptimisticTransaction` holds one instance per opType as a field, so each commit is capped at 2 events per check.

## How was this patch tested?

Added throttling test cases to `CommitSanityCheckSuite` covering both the empty-file and null-partition checks across the regular and `commitLarge` commit paths: a commit with 5 invalid `AddFile`s emits exactly 2 events, and a subsequent commit re-allows 2 (confirming per-commit scoping).

## Does this PR introduce _any_ user-facing changes?

No.
