### PR TITLE
fix: [Kernel] Fix Pagination Log Segment Validation for Staged Commit File Renames

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/LogSegment.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/LogSegment.java
@@ -418,8 +418,19 @@ public class LogSegment {
 
   @Override
   public int hashCode() {
-    // TODO: support staged commits #4927
-    return Objects.hash(deltas, checkpoints, compactions);
+    // Use version numbers of log files instead of their full paths for hash computation
+    // so that staged commit file renames (e.g., 9.uuid.json -> 9.json) don't change the hash.
+    // This is required for pagination log segment validation (issue #4927).
+    List<Long> deltaVersions = deltas.stream()
+        .map(fs -> FileNames.deltaVersion(fs.getPath()))
+        .collect(Collectors.toList());
+    List<Long> checkpointVersions = checkpoints.stream()
+        .map(fs -> FileNames.checkpointVersion(fs.getPath()))
+        .collect(Collectors.toList());
+    List<Tuple2<Long, Long>> compactionRanges = compactions.stream()
+        .map(fs -> FileNames.logCompactionVersions(fs.getPath()))
+        .collect(Collectors.toList());
+    return Objects.hash(deltaVersions, checkpointVersions, compactionRanges);
   }
 
   //////////////////////////////


### PR DESCRIPTION
Fixes #4927

When paginating through the commit log, staged commit file renames (e.g., `9.uuid.json` → `9.json`) were incorrectly treated as log segment changes. This happened because `LogSegment.hashCode()` included the full file paths in its hash computation. When the same commit version had a different filename (staged vs committed), the hash changed, causing pagination validation to reject the request.

**The Fix:**
- Changed `LogSegment.hashCode()` to extract numeric version numbers from filenames before hashing, instead of using the full file paths
- This means `9.uuid.json` and `9.json` (both representing version 9) will produce the same hash
- Pagination validation now correctly allows staged/committed file name transitions

**Implementation details:**
- For delta files: uses `FileNames.deltaVersion()` to extract the numeric version from the path
- For checkpoint files: uses `FileNames.checkpointVersion()`
- For compaction files: uses `FileNames.logCompactionVersions()` to extract start/end versions
- No behavior change for non-staged scenarios (versions are the same, just extracted differently)