### PR TITLE
[Spark] Refactor Delta Sharing snapshot loading into a FileIndex-free helper

### DIFF
--- a/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingDeltaLogBuilder.scala
+++ b/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingDeltaLogBuilder.scala
@@ -1,0 +1,125 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.sharing.spark
+
+import java.lang.ref.WeakReference
+
+import io.delta.sharing.client.DeltaSharingClient
+import io.delta.sharing.client.model.{Table => DeltaSharingTable}
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.delta.sharing.CachedTableManager
+import org.apache.spark.internal.Logging
+
+object DeltaSharingDeltaLogBuilder extends Logging {
+
+  /**
+   * Build the synthetic Delta log for a single-version (snapshot) Delta Sharing read: issue the
+   * getFiles RPC, fabricate a version-0 Delta log in the BlockManager (served back through the
+   * synthetic `delta-sharing-log://` Hadoop FS), register the file-id -> presigned-url mapping with
+   * the [[CachedTableManager]], and return the encoded `delta-sharing-log://` [[Path]].
+   *
+   * Snapshot construction is left to the caller: the V1 path ([[DeltaSharingFileIndex]]) feeds the
+   * path to classic `DeltaLog.forTable`; the DSV2 scan feeds `.toString` to Delta Kernel's
+   * `PathBasedSnapshotManager`, whose DefaultEngine reads the same synthetic Hadoop FS.
+   *
+   * @param client Delta Sharing client for the getFiles RPC and presigned-url refresh.
+   * @param table the shared table to fetch.
+   * @param options read options; supplies versionAsOf / timestampAsOf for the snapshot.
+   * @param tablePath the shared table path; base of both the synthetic log path and the
+   *   [[CachedTableManager]] key.
+   * @param queryParamsHashId hash of the query parameters, appended as a suffix to the table path
+   *   and the cache key so different query shapes on the same table stay distinct.
+   * @param jsonPredicateHints optional server-side filter hints forwarded to getFiles.
+   * @param limit optional row limit forwarded to getFiles.
+   * @param anchor object whose lifetime bounds the [[CachedTableManager]] entry. A
+   *   [[WeakReference]] to it is registered, so the cached presigned URLs become collectable once
+   *   the anchor is unreachable. The anchor must be a per-query object: V1 passes the per-query
+   *   [[DeltaSharingFileIndex]]; the DSV2 path must pass the per-query `Scan`, not the per-table
+   *   `Table`. A `Table` is cached by the catalog and outlives the query, so anchoring to it would
+   *   pin stale presigned URLs in the cache.
+   * @param logPrefix caller tag for the fetch log line, so the shared loader does not hard-code a
+   *   DSV2 tag onto plain V1 reads.
+   */
+  def buildSnapshotDeltaLogPath(
+      client: DeltaSharingClient,
+      table: DeltaSharingTable,
+      options: DeltaSharingOptions,
+      tablePath: String,
+      queryParamsHashId: String,
+      jsonPredicateHints: Option[String],
+      limit: Option[Long],
+      anchor: AnyRef,
+      logPrefix: String): Path = {
+    // 1. Call client.getFiles.
+    val startTime = System.currentTimeMillis()
+    val deltaTableFiles = client.getFiles(
+      table = table,
+      predicates = Nil,
+      limit = limit,
+      versionAsOf = options.versionAsOf,
+      timestampAsOf = options.timestampAsOf,
+      jsonPredicateHints = jsonPredicateHints,
+      refreshToken = None,
+      fileIdHash = None
+    )
+    logInfo(
+      s"$logPrefix: fetched ${deltaTableFiles.lines.size} lines for table $table with version " +
+      s"${deltaTableFiles.version} from delta sharing server, took " +
+      s"${(System.currentTimeMillis() - startTime) / 1000.0}s."
+    )
+
+    // 2. Prepare a DeltaLog.
+    val tablePathWithHashIdSuffix = DeltaSharingUtils.getTablePathWithIdSuffix(
+      client.getProfileProvider.getCustomTablePath(tablePath),
+      queryParamsHashId
+    )
+    val deltaLogMetadata = DeltaSharingLogFileSystem.constructLocalDeltaLogAtVersionZero(
+      deltaTableFiles.lines,
+      tablePathWithHashIdSuffix
+    )
+
+    // 3. Register parquet file id to url mapping.
+    CachedTableManager.INSTANCE.register(
+      // Using tablePath directly because it will be customized within CachedTableManager.
+      tablePath = DeltaSharingUtils.getTablePathWithIdSuffix(tablePath, queryParamsHashId),
+      idToUrl = deltaLogMetadata.idToUrl,
+      refs = Seq(new WeakReference(anchor)),
+      profileProvider = client.getProfileProvider,
+      refresher = DeltaSharingUtils.getRefresherForGetFiles(
+        client = client,
+        table = table,
+        predicates = Nil,
+        limit = limit,
+        versionAsOf = options.versionAsOf,
+        timestampAsOf = options.timestampAsOf,
+        jsonPredicateHints = jsonPredicateHints,
+        useRefreshToken = true
+      ),
+      expirationTimestamp =
+        if (CachedTableManager.INSTANCE
+            .isValidUrlExpirationTime(deltaLogMetadata.minUrlExpirationTimestamp)) {
+          deltaLogMetadata.minUrlExpirationTimestamp.get
+        } else {
+          System.currentTimeMillis() + CachedTableManager.INSTANCE.preSignedUrlExpirationMs
+        },
+      refreshToken = deltaTableFiles.refreshToken
+    )
+
+    DeltaSharingLogFileSystem.encode(tablePathWithHashIdSuffix)
+  }
+}

