### PR TITLE
Do not push down non-deterministic partition predicates with limit

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -488,6 +488,17 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .booleanConf
       .createWithDefault(true)
 
+  val DELTA_LIMIT_PUSHDOWN_SKIP_NON_DETERMINISTIC_FILTERS =
+    buildConf("stats.limitPushdown.skipNonDeterministicFilters.enabled")
+      .internal()
+      .doc("If true, non-deterministic predicates (e.g. rand()) are not eligible for Delta limit " +
+        "push-down. Such predicates reference no columns, so they would otherwise be treated as " +
+        "partition-only filters, evaluated once per file during limit-based file pruning and " +
+        "again per row at execution, double-filtering the data. When false, restores the legacy " +
+        "(incorrect) behavior of pushing them down.")
+      .booleanConf
+      .createWithDefault(true)
+
   val DELTA_MAX_RETRY_COMMIT_ATTEMPTS =
     buildConf("maxCommitAttempts")
       .internal()

--- a/spark/src/main/scala/org/apache/spark/sql/delta/stats/PrepareDeltaScan.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/stats/PrepareDeltaScan.scala
@@ -293,8 +293,26 @@ trait PrepareDeltaScanBase extends Rule[LogicalPlan]
         fileIndex: FileIndexType): Boolean = {
       val partitionColumns = getPartitionColumns(fileIndex)
       import DeltaTableUtils._
-      filters.forall(expr => !containsSubquery(expr) &&
-        isPredicatePartitionColumnsOnly(expr, partitionColumns, spark))
+      // Gate for the LIMIT file-pruning path. Only consulted in DeltaTableScan.unapply when
+      // matching LocalLimit + PhysicalOperation; if true, prepareDeltaScan calls
+      // filesForScan(limit, filters) (PrepareDeltaScan.filesForScan ->
+      // DataSkippingReader.filesForScan(limit, partitionFilters)), which applies filters during
+      // file listing and caps files at ~limit via pruneFilesByLimit. optimizeGeneratedColumns
+      // then swaps in PreparedDeltaFileIndex but leaves Filter nodes in the plan.
+      //
+      // A non-deterministic predicate (e.g. rand() > 0.5) references no columns, so
+      // isPredicatePartitionColumnsOnly is vacuously true and would enter that path. rand() is
+      // then evaluated during file listing (withStats.where) and again at execution (Filter in
+      // the plan), with independent random outcomes each time. The no-limit path
+      // (filesForScan(filters) -> filesForScanImpl) already drops non-deterministic filters
+      // from file skipping; exclude them here so we fall back to that path.
+      val skipNonDeterministicFilters =
+        spark.conf.get(DeltaSQLConf.DELTA_LIMIT_PUSHDOWN_SKIP_NON_DETERMINISTIC_FILTERS)
+      filters.forall { expr =>
+        !containsSubquery(expr) &&
+          (!skipNonDeterministicFilters || expr.deterministic) &&
+          isPredicatePartitionColumnsOnly(expr, partitionColumns, spark)
+      }
     }
 
     protected def limitPushdownEnabled(plan: LogicalPlan): Boolean

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLimitPushDownSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLimitPushDownSuite.scala
@@ -201,6 +201,118 @@ trait DeltaLimitPushDownTests extends QueryTest
     }
   }
 
