### PR TITLE
[Delta][UniForm] Iceberg V3: support geo type

### DIFF
--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergSchemaUtils.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergSchemaUtils.scala
@@ -21,7 +21,9 @@ import scala.collection.JavaConverters._
 import org.apache.spark.sql.delta.{DeltaColumnMapping, SnapshotDescriptor}
 import org.apache.spark.sql.delta.actions.Protocol
 import org.apache.spark.sql.delta.metering.DeltaLogging
+import org.apache.spark.sql.delta.shims.GeoTypesShim
 import shadedForDelta.org.apache.iceberg.{Schema => IcebergSchema}
+import shadedForDelta.org.apache.iceberg.types.{EdgeAlgorithm => IcebergEdgeAlgorithm}
 import shadedForDelta.org.apache.iceberg.types.{Type => IcebergType, Types => IcebergTypes}
 
 import org.apache.spark.sql.types._
@@ -125,6 +127,11 @@ trait IcebergSchemaUtils extends DeltaLogging {
         }
 
       case variantType: VariantType => IcebergTypes.VariantType.get()
+      case dt if GeoTypesShim.isGeometryType(dt) =>
+        IcebergTypes.GeometryType.of(GeoTypesShim.geometryCrs(dt))
+      case dt if GeoTypesShim.isGeographyType(dt) =>
+        val (crs, algorithm) = GeoTypesShim.geographyCrsAndAlgorithm(dt)
+        IcebergTypes.GeographyType.of(crs, IcebergEdgeAlgorithm.fromName(algorithm))
       case atomicType: AtomicType => convertAtomic(atomicType)
 
       case other =>

--- a/spark/src/main/scala-shims/spark-4.1/GeoTypesShim.scala
+++ b/spark/src/main/scala-shims/spark-4.1/GeoTypesShim.scala
@@ -27,8 +27,17 @@ import org.apache.spark.sql.types.{DataType, GeographyType, GeometryType}
  */
 object GeoTypesShim {
   /** Returns true if `dt` is `GeometryType` or `GeographyType`. */
-  def isGeoSpatialType(dt: DataType): Boolean = dt match {
-    case _: GeometryType | _: GeographyType => true
+  def isGeoSpatialType(dt: DataType): Boolean = isGeometryType(dt) || isGeographyType(dt)
+
+  /** Returns true if `dt` is `GeometryType`. */
+  def isGeometryType(dt: DataType): Boolean = dt match {
+    case _: GeometryType => true
+    case _ => false
+  }
+
+  /** Returns true if `dt` is `GeographyType`. */
+  def isGeographyType(dt: DataType): Boolean = dt match {
+    case _: GeographyType => true
     case _ => false
   }
 
@@ -52,4 +61,19 @@ object GeoTypesShim {
     classOf[ST_GeomFromWKB],
     classOf[ST_SetSrid],
     classOf[ST_Srid])
+
+  /** Returns the CRS of a `GeometryType`. Only valid when `isGeometryType(dt)` is true. */
+  def geometryCrs(dt: DataType): String = dt match {
+    case g: GeometryType => g.crs
+    case _ => throw new IllegalArgumentException(s"Not a geometry type: $dt")
+  }
+
+  /**
+   * Returns the CRS and edge interpolation algorithm name (e.g. "SPHERICAL") of a
+   * `GeographyType`. Only valid when `isGeographyType(dt)` is true.
+   */
+  def geographyCrsAndAlgorithm(dt: DataType): (String, String) = dt match {
+    case g: GeographyType => (g.crs, g.algorithm.toString)
+    case _ => throw new IllegalArgumentException(s"Not a geography type: $dt")
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Adds Delta UniForm (Delta → Iceberg) conversion support for the Spark geospatial types GeometryType and GeographyType, for IcebergCompat V3 / Iceberg V3 tables.

Iceberg V3 introduced native geometry and geography types. Before this change, converting a UniForm-enabled Delta table that has a geo column would fall through to the unsupported-type path (Cannot convert Delta type ... to Iceberg). This maps the Spark geo types to their Iceberg V3 equivalents so the generated Iceberg metadata represents them faithfully.

Changes:
- iceberg/.../IcebergSchemaUtils.scala — in the schema converter, add cases that map Spark GeometryType → IcebergTypes.GeometryType.of(crs) and GeographyType → IcebergTypes.GeographyType.of(crs, edgeAlgorithm). The geo types are reached via GeoTypesShim so the converter takes no hard compile dependency on Spark versions that don't have these types, and the edge-interpolation algorithm is translated through IcebergEdgeAlgorithm.fromName(...).
- spark/src/main/scala-shims/spark-4.1/GeoTypesShim.scala — add isGeometryType, isGeographyType, geometryCrs, and geographyCrsAndAlgorithm accessors, and refactor isGeoSpatialType to compose the two predicates.

This brings the geo conversion mapping to OSS Delta (companion to the corresponding Databricks Runtime change).


## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
test will come later when we enable V3
## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No
