### PR TITLE
[Spark] Add geoTypes to GeoTypesShim

### DIFF
--- a/spark/src/main/scala-shims/spark-4.0/GeoTypesShim.scala
+++ b/spark/src/main/scala-shims/spark-4.0/GeoTypesShim.scala
@@ -46,6 +46,9 @@ object GeoTypesShim {
    */
   val geoExpressions: Set[Class[_]] = Set.empty[Class[_]]
 
+  /** Geospatial Catalyst type classes; empty on Spark 4.0 where these types do not exist. */
+  val geoTypes: Seq[Class[_]] = Seq.empty[Class[_]]
+
   /** Returns the CRS of a `GeometryType`. Only valid when `isGeometryType(dt)` is true. */
   def geometryCrs(dt: DataType): String =
     throw new IllegalArgumentException(s"Not a geometry type: $dt")

--- a/spark/src/main/scala-shims/spark-4.2/GeoTypesShim.scala
+++ b/spark/src/main/scala-shims/spark-4.2/GeoTypesShim.scala
@@ -62,6 +62,9 @@ object GeoTypesShim {
     classOf[ST_SetSrid],
     classOf[ST_Srid])
 
+  /** Geospatial Catalyst type classes (`GeometryType`, `GeographyType`). */
+  val geoTypes: Seq[Class[_]] = Seq(classOf[GeometryType], classOf[GeographyType])
+
   /** Returns the CRS of a `GeometryType`. Only valid when `isGeometryType(dt)` is true. */
   def geometryCrs(dt: DataType): String = dt match {
     case g: GeometryType => g.crs


### PR DESCRIPTION
## Description

Adds a `geoTypes` member to `GeoTypesShim` listing the geospatial Catalyst type classes:

- **Spark 4.2** shim: `Seq(classOf[GeometryType], classOf[GeographyType])`
- **Spark 4.0** shim: `Seq.empty[Class[_]]` (these types do not exist on Spark 4.0)

The **Spark 4.1** shim is intentionally left unchanged and will be updated in a separate PR.

## How was this patch tested?

Trivial member addition. The Spark 4.2 shim already imports and uses `GeometryType`/`GeographyType`; the 4.0 shim returns an empty `Seq` with no new imports. No behavior change to existing methods.

## Does this PR introduce _any_ user-facing changes?

No.

This pull request and its description were written by Isaac.