### PR TITLE
[Spark] Fix flaky ConvertToDelta "= character" test under parallel execution

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/ConvertToDeltaSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/ConvertToDeltaSuiteBase.scala
@@ -551,7 +551,7 @@ trait ConvertToDeltaSuiteBase extends ConvertToDeltaSuiteBaseCommons
 
       assert(files.length == 1)
       fs.rename(
-        files.head, new Path(files.head.getParent.getName, "some-data-id=1.snappy.parquet"))
+        files.head, new Path(files.head.getParent.toString, "some-data-id=1.snappy.parquet"))
 
       convertToDelta(s"parquet.`$tempDir`", Some("part string"))
       checkAnswer(spark.read.format("delta").load(tempDir), Row(1, "1"))


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Fixes a flaky test in `ConvertToDeltaSuiteBase`: `"allow file names to have = character"`.

The test renames its single data file using `files.head.getParent.getName`, which returns the bare relative path `"part=1"` (only the final path component, not the absolute parent). Hadoop resolves a relative rename destination against the forked test JVM's working directory, which is shared across parallel test forks, rather than the test's own temp directory. When a `part=1` directory already exists at that shared location, the rename succeeds and moves the only data file out of the test's temp dir, so the subsequent `CONVERT TO DELTA` finds an empty directory and throws `DELTA_EMPTY_DIRECTORY`. Whether this occurs depends on test scheduling/parallelism, which makes the test flaky.

The fix uses `files.head.getParent.toString` (the absolute parent path) so the rename stays inside the test's own temp directory. This matches the sibling test `"allow file names to not have .parquet suffix"` immediately below, which already uses `getParent.toString`.

## How was this patch tested?

Existing test `ConvertToDeltaSuiteBase."allow file names to have = character"`. The change makes the rename target the test's own temp directory, removing the dependency on the contents of the shared fork working directory, so the test no longer fails depending on test ordering/parallelism.

## Does this PR introduce _any_ user-facing changes?

No. Test-only change.
