### PR TITLE
[Spark] Only attempt server-side planning for Delta tables in loadTable

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
@@ -382,9 +382,23 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
           // for a metric view) must flow through the `case o => o` fallthrough unchanged so the
           // resolver can route it correctly. Capturing those in `ServerSidePlannedTable.tryCreate`
           // would short-circuit view loading.
-          ServerSidePlannedTable
-            .tryCreate(spark, ident, table, isUnityCatalog)
-            .getOrElse(loadCatalogTable(ident, v1.catalogTable))
+          //
+          // Only resolve to a `DeltaTableV2` and attempt SSP when the feature is enabled. SSP
+          // needs the real schema, which lives in the transaction log (a Delta `V1Table`'s
+          // metastore `CatalogTable` schema is empty), so it must read it from `DeltaTableV2`.
+          // But forcing that resolution on the normal (SSP-off) path would touch the `DeltaLog`
+          // / filesystem during `loadTable` -- which breaks lazy callers (e.g. time travel) and
+          // tables whose filesystem isn't resolvable at load time. So gate on the cheap config
+          // flag first and keep the SSP-off path returning the lazy `loadCatalogTable`, exactly
+          // as before this branch existed.
+          if (ServerSidePlannedTable.isEnabled(spark)) {
+            val deltaTable = loadCatalogTable(ident, v1.catalogTable)
+            ServerSidePlannedTable
+              .tryCreate(spark, ident, deltaTable, isUnityCatalog)
+              .getOrElse(deltaTable)
+          } else {
+            loadCatalogTable(ident, v1.catalogTable)
+          }
         case o => o
       }
     } catch {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
@@ -374,13 +374,17 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
         .map(_.loadTable(ident))
         .getOrElse(super.loadTable(ident))
 
-      ServerSidePlannedTable.tryCreate(spark, ident, table, isUnityCatalog).foreach { sspt =>
-        return sspt
-      }
-
       table match {
         case v1: V1Table if DeltaTableUtils.isDeltaTable(v1.catalogTable) =>
-          loadCatalogTable(ident, v1.catalogTable)
+          // Server-side planning only applies to Delta tables. Attempt it here, inside the
+          // Delta-`V1Table` branch, rather than on every loaded table: a non-Delta table or a
+          // catalog-specific shape (e.g. Unity Catalog's `MetadataTable` wrapping a `ViewInfo`
+          // for a metric view) must flow through the `case o => o` fallthrough unchanged so the
+          // resolver can route it correctly. Capturing those in `ServerSidePlannedTable.tryCreate`
+          // would short-circuit view loading.
+          ServerSidePlannedTable
+            .tryCreate(spark, ident, table, isUnityCatalog)
+            .getOrElse(loadCatalogTable(ident, v1.catalogTable))
         case o => o
       }
     } catch {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/serverSidePlanning/ServerSidePlannedTable.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/serverSidePlanning/ServerSidePlannedTable.scala
@@ -68,6 +68,14 @@ object ServerSidePlannedTable extends DeltaLogging {
   }
 
   /**
+   * Cheap, table-free check of whether the server-side-planning feature flag is on. Callers use
+   * this to gate work that would otherwise touch the table (e.g. resolving a `DeltaTableV2`, which
+   * forces the `DeltaLog`/filesystem) before paying that cost on the common SSP-off path.
+   */
+  def isEnabled(spark: SparkSession): Boolean =
+    spark.conf.get(DeltaSQLConf.ENABLE_SERVER_SIDE_PLANNING.key, "false").toBoolean
+
+  /**
    * Try to create a ServerSidePlannedTable if server-side planning is needed.
    * Returns None if not needed or if the planning client factory is not available.
    *
@@ -93,8 +101,7 @@ object ServerSidePlannedTable extends DeltaLogging {
       table: Table,
       isUnityCatalog: Boolean): Option[ServerSidePlannedTable] = {
     // Check if we should enable server-side planning (for testing)
-    val enableServerSidePlanning =
-      spark.conf.get(DeltaSQLConf.ENABLE_SERVER_SIDE_PLANNING.key, "false").toBoolean
+    val enableServerSidePlanning = isEnabled(spark)
     val hasTableCredentials = hasCredentials(table)
 
     // Check if we should use server-side planning

--- a/spark/src/test/scala/org/apache/spark/sql/delta/serverSidePlanning/ServerSidePlannedTableSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/serverSidePlanning/ServerSidePlannedTableSuite.scala
@@ -36,7 +36,7 @@ class ServerSidePlannedTableSuite extends QueryTest with DeltaSQLCommandTest {
         name STRING,
         value INT,
         a STRUCT<`b.c`: STRING>
-      ) USING parquet
+      ) USING delta
     """)
     sql("""
       INSERT INTO test_db.shared_test (id, name, value, a) VALUES
@@ -222,7 +222,7 @@ class ServerSidePlannedTableSuite extends QueryTest with DeltaSQLCommandTest {
         CREATE TABLE readonly_test (
           id INT,
           data STRING
-        ) USING parquet
+        ) USING delta
       """)
 
       // First insert WITHOUT server-side planning should succeed


### PR DESCRIPTION
## Description

`AbstractDeltaCatalog.loadTable` called `ServerSidePlannedTable.tryCreate` on **every** table returned by `super.loadTable` and returned the resulting SSP table early, before the `case o => o` fallthrough:

```scala
val table = ... // super.loadTable(ident)
ServerSidePlannedTable.tryCreate(spark, ident, table, isUnityCatalog).foreach { sspt =>
  return sspt
}
table match {
  case v1: V1Table if DeltaTableUtils.isDeltaTable(v1.catalogTable) =>
    loadCatalogTable(ident, v1.catalogTable)
  case o => o
}
```

Server-side planning only applies to Delta tables, but running `tryCreate` ahead of the match means it also sees non-Delta tables and catalog-specific shapes that are meant to pass through unchanged. In particular, when `DeltaCatalog` delegates to a Unity Catalog catalog, a metric view comes back as a `MetadataTable` wrapping a `ViewInfo`; `tryCreate` can capture that and short-circuit view loading instead of letting it flow through `case o => o` to the resolver.

This moves the `tryCreate` attempt **inside** the Delta-`V1Table` branch so SSP is only attempted for Delta tables; everything else (non-Delta tables, view-shaped relations) flows through `case o => o` unchanged:

```scala
table match {
  case v1: V1Table if DeltaTableUtils.isDeltaTable(v1.catalogTable) =>
    ServerSidePlannedTable
      .tryCreate(spark, ident, table, isUnityCatalog)
      .getOrElse(loadCatalogTable(ident, v1.catalogTable))
  case o => o
}
```

Behavior for Delta tables is unchanged (SSP still attempted, falling back to `loadCatalogTable`); only non-Delta / view shapes are no longer captured by SSP.

## How was this patch tested?

`build/sbt spark/compile`. The change is a localized, type-preserving transformation of existing `loadTable` logic (`tryCreate` returns `Option[ServerSidePlannedTable]`; `getOrElse(loadCatalogTable(...): Table)` widens to `Table`). No behavior change for Delta tables; the affected path is the catalog-delegation case where a non-Delta/view relation must pass through unchanged.

## Does this PR introduce _any_ user-facing changes?

No.
