### PR TITLE
[Spark] Support CHANGES (Auto-CDF) reads in AUTO v2 enable mode

### DIFF
--- a/spark-unified/src/main/java/org/apache/spark/sql/delta/catalog/DeltaCatalog.java
+++ b/spark-unified/src/main/java/org/apache/spark/sql/delta/catalog/DeltaCatalog.java
@@ -106,28 +106,6 @@ public class DeltaCatalog extends AbstractDeltaCatalog implements ChangelogSuppo
   }
 
   /**
-   * Re-resolves an already-loaded V1 {@link DeltaTableV2} to the sparkV2 {@link DeltaV2Table}
-   * connector for an Auto-CDF (CHANGES) read.
-   *
-   * <p>The Spark 4.2 {@code ChangelogSupport} trait calls this from {@code loadChangelog} to
-   * obtain the V2 table without forcing STRICT mode.
-   *
-   * <p>Note: intentionally not annotated with {@code @Override}. This method satisfies the abstract
-   * {@code asV2ChangelogTable} declared by {@code ChangelogSupport} only in the Spark 4.2 shim; the
-   * 4.0/4.1 shims use an empty {@code ChangelogSupport}, where this is just an unused helper.
-   *
-   * @param ident the table identifier
-   * @param table the V1 connector table previously resolved by {@link #loadTable}
-   * @return the same table resolved through the sparkV2 connector
-   */
-  public DeltaV2Table asV2ChangelogTable(Identifier ident, DeltaTableV2 table) {
-    if (table.catalogTable().isDefined()) {
-      return new DeltaV2Table(ident, table.catalogTable().get(), new HashMap<>());
-    }
-    return new DeltaV2Table(ident, table.path().toString());
-  }
-
-  /**
    * Loads a table based on the {@link DeltaV2Mode} SQL configuration.
    *
    * <p>This method checks the configuration and delegates to the appropriate supplier:

--- a/spark-unified/src/main/java/org/apache/spark/sql/delta/catalog/DeltaCatalog.java
+++ b/spark-unified/src/main/java/org/apache/spark/sql/delta/catalog/DeltaCatalog.java
@@ -106,6 +106,31 @@ public class DeltaCatalog extends AbstractDeltaCatalog implements ChangelogSuppo
   }
 
   /**
+   * Re-resolves an already-loaded V1 {@link DeltaTableV2} to the sparkV2 {@link DeltaV2Table}
+   * connector for an Auto-CDF (CHANGES) read.
+   *
+   * <p>Auto-CDF is V2-only, but in AUTO mode {@link #loadCatalogTable}/{@link #loadPathTable}
+   * return the V1 connector for general reads/writes. The Spark 4.2 {@code ChangelogSupport} trait
+   * calls this from {@code loadChangelog} to obtain the V2 table without forcing STRICT mode.
+   * Keeping the V2 construction here (next to the V1/V2 routing) means the changelog trait does not
+   * need to reach into V1 connector internals.
+   *
+   * <p>Note: intentionally not annotated with {@code @Override}. This method satisfies the abstract
+   * {@code asV2ChangelogTable} declared by {@code ChangelogSupport} only in the Spark 4.2 shim; the
+   * 4.0/4.1 shims use an empty {@code ChangelogSupport}, where this is just an unused helper.
+   *
+   * @param ident the table identifier
+   * @param table the V1 connector table previously resolved by {@link #loadTable}
+   * @return the same table resolved through the sparkV2 connector
+   */
+  public DeltaV2Table asV2ChangelogTable(Identifier ident, DeltaTableV2 table) {
+    if (table.catalogTable().isDefined()) {
+      return new DeltaV2Table(ident, table.catalogTable().get(), new HashMap<>());
+    }
+    return new DeltaV2Table(ident, table.path().toString());
+  }
+
+  /**
    * Loads a table based on the {@link DeltaV2Mode} SQL configuration.
    *
    * <p>This method checks the configuration and delegates to the appropriate supplier:

--- a/spark-unified/src/main/java/org/apache/spark/sql/delta/catalog/DeltaCatalog.java
+++ b/spark-unified/src/main/java/org/apache/spark/sql/delta/catalog/DeltaCatalog.java
@@ -109,11 +109,8 @@ public class DeltaCatalog extends AbstractDeltaCatalog implements ChangelogSuppo
    * Re-resolves an already-loaded V1 {@link DeltaTableV2} to the sparkV2 {@link DeltaV2Table}
    * connector for an Auto-CDF (CHANGES) read.
    *
-   * <p>Auto-CDF is V2-only, but in AUTO mode {@link #loadCatalogTable}/{@link #loadPathTable}
-   * return the V1 connector for general reads/writes. The Spark 4.2 {@code ChangelogSupport} trait
-   * calls this from {@code loadChangelog} to obtain the V2 table without forcing STRICT mode.
-   * Keeping the V2 construction here (next to the V1/V2 routing) means the changelog trait does not
-   * need to reach into V1 connector internals.
+   * <p>The Spark 4.2 {@code ChangelogSupport} trait calls this from {@code loadChangelog} to
+   * obtain the V2 table without forcing STRICT mode.
    *
    * <p>Note: intentionally not annotated with {@code @Override}. This method satisfies the abstract
    * {@code asV2ChangelogTable} declared by {@code ChangelogSupport} only in the Spark 4.2 shim; the

--- a/spark-unified/src/main/scala-shims/spark-4.2/org/apache/spark/sql/delta/catalog/ChangelogSupport.scala
+++ b/spark-unified/src/main/scala-shims/spark-4.2/org/apache/spark/sql/delta/catalog/ChangelogSupport.scala
@@ -65,15 +65,10 @@ trait ChangelogSupport extends TableCatalog {
     val routeChangelogToV2 = new DeltaV2Mode(spark.sessionState.conf).shouldRouteChangelogToV2()
     val sparkTable = loadTable(ident) match {
       case st: DeltaV2Table => st
+      // Auto-CDF is V2-only. Re-resolve to V2.
       case v1: DeltaTableV2 if routeChangelogToV2 =>
-        // In AUTO mode the catalog returns the V1 connector (DeltaTableV2) for general batch
-        // reads/writes, but Auto-CDF only flows through the V2 connector. Re-resolve the same
-        // table as a DeltaV2Table so CHANGES queries work without forcing STRICT mode.
         asV2ChangelogTable(ident, v1)
       case other =>
-        // Auto-CDF only supports the V2 connector and the mode does not route CHANGES to it
-        // (e.g. NONE). V1 Delta tables keep going through the legacy CDF path that DeltaCatalog
-        // already exposes.
         DeltaErrors.throwChangelogRequiresV2Table(ident.toString, other.getClass.getName)
     }
     val (startVersion, endVersion) = resolveRange(sparkTable, changelogInfo.range())

--- a/spark-unified/src/main/scala-shims/spark-4.2/org/apache/spark/sql/delta/catalog/ChangelogSupport.scala
+++ b/spark-unified/src/main/scala-shims/spark-4.2/org/apache/spark/sql/delta/catalog/ChangelogSupport.scala
@@ -22,7 +22,7 @@ import io.delta.spark.internal.v2.read.changelog.DeltaChangelog
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.connector.catalog.{Changelog, ChangelogInfo, Identifier, TableCatalog}
 import org.apache.spark.sql.connector.catalog.ChangelogRange.{TimestampRange, UnboundedRange, VersionRange}
-import org.apache.spark.sql.delta.DeltaErrors
+import org.apache.spark.sql.delta.{DeltaErrors, DeltaV2Mode}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 
 /**
@@ -34,8 +34,9 @@ import org.apache.spark.sql.delta.sources.DeltaSQLConf
  * `TableCatalog` implementation.
  *
  * <p>The trait is intentionally thin. `loadChangelog` resolves the table via the catalog's own
- * `loadTable`, validates that the result is a V2 [[DeltaV2Table]] (read-time CDF only flows
- * through the V2 connector. V1 tables go through the legacy Delta CDF path), resolves the
+ * `loadTable`. Read-time CDF only flows through the V2 connector, so in `AUTO`/`STRICT` mode (see
+ * [[DeltaV2Mode.shouldRouteChangelogToV2]]) a V1 `DeltaTableV2` is re-resolved as a
+ * [[DeltaV2Table]] for the CHANGES read; in `NONE` mode it is rejected. It then resolves the
  * requested [[ChangelogRange]] against the table's snapshot manager, and wraps everything into
  * a [[DeltaChangelog]]. All connector-level work (loading snapshots, validating row tracking,
  * inspecting metadata actions) is deferred to the read path inside [[DeltaChangelog]].
@@ -46,6 +47,14 @@ import org.apache.spark.sql.delta.sources.DeltaSQLConf
  */
 trait ChangelogSupport extends TableCatalog {
 
+  /**
+   * Re-resolves an already-loaded V1 [[DeltaTableV2]] to the sparkV2 [[DeltaV2Table]] connector for
+   * an Auto-CDF read. Implemented by the concrete catalog so all V1/V2 connector construction stays
+   * in one place (see `DeltaCatalog.asV2ChangelogTable`) and this trait does not need to reach into
+   * V1 connector internals.
+   */
+  def asV2ChangelogTable(ident: Identifier, table: DeltaTableV2): DeltaV2Table
+
   override def loadChangelog(ident: Identifier, changelogInfo: ChangelogInfo): Changelog = {
     val spark = SparkSession.active
     if (!spark.sessionState.conf.getConf(DeltaSQLConf.DELTA_CHANGELOG_V2_ENABLED)) {
@@ -53,11 +62,18 @@ trait ChangelogSupport extends TableCatalog {
       // UNSUPPORTED_FEATURE.CHANGE_DATA_CAPTURE to the user.
       return super.loadChangelog(ident, changelogInfo)
     }
+    val routeChangelogToV2 = new DeltaV2Mode(spark.sessionState.conf).shouldRouteChangelogToV2()
     val sparkTable = loadTable(ident) match {
       case st: DeltaV2Table => st
+      case v1: DeltaTableV2 if routeChangelogToV2 =>
+        // In AUTO mode the catalog returns the V1 connector (DeltaTableV2) for general batch
+        // reads/writes, but Auto-CDF only flows through the V2 connector. Re-resolve the same
+        // table as a DeltaV2Table so CHANGES queries work without forcing STRICT mode.
+        asV2ChangelogTable(ident, v1)
       case other =>
-        // Auto-CDF only supports the V2 connector. V1 Delta tables (DeltaTableV2 under the
-        // hood) keep going through the legacy CDF path that DeltaCatalog already exposes.
+        // Auto-CDF only supports the V2 connector and the mode does not route CHANGES to it
+        // (e.g. NONE). V1 Delta tables keep going through the legacy CDF path that DeltaCatalog
+        // already exposes.
         DeltaErrors.throwChangelogRequiresV2Table(ident.toString, other.getClass.getName)
     }
     val (startVersion, endVersion) = resolveRange(sparkTable, changelogInfo.range())

--- a/spark-unified/src/main/scala-shims/spark-4.2/org/apache/spark/sql/delta/catalog/ChangelogSupport.scala
+++ b/spark-unified/src/main/scala-shims/spark-4.2/org/apache/spark/sql/delta/catalog/ChangelogSupport.scala
@@ -35,25 +35,17 @@ import org.apache.spark.sql.delta.sources.DeltaSQLConf
  *
  * <p>The trait is intentionally thin. `loadChangelog` resolves the table via the catalog's own
  * `loadTable`. Read-time CDF only flows through the V2 connector, so in `AUTO`/`STRICT` mode (see
- * [[DeltaV2Mode.shouldRouteChangelogToV2]]) a V1 `DeltaTableV2` is re-resolved as a
- * [[DeltaV2Table]] for the CHANGES read; in `NONE` mode it is rejected. It then resolves the
- * requested [[ChangelogRange]] against the table's snapshot manager, and wraps everything into
- * a [[DeltaChangelog]]. All connector-level work (loading snapshots, validating row tracking,
- * inspecting metadata actions) is deferred to the read path inside [[DeltaChangelog]].
+ * [[DeltaV2Mode.shouldRouteChangelogToV2]]) the table is re-resolved to a [[DeltaV2Table]] for the
+ * CHANGES read; in `NONE` mode it is rejected. It then resolves the requested [[ChangelogRange]]
+ * against the table's snapshot manager, and wraps everything into a [[DeltaChangelog]].
+ * All connector-level work (loading snapshots, validating row tracking, inspecting metadata
+ * actions) is deferred to the read path inside [[DeltaChangelog]].
  *
  * <p>The whole entry point is gated by [[DeltaSQLConf.DELTA_CHANGELOG_V2_ENABLED]] (default
  * `false`). When the flag is off the trait delegates to the parent `loadChangelog` default,
  * which surfaces `UNSUPPORTED_FEATURE.CHANGE_DATA_CAPTURE`.
  */
 trait ChangelogSupport extends TableCatalog {
-
-  /**
-   * Re-resolves an already-loaded V1 [[DeltaTableV2]] to the sparkV2 [[DeltaV2Table]] connector for
-   * an Auto-CDF read. Implemented by the concrete catalog so all V1/V2 connector construction stays
-   * in one place (see `DeltaCatalog.asV2ChangelogTable`) and this trait does not need to reach into
-   * V1 connector internals.
-   */
-  def asV2ChangelogTable(ident: Identifier, table: DeltaTableV2): DeltaV2Table
 
   override def loadChangelog(ident: Identifier, changelogInfo: ChangelogInfo): Changelog = {
     val spark = SparkSession.active
@@ -73,6 +65,21 @@ trait ChangelogSupport extends TableCatalog {
     }
     val (startVersion, endVersion) = resolveRange(sparkTable, changelogInfo.range())
     new DeltaChangelog(ident.name(), sparkTable, startVersion, endVersion)
+  }
+
+  /**
+   * Re-resolves an already-loaded V1 [[DeltaTableV2]] to the sparkV2 [[DeltaV2Table]].
+   *
+   * @param ident the table identifier
+   * @param table the V1 connector table previously resolved by [[loadTable]]
+   * @return the same table resolved through the sparkV2 connector
+   */
+  private def asV2ChangelogTable(ident: Identifier, table: DeltaTableV2): DeltaV2Table = {
+    if (table.catalogTable.isDefined) {
+      new DeltaV2Table(ident, table.catalogTable.get, new java.util.HashMap[String, String]())
+    } else {
+      new DeltaV2Table(ident, table.path.toString)
+    }
   }
 
   /**

--- a/spark-unified/src/test/scala-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogCatalogIntegrationTest.java
+++ b/spark-unified/src/test/scala-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogCatalogIntegrationTest.java
@@ -185,10 +185,9 @@ public class DeltaChangelogCatalogIntegrationTest extends DeltaChangelogTestBase
   // ===========================================================================================
 
   /**
-   * In AUTO mode (the production default) the catalog returns the V1 connector for general
-   * reads/writes, but Auto-CDF only flows through the V2 connector. {@code ChangelogSupport}
-   * re-resolves the table to a {@code DeltaV2Table} for the CHANGES read, so a SQL CHANGES query
-   * must succeed without forcing STRICT mode.
+   * Auto-CDF only flows through the V2 connector. {@code ChangelogSupport} re-resolves the
+   * table to a {@code DeltaV2Table} for the CHANGES read, so a SQL CHANGES query must succeed
+   * without forcing STRICT mode.
    */
   @Test
   public void testAutoModeRoutesChangesToV2() throws Exception {
@@ -230,6 +229,57 @@ public class DeltaChangelogCatalogIntegrationTest extends DeltaChangelogTestBase
                             3,
                             rows.size(),
                             "Expected three inserts in the v1..v3 range under AUTO");
+                        for (int i = 0; i < 3; i++) {
+                          assertEquals(
+                              (long) (i + 1), ((Number) rows.get(i).getAs("id")).longValue());
+                          assertEquals("insert", rows.get(i).getAs("_change_type"));
+                        }
+                      });
+                }));
+  }
+
+  /**
+   * STRICT routes every operation to the V2 connector, so loadTable already returns a
+   * {@code DeltaV2Table} and the CHANGES read succeeds without any re-resolution.
+   */
+  @Test
+  public void testStrictModeRoutesChangesToV2() throws Exception {
+    String tableName = "dsv2_cdc_catalog_strict_" + System.nanoTime();
+    String tablePath = System.getProperty("java.io.tmpdir") + "/" + tableName;
+
+    withTable(
+        tablePath,
+        () ->
+            withTable(
+                new String[] {tableName},
+                () -> {
+                  spark.sql(
+                      String.format(
+                          "CREATE TABLE %s (id BIGINT, name STRING) USING delta LOCATION '%s' "
+                              + "TBLPROPERTIES ('delta.enableDeletionVectors'='false', "
+                              + "'delta.enableRowTracking'='true')",
+                          tableName, tablePath));
+                  spark.sql(String.format("INSERT INTO %s VALUES (1, 'Alice')", tableName));
+                  spark.sql(String.format("INSERT INTO %s VALUES (2, 'Bob')", tableName));
+                  spark.sql(String.format("INSERT INTO %s VALUES (3, 'Charlie')", tableName));
+
+                  withSQLConf(
+                      "spark.databricks.delta.v2.enableMode",
+                      "STRICT",
+                      () -> {
+                        List<Row> rows =
+                            spark
+                                .sql(
+                                    String.format(
+                                        "SELECT id, name, _change_type "
+                                            + "FROM %s CHANGES FROM VERSION 1 TO VERSION 3",
+                                        tableName))
+                                .orderBy("_commit_version", "id")
+                                .collectAsList();
+                        assertEquals(
+                            3,
+                            rows.size(),
+                            "Expected three inserts in the v1..v3 range under STRICT");
                         for (int i = 0; i < 3; i++) {
                           assertEquals(
                               (long) (i + 1), ((Number) rows.get(i).getAs("id")).longValue());

--- a/spark-unified/src/test/scala-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogCatalogIntegrationTest.java
+++ b/spark-unified/src/test/scala-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogCatalogIntegrationTest.java
@@ -181,6 +181,111 @@ public class DeltaChangelogCatalogIntegrationTest extends DeltaChangelogTestBase
   }
 
   // ===========================================================================================
+  // Connector-mode routing for CHANGES reads
+  // ===========================================================================================
+
+  /**
+   * In AUTO mode (the production default) the catalog returns the V1 connector for general
+   * reads/writes, but Auto-CDF only flows through the V2 connector. {@code ChangelogSupport}
+   * re-resolves the table to a {@code DeltaV2Table} for the CHANGES read, so a SQL CHANGES query
+   * must succeed without forcing STRICT mode.
+   */
+  @Test
+  public void testAutoModeRoutesChangesToV2() throws Exception {
+    String tableName = "dsv2_cdc_catalog_auto_" + System.nanoTime();
+    String tablePath = System.getProperty("java.io.tmpdir") + "/" + tableName;
+
+    withTable(
+        tablePath,
+        () ->
+            withTable(
+                new String[] {tableName},
+                () -> {
+                  spark.sql(
+                      String.format(
+                          "CREATE TABLE %s (id BIGINT, name STRING) USING delta LOCATION '%s' "
+                              + "TBLPROPERTIES ('delta.enableDeletionVectors'='false', "
+                              + "'delta.enableRowTracking'='true')",
+                          tableName, tablePath));
+                  spark.sql(String.format("INSERT INTO %s VALUES (1, 'Alice')", tableName));
+                  spark.sql(String.format("INSERT INTO %s VALUES (2, 'Bob')", tableName));
+                  spark.sql(String.format("INSERT INTO %s VALUES (3, 'Charlie')", tableName));
+
+                  // CREATE/INSERTs above run on the V1 connector under AUTO. The CHANGES read must
+                  // still succeed: ChangelogSupport re-resolves the table to the V2 connector.
+                  withSQLConf(
+                      "spark.databricks.delta.v2.enableMode",
+                      "AUTO",
+                      () -> {
+                        List<Row> rows =
+                            spark
+                                .sql(
+                                    String.format(
+                                        "SELECT id, name, _change_type "
+                                            + "FROM %s CHANGES FROM VERSION 1 TO VERSION 3",
+                                        tableName))
+                                .orderBy("_commit_version", "id")
+                                .collectAsList();
+                        assertEquals(
+                            3,
+                            rows.size(),
+                            "Expected three inserts in the v1..v3 range under AUTO");
+                        for (int i = 0; i < 3; i++) {
+                          assertEquals(
+                              (long) (i + 1), ((Number) rows.get(i).getAs("id")).longValue());
+                          assertEquals("insert", rows.get(i).getAs("_change_type"));
+                        }
+                      });
+                }));
+  }
+
+  /**
+   * NONE mode keeps every operation on the V1 connector, so the V2 Auto-CDF path is unavailable.
+   * A CHANGES read must be rejected with {@code DELTA_CHANGELOG_REQUIRES_V2_TABLE}.
+   */
+  @Test
+  public void testNoneModeRejectsChanges() throws Exception {
+    String tableName = "dsv2_cdc_catalog_none_" + System.nanoTime();
+    String tablePath = System.getProperty("java.io.tmpdir") + "/" + tableName;
+
+    withTable(
+        tablePath,
+        () ->
+            withTable(
+                new String[] {tableName},
+                () -> {
+                  spark.sql(
+                      String.format(
+                          "CREATE TABLE %s (id BIGINT, name STRING) USING delta LOCATION '%s' "
+                              + "TBLPROPERTIES ('delta.enableDeletionVectors'='false', "
+                              + "'delta.enableRowTracking'='true')",
+                          tableName, tablePath));
+                  spark.sql(String.format("INSERT INTO %s VALUES (1, 'Alice')", tableName));
+
+                  withSQLConf(
+                      "spark.databricks.delta.v2.enableMode",
+                      "NONE",
+                      () -> {
+                        Exception ex =
+                            assertThrows(
+                                Exception.class,
+                                () ->
+                                    spark
+                                        .sql(
+                                            String.format(
+                                                "SELECT * FROM %s CHANGES FROM VERSION 0 TO "
+                                                    + "VERSION 1",
+                                                tableName))
+                                        .collectAsList());
+                        assertTrue(
+                            ex.getMessage().contains("DELTA_CHANGELOG_REQUIRES_V2_TABLE"),
+                            "Expected V2-connector-required error under NONE, got: "
+                                + ex.getMessage());
+                      });
+                }));
+  }
+
+  // ===========================================================================================
   // Bounds inclusivity/exclusivity testing
   // ===========================================================================================
 

--- a/spark/src/main/java/org/apache/spark/sql/delta/DeltaV2Mode.java
+++ b/spark/src/main/java/org/apache/spark/sql/delta/DeltaV2Mode.java
@@ -91,6 +91,30 @@ public class DeltaV2Mode {
   }
 
   /**
+   * Determines if catalog-driven CHANGES reads (TableCatalog.loadChangelog, i.e. Auto-CDF) should
+   * route to the sparkV2 connector.
+   *
+   * <p>Auto-CDF is only implemented by the sparkV2 connector ({@link
+   * io.delta.spark.internal.v2.catalog.DeltaV2Table}), so both AUTO and STRICT route CHANGES reads
+   * to the V2 connector. This is distinct from {@link #shouldCatalogReturnV2Tables()}: AUTO keeps
+   * general batch reads/writes on the sparkV1 connector (full feature support) and only opts into
+   * V2 for V2-supported operations like CHANGES. NONE keeps everything on sparkV1, so the V2
+   * Auto-CDF path is not available.
+   *
+   * @return true if CHANGES reads should use the sparkV2 connector
+   */
+  public boolean shouldRouteChangelogToV2() {
+    switch (mode()) {
+      case STRICT:
+      case AUTO:
+        return true;
+      default:
+        // NONE or unknown: the V2 Auto-CDF path is not available.
+        return false;
+    }
+  }
+
+  /**
    * Determines if the provided schema should be trusted without validation for streaming reads.
    * This is used to bypass DeltaLog schema loading for Unity Catalog tables where the catalog
    * already provides the correct schema.

--- a/spark/src/main/java/org/apache/spark/sql/delta/DeltaV2Mode.java
+++ b/spark/src/main/java/org/apache/spark/sql/delta/DeltaV2Mode.java
@@ -91,15 +91,7 @@ public class DeltaV2Mode {
   }
 
   /**
-   * Determines if catalog-driven CHANGES reads (TableCatalog.loadChangelog, i.e. Auto-CDF) should
-   * route to the sparkV2 connector.
-   *
-   * <p>Auto-CDF is only implemented by the sparkV2 connector ({@link
-   * io.delta.spark.internal.v2.catalog.DeltaV2Table}), so both AUTO and STRICT route CHANGES reads
-   * to the V2 connector. This is distinct from {@link #shouldCatalogReturnV2Tables()}: AUTO keeps
-   * general batch reads/writes on the sparkV1 connector (full feature support) and only opts into
-   * V2 for V2-supported operations like CHANGES. NONE keeps everything on sparkV1, so the V2
-   * Auto-CDF path is not available.
+   * Determines if catalog-driven Auto-CDF (CHANGES) reads should route to the sparkV2 connector.
    *
    * @return true if CHANGES reads should use the sparkV2 connector
    */

--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -412,7 +412,7 @@
   "DELTA_CHANGELOG_REQUIRES_V2_TABLE" : {
     "message" : [
       "Auto-CDF reads on `<tableName>` require the V2 Delta connector, but the catalog resolved the table to `<actualClassName>`.",
-      "Set the Delta V2 mode SQL conf to `STRICT` (or `AUTO`, if AUTO routes CHANGES queries) to read this table through the V2 connector."
+      "Set the Delta V2 mode SQL conf to `AUTO` or `STRICT` to read this table through the V2 connector."
     ],
     "sqlState" : "0AKDE"
   },

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -652,9 +652,10 @@ trait DeltaErrorsBase
 
   /**
    * Auto-CDF batch read rejected because the table resolved by the catalog is not a V2
-   * [[io.delta.spark.internal.v2.catalog.DeltaV2Table]]. The V2 connector is the only path that
-   * implements the catalog-driven CHANGES surface. V1 Delta tables (`DeltaTableV2`) continue to
-   * use the legacy CDF path that does not go through `TableCatalog.loadChangelog`.
+   * [[io.delta.spark.internal.v2.catalog.DeltaV2Table]] and the Delta V2 mode does not route
+   * CHANGES queries to the V2 connector. The V2 connector is the only path that implements the
+   * catalog-driven CHANGES surface. In `AUTO`/`STRICT` mode the catalog re-resolves V1 tables to
+   * the V2 connector for CHANGES; in `NONE` mode this is rejected.
    *
    * Returns `Nothing` so Scala callers can use this in expression position (e.g. as a `match`
    * arm) without an explicit `throw`. Java callers invoke it as a statement.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -652,10 +652,10 @@ trait DeltaErrorsBase
 
   /**
    * Auto-CDF batch read rejected because the table resolved by the catalog is not a V2
-   * [[io.delta.spark.internal.v2.catalog.DeltaV2Table]] and the Delta V2 mode does not route
-   * CHANGES queries to the V2 connector. The V2 connector is the only path that implements the
-   * catalog-driven CHANGES surface. In `AUTO`/`STRICT` mode the catalog re-resolves V1 tables to
-   * the V2 connector for CHANGES; in `NONE` mode this is rejected.
+   * [[io.delta.spark.internal.v2.catalog.DeltaV2Table]]. The V2 connector is the only path that
+   * implements the catalog-driven CHANGES surface. V1 Delta tables (`DeltaTableV2`) continue to
+   * use the legacy CDF path that does not go through `TableCatalog.loadChangelog`. Use
+   * `AUTO`/`STRICT` mode so the catalog re-resolves V1 tables to the V2 connector for CHANGES.
    *
    * Returns `Nothing` so Scala callers can use this in expression position (e.g. as a `match`
    * arm) without an explicit `throw`. Java callers invoke it as a statement.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
The CHANGES interface was only working in strict mode. This PR extends the codebase so that it now also is running in AUTO mode through the DSv2 interface. AUTO now keeps general batch reads/writes on the V1 connector (full feature support) and only opts into V2 for V2-supported operations like CHANGES. This leads to all CHANGES queries to be routed through DSv2 codepaths instead of DSv1 paths as currently is the case when mode is not set to strict.  

## How was this patch tested?
Local run of added tests.
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
