### PR TITLE
fix: [Kernel] Remove unnecessary N.json cloud read for InCommitTimestamp value

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ProtocolMetadataLogReplay.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ProtocolMetadataLogReplay.java
@@ -31,6 +31,8 @@ import io.delta.kernel.internal.util.FileNames;
 import io.delta.kernel.types.StructType;
 import io.delta.kernel.utils.CloseableIterator;
 import io.delta.kernel.utils.FileStatus;
+import static java.util.Objects.requireNonNull;
+
 import java.io.IOException;
 import java.util.Optional;
 import org.slf4j.Logger;
@@ -50,11 +52,21 @@ public class ProtocolMetadataLogReplay {
     public final Protocol protocol;
     public final Metadata metadata;
     private final long numDeltaFilesRead;
+    private final Optional<Long> inCommitTimestampOpt;
 
-    public Result(Protocol protocol, Metadata metadata, long numDeltaFilesRead) {
+    public Result(
+        Protocol protocol,
+        Metadata metadata,
+        long numDeltaFilesRead,
+        Optional<Long> inCommitTimestampOpt) {
       this.protocol = protocol;
       this.metadata = metadata;
       this.numDeltaFilesRead = numDeltaFilesRead;
+      this.inCommitTimestampOpt = requireNonNull(inCommitTimestampOpt);
+    }
+
+    public Optional<Long> getInCommitTimestampOpt() {
+      return inCommitTimestampOpt;
     }
   }
 
@@ -108,7 +120,7 @@ public class ProtocolMetadataLogReplay {
 
         final Protocol protocol = crcInfo.get().getProtocol();
         final Metadata metadata = crcInfo.get().getMetadata();
-        return new Result(protocol, metadata, 0 /* logFilesRead */);
+        return new Result(protocol, metadata, 0 /* logFilesRead */, Optional.empty());
       }
     }
 
@@ -118,6 +130,10 @@ public class ProtocolMetadataLogReplay {
     long numDeltaFilesRead = 0;
     Protocol protocol = null;
     Metadata metadata = null;
+    // Track the timestamp from the ActionWrapper at the snapshot version's delta file.
+    // When InCommitTimestamp is enabled this contains the ICT from the CommitInfo,
+    // allowing us to avoid a separate N.json cloud read later.
+    Optional<Long> inCommitTimestampOpt = Optional.empty();
 
     try (CloseableIterator<ActionWrapper> reverseIter =
         new ActionsIterator(
@@ -132,6 +148,11 @@ public class ProtocolMetadataLogReplay {
         // Load this lazily (as needed). We may be able to just use the CRC.
         ColumnarBatch columnarBatch = null;
 
+        // If this is the snapshot version's delta file and has a timestamp (ICT), track it.
+        if (version == snapshotVersion && nextElem.getTimestamp().isPresent()) {
+          inCommitTimestampOpt = nextElem.getTimestamp();
+        }
+
         if (protocol == null) {
           columnarBatch = nextElem.getColumnarBatch();
           assert (columnarBatch.getSchema().equals(PROTOCOL_METADATA_READ_SCHEMA));
@@ -144,7 +165,8 @@ public class ProtocolMetadataLogReplay {
 
               if (metadata != null) {
                 // Stop since we have found the latest Protocol and Metadata.
-                return new Result(protocol, metadata, numDeltaFilesRead);
+                return new Result(
+                    protocol, metadata, numDeltaFilesRead, inCommitTimestampOpt);
               }
 
               break; // We just found the protocol, exit this for-loop
@@ -165,7 +187,8 @@ public class ProtocolMetadataLogReplay {
 
               if (protocol != null) {
                 // Stop since we have found the latest Protocol and Metadata.
-                return new Result(protocol, metadata, numDeltaFilesRead);
+                return new Result(
+                    protocol, metadata, numDeltaFilesRead, inCommitTimestampOpt);
               }
 
               break; // We just found the metadata, exit this for-loop
@@ -188,7 +211,8 @@ public class ProtocolMetadataLogReplay {
               metadata = crcInfo.get().getMetadata();
             }
 
-            return new Result(protocol, metadata, numDeltaFilesRead);
+            return new Result(
+                protocol, metadata, numDeltaFilesRead, inCommitTimestampOpt);
           }
         }
       }
@@ -206,7 +230,7 @@ public class ProtocolMetadataLogReplay {
           String.format("No metadata found at version %s", logSegment.getVersion()));
     }
 
-    return new Result(protocol, metadata, numDeltaFilesRead);
+    return new Result(protocol, metadata, numDeltaFilesRead, inCommitTimestampOpt);
   }
 
   private static void validateCrcInfoMatchesExpectedVersion(CRCInfo crcInfo, long expectedVersion) {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
@@ -179,7 +179,7 @@ public class SnapshotManager {
             protocolMetadataResult.metadata,
             DefaultFileSystemManagedTableOnlyCommitter.INSTANCE,
             snapshotContext,
-            Optional.empty() /* inCommitTimestampOpt */);
+            protocolMetadataResult.getInCommitTimestampOpt());
 
     return snapshot;
   }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/table/SnapshotFactory.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/table/SnapshotFactory.java
@@ -192,6 +192,7 @@ public class SnapshotFactory {
 
     Protocol protocol;
     Metadata metadata;
+    Optional<Long> inCommitTimestampOpt = Optional.empty();
 
     if (ctx.protocolAndMetadataOpt.isPresent()) {
       protocol = ctx.protocolAndMetadataOpt.get()._1;
@@ -206,6 +207,7 @@ public class SnapshotFactory {
               snapshotCtx.getSnapshotMetrics());
       protocol = result.protocol;
       metadata = result.metadata;
+      inCommitTimestampOpt = result.getInCommitTimestampOpt();
     }
 
     // We require maxCatalogVersion to be provided for catalogManaged tables. We cannot validate
@@ -224,7 +226,7 @@ public class SnapshotFactory {
         metadata,
         ctx.committerOpt.orElse(DefaultFileSystemManagedTableOnlyCommitter.INSTANCE),
         snapshotCtx,
-        Optional.empty() /* inCommitTimestampOpt */);
+        inCommitTimestampOpt);
   }
 
   private SnapshotQueryContext getSnapshotQueryContext() {


### PR DESCRIPTION
Fixes #4914

## Problem
When building a Snapshot, Kernel issues a separate cloud read to fetch `N.json` just to get the in-commit-timestamp from the CommitInfo action. This is unnecessary in ~99.99% of cases.

## Analysis
- **CRC path**: If the snapshot is built from a `.crc` file, the ICT value is already available there
- **JSON path**: If reading via delta log `.json` files, the CommitInfo action is guaranteed to be the first action in the version's N.json file. Since we already read this file to resolve the latest Protocol and Metadata, we encounter the ICT during that read.

## Fix
Captured the ICT value from `ActionWrapper.getTimestamp()` during the Protocol/Metadata resolution phase in `ProtocolMetadataLogReplay` and threaded it through `Result` → `SnapshotManager` → `SnapshotFactory` → `Snapshot` constructor, eliminating the separate N.json cloud read.

## Changes (3 files, +34/-8)
- `ProtocolMetadataLogReplay.java`: Added `inCommitTimestampOpt` to `Result`, capture from `ActionWrapper.getTimestamp()` during log replay
- `SnapshotManager.java`: Passes `protocolMetadataResult.getInCommitTimestampOpt()` instead of `Optional.empty()`
- `SnapshotFactory.java`: Passes captured ICT instead of `Optional.empty()`

This is purely an optimization — the N.json read behavior is unchanged when ICT is not enabled.