### PR TITLE
[Kernel] Add specific exception subclasses for loadSnapshotAt version failures

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/exceptions/VersionToLoadAfterLatestCommitException.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/exceptions/VersionToLoadAfterLatestCommitException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.exceptions;
+
+import io.delta.kernel.annotation.Evolving;
+
+/**
+ * Thrown when the requested version to load is higher than the latest version available in the
+ * Delta log, i.e. it has not been materialized yet. This is typically recoverable: a consumer may
+ * retry once the requested version has been committed.
+ *
+ * @since 4.3.0
+ */
+@Evolving
+public class VersionToLoadAfterLatestCommitException extends KernelException {
+
+  public VersionToLoadAfterLatestCommitException(String message) {
+    super(message);
+  }
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/exceptions/VersionTruncatedException.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/exceptions/VersionTruncatedException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.exceptions;
+
+import io.delta.kernel.annotation.Evolving;
+
+/**
+ * Thrown when the requested version to load is lower than the earliest version available in the
+ * Delta log because the log has been truncated (e.g. by manual deletion or the log/checkpoint
+ * retention policy). This is unrecoverable for the requested version.
+ *
+ * @since 4.3.0
+ */
+@Evolving
+public class VersionTruncatedException extends KernelException {
+
+  public VersionTruncatedException(String message) {
+    super(message);
+  }
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
@@ -58,7 +58,7 @@ public final class DeltaErrors {
                 + "manual deletion or the log/checkpoint retention policy. The earliest available "
                 + "version is %s.",
             tablePath, versionToLoad, earliestVersion);
-    return new KernelException(message);
+    return new VersionTruncatedException(message);
   }
 
   public static KernelException versionToLoadAfterLatestCommit(
@@ -68,7 +68,7 @@ public final class DeltaErrors {
             "%s: Cannot load table version %s as it does not exist. "
                 + "The latest available version is %s.",
             tablePath, versionToLoad, latestVersion);
-    return new KernelException(message);
+    return new VersionToLoadAfterLatestCommitException(message);
   }
 
   public static KernelException timestampBeforeFirstAvailableCommit(

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/SnapshotManagerSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/SnapshotManagerSuite.scala
@@ -23,7 +23,7 @@ import scala.reflect.ClassTag
 
 import io.delta.kernel.data.{ColumnarBatch, ColumnVector}
 import io.delta.kernel.engine.FileReadResult
-import io.delta.kernel.exceptions.{InvalidTableException, TableNotFoundException}
+import io.delta.kernel.exceptions.{InvalidTableException, TableNotFoundException, VersionToLoadAfterLatestCommitException, VersionTruncatedException}
 import io.delta.kernel.expressions.Predicate
 import io.delta.kernel.internal.checkpoints.{CheckpointInstance, CheckpointMetaData, SidecarFile}
 import io.delta.kernel.internal.fs.Path
@@ -411,12 +411,12 @@ class SnapshotManagerSuite extends AnyFunSuite with MockFileSystemClientUtils {
   }
 
   test("getLogSegmentForVersion: versionToLoad higher than possible") {
-    testExpectedError[RuntimeException](
+    testExpectedError[VersionToLoadAfterLatestCommitException](
       files = deltaFileStatuses(Seq(0L)),
       versionToLoad = Optional.of(15),
       expectedErrorMessageContains =
         "Cannot load table version 15 as it does not exist. The latest available version is 0")
-    testExpectedError[RuntimeException](
+    testExpectedError[VersionToLoadAfterLatestCommitException](
       files = deltaFileStatuses((10L until 13L)) ++ singularCheckpointFileStatuses(Seq(10L)),
       versionToLoad = Optional.of(15),
       expectedErrorMessageContains =
@@ -475,7 +475,7 @@ class SnapshotManagerSuite extends AnyFunSuite with MockFileSystemClientUtils {
   }
 
   test("getLogSegmentForVersion: versionToLoad not constructable from history") {
-    testExpectedError[RuntimeException](
+    testExpectedError[VersionTruncatedException](
       deltaFileStatuses(20L until 25L) ++ singularCheckpointFileStatuses(Seq(20L)),
       versionToLoad = Optional.of(15),
       expectedErrorMessageContains = "Cannot load table version 15")


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Kernel

## Description

When loading a snapshot at a specific version, `SnapshotManager` currently signals both out-of-range failures with a generic `KernelException`, so callers can only tell them apart by string-matching the message.

This adds two typed subclasses of `KernelException` and returns them from the corresponding `DeltaErrors` factory methods:

- `VersionToLoadAfterLatestCommitException` — the requested version is higher than the latest commit (not materialized yet; typically recoverable by retrying).
- `VersionTruncatedException` — the requested version is lower than the earliest available commit because the log has been truncated (unrecoverable for that version).

Both extend `KernelException`, mirroring how `DeltaErrors#missingCheckpoint` already returns an `InvalidTableException`. Connectors can now `catch` the specific type instead of parsing the message — e.g. the delta-spark V2 CDC `SparkMicroBatchStream` can swallow `VersionToLoadAfterLatestCommitException` to wait for the version to be committed.

Resolves #6745.

## How was this patch tested?

Updated the existing `SnapshotManagerSuite` cases that exercise these two paths (`getLogSegmentForVersion: versionToLoad higher than possible` and `... not constructable from history`) to assert the specific exception type is thrown instead of the generic `RuntimeException`.

## Does this PR introduce _any_ user-facing changes?

No behavioral change: both new types extend `KernelException`, so existing `catch (KernelException ...)` keeps working and the messages are unchanged. Callers simply gain the option to catch the narrower types.