### PR TITLE
Add validation in DeltaLog.getChangeLogFiles around continuity in versions

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/ContiguousVersionIterator.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ContiguousVersionIterator.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.delta.ContiguousVersionIterator.GapEvent
+import org.apache.spark.sql.util.ScalaExtensions._
+
+/**
+ * Wraps an arbitrary iterator of `T`s and verifies that the version extracted from each
+ * successive item via `getVersionFromItem` is exactly `prev + 1`. The version of the first
+ * emitted item is not constrained, since the underlying iterator may legitimately start at any
+ * version (e.g. when the caller asked for `startVersion` but the earliest available item is
+ * later).
+ *
+ * Behaviour on a gap (`logGap` is invoked in both modes so telemetry is consistent):
+ *   - `treatGapAsFatal = true`  -> invoke `logGap`, then throw an [[IllegalStateException]].
+ *   - `treatGapAsFatal = false` -> invoke `logGap` and continue.
+ */
+private[delta] class ContiguousVersionIterator[T](
+    underlying: Iterator[T],
+    getVersionFromItem: T => Long,
+    treatGapAsFatal: Boolean,
+    logGap: GapEvent[T] => Unit)
+  extends Iterator[T] {
+
+  private var prevItem: Option[T] = None
+
+  override def hasNext: Boolean = underlying.hasNext
+
+  override def next(): T = {
+    val item = underlying.next()
+    val version = getVersionFromItem(item)
+    prevItem.ifDefined { prev =>
+      val prevVersion = getVersionFromItem(prev)
+      val expectedVersion = prevVersion + 1
+      if (version != expectedVersion) {
+        val gap = GapEvent(
+          prevItem = prev,
+          prevVersion = prevVersion,
+          nextItem = item,
+          nextVersion = version)
+        logGap(gap)
+        if (treatGapAsFatal) {
+          throw new IllegalStateException(
+            s"Non-contiguous versions: expected $expectedVersion, got $version " +
+              s"(prevItem=$prev, nextItem=$item).")
+        }
+      }
+    }
+    prevItem = Some(item)
+    item
+  }
+}
+
+object ContiguousVersionIterator {
+  /**
+   * Describes a single non-contiguity event seen by [[ContiguousVersionIterator]].
+   * `prevItem` / `nextItem` carry the surrounding items so that the `logGap` callback can
+   * extract type-specific metadata (e.g. file name and modification time for a `FileStatus`).
+   */
+  case class GapEvent[T](prevItem: T, prevVersion: Long, nextItem: T, nextVersion: Long)
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -36,7 +36,7 @@ import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.commands.WriteIntoDelta
 import org.apache.spark.sql.delta.coordinatedcommits.CoordinatedCommitsUtils
 import org.apache.spark.sql.delta.files.{TahoeBatchFileIndex, TahoeLogFileIndex}
-import org.apache.spark.sql.delta.metering.{DeltaLogging, DeltaLoggingProvider}
+import org.apache.spark.sql.delta.metering.{DeltaLogging, DeltaLoggingProvider, ThrottledEventLogger}
 import org.apache.spark.sql.delta.redirect.RedirectFeature
 import org.apache.spark.sql.delta.schema.{SchemaMergingUtils, SchemaUtils}
 import org.apache.spark.sql.delta.sources._
@@ -409,12 +409,44 @@ class DeltaLog private(
       this, catalogTableOpt, startVersion)
     // Subtract 1 to ensure that we have the same check for the inclusive startVersion
     var lastSeenVersion = startVersion - 1
-    deltasWithVersion.map { case (status, version) =>
+    val result = deltasWithVersion.map { case (status, version) =>
       if (failOnDataLoss && version > lastSeenVersion + 1) {
         throw DeltaErrors.failOnDataLossException(lastSeenVersion + 1, version)
       }
       lastSeenVersion = version
       (version, status)
+    }
+
+    val conf = spark.sessionState.conf
+    val logGaps = conf.getConf(DeltaSQLConf.DELTA_GET_CHANGE_LOG_FILES_LOG_GAPS)
+    val failOnGap =
+      conf.getConf(DeltaSQLConf.DELTA_GET_CHANGE_LOG_FILES_FAIL_ON_GAPS_IN_TESTS) &&
+        DeltaUtils.isTesting
+    if (!logGaps && !failOnGap) {
+      result
+    } else {
+      // Per-call cap so a single iteration cannot emit more than 2 gap events even if the
+      // underlying log has many gaps; the throttler's lifetime is tied to this iterator.
+      val gapEventLogger = new ThrottledEventLogger(maxEventsToLog = 2)
+      new ContiguousVersionIterator[(Long, FileStatus)](
+        underlying = result,
+        getVersionFromItem = _._1,
+        treatGapAsFatal = failOnGap,
+        logGap = if (logGaps) {
+          gap => gapEventLogger.recordThrottledDeltaEvent(
+            this,
+            "delta.getChangeLogFiles.versionGap",
+            data = Map(
+              "startVersion" -> startVersion,
+              "prevVersion" -> gap.prevVersion,
+              "prevFileName" -> gap.prevItem._2.getPath.getName,
+              "prevModificationTime" -> gap.prevItem._2.getModificationTime,
+              "nextVersion" -> gap.nextVersion,
+              "nextFileName" -> gap.nextItem._2.getPath.getName,
+              "nextModificationTime" -> gap.nextItem._2.getModificationTime))
+        } else {
+          _ => ()
+        })
     }
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -2420,6 +2420,26 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .booleanConf
       .createWithDefault(false)
 
+  val DELTA_GET_CHANGE_LOG_FILES_LOG_GAPS =
+    buildConf("deltaLog.getChangeLogFiles.logGaps")
+      .internal()
+      .doc(
+        """Whether `DeltaLog.getChangeLogFiles` emits a `delta.getChangeLogFiles.versionGap`
+          |usage event when the iterator it returns emits two successive versions that are not
+          |exactly `prev + 1` (a gap).""".stripMargin)
+      .booleanConf
+      .createWithDefault(true)
+
+  val DELTA_GET_CHANGE_LOG_FILES_FAIL_ON_GAPS_IN_TESTS =
+    buildConf("deltaLog.getChangeLogFiles.failOnGapsInTests")
+      .internal()
+      .doc(
+        """When true, `DeltaLog.getChangeLogFiles` throws on a version gap if we are running in
+          |a test JVM (`DeltaUtils.isTesting`). No-op in production. Used to catch unintentional
+          |gap-producing changes during test runs without affecting prod behaviour.""".stripMargin)
+      .booleanConf
+      .createWithDefault(true)
+
   val DELTA_CHANGELOG_V2_ENABLED =
     buildConf("changelogV2.enabled")
       .internal()

--- a/spark/src/test/scala/org/apache/spark/sql/delta/ContiguousVersionIteratorSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/ContiguousVersionIteratorSuite.scala
@@ -1,0 +1,120 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import scala.collection.mutable.ArrayBuffer
+
+import org.apache.spark.sql.delta.ContiguousVersionIterator.GapEvent
+
+import org.apache.spark.SparkFunSuite
+
+class ContiguousVersionIteratorSuite extends SparkFunSuite {
+
+  /**
+   * Wraps `items` in a [[ContiguousVersionIterator]] that treats the items' Long themselves as
+   * versions and collects any [[GapEvent]]s into the returned buffer.
+   */
+  private def wrap(
+      items: Seq[Long],
+      treatGapAsFatal: Boolean)
+    : (ContiguousVersionIterator[Long], ArrayBuffer[GapEvent[Long]]) = {
+    val gaps = ArrayBuffer.empty[GapEvent[Long]]
+    val iter = new ContiguousVersionIterator[Long](
+      underlying = items.iterator,
+      getVersionFromItem = identity,
+      treatGapAsFatal = treatGapAsFatal,
+      logGap = gap => gaps += gap)
+    (iter, gaps)
+  }
+
+  test("empty iterator: no gaps, no events") {
+    val (iter, gaps) = wrap(Seq.empty, treatGapAsFatal = true)
+    assert(iter.toSeq.isEmpty)
+    assert(gaps.isEmpty)
+  }
+
+  test("single-element iterator: no contiguity check on the first item") {
+    // First emitted version is unconstrained -- even though 42 != 0, no gap should fire.
+    val (iter, gaps) = wrap(Seq(42L), treatGapAsFatal = true)
+    assert(iter.toSeq === Seq(42L))
+    assert(gaps.isEmpty)
+  }
+
+  test("contiguous sequence starting at 0: no events fire") {
+    val (iter, gaps) = wrap(Seq(0L, 1L, 2L, 3L), treatGapAsFatal = true)
+    assert(iter.toSeq === Seq(0L, 1L, 2L, 3L))
+    assert(gaps.isEmpty)
+  }
+
+  test("contiguous sequence starting later than 0: no events fire") {
+    // First version is unconstrained, only successive contiguity matters.
+    val (iter, gaps) = wrap(Seq(5L, 6L, 7L), treatGapAsFatal = true)
+    assert(iter.toSeq === Seq(5L, 6L, 7L))
+    assert(gaps.isEmpty)
+  }
+
+  test("gap with treatGapAsFatal = true: records GapEvent then throws") {
+    val (iter, gaps) = wrap(Seq(0L, 1L, 3L), treatGapAsFatal = true)
+    val e = intercept[IllegalStateException] {
+      iter.toList
+    }
+    assert(e.getMessage.contains("expected 2"))
+    assert(e.getMessage.contains("got 3"))
+    // FATAL must still call logGap so the event lands in telemetry before the throw.
+    assert(gaps === Seq(GapEvent(prevItem = 1L, prevVersion = 1L, nextItem = 3L, nextVersion = 3L)))
+  }
+
+  test("gap with treatGapAsFatal = false: records GapEvent and continues") {
+    val (iter, gaps) = wrap(Seq(0L, 1L, 3L, 4L), treatGapAsFatal = false)
+    assert(iter.toSeq === Seq(0L, 1L, 3L, 4L))
+    assert(gaps === Seq(GapEvent(prevItem = 1L, prevVersion = 1L, nextItem = 3L, nextVersion = 3L)))
+  }
+
+  test("multiple gaps with treatGapAsFatal = false: all gaps recorded") {
+    val (iter, gaps) = wrap(Seq(0L, 2L, 5L, 6L, 8L), treatGapAsFatal = false)
+    assert(iter.toSeq === Seq(0L, 2L, 5L, 6L, 8L))
+    assert(gaps === Seq(
+      GapEvent(prevItem = 0L, prevVersion = 0L, nextItem = 2L, nextVersion = 2L),
+      GapEvent(prevItem = 2L, prevVersion = 2L, nextItem = 5L, nextVersion = 5L),
+      GapEvent(prevItem = 6L, prevVersion = 6L, nextItem = 8L, nextVersion = 8L)))
+  }
+
+  test("getVersionFromItem extractor: works with arbitrary payload types") {
+    case class Row(version: Long, payload: String)
+    val rows = Seq(Row(10, "a"), Row(11, "b"), Row(13, "c"))
+    val gaps = ArrayBuffer.empty[GapEvent[Row]]
+    val iter = new ContiguousVersionIterator[Row](
+      underlying = rows.iterator,
+      getVersionFromItem = _.version,
+      treatGapAsFatal = false,
+      logGap = gap => gaps += gap)
+    assert(iter.toSeq === rows)
+    assert(gaps === Seq(GapEvent(
+      prevItem = Row(11, "b"), prevVersion = 11L,
+      nextItem = Row(13, "c"), nextVersion = 13L)))
+  }
+
+  test("lazy consumption: items before a fatal gap are still emitted") {
+    val (iter, _) = wrap(Seq(0L, 1L, 5L), treatGapAsFatal = true)
+    assert(iter.next() === 0L)
+    assert(iter.next() === 1L)
+    // The gap is only detected when we try to consume the third item.
+    intercept[IllegalStateException] {
+      iter.next()
+    }
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
@@ -23,6 +23,7 @@ import java.util.{Locale, Optional}
 import scala.collection.JavaConverters._
 import scala.language.postfixOps
 
+import com.databricks.spark.util.Log4jUsageLogger
 import org.apache.spark.sql.delta.DeltaOperations.Truncate
 import org.apache.spark.sql.delta.DeltaTestUtils.createTestAddFile
 import org.apache.spark.sql.delta.actions._
@@ -885,6 +886,115 @@ class DeltaLogSuite extends QueryTest
 
   test("DeltaLog.createDataFrame should not drop null columns without feature flag") {
     testCreateDataFrame(shouldDropNullTypeColumns = false)
+  }
+
+  /**
+   * Creates a delta table with `numVersions + 1` commits (1 CREATE + `numVersions` INSERTs, so
+   * versions `0..numVersions`), then deletes the requested commit JSON files so the next
+   * listing returns a non-contiguous sequence. Returns the [[DeltaLog]] of the resulting table.
+   */
+  private def createDeltaTableWithCommitGaps(
+      tableDir: File,
+      numVersions: Int,
+      versionsToDelete: Seq[Long]): DeltaLog = {
+    val log = DeltaLog.forTable(spark, tableDir.getCanonicalPath)
+    spark.sql(s"CREATE TABLE delta.`${tableDir.getCanonicalPath}` (id INT) USING delta")
+    (1 to numVersions).foreach { i =>
+      spark.sql(s"INSERT INTO delta.`${tableDir.getCanonicalPath}` VALUES ($i)")
+    }
+    val fs = log.logPath.getFileSystem(log.newDeltaHadoopConf())
+    versionsToDelete.foreach { v =>
+      val deltaFile = FileNames.unsafeDeltaFile(log.logPath, v)
+      assert(fs.delete(deltaFile, false),
+        s"failed to delete $deltaFile when seeding commit gaps for the test")
+    }
+    log
+  }
+
+  for (api <- Seq("getChangeLogFiles", "getChanges")) {
+    test(s"$api: failOnGapsInTests=true records the gap usage event and then throws") {
+      withTempDir { tableDir =>
+        val log = createDeltaTableWithCommitGaps(
+          tableDir, numVersions = 10, versionsToDelete = Seq(0, 1, 2, 3, 7))
+        val records = Log4jUsageLogger.track {
+          withSQLConf(
+              DeltaSQLConf.DELTA_GET_CHANGE_LOG_FILES_LOG_GAPS.key -> "true",
+              DeltaSQLConf.DELTA_GET_CHANGE_LOG_FILES_FAIL_ON_GAPS_IN_TESTS.key -> "true") {
+            val e = intercept[IllegalStateException] {
+              val iter =
+                if (api == "getChangeLogFiles") log.getChangeLogFiles(startVersion = 0)
+                else log.getChanges(startVersion = 0)
+              // Consume the iterator. We expect a gap between version 6 and version 8 (we
+              // deleted version 7); the iterator starts at version 4 because versions 0..3
+              // were deleted (no constraint on the first emitted version).
+              iter.toList
+            }
+            assert(e.getMessage.contains("expected 7"))
+            assert(e.getMessage.contains("got 8"))
+          }
+        }
+        val gapEvents = records.filter(
+          _.tags.get("opType").contains("delta.getChangeLogFiles.versionGap"))
+        assert(gapEvents.size === 1,
+          "FATAL mode must still emit the gap usage event before throwing, " +
+            s"got: $gapEvents")
+      }
+    }
+
+    test(s"$api: logGaps=true (failOnGapsInTests=false) throttles to at most 2 even with 4 gaps") {
+      // Versions present after deletion: 2,3,4,7,8,9,11,12,13,15,16,19,20. Deleting 0/1 just
+      // shifts the start (no gap fires for the unconstrained first emit). The four honest gaps
+      // are 4->7, 9->11, 13->15, 16->19. The ThrottledEventLogger caps emission at the first 2.
+      withTempDir { tableDir =>
+        val log = createDeltaTableWithCommitGaps(
+          tableDir, numVersions = 20, versionsToDelete = Seq(0, 1, 5, 6, 10, 14, 17, 18))
+        val records = Log4jUsageLogger.track {
+          withSQLConf(
+              DeltaSQLConf.DELTA_GET_CHANGE_LOG_FILES_LOG_GAPS.key -> "true",
+              DeltaSQLConf.DELTA_GET_CHANGE_LOG_FILES_FAIL_ON_GAPS_IN_TESTS.key -> "false") {
+            val iter =
+              if (api == "getChangeLogFiles") log.getChangeLogFiles(startVersion = 0)
+              else log.getChanges(startVersion = 0)
+            iter.toList // force-consume so all gaps are observed
+          }
+        }
+        val gapEvents = records.filter(
+          _.tags.get("opType").contains("delta.getChangeLogFiles.versionGap"))
+        assert(gapEvents.size === 2,
+          s"expected the throttler to cap at 2 gap events despite 4 underlying gaps, " +
+            s"got ${gapEvents.size}: $gapEvents")
+
+        // The two events that survive throttling are the first two encountered, in order.
+        val payloads = gapEvents.map(r => JsonUtils.fromJson[Map[String, Any]](r.blob))
+        assert(payloads(0)("prevVersion").toString == "4" &&
+            payloads(0)("nextVersion").toString == "7",
+          s"first gap event should describe the 4->7 gap, got: ${payloads(0)}")
+        assert(payloads(1)("prevVersion").toString == "9" &&
+            payloads(1)("nextVersion").toString == "11",
+          s"second gap event should describe the 9->11 gap, got: ${payloads(1)}")
+      }
+    }
+
+    test(s"$api: both switches off skips the check entirely") {
+      withTempDir { tableDir =>
+        val log = createDeltaTableWithCommitGaps(
+          tableDir, numVersions = 10, versionsToDelete = Seq(0, 1, 2, 3, 7))
+        val records = Log4jUsageLogger.track {
+          withSQLConf(
+              DeltaSQLConf.DELTA_GET_CHANGE_LOG_FILES_LOG_GAPS.key -> "false",
+              DeltaSQLConf.DELTA_GET_CHANGE_LOG_FILES_FAIL_ON_GAPS_IN_TESTS.key -> "false") {
+            val iter =
+              if (api == "getChangeLogFiles") log.getChangeLogFiles(startVersion = 0)
+              else log.getChanges(startVersion = 0)
+            iter.toList // must not throw
+          }
+        }
+        val gapEvents = records.filter(
+          _.tags.get("opType").contains("delta.getChangeLogFiles.versionGap"))
+        assert(gapEvents.isEmpty,
+          s"expected no gap events when both switches are off, got: $gapEvents")
+      }
+    }
   }
 }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
@@ -55,6 +55,13 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
   with DeltaColumnMappingTestUtils
   with DeltaSQLCommandTest {
 
+  // Many tests in this suite deliberately delete commit JSON files to exercise streaming's own
+  // missing-commit-file / failOnDataLoss handling. The DeltaLog.getChangeLogFiles version-gap
+  // validator (which throws in tests by default) would pre-empt that streaming-layer check
+  // with a different error class, so disable the test-only throw suite-wide.
+  override protected def sparkConf: SparkConf = super.sparkConf
+    .set(DeltaSQLConf.DELTA_GET_CHANGE_LOG_FILES_FAIL_ON_GAPS_IN_TESTS.key, "false")
+
   import testImplicits._
 
   def testNullTypeColumn(shouldDropNullTypeColumns: Boolean): Unit = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adds a contiguous-version invariant check to the iterator returned by `DeltaLog.getChangeLogFiles`. The iterator now wraps its results in a new `ContiguousVersionIterator[T]` that verifies each emitted version is exactly `prev + 1`. The version of the first emitted item is intentionally unconstrained, since the underlying log listing may legitimately start later than the caller's `startVersion`.

Behaviour is gated by two new internal confs in `DeltaSQLConf`:

- `deltaLog.getChangeLogFiles.logGaps` (default `true`): emit a `delta.getChangeLogFiles.versionGap` usage event when a gap is observed. The events are capped per call via a `ThrottledEventLogger` (max 2 events per iteration) so a pathological log can't flood telemetry.
- `deltaLog.getChangeLogFiles.failOnGapsInTests` (default `true`): in test JVMs only (`DeltaUtils.isTesting`), throw an `IllegalStateException` on the first gap so unintentional gap-producing changes are caught loudly. No-op in production.

Both code paths reach the check: `getChangeLogFiles` directly, and `getChanges` indirectly via the same underlying iterator.

The new `ContiguousVersionIterator[T]` is generic over the payload type (`getVersionFromItem: T => Long`), so the same primitive can be reused by other delta-log iterators in the future without re-implementing gap detection.

## How was this patch tested?

Two new suites:

- `ContiguousVersionIteratorSuite`: pure unit tests on the iterator primitive — empty input, single-element (first version unconstrained), contiguous sequences starting at 0 or later, fatal vs. non-fatal gap handling, multi-gap accumulation, arbitrary payload extraction, and lazy consumption ordering.
- `DeltaLogSuite`: end-to-end tests exercising both `getChangeLogFiles` and `getChanges` against a delta table whose commit JSONs have been deliberately deleted to create gaps, asserting (a) FATAL mode logs the gap event before throwing, (b) LOG-only mode throttles to at most two events even when the log has four real gaps, and (c) both switches off skips the check entirely (no events, no throw).