--- a/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingFileIndex.scala
+++ b/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingFileIndex.scala
@@ -16,7 +16,6 @@
 
 package io.delta.sharing.spark
 
-import java.lang.ref.WeakReference
 import java.util.UUID
 
 import org.apache.spark.sql.delta.{DeltaFileFormat, DeltaLog}
@@ -27,7 +26,6 @@ import io.delta.sharing.client.util.{ConfUtils, JsonUtils}
 import io.delta.sharing.filters.{AndOp, BaseOp, OpConverter}
 import org.apache.hadoop.fs.Path
 
-import org.apache.spark.delta.sharing.CachedTableManager
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions.Expression
@@ -140,74 +138,23 @@ case class DeltaSharingFileIndex(
       jsonPredicateHints: Option[String],
       queryParamsHashId: String,
       overrideLimit: Option[Long]): DeltaLog = {
-    //  1. Call client.getFiles.
-    val startTime = System.currentTimeMillis()
-    val deltaTableFiles = client.getFiles(
+    // The getFiles RPC, synthetic delta-log construction, and CachedTableManager registration now
+    // live in the shared DeltaSharingDeltaLogBuilder so the DSV2 scan path can build a snapshot the
+    // same way. This path then opens the synthetic log as a classic DeltaLog (unchanged behavior).
+    // The CachedTableManager WeakReference is anchored to this FileIndex, which is per-query.
+    val encodedPath = DeltaSharingDeltaLogBuilder.buildSnapshotDeltaLogPath(
+      client = client,
       table = table,
-      predicates = Nil,
-      limit = overrideLimit.orElse(limitHint),
-      versionAsOf = params.options.versionAsOf,
-      timestampAsOf = params.options.timestampAsOf,
+      options = params.options,
+      tablePath = params.path.toString,
+      queryParamsHashId = queryParamsHashId,
       jsonPredicateHints = jsonPredicateHints,
-      refreshToken = None,
-      fileIdHash = None
-    )
-    logInfo(
-      s"Fetched ${deltaTableFiles.lines.size} lines for table $table with version " +
-      s"${deltaTableFiles.version} from delta sharing server, took " +
-      s"${(System.currentTimeMillis() - startTime) / 1000.0}s."
+      limit = overrideLimit.orElse(limitHint),
+      anchor = this,
+      logPrefix = "Delta Sharing (v1)"
     )
 
-    // 2. Prepare a DeltaLog.
-    val tablePathWithHashIdSuffix = DeltaSharingUtils.getTablePathWithIdSuffix(
-      client.getProfileProvider.getCustomTablePath(
-        params.path.toString
-      ),
-      queryParamsHashId
-    )
-    val deltaLogMetadata =
-      DeltaSharingLogFileSystem.constructLocalDeltaLogAtVersionZero(
-        deltaTableFiles.lines,
-        tablePathWithHashIdSuffix
-      )
-
-    // 3. Register parquet file id to url mapping
-    CachedTableManager.INSTANCE.register(
-      // Using params.path directly because it will be customized within CachedTableManager.
-      tablePath = DeltaSharingUtils.getTablePathWithIdSuffix(
-        params.path.toString,
-        queryParamsHashId
-      ),
-      idToUrl = deltaLogMetadata.idToUrl,
-      refs = Seq(new WeakReference(this)),
-      profileProvider = client.getProfileProvider,
-      refresher = DeltaSharingUtils.getRefresherForGetFiles(
-        client = client,
-        table = table,
-        predicates = Nil,
-        limit = overrideLimit.orElse(limitHint),
-        versionAsOf = params.options.versionAsOf,
-        timestampAsOf = params.options.timestampAsOf,
-        jsonPredicateHints = jsonPredicateHints,
-        useRefreshToken = true
-      ),
-      expirationTimestamp =
-        if (CachedTableManager.INSTANCE
-            .isValidUrlExpirationTime(deltaLogMetadata.minUrlExpirationTimestamp)) {
-          deltaLogMetadata.minUrlExpirationTimestamp.get
-        } else {
-          System.currentTimeMillis() + CachedTableManager.INSTANCE.preSignedUrlExpirationMs
-        },
-      refreshToken = deltaTableFiles.refreshToken
-    )
-
-    // 4. Create a local file index and call listFiles of this class.
-    val deltaLog = DeltaLog.forTable(
-      params.spark,
-      DeltaSharingLogFileSystem.encode(tablePathWithHashIdSuffix)
-    )
-
-    deltaLog
+    DeltaLog.forTable(params.spark, encodedPath)
   }
 
   def asTahoeFileIndex(

--- a/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingDeltaLogBuilderSuite.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingDeltaLogBuilderSuite.scala
@@ -24,6 +24,7 @@ import io.delta.sharing.client.{DeltaSharingClient, DeltaSharingRestClient}
 import io.delta.sharing.client.model.{Table => DeltaSharingTable}
 import org.apache.commons.io.FileUtils
 import org.apache.hadoop.fs.Path
+import org.apache.logging.log4j.Level
 
 import org.apache.spark.delta.sharing.CachedTableManager
 import org.apache.spark.sql.{QueryTest, SparkSession}
@@ -194,7 +195,10 @@ class DeltaSharingDeltaLogBuilderSuite
       val appender = new LogAppender("snapshot loader fetch log")
       withLogAppender(
         appender,
-        loggerNames = Seq("io.delta.sharing.spark.DeltaSharingDeltaLogBuilder")) {
+        loggerNames = Seq("io.delta.sharing.spark.DeltaSharingDeltaLogBuilder"),
+        // Pin the level: withLogAppender's default level differs by Spark version (None on 4.0,
+        // Some(INFO) on 4.1+), and without it the INFO line is filtered out under Spark 4.0.
+        level = Some(Level.INFO)) {
         DeltaSharingDeltaLogBuilder.buildSnapshotDeltaLogPath(
           client = client,
           table = dsTable,

--- a/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingDeltaLogBuilderSuite.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingDeltaLogBuilderSuite.scala
@@ -1,0 +1,214 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.sharing.spark
+
+import java.io.File
+
+import org.apache.spark.sql.delta.DeltaLog
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import io.delta.sharing.client.{DeltaSharingClient, DeltaSharingRestClient}
+import io.delta.sharing.client.model.{Table => DeltaSharingTable}
+import org.apache.commons.io.FileUtils
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.delta.sharing.CachedTableManager
+import org.apache.spark.sql.{QueryTest, SparkSession}
+import org.apache.spark.sql.delta.sharing.DeltaSharingTestSparkUtils
+
+/**
+ * Unit tests for [[DeltaSharingDeltaLogBuilder.buildSnapshotDeltaLogPath]], the FileIndex-free
+ * snapshot-construction helper shared by the V1 path and (eventually) the DSV2 scan. The mocked
+ * client and JSON fixtures are reused from [[DeltaSharingFileIndexSuite]] (`TestUtils` and
+ * `TestDeltaSharingClientForFileIndex`, same package).
+ */
+class DeltaSharingDeltaLogBuilderSuite
+    extends QueryTest
+    with DeltaSQLCommandTest
+    with DeltaSharingDataSourceDeltaTestUtils
+    with DeltaSharingTestSparkUtils {
+
+  private val shareName = "share"
+  private val schemaName = "default"
+  private val sharedTableName = "table"
+
+  /** Build the inputs to `buildSnapshotDeltaLogPath` against the mocked client. */
+  private def setup(
+      profilePath: String): (DeltaSharingClient, DeltaSharingTable, DeltaSharingOptions, Path) = {
+    val tablePath = new Path(s"$profilePath#$shareName.$schemaName.$sharedTableName")
+    // Resolves to TestDeltaSharingClientForFileIndex via spark.delta.sharing.client.class.
+    val client = DeltaSharingRestClient(profilePath, Map.empty, false, "delta")
+    val options = new DeltaSharingOptions(Map("path" -> tablePath.toString))
+    val dsTable = DeltaSharingTable(share = shareName, schema = schemaName, name = sharedTableName)
+    (client, dsTable, options, tablePath)
+  }
+
+  /** Write a profile file and run `f` with the sharing test confs applied. */
+  private def withProfile(f: String => Unit): Unit = {
+    withTempDir { tempDir =>
+      val profileFile = new File(tempDir, "foo.share")
+      FileUtils.writeStringToFile(
+        profileFile,
+        s"""{
+           |  "shareCredentialsVersion": 1,
+           |  "endpoint": "https://localhost:12345/not-used-endpoint",
+           |  "bearerToken": "mock"
+           |}""".stripMargin,
+        "utf-8"
+      )
+      withSQLConf(
+        "spark.delta.sharing.client.class" -> classOf[TestDeltaSharingClientForFileIndex].getName,
+        "fs.delta-sharing-log.impl" -> classOf[DeltaSharingLogFileSystem].getName,
+        "spark.delta.sharing.profile.provider.class" ->
+        "io.delta.sharing.client.DeltaSharingFileProfileProvider"
+      ) {
+        f(profileFile.getCanonicalPath)
+      }
+    }
+  }
+
+  test("constructs a readable version-0 delta log from the getFiles response") {
+    withProfile { profilePath =>
+      val (client, dsTable, options, tablePath) = setup(profilePath)
+      val testClient = client.asInstanceOf[TestDeltaSharingClientForFileIndex]
+
+      // A plain Object as anchor proves the helper does not depend on the FileIndex interface.
+      val encodedPath = DeltaSharingDeltaLogBuilder.buildSnapshotDeltaLogPath(
+        client = client,
+        table = dsTable,
+        options = options,
+        tablePath = tablePath.toString,
+        queryParamsHashId = "hashA",
+        jsonPredicateHints = None,
+        limit = None,
+        anchor = new Object(),
+        logPrefix = "Test"
+      )
+
+      // Exactly one getFiles RPC was issued (numGetFileCalls starts at -1).
+      assert(testClient.numGetFileCalls == 0)
+
+      // The returned path is the synthetic log, openable as a classic version-0 DeltaLog (the V1
+      // path). The two add files come from the mocked getFiles response.
+      assert(encodedPath.toString.startsWith("delta-sharing-log:"))
+      // The query-params hash is the table-path suffix (getTablePathWithIdSuffix appends `_<id>`),
+      // so different query shapes on the same table get distinct synthetic log paths.
+      assert(encodedPath.toString.endsWith("_hashA"))
+      val snapshot = DeltaLog.forTable(SparkSession.active, encodedPath).update()
+      assert(snapshot.version == 0)
+      assert(snapshot.allFiles.count() == 2)
+    }
+  }
+
+  test("distinguishes query shapes on the same table via the query-params hash") {
+    withProfile { profilePath =>
+      val (client, dsTable, options, tablePath) = setup(profilePath)
+      CachedTableManager.INSTANCE.clear()
+      val sizeBefore = CachedTableManager.INSTANCE.size()
+
+      // Strong refs keep the registered WeakReference anchors alive until the size assertion.
+      val anchorA = new Object()
+      val anchorB = new Object()
+      def build(hashId: String, anchor: AnyRef): Path =
+        DeltaSharingDeltaLogBuilder.buildSnapshotDeltaLogPath(
+          client = client,
+          table = dsTable,
+          options = options,
+          tablePath = tablePath.toString,
+          queryParamsHashId = hashId,
+          jsonPredicateHints = None,
+          limit = None,
+          anchor = anchor,
+          logPrefix = "Test"
+        )
+
+      // Two query shapes on the same table, distinguished only by queryParamsHashId.
+      val pathA = build("hashA", anchorA)
+      val pathB = build("hashB", anchorB)
+
+      // The hash is the table-path suffix, so the two shapes get distinct synthetic log paths...
+      assert(pathA.toString.endsWith("_hashA"))
+      assert(pathB.toString.endsWith("_hashB"))
+      assert(pathA.toString != pathB.toString)
+
+      // ...and two distinct CachedTableManager entries, so the shapes don't clobber each other.
+      assert(CachedTableManager.INSTANCE.size() == sizeBefore + 2)
+
+      // Assert directly on the entry key. CachedTableManager has no containsKey, but its test hook
+      // getQueryStateSize(tablePath) throws on a path that isn't cached. So the hash is part of the
+      // cache key: each shape's hash-suffixed path is cached (size value is irrelevant -- only the
+      // absence of a throw matters), while the bare un-suffixed table path is not.
+      def cacheKey(hashId: String): String =
+        client.getProfileProvider.getCustomTablePath(
+          DeltaSharingUtils.getTablePathWithIdSuffix(tablePath.toString, hashId))
+      assert(CachedTableManager.INSTANCE.getQueryStateSize(cacheKey("hashA")) >= 0)
+      assert(CachedTableManager.INSTANCE.getQueryStateSize(cacheKey("hashB")) >= 0)
+      intercept[IllegalStateException] {
+        CachedTableManager.INSTANCE.getQueryStateSize(
+          client.getProfileProvider.getCustomTablePath(tablePath.toString))
+      }
+
+      assert(anchorA != null && anchorB != null)
+    }
+  }
+
+  test("threads limit and jsonPredicateHints into the getFiles RPC") {
+    withProfile { profilePath =>
+      val (client, dsTable, options, tablePath) = setup(profilePath)
+      val testClient = client.asInstanceOf[TestDeltaSharingClientForFileIndex]
+      val jsonHint = """{"op":"equal","children":[]}"""
+
+      DeltaSharingDeltaLogBuilder.buildSnapshotDeltaLogPath(
+        client = client,
+        table = dsTable,
+        options = options,
+        tablePath = tablePath.toString,
+        queryParamsHashId = "hashC",
+        jsonPredicateHints = Some(jsonHint),
+        limit = Some(5L),
+        anchor = new Object(),
+        logPrefix = "Test"
+      )
+
+      assert(testClient.savedLimits == Seq(5L))
+      assert(testClient.savedJsonPredicateHints == Seq(jsonHint))
+    }
+  }
+
+  test("tags the fetch log line with the caller's logPrefix") {
+    withProfile { profilePath =>
+      val (client, dsTable, options, tablePath) = setup(profilePath)
+      val appender = new LogAppender("snapshot loader fetch log")
+      withLogAppender(
+        appender,
+        loggerNames = Seq("io.delta.sharing.spark.DeltaSharingDeltaLogBuilder")) {
+        DeltaSharingDeltaLogBuilder.buildSnapshotDeltaLogPath(
+          client = client,
+          table = dsTable,
+          options = options,
+          tablePath = tablePath.toString,
+          queryParamsHashId = "hashD",
+          jsonPredicateHints = None,
+          limit = None,
+          anchor = new Object(),
+          logPrefix = "Delta Sharing (v1)"
+        )
+      }
+      assert(appender.loggingEvents.exists(
+        _.getMessage.getFormattedMessage.contains("Delta Sharing (v1): fetched")))
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the title, for example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Refactors Delta Sharing snapshot loading so the logic no longer depends on the `FileIndex` interface.

The heavy lifting of `DeltaSharingFileIndex.createDeltaLog` is extracted into a new, `FileIndex`-free helper `DeltaSharingDeltaLogBuilder.buildSnapshotDeltaLogPath`. The helper issues the getFiles RPC, fabricates the version-0 synthetic Delta log (served back through the `delta-sharing-log://` Hadoop file system), registers the file-id -> presigned-url mapping with the `CachedTableManager`, and returns the encoded `delta-sharing-log://` `Path`.

`DeltaSharingFileIndex` now delegates to this helper and opens the returned path as a classic `DeltaLog`, exactly as before. Moving the logic out of the `FileIndex` lets other snapshot-construction paths reuse it without depending on the `FileIndex` interface.

The `CachedTableManager` `WeakReference` anchor is now a parameter supplied by the caller instead of being hardcoded to the `FileIndex`. Each caller can supply a per-query object whose lifetime bounds the cached presigned URLs, so the cached entries become collectable once the query that produced them is gone.

This is a pure refactor with no behavior change.

## How was this patch tested?

Added `DeltaSharingDeltaLogBuilderSuite`, which exercises the helper directly:
- version-0 Delta log construction from the getFiles response (openable as a classic `DeltaLog`);
- distinct `CachedTableManager` entries per query-params hash, so different query shapes on the same table do not clobber each other;
- threading of `limit` and `jsonPredicateHints` into the getFiles RPC;
- log-line prefix tagging by the caller.

The existing `DeltaSharingFileIndexSuite` and `DeltaSharingDataSourceDeltaSuite` pass unchanged, confirming no behavior change.

## Does this PR introduce _any_ user-facing change?

No.
