### PR TITLE
[Spark][kernel] Translate "Delta sources should verify the protocol reader version" mismatch from #5900

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/exceptions/UnsupportedProtocolVersionException.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/exceptions/UnsupportedProtocolVersionException.java
@@ -34,11 +34,15 @@ public class UnsupportedProtocolVersionException extends KernelException {
   }
 
   private final String tablePath;
-  private final int version;
+  private final int minReaderVersion;
+  private final int minWriterVersion;
   private final ProtocolVersionType versionType;
 
   public UnsupportedProtocolVersionException(
-      String tablePath, int version, ProtocolVersionType versionType) {
+      String tablePath,
+      int minReaderVersion,
+      int minWriterVersion,
+      ProtocolVersionType versionType) {
     super(
         String.format(
             "Unsupported Delta protocol %s version: table `%s` requires %s version %s "
@@ -46,9 +50,10 @@ public class UnsupportedProtocolVersionException extends KernelException {
             versionType.name().toLowerCase(),
             tablePath,
             versionType.name().toLowerCase(),
-            version));
+            versionType == ProtocolVersionType.READER ? minReaderVersion : minWriterVersion));
     this.tablePath = tablePath;
-    this.version = version;
+    this.minReaderVersion = minReaderVersion;
+    this.minWriterVersion = minWriterVersion;
     this.versionType = versionType;
   }
 
@@ -57,12 +62,22 @@ public class UnsupportedProtocolVersionException extends KernelException {
     return tablePath;
   }
 
