### PR TITLE
Refactor type widening tests to use name-based access

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTestUtils.scala
@@ -746,6 +746,13 @@ trait DeltaDMLTestUtils
 
   protected def tableIdentifier: TableIdentifier
 
+  /**
+   * The backtick-quoted, fully-qualified name of the table under test as it appears in analyzer
+   * error messages (e.g. `spark_catalog`.`db`.`table`). Differs between path-based and name-based
+   * access, so tests that assert on table names in errors should use this instead of hardcoding.
+   */
+  protected def qualifiedErrorTableName: String
+
   protected def dropTable(): Unit
 
   /**
@@ -967,6 +974,8 @@ trait DeltaDMLTestUtilsPathBased extends DeltaDMLTestUtils {
 
   override protected def tableSQLIdentifier: String = s"delta.`$tempPath`"
 
+  override protected def qualifiedErrorTableName: String = s"`spark_catalog`.`delta`.`$tempPath`"
+
   protected def readDeltaTable(path: String): DataFrame = {
     spark.read.format("delta").load(path)
   }
@@ -1004,6 +1013,9 @@ trait DeltaDMLTestUtilsNameBased extends DeltaDMLTestUtils {
   // true, the table name used for dropping the table will not match the created table
   // name, causing the table not being dropped.
   override protected def tableSQLIdentifier: String = "test_delta_table"
+
+  override protected def qualifiedErrorTableName: String =
+    s"`spark_catalog`.`default`.`$tableSQLIdentifier`"
 
   override protected def dropTable(): Unit = {
     spark.sql(s"DROP TABLE IF EXISTS $tableSQLIdentifier")

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningAlterTableNestedSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningAlterTableNestedSuite.scala
@@ -16,6 +16,8 @@
 
 package org.apache.spark.sql.delta.typewidening
 
+import org.apache.spark.sql.delta.DeltaDMLTestUtilsNameBased
+
 import org.apache.spark.sql.{AnalysisException, QueryTest}
 import org.apache.spark.sql.execution.datasources.parquet.ParquetTest
 import org.apache.spark.sql.types._
@@ -28,6 +30,7 @@ class TypeWideningAlterTableNestedSuite
   extends QueryTest
     with ParquetTest
     with TypeWideningTestMixin
+    with DeltaDMLTestUtilsNameBased
     with TypeWideningAlterTableNestedTests
 
 trait TypeWideningAlterTableNestedTests {
@@ -37,7 +40,7 @@ trait TypeWideningAlterTableNestedTests {
 
   /** Create a table with a struct, map and array for each test. */
   protected def createNestedTable(): Unit = {
-    sql(s"CREATE TABLE delta.`$tempPath` " +
+    sql(s"CREATE TABLE $tableSQLIdentifier " +
       "(s struct<a: byte>, m map<byte, short>, a array<short>) USING DELTA")
     append(Seq((1, 2, 3, 4))
       .toDF("a", "b", "c", "d")
@@ -46,7 +49,7 @@ trait TypeWideningAlterTableNestedTests {
         "map(cast(b as byte), cast(c as short)) as m",
         "array(cast(d as short)) as a"))
 
-    assert(readDeltaTable(tempPath).schema === new StructType()
+    assert(readDeltaTableByIdentifier().schema === new StructType()
       .add("s", new StructType().add("a", ByteType))
       .add("m", MapType(ByteType, ShortType))
       .add("a", ArrayType(ShortType)))
@@ -55,12 +58,12 @@ trait TypeWideningAlterTableNestedTests {
   test("unsupported ALTER TABLE CHANGE COLUMN on non-leaf fields") {
     createNestedTable()
     // Running ALTER TABLE CHANGE COLUMN on non-leaf fields is invalid.
-    var alterTableSql = s"ALTER TABLE delta.`$tempPath` CHANGE COLUMN s TYPE struct<a: short>"
+    var alterTableSql = s"ALTER TABLE $tableSQLIdentifier CHANGE COLUMN s TYPE struct<a: short>"
     checkError(
       intercept[AnalysisException] { sql(alterTableSql) },
       "CANNOT_UPDATE_FIELD.STRUCT_TYPE",
       parameters = Map(
-        "table" -> s"`spark_catalog`.`delta`.`$tempPath`",
+        "table" -> qualifiedErrorTableName,
         "fieldName" -> "`s`"
       ),
       context = ExpectedContext(
@@ -69,12 +72,12 @@ trait TypeWideningAlterTableNestedTests {
         stop = alterTableSql.length - 1)
     )
 
-    alterTableSql = s"ALTER TABLE delta.`$tempPath` CHANGE COLUMN m TYPE map<int, int>"
+    alterTableSql = s"ALTER TABLE $tableSQLIdentifier CHANGE COLUMN m TYPE map<int, int>"
     checkError(
       intercept[AnalysisException] { sql(alterTableSql) },
       "CANNOT_UPDATE_FIELD.MAP_TYPE",
       parameters = Map(
-        "table" -> s"`spark_catalog`.`delta`.`$tempPath`",
+        "table" -> qualifiedErrorTableName,
         "fieldName" -> "`m`"
       ),
       context = ExpectedContext(
@@ -83,12 +86,12 @@ trait TypeWideningAlterTableNestedTests {
         stop = alterTableSql.length - 1)
     )
 
-    alterTableSql = s"ALTER TABLE delta.`$tempPath` CHANGE COLUMN a TYPE array<int>"
+    alterTableSql = s"ALTER TABLE $tableSQLIdentifier CHANGE COLUMN a TYPE array<int>"
     checkError(
       intercept[AnalysisException] { sql(alterTableSql) },
       "CANNOT_UPDATE_FIELD.ARRAY_TYPE",
       parameters = Map(
-        "table" -> s"`spark_catalog`.`delta`.`$tempPath`",
+        "table" -> qualifiedErrorTableName,
         "fieldName" -> "`a`"
       ),
       context = ExpectedContext(
@@ -100,12 +103,12 @@ trait TypeWideningAlterTableNestedTests {
 
   test("type widening with ALTER TABLE on nested fields") {
     createNestedTable()
-    sql(s"ALTER TABLE delta.`$tempPath` CHANGE COLUMN s.a TYPE short")
-    sql(s"ALTER TABLE delta.`$tempPath` CHANGE COLUMN m.key TYPE int")
-    sql(s"ALTER TABLE delta.`$tempPath` CHANGE COLUMN m.value TYPE int")
-    sql(s"ALTER TABLE delta.`$tempPath` CHANGE COLUMN a.element TYPE int")
+    sql(s"ALTER TABLE $tableSQLIdentifier CHANGE COLUMN s.a TYPE short")
+    sql(s"ALTER TABLE $tableSQLIdentifier CHANGE COLUMN m.key TYPE int")
+    sql(s"ALTER TABLE $tableSQLIdentifier CHANGE COLUMN m.value TYPE int")
+    sql(s"ALTER TABLE $tableSQLIdentifier CHANGE COLUMN a.element TYPE int")
 
-    assert(readDeltaTable(tempPath).schema === new StructType()
+    assert(readDeltaTableByIdentifier().schema === new StructType()
       .add("s", new StructType()
         .add("a", ShortType))
       .add("m", MapType(IntegerType, IntegerType))
@@ -116,7 +119,7 @@ trait TypeWideningAlterTableNestedTests {
         .selectExpr("named_struct('a', cast(a as short)) as s", "map(b, c) as m", "array(d) as a"))
 
     checkAnswer(
-      readDeltaTable(tempPath),
+      readDeltaTableByIdentifier(),
       Seq((1, 2, 3, 4), (5, 6, 7, 8))
         .toDF("a", "b", "c", "d")
         .selectExpr("named_struct('a', cast(a as short)) as s", "map(b, c) as m", "array(d) as a"))
@@ -124,9 +127,9 @@ trait TypeWideningAlterTableNestedTests {
 
   test("type widening using ALTER TABLE REPLACE COLUMNS on nested fields") {
     createNestedTable()
-    sql(s"ALTER TABLE delta.`$tempPath` REPLACE COLUMNS " +
+    sql(s"ALTER TABLE $tableSQLIdentifier REPLACE COLUMNS " +
       "(s struct<a: short>, m map<int, int>, a array<int>)")
-    assert(readDeltaTable(tempPath).schema === new StructType()
+    assert(readDeltaTableByIdentifier().schema === new StructType()
       .add("s", new StructType()
         .add("a", ShortType))
       .add("m", MapType(IntegerType, IntegerType))
@@ -137,7 +140,7 @@ trait TypeWideningAlterTableNestedTests {
         .selectExpr("named_struct('a', cast(a as short)) as s", "map(b, c) as m", "array(d) as a"))
 
     checkAnswer(
-      readDeltaTable(tempPath),
+      readDeltaTableByIdentifier(),
       Seq((1, 2, 3, 4), (5, 6, 7, 8))
         .toDF("a", "b", "c", "d")
         .selectExpr("named_struct('a', cast(a as short)) as s", "map(b, c) as m", "array(d) as a"))

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningAlterTableSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningAlterTableSuite.scala
@@ -35,6 +35,7 @@ class TypeWideningAlterTableSuite
   extends TypeWideningAlterTableTests
     with ParquetTest
     with TypeWideningTestMixin
+    with DeltaDMLTestUtilsNameBased
 
 trait TypeWideningAlterTableTests extends QueryTest
     with QueryErrorsBase
@@ -57,11 +58,11 @@ trait TypeWideningAlterTableTests extends QueryTest
       }
 
       writeData(testCase.initialValuesDF)
-      sql(s"ALTER TABLE delta.`$tempPath` CHANGE COLUMN value TYPE ${testCase.toType.sql}")
+      sql(s"ALTER TABLE $tableSQLIdentifier CHANGE COLUMN value TYPE ${testCase.toType.sql}")
       withAllParquetReaders {
-        assert(readDeltaTable(tempPath).schema("value").dataType === testCase.toType)
+        assert(readDeltaTableByIdentifier().schema("value").dataType === testCase.toType)
         checkAnswerWithTolerance(
-          actualDf = readDeltaTable(tempPath).select("value"),
+          actualDf = readDeltaTableByIdentifier().select("value"),
           expectedDf = testCase.initialValuesDF.select($"value".cast(testCase.toType)),
           toType = testCase.toType
         )
@@ -69,7 +70,7 @@ trait TypeWideningAlterTableTests extends QueryTest
       writeData(testCase.additionalValuesDF)
       withAllParquetReaders {
         checkAnswerWithTolerance(
-          actualDf = readDeltaTable(tempPath).select("value"),
+          actualDf = readDeltaTableByIdentifier().select("value"),
           expectedDf = testCase.expectedResult.select($"value".cast(testCase.toType)),
           toType = testCase.toType
         )
@@ -91,7 +92,7 @@ trait TypeWideningAlterTableTests extends QueryTest
       }
 
       val alterTableSql =
-        s"ALTER TABLE delta.`$tempPath` CHANGE COLUMN value TYPE ${testCase.toType.sql}"
+        s"ALTER TABLE $tableSQLIdentifier CHANGE COLUMN value TYPE ${testCase.toType.sql}"
 
       // Type changes that aren't upcast are rejected early during analysis by Spark, while upcasts
       // are rejected in Delta when the ALTER TABLE command is executed.
@@ -115,7 +116,7 @@ trait TypeWideningAlterTableTests extends QueryTest
           "NOT_SUPPORTED_CHANGE_COLUMN",
           sqlState = None,
           parameters = Map(
-            "table" -> s"`spark_catalog`.`delta`.`$tempPath`",
+            "table" -> qualifiedErrorTableName,
             "originName" -> toSQLId("value"),
             "originType" -> toSQLType(testCase.fromType),
             "newName" -> toSQLId("value"),
@@ -131,12 +132,12 @@ trait TypeWideningAlterTableTests extends QueryTest
 
   test("type widening using ALTER TABLE REPLACE COLUMNS") {
     append(Seq(1, 2).toDF("value").select($"value".cast(ShortType)))
-    assert(readDeltaTable(tempPath).schema === new StructType().add("value", ShortType))
-    sql(s"ALTER TABLE delta.`$tempPath` REPLACE COLUMNS (value INT)")
-    assert(readDeltaTable(tempPath).schema === new StructType().add("value", IntegerType))
-    checkAnswer(readDeltaTable(tempPath), Seq(Row(1), Row(2)))
+    assert(readDeltaTableByIdentifier().schema === new StructType().add("value", ShortType))
+    sql(s"ALTER TABLE $tableSQLIdentifier REPLACE COLUMNS (value INT)")
+    assert(readDeltaTableByIdentifier().schema === new StructType().add("value", IntegerType))
+    checkAnswer(readDeltaTableByIdentifier(), Seq(Row(1), Row(2)))
     append(Seq(3, 4).toDF("value"))
-    checkAnswer(readDeltaTable(tempPath), Seq(Row(1), Row(2), Row(3), Row(4)))
+    checkAnswer(readDeltaTableByIdentifier(), Seq(Row(1), Row(2), Row(3), Row(4)))
   }
 
   def withTimestampNTZDisabled(f: => Unit): Unit = {
@@ -156,7 +157,7 @@ trait TypeWideningAlterTableTests extends QueryTest
   test(
     "widening Date -> TimestampNTZ rejected when TimestampNTZ feature isn't supported") {
     withTimestampNTZDisabled {
-      sql(s"CREATE TABLE delta.`$tempPath` (a date) USING DELTA")
+      sql(s"CREATE TABLE $tableSQLIdentifier (a date) USING DELTA")
       val currentProtocol = deltaLog.unsafeVolatileSnapshot.protocol
       val currentFeatures = currentProtocol.implicitlyAndExplicitlySupportedFeatures
         .map(_.name)
@@ -166,7 +167,7 @@ trait TypeWideningAlterTableTests extends QueryTest
 
       checkError(
         intercept[DeltaTableFeatureException] {
-          sql(s"ALTER TABLE delta.`$tempPath` CHANGE COLUMN a TYPE TIMESTAMP_NTZ")
+          sql(s"ALTER TABLE $tableSQLIdentifier CHANGE COLUMN a TYPE TIMESTAMP_NTZ")
         },
         "DELTA_FEATURES_REQUIRE_MANUAL_ENABLEMENT",
         parameters = Map(
@@ -178,9 +179,9 @@ trait TypeWideningAlterTableTests extends QueryTest
   }
 
   test("type widening type change metrics") {
-    sql(s"CREATE TABLE delta.`$tempDir` (a byte) USING DELTA")
+    sql(s"CREATE TABLE $tableSQLIdentifier (a byte) USING DELTA")
     val usageLogs = Log4jUsageLogger.track {
-      sql(s"ALTER TABLE delta.`$tempDir` CHANGE COLUMN a TYPE int")
+      sql(s"ALTER TABLE $tableSQLIdentifier CHANGE COLUMN a TYPE int")
     }
 
     val metrics = filterUsageRecords(usageLogs, "delta.typeWidening.typeChanges")
@@ -199,11 +200,11 @@ trait TypeWideningAlterTableTests extends QueryTest
     val dataWithUDT =
       (1 to 10).map(x => Tuple2(x.toByte, new TestUDT.MyDenseVector(Array(x*0.5, x*2.0))))
     append(dataWithUDT.toDF("a", "udt"))
-    sql(s"ALTER TABLE delta.`$tempDir` CHANGE COLUMN a TYPE int")
+    sql(s"ALTER TABLE $tableSQLIdentifier CHANGE COLUMN a TYPE int")
   }
 
   test("type widening with null type in table") {
-    sql(s"CREATE TABLE delta.`$tempDir` (a byte, n VOID) USING DELTA")
-    sql(s"ALTER TABLE delta.`$tempDir` CHANGE COLUMN a TYPE int")
+    sql(s"CREATE TABLE $tableSQLIdentifier (a byte, n VOID) USING DELTA")
+    sql(s"ALTER TABLE $tableSQLIdentifier CHANGE COLUMN a TYPE int")
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningConstraintsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningConstraintsSuite.scala
@@ -17,6 +17,7 @@
 package org.apache.spark.sql.delta.typewidening
 
 import org.apache.spark.sql.delta.DeltaAnalysisException
+import org.apache.spark.sql.delta.DeltaDMLTestUtilsNameBased
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 
 import org.apache.spark.sql.{QueryTest, Row}
@@ -30,6 +31,7 @@ import org.apache.spark.sql.types._
 class TypeWideningConstraintsSuite
   extends QueryTest
     with TypeWideningTestMixin
+    with DeltaDMLTestUtilsNameBased
     with TypeWideningConstraintsTests
 
 trait TypeWideningConstraintsTests { self: QueryTest with TypeWideningTestMixin =>

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningGeneratedColumnsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningGeneratedColumnsSuite.scala
@@ -29,6 +29,7 @@ import org.apache.spark.sql.types._
 class TypeWideningGeneratedColumnsSuite
   extends QueryTest
     with TypeWideningTestMixin
+    with DeltaDMLTestUtilsNameBased
     with GeneratedColumnTest
     with TypeWideningGeneratedColumnTests
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningInsertSchemaEvolutionBasicSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningInsertSchemaEvolutionBasicSuite.scala
@@ -38,8 +38,8 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap
  */
 class TypeWideningInsertSchemaEvolutionBasicSuite
     extends QueryTest
-    with DeltaDMLTestUtils
     with TypeWideningTestMixin
+    with DeltaDMLTestUtilsNameBased
     with TypeWideningInsertSchemaEvolutionBasicTests {
 
   protected override def sparkConf: SparkConf = {
@@ -72,12 +72,12 @@ trait TypeWideningInsertSchemaEvolutionBasicTests
           .format("delta")
           .mode("append")
           .option("mergeSchema", "true")
-          .insertInto(s"delta.`$tempPath`")
+          .insertInto(tableSQLIdentifier)
       }
 
-      assert(readDeltaTable(tempPath).schema("value").dataType === testCase.toType)
+      assert(readDeltaTableByIdentifier().schema("value").dataType === testCase.toType)
       checkAnswerWithTolerance(
-        actualDf = readDeltaTable(tempPath).select("value"),
+        actualDf = readDeltaTableByIdentifier().select("value"),
         expectedDf = testCase.expectedResult.select($"value".cast(testCase.toType)),
         toType = testCase.toType
       )
@@ -98,10 +98,10 @@ trait TypeWideningInsertSchemaEvolutionBasicTests
           .format("delta")
           .mode("append")
           .option("mergeSchema", "true")
-          .insertInto(s"delta.`$tempPath`")
+          .insertInto(tableSQLIdentifier)
       }
 
-      assert(readDeltaTable(tempPath).schema("value").dataType === testCase.fromType)
+      assert(readDeltaTableByIdentifier().schema("value").dataType === testCase.fromType)
     }
   }
 
@@ -119,11 +119,11 @@ trait TypeWideningInsertSchemaEvolutionBasicTests
         .format("delta")
         .mode("append")
         .option("mergeSchema", "true")
-        .insertInto(s"delta.`$tempPath`")
+        .insertInto(tableSQLIdentifier)
       }
     }
 
-    assert(readDeltaTable(tempPath).schema("value").dataType === testCase.fromType)
+    assert(readDeltaTableByIdentifier().schema("value").dataType === testCase.fromType)
     assert(events.exists(event => event.metric == "tahoeEvent" &&
       event.tags.get("opType") == Option("delta.typeWidening.missedAutomaticWidening")))
   }
@@ -139,11 +139,11 @@ trait TypeWideningInsertSchemaEvolutionBasicTests
         .format("delta")
         .mode("append")
         .option("mergeSchema", "true")
-        .insertInto(s"delta.`$tempPath`")
+        .insertInto(tableSQLIdentifier)
       }
     }
 
-    assert(readDeltaTable(tempPath).schema("value").dataType === testCase.toType)
+    assert(readDeltaTableByIdentifier().schema("value").dataType === testCase.toType)
     assert(!events.exists(event => event.metric == "tahoeEvent" &&
       event.tags.get("opType") == Option("delta.typeWidening.missedAutomaticWidening")))
   }
@@ -156,11 +156,11 @@ trait TypeWideningInsertSchemaEvolutionBasicTests
       testCase.additionalValuesDF
         .write
         .mode("append")
-        .insertInto(s"delta.`$tempPath`")
+        .insertInto(tableSQLIdentifier)
 
-      assert(readDeltaTable(tempPath).schema("value").dataType === testCase.toType)
+      assert(readDeltaTableByIdentifier().schema("value").dataType === testCase.toType)
       checkAnswerWithTolerance(
-        actualDf = readDeltaTable(tempPath).select("value"),
+        actualDf = readDeltaTableByIdentifier().select("value"),
         expectedDf = testCase.expectedResult.select($"value".cast(testCase.toType)),
         toType = testCase.toType
       )
@@ -179,36 +179,36 @@ trait TypeWideningInsertSchemaEvolutionBasicTests
       // that the table schema didn't evolve.
       withSQLConf(SQLConf.STORE_ASSIGNMENT_POLICY.key -> StoreAssignmentPolicy.LEGACY.toString) {
         testCase.additionalValuesDF.write.mode("append")
-          .insertInto(s"delta.`$tempPath`")
-        assert(readDeltaTable(tempPath).schema("value").dataType === testCase.fromType)
+          .insertInto(tableSQLIdentifier)
+        assert(readDeltaTableByIdentifier().schema("value").dataType === testCase.fromType)
       }
     }
   }
 
   test("INSERT - type widening isn't applied when schema evolution is disabled") {
-    sql(s"CREATE TABLE delta.`$tempPath` (a short) USING DELTA")
+    sql(s"CREATE TABLE $tableSQLIdentifier (a short) USING DELTA")
     withSQLConf(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> "false") {
       // Insert integer values. This should succeed and downcast the values to short.
-      sql(s"INSERT INTO delta.`$tempPath` VALUES (1), (2)")
-      assert(readDeltaTable(tempPath).schema("a").dataType === ShortType)
-      checkAnswer(readDeltaTable(tempPath),
+      sql(s"INSERT INTO $tableSQLIdentifier VALUES (1), (2)")
+      assert(readDeltaTableByIdentifier().schema("a").dataType === ShortType)
+      checkAnswer(readDeltaTableByIdentifier(),
         Seq(1, 2).toDF("a").select($"a".cast(ShortType)))
     }
 
     // Check that we would actually widen if schema evolution was enabled.
     withSQLConf(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> "true") {
-      sql(s"INSERT INTO delta.`$tempPath` VALUES (3), (4)")
-      assert(readDeltaTable(tempPath).schema("a").dataType === IntegerType)
-      checkAnswer(readDeltaTable(tempPath), Seq(1, 2, 3, 4).toDF("a"))
+      sql(s"INSERT INTO $tableSQLIdentifier VALUES (3), (4)")
+      assert(readDeltaTableByIdentifier().schema("a").dataType === IntegerType)
+      checkAnswer(readDeltaTableByIdentifier(), Seq(1, 2, 3, 4).toDF("a"))
     }
   }
 
   test("INSERT - type widening isn't applied when it's disabled") {
-    sql(s"CREATE TABLE delta.`$tempPath` (a short) USING DELTA")
-    enableTypeWidening(tempPath, enabled = false)
-    sql(s"INSERT INTO delta.`$tempPath` VALUES (1), (2)")
-    assert(readDeltaTable(tempPath).schema("a").dataType === ShortType)
-    checkAnswer(readDeltaTable(tempPath),
+    sql(s"CREATE TABLE $tableSQLIdentifier (a short) USING DELTA")
+    enableTypeWidening(enabled = false)
+    sql(s"INSERT INTO $tableSQLIdentifier VALUES (1), (2)")
+    assert(readDeltaTableByIdentifier().schema("a").dataType === ShortType)
+    checkAnswer(readDeltaTableByIdentifier(),
       Seq(1, 2).toDF("a").select($"a".cast(ShortType)))
   }
 
@@ -244,27 +244,29 @@ trait TypeWideningInsertSchemaEvolutionBasicTests
     AppendData.byPosition(relation, df.queryExecution.logical)
   }
 
-  test(s"INSERT - fail if type widening gets enabled by a concurrent transaction") {
-    sql(s"CREATE TABLE delta.`$tempPath` (a short) USING DELTA")
-    enableTypeWidening(tempPath, enabled = false)
+  test(s"INSERT - fail if type widening gets enabled by a concurrent transaction",
+      NameBasedAccessIncompatible) {
+    sql(s"CREATE TABLE $tableSQLIdentifier (a short) USING DELTA")
+    enableTypeWidening(enabled = false)
     val insert = createInsertPlan(Seq(1).toDF("a"))
     // Enabling type widening after analysis doesn't impact the insert operation: the data is
     // already cast to conform to the current schema.
-    enableTypeWidening(tempPath, enabled = true)
+    enableTypeWidening(enabled = true)
     DataFrameUtils.ofRows(spark, insert).collect()
-    assert(readDeltaTable(tempPath).schema == new StructType().add("a", ShortType))
-    checkAnswer(readDeltaTable(tempPath), Row(1))
+    assert(readDeltaTableByIdentifier().schema == new StructType().add("a", ShortType))
+    checkAnswer(readDeltaTableByIdentifier(), Row(1))
   }
 
-  test(s"INSERT - fail if type widening gets disabled by a concurrent transaction") {
-    sql(s"CREATE TABLE delta.`$tempPath` (a short) USING DELTA")
+  test(s"INSERT - fail if type widening gets disabled by a concurrent transaction",
+      NameBasedAccessIncompatible) {
+    sql(s"CREATE TABLE $tableSQLIdentifier (a short) USING DELTA")
     val insert = createInsertPlan(Seq(1).toDF("a"))
     // Disabling type widening after analysis results in inserting data with a wider type into the
     // table while type widening is actually disabled during execution. We do actually widen the
     // table schema in that case because `short` and `int` are both stored as INT32 in parquet.
-    enableTypeWidening(tempPath, enabled = false)
+    enableTypeWidening(enabled = false)
     DataFrameUtils.ofRows(spark, insert).collect()
-    assert(readDeltaTable(tempPath).schema == new StructType().add("a", IntegerType))
-    checkAnswer(readDeltaTable(tempPath), Row(1))
+    assert(readDeltaTableByIdentifier().schema == new StructType().add("a", IntegerType))
+    checkAnswer(readDeltaTableByIdentifier(), Row(1))
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningInsertSchemaEvolutionExtendedSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningInsertSchemaEvolutionExtendedSuite.scala
@@ -25,10 +25,9 @@ import org.apache.spark.sql.types._
 
 class TypeWideningInsertSchemaEvolutionExtendedSuite
   extends QueryTest
-  with DeltaDMLTestUtils
   with TypeWideningTestMixin
-  with TypeWideningInsertSchemaEvolutionExtendedTests {
-}
+  with DeltaDMLTestUtilsNameBased
+  with TypeWideningInsertSchemaEvolutionExtendedTests
 
 trait TypeWideningInsertSchemaEvolutionExtendedTests
   extends DeltaInsertIntoTest

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningMergeIntoSchemaEvolutionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningMergeIntoSchemaEvolutionSuite.scala
@@ -31,8 +31,8 @@ import org.apache.spark.sql.types._
  */
 class TypeWideningMergeIntoSchemaEvolutionSuite
     extends TypeWideningMergeIntoSchemaEvolutionTests
-    with DeltaDMLTestUtils
-    with TypeWideningTestMixin {
+    with TypeWideningTestMixin
+    with DeltaDMLTestUtilsNameBased {
 
   protected override def sparkConf: SparkConf = {
     super.sparkConf
@@ -53,20 +53,20 @@ trait TypeWideningMergeIntoSchemaEvolutionTests extends QueryTest
 
   test(s"MERGE - always automatic type widening TINYINT -> DOUBLE") {
     withTable("source") {
-      sql(s"CREATE TABLE delta.`$tempPath` (a short) USING DELTA")
+      sql(s"CREATE TABLE $tableSQLIdentifier (a short) USING DELTA")
       sql("CREATE TABLE source (a double) USING DELTA")
       sql("INSERT INTO source VALUES (3.0), (-10.5)")
 
       withSQLConf(DeltaSQLConf.DELTA_ALLOW_AUTOMATIC_WIDENING.key -> "always") {
         // Merge double values. This should succeed and widen the short column to double.
         executeMerge(
-          tgt = s"delta.`$tempPath` t",
+          tgt = s"$tableSQLIdentifier t",
           src = "source",
           cond = "0 = 1",
           clauses = insert("*")
         )
-        assert(readDeltaTable(tempPath).schema("a").dataType === DoubleType)
-        checkAnswer(readDeltaTable(tempPath),
+        assert(readDeltaTableByIdentifier().schema("a").dataType === DoubleType)
+        checkAnswer(readDeltaTableByIdentifier(),
           Seq(3.0, -10.5).toDF("a"))
       }
     }
@@ -74,7 +74,7 @@ trait TypeWideningMergeIntoSchemaEvolutionTests extends QueryTest
 
   test(s"MERGE - never automatic type widening TINYINT -> INT") {
     withTable("source") {
-      sql(s"CREATE TABLE delta.`$tempPath` (a short) USING DELTA")
+      sql(s"CREATE TABLE $tableSQLIdentifier (a short) USING DELTA")
       sql("CREATE TABLE source (a int) USING DELTA")
       sql("INSERT INTO source VALUES (1), (2)")
 
@@ -82,12 +82,12 @@ trait TypeWideningMergeIntoSchemaEvolutionTests extends QueryTest
         SQLConf.STORE_ASSIGNMENT_POLICY.key -> StoreAssignmentPolicy.LEGACY.toString) {
         // Merge int values into short column. This should not widen the target schema.
         executeMerge(
-          tgt = s"delta.`$tempPath` t",
+          tgt = s"$tableSQLIdentifier t",
           src = "source",
           cond = "0 = 1",
           clauses = insert("*")
         )
-        assert(readDeltaTable(tempPath).schema("a").dataType === ShortType)
+        assert(readDeltaTableByIdentifier().schema("a").dataType === ShortType)
       }
     }
   }
@@ -103,14 +103,14 @@ trait TypeWideningMergeIntoSchemaEvolutionTests extends QueryTest
         // We mainly want to ensure type widening is correctly applied to the schema. We use a
         // trivial insert only merge to make it easier to validate results.
         executeMerge(
-          tgt = s"delta.`$tempPath` t",
+          tgt = s"$tableSQLIdentifier t",
           src = "source",
           cond = "0 = 1",
           clauses = insert("*"))
 
-        assert(readDeltaTable(tempPath).schema("value").dataType === testCase.toType)
+        assert(readDeltaTableByIdentifier().schema("value").dataType === testCase.toType)
         checkAnswerWithTolerance(
-          actualDf = readDeltaTable(tempPath).select("value"),
+          actualDf = readDeltaTableByIdentifier().select("value"),
           expectedDf = testCase.expectedResult.select($"value".cast(testCase.toType)),
           toType = testCase.toType
         )
@@ -133,11 +133,11 @@ trait TypeWideningMergeIntoSchemaEvolutionTests extends QueryTest
         // that the table schema didn't evolve.
         withSQLConf(SQLConf.STORE_ASSIGNMENT_POLICY.key -> StoreAssignmentPolicy.LEGACY.toString) {
           executeMerge(
-            tgt = s"delta.`$tempPath` t",
+            tgt = s"$tableSQLIdentifier t",
             src = "source",
             cond = "0 = 1",
             clauses = insert("*"))
-          assert(readDeltaTable(tempPath).schema("value").dataType === testCase.fromType)
+          assert(readDeltaTableByIdentifier().schema("value").dataType === testCase.fromType)
         }
       }
     }
@@ -145,20 +145,20 @@ trait TypeWideningMergeIntoSchemaEvolutionTests extends QueryTest
 
   test("MERGE - type widening isn't applied when it's disabled") {
     withTable("source") {
-      sql(s"CREATE TABLE delta.`$tempPath` (a short) USING DELTA")
+      sql(s"CREATE TABLE $tableSQLIdentifier (a short) USING DELTA")
       sql("CREATE TABLE source (a int) USING DELTA")
       sql("INSERT INTO source VALUES (1), (2)")
-      enableTypeWidening(tempPath, enabled = false)
+      enableTypeWidening(enabled = false)
       withSQLConf(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> "true") {
         // Merge integer values. This should succeed and downcast the values to short.
         executeMerge(
-          tgt = s"delta.`$tempPath` t",
+          tgt = s"$tableSQLIdentifier t",
           src = "source",
           cond = "0 = 1",
           clauses = insert("*")
         )
-        assert(readDeltaTable(tempPath).schema("a").dataType === ShortType)
-        checkAnswer(readDeltaTable(tempPath),
+        assert(readDeltaTableByIdentifier().schema("a").dataType === ShortType)
+        checkAnswer(readDeltaTableByIdentifier(),
           Seq(1, 2).toDF("a").select($"a".cast(ShortType)))
       }
     }
@@ -166,33 +166,33 @@ trait TypeWideningMergeIntoSchemaEvolutionTests extends QueryTest
 
   test("MERGE - type widening isn't applied when schema evolution is disabled") {
     withTable("source") {
-      sql(s"CREATE TABLE delta.`$tempPath` (a short) USING DELTA")
+      sql(s"CREATE TABLE $tableSQLIdentifier (a short) USING DELTA")
       sql("CREATE TABLE source (a int) USING DELTA")
       sql("INSERT INTO source VALUES (1), (2)")
 
       withSQLConf(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> "false") {
         // Merge integer values. This should succeed and downcast the values to short.
         executeMerge(
-          tgt = s"delta.`$tempPath` t",
+          tgt = s"$tableSQLIdentifier t",
           src = "source",
           cond = "0 = 1",
           clauses = insert("*")
         )
-        assert(readDeltaTable(tempPath).schema("a").dataType === ShortType)
-        checkAnswer(readDeltaTable(tempPath),
+        assert(readDeltaTableByIdentifier().schema("a").dataType === ShortType)
+        checkAnswer(readDeltaTableByIdentifier(),
           Seq(1, 2).toDF("a").select($"a".cast(ShortType)))
       }
 
       // Check that we would actually widen if schema evolution was enabled.
       withSQLConf(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> "true") {
         executeMerge(
-          tgt = s"delta.`$tempPath` t",
+          tgt = s"$tableSQLIdentifier t",
           src = "source",
           cond = "0 = 1",
           clauses = insert("*")
         )
-        assert(readDeltaTable(tempPath).schema("a").dataType === IntegerType)
-        checkAnswer(readDeltaTable(tempPath), Seq(1, 2, 1, 2).toDF("a"))
+        assert(readDeltaTableByIdentifier().schema("a").dataType === IntegerType)
+        checkAnswer(readDeltaTableByIdentifier(), Seq(1, 2, 1, 2).toDF("a"))
       }
     }
   }
@@ -355,9 +355,9 @@ trait TypeWideningMergeIntoSchemaEvolutionTests extends QueryTest
 
   for (enabled <- BOOLEAN_DOMAIN)
   test(s"MERGE - fail if type widening gets ${if (enabled) "enabled" else "disabled"} by a " +
-    "concurrent transaction") {
-    sql(s"CREATE TABLE delta.`$tempPath` (a short) USING DELTA")
-    enableTypeWidening(tempPath, !enabled)
+    "concurrent transaction", NameBasedAccessIncompatible) {
+    sql(s"CREATE TABLE $tableSQLIdentifier (a short) USING DELTA")
+    enableTypeWidening(enabled = !enabled)
     val target = io.delta.tables.DeltaTable.forPath(tempPath)
     import testImplicits._
     val merge = target.as("target")
@@ -368,7 +368,7 @@ trait TypeWideningMergeIntoSchemaEvolutionTests extends QueryTest
 
     // The MERGE operation was created with the previous type widening value, which will apply
     // during analysis. Toggle type widening so that the actual MERGE runs with a different setting.
-    enableTypeWidening(tempPath, enabled)
+    enableTypeWidening(enabled = enabled)
     intercept[MetadataChangedException] {
       merge.execute()
     }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningTableFeatureSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningTableFeatureSuite.scala
@@ -52,7 +52,7 @@ trait TypeWideningTableFeatureEnablementTests extends QueryTest
       s"TBLPROPERTIES ('${DeltaConfigs.ENABLE_TYPE_WIDENING.key}' = 'true')")
     assert(isTypeWideningSupported)
     assert(isTypeWideningEnabled)
-    enableTypeWidening(tempPath, enabled = false)
+    enableTypeWidening(enabled = false)
     assert(isTypeWideningSupported)
     assert(!isTypeWideningEnabled)
   }
@@ -63,14 +63,14 @@ trait TypeWideningTableFeatureEnablementTests extends QueryTest
     assert(!isTypeWideningSupported)
     assert(!isTypeWideningEnabled)
     // Setting the property to false shouldn't add the table feature if it's not present.
-    enableTypeWidening(tempPath, enabled = false)
+    enableTypeWidening(enabled = false)
     assert(!isTypeWideningSupported)
     assert(!isTypeWideningEnabled)
 
-    enableTypeWidening(tempPath)
+    enableTypeWidening()
     assert(isTypeWideningSupported)
     assert(isTypeWideningEnabled)
-    enableTypeWidening(tempPath, enabled = false)
+    enableTypeWidening(enabled = false)
     assert(isTypeWideningSupported)
     assert(!isTypeWideningEnabled)
   }
@@ -134,9 +134,9 @@ trait TypeWideningTableFeatureEnablementTests extends QueryTest
     sql(s"CREATE TABLE delta.`$tempPath` (a int) USING DELTA " +
       s"TBLPROPERTIES ('${DeltaConfigs.ENABLE_TYPE_WIDENING.key}' = 'false')")
     sql(s"ALTER TABLE delta.`$tempPath` CHANGE COLUMN a TYPE INT")
-    enableTypeWidening(tempPath, enabled = true)
+    enableTypeWidening(enabled = true)
     sql(s"ALTER TABLE delta.`$tempPath` CHANGE COLUMN a TYPE INT")
-    enableTypeWidening(tempPath, enabled = false)
+    enableTypeWidening(enabled = false)
     sql(s"ALTER TABLE delta.`$tempPath` CHANGE COLUMN a TYPE INT")
   }
 }
@@ -222,7 +222,7 @@ trait TypeWideningTableFeatureDropTests
       sql(s"CREATE TABLE delta.`$tempPath` (a byte) USING DELTA " +
         s"TBLPROPERTIES ('${DeltaConfigs.ENABLE_TYPE_WIDENING.key}' = 'false')")
       addSingleFile(Seq(1, 2, 3), ByteType)
-      enableTypeWidening(tempPath)
+      enableTypeWidening()
       sql(s"ALTER TABLE delta.`$tempPath` CHANGE COLUMN a TYPE int")
 
       dropTableFeature(
@@ -731,7 +731,7 @@ trait TypeWideningTableFeatureVersionTests extends QueryTest
     addTableFeature(tempPath, TypeWideningPreviewTableFeature)
     assertFeatureSupported(preview = true, stable = true)
 
-    enableTypeWidening(tempPath)
+    enableTypeWidening()
     addSingleFile(Seq(1), ByteType)
     sql(s"ALTER TABLE delta.`$tempPath` CHANGE COLUMN a TYPE int")
     // Dropping the stable feature doesn't also drop the preview feature.
@@ -772,7 +772,7 @@ trait TypeWideningTableFeatureVersionTests extends QueryTest
     assertFeatureSupported(preview = true, stable = false)
 
     // Enable the table property, this should keep the preview feature but not add the stable one.
-    enableTypeWidening(tempPath)
+    enableTypeWidening()
     assertFeatureSupported(preview = true, stable = false)
 
     addSingleFile(Seq(1), ByteType)
@@ -808,7 +808,7 @@ trait TypeWideningTableFeatureVersionTests extends QueryTest
       s"TBLPROPERTIES ('${DeltaConfigs.ENABLE_TYPE_WIDENING.key}' = 'false')")
 
     addTableFeature(tempPath, TypeWideningPreviewTableFeature)
-    enableTypeWidening(tempPath)
+    enableTypeWidening()
     addSingleFile(Seq(1), ByteType)
     sql(s"ALTER TABLE delta.`$tempPath` CHANGE COLUMN a TYPE short")
 
@@ -847,7 +847,7 @@ trait TypeWideningTableFeatureVersionTests extends QueryTest
       s"TBLPROPERTIES ('${DeltaConfigs.ENABLE_TYPE_WIDENING.key}' = 'false')")
 
     addTableFeature(tempPath, TypeWideningTableFeature)
-    enableTypeWidening(tempPath)
+    enableTypeWidening()
     addSingleFile(Seq(1), ByteType)
     sql(s"ALTER TABLE delta.`$tempPath` CHANGE COLUMN a TYPE short")
     assert(deltaLog.update().metadata.schema === new StructType()

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningTestMixin.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningTestMixin.scala
@@ -58,9 +58,15 @@ trait TypeWideningTestMixin
       .set(DeltaSQLConf.FAST_DROP_FEATURE_ENABLED.key, false.toString)
   }
 
-  /** Enable (or disable) type widening for the table under the given path. */
-  protected def enableTypeWidening(tablePath: String, enabled: Boolean = true): Unit =
-    sql(s"ALTER TABLE delta.`$tablePath` " +
+  /**
+   * Enable (or disable) type widening for the table under test. `table` defaults to the table under
+   * test ([[tableSQLIdentifier]]) so the same test body works with both path-based and name-based
+   * access; callers may pass an explicit identifier to target a different table.
+   */
+  protected def enableTypeWidening(
+      table: String = tableSQLIdentifier,
+      enabled: Boolean = true): Unit =
+    sql(s"ALTER TABLE $table " +
           s"SET TBLPROPERTIES('${DeltaConfigs.ENABLE_TYPE_WIDENING.key}' = '${enabled.toString}')")
 
   /** Whether the test table supports the type widening table feature. */


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other

## Description
Refactor to remove direct dependency on path-based access in type widening tests - typically use tableSQLIdentifier instead of delta.<path> - and use name-based access rather than path-based.

Motivation:
- Unblocks integrating with DSv2 earlier - DSv2 doesn't support path-based writes yet.
- Name-based access is the more common pattern rather than path-based

This is a test-only refactor with no changes to production code.

## How was this patch tested?
Existing type widening test suites continue to pass with the refactored name-based access.

## Does this PR introduce _any_ user-facing changes?
No.
