### PR TITLE
[Flink] Add credentials.source table option for ambient credentials

### DIFF
--- a/flink/src/main/java/io/delta/flink/sink/TableBuilder.java
+++ b/flink/src/main/java/io/delta/flink/sink/TableBuilder.java
@@ -199,6 +199,16 @@ public class TableBuilder {
     return this;
   }
 
+  /**
+   * Sets the source of storage credentials for this table: {@code "uc"} (default) to fetch
+   * temporary credentials from Unity Catalog, or {@code "ambient"} to fetch nothing and rely on the
+   * runtime environment (workload identity, instance profile, ADC, or core-site.xml).
+   */
+  public TableBuilder withCredentialSource(String credentialSource) {
+    this.configurations.put(TableConf.CREDENTIALS_SOURCE.key(), credentialSource);
+    return this;
+  }
+
   public TableBuilder withConfigurations(Map<String, String> configurations) {
     this.configurations.clear();
     this.configurations.putAll(configurations);

--- a/flink/src/main/java/io/delta/flink/table/AbstractKernelTable.java
+++ b/flink/src/main/java/io/delta/flink/table/AbstractKernelTable.java
@@ -582,8 +582,22 @@ public abstract class AbstractKernelTable implements DeltaTable {
   }
 
   private CredentialManager createCredentialManager() {
-    return new CredentialManager(
-        () -> catalog.getCredentials(this.getTableUUID()), this::refreshCredential);
+    String source = this.conf.getCredentialSource();
+    if (source.equalsIgnoreCase("ambient")) {
+      // Do not fetch credentials from Unity Catalog; rely on the ambient environment
+      // (workload identity, instance profile, ADC, or core-site.xml) to supply them.
+      return new CredentialManager.AmbientCredentialManager();
+    } else if (source.equalsIgnoreCase("uc")) {
+      return new CredentialManager(
+          () -> catalog.getCredentials(this.getTableUUID()), this::refreshCredential);
+    } else {
+      throw new IllegalArgumentException(
+          "Unsupported "
+              + TableConf.CREDENTIALS_SOURCE.key()
+              + " '"
+              + source
+              + "'. Supported values: 'uc' (default), 'ambient'.");
+    }
   }
 
   /**

--- a/flink/src/main/java/io/delta/flink/table/CredentialManager.java
+++ b/flink/src/main/java/io/delta/flink/table/CredentialManager.java
@@ -17,6 +17,7 @@
 package io.delta.flink.table;
 
 import io.delta.flink.Conf;
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -55,6 +56,23 @@ import java.util.function.Supplier;
  */
 public class CredentialManager {
 
+  /**
+   * A {@link CredentialManager} that fetches no credentials. It relies on the ambient environment
+   * to provide them -- for example GKE Workload Identity, an AWS instance profile, or an Azure
+   * managed identity resolved by the filesystem's default credential chain, or static settings in
+   * {@code core-site.xml}. {@link #getCredentials()} always returns an empty map, and no refresh is
+   * ever scheduled.
+   */
+  public static class AmbientCredentialManager extends CredentialManager {
+    public AmbientCredentialManager() {
+      super(Collections::emptyMap, () -> {});
+    }
+
+    @Override
+    Map<String, String> getCredentials() {
+      return Collections.emptyMap();
+    }
+  }
   /**
    * Key in the credential map that represents the credential expiration time.
    *

--- a/flink/src/main/java/io/delta/flink/table/TableConf.java
+++ b/flink/src/main/java/io/delta/flink/table/TableConf.java
@@ -58,6 +58,17 @@ public class TableConf implements Serializable {
           .defaultValue(true)
           .withDescription("Whether to generate checksum files for commits on this table.");
 
+  /** Source of storage credentials for this table. */
+  public static final ConfigOption<String> CREDENTIALS_SOURCE =
+      ConfigOptions.key("credentials.source")
+          .stringType()
+          .defaultValue("uc")
+          .withDescription(
+              "Source of storage credentials: \"uc\" (default) to fetch temporary credentials from "
+                  + "Unity Catalog, or \"ambient\" to fetch nothing and rely on the runtime "
+                  + "environment (workload identity, instance profile, ADC, or core-site.xml) to "
+                  + "supply them.");
+
   private static final Map<String, String> DEFAULT_CONFS =
       Map.of("delta.feature.v2Checkpoint", "supported");
 
@@ -126,6 +137,11 @@ public class TableConf implements Serializable {
   /** @return whether checksum file creation is enabled for this table */
   public boolean isChecksumEnabled() {
     return cfg.get(CHECKSUM_ENABLED);
+  }
+
+  /** @return the storage credential source for this table ("uc" or "ambient") */
+  public String getCredentialSource() {
+    return cfg.get(CREDENTIALS_SOURCE);
   }
 
   /**

--- a/flink/src/test/java/io/delta/flink/table/AbstractKernelTableTest.java
+++ b/flink/src/test/java/io/delta/flink/table/AbstractKernelTableTest.java
@@ -162,6 +162,48 @@ class AbstractKernelTableTest extends TestHelper {
   }
 
   @Test
+  void testCredentialManagerFromConf() {
+    StructType schema = new StructType().add("id", IntegerType.INTEGER);
+    String key = TableConf.CREDENTIALS_SOURCE.key();
+
+    // Default (no conf) and explicit "uc" both yield a UC-vending manager, not the ambient one.
+    withTestTable(
+        schema,
+        Collections.emptyList(),
+        table ->
+            assertFalse(
+                table.credentialManager instanceof CredentialManager.AmbientCredentialManager));
+    withTestTable(
+        schema,
+        Collections.emptyList(),
+        Map.of(key, "uc"),
+        table ->
+            assertFalse(
+                table.credentialManager instanceof CredentialManager.AmbientCredentialManager));
+
+    // "ambient" (case-insensitive) yields the no-op manager that fetches no credentials.
+    withTestTable(
+        schema,
+        Collections.emptyList(),
+        Map.of(key, "AMBIENT"),
+        table -> {
+          assertInstanceOf(
+              CredentialManager.AmbientCredentialManager.class, table.credentialManager);
+          assertTrue(table.credentialManager.getCredentials().isEmpty());
+        });
+
+    // An unknown source fails fast.
+    withTempDir(
+        dir -> {
+          LocalFileSystemTable table =
+              new LocalFileSystemTable(
+                  dir.toURI(), Map.of(key, "not-a-source"), schema, Collections.emptyList());
+          IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, table::open);
+          assertTrue(ex.getMessage().contains(key));
+        });
+  }
+
+  @Test
   void testCreateTableAndCommitWithoutPartition() {
     StructType schema =
         new StructType().add("id", IntegerType.INTEGER).add("part", StringType.STRING);


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [x] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

The Flink connector currently fetches storage credentials only from Unity Catalog (UC credential vending). Workloads that authenticate to cloud storage through the runtime environment instead — e.g. GKE Workload Identity, an AWS instance profile, Application Default Credentials, or static settings in `core-site.xml` — had no way to opt out of UC vending, so the connector would try to vend credentials it doesn't need.

This adds a per-table `credentials.source` option with two values:

- `uc` (default) — fetch temporary credentials from Unity Catalog. Unchanged behavior.
- `ambient` — use a new `CredentialManager.AmbientCredentialManager` that fetches nothing and relies on the filesystem's default credential chain (workload identity, instance profile, ADC, or `core-site.xml`).

Details:
- The option lives on `TableConf` (`credentials.source`, default `uc`), consistent with the other typed `ConfigOption`s. It is a client-side/runtime setting and is not persisted into the table's catalog properties.
- `AbstractKernelTable.createCredentialManager()` selects the manager from the option; an unknown value fails fast with a clear error.
- It is settable per table via `TableBuilder.withCredentialSource(...)` or through the configuration map.

Tracking issue: https://github.com/delta-io/delta/issues/5901

## How was this patch tested?

- Added a unit test in `AbstractKernelTableTest` (`testCredentialManagerFromConf`) that exercises the real path through `open()` → `createCredentialManager()`: default and explicit `uc` yield the UC-vending manager, `ambient` (case-insensitive) yields `AmbientCredentialManager` whose `getCredentials()` is empty, and an unknown value throws `IllegalArgumentException`.
- Ran locally: `build/sbt "flink / javafmt" "flink / Test / javafmt" "flink / test" "flink / Compile / doc"` — all succeed.

## Does this PR introduce _any_ user-facing changes?

Yes, additive only. A new optional table option `credentials.source` is available; its default is `uc`, which preserves existing behavior. Setting it to `ambient` makes the connector skip UC credential vending and rely on ambient/environment credentials.