-  /** @return the unsupported protocol version */
-  public int getVersion() {
-    return version;
+  /** @return the table's required minimum reader protocol version */
+  public int getMinReaderVersion() {
+    return minReaderVersion;
   }
 
-  /** @return the type of protocol version (READER or WRITER) */
+  /** @return the table's required minimum writer protocol version */
+  public int getMinWriterVersion() {
+    return minWriterVersion;
+  }
+
+  /** @return the unsupported protocol version */
+  public int getVersion() {
+    return versionType == ProtocolVersionType.READER ? minReaderVersion : minWriterVersion;
+  }
+
+  /** @return the type of protocol version that is unsupported */
   public ProtocolVersionType getVersionType() {
     return versionType;
   }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
@@ -159,18 +159,20 @@ public final class DeltaErrors {
 
   /* ------------------------ PROTOCOL EXCEPTIONS ----------------------------- */
   public static UnsupportedProtocolVersionException unsupportedReaderProtocol(
-      String tablePath, int tableReaderVersion) {
+      String tablePath, int minReaderVersion, int minWriterVersion) {
     return new UnsupportedProtocolVersionException(
         tablePath,
-        tableReaderVersion,
+        minReaderVersion,
+        minWriterVersion,
         UnsupportedProtocolVersionException.ProtocolVersionType.READER);
   }
 
   public static UnsupportedProtocolVersionException unsupportedWriterProtocol(
-      String tablePath, int tableWriterVersion) {
+      String tablePath, int minReaderVersion, int minWriterVersion) {
     return new UnsupportedProtocolVersionException(
         tablePath,
-        tableWriterVersion,
+        minReaderVersion,
+        minWriterVersion,
         UnsupportedProtocolVersionException.ProtocolVersionType.WRITER);
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/tablefeatures/TableFeatures.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/tablefeatures/TableFeatures.java
@@ -774,7 +774,8 @@ public class TableFeatures {
   /** Utility method to check if the table with given protocol is readable by the Kernel. */
   public static void validateKernelCanReadTheTable(Protocol protocol, String tablePath) {
     if (protocol.getMinReaderVersion() > TABLE_FEATURES_MIN_READER_VERSION) {
-      throw DeltaErrors.unsupportedReaderProtocol(tablePath, protocol.getMinReaderVersion());
+      throw DeltaErrors.unsupportedReaderProtocol(
+          tablePath, protocol.getMinReaderVersion(), protocol.getMinWriterVersion());
     }
 
     Set<TableFeature> unsupportedFeatures =
@@ -798,7 +799,8 @@ public class TableFeatures {
     validateKernelCanReadTheTable(protocol, tablePath);
 
     if (protocol.getMinWriterVersion() > TABLE_FEATURES_MIN_WRITER_VERSION) {
-      throw unsupportedWriterProtocol(tablePath, protocol.getMinWriterVersion());
+      throw unsupportedWriterProtocol(
+          tablePath, protocol.getMinReaderVersion(), protocol.getMinWriterVersion());
     }
 
     Set<TableFeature> unsupportedFeatures =

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/exceptions/ExceptionSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/exceptions/ExceptionSuite.scala
@@ -58,12 +58,15 @@ class ExceptionSuite extends AnyFunSuite {
 
   test("UnsupportedProtocolVersionException - reader version") {
     val tablePath = "/path/to/table"
-    val version = 3
+    val minReaderVersion = 3
+    val minWriterVersion = 2
 
-    val ex = DeltaErrors.unsupportedReaderProtocol(tablePath, version)
+    val ex = DeltaErrors.unsupportedReaderProtocol(tablePath, minReaderVersion, minWriterVersion)
 
     assert(ex.getTablePath == tablePath)
-    assert(ex.getVersion == version)
+    assert(ex.getMinReaderVersion == minReaderVersion)
+    assert(ex.getMinWriterVersion == minWriterVersion)
+    assert(ex.getVersion == minReaderVersion)
     assert(ex.getVersionType == ProtocolVersionType.READER)
     assert(ex.getMessage.contains("reader"))
     assert(ex.getMessage.contains("version 3"))
@@ -71,12 +74,15 @@ class ExceptionSuite extends AnyFunSuite {
 
   test("UnsupportedProtocolVersionException - writer version") {
     val tablePath = "/path/to/table"
-    val version = 7
+    val minReaderVersion = 1
+    val minWriterVersion = 7
 
-    val ex = DeltaErrors.unsupportedWriterProtocol(tablePath, version)
+    val ex = DeltaErrors.unsupportedWriterProtocol(tablePath, minReaderVersion, minWriterVersion)
 
     assert(ex.getTablePath == tablePath)
-    assert(ex.getVersion == version)
+    assert(ex.getMinReaderVersion == minReaderVersion)
+    assert(ex.getMinWriterVersion == minWriterVersion)
+    assert(ex.getVersion == minWriterVersion)
     assert(ex.getVersionType == ProtocolVersionType.WRITER)
     assert(ex.getMessage.contains("writer"))
     assert(ex.getMessage.contains("version 7"))

--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSuite.scala
@@ -145,6 +145,8 @@ object DeltaV2SourceSuite {
     "deltaSourceIgnoreDeleteError contains removeFile, version, tablePath",
     "deltaSourceIgnoreChangesError contains changeInfo, version, tablePath",
     "excludeRegex throws good error on bad regex pattern",
+    "no schema should throw an exception",
+    "Delta sources should verify the protocol reader version",
 
     // ========== Misc tests ==========
     "a fast writer should not starve a Delta source",
@@ -181,10 +183,6 @@ object DeltaV2SourceSuite {
     "incremental: commit file gap between versions, failOnDataLoss=false succeeds",
 
     // === Misc ===
-    // TODO(#5900): fix exception mismatch
-    "no schema should throw an exception",
-    // TODO(#5900): fix exception mismatch
-    "Delta sources should verify the protocol reader version",
     // TODO(#5895): gracefully handle corrupt checkpoint
     "start from corrupt checkpoint",
 

--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSuite.scala
@@ -145,7 +145,6 @@ object DeltaV2SourceSuite {
     "deltaSourceIgnoreDeleteError contains removeFile, version, tablePath",
     "deltaSourceIgnoreChangesError contains changeInfo, version, tablePath",
     "excludeRegex throws good error on bad regex pattern",
-    "no schema should throw an exception",
     "Delta sources should verify the protocol reader version",
 
     // ========== Misc tests ==========
@@ -183,6 +182,8 @@ object DeltaV2SourceSuite {
     "incremental: commit file gap between versions, failOnDataLoss=false succeeds",
 
     // === Misc ===
+    // TODO(#5900): fix exception mismatch
+    "no schema should throw an exception",
     // TODO(#5895): gracefully handle corrupt checkpoint
     "start from corrupt checkpoint",
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -1390,14 +1390,6 @@ trait DeltaErrorsBase
   }
 
   /**
-   * Throws [[schemaNotSetException]]. Returns `Nothing` so Java callers can invoke it as a
-   * statement to raise the checked [[DeltaAnalysisException]].
-   */
-  def throwSchemaNotSet(): Nothing = {
-    throw schemaNotSetException
-  }
-
-  /**
    * Java-friendly factory for [[InvalidProtocolVersionException]]. The supported reader/writer
    * version sets are `private[delta]` so this must be built in Scala.
    */

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -24,7 +24,7 @@ import java.util.{ConcurrentModificationException, UUID}
 import scala.collection.JavaConverters._
 
 import org.apache.spark.sql.delta.skipping.clustering.temp.{ClusterBySpec}
-import org.apache.spark.sql.delta.actions.{CommitInfo, Metadata, Protocol, TableFeatureProtocolUtils}
+import org.apache.spark.sql.delta.actions.{Action, CommitInfo, Metadata, Protocol, TableFeatureProtocolUtils}
 import org.apache.spark.sql.delta.commands.{AlterTableDropFeatureDeltaCommand, DeltaGenerateCommand}
 import org.apache.spark.sql.delta.constraints.Constraints
 import org.apache.spark.sql.delta.hooks.AutoCompactType
@@ -1387,6 +1387,30 @@ trait DeltaErrorsBase
       errorClass = "DELTA_SCHEMA_NOT_SET",
       messageParameters = Array.empty
     )
+  }
+
+  /**
+   * Throws [[schemaNotSetException]]. Returns `Nothing` so Java callers can invoke it as a
+   * statement to raise the checked [[DeltaAnalysisException]].
+   */
+  def throwSchemaNotSet(): Nothing = {
+    throw schemaNotSetException
+  }
+
+  /**
+   * Java-friendly factory for [[InvalidProtocolVersionException]]. The supported reader/writer
+   * version sets are `private[delta]` so this must be built in Scala.
+   */
+  def invalidProtocolVersionError(
+      tableNameOrPath: String,
+      readerRequiredVersion: Int,
+      writerRequiredVersion: Int): Throwable = {
+    InvalidProtocolVersionException(
+      tableNameOrPath,
+      readerRequiredVersion,
+      writerRequiredVersion,
+      Action.supportedReaderVersionNumbers.toSeq,
+      Action.supportedWriterVersionNumbers.toSeq)
   }
 
   def specifySchemaAtReadTimeException: Throwable = {

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
@@ -23,6 +23,7 @@ import static java.util.Objects.requireNonNull;
 import io.delta.kernel.Snapshot;
 import io.delta.kernel.defaults.engine.DefaultEngine;
 import io.delta.kernel.engine.Engine;
+import io.delta.kernel.exceptions.TableNotFoundException;
 import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.internal.rowtracking.RowTracking;
 import io.delta.spark.internal.v2.read.MetadataEvolutionHandler;
@@ -44,6 +45,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.catalog.CatalogTable;
@@ -62,6 +64,7 @@ import org.apache.spark.sql.connector.read.ScanBuilder;
 import org.apache.spark.sql.connector.read.Statistics;
 import org.apache.spark.sql.connector.write.LogicalWriteInfo;
 import org.apache.spark.sql.connector.write.WriteBuilder;
+import org.apache.spark.sql.delta.DeltaErrors;
 import org.apache.spark.sql.delta.DeltaTableUtils;
 import org.apache.spark.sql.delta.RowCommitVersion$;
 import org.apache.spark.sql.delta.RowId$;
@@ -199,7 +202,18 @@ public class DeltaV2Table
     this.kernelEngine = DefaultEngine.create(this.hadoopConf);
     this.snapshotManager = SnapshotManagerFactory.create(tablePath, kernelEngine, catalogTable);
     // Load the initial snapshot through the manager
-    this.initialSnapshot = snapshotManager.loadLatestSnapshot();
+    Snapshot loadedSnapshot;
+    try {
+      loadedSnapshot = snapshotManager.loadLatestSnapshot();
+    } catch (TableNotFoundException e) {
+      // The _delta_log directory exists but holds no commits: the location is an initialized but
+      // empty Delta table.
+      if (deltaLogDirExists()) {
+        DeltaErrors.throwSchemaNotSet();
+      }
+      throw e;
+    }
+    this.initialSnapshot = loadedSnapshot;
 
     this.isCDCRead = CDCReader.isCDCRead(new CaseInsensitiveStringMap(this.options));
 
@@ -224,6 +238,17 @@ public class DeltaV2Table
     // Schema-related metadata is lazily computed on first access within SchemaProvider
     this.schemaProvider =
         new SchemaProvider(SparkSession.active(), rawSchema, partitionColumnNames);
+  }
+
+  /** Returns whether the table's {@code _delta_log} directory exists. */
+  private boolean deltaLogDirExists() {
+    try {
+      Path logPath = new Path(tablePath, "_delta_log");
+      FileSystem fs = logPath.getFileSystem(hadoopConf);
+      return fs.exists(logPath);
+    } catch (Exception ioe) {
+      return false;
+    }
   }
 
   /**

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
@@ -23,7 +23,6 @@ import static java.util.Objects.requireNonNull;
 import io.delta.kernel.Snapshot;
 import io.delta.kernel.defaults.engine.DefaultEngine;
 import io.delta.kernel.engine.Engine;
-import io.delta.kernel.exceptions.TableNotFoundException;
 import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.internal.rowtracking.RowTracking;
 import io.delta.spark.internal.v2.read.MetadataEvolutionHandler;
@@ -45,7 +44,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.catalog.CatalogTable;
@@ -64,7 +62,6 @@ import org.apache.spark.sql.connector.read.ScanBuilder;
 import org.apache.spark.sql.connector.read.Statistics;
 import org.apache.spark.sql.connector.write.LogicalWriteInfo;
 import org.apache.spark.sql.connector.write.WriteBuilder;
-import org.apache.spark.sql.delta.DeltaErrors;
 import org.apache.spark.sql.delta.DeltaTableUtils;
 import org.apache.spark.sql.delta.RowCommitVersion$;
 import org.apache.spark.sql.delta.RowId$;
@@ -202,18 +199,7 @@ public class DeltaV2Table
     this.kernelEngine = DefaultEngine.create(this.hadoopConf);
     this.snapshotManager = SnapshotManagerFactory.create(tablePath, kernelEngine, catalogTable);
     // Load the initial snapshot through the manager
-    Snapshot loadedSnapshot;
-    try {
-      loadedSnapshot = snapshotManager.loadLatestSnapshot();
-    } catch (TableNotFoundException e) {
-      // The _delta_log directory exists but holds no commits: the location is an initialized but
-      // empty Delta table.
-      if (deltaLogDirExists()) {
-        DeltaErrors.throwSchemaNotSet();
-      }
-      throw e;
-    }
-    this.initialSnapshot = loadedSnapshot;
+    this.initialSnapshot = snapshotManager.loadLatestSnapshot();
 
     this.isCDCRead = CDCReader.isCDCRead(new CaseInsensitiveStringMap(this.options));
 
@@ -238,17 +224,6 @@ public class DeltaV2Table
     // Schema-related metadata is lazily computed on first access within SchemaProvider
     this.schemaProvider =
         new SchemaProvider(SparkSession.active(), rawSchema, partitionColumnNames);
-  }
-
-  /** Returns whether the table's {@code _delta_log} directory exists. */
-  private boolean deltaLogDirExists() {
-    try {
-      Path logPath = new Path(tablePath, "_delta_log");
-      FileSystem fs = logPath.getFileSystem(hadoopConf);
-      return fs.exists(logPath);
-    } catch (Exception ioe) {
-      return false;
-    }
   }
 
   /**

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkMicroBatchStream.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkMicroBatchStream.java
@@ -28,6 +28,7 @@ import io.delta.kernel.data.ColumnarBatch;
 import io.delta.kernel.data.FilteredColumnarBatch;
 import io.delta.kernel.defaults.engine.DefaultEngine;
 import io.delta.kernel.engine.Engine;
+import io.delta.kernel.exceptions.UnsupportedProtocolVersionException;
 import io.delta.kernel.exceptions.UnsupportedTableFeatureException;
 import io.delta.kernel.internal.DeltaHistoryManager;
 import io.delta.kernel.internal.DeltaLogActionUtils.DeltaAction;
@@ -499,6 +500,16 @@ public class SparkMicroBatchStream
       if (interruptCause.isPresent()) {
         throw new UncheckedIOException(interruptCause.get());
       }
+      // Translate Kernel's protocol-version error into Delta's InvalidProtocolVersionException.
+      Optional<UnsupportedProtocolVersionException> protocolCause = findUnsupportedProtocolCause(e);
+      if (protocolCause.isPresent()) {
+        UnsupportedProtocolVersionException p = protocolCause.get();
+        boolean isReader =
+            p.getVersionType() == UnsupportedProtocolVersionException.ProtocolVersionType.READER;
+        throw (RuntimeException)
+            DeltaErrors.invalidProtocolVersionError(
+                p.getTablePath(), isReader ? p.getVersion() : 0, isReader ? 0 : p.getVersion());
+      }
       throw e;
     }
   }
@@ -743,6 +754,22 @@ public class SparkMicroBatchStream
     Throwable cause = t.getCause();
     if (cause instanceof ClosedByInterruptException) {
       return Optional.of((ClosedByInterruptException) cause);
+    }
+    return Optional.empty();
+  }
+
+  /**
+   * Walks the cause chain of the given throwable looking for a Kernel {@link
+   * UnsupportedProtocolVersionException}.
+   */
+  static Optional<UnsupportedProtocolVersionException> findUnsupportedProtocolCause(Throwable t) {
+    for (Throwable current = t; current != null; current = current.getCause()) {
+      if (current instanceof UnsupportedProtocolVersionException) {
+        return Optional.of((UnsupportedProtocolVersionException) current);
+      }
+      if (current.getCause() == current) {
+        break;
+      }
     }
     return Optional.empty();
   }

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkMicroBatchStream.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkMicroBatchStream.java
@@ -504,11 +504,9 @@ public class SparkMicroBatchStream
       Optional<UnsupportedProtocolVersionException> protocolCause = findUnsupportedProtocolCause(e);
       if (protocolCause.isPresent()) {
         UnsupportedProtocolVersionException p = protocolCause.get();
-        boolean isReader =
-            p.getVersionType() == UnsupportedProtocolVersionException.ProtocolVersionType.READER;
         throw (RuntimeException)
             DeltaErrors.invalidProtocolVersionError(
-                p.getTablePath(), isReader ? p.getVersion() : 0, isReader ? 0 : p.getVersion());
+                p.getTablePath(), p.getMinReaderVersion(), p.getMinWriterVersion());
       }
       throw e;
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Resolves #5900 (partly, other part in #7107)
(Scoped down from #7025)

When using DSv2 connector, a streaming read surfaces Kernel-native exceptions instead of the Spark/Delta exceptions the DSv1 path raises. This PR translates one of them at its surfacing points to be consistent with DSv1:
A running stream that gets to an unsupported reader protocol version now fails with `org.apache.spark.sql.delta.InvalidProtocolVersionException` instead of Kernel's `UnsupportedProtocolVersionException`.

The translations are inline as such:
- `DeltaErrors` gains an `invalidProtocolVersionError(...)` factory.
- `SparkMicroBatchStream` translates `UnsupportedProtocolVersionException` in `latestOffset`.


## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

Enabled the previously expected-to-fail test in `DeltaV2SourceSuite`:
- `Delta sources should verify the protocol reader version`

All test runs still passed after.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No