+  // Non-deterministic predicates can be misclassified as partition-only for limit push-down.
+  // DELTA_LIMIT_PUSHDOWN_SKIP_NON_DETERMINISTIC_FILTERS gates the fix.
+  //
+  // E2E over writeNonDetTestTable (10000 rows, partition col a). LIMIT = 500.
+  //
+  // scalastyle:off line.size.limit
+  // | Predicate                                         | Gate on: rows | Gate on: scan | Gate off: rows   | Gate off: scan |
+  // |---------------------------------------------------|---------------|---------------|------------------|----------------|
+  // | rand() > 0.5                                      | 500           | full          | < 500            | partial        |
+  // | monotonically_increasing_id() % 2 = 0             | 500           | full          | < 500            | partial        |
+  // | hash(uuid()) % 100 < 50                           | 500           | full          | < 500            | partial        |
+  // | xxhash64(uuid()) < 0                              | 500           | full          | < 500            | partial        |
+  // | spark_partition_id() % 2 = 0                      | 500           | full          | < 500            | partial        |
+  // | substring(uuid(), 1, 1) < '8'                     | 500           | full          | < 500            | partial        |
+  // | a = 1 OR hash(uuid()) % 2 = 0                     | 500           | full          | < 500            | partial        |
+  // | (a < 50) OR monotonically_increasing_id() % 2 = 0 | 500           | full          | 500 (no assert)  | partial        |
+  // scalastyle:on line.size.limit
+  //
+  // Gate on: skipNonDeterministicFilters=true. Gate off: legacy (false). Control: a >= 0 still
+  // uses limit push-down under gate on (scanned < total).
+
+  private val nonDetLimitRowCount = 500
+
+  // (predicate, expectLegacyRowLoss) - gate-off row < limit only when double-filtering is visible.
+  private val nonDetLimitPredicates: Seq[(String, Boolean)] = Seq(
+    ("rand() > 0.5", true),
+    ("monotonically_increasing_id() % 2 = 0", true),
+    ("hash(uuid()) % 100 < 50", true),
+    ("xxhash64(uuid()) < 0", true),
+    ("spark_partition_id() % 2 = 0", true),
+    ("substring(uuid(), 1, 1) < '8'", true),
+    ("a = 1 OR hash(uuid()) % 2 = 0", true),
+    ("(a < 50) OR monotonically_increasing_id() % 2 = 0", false)
+  )
+
+  private def withNonDetLimitPushdownConfs(skipNonDeterministic: Boolean)(thunk: => Unit): Unit = {
+    withSQLConf(
+        DeltaSQLConf.DELTA_LIMIT_PUSHDOWN_ENABLED.key -> "true",
+        DeltaSQLConf.DELTA_LIMIT_PUSHDOWN_SKIP_NON_DETERMINISTIC_FILTERS.key ->
+          skipNonDeterministic.toString) {
+      thunk
+    }
+  }
+
+  private def collectWhereLimit(
+      tableName: String,
+      predicate: String,
+      limit: Int): Array[Row] = {
+    spark.read.format("delta").table(tableName).where(predicate).limit(limit).collect()
+  }
+
+  private def writeNonDetTestTable(tableName: String): Unit = {
+    // 100 partitions x 100 rows = 10000 rows, one file per partition, so that an (incorrectly
+    // triggered) limit push-down prunes down to a small subset of files.
+    spark.range(10000)
+      .selectExpr("int(id % 100) as a", "int(id) as b")
+      .write.format("delta").partitionBy("a").saveAsTable(tableName)
+
+    val describeRows = spark.sql(s"DESCRIBE EXTENDED $tableName").collect()
+    val partitionInfoIdx = describeRows.indexWhere(_.getString(0) == "# Partition Information")
+    assert(partitionInfoIdx >= 0,
+      s"DESCRIBE EXTENDED $tableName did not contain # Partition Information")
+    val partitionCols = describeRows.drop(partitionInfoIdx + 2)
+      .takeWhile(row => row.getString(0) != null && !row.getString(0).startsWith("#"))
+      .map(_.getString(0))
+    assert(partitionCols.contains("a"),
+      s"Expected partition column a in DESCRIBE EXTENDED, got $partitionCols")
+  }
+
+  test("non-deterministic predicates are not pushed down with limit (gate on)") {
+    withTempTable(createTable = false) { tableName =>
+      writeNonDetTestTable(tableName)
+      withNonDetLimitPushdownConfs(skipNonDeterministic = true) {
+        nonDetLimitPredicates.foreach { case (predicate, _) =>
+          val Seq(scan) = getScanReport {
+            val rows = collectWhereLimit(tableName, predicate, nonDetLimitRowCount)
+            assert(rows.length === nonDetLimitRowCount,
+              s"Predicate '$predicate': expected $nonDetLimitRowCount rows but got ${rows.length}")
+          }
+          assert(scan.size("scanned").bytesCompressed === scan.size("total").bytesCompressed,
+            s"Predicate '$predicate': expected full-table scan")
+        }
+
+        val Seq(detScan) = getScanReport {
+          collectWhereLimit(tableName, "a >= 0", nonDetLimitRowCount)
+        }
+        assert(detScan.size("scanned").bytesCompressed.get <
+          detScan.size("total").bytesCompressed.get)
+      }
+    }
+  }
+
+  test("non-deterministic predicates are incorrectly pushed down with limit (gate off, legacy)") {
+    withTempTable(createTable = false) { tableName =>
+      writeNonDetTestTable(tableName)
+      withNonDetLimitPushdownConfs(skipNonDeterministic = false) {
+        nonDetLimitPredicates.foreach { case (predicate, expectLegacyRowLoss) =>
+          val Seq(scan) = getScanReport {
+            val rows = collectWhereLimit(tableName, predicate, nonDetLimitRowCount)
+            if (expectLegacyRowLoss) {
+              assert(rows.length < nonDetLimitRowCount,
+                s"Predicate '$predicate': expected fewer than $nonDetLimitRowCount rows " +
+                  s"(double-filtered) but got ${rows.length}")
+            }
+          }
+          assert(scan.size("scanned").bytesCompressed.get < scan.size("total").bytesCompressed.get,
+            s"Predicate '$predicate': expected partial scan (limit push-down)")
+        }
+      }
+    }
+  }
+
   test("limit push-down flag") {
     withTempTable(createTable = false) { tableName =>
       val ds = Seq((1, 4), (2, 5), (3, 6)).toDF("key", "value").as[(Int, Int)]


### PR DESCRIPTION
## Description

When a query combines a filter with a `LIMIT`, Delta's limit-based file pruning
(`DeltaTableScan` matching `LocalLimit` + `PhysicalOperation`) treats predicates that
reference no columns as partition-only filters and applies them during file listing,
capping the number of files scanned.

A non-deterministic predicate such as `rand() > 0.5` references no columns, so it is
vacuously classified as partition-only and enters this path. The predicate is then
evaluated twice with independent random outcomes: once during file listing
(`withStats.where`) and again per row at execution (the `Filter` node left in the plan).
This double-filtering can drop rows and return fewer than `LIMIT` results.

This change excludes non-deterministic predicates from the limit push-down path so they
fall back to the regular scan path (which already drops non-deterministic filters from
file skipping). A new conf, `DELTA_LIMIT_PUSHDOWN_SKIP_NON_DETERMINISTIC_FILTERS`
(default `true`), gates the fix and can restore the legacy behavior if needed.

## How was this patch tested?

Added `DeltaLimitPushDownSuite` tests covering a range of non-deterministic predicates
(`rand()`, `monotonically_increasing_id()`, `hash(uuid())`, `spark_partition_id()`, etc.)
with the gate both on and off, asserting full result sets and full-table scans under the
fix, and the legacy double-filtering behavior when disabled.

## Does this PR introduce _any_ user-facing change?

No.