### PR TITLE
Rename histogramOpt to fileSizeHistogram in VersionChecksum

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/Checksum.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Checksum.scala
@@ -59,10 +59,10 @@ import org.apache.spark.util.{SerializableConfiguration, Utils}
  * @param numDeletionVectorsOpt The number of Deletion Vectors present in the snapshot.
  * @param numMetadata Number of `Metadata` actions in the snapshot
  * @param numProtocol Number of `Protocol` actions in the snapshot
- * @param histogramOpt Optional file size histogram. Note: the Delta spec field name is
- *                     `fileSizeHistogram` (used by Kernel/Java/Rust). Delta-Spark historically
- *                     wrote `histogramOpt`. The `@JsonAlias` allows reading both field names so
- *                     that CRC files written by either Kernel or Delta-Spark are compatible.
+ * @param fileSizeHistogram Optional file size histogram. This is the Delta spec field name
+ *                          (used by Kernel/Java/Rust). Delta-Spark historically wrote this as
+ *                          `histogramOpt`. The `@JsonAlias` allows reading both field names so
+ *                          that CRC files written by either Kernel or Delta-Spark are compatible.
  * @param deletedRecordCountsHistogramOpt A histogram of the deleted records count distribution
  *                                        for all the files in the snapshot.
  */
@@ -82,18 +82,18 @@ case class VersionChecksum(
     domainMetadata: Option[Seq[DomainMetadata]],
     metadata: Metadata,
     protocol: Protocol,
-    // Accept both "histogramOpt" (legacy Delta-Spark) and
-    // "fileSizeHistogram" (Delta spec / Kernel).
-    @JsonAlias(Array("fileSizeHistogram"))
-    histogramOpt: Option[FileSizeHistogram],
+    // Accept both "fileSizeHistogram" (Delta spec / Kernel) and
+    // "histogramOpt" (legacy Delta-Spark).
+    @JsonAlias(Array("histogramOpt"))
+    fileSizeHistogram: Option[FileSizeHistogram],
     deletedRecordCountsHistogramOpt: Option[DeletedRecordCountsHistogram],
     allFiles: Option[Seq[AddFile]]) {
 
   /**
-   * Converts to the protocol-compliant representation that serializes the histogram field as
-   * `fileSizeHistogram` (the Delta spec field name) instead of `histogramOpt`.
+   * Converts to the legacy representation that serializes the histogram field as
+   * `histogramOpt` (the legacy Delta-Spark field name) instead of `fileSizeHistogram`.
    */
-  def toProtocolCompliant: VersionChecksumProtocolCompliant = VersionChecksumProtocolCompliant(
+  def toLegacy: VersionChecksumLegacy = VersionChecksumLegacy(
     txnId = txnId,
     tableSizeBytes = tableSizeBytes,
     numFiles = numFiles,
@@ -106,18 +106,18 @@ case class VersionChecksum(
     domainMetadata = domainMetadata,
     metadata = metadata,
     protocol = protocol,
-    fileSizeHistogram = histogramOpt,
+    histogramOpt = fileSizeHistogram,
     deletedRecordCountsHistogramOpt = deletedRecordCountsHistogramOpt,
     allFiles = allFiles
   )
 }
 
 /**
- * Protocol-compliant version of [[VersionChecksum]] that serializes the file size histogram
- * using the Delta spec field name `fileSizeHistogram` instead of the legacy `histogramOpt`.
- * Used only for CRC file writes when the protocol-compliant flag is enabled.
+ * Legacy version of [[VersionChecksum]] that serializes the file size histogram
+ * using the legacy Delta-Spark field name `histogramOpt` instead of `fileSizeHistogram`.
+ * Used only for CRC file writes when the protocol-compliant flag is disabled.
  */
-case class VersionChecksumProtocolCompliant(
+case class VersionChecksumLegacy(
     txnId: Option[String],
     tableSizeBytes: Long,
     numFiles: Long,
@@ -133,7 +133,7 @@ case class VersionChecksumProtocolCompliant(
     domainMetadata: Option[Seq[DomainMetadata]],
     metadata: Metadata,
     protocol: Protocol,
-    fileSizeHistogram: Option[FileSizeHistogram],
+    histogramOpt: Option[FileSizeHistogram],
     deletedRecordCountsHistogramOpt: Option[DeletedRecordCountsHistogram],
     allFiles: Option[Seq[AddFile]])
 
@@ -167,9 +167,9 @@ trait RecordChecksum extends DeltaLogging {
     try {
       val toWrite = (if (spark.conf.get(
           DeltaSQLConf.DELTA_CHECKSUM_HISTOGRAM_FIELD_FOLLOWS_PROTOCOL)) {
-        JsonUtils.toJson(checksum.toProtocolCompliant)
-      } else {
         JsonUtils.toJson(checksum)
+      } else {
+        JsonUtils.toJson(checksum.toLegacy)
       }) + "\n"
       eventData("jsonSerializationTimeTakenMs") = System.currentTimeMillis() - startTimeMs
       eventData("checksumLength") = toWrite.length
@@ -273,7 +273,7 @@ trait RecordChecksum extends DeltaLogging {
           .filterNot(_.protocol == null)
           // If the old CRC doesn't have file size histogram, we can't use it to generate new CRC
           // in case `mustIncludeFileSizeHistogram` is set.
-          .filterNot(_.histogramOpt.isEmpty && mustIncludeFileSizeHistogram)
+          .filterNot(_.fileSizeHistogram.isEmpty && mustIncludeFileSizeHistogram)
 
         val oldCrc = oldCrcFiltered.getOrElse {
           return Left("OLD_CRC_INCOMPLETE")
@@ -364,12 +364,11 @@ trait RecordChecksum extends DeltaLogging {
     var numFiles = oldVersionChecksum.numFiles
     var protocol = oldVersionChecksum.protocol
     var metadata = oldVersionChecksum.metadata
-    val histogramOpt =
-      Option.when (spark.conf.get(DeltaSQLConf.DELTA_FILE_SIZE_HISTOGRAM_ENABLED)) {
-        oldVersionChecksum.histogramOpt.map { h =>
-          FileSizeHistogram(h.sortedBinBoundaries, h.fileCounts.clone(), h.totalBytes.clone())
-        }
-      }.flatten
+    val fileSizeHistogram = if (spark.conf.get(DeltaSQLConf.DELTA_FILE_SIZE_HISTOGRAM_ENABLED)) {
+      oldVersionChecksum.fileSizeHistogram.map { h =>
+        FileSizeHistogram(h.sortedBinBoundaries, h.fileCounts.clone(), h.totalBytes.clone())
+      }
+    } else None
 
     // In incremental computation, tables initialized with DVs disabled contain None DV
     // statistics. DV statistics remain None even if DVs are enabled at a random point
@@ -412,7 +411,7 @@ trait RecordChecksum extends DeltaLogging {
         tableSizeBytes += a.size
         numFiles += 1
 
-        histogramOpt.foreach(_.insert(a.size))
+        fileSizeHistogram.foreach(_.insert(a.size))
         // Only accumulate DV statistics when base stats are not None.
         val (dvCount, dvCardinality) =
           Option(a.deletionVector).map(1L -> _.cardinality).getOrElse(0L -> 0L)
@@ -428,7 +427,7 @@ trait RecordChecksum extends DeltaLogging {
         tableSizeBytes -= size
         numFiles -= 1
 
-        histogramOpt.foreach(_.remove(size))
+        fileSizeHistogram.foreach(_.remove(size))
         // Only accumulate DV statistics when base stats are not None.
         val (dvCount, dvCardinality) =
           Option(r.deletionVector).map(1L -> _.cardinality).getOrElse(0L -> 0L)
@@ -545,7 +544,7 @@ trait RecordChecksum extends DeltaLogging {
       domainMetadata = domainMetadata,
       allFiles = allFiles,
       deletedRecordCountsHistogramOpt = deletedRecordCountsHistogramOpt,
-      histogramOpt = histogramOpt
+      fileSizeHistogram = fileSizeHistogram
     ))
   }
 
@@ -1009,7 +1008,8 @@ trait ValidateChecksum extends DeltaLogging { self: Snapshot =>
       }
     }
     if (spark.sessionState.conf.getConf(DeltaSQLConf.DELTA_FILE_SIZE_HISTOGRAM_ENABLED)) {
-      compareFileSizeHistogram(checksum.histogramOpt, computedStateToCheckAgainst.fileSizeHistogram)
+      compareFileSizeHistogram(
+        checksum.fileSizeHistogram, computedStateToCheckAgainst.fileSizeHistogram)
     }
     // Deletion vectors metrics.
     if (DeletionVectorUtils.deletionVectorsReadable(self)) {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -2795,7 +2795,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
       isolationLevel = isolationLevel,
       // We don't use postCommitSnapshot.fileSizeHistogram here
       // because it can trigger full state reconstruction.
-      fileSizeHistogramOpt = postCommitSnapshot.checksumOpt.flatMap(_.histogramOpt),
+      fileSizeHistogramOpt = postCommitSnapshot.checksumOpt.flatMap(_.fileSizeHistogram),
       commitInfoOpt = currentTransactionInfo.commitInfo,
       commitSizeBytes = commitSizeBytes
     )

--- a/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
@@ -666,8 +666,8 @@ class Snapshot(
     deletedRecordCountsHistogramOpt = checksumOpt.flatMap(_.deletedRecordCountsHistogramOpt)
       .orElse(Option.when(_computedStateTriggered)(deletedRecordCountsHistogramOpt).flatten)
       .filter(_ => deletionVectorsReadableAndHistogramEnabled),
-    histogramOpt = Option.when(fileSizeHistogramEnabled) {
-      checksumOpt.flatMap(_.histogramOpt)
+    fileSizeHistogram = Option.when(fileSizeHistogramEnabled) {
+      checksumOpt.flatMap(_.fileSizeHistogram)
         .orElse(Option.when(_computedStateTriggered)(fileSizeHistogram).flatten)
     }.flatten
   )

--- a/spark/src/main/scala/org/apache/spark/sql/delta/hooks/metrics/UpdateMetricsHook.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/hooks/metrics/UpdateMetricsHook.scala
@@ -22,6 +22,10 @@ import java.util.concurrent.atomic.AtomicInteger
 import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
 
+import org.apache.spark.internal.MDC
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
+import org.apache.spark.sql.connector.catalog.{Identifier, Table}
 import org.apache.spark.sql.delta.CommittedTransaction
 import org.apache.spark.sql.delta.catalog.AbstractDeltaCatalogClient
 import org.apache.spark.sql.delta.hooks.PostCommitHook
@@ -30,11 +34,6 @@ import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.CatalogTableUtils
 import org.apache.spark.sql.delta.util.threads.DeltaThreadPool
-
-import org.apache.spark.internal.MDC
-import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.catalyst.catalog.CatalogTable
-import org.apache.spark.sql.connector.catalog.{Identifier, Table}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 /**
@@ -88,7 +87,7 @@ case class UpdateMetricsHook(catalogTable: Option[CatalogTable])
     val committedActions = txn.committedActions
     val committedVersion = txn.committedVersion
     // Read histogram from the CRC only -- avoids triggering state reconstruction.
-    val snapshotHistogram = txn.postCommitSnapshot.checksumOpt.flatMap(_.histogramOpt)
+    val snapshotHistogram = txn.postCommitSnapshot.checksumOpt.flatMap(_.fileSizeHistogram)
     val logPath = txn.deltaLog.logPath
 
     implicit val ec: ExecutionContext =

--- a/spark/src/test/scala/org/apache/spark/sql/delta/FileSizeHistogramSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/FileSizeHistogramSuite.scala
@@ -548,8 +548,8 @@ class FileSizeHistogramSuite extends QueryTest
     val checksum = JsonUtils.mapper.readValue[VersionChecksum](oldWriterJson)
 
     // Verify the histogram was deserialized correctly
-    assert(checksum.histogramOpt.isDefined)
-    val histogram = checksum.histogramOpt.get
+    assert(checksum.fileSizeHistogram.isDefined)
+    val histogram = checksum.fileSizeHistogram.get
 
     // Validate histogram fields
     assert(histogram.sortedBinBoundaries ===
@@ -562,11 +562,11 @@ class FileSizeHistogramSuite extends QueryTest
 
     // Verify histogram can be serialized back to JSON
     val roundTripJson = JsonUtils.toJson(checksum)
-    assert(roundTripJson.contains("histogramOpt"))
+    assert(roundTripJson.contains("fileSizeHistogram"))
     assert(roundTripJson.contains("sortedBinBoundaries"))
 
     // Verify roundtrip deserialization works
     val roundTripChecksum = JsonUtils.mapper.readValue[VersionChecksum](roundTripJson)
-    assert(roundTripChecksum.histogramOpt.get.equals(histogram))
+    assert(roundTripChecksum.fileSizeHistogram.get.equals(histogram))
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/VersionChecksumHistogramCompatSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/VersionChecksumHistogramCompatSuite.scala
@@ -29,8 +29,8 @@ import org.apache.spark.sql.test.SharedSparkSession
  *
  * Delta spec and Kernel (Java/Rust) write CRC files using "fileSizeHistogram" as the JSON field
  * name, while Delta-Spark historically used "histogramOpt". The `@JsonAlias` on
- * [[VersionChecksum.histogramOpt]] allows reading both field names so that CRC files written by
- * either Kernel or Delta-Spark are compatible.
+ * [[VersionChecksum.fileSizeHistogram]] allows reading both field names so that CRC files written
+ * by either Kernel or Delta-Spark are compatible.
  */
 class VersionChecksumHistogramCompatSuite
   extends QueryTest
@@ -70,9 +70,9 @@ class VersionChecksumHistogramCompatSuite
         |}""".stripMargin
 
     val parsedChecksum = JsonUtils.mapper.readValue[VersionChecksum](kernelWrittenJson)
-    assert(parsedChecksum.histogramOpt.isDefined,
-      "histogramOpt should be populated from the fileSizeHistogram JSON field")
-    val parsedHistogram = parsedChecksum.histogramOpt.get
+    assert(parsedChecksum.fileSizeHistogram.isDefined,
+      "fileSizeHistogram should be populated from the fileSizeHistogram JSON field")
+    val parsedHistogram = parsedChecksum.fileSizeHistogram.get
     assert(parsedHistogram.sortedBinBoundaries ===
       IndexedSeq(0L, 1024L, 10240L, 102400L, 1048576L, 10485760L))
     assert(parsedHistogram.fileCounts.toSeq === Seq(2L, 1L, 0L, 1L, 1L, 0L))
@@ -94,33 +94,33 @@ class VersionChecksumHistogramCompatSuite
       DeltaLog.clearCache()
       val snapshotA = DeltaLog.forTable(spark, dir.getAbsolutePath).snapshot
       assert(snapshotA.checksumOpt.isDefined)
-      assert(snapshotA.checksumOpt.get.histogramOpt.isDefined,
-        "Scenario A: histogramOpt should be populated from the fileSizeHistogram JSON field")
-      assert(snapshotA.checksumOpt.get.histogramOpt.get === parsedHistogram)
+      assert(snapshotA.checksumOpt.get.fileSizeHistogram.isDefined,
+        "Scenario A: fileSizeHistogram should be populated from the fileSizeHistogram JSON field")
+      assert(snapshotA.checksumOpt.get.fileSizeHistogram.get === parsedHistogram)
 
-      // Scenario B: read the real CRC produced by Delta-Spark, replace "histogramOpt" key
-      // with "fileSizeHistogram" (simulating a CRC rewritten by Kernel), and read it back
+      // Scenario B: read the real CRC produced by Delta-Spark, replace "fileSizeHistogram" key
+      // with "histogramOpt" (simulating a CRC written by legacy Delta-Spark), and read it back.
       val realChecksum = log.readChecksum(version).get
-      assert(realChecksum.histogramOpt.isDefined, "expected histogram in real CRC")
-      val realHistogram = realChecksum.histogramOpt.get
-      val kernelFormatJson = JsonUtils.toJson(realChecksum)
-        .replace("\"histogramOpt\":", "\"fileSizeHistogram\":")
+      assert(realChecksum.fileSizeHistogram.isDefined, "expected histogram in real CRC")
+      val realHistogram = realChecksum.fileSizeHistogram.get
+      val legacyFormatJson = JsonUtils.toJson(realChecksum)
+        .replace("\"fileSizeHistogram\":", "\"histogramOpt\":")
       log.store.write(
         FileNames.checksumFile(log.logPath, version),
-        Iterator(kernelFormatJson),
+        Iterator(legacyFormatJson),
         overwrite = true)
       DeltaLog.clearCache()
       val snapshotB = DeltaLog.forTable(spark, dir.getAbsolutePath).snapshot
       assert(snapshotB.checksumOpt.isDefined)
-      assert(snapshotB.checksumOpt.get.histogramOpt.isDefined,
-        "Scenario B: histogramOpt should be populated from the fileSizeHistogram JSON field")
-      assert(snapshotB.checksumOpt.get.histogramOpt.get === realHistogram)
+      assert(snapshotB.checksumOpt.get.fileSizeHistogram.isDefined,
+        "Scenario B: fileSizeHistogram should be populated from the histogramOpt JSON field")
+      assert(snapshotB.checksumOpt.get.fileSizeHistogram.get === realHistogram)
     }
   }
 
   test("CRC missing both histogramOpt and fileSizeHistogram fields deserializes without error") {
     // CRC files written before histogram support was added have neither field.
-    // Readers must gracefully return None for histogramOpt.
+    // Readers must gracefully return None for fileSizeHistogram.
     val noHistogramJson =
       """{
         |  "txnId": "old-txn-id",
@@ -140,15 +140,15 @@ class VersionChecksumHistogramCompatSuite
         |}""".stripMargin
 
     val checksum = JsonUtils.mapper.readValue[VersionChecksum](noHistogramJson)
-    assert(checksum.histogramOpt.isEmpty,
-      "histogramOpt should be None when neither histogramOpt nor fileSizeHistogram is present")
+    assert(checksum.fileSizeHistogram.isEmpty,
+      "fileSizeHistogram should be None when neither histogramOpt nor fileSizeHistogram is present")
   }
 
   test("CRC with both histogramOpt and fileSizeHistogram - last field in JSON takes priority") {
     // In practice a CRC will only contain one of these fields (Delta-Spark writes
     // histogramOpt, Kernel writes fileSizeHistogram). However, if both are present,
     // Jackson maps both to the same
-    // VersionChecksum.histogramOpt field (via @JsonAlias) and processes them sequentially,
+    // VersionChecksum.fileSizeHistogram field (via @JsonAlias) and processes them sequentially,
     // so the LAST occurrence in the JSON wins. This test documents that behavior.
 
     // Part 1: hardcoded JSON (unit-level deserialization check)
@@ -186,7 +186,7 @@ class VersionChecksumHistogramCompatSuite
         |}""".stripMargin
 
     val checksumCase1 = JsonUtils.mapper.readValue[VersionChecksum](fileSizeHistogramLast)
-    assert(checksumCase1.histogramOpt.get.fileCounts.toSeq === Seq(1L, 2L, 3L),
+    assert(checksumCase1.fileSizeHistogram.get.fileCounts.toSeq === Seq(1L, 2L, 3L),
       "fileSizeHistogram (last in JSON) should win over histogramOpt")
 
     // Case 2: histogramOpt appears last -> histogramOpt value wins
@@ -220,7 +220,7 @@ class VersionChecksumHistogramCompatSuite
         |}""".stripMargin
 
     val checksumCase2 = JsonUtils.mapper.readValue[VersionChecksum](histogramOptLast)
-    assert(checksumCase2.histogramOpt.get.fileCounts.toSeq === Seq(10L, 20L, 30L),
+    assert(checksumCase2.fileSizeHistogram.get.fileCounts.toSeq === Seq(10L, 20L, 30L),
       "histogramOpt (last in JSON) should win over fileSizeHistogram")
 
     // Part 2: integration check via real Delta table and DeltaLog
@@ -242,31 +242,31 @@ class VersionChecksumHistogramCompatSuite
       DeltaLog.clearCache()
       val snapshotA = DeltaLog.forTable(spark, dir.getAbsolutePath).snapshot
       assert(snapshotA.checksumOpt.isDefined)
-      assert(snapshotA.checksumOpt.get.histogramOpt.get.fileCounts.toSeq === Seq(1L, 2L, 3L),
+      assert(snapshotA.checksumOpt.get.fileSizeHistogram.get.fileCounts.toSeq === Seq(1L, 2L, 3L),
         "Scenario A: fileSizeHistogram (last in JSON) should win over histogramOpt")
 
       // Scenario B: read the real CRC produced by Delta-Spark, inject both fields by
-      // appending "fileSizeHistogram" (with bumped fileCounts) after the existing
-      // "histogramOpt", and verify fileSizeHistogram wins when read back via DeltaLog
+      // appending a second "histogramOpt" (with bumped fileCounts) after the existing
+      // "fileSizeHistogram", and verify histogramOpt wins when it appears last.
       val realChecksum = log.readChecksum(version).get
-      assert(realChecksum.histogramOpt.isDefined, "expected histogram in real CRC")
-      val realHistogramJson = JsonUtils.toJson(realChecksum.histogramOpt.get)
-      val altHistogram = realChecksum.histogramOpt.get.copy(
-        fileCounts = realChecksum.histogramOpt.get.fileCounts.map(_ + 1))
+      assert(realChecksum.fileSizeHistogram.isDefined, "expected histogram in real CRC")
+      val realHistogramJson = JsonUtils.toJson(realChecksum.fileSizeHistogram.get)
+      val altHistogram = realChecksum.fileSizeHistogram.get.copy(
+        fileCounts = realChecksum.fileSizeHistogram.get.fileCounts.map(_ + 1))
       val altHistogramJson = JsonUtils.toJson(altHistogram)
-      // Insert fileSizeHistogram after histogramOpt so it appears last and wins
-      val bothFieldsFSHLast = JsonUtils.toJson(realChecksum).replace(
-        s""""histogramOpt":$realHistogramJson""",
-        s""""histogramOpt":$realHistogramJson,"fileSizeHistogram":$altHistogramJson""")
+      // Insert histogramOpt after fileSizeHistogram so it appears last and wins.
+      val bothFieldsHistogramOptLast = JsonUtils.toJson(realChecksum).replace(
+        s""""fileSizeHistogram":$realHistogramJson""",
+        s""""fileSizeHistogram":$realHistogramJson,"histogramOpt":$altHistogramJson""")
       log.store.write(
         FileNames.checksumFile(log.logPath, version),
-        Iterator(bothFieldsFSHLast),
+        Iterator(bothFieldsHistogramOptLast),
         overwrite = true)
       DeltaLog.clearCache()
       val snapshotB = DeltaLog.forTable(spark, dir.getAbsolutePath).snapshot
       assert(snapshotB.checksumOpt.isDefined)
-      assert(snapshotB.checksumOpt.get.histogramOpt.get === altHistogram,
-        "Scenario B: fileSizeHistogram (last in JSON) should win over histogramOpt")
+      assert(snapshotB.checksumOpt.get.fileSizeHistogram.get === altHistogram,
+        "Scenario B: histogramOpt (last in JSON) should win over fileSizeHistogram")
     }
   }
 
@@ -279,7 +279,7 @@ class VersionChecksumHistogramCompatSuite
         sortedBinBoundaries = Vector(0L, 1024L, 10240L),
         fileCounts = Array(5L, 10L, 15L),
         totalBytes = Array(100L, 200L, 300L))
-      val checksum = deltaLog.snapshot.checksumOpt.get.copy(histogramOpt = Some(testHistogram))
+      val checksum = deltaLog.snapshot.checksumOpt.get.copy(fileSizeHistogram = Some(testHistogram))
 
       val currentSpark = spark
       val currentLog = deltaLog
@@ -317,35 +317,35 @@ class VersionChecksumHistogramCompatSuite
       // Both CRCs should be readable and produce the same histogram
       val checksumOff = JsonUtils.mapper.readValue[VersionChecksum](crcJsonOff)
       val checksumOn = JsonUtils.mapper.readValue[VersionChecksum](crcJsonOn)
-      assert(checksumOff.histogramOpt.get === testHistogram,
+      assert(checksumOff.fileSizeHistogram.get === testHistogram,
         "Flag OFF: read-back histogram should match the test histogram")
-      assert(checksumOn.histogramOpt.get === testHistogram,
+      assert(checksumOn.fileSizeHistogram.get === testHistogram,
         "Flag ON: read-back histogram should match the test histogram")
     }
   }
 
-  test("VersionChecksumProtocolCompliant fields match VersionChecksum") {
+  test("VersionChecksumLegacy fields match VersionChecksum") {
     // Use reflection to ensure the two classes stay in sync. If someone adds a field to
-    // VersionChecksum but forgets VersionChecksumProtocolCompliant, this test will catch it.
+    // VersionChecksum but forgets VersionChecksumLegacy, this test will catch it.
     val checksumFields = classOf[VersionChecksum].getDeclaredFields
       .map(f => (f.getName, f.getType)).toSet
-    val protocolCompliantFields = classOf[VersionChecksumProtocolCompliant].getDeclaredFields
+    val legacyFields = classOf[VersionChecksumLegacy].getDeclaredFields
       .map(f => (f.getName, f.getType)).toSet
 
-    // The only difference should be histogramOpt vs fileSizeHistogram (same type)
-    val expectedOnlyInChecksum = Set(("histogramOpt", classOf[Option[_]]))
-    val expectedOnlyInProtocolCompliant = Set(("fileSizeHistogram", classOf[Option[_]]))
+    // The only difference should be fileSizeHistogram vs histogramOpt (same type).
+    val expectedOnlyInChecksum = Set(("fileSizeHistogram", classOf[Option[_]]))
+    val expectedOnlyInLegacy = Set(("histogramOpt", classOf[Option[_]]))
 
-    val onlyInChecksum = checksumFields -- protocolCompliantFields
-    val onlyInProtocolCompliant = protocolCompliantFields -- checksumFields
+    val onlyInChecksum = checksumFields -- legacyFields
+    val onlyInLegacy = legacyFields -- checksumFields
 
     assert(onlyInChecksum === expectedOnlyInChecksum,
       s"Unexpected fields only in VersionChecksum: $onlyInChecksum. " +
         "Did you add a new field to VersionChecksum without updating " +
-        "VersionChecksumProtocolCompliant?")
-    assert(onlyInProtocolCompliant === expectedOnlyInProtocolCompliant,
-      s"Unexpected fields only in VersionChecksumProtocolCompliant: $onlyInProtocolCompliant. " +
-        "Did you add a new field to VersionChecksumProtocolCompliant without updating " +
+        "VersionChecksumLegacy?")
+    assert(onlyInLegacy === expectedOnlyInLegacy,
+      s"Unexpected fields only in VersionChecksumLegacy: $onlyInLegacy. " +
+        "Did you add a new field to VersionChecksumLegacy without updating " +
         "VersionChecksum?")
   }
 }


### PR DESCRIPTION
## Description

Make `fileSizeHistogram` the primary field name in `VersionChecksum`, aligning Delta-Spark with the Delta spec field name used by Kernel (Java/Rust). The legacy `histogramOpt` name is retained via `@JsonAlias` for backward compatibility when reading CRC files written by older Delta-Spark versions.

The secondary class `VersionChecksumProtocolCompliant` is renamed to `VersionChecksumLegacy` (with field `histogramOpt`), used only for CRC file writes when the protocol-compliant flag is disabled.

### Changes
- `VersionChecksum.histogramOpt` → `VersionChecksum.fileSizeHistogram` (with `@JsonAlias(Array("histogramOpt"))` for read compat)
- `VersionChecksumProtocolCompliant` → `VersionChecksumLegacy` (mirrors VersionChecksum but uses `histogramOpt` for legacy writes)
- `toProtocolCompliant` → `toLegacy`
- Swapped the write logic: flag ON writes `fileSizeHistogram` (default), flag OFF writes `histogramOpt` (legacy)
- Updated all references in `OptimisticTransaction`, `UpdateMetricsHook`, `Snapshot`, and `ValidateChecksum`
- Updated tests in `FileSizeHistogramSuite` and `VersionChecksumHistogramCompatSuite`

## How was this patch tested?

Existing unit tests updated to use the new field name. No behavioral changes — only field/class renaming.