### PR TITLE
Fix ParseException in v2 catalog statistics for column names with spaces

### DIFF
--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/StatsUtils.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/StatsUtils.java
@@ -98,7 +98,15 @@ public final class StatsUtils {
         continue;
       }
 
-      NamedReference ref = FieldReference.apply(colName);
+      // Use FieldReference.column (a single literal part) rather than FieldReference.apply, which
+      // re-parses the string as a multi-part SQL identifier. colName is always a top-level column
+      // name -- it must match a top-level field in columnTypes above, and catalog column stats are
+      // never collected for nested fields -- so a single-part reference is correct. Under column
+      // mapping the name may contain spaces, dots, etc. that are invalid in an unquoted identifier
+      // (e.g. "Extract Year"); FieldReference.apply would throw a ParseException on a space or
+      // silently mis-split a dotted name ("a.b" -> [a, b]), while column() keeps it as one part.
+      // See SparkScan, which builds its NamedReferences the same way.
+      NamedReference ref = FieldReference.column(colName);
       int version = stat.version();
 
       // Eagerly parse min/max to avoid repeated fromExternalString calls

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/StatsUtilsTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/StatsUtilsTest.java
@@ -143,6 +143,49 @@ class StatsUtilsTest {
     assertNotNull(result.get(FieldReference.apply("id")), "id stats should be present");
   }
 
+  @Test
+  void testToV2Statistics_columnNameWithSpace() {
+    // Regression test: under Delta column mapping a column name may contain a space (e.g.
+    // "Extract Year"). buildColumnStats used to call FieldReference.apply(colName),
+    // which re-parses the name as a multi-part SQL identifier and throws a ParseException on the
+    // space -- failing the entire v2 scan even when the query never references that column.
+    String colName = "Extract Year";
+    StructType dataSchema = new StructType().add(colName, DataTypes.LongType);
+    StructType partitionSchema = new StructType();
+
+    CatalogColumnStat colStat =
+        new CatalogColumnStat(
+            Option.apply(BigInt(3L)), // distinctCount
+            Option.apply("2020"), // min
+            Option.apply("2022"), // max
+            Option.apply(BigInt(0L)), // nullCount
+            Option.apply((Object) 8L), // avgLen
+            Option.apply((Object) 8L), // maxLen
+            Option.empty(), // histogram
+            CatalogColumnStat.VERSION());
+
+    scala.collection.immutable.Map<String, CatalogColumnStat> colStatsMap =
+        buildScalaMap(new String[] {colName}, new CatalogColumnStat[] {colStat});
+
+    CatalogStatistics catalogStats =
+        new CatalogStatistics(BigInt(256L), Option.apply(BigInt(3L)), colStatsMap);
+
+    // Must not throw: before the fix this raised a ParseException on the space in "Extract Year".
+    Statistics v2Stats = StatsUtils.toV2Statistics(catalogStats, dataSchema, partitionSchema);
+
+    Map<NamedReference, ColumnStatistics> result = v2Stats.columnStats();
+    assertEquals(1, result.size(), "Should have 1 column stat");
+
+    // The reference must be a single literal part, not split into ["Extract", "Year"].
+    NamedReference ref = FieldReference.column(colName);
+    assertEquals(1, ref.fieldNames().length, "column name must stay a single identifier part");
+    assertEquals(colName, ref.fieldNames()[0]);
+
+    ColumnStatistics stats = result.get(ref);
+    assertNotNull(stats, "stats for the space-containing column should be present");
+    assertEquals(3L, stats.distinctCount().getAsLong(), "distinctCount should be 3");
+  }
+
   private static scala.math.BigInt BigInt(long value) {
     return scala.math.BigInt.apply(value);
   }


### PR DESCRIPTION
## Description

`StatsUtils.buildColumnStats` builds a `NamedReference` for each catalog column statistic via `FieldReference.apply`, which re-parses the string as a multi-part SQL identifier. A column name that contains a space or dot — possible under column mapping — is not a valid unquoted identifier, so `FieldReference.apply` throws a `ParseException`. Catalog statistics are built for the full table before column pruning, so the query fails even when it never references the offending column.

This switches to `FieldReference.column`, which constructs a single-part reference without parsing — matching the idiom already used in `SparkScan` (`FieldReference.column(field.name())`). This is the only such re-parsing site in the connector.

## How was this patch tested?

Adds a regression test (`StatsUtilsTest.testToV2Statistics_columnNameWithSpace`) that builds catalog statistics for a column named `Extract Year` and asserts the resulting reference stays a single literal identifier part. The test fails with a `ParseException` before the fix and passes after.
