### PR TITLE
perf: [Kernel] Skip creating empty FilteredColumnarBatch in ActiveAddFilesIterator

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ActiveAddFilesIterator.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ActiveAddFilesIterator.java
@@ -277,7 +277,14 @@ public class ActiveAddFilesIterator implements CloseableIterator<FilteredColumna
                           .createSelectionVector(selectionVectorBuffer, 0, addsVector.getSize()),
                   "Create selection vector for selected scan files"));
     }
-    // TODO: skip batch if all AddFiles are unselected; issue #4941
+    // If all AddFiles in this batch are filtered out, skip creating an empty
+    // FilteredColumnarBatch and advance to the next batch instead.
+    if (numSelectedRows == 0) {
+      Utils.closeCloseables(scanAddFiles);
+      prepareNext();
+      return;
+    }
+
     next =
         Optional.of(
             new FilteredColumnarBatch(


### PR DESCRIPTION
Fixes #4941

When scanning files and all AddFiles in a batch are filtered out (e.g., by partition pruning or data skipping), we currently create an empty FilteredColumnarBatch anyway. This skips that unnecessary allocation.

Change:
- In `ActiveAddFilesIterator`, if no AddFiles survive filtering, skip the batch entirely instead of returning an empty FilteredColumnarBatch.
- Saves allocation + serialization overhead in filtered scans.