### PR TITLE
[Spark] Clean up the changelog implementation

### DIFF
--- a/spark-unified/src/main/scala-shims/spark-4.0/org/apache/spark/sql/delta/catalog/ChangelogSupport.scala
+++ b/spark-unified/src/main/scala-shims/spark-4.0/org/apache/spark/sql/delta/catalog/ChangelogSupport.scala
@@ -23,11 +23,11 @@ import org.apache.spark.sql.connector.catalog.TableCatalog
  *
  * <p>The catalog-driven `TableCatalog.loadChangelog` entrypoint and its supporting types
  * (`Changelog`, `ChangelogInfo`, `ChangelogRange`) were introduced in Spark 4.2 via
- * SPARK-56685. They do not exist in Spark 4.0/4.1, so the Auto-CDF wiring is compiled in only
+ * SPARK-56685. They do not exist in Spark 4.0/4.1, so the read-time CDF wiring is compiled in only
  * when building against Spark 4.2 (see `scala-shims/spark-4.2/...ChangelogSupport.scala`).
  *
  * <p>In 4.0/4.1 builds, mixing this empty trait into `DeltaCatalog` is a no-op: there is no
- * `loadChangelog` to override, and downstream Auto-CDF classes (`DeltaChangelog`, etc.) live in
+ * `loadChangelog` to override, and downstream read-time CDF classes (`DeltaChangelog`, etc.) live in
  * version-specific `java-shims/spark-4.2/` dirs and are not present here either.
  */
 trait ChangelogSupport extends TableCatalog

--- a/spark-unified/src/main/scala-shims/spark-4.0/org/apache/spark/sql/delta/catalog/ChangelogSupport.scala
+++ b/spark-unified/src/main/scala-shims/spark-4.0/org/apache/spark/sql/delta/catalog/ChangelogSupport.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.connector.catalog.TableCatalog
  * when building against Spark 4.2 (see `scala-shims/spark-4.2/...ChangelogSupport.scala`).
  *
  * <p>In 4.0/4.1 builds, mixing this empty trait into `DeltaCatalog` is a no-op: there is no
- * `loadChangelog` to override, and downstream read-time CDF classes (`DeltaChangelog`, etc.) live in
- * version-specific `java-shims/spark-4.2/` dirs and are not present here either.
+ * `loadChangelog` to override, and downstream read-time CDF classes (`DeltaChangelog`, etc.)
+ * live in version-specific `java-shims/spark-4.2/` dirs and are not present here either.
  */
 trait ChangelogSupport extends TableCatalog

--- a/spark-unified/src/main/scala-shims/spark-4.1/org/apache/spark/sql/delta/catalog/ChangelogSupport.scala
+++ b/spark-unified/src/main/scala-shims/spark-4.1/org/apache/spark/sql/delta/catalog/ChangelogSupport.scala
@@ -23,11 +23,11 @@ import org.apache.spark.sql.connector.catalog.TableCatalog
  *
  * <p>The catalog-driven `TableCatalog.loadChangelog` entrypoint and its supporting types
  * (`Changelog`, `ChangelogInfo`, `ChangelogRange`) were introduced in Spark 4.2 via
- * SPARK-56685. They do not exist in Spark 4.0/4.1, so the Auto-CDF wiring is compiled in only
+ * SPARK-56685. They do not exist in Spark 4.0/4.1, so the read-time CDF wiring is compiled in only
  * when building against Spark 4.2 (see `scala-shims/spark-4.2/...ChangelogSupport.scala`).
  *
  * <p>In 4.0/4.1 builds, mixing this empty trait into `DeltaCatalog` is a no-op: there is no
- * `loadChangelog` to override, and downstream Auto-CDF classes (`DeltaChangelog`, etc.) live in
+ * `loadChangelog` to override, and downstream read-time CDF classes (`DeltaChangelog`, etc.) live in
  * version-specific `java-shims/spark-4.2/` dirs and are not present here either.
  */
 trait ChangelogSupport extends TableCatalog

--- a/spark-unified/src/main/scala-shims/spark-4.1/org/apache/spark/sql/delta/catalog/ChangelogSupport.scala
+++ b/spark-unified/src/main/scala-shims/spark-4.1/org/apache/spark/sql/delta/catalog/ChangelogSupport.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.connector.catalog.TableCatalog
  * when building against Spark 4.2 (see `scala-shims/spark-4.2/...ChangelogSupport.scala`).
  *
  * <p>In 4.0/4.1 builds, mixing this empty trait into `DeltaCatalog` is a no-op: there is no
- * `loadChangelog` to override, and downstream read-time CDF classes (`DeltaChangelog`, etc.) live in
- * version-specific `java-shims/spark-4.2/` dirs and are not present here either.
+ * `loadChangelog` to override, and downstream read-time CDF classes (`DeltaChangelog`, etc.)
+ * live in version-specific `java-shims/spark-4.2/` dirs and are not present here either.
  */
 trait ChangelogSupport extends TableCatalog

--- a/spark-unified/src/main/scala-shims/spark-4.2/org/apache/spark/sql/delta/catalog/ChangelogSupport.scala
+++ b/spark-unified/src/main/scala-shims/spark-4.2/org/apache/spark/sql/delta/catalog/ChangelogSupport.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.delta.{DeltaErrors, DeltaV2Mode}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 
 /**
- * Mixed into a [[TableCatalog]] implementation to add Auto-CDF support. Provides the
+ * Mixed into a [[TableCatalog]] implementation to add read-time CDF support. Provides the
  * catalog-driven `TableCatalog.loadChangelog` entrypoint introduced by SPARK-56685.
  *
  * <p>This trait extends [[TableCatalog]] as a dependency marker: every concrete catalog that
@@ -57,7 +57,7 @@ trait ChangelogSupport extends TableCatalog {
     val routeChangelogToV2 = new DeltaV2Mode(spark.sessionState.conf).shouldRouteChangelogToV2()
     val sparkTable = loadTable(ident) match {
       case st: DeltaV2Table => st
-      // Auto-CDF is V2-only. Re-resolve to V2.
+      // Read-time CDF is V2-only. Re-resolve to V2.
       case v1: DeltaTableV2 if routeChangelogToV2 =>
         asV2ChangelogTable(ident, v1)
       case other =>

--- a/spark-unified/src/test/scala-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogCatalogIntegrationTest.java
+++ b/spark-unified/src/test/scala-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogCatalogIntegrationTest.java
@@ -951,11 +951,12 @@ public class DeltaChangelogCatalogIntegrationTest extends DeltaChangelogTestBase
   }
 
   /**
-   * A CHANGES read across a range where the table schema evolves mid-range must be rejected with
-   * {@code DELTA_CHANGELOG_SCHEMA_CHANGE_IN_RANGE}.
+   * A CHANGES read across an additive mid-range schema change (adding a nullable column) is read
+   * compatible and must succeed. Rows from before the change are read with the end schema, leaving
+   * the added column null.
    */
   @Test
-  public void testChangelogRejectsSchemaChangeMidRange() throws Exception {
+  public void testChangelogAllowsAdditiveSchemaChangeMidRange() throws Exception {
     String tableName = "dsv2_cdc_catalog_schema_change_" + System.nanoTime();
     String tablePath = System.getProperty("java.io.tmpdir") + "/" + tableName;
 
@@ -973,7 +974,7 @@ public class DeltaChangelogCatalogIntegrationTest extends DeltaChangelogTestBase
                               + "'delta.enableRowTracking'='true')",
                           tableName, tablePath));
                   spark.sql(String.format("INSERT INTO %s VALUES (1, 'Alice')", tableName));
-                  // Schema change mid-range: add a column.
+                  // Additive schema change mid-range: add a nullable column.
                   spark.sql(String.format("ALTER TABLE %s ADD COLUMN extra STRING", tableName));
                   spark.sql(String.format("INSERT INTO %s VALUES (2, 'Bob', 'x')", tableName));
 
@@ -981,20 +982,16 @@ public class DeltaChangelogCatalogIntegrationTest extends DeltaChangelogTestBase
                       "spark.databricks.delta.v2.enableMode",
                       "STRICT",
                       () -> {
-                        Exception ex =
-                            assertThrows(
-                                Exception.class,
-                                () ->
-                                    spark
-                                        .sql(
-                                            String.format(
-                                                "SELECT * FROM %s CHANGES FROM VERSION 1 TO "
-                                                    + "VERSION 3",
-                                                tableName))
-                                        .collectAsList());
-                        assertTrue(
-                            ex.getMessage().contains("DELTA_CHANGELOG_SCHEMA_CHANGE_IN_RANGE"),
-                            "Expected schema-change error, got: " + ex.getMessage());
+                        List<Row> rows =
+                            spark
+                                .sql(
+                                    String.format(
+                                        "SELECT id, _change_type FROM %s "
+                                            + "CHANGES FROM VERSION 1 TO VERSION 3",
+                                        tableName))
+                                .collectAsList();
+                        assertEquals(
+                            2, rows.size(), "Additive schema change should not fail the read");
                       });
                 }));
   }

--- a/spark-unified/src/test/scala-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogCatalogIntegrationTest.java
+++ b/spark-unified/src/test/scala-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogCatalogIntegrationTest.java
@@ -25,10 +25,14 @@ import io.delta.spark.internal.v2.snapshot.SnapshotManagerFactory;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 import org.apache.spark.sql.AnalysisException;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Integration tests for catalog-routed CDC entrypoint (TableCatalog.loadChangelog).
@@ -972,5 +976,76 @@ public class DeltaChangelogCatalogIntegrationTest extends DeltaChangelogTestBase
                     "Expected schema-change error, got: " + ex.getMessage());
               });
         });
+  }
+
+  /**
+   * Every Delta-supported type widening (delta.enableTypeWidening) applied mid-range is read
+   * compatible: rows written before the change are upcast to the end (wider) type. The value is
+   * compared as a string so one assertion covers every numeric/temporal target type.
+   */
+  @ParameterizedTest(name = "{0} -> {1}")
+  @MethodSource("typeWideningCases")
+  public void testChangelogAllowsTypeWideningMidRange(
+      String fromType,
+      String toType,
+      String v1Literal,
+      String v3Literal,
+      String expectedV1,
+      String expectedV3)
+      throws Exception {
+    String tableName = "dsv2_cdc_catalog_widen_" + System.nanoTime();
+
+    withTable(
+        new String[] {tableName},
+        () -> {
+          spark.sql(
+              String.format(
+                  "CREATE TABLE %s (id BIGINT, val %s) USING delta TBLPROPERTIES "
+                      + "('delta.enableDeletionVectors'='false', 'delta.enableRowTracking'='true', "
+                      + "'delta.enableTypeWidening'='true', 'delta.feature.timestampNtz'='supported')",
+                  tableName, fromType));
+          spark.sql(String.format("INSERT INTO %s VALUES (1, %s)", tableName, v1Literal)); // v1
+          spark.sql(
+              String.format("ALTER TABLE %s ALTER COLUMN val TYPE %s", tableName, toType)); // v2
+          spark.sql(String.format("INSERT INTO %s VALUES (2, %s)", tableName, v3Literal)); // v3
+
+          withSQLConf(
+              "spark.databricks.delta.v2.enableMode",
+              "STRICT",
+              () -> {
+                List<Row> rows =
+                    spark
+                        .sql(
+                            String.format(
+                                "SELECT id, CAST(val AS STRING) AS val, _change_type FROM %s "
+                                    + "CHANGES FROM VERSION 1 TO VERSION 3",
+                                tableName))
+                        .orderBy("id")
+                        .collectAsList();
+                assertEquals(2, rows.size(), "Expected both inserts across the widening");
+                // v1 was written as fromType; it must read back upcast to toType.
+                assertEquals(expectedV1, rows.get(0).getString(1), "v1 value upcast to " + toType);
+                assertEquals(expectedV3, rows.get(1).getString(1), "v3 value as " + toType);
+              });
+        });
+  }
+
+  static Stream<Arguments> typeWideningCases() {
+    return Stream.of(
+        Arguments.of("INT", "BIGINT", "10", "20", "10", "20"),
+        Arguments.of("TINYINT", "INT", "10", "20", "10", "20"),
+        Arguments.of("SMALLINT", "BIGINT", "10", "20", "10", "20"),
+        Arguments.of("FLOAT", "DOUBLE", "1.5", "2.5", "1.5", "2.5"),
+        Arguments.of("INT", "DOUBLE", "10", "20", "10.0", "20.0"),
+        Arguments.of("DECIMAL(10,2)", "DECIMAL(20,4)", "1.25", "2.50", "1.2500", "2.5000"),
+        Arguments.of("INT", "DECIMAL(20,0)", "10", "20", "10", "20"),
+        Arguments.of("BIGINT", "DECIMAL(20,0)", "10", "20", "10", "20"),
+        Arguments.of(
+            "DATE",
+            "TIMESTAMP_NTZ",
+            "DATE'2020-01-01'",
+            "DATE'2021-06-15'",
+            "2020-01-01 00:00:00",
+            "2021-06-15 00:00:00"));
   }
 }

--- a/spark-unified/src/test/scala-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogCatalogIntegrationTest.java
+++ b/spark-unified/src/test/scala-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogCatalogIntegrationTest.java
@@ -59,36 +59,43 @@ public class DeltaChangelogCatalogIntegrationTest extends DeltaChangelogTestBase
    */
   private void withHistoryTable(String suffix, ThrowingConsumer body) throws Exception {
     String tableName = "dsv2_cdc_catalog_ts_" + suffix + "_" + System.nanoTime();
-    String tablePath = System.getProperty("java.io.tmpdir") + "/" + tableName;
     withTable(
-        tablePath,
-        () ->
-            withTable(
-                new String[] {tableName},
-                () -> {
-                  spark.sql(
-                      String.format(
-                          "CREATE TABLE %s (id BIGINT, name STRING) USING delta LOCATION '%s' TBLPROPERTIES "
-                              + "('delta.enableDeletionVectors'='false', 'delta.enableRowTracking'='true')",
-                          tableName, tablePath));
-                  spark.sql(String.format("INSERT INTO %s VALUES (1, 'Alice')", tableName));
-                  spark.sql(String.format("INSERT INTO %s VALUES (2, 'Bob')", tableName));
-                  spark.sql(String.format("INSERT INTO %s VALUES (3, 'Charlie')", tableName));
-                  spark.sql(String.format("INSERT INTO %s VALUES (4, 'Dave')", tableName));
-                  spark.sql(String.format("INSERT INTO %s VALUES (5, 'Eve')", tableName));
-                  // Read-time CDF requires the V2 connector at read time. Writes above run in the
-                  // session-default mode (AUTO → V1 connector for INSERT). The CHANGES read in
-                  // the test body needs STRICT to ensure loadTable returns a V2 DeltaV2Table.
-                  withSQLConf(
-                      "spark.databricks.delta.v2.enableMode",
-                      "STRICT",
-                      () -> body.accept(tableName, tablePath));
-                }));
+        new String[] {tableName},
+        () -> {
+          spark.sql(
+              String.format(
+                  "CREATE TABLE %s (id BIGINT, name STRING) USING delta TBLPROPERTIES "
+                      + "('delta.enableDeletionVectors'='false', 'delta.enableRowTracking'='true')",
+                  tableName));
+          spark.sql(String.format("INSERT INTO %s VALUES (1, 'Alice')", tableName));
+          spark.sql(String.format("INSERT INTO %s VALUES (2, 'Bob')", tableName));
+          spark.sql(String.format("INSERT INTO %s VALUES (3, 'Charlie')", tableName));
+          spark.sql(String.format("INSERT INTO %s VALUES (4, 'Dave')", tableName));
+          spark.sql(String.format("INSERT INTO %s VALUES (5, 'Eve')", tableName));
+          // Resolve the managed table's location now, while the session is still in the default
+          // mode. DESCRIBE DETAIL would fail under the STRICT mode set below (the table resolves to
+          // a V2 DeltaV2Table that the v1 command can't address). The location lets commitTimestamp
+          // read commit timestamps through the kernel snapshot manager, mode-independently.
+          String location =
+              spark
+                  .sql("DESCRIBE DETAIL " + tableName)
+                  .select("location")
+                  .head()
+                  .getString(0)
+                  .replaceFirst("^file:/+", "/");
+          // Read-time CDF requires the V2 connector at read time. Writes above run in the
+          // session-default mode (AUTO -> V1 connector for INSERT). The CHANGES read in
+          // the test body needs STRICT to ensure loadTable returns a V2 DeltaV2Table.
+          withSQLConf(
+              "spark.databricks.delta.v2.enableMode",
+              "STRICT",
+              () -> body.accept(tableName, location));
+        });
   }
 
   @FunctionalInterface
   private interface ThrowingConsumer {
-    void accept(String tableName, String tablePath) throws Exception;
+    void accept(String tableName, String tableLocation) throws Exception;
   }
 
   /**
@@ -96,9 +103,11 @@ public class DeltaChangelogCatalogIntegrationTest extends DeltaChangelogTestBase
    * kernel snapshot manager, so it works irrespective of the catalog mode flipped on by the test
    * body (which keeps the catalog in STRICT for the read path of read-time CDF).
    */
-  private java.sql.Timestamp commitTimestamp(String tablePath, long version) {
+  private java.sql.Timestamp commitTimestamp(String tableLocation, long version) {
+    // Reads through the kernel snapshot manager, so it works inside the STRICT block the test body
+    // runs in. tableLocation is resolved by withHistoryTable before STRICT is set.
     DeltaSnapshotManager snapshotManager =
-        SnapshotManagerFactory.create(tablePath, defaultEngine, Optional.empty());
+        SnapshotManagerFactory.create(tableLocation, defaultEngine, Optional.empty());
     long millis = snapshotManager.loadSnapshotAt(version).getTimestamp(defaultEngine);
     return new java.sql.Timestamp(millis);
   }
@@ -108,9 +117,9 @@ public class DeltaChangelogCatalogIntegrationTest extends DeltaChangelogTestBase
    * getActiveCommitAtTime} with inputs that don't coincide with any commit's exact ts, so bounds
    * inclusivity does not change the resolved version.
    */
-  private String betweenCommits(String tablePath, long earlier, long later) {
-    long earlierMs = commitTimestamp(tablePath, earlier).getTime();
-    long laterMs = commitTimestamp(tablePath, later).getTime();
+  private String betweenCommits(String tableLocation, long earlier, long later) {
+    long earlierMs = commitTimestamp(tableLocation, earlier).getTime();
+    long laterMs = commitTimestamp(tableLocation, later).getTime();
     return new java.sql.Timestamp(earlierMs + (laterMs - earlierMs) / 2).toString();
   }
 
@@ -121,63 +130,55 @@ public class DeltaChangelogCatalogIntegrationTest extends DeltaChangelogTestBase
   @Test
   public void testSqlAndDataFrameChangesMatchForVersionRange() throws Exception {
     String tableName = "dsv2_cdc_catalog_" + System.nanoTime();
-    String tablePath = System.getProperty("java.io.tmpdir") + "/" + tableName;
 
     withTable(
-        tablePath,
-        () ->
-            withTable(
-                new String[] {tableName},
-                () -> {
-                  spark.sql(
-                      String.format(
-                          "CREATE TABLE %s (id BIGINT, name STRING) USING delta LOCATION '%s' TBLPROPERTIES "
-                              + "('delta.enableDeletionVectors'='false', 'delta.enableRowTracking'='true')",
-                          tableName, tablePath));
-                  spark.sql(
-                      String.format("INSERT INTO %s VALUES (1, 'Alice'), (2, 'Bob')", tableName));
-                  spark.sql(String.format("DELETE FROM %s WHERE id = 1", tableName));
+        new String[] {tableName},
+        () -> {
+          spark.sql(
+              String.format(
+                  "CREATE TABLE %s (id BIGINT, name STRING) USING delta TBLPROPERTIES "
+                      + "('delta.enableDeletionVectors'='false', 'delta.enableRowTracking'='true')",
+                  tableName));
+          spark.sql(String.format("INSERT INTO %s VALUES (1, 'Alice'), (2, 'Bob')", tableName));
+          spark.sql(String.format("DELETE FROM %s WHERE id = 1", tableName));
 
-                  // CHANGES read needs the V2 connector; see withHistoryTable for the rationale.
-                  withSQLConf(
-                      "spark.databricks.delta.v2.enableMode",
-                      "STRICT",
-                      () -> {
-                        Dataset<Row> sqlDf =
-                            spark
-                                .sql(
-                                    String.format(
-                                        "SELECT id, name, _change_type, _commit_version "
-                                            + "FROM %s CHANGES FROM VERSION 1 TO VERSION 2",
-                                        tableName))
-                                .orderBy("_commit_version", "id", "_change_type", "name");
+          // CHANGES read needs the V2 connector; see withHistoryTable for the rationale.
+          withSQLConf(
+              "spark.databricks.delta.v2.enableMode",
+              "STRICT",
+              () -> {
+                Dataset<Row> sqlDf =
+                    spark
+                        .sql(
+                            String.format(
+                                "SELECT id, name, _change_type, _commit_version "
+                                    + "FROM %s CHANGES FROM VERSION 1 TO VERSION 2",
+                                tableName))
+                        .orderBy("_commit_version", "id", "_change_type", "name");
 
-                        Dataset<Row> apiDf =
-                            spark
-                                .read()
-                                .option("startingVersion", "1")
-                                .option("endingVersion", "2")
-                                .changes(tableName)
-                                .select("id", "name", "_change_type", "_commit_version")
-                                .orderBy("_commit_version", "id", "_change_type", "name");
+                Dataset<Row> apiDf =
+                    spark
+                        .read()
+                        .option("startingVersion", "1")
+                        .option("endingVersion", "2")
+                        .changes(tableName)
+                        .select("id", "name", "_change_type", "_commit_version")
+                        .orderBy("_commit_version", "id", "_change_type", "name");
 
-                        List<Row> sqlRows = sqlDf.collectAsList();
-                        List<Row> apiRows = apiDf.collectAsList();
-                        assertFalse(
-                            sqlRows.isEmpty(),
-                            "Expected non-empty CDC output for VERSION 1..2 range");
-                        assertEquals(
-                            sqlRows,
-                            apiRows,
-                            "SQL CHANGES and DataFrameReader.changes should match");
+                List<Row> sqlRows = sqlDf.collectAsList();
+                List<Row> apiRows = apiDf.collectAsList();
+                assertFalse(
+                    sqlRows.isEmpty(), "Expected non-empty CDC output for VERSION 1..2 range");
+                assertEquals(
+                    sqlRows, apiRows, "SQL CHANGES and DataFrameReader.changes should match");
 
-                        List<String> fieldNames = Arrays.asList(sqlDf.schema().fieldNames());
-                        assertTrue(fieldNames.contains("id"));
-                        assertTrue(fieldNames.contains("name"));
-                        assertTrue(fieldNames.contains("_change_type"));
-                        assertTrue(fieldNames.contains("_commit_version"));
-                      });
-                }));
+                List<String> fieldNames = Arrays.asList(sqlDf.schema().fieldNames());
+                assertTrue(fieldNames.contains("id"));
+                assertTrue(fieldNames.contains("name"));
+                assertTrue(fieldNames.contains("_change_type"));
+                assertTrue(fieldNames.contains("_commit_version"));
+              });
+        });
   }
 
   // ===========================================================================================
@@ -192,50 +193,43 @@ public class DeltaChangelogCatalogIntegrationTest extends DeltaChangelogTestBase
   @Test
   public void testAutoModeRoutesChangesToV2() throws Exception {
     String tableName = "dsv2_cdc_catalog_auto_" + System.nanoTime();
-    String tablePath = System.getProperty("java.io.tmpdir") + "/" + tableName;
 
     withTable(
-        tablePath,
-        () ->
-            withTable(
-                new String[] {tableName},
-                () -> {
-                  spark.sql(
-                      String.format(
-                          "CREATE TABLE %s (id BIGINT, name STRING) USING delta LOCATION '%s' "
-                              + "TBLPROPERTIES ('delta.enableDeletionVectors'='false', "
-                              + "'delta.enableRowTracking'='true')",
-                          tableName, tablePath));
-                  spark.sql(String.format("INSERT INTO %s VALUES (1, 'Alice')", tableName));
-                  spark.sql(String.format("INSERT INTO %s VALUES (2, 'Bob')", tableName));
-                  spark.sql(String.format("INSERT INTO %s VALUES (3, 'Charlie')", tableName));
+        new String[] {tableName},
+        () -> {
+          spark.sql(
+              String.format(
+                  "CREATE TABLE %s (id BIGINT, name STRING) USING delta "
+                      + "TBLPROPERTIES ('delta.enableDeletionVectors'='false', "
+                      + "'delta.enableRowTracking'='true')",
+                  tableName));
+          spark.sql(String.format("INSERT INTO %s VALUES (1, 'Alice')", tableName));
+          spark.sql(String.format("INSERT INTO %s VALUES (2, 'Bob')", tableName));
+          spark.sql(String.format("INSERT INTO %s VALUES (3, 'Charlie')", tableName));
 
-                  // CREATE/INSERTs above run on the V1 connector under AUTO. The CHANGES read must
-                  // still succeed: ChangelogSupport re-resolves the table to the V2 connector.
-                  withSQLConf(
-                      "spark.databricks.delta.v2.enableMode",
-                      "AUTO",
-                      () -> {
-                        List<Row> rows =
-                            spark
-                                .sql(
-                                    String.format(
-                                        "SELECT id, name, _change_type "
-                                            + "FROM %s CHANGES FROM VERSION 1 TO VERSION 3",
-                                        tableName))
-                                .orderBy("_commit_version", "id")
-                                .collectAsList();
-                        assertEquals(
-                            3,
-                            rows.size(),
-                            "Expected three inserts in the v1..v3 range under AUTO");
-                        for (int i = 0; i < 3; i++) {
-                          assertEquals(
-                              (long) (i + 1), ((Number) rows.get(i).getAs("id")).longValue());
-                          assertEquals("insert", rows.get(i).getAs("_change_type"));
-                        }
-                      });
-                }));
+          // CREATE/INSERTs above run on the V1 connector under AUTO. The CHANGES read must
+          // still succeed: ChangelogSupport re-resolves the table to the V2 connector.
+          withSQLConf(
+              "spark.databricks.delta.v2.enableMode",
+              "AUTO",
+              () -> {
+                List<Row> rows =
+                    spark
+                        .sql(
+                            String.format(
+                                "SELECT id, name, _change_type "
+                                    + "FROM %s CHANGES FROM VERSION 1 TO VERSION 3",
+                                tableName))
+                        .orderBy("_commit_version", "id")
+                        .collectAsList();
+                assertEquals(
+                    3, rows.size(), "Expected three inserts in the v1..v3 range under AUTO");
+                for (int i = 0; i < 3; i++) {
+                  assertEquals((long) (i + 1), ((Number) rows.get(i).getAs("id")).longValue());
+                  assertEquals("insert", rows.get(i).getAs("_change_type"));
+                }
+              });
+        });
   }
 
   /**
@@ -245,48 +239,41 @@ public class DeltaChangelogCatalogIntegrationTest extends DeltaChangelogTestBase
   @Test
   public void testStrictModeRoutesChangesToV2() throws Exception {
     String tableName = "dsv2_cdc_catalog_strict_" + System.nanoTime();
-    String tablePath = System.getProperty("java.io.tmpdir") + "/" + tableName;
 
     withTable(
-        tablePath,
-        () ->
-            withTable(
-                new String[] {tableName},
-                () -> {
-                  spark.sql(
-                      String.format(
-                          "CREATE TABLE %s (id BIGINT, name STRING) USING delta LOCATION '%s' "
-                              + "TBLPROPERTIES ('delta.enableDeletionVectors'='false', "
-                              + "'delta.enableRowTracking'='true')",
-                          tableName, tablePath));
-                  spark.sql(String.format("INSERT INTO %s VALUES (1, 'Alice')", tableName));
-                  spark.sql(String.format("INSERT INTO %s VALUES (2, 'Bob')", tableName));
-                  spark.sql(String.format("INSERT INTO %s VALUES (3, 'Charlie')", tableName));
+        new String[] {tableName},
+        () -> {
+          spark.sql(
+              String.format(
+                  "CREATE TABLE %s (id BIGINT, name STRING) USING delta "
+                      + "TBLPROPERTIES ('delta.enableDeletionVectors'='false', "
+                      + "'delta.enableRowTracking'='true')",
+                  tableName));
+          spark.sql(String.format("INSERT INTO %s VALUES (1, 'Alice')", tableName));
+          spark.sql(String.format("INSERT INTO %s VALUES (2, 'Bob')", tableName));
+          spark.sql(String.format("INSERT INTO %s VALUES (3, 'Charlie')", tableName));
 
-                  withSQLConf(
-                      "spark.databricks.delta.v2.enableMode",
-                      "STRICT",
-                      () -> {
-                        List<Row> rows =
-                            spark
-                                .sql(
-                                    String.format(
-                                        "SELECT id, name, _change_type "
-                                            + "FROM %s CHANGES FROM VERSION 1 TO VERSION 3",
-                                        tableName))
-                                .orderBy("_commit_version", "id")
-                                .collectAsList();
-                        assertEquals(
-                            3,
-                            rows.size(),
-                            "Expected three inserts in the v1..v3 range under STRICT");
-                        for (int i = 0; i < 3; i++) {
-                          assertEquals(
-                              (long) (i + 1), ((Number) rows.get(i).getAs("id")).longValue());
-                          assertEquals("insert", rows.get(i).getAs("_change_type"));
-                        }
-                      });
-                }));
+          withSQLConf(
+              "spark.databricks.delta.v2.enableMode",
+              "STRICT",
+              () -> {
+                List<Row> rows =
+                    spark
+                        .sql(
+                            String.format(
+                                "SELECT id, name, _change_type "
+                                    + "FROM %s CHANGES FROM VERSION 1 TO VERSION 3",
+                                tableName))
+                        .orderBy("_commit_version", "id")
+                        .collectAsList();
+                assertEquals(
+                    3, rows.size(), "Expected three inserts in the v1..v3 range under STRICT");
+                for (int i = 0; i < 3; i++) {
+                  assertEquals((long) (i + 1), ((Number) rows.get(i).getAs("id")).longValue());
+                  assertEquals("insert", rows.get(i).getAs("_change_type"));
+                }
+              });
+        });
   }
 
   /**
@@ -296,43 +283,37 @@ public class DeltaChangelogCatalogIntegrationTest extends DeltaChangelogTestBase
   @Test
   public void testNoneModeRejectsChanges() throws Exception {
     String tableName = "dsv2_cdc_catalog_none_" + System.nanoTime();
-    String tablePath = System.getProperty("java.io.tmpdir") + "/" + tableName;
 
     withTable(
-        tablePath,
-        () ->
-            withTable(
-                new String[] {tableName},
-                () -> {
-                  spark.sql(
-                      String.format(
-                          "CREATE TABLE %s (id BIGINT, name STRING) USING delta LOCATION '%s' "
-                              + "TBLPROPERTIES ('delta.enableDeletionVectors'='false', "
-                              + "'delta.enableRowTracking'='true')",
-                          tableName, tablePath));
-                  spark.sql(String.format("INSERT INTO %s VALUES (1, 'Alice')", tableName));
+        new String[] {tableName},
+        () -> {
+          spark.sql(
+              String.format(
+                  "CREATE TABLE %s (id BIGINT, name STRING) USING delta "
+                      + "TBLPROPERTIES ('delta.enableDeletionVectors'='false', "
+                      + "'delta.enableRowTracking'='true')",
+                  tableName));
+          spark.sql(String.format("INSERT INTO %s VALUES (1, 'Alice')", tableName));
 
-                  withSQLConf(
-                      "spark.databricks.delta.v2.enableMode",
-                      "NONE",
-                      () -> {
-                        Exception ex =
-                            assertThrows(
-                                Exception.class,
-                                () ->
-                                    spark
-                                        .sql(
-                                            String.format(
-                                                "SELECT * FROM %s CHANGES FROM VERSION 0 TO "
-                                                    + "VERSION 1",
-                                                tableName))
-                                        .collectAsList());
-                        assertTrue(
-                            ex.getMessage().contains("DELTA_CHANGELOG_REQUIRES_V2_TABLE"),
-                            "Expected V2-connector-required error under NONE, got: "
-                                + ex.getMessage());
-                      });
-                }));
+          withSQLConf(
+              "spark.databricks.delta.v2.enableMode",
+              "NONE",
+              () -> {
+                Exception ex =
+                    assertThrows(
+                        Exception.class,
+                        () ->
+                            spark
+                                .sql(
+                                    String.format(
+                                        "SELECT * FROM %s CHANGES FROM VERSION 0 TO " + "VERSION 1",
+                                        tableName))
+                                .collectAsList());
+                assertTrue(
+                    ex.getMessage().contains("DELTA_CHANGELOG_REQUIRES_V2_TABLE"),
+                    "Expected V2-connector-required error under NONE, got: " + ex.getMessage());
+              });
+        });
   }
 
   // ===========================================================================================
@@ -345,9 +326,9 @@ public class DeltaChangelogCatalogIntegrationTest extends DeltaChangelogTestBase
   public void testTimestampRangeReadsAllChanges() throws Exception {
     withHistoryTable(
         "all",
-        (tableName, tablePath) -> {
-          String startTs = commitTimestamp(tablePath, 0).toString();
-          String endTs = commitTimestamp(tablePath, 5).toString();
+        (tableName, location) -> {
+          String startTs = commitTimestamp(location, 0).toString();
+          String endTs = commitTimestamp(location, 5).toString();
 
           Dataset<Row> changes =
               spark
@@ -371,9 +352,9 @@ public class DeltaChangelogCatalogIntegrationTest extends DeltaChangelogTestBase
   public void testTimestampRangePartialMiddleCommit() throws Exception {
     withHistoryTable(
         "partial",
-        (tableName, tablePath) -> {
+        (tableName, location) -> {
           // Both bounds resolve to v3; range = [v3, v3] inclusive.
-          String tsV3 = commitTimestamp(tablePath, 3).toString();
+          String tsV3 = commitTimestamp(location, 3).toString();
           Dataset<Row> changes =
               spark.sql(
                   String.format(
@@ -392,13 +373,13 @@ public class DeltaChangelogCatalogIntegrationTest extends DeltaChangelogTestBase
   public void testTimestampRangeBetweenCommitTimestamps() throws Exception {
     withHistoryTable(
         "between",
-        (tableName, tablePath) -> {
+        (tableName, location) -> {
           // Start strictly between v1 and v2: getActiveCommitAtTime returns the latest commit
           // with ts <= start, so start resolves to v1.
           // End strictly between v2 and v3: same rule, end resolves to v2.
           // Range = [v1, v2] = Alice + Bob.
-          String startTs = betweenCommits(tablePath, 1, 2);
-          String endTs = betweenCommits(tablePath, 2, 3);
+          String startTs = betweenCommits(location, 1, 2);
+          String endTs = betweenCommits(location, 2, 3);
 
           Dataset<Row> changes =
               spark
@@ -422,9 +403,9 @@ public class DeltaChangelogCatalogIntegrationTest extends DeltaChangelogTestBase
   public void testTimestampRangeExclusiveBoundsSkipBoundaryCommits() throws Exception {
     withHistoryTable(
         "excl",
-        (tableName, tablePath) -> {
-          String tsV1 = commitTimestamp(tablePath, 1).toString();
-          String tsV3 = commitTimestamp(tablePath, 3).toString();
+        (tableName, location) -> {
+          String tsV1 = commitTimestamp(location, 1).toString();
+          String tsV3 = commitTimestamp(location, 3).toString();
 
           // FROM tsV1 EXCLUSIVE bumps start to v2; TO tsV3 EXCLUSIVE drops end to v2.
           // Range = [v2, v2] = only the (2, 'Bob') insert.
@@ -446,9 +427,9 @@ public class DeltaChangelogCatalogIntegrationTest extends DeltaChangelogTestBase
   public void testTimestampRangeMixedBoundsStartExclusiveEndInclusive() throws Exception {
     withHistoryTable(
         "mixed_se_ei",
-        (tableName, tablePath) -> {
-          String tsV1 = commitTimestamp(tablePath, 1).toString();
-          String tsV3 = commitTimestamp(tablePath, 3).toString();
+        (tableName, location) -> {
+          String tsV1 = commitTimestamp(location, 1).toString();
+          String tsV3 = commitTimestamp(location, 3).toString();
 
           // FROM tsV1 EXCLUSIVE bumps start to v2; TO tsV3 (default INCLUSIVE) keeps end at v3.
           // Range = [v2, v3] = Bob + Charlie.
@@ -472,9 +453,9 @@ public class DeltaChangelogCatalogIntegrationTest extends DeltaChangelogTestBase
   public void testTimestampRangeMixedBoundsStartInclusiveEndExclusive() throws Exception {
     withHistoryTable(
         "mixed_si_ee",
-        (tableName, tablePath) -> {
-          String tsV1 = commitTimestamp(tablePath, 1).toString();
-          String tsV3 = commitTimestamp(tablePath, 3).toString();
+        (tableName, location) -> {
+          String tsV1 = commitTimestamp(location, 1).toString();
+          String tsV3 = commitTimestamp(location, 3).toString();
 
           // FROM tsV1 (default INCLUSIVE) keeps start at v1; TO tsV3 EXCLUSIVE drops end to v2.
           // Range = [v1, v2] = Alice + Bob.
@@ -500,10 +481,10 @@ public class DeltaChangelogCatalogIntegrationTest extends DeltaChangelogTestBase
   public void testTimestampRangeOpenEndedReadsToLatest() throws Exception {
     withHistoryTable(
         "open_incl",
-        (tableName, tablePath) -> {
+        (tableName, location) -> {
           // FROM tsV1 (default INCLUSIVE) keeps start at v1; no TO clause = read to latest (v5).
           // Range = [v1, v5] = all five inserts.
-          String tsV1 = commitTimestamp(tablePath, 1).toString();
+          String tsV1 = commitTimestamp(location, 1).toString();
 
           Dataset<Row> changes =
               spark
@@ -525,10 +506,10 @@ public class DeltaChangelogCatalogIntegrationTest extends DeltaChangelogTestBase
   public void testTimestampRangeOpenEndedExclusiveStart() throws Exception {
     withHistoryTable(
         "open_excl",
-        (tableName, tablePath) -> {
+        (tableName, location) -> {
           // FROM tsV1 EXCLUSIVE bumps start to v2; no TO clause = read to latest (v5).
           // Range = [v2, v5] = Bob + Charlie + Dave + Eve.
-          String tsV1 = commitTimestamp(tablePath, 1).toString();
+          String tsV1 = commitTimestamp(location, 1).toString();
 
           Dataset<Row> changes =
               spark
@@ -552,10 +533,10 @@ public class DeltaChangelogCatalogIntegrationTest extends DeltaChangelogTestBase
   public void testTimestampRangeRejectsEmptyExclusiveRange() throws Exception {
     withHistoryTable(
         "empty_excl",
-        (tableName, tablePath) -> {
+        (tableName, location) -> {
           // Both bounds at tsV3 with EXCL on both sides:
           //   start adjusts to v4, end adjusts to v2 -> start > end -> DELTA_INVALID_CDC_RANGE.
-          String tsV3 = commitTimestamp(tablePath, 3).toString();
+          String tsV3 = commitTimestamp(location, 3).toString();
 
           Exception ex =
               assertThrows(
@@ -580,7 +561,7 @@ public class DeltaChangelogCatalogIntegrationTest extends DeltaChangelogTestBase
   public void testTimestampRangeBeforeEarliestCommitFails() throws Exception {
     withHistoryTable(
         "past_ts",
-        (tableName, tablePath) -> {
+        (tableName, location) -> {
           Exception ex =
               assertThrows(
                   Exception.class,
@@ -604,77 +585,67 @@ public class DeltaChangelogCatalogIntegrationTest extends DeltaChangelogTestBase
   @Test
   public void testTimestampRangeAfterLatestCommitFails() throws Exception {
     String tableName = "dsv2_cdc_catalog_ts_future_" + System.nanoTime();
-    String tablePath = System.getProperty("java.io.tmpdir") + "/" + tableName;
 
     withTable(
-        tablePath,
-        () ->
-            withTable(
-                new String[] {tableName},
-                () -> {
-                  spark.sql(
-                      String.format(
-                          "CREATE TABLE %s (id BIGINT, name STRING) USING delta LOCATION '%s' TBLPROPERTIES "
-                              + "('delta.enableDeletionVectors'='false', 'delta.enableRowTracking'='true')",
-                          tableName, tablePath));
-                  spark.sql(String.format("INSERT INTO %s VALUES (1, 'Alice')", tableName));
+        new String[] {tableName},
+        () -> {
+          spark.sql(
+              String.format(
+                  "CREATE TABLE %s (id BIGINT, name STRING) USING delta TBLPROPERTIES "
+                      + "('delta.enableDeletionVectors'='false', 'delta.enableRowTracking'='true')",
+                  tableName));
+          spark.sql(String.format("INSERT INTO %s VALUES (1, 'Alice')", tableName));
 
-                  withSQLConf(
-                      "spark.databricks.delta.v2.enableMode",
-                      "STRICT",
-                      () -> {
-                        Exception ex =
-                            assertThrows(
-                                Exception.class,
-                                () ->
-                                    spark
-                                        .sql(
-                                            String.format(
-                                                "SELECT * FROM %s CHANGES FROM TIMESTAMP "
-                                                    + "'9999-01-01 00:00:00' TO TIMESTAMP "
-                                                    + "'9999-01-02 00:00:00'",
-                                                tableName))
-                                        .collectAsList());
-                        assertTrue(
-                            ex.getMessage().contains("DELTA_TIMESTAMP_GREATER_THAN_COMMIT")
-                                || ex.getMessage().contains("after the latest version")
-                                || ex.getMessage().contains("after the latest available version"),
-                            "Expected timestamp-after-latest error, got: " + ex.getMessage());
-                      });
-                }));
+          withSQLConf(
+              "spark.databricks.delta.v2.enableMode",
+              "STRICT",
+              () -> {
+                Exception ex =
+                    assertThrows(
+                        Exception.class,
+                        () ->
+                            spark
+                                .sql(
+                                    String.format(
+                                        "SELECT * FROM %s CHANGES FROM TIMESTAMP "
+                                            + "'9999-01-01 00:00:00' TO TIMESTAMP "
+                                            + "'9999-01-02 00:00:00'",
+                                        tableName))
+                                .collectAsList());
+                assertTrue(
+                    ex.getMessage().contains("DELTA_TIMESTAMP_GREATER_THAN_COMMIT")
+                        || ex.getMessage().contains("after the latest version")
+                        || ex.getMessage().contains("after the latest available version"),
+                    "Expected timestamp-after-latest error, got: " + ex.getMessage());
+              });
+        });
   }
 
   @Test
   public void testUnboundedBatchChangesIsRejectedForNow() throws Exception {
     String tableName = "dsv2_cdc_catalog_unbounded_" + System.nanoTime();
-    String tablePath = System.getProperty("java.io.tmpdir") + "/" + tableName;
 
     withTable(
-        tablePath,
-        () ->
-            withTable(
-                new String[] {tableName},
-                () -> {
-                  spark.sql(
-                      String.format(
-                          "CREATE TABLE %s (id BIGINT, name STRING) USING delta LOCATION '%s'",
-                          tableName, tablePath));
-                  spark.sql(String.format("INSERT INTO %s VALUES (1, 'Alice')", tableName));
+        new String[] {tableName},
+        () -> {
+          spark.sql(
+              String.format("CREATE TABLE %s (id BIGINT, name STRING) USING delta", tableName));
+          spark.sql(String.format("INSERT INTO %s VALUES (1, 'Alice')", tableName));
 
-                  withSQLConf(
-                      "spark.databricks.delta.v2.enableMode",
-                      "STRICT",
-                      () -> {
-                        AnalysisException ex =
-                            assertThrows(
-                                AnalysisException.class,
-                                () -> spark.read().changes(tableName).collectAsList());
-                        assertTrue(
-                            ex.getMessage().contains("DELTA_CHANGELOG_UNBOUNDED_RANGE"),
-                            "Expected loadChangelog rejection for unbounded batch range, got: "
-                                + ex.getMessage());
-                      });
-                }));
+          withSQLConf(
+              "spark.databricks.delta.v2.enableMode",
+              "STRICT",
+              () -> {
+                AnalysisException ex =
+                    assertThrows(
+                        AnalysisException.class,
+                        () -> spark.read().changes(tableName).collectAsList());
+                assertTrue(
+                    ex.getMessage().contains("DELTA_CHANGELOG_UNBOUNDED_RANGE"),
+                    "Expected loadChangelog rejection for unbounded batch range, got: "
+                        + ex.getMessage());
+              });
+        });
   }
 
   // ===========================================================================================
@@ -689,42 +660,37 @@ public class DeltaChangelogCatalogIntegrationTest extends DeltaChangelogTestBase
   @Test
   public void testChangelogRejectsTableWithoutRowTracking() throws Exception {
     String tableName = "dsv2_cdc_catalog_no_rt_" + System.nanoTime();
-    String tablePath = System.getProperty("java.io.tmpdir") + "/" + tableName;
 
     withTable(
-        tablePath,
-        () ->
-            withTable(
-                new String[] {tableName},
-                () -> {
-                  // Table created without delta.enableRowTracking.
-                  spark.sql(
-                      String.format(
-                          "CREATE TABLE %s (id BIGINT, name STRING) USING delta LOCATION '%s' "
-                              + "TBLPROPERTIES ('delta.enableDeletionVectors'='false')",
-                          tableName, tablePath));
-                  spark.sql(String.format("INSERT INTO %s VALUES (1, 'Alice')", tableName));
+        new String[] {tableName},
+        () -> {
+          // Table created without delta.enableRowTracking.
+          spark.sql(
+              String.format(
+                  "CREATE TABLE %s (id BIGINT, name STRING) USING delta "
+                      + "TBLPROPERTIES ('delta.enableDeletionVectors'='false')",
+                  tableName));
+          spark.sql(String.format("INSERT INTO %s VALUES (1, 'Alice')", tableName));
 
-                  withSQLConf(
-                      "spark.databricks.delta.v2.enableMode",
-                      "STRICT",
-                      () -> {
-                        Exception ex =
-                            assertThrows(
-                                Exception.class,
-                                () ->
-                                    spark
-                                        .sql(
-                                            String.format(
-                                                "SELECT * FROM %s CHANGES FROM VERSION 0 TO "
-                                                    + "VERSION 1",
-                                                tableName))
-                                        .collectAsList());
-                        assertTrue(
-                            ex.getMessage().contains("DELTA_CHANGELOG_REQUIRES_ROW_TRACKING"),
-                            "Expected row-tracking required error, got: " + ex.getMessage());
-                      });
-                }));
+          withSQLConf(
+              "spark.databricks.delta.v2.enableMode",
+              "STRICT",
+              () -> {
+                Exception ex =
+                    assertThrows(
+                        Exception.class,
+                        () ->
+                            spark
+                                .sql(
+                                    String.format(
+                                        "SELECT * FROM %s CHANGES FROM VERSION 0 TO " + "VERSION 1",
+                                        tableName))
+                                .collectAsList());
+                assertTrue(
+                    ex.getMessage().contains("DELTA_CHANGELOG_REQUIRES_ROW_TRACKING"),
+                    "Expected row-tracking required error, got: " + ex.getMessage());
+              });
+        });
   }
 
   /**
@@ -735,50 +701,45 @@ public class DeltaChangelogCatalogIntegrationTest extends DeltaChangelogTestBase
   @Test
   public void testChangelogRejectsRowTrackingDisabledAtEnd() throws Exception {
     String tableName = "dsv2_cdc_catalog_rt_disabled_end_" + System.nanoTime();
-    String tablePath = System.getProperty("java.io.tmpdir") + "/" + tableName;
 
     withTable(
-        tablePath,
-        () ->
-            withTable(
-                new String[] {tableName},
-                () -> {
-                  // v0: CREATE with row tracking enabled.
-                  spark.sql(
-                      String.format(
-                          "CREATE TABLE %s (id BIGINT, name STRING) USING delta LOCATION '%s' "
-                              + "TBLPROPERTIES "
-                              + "('delta.enableDeletionVectors'='false', "
-                              + "'delta.enableRowTracking'='true')",
-                          tableName, tablePath));
-                  // v1: INSERT (row tracking still on).
-                  spark.sql(String.format("INSERT INTO %s VALUES (1, 'Alice')", tableName));
-                  // v2: disable row tracking via ALTER TBLPROPERTIES.
-                  spark.sql(
-                      String.format(
-                          "ALTER TABLE %s SET TBLPROPERTIES ('delta.enableRowTracking'='false')",
-                          tableName));
+        new String[] {tableName},
+        () -> {
+          // v0: CREATE with row tracking enabled.
+          spark.sql(
+              String.format(
+                  "CREATE TABLE %s (id BIGINT, name STRING) USING delta "
+                      + "TBLPROPERTIES "
+                      + "('delta.enableDeletionVectors'='false', "
+                      + "'delta.enableRowTracking'='true')",
+                  tableName));
+          // v1: INSERT (row tracking still on).
+          spark.sql(String.format("INSERT INTO %s VALUES (1, 'Alice')", tableName));
+          // v2: disable row tracking via ALTER TBLPROPERTIES.
+          spark.sql(
+              String.format(
+                  "ALTER TABLE %s SET TBLPROPERTIES ('delta.enableRowTracking'='false')",
+                  tableName));
 
-                  withSQLConf(
-                      "spark.databricks.delta.v2.enableMode",
-                      "STRICT",
-                      () -> {
-                        Exception ex =
-                            assertThrows(
-                                Exception.class,
-                                () ->
-                                    spark
-                                        .sql(
-                                            String.format(
-                                                "SELECT * FROM %s CHANGES FROM VERSION 0 TO "
-                                                    + "VERSION 2",
-                                                tableName))
-                                        .collectAsList());
-                        assertTrue(
-                            ex.getMessage().contains("DELTA_CHANGELOG_REQUIRES_ROW_TRACKING"),
-                            "Expected eager end-snapshot RT error, got: " + ex.getMessage());
-                      });
-                }));
+          withSQLConf(
+              "spark.databricks.delta.v2.enableMode",
+              "STRICT",
+              () -> {
+                Exception ex =
+                    assertThrows(
+                        Exception.class,
+                        () ->
+                            spark
+                                .sql(
+                                    String.format(
+                                        "SELECT * FROM %s CHANGES FROM VERSION 0 TO " + "VERSION 2",
+                                        tableName))
+                                .collectAsList());
+                assertTrue(
+                    ex.getMessage().contains("DELTA_CHANGELOG_REQUIRES_ROW_TRACKING"),
+                    "Expected eager end-snapshot RT error, got: " + ex.getMessage());
+              });
+        });
   }
 
   /**
@@ -791,57 +752,51 @@ public class DeltaChangelogCatalogIntegrationTest extends DeltaChangelogTestBase
   @Test
   public void testChangelogRejectsRowTrackingDisabledMidRange() throws Exception {
     String tableName = "dsv2_cdc_catalog_rt_disabled_mid_" + System.nanoTime();
-    String tablePath = System.getProperty("java.io.tmpdir") + "/" + tableName;
 
     withTable(
-        tablePath,
-        () ->
-            withTable(
-                new String[] {tableName},
-                () -> {
-                  // v0: CREATE with row tracking enabled.
-                  spark.sql(
-                      String.format(
-                          "CREATE TABLE %s (id BIGINT, name STRING) USING delta LOCATION '%s' "
-                              + "TBLPROPERTIES "
-                              + "('delta.enableDeletionVectors'='false', "
-                              + "'delta.enableRowTracking'='true')",
-                          tableName, tablePath));
-                  // v1: INSERT (RT still on).
-                  spark.sql(String.format("INSERT INTO %s VALUES (1, 'Alice')", tableName));
-                  // v2: ALTER TBLPROPERTIES sets RT off (Metadata commit inside the range).
-                  spark.sql(
-                      String.format(
-                          "ALTER TABLE %s SET TBLPROPERTIES ('delta.enableRowTracking'='false')",
-                          tableName));
-                  // v3: ALTER TBLPROPERTIES turns RT back on, so the end-snapshot check passes
-                  // and the failure must come from the per-commit loop at v2.
-                  spark.sql(
-                      String.format(
-                          "ALTER TABLE %s SET TBLPROPERTIES ('delta.enableRowTracking'='true')",
-                          tableName));
+        new String[] {tableName},
+        () -> {
+          // v0: CREATE with row tracking enabled.
+          spark.sql(
+              String.format(
+                  "CREATE TABLE %s (id BIGINT, name STRING) USING delta "
+                      + "TBLPROPERTIES "
+                      + "('delta.enableDeletionVectors'='false', "
+                      + "'delta.enableRowTracking'='true')",
+                  tableName));
+          // v1: INSERT (RT still on).
+          spark.sql(String.format("INSERT INTO %s VALUES (1, 'Alice')", tableName));
+          // v2: ALTER TBLPROPERTIES sets RT off (Metadata commit inside the range).
+          spark.sql(
+              String.format(
+                  "ALTER TABLE %s SET TBLPROPERTIES ('delta.enableRowTracking'='false')",
+                  tableName));
+          // v3: ALTER TBLPROPERTIES turns RT back on, so the end-snapshot check passes
+          // and the failure must come from the per-commit loop at v2.
+          spark.sql(
+              String.format(
+                  "ALTER TABLE %s SET TBLPROPERTIES ('delta.enableRowTracking'='true')",
+                  tableName));
 
-                  withSQLConf(
-                      "spark.databricks.delta.v2.enableMode",
-                      "STRICT",
-                      () -> {
-                        Exception ex =
-                            assertThrows(
-                                Exception.class,
-                                () ->
-                                    spark
-                                        .sql(
-                                            String.format(
-                                                "SELECT * FROM %s CHANGES FROM VERSION 0 TO "
-                                                    + "VERSION 3",
-                                                tableName))
-                                        .collectAsList());
-                        assertTrue(
-                            ex.getMessage()
-                                .contains("DELTA_CHANGELOG_ROW_TRACKING_DISABLED_IN_RANGE"),
-                            "Expected per-commit mid-range RT error, got: " + ex.getMessage());
-                      });
-                }));
+          withSQLConf(
+              "spark.databricks.delta.v2.enableMode",
+              "STRICT",
+              () -> {
+                Exception ex =
+                    assertThrows(
+                        Exception.class,
+                        () ->
+                            spark
+                                .sql(
+                                    String.format(
+                                        "SELECT * FROM %s CHANGES FROM VERSION 0 TO " + "VERSION 3",
+                                        tableName))
+                                .collectAsList());
+                assertTrue(
+                    ex.getMessage().contains("DELTA_CHANGELOG_ROW_TRACKING_DISABLED_IN_RANGE"),
+                    "Expected per-commit mid-range RT error, got: " + ex.getMessage());
+              });
+        });
   }
 
   /**
@@ -851,53 +806,45 @@ public class DeltaChangelogCatalogIntegrationTest extends DeltaChangelogTestBase
   @Test
   public void testChangelogAllowsRowTrackingToggleBeforeRange() throws Exception {
     String tableName = "dsv2_cdc_catalog_rt_toggle_before_" + System.nanoTime();
-    String tablePath = System.getProperty("java.io.tmpdir") + "/" + tableName;
 
     withTable(
-        tablePath,
-        () ->
-            withTable(
-                new String[] {tableName},
-                () -> {
-                  // v0: CREATE with row tracking enabled.
-                  spark.sql(
-                      String.format(
-                          "CREATE TABLE %s (id BIGINT, name STRING) USING delta LOCATION '%s' "
-                              + "TBLPROPERTIES "
-                              + "('delta.enableDeletionVectors'='false', "
-                              + "'delta.enableRowTracking'='true')",
-                          tableName, tablePath));
-                  // v1: INSERT (row tracking on).
-                  spark.sql(String.format("INSERT INTO %s VALUES (1, 'Alice')", tableName));
-                  // v2: disable row tracking, v3: re-enable it -- both before the read range.
-                  spark.sql(
-                      String.format(
-                          "ALTER TABLE %s SET TBLPROPERTIES ('delta.enableRowTracking'='false')",
-                          tableName));
-                  spark.sql(
-                      String.format(
-                          "ALTER TABLE %s SET TBLPROPERTIES ('delta.enableRowTracking'='true')",
-                          tableName));
-                  // v4, v5: INSERTs inside the row-tracking-enabled read range.
-                  spark.sql(String.format("INSERT INTO %s VALUES (2, 'Bob')", tableName));
-                  spark.sql(String.format("INSERT INTO %s VALUES (3, 'Charlie')", tableName));
+        new String[] {tableName},
+        () -> {
+          // v0: CREATE with row tracking enabled.
+          spark.sql(
+              String.format(
+                  "CREATE TABLE %s (id BIGINT, name STRING) USING delta TBLPROPERTIES "
+                      + "('delta.enableDeletionVectors'='false', 'delta.enableRowTracking'='true')",
+                  tableName));
+          // v1: INSERT (row tracking on).
+          spark.sql(String.format("INSERT INTO %s VALUES (1, 'Alice')", tableName));
+          // v2: disable row tracking, v3: re-enable it -- both before the read range.
+          spark.sql(
+              String.format(
+                  "ALTER TABLE %s SET TBLPROPERTIES ('delta.enableRowTracking'='false')",
+                  tableName));
+          spark.sql(
+              String.format(
+                  "ALTER TABLE %s SET TBLPROPERTIES ('delta.enableRowTracking'='true')", tableName));
+          // v4, v5: INSERTs inside the row-tracking-enabled read range.
+          spark.sql(String.format("INSERT INTO %s VALUES (2, 'Bob')", tableName));
+          spark.sql(String.format("INSERT INTO %s VALUES (3, 'Charlie')", tableName));
 
-                  withSQLConf(
-                      "spark.databricks.delta.v2.enableMode",
-                      "STRICT",
-                      () -> {
-                        List<Row> rows =
-                            spark
-                                .sql(
-                                    String.format(
-                                        "SELECT id, _change_type FROM %s "
-                                            + "CHANGES FROM VERSION 4 TO VERSION 5",
-                                        tableName))
-                                .collectAsList();
-                        assertEquals(
-                            2, rows.size(), "Expected the two in-range inserts to be returned");
-                      });
-                }));
+          withSQLConf(
+              "spark.databricks.delta.v2.enableMode",
+              "STRICT",
+              () -> {
+                List<Row> rows =
+                    spark
+                        .sql(
+                            String.format(
+                                "SELECT id, _change_type FROM %s "
+                                    + "CHANGES FROM VERSION 4 TO VERSION 5",
+                                tableName))
+                        .collectAsList();
+                assertEquals(2, rows.size(), "Expected the two in-range inserts to be returned");
+              });
+        });
   }
 
   /**
@@ -907,47 +854,40 @@ public class DeltaChangelogCatalogIntegrationTest extends DeltaChangelogTestBase
   @Test
   public void testChangelogAllowsRowTrackingDisabledAfterRange() throws Exception {
     String tableName = "dsv2_cdc_catalog_rt_disabled_after_" + System.nanoTime();
-    String tablePath = System.getProperty("java.io.tmpdir") + "/" + tableName;
 
     withTable(
-        tablePath,
-        () ->
-            withTable(
-                new String[] {tableName},
-                () -> {
-                  // v0: CREATE with row tracking enabled.
-                  spark.sql(
-                      String.format(
-                          "CREATE TABLE %s (id BIGINT, name STRING) USING delta LOCATION '%s' "
-                              + "TBLPROPERTIES "
-                              + "('delta.enableDeletionVectors'='false', "
-                              + "'delta.enableRowTracking'='true')",
-                          tableName, tablePath));
-                  // v1, v2: INSERTs inside the row-tracking-enabled read range.
-                  spark.sql(String.format("INSERT INTO %s VALUES (1, 'Alice')", tableName));
-                  spark.sql(String.format("INSERT INTO %s VALUES (2, 'Bob')", tableName));
-                  // v3: disable row tracking after the range.
-                  spark.sql(
-                      String.format(
-                          "ALTER TABLE %s SET TBLPROPERTIES ('delta.enableRowTracking'='false')",
-                          tableName));
+        new String[] {tableName},
+        () -> {
+          // v0: CREATE with row tracking enabled.
+          spark.sql(
+              String.format(
+                  "CREATE TABLE %s (id BIGINT, name STRING) USING delta TBLPROPERTIES "
+                      + "('delta.enableDeletionVectors'='false', 'delta.enableRowTracking'='true')",
+                  tableName));
+          // v1, v2: INSERTs inside the row-tracking-enabled read range.
+          spark.sql(String.format("INSERT INTO %s VALUES (1, 'Alice')", tableName));
+          spark.sql(String.format("INSERT INTO %s VALUES (2, 'Bob')", tableName));
+          // v3: disable row tracking after the range.
+          spark.sql(
+              String.format(
+                  "ALTER TABLE %s SET TBLPROPERTIES ('delta.enableRowTracking'='false')",
+                  tableName));
 
-                  withSQLConf(
-                      "spark.databricks.delta.v2.enableMode",
-                      "STRICT",
-                      () -> {
-                        List<Row> rows =
-                            spark
-                                .sql(
-                                    String.format(
-                                        "SELECT id, _change_type FROM %s "
-                                            + "CHANGES FROM VERSION 1 TO VERSION 2",
-                                        tableName))
-                                .collectAsList();
-                        assertEquals(
-                            2, rows.size(), "Expected the two in-range inserts to be returned");
-                      });
-                }));
+          withSQLConf(
+              "spark.databricks.delta.v2.enableMode",
+              "STRICT",
+              () -> {
+                List<Row> rows =
+                    spark
+                        .sql(
+                            String.format(
+                                "SELECT id, _change_type FROM %s "
+                                    + "CHANGES FROM VERSION 1 TO VERSION 2",
+                                tableName))
+                        .collectAsList();
+                assertEquals(2, rows.size(), "Expected the two in-range inserts to be returned");
+              });
+        });
   }
 
   /**
@@ -958,42 +898,35 @@ public class DeltaChangelogCatalogIntegrationTest extends DeltaChangelogTestBase
   @Test
   public void testChangelogAllowsAdditiveSchemaChangeMidRange() throws Exception {
     String tableName = "dsv2_cdc_catalog_schema_change_" + System.nanoTime();
-    String tablePath = System.getProperty("java.io.tmpdir") + "/" + tableName;
 
     withTable(
-        tablePath,
-        () ->
-            withTable(
-                new String[] {tableName},
-                () -> {
-                  spark.sql(
-                      String.format(
-                          "CREATE TABLE %s (id BIGINT, name STRING) USING delta LOCATION '%s' "
-                              + "TBLPROPERTIES "
-                              + "('delta.enableDeletionVectors'='false', "
-                              + "'delta.enableRowTracking'='true')",
-                          tableName, tablePath));
-                  spark.sql(String.format("INSERT INTO %s VALUES (1, 'Alice')", tableName));
-                  // Additive schema change mid-range: add a nullable column.
-                  spark.sql(String.format("ALTER TABLE %s ADD COLUMN extra STRING", tableName));
-                  spark.sql(String.format("INSERT INTO %s VALUES (2, 'Bob', 'x')", tableName));
+        new String[] {tableName},
+        () -> {
+          spark.sql(
+              String.format(
+                  "CREATE TABLE %s (id BIGINT, name STRING) USING delta TBLPROPERTIES "
+                      + "('delta.enableDeletionVectors'='false', 'delta.enableRowTracking'='true')",
+                  tableName));
+          spark.sql(String.format("INSERT INTO %s VALUES (1, 'Alice')", tableName));
+          // Additive schema change mid-range: add a nullable column.
+          spark.sql(String.format("ALTER TABLE %s ADD COLUMN extra STRING", tableName));
+          spark.sql(String.format("INSERT INTO %s VALUES (2, 'Bob', 'x')", tableName));
 
-                  withSQLConf(
-                      "spark.databricks.delta.v2.enableMode",
-                      "STRICT",
-                      () -> {
-                        List<Row> rows =
-                            spark
-                                .sql(
-                                    String.format(
-                                        "SELECT id, _change_type FROM %s "
-                                            + "CHANGES FROM VERSION 1 TO VERSION 3",
-                                        tableName))
-                                .collectAsList();
-                        assertEquals(
-                            2, rows.size(), "Additive schema change should not fail the read");
-                      });
-                }));
+          withSQLConf(
+              "spark.databricks.delta.v2.enableMode",
+              "STRICT",
+              () -> {
+                List<Row> rows =
+                    spark
+                        .sql(
+                            String.format(
+                                "SELECT id, _change_type FROM %s "
+                                    + "CHANGES FROM VERSION 1 TO VERSION 3",
+                                tableName))
+                        .collectAsList();
+                assertEquals(2, rows.size(), "Additive schema change should not fail the read");
+              });
+        });
   }
 
   /**
@@ -1004,47 +937,40 @@ public class DeltaChangelogCatalogIntegrationTest extends DeltaChangelogTestBase
   @Test
   public void testChangelogRejectsIncompatibleSchemaChangeMidRange() throws Exception {
     String tableName = "dsv2_cdc_catalog_drop_col_" + System.nanoTime();
-    String tablePath = System.getProperty("java.io.tmpdir") + "/" + tableName;
 
     withTable(
-        tablePath,
-        () ->
-            withTable(
-                new String[] {tableName},
-                () -> {
-                  // Column mapping is required to drop a column.
-                  spark.sql(
-                      String.format(
-                          "CREATE TABLE %s (id BIGINT, name STRING, extra STRING) USING delta "
-                              + "LOCATION '%s' TBLPROPERTIES "
-                              + "('delta.enableDeletionVectors'='false', "
-                              + "'delta.enableRowTracking'='true', "
-                              + "'delta.columnMapping.mode'='name')",
-                          tableName, tablePath));
-                  spark.sql(String.format("INSERT INTO %s VALUES (1, 'Alice', 'x')", tableName));
-                  // Non-additive schema change mid-range: drop a column.
-                  spark.sql(String.format("ALTER TABLE %s DROP COLUMN extra", tableName));
-                  spark.sql(String.format("INSERT INTO %s VALUES (2, 'Bob')", tableName));
+        new String[] {tableName},
+        () -> {
+          // Column mapping is required to drop a column.
+          spark.sql(
+              String.format(
+                  "CREATE TABLE %s (id BIGINT, name STRING, extra STRING) USING delta TBLPROPERTIES "
+                      + "('delta.enableDeletionVectors'='false', 'delta.enableRowTracking'='true', "
+                      + "'delta.columnMapping.mode'='name')",
+                  tableName));
+          spark.sql(String.format("INSERT INTO %s VALUES (1, 'Alice', 'x')", tableName));
+          // Non-additive schema change mid-range: drop a column.
+          spark.sql(String.format("ALTER TABLE %s DROP COLUMN extra", tableName));
+          spark.sql(String.format("INSERT INTO %s VALUES (2, 'Bob')", tableName));
 
-                  withSQLConf(
-                      "spark.databricks.delta.v2.enableMode",
-                      "STRICT",
-                      () -> {
-                        Exception ex =
-                            assertThrows(
-                                Exception.class,
-                                () ->
-                                    spark
-                                        .sql(
-                                            String.format(
-                                                "SELECT * FROM %s CHANGES FROM VERSION 1 TO "
-                                                    + "VERSION 3",
-                                                tableName))
-                                        .collectAsList());
-                        assertTrue(
-                            ex.getMessage().contains("DELTA_CHANGELOG_SCHEMA_CHANGE_IN_RANGE"),
-                            "Expected schema-change error, got: " + ex.getMessage());
-                      });
-                }));
+          withSQLConf(
+              "spark.databricks.delta.v2.enableMode",
+              "STRICT",
+              () -> {
+                Exception ex =
+                    assertThrows(
+                        Exception.class,
+                        () ->
+                            spark
+                                .sql(
+                                    String.format(
+                                        "SELECT * FROM %s CHANGES FROM VERSION 1 TO VERSION 3",
+                                        tableName))
+                                .collectAsList());
+                assertTrue(
+                    ex.getMessage().contains("DELTA_CHANGELOG_SCHEMA_CHANGE_IN_RANGE"),
+                    "Expected schema-change error, got: " + ex.getMessage());
+              });
+        });
   }
 }

--- a/spark-unified/src/test/scala-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogCatalogIntegrationTest.java
+++ b/spark-unified/src/test/scala-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogCatalogIntegrationTest.java
@@ -845,6 +845,112 @@ public class DeltaChangelogCatalogIntegrationTest extends DeltaChangelogTestBase
   }
 
   /**
+   * Row tracking is toggled off and back on entirely BEFORE the requested range. The read range
+   * itself stays row-tracking-enabled, so the out-of-range toggle must not fail the read.
+   */
+  @Test
+  public void testChangelogAllowsRowTrackingToggleBeforeRange() throws Exception {
+    String tableName = "dsv2_cdc_catalog_rt_toggle_before_" + System.nanoTime();
+    String tablePath = System.getProperty("java.io.tmpdir") + "/" + tableName;
+
+    withTable(
+        tablePath,
+        () ->
+            withTable(
+                new String[] {tableName},
+                () -> {
+                  // v0: CREATE with row tracking enabled.
+                  spark.sql(
+                      String.format(
+                          "CREATE TABLE %s (id BIGINT, name STRING) USING delta LOCATION '%s' "
+                              + "TBLPROPERTIES "
+                              + "('delta.enableDeletionVectors'='false', "
+                              + "'delta.enableRowTracking'='true')",
+                          tableName, tablePath));
+                  // v1: INSERT (row tracking on).
+                  spark.sql(String.format("INSERT INTO %s VALUES (1, 'Alice')", tableName));
+                  // v2: disable row tracking, v3: re-enable it -- both before the read range.
+                  spark.sql(
+                      String.format(
+                          "ALTER TABLE %s SET TBLPROPERTIES ('delta.enableRowTracking'='false')",
+                          tableName));
+                  spark.sql(
+                      String.format(
+                          "ALTER TABLE %s SET TBLPROPERTIES ('delta.enableRowTracking'='true')",
+                          tableName));
+                  // v4, v5: INSERTs inside the row-tracking-enabled read range.
+                  spark.sql(String.format("INSERT INTO %s VALUES (2, 'Bob')", tableName));
+                  spark.sql(String.format("INSERT INTO %s VALUES (3, 'Charlie')", tableName));
+
+                  withSQLConf(
+                      "spark.databricks.delta.v2.enableMode",
+                      "STRICT",
+                      () -> {
+                        List<Row> rows =
+                            spark
+                                .sql(
+                                    String.format(
+                                        "SELECT id, _change_type FROM %s "
+                                            + "CHANGES FROM VERSION 4 TO VERSION 5",
+                                        tableName))
+                                .collectAsList();
+                        assertEquals(
+                            2, rows.size(), "Expected the two in-range inserts to be returned");
+                      });
+                }));
+  }
+
+  /**
+   * Row tracking is disabled at a commit AFTER the requested range. The read range stays
+   * row-tracking-enabled, so the later toggle must not fail the read.
+   */
+  @Test
+  public void testChangelogAllowsRowTrackingDisabledAfterRange() throws Exception {
+    String tableName = "dsv2_cdc_catalog_rt_disabled_after_" + System.nanoTime();
+    String tablePath = System.getProperty("java.io.tmpdir") + "/" + tableName;
+
+    withTable(
+        tablePath,
+        () ->
+            withTable(
+                new String[] {tableName},
+                () -> {
+                  // v0: CREATE with row tracking enabled.
+                  spark.sql(
+                      String.format(
+                          "CREATE TABLE %s (id BIGINT, name STRING) USING delta LOCATION '%s' "
+                              + "TBLPROPERTIES "
+                              + "('delta.enableDeletionVectors'='false', "
+                              + "'delta.enableRowTracking'='true')",
+                          tableName, tablePath));
+                  // v1, v2: INSERTs inside the row-tracking-enabled read range.
+                  spark.sql(String.format("INSERT INTO %s VALUES (1, 'Alice')", tableName));
+                  spark.sql(String.format("INSERT INTO %s VALUES (2, 'Bob')", tableName));
+                  // v3: disable row tracking after the range.
+                  spark.sql(
+                      String.format(
+                          "ALTER TABLE %s SET TBLPROPERTIES ('delta.enableRowTracking'='false')",
+                          tableName));
+
+                  withSQLConf(
+                      "spark.databricks.delta.v2.enableMode",
+                      "STRICT",
+                      () -> {
+                        List<Row> rows =
+                            spark
+                                .sql(
+                                    String.format(
+                                        "SELECT id, _change_type FROM %s "
+                                            + "CHANGES FROM VERSION 1 TO VERSION 2",
+                                        tableName))
+                                .collectAsList();
+                        assertEquals(
+                            2, rows.size(), "Expected the two in-range inserts to be returned");
+                      });
+                }));
+  }
+
+  /**
    * A CHANGES read across a range where the table schema evolves mid-range must be rejected with
    * {@code DELTA_CHANGELOG_SCHEMA_CHANGE_IN_RANGE}.
    */

--- a/spark-unified/src/test/scala-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogCatalogIntegrationTest.java
+++ b/spark-unified/src/test/scala-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogCatalogIntegrationTest.java
@@ -94,7 +94,7 @@ public class DeltaChangelogCatalogIntegrationTest extends DeltaChangelogTestBase
   /**
    * Returns the commit timestamp of {@code version}. Resolves the snapshot directly through the
    * kernel snapshot manager, so it works irrespective of the catalog mode flipped on by the test
-   * body (which keeps the catalog in STRICT for the read-time CDF path).
+   * body (which keeps the catalog in STRICT for the read path of read-time CDF).
    */
   private java.sql.Timestamp commitTimestamp(String tablePath, long version) {
     DeltaSnapshotManager snapshotManager =

--- a/spark-unified/src/test/scala-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogCatalogIntegrationTest.java
+++ b/spark-unified/src/test/scala-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogCatalogIntegrationTest.java
@@ -94,7 +94,7 @@ public class DeltaChangelogCatalogIntegrationTest extends DeltaChangelogTestBase
   /**
    * Returns the commit timestamp of {@code version}. Resolves the snapshot directly through the
    * kernel snapshot manager, so it works irrespective of the catalog mode flipped on by the test
-   * body (which keeps the catalog in STRICT for the read-time CDF read path).
+   * body (which keeps the catalog in STRICT for the read-time CDF path).
    */
   private java.sql.Timestamp commitTimestamp(String tablePath, long version) {
     DeltaSnapshotManager snapshotManager =
@@ -992,6 +992,58 @@ public class DeltaChangelogCatalogIntegrationTest extends DeltaChangelogTestBase
                                 .collectAsList();
                         assertEquals(
                             2, rows.size(), "Additive schema change should not fail the read");
+                      });
+                }));
+  }
+
+  /**
+   * A non-read-compatible mid-range schema change (dropping a column) must be rejected with {@code
+   * DELTA_CHANGELOG_SCHEMA_CHANGE_IN_RANGE}: the end schema can no longer read the data written
+   * before the drop.
+   */
+  @Test
+  public void testChangelogRejectsIncompatibleSchemaChangeMidRange() throws Exception {
+    String tableName = "dsv2_cdc_catalog_drop_col_" + System.nanoTime();
+    String tablePath = System.getProperty("java.io.tmpdir") + "/" + tableName;
+
+    withTable(
+        tablePath,
+        () ->
+            withTable(
+                new String[] {tableName},
+                () -> {
+                  // Column mapping is required to drop a column.
+                  spark.sql(
+                      String.format(
+                          "CREATE TABLE %s (id BIGINT, name STRING, extra STRING) USING delta "
+                              + "LOCATION '%s' TBLPROPERTIES "
+                              + "('delta.enableDeletionVectors'='false', "
+                              + "'delta.enableRowTracking'='true', "
+                              + "'delta.columnMapping.mode'='name')",
+                          tableName, tablePath));
+                  spark.sql(String.format("INSERT INTO %s VALUES (1, 'Alice', 'x')", tableName));
+                  // Non-additive schema change mid-range: drop a column.
+                  spark.sql(String.format("ALTER TABLE %s DROP COLUMN extra", tableName));
+                  spark.sql(String.format("INSERT INTO %s VALUES (2, 'Bob')", tableName));
+
+                  withSQLConf(
+                      "spark.databricks.delta.v2.enableMode",
+                      "STRICT",
+                      () -> {
+                        Exception ex =
+                            assertThrows(
+                                Exception.class,
+                                () ->
+                                    spark
+                                        .sql(
+                                            String.format(
+                                                "SELECT * FROM %s CHANGES FROM VERSION 1 TO "
+                                                    + "VERSION 3",
+                                                tableName))
+                                        .collectAsList());
+                        assertTrue(
+                            ex.getMessage().contains("DELTA_CHANGELOG_SCHEMA_CHANGE_IN_RANGE"),
+                            "Expected schema-change error, got: " + ex.getMessage());
                       });
                 }));
   }

--- a/spark-unified/src/test/scala-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogCatalogIntegrationTest.java
+++ b/spark-unified/src/test/scala-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogCatalogIntegrationTest.java
@@ -76,7 +76,7 @@ public class DeltaChangelogCatalogIntegrationTest extends DeltaChangelogTestBase
                   spark.sql(String.format("INSERT INTO %s VALUES (3, 'Charlie')", tableName));
                   spark.sql(String.format("INSERT INTO %s VALUES (4, 'Dave')", tableName));
                   spark.sql(String.format("INSERT INTO %s VALUES (5, 'Eve')", tableName));
-                  // Auto-CDF requires the V2 connector at read time. Writes above run in the
+                  // Read-time CDF requires the V2 connector at read time. Writes above run in the
                   // session-default mode (AUTO → V1 connector for INSERT). The CHANGES read in
                   // the test body needs STRICT to ensure loadTable returns a V2 DeltaV2Table.
                   withSQLConf(
@@ -94,7 +94,7 @@ public class DeltaChangelogCatalogIntegrationTest extends DeltaChangelogTestBase
   /**
    * Returns the commit timestamp of {@code version}. Resolves the snapshot directly through the
    * kernel snapshot manager, so it works irrespective of the catalog mode flipped on by the test
-   * body (which keeps the catalog in STRICT for the Auto-CDF read path).
+   * body (which keeps the catalog in STRICT for the read-time CDF read path).
    */
   private java.sql.Timestamp commitTimestamp(String tablePath, long version) {
     DeltaSnapshotManager snapshotManager =

--- a/spark-unified/src/test/scala-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogCatalogIntegrationTest.java
+++ b/spark-unified/src/test/scala-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogCatalogIntegrationTest.java
@@ -25,14 +25,10 @@ import io.delta.spark.internal.v2.snapshot.SnapshotManagerFactory;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Stream;
 import org.apache.spark.sql.AnalysisException;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Integration tests for catalog-routed CDC entrypoint (TableCatalog.loadChangelog).
@@ -996,20 +992,12 @@ public class DeltaChangelogCatalogIntegrationTest extends DeltaChangelogTestBase
   }
 
   /**
-   * Every Delta-supported type widening (delta.enableTypeWidening) applied mid-range is read
-   * compatible: rows written before the change are upcast to the end (wider) type. The value is
-   * compared as a string so one assertion covers every numeric/temporal target type.
+   * A supported type-widening mid-range change (INT to LONG, with delta.enableTypeWidening) is read
+   * compatible: rows written before the change are upcast to the end (wider) type. This exercises
+   * the changelog wiring; the widening rules themselves are covered by SchemaUtils.isReadCompatible.
    */
-  @ParameterizedTest(name = "{0} -> {1}")
-  @MethodSource("typeWideningCases")
-  public void testChangelogAllowsTypeWideningMidRange(
-      String fromType,
-      String toType,
-      String v1Literal,
-      String v3Literal,
-      String expectedV1,
-      String expectedV3)
-      throws Exception {
+  @Test
+  public void testChangelogAllowsTypeWideningMidRange() throws Exception {
     String tableName = "dsv2_cdc_catalog_widen_" + System.nanoTime();
 
     withTable(
@@ -1017,14 +1005,14 @@ public class DeltaChangelogCatalogIntegrationTest extends DeltaChangelogTestBase
         () -> {
           spark.sql(
               String.format(
-                  "CREATE TABLE %s (id BIGINT, val %s) USING delta TBLPROPERTIES "
+                  "CREATE TABLE %s (id BIGINT, val INT) USING delta TBLPROPERTIES "
                       + "('delta.enableDeletionVectors'='false', 'delta.enableRowTracking'='true', "
-                      + "'delta.enableTypeWidening'='true', 'delta.feature.timestampNtz'='supported')",
-                  tableName, fromType));
-          spark.sql(String.format("INSERT INTO %s VALUES (1, %s)", tableName, v1Literal)); // v1
+                      + "'delta.enableTypeWidening'='true')",
+                  tableName));
+          spark.sql(String.format("INSERT INTO %s VALUES (1, 10)", tableName)); // v1: val is INT
           spark.sql(
-              String.format("ALTER TABLE %s ALTER COLUMN val TYPE %s", tableName, toType)); // v2
-          spark.sql(String.format("INSERT INTO %s VALUES (2, %s)", tableName, v3Literal)); // v3
+              String.format("ALTER TABLE %s ALTER COLUMN val TYPE BIGINT", tableName)); // v2: widen
+          spark.sql(String.format("INSERT INTO %s VALUES (2, 20)", tableName)); // v3: val is LONG
 
           withSQLConf(
               "spark.databricks.delta.v2.enableMode",
@@ -1034,35 +1022,16 @@ public class DeltaChangelogCatalogIntegrationTest extends DeltaChangelogTestBase
                     spark
                         .sql(
                             String.format(
-                                "SELECT id, CAST(val AS STRING) AS val, _change_type FROM %s "
+                                "SELECT id, val, _change_type FROM %s "
                                     + "CHANGES FROM VERSION 1 TO VERSION 3",
                                 tableName))
                         .orderBy("id")
                         .collectAsList();
                 assertEquals(2, rows.size(), "Expected both inserts across the widening");
-                // v1 was written as fromType; it must read back upcast to toType.
-                assertEquals(expectedV1, rows.get(0).getString(1), "v1 value upcast to " + toType);
-                assertEquals(expectedV3, rows.get(1).getString(1), "v3 value as " + toType);
+                // v1 was written as INT; it must read back as the widened LONG value.
+                assertEquals(10L, rows.get(0).getLong(1), "v1 val should read back as LONG 10");
+                assertEquals(20L, rows.get(1).getLong(1), "v3 val should be LONG 20");
               });
         });
-  }
-
-  static Stream<Arguments> typeWideningCases() {
-    return Stream.of(
-        Arguments.of("INT", "BIGINT", "10", "20", "10", "20"),
-        Arguments.of("TINYINT", "INT", "10", "20", "10", "20"),
-        Arguments.of("SMALLINT", "BIGINT", "10", "20", "10", "20"),
-        Arguments.of("FLOAT", "DOUBLE", "1.5", "2.5", "1.5", "2.5"),
-        Arguments.of("INT", "DOUBLE", "10", "20", "10.0", "20.0"),
-        Arguments.of("DECIMAL(10,2)", "DECIMAL(20,4)", "1.25", "2.50", "1.2500", "2.5000"),
-        Arguments.of("INT", "DECIMAL(20,0)", "10", "20", "10", "20"),
-        Arguments.of("BIGINT", "DECIMAL(20,0)", "10", "20", "10", "20"),
-        Arguments.of(
-            "DATE",
-            "TIMESTAMP_NTZ",
-            "DATE'2020-01-01'",
-            "DATE'2021-06-15'",
-            "2020-01-01 00:00:00",
-            "2021-06-15 00:00:00"));
   }
 }

--- a/spark-unified/src/test/scala-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogCatalogIntegrationTest.java
+++ b/spark-unified/src/test/scala-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogCatalogIntegrationTest.java
@@ -992,12 +992,12 @@ public class DeltaChangelogCatalogIntegrationTest extends DeltaChangelogTestBase
   }
 
   /**
-   * A supported type-widening mid-range change (INT to LONG, with delta.enableTypeWidening) is read
-   * compatible: rows written before the change are upcast to the end (wider) type. This exercises
-   * the changelog wiring; the widening rules themselves are covered by SchemaUtils.isReadCompatible.
+   * A type-widening mid-range change (INT to LONG) is a schema change that the changelog read does
+   * not support, so it must be rejected with {@code DELTA_CHANGELOG_SCHEMA_CHANGE_IN_RANGE}. The
+   * check uses SchemaUtils.isReadCompatible, which does not permit type changes.
    */
   @Test
-  public void testChangelogAllowsTypeWideningMidRange() throws Exception {
+  public void testChangelogRejectsTypeWideningMidRange() throws Exception {
     String tableName = "dsv2_cdc_catalog_widen_" + System.nanoTime();
 
     withTable(
@@ -1018,19 +1018,19 @@ public class DeltaChangelogCatalogIntegrationTest extends DeltaChangelogTestBase
               "spark.databricks.delta.v2.enableMode",
               "STRICT",
               () -> {
-                List<Row> rows =
-                    spark
-                        .sql(
-                            String.format(
-                                "SELECT id, val, _change_type FROM %s "
-                                    + "CHANGES FROM VERSION 1 TO VERSION 3",
-                                tableName))
-                        .orderBy("id")
-                        .collectAsList();
-                assertEquals(2, rows.size(), "Expected both inserts across the widening");
-                // v1 was written as INT; it must read back as the widened LONG value.
-                assertEquals(10L, rows.get(0).getLong(1), "v1 val should read back as LONG 10");
-                assertEquals(20L, rows.get(1).getLong(1), "v3 val should be LONG 20");
+                Exception ex =
+                    assertThrows(
+                        Exception.class,
+                        () ->
+                            spark
+                                .sql(
+                                    String.format(
+                                        "SELECT * FROM %s CHANGES FROM VERSION 1 TO VERSION 3",
+                                        tableName))
+                                .collectAsList());
+                assertTrue(
+                    ex.getMessage().contains("DELTA_CHANGELOG_SCHEMA_CHANGE_IN_RANGE"),
+                    "Expected schema-change error, got: " + ex.getMessage());
               });
         });
   }

--- a/spark-unified/src/test/scala-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogCatalogIntegrationTest.java
+++ b/spark-unified/src/test/scala-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogCatalogIntegrationTest.java
@@ -842,11 +842,16 @@ public class DeltaChangelogCatalogIntegrationTest extends DeltaChangelogTestBase
                     spark
                         .sql(
                             String.format(
-                                "SELECT id, _change_type FROM %s "
+                                "SELECT id, name, _change_type FROM %s "
                                     + "CHANGES FROM VERSION 4 TO VERSION 5",
                                 tableName))
+                        .orderBy("id")
                         .collectAsList();
                 assertEquals(2, rows.size(), "Expected the two in-range inserts to be returned");
+                assertEquals(2L, rows.get(0).getLong(0), "Expected id of Bob to be 2");
+                assertEquals("Bob", rows.get(0).getString(1), "Expected name to be Bob");
+                assertEquals(3L, rows.get(1).getLong(0), "Expected id of Charlie to be 3");
+                assertEquals("Charlie", rows.get(1).getString(1), "Expected name to be Charlie");
               });
         });
   }
@@ -885,11 +890,16 @@ public class DeltaChangelogCatalogIntegrationTest extends DeltaChangelogTestBase
                     spark
                         .sql(
                             String.format(
-                                "SELECT id, _change_type FROM %s "
+                                "SELECT id, name, _change_type FROM %s "
                                     + "CHANGES FROM VERSION 1 TO VERSION 2",
                                 tableName))
+                        .orderBy("id")
                         .collectAsList();
                 assertEquals(2, rows.size(), "Expected the two in-range inserts to be returned");
+                assertEquals(1L, rows.get(0).getLong(0), "Expected id of Alice to be 1");
+                assertEquals("Alice", rows.get(0).getString(1), "Expected name to be Alice");
+                assertEquals(2L, rows.get(1).getLong(0), "Expected id of Bob to be 2");
+                assertEquals("Bob", rows.get(1).getString(1), "Expected name to be Bob");
               });
         });
   }
@@ -924,11 +934,18 @@ public class DeltaChangelogCatalogIntegrationTest extends DeltaChangelogTestBase
                     spark
                         .sql(
                             String.format(
-                                "SELECT id, _change_type FROM %s "
+                                "SELECT id, name, extra, _change_type FROM %s "
                                     + "CHANGES FROM VERSION 1 TO VERSION 3",
                                 tableName))
+                        .orderBy("id")
                         .collectAsList();
                 assertEquals(2, rows.size(), "Additive schema change should not fail the read");
+                assertEquals(1L, rows.get(0).getLong(0), "Expected id of Alice to be 1");
+                assertEquals("Alice", rows.get(0).getString(1), "Expected name to be Alice");
+                assertTrue(rows.get(0).isNullAt(2), "extra is null for the pre-change Alice row");
+                assertEquals(2L, rows.get(1).getLong(0), "Expected id of Bob to be 2");
+                assertEquals("Bob", rows.get(1).getString(1), "Expected name to be Bob");
+                assertEquals("x", rows.get(1).getString(2), "Expected Bob's extra value to be x");
               });
         });
   }

--- a/spark-unified/src/test/scala-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogDvTest.java
+++ b/spark-unified/src/test/scala-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogDvTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
- * Integration tests for Auto-CDF / DSv2 changelog with Deletion Vectors (DVs) that are NOT
+ * Integration tests for read-time CDF / DSv2 changelog with Deletion Vectors (DVs) that are NOT
  * covered by parameterized DV-on/off variants of
  * {@link DeltaChangelogDirectBatchExecutionTest}. The parameterized tests already cover the
  * basic single-file DELETE and UPDATE; this file holds scenarios that need DV-specific table

--- a/spark-unified/src/test/scala-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogTestBase.java
+++ b/spark-unified/src/test/scala-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogTestBase.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.BeforeAll;
  *   <li>The hybrid {@code DeltaCatalog} (spark-unified) as {@code spark_catalog}, so {@code
  *       TableCatalog.loadChangelog} routes into the {@code ChangelogSupport} trait.
  *   <li>{@code spark.databricks.delta.changelogV2.enabled = true}, the SQLConf gate behind which
- *       Auto-CDF is hidden in production.
+ *       Read-time CDF is hidden in production.
  * </ul>
  *
  * <p>Keeping these two settings out of {@code DeltaV2TestBase} means the rest of the V2 test suites

--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -404,8 +404,20 @@
   },
   "DELTA_CHANGELOG_READ_FAILED" : {
     "message" : [
-      "Failed to read the changelog while <context>."
+      "Failed to read the changelog."
     ],
+    "subClass" : {
+      "PLAN_INPUT_PARTITIONS" : {
+        "message" : [
+          "Failed while planning the input partitions."
+        ]
+      },
+      "PROCESS_COMMIT_ACTIONS" : {
+        "message" : [
+          "Failed while processing the commit actions."
+        ]
+      }
+    },
     "sqlState" : "XXKDS"
   },
   "DELTA_CHANGELOG_REQUIRES_ROW_TRACKING" : {

--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -402,6 +402,12 @@
     ],
     "sqlState" : "22003"
   },
+  "DELTA_CHANGELOG_READ_FAILED" : {
+    "message" : [
+      "Failed to read the changelog while <context>."
+    ],
+    "sqlState" : "XXKDS"
+  },
   "DELTA_CHANGELOG_REQUIRES_ROW_TRACKING" : {
     "message" : [
       "Change data capture via CHANGES on `<tableName>` requires row tracking.",

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -696,21 +696,6 @@ trait DeltaErrorsBase
       messageParameters = Array(version.toString))
   }
 
-  /**
-   * Read-time CDF batch read failed while reading the changelog (e.g. an IO error while iterating
-   * commit actions or planning input partitions). A cause that already carries a Spark error class
-   * is rethrown unchanged so its user-facing class is preserved. Anything else is wrapped in a
-   * Delta error class rather than a bare RuntimeException. `errorSubClass` names the phase, e.g.
-   * "PROCESS_COMMIT_ACTIONS".
-   */
-  def throwChangelogReadFailed(errorSubClass: String, cause: Throwable): Nothing = cause match {
-    case _: SparkThrowable => throw cause
-    case other =>
-      throw new DeltaIllegalStateException(
-        errorClass = "DELTA_CHANGELOG_READ_FAILED." + errorSubClass,
-        cause = other)
-  }
-
   def setTransactionVersionConflict(appId: String, version1: Long, version2: Long): Throwable = {
     new IllegalArgumentException(
       s"Two SetTransaction actions within the same transaction have the same appId ${appId} but " +

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -696,6 +696,21 @@ trait DeltaErrorsBase
       messageParameters = Array(version.toString))
   }
 
+  /**
+   * Read-time CDF batch read failed while reading the changelog (e.g. an IO error while iterating
+   * commit actions or planning input partitions). A cause that already carries a Spark error class
+   * is rethrown unchanged so its user-facing class is preserved. Anything else is wrapped in a
+   * Delta error class rather than a bare RuntimeException. `errorSubClass` names the phase, e.g.
+   * "PROCESS_COMMIT_ACTIONS".
+   */
+  def throwChangelogReadFailed(errorSubClass: String, cause: Throwable): Nothing = cause match {
+    case _: SparkThrowable => throw cause
+    case other =>
+      throw new DeltaIllegalStateException(
+        errorClass = "DELTA_CHANGELOG_READ_FAILED." + errorSubClass,
+        cause = other)
+  }
+
   def setTransactionVersionConflict(appId: String, version1: Long, version2: Long): Throwable = {
     new IllegalArgumentException(
       s"Two SetTransaction actions within the same transaction have the same appId ${appId} but " +

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -39,7 +39,7 @@ import org.apache.spark.sql.delta.util.JsonUtils
 import io.delta.exceptions
 import org.apache.hadoop.fs.{ChecksumException, Path}
 
-import org.apache.spark.{SparkConf, SparkEnv, SparkException}
+import org.apache.spark.{SparkConf, SparkEnv, SparkException, SparkThrowable}
 import org.apache.spark.sql.{AnalysisException, SparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
@@ -700,16 +700,15 @@ trait DeltaErrorsBase
    * Read-time CDF batch read failed while reading the changelog (e.g. an IO error while iterating
    * commit actions or planning input partitions). A cause that already carries a Spark error class
    * is rethrown unchanged so its user-facing class is preserved. Anything else is wrapped in a
-   * Delta error class rather than a bare RuntimeException. `context` names the phase, e.g.
-   * "processing commit actions".
+   * Delta error class rather than a bare RuntimeException. `errorSubClass` names the phase, e.g.
+   * "PROCESS_COMMIT_ACTIONS".
    */
-  def throwChangelogReadFailed(context: String, cause: Throwable): Nothing = cause match {
-    case t: org.apache.spark.SparkThrowable => throw t.asInstanceOf[Throwable]
-    case t =>
+  def throwChangelogReadFailed(errorSubClass: String, cause: Throwable): Nothing = cause match {
+    case _: SparkThrowable => throw cause
+    case other =>
       throw new DeltaIllegalStateException(
-        errorClass = "DELTA_CHANGELOG_READ_FAILED",
-        messageParameters = Array(context),
-        cause = t)
+        errorClass = "DELTA_CHANGELOG_READ_FAILED." + errorSubClass,
+        cause = other)
   }
 
   def setTransactionVersionConflict(appId: String, version1: Long, version2: Long): Throwable = {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -696,6 +696,22 @@ trait DeltaErrorsBase
       messageParameters = Array(version.toString))
   }
 
+  /**
+   * Read-time CDF batch read failed while reading the changelog (e.g. an IO error while iterating
+   * commit actions or planning input partitions). A cause that already carries a Spark error class
+   * is rethrown unchanged so its user-facing class is preserved. Anything else is wrapped in a
+   * Delta error class rather than a bare RuntimeException. `context` names the phase, e.g.
+   * "processing commit actions".
+   */
+  def throwChangelogReadFailed(context: String, cause: Throwable): Nothing = cause match {
+    case t: org.apache.spark.SparkThrowable => throw t.asInstanceOf[Throwable]
+    case t =>
+      throw new DeltaIllegalStateException(
+        errorClass = "DELTA_CHANGELOG_READ_FAILED",
+        messageParameters = Array(context),
+        cause = t)
+  }
+
   def setTransactionVersionConflict(appId: String, version1: Long, version2: Long): Throwable = {
     new IllegalArgumentException(
       s"Two SetTransaction actions within the same transaction have the same appId ${appId} but " +

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -634,7 +634,7 @@ trait DeltaErrorsBase
   }
 
   /**
-   * Auto-CDF batch read rejected because the source table does not have row tracking enabled.
+   * Read-time CDF batch read rejected because the source table does not have row tracking enabled.
    * Row tracking is required for the V2 changelog reader to identify rows across commits.
    *
    * Returns `Nothing` so Scala callers can use this in expression position (e.g. as a `match`
@@ -647,7 +647,7 @@ trait DeltaErrorsBase
   }
 
   /**
-   * Auto-CDF batch read rejected because the user requested an unbounded changelog range.
+   * Read-time CDF batch read rejected because the user requested an unbounded changelog range.
    * Batch CHANGES queries require explicit start and end bounds.
    *
    * Returns `Nothing` so Scala callers can use this in expression position (e.g. as a `match`
@@ -660,7 +660,7 @@ trait DeltaErrorsBase
   }
 
   /**
-   * Auto-CDF batch read rejected because the table resolved by the catalog is not a V2
+   * Read-time CDF batch read rejected because the table resolved by the catalog is not a V2
    * [[io.delta.spark.internal.v2.catalog.DeltaV2Table]]. The V2 connector is the only path that
    * implements the catalog-driven CHANGES surface. V1 Delta tables (`DeltaTableV2`) continue to
    * use the legacy CDF path that does not go through `TableCatalog.loadChangelog`. Use
@@ -676,7 +676,7 @@ trait DeltaErrorsBase
   }
 
   /**
-   * Auto-CDF batch read rejected because the table schema differs at some commit within the
+   * Read-time CDF batch read rejected because the table schema differs at some commit within the
    * requested range. The connector requires the schema to be stable across the read range so
    * that downstream batch CDC post-processing sees a single schema.
    */
@@ -687,7 +687,7 @@ trait DeltaErrorsBase
   }
 
   /**
-   * Auto-CDF batch read rejected because row tracking was disabled at some commit within the
+   * Read-time CDF batch read rejected because row tracking was disabled at some commit within the
    * requested range (the `delta.enableRowTracking` table property was set to `false`).
    */
   def throwChangelogRowTrackingDisabledInRange(version: Long): Nothing = {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -2477,7 +2477,7 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .doc(
         """When enabled, the V2 connector's hybrid DeltaCatalog answers
           |CHANGES FROM ... batch queries (TableCatalog.loadChangelog) using the
-          |kernel-based Auto-CDF reader stack. When disabled, the catalog falls back to the
+          |kernel-based read-time CDF reader stack. When disabled, the catalog falls back to the
           |default behavior (UNSUPPORTED_FEATURE.CHANGE_DATA_CAPTURE).""".stripMargin)
       .booleanConf
       .createWithDefault(false)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -2957,6 +2957,25 @@ trait DeltaErrorsSuiteBase
     }
   }
 
+  test("throwChangelogReadFailed preserves SparkThrowable cause and wraps others") {
+    // A cause that already carries a Spark error class is rethrown unchanged.
+    val sparkThrowableCause = new DeltaAnalysisException(
+      errorClass = "DELTA_CHANGELOG_UNBOUNDED_RANGE",
+      messageParameters = Array.empty[String])
+    val passed = intercept[DeltaAnalysisException] {
+      DeltaErrors.throwChangelogReadFailed("processing commit actions", sparkThrowableCause)
+    }
+    assert(passed eq sparkThrowableCause)
+
+    // Any other cause is wrapped in DELTA_CHANGELOG_READ_FAILED.
+    val wrapped = intercept[DeltaIllegalStateException] {
+      DeltaErrors.throwChangelogReadFailed(
+        "planning input partitions", new RuntimeException("boom"))
+    }
+    checkError(wrapped, "DELTA_CHANGELOG_READ_FAILED", "XXKDS",
+      Map("context" -> "planning input partitions"))
+  }
+
   private def setCustomContext(session: SparkSession, context: SparkContext): Unit = {
     val scField = session.getClass.getDeclaredField("sparkContext")
     scField.setAccessible(true)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -2957,6 +2957,24 @@ trait DeltaErrorsSuiteBase
     }
   }
 
+  test("throwChangelogReadFailed preserves SparkThrowable cause and wraps others") {
+    // A cause that already carries a Spark error class is rethrown unchanged.
+    val sparkThrowableCause = new DeltaAnalysisException(
+      errorClass = "DELTA_CHANGELOG_UNBOUNDED_RANGE",
+      messageParameters = Array.empty[String])
+    val passed = intercept[DeltaAnalysisException] {
+      DeltaErrors.throwChangelogReadFailed("PROCESS_COMMIT_ACTIONS", sparkThrowableCause)
+    }
+    assert(passed eq sparkThrowableCause)
+
+    // Any other cause is wrapped in a DELTA_CHANGELOG_READ_FAILED sub-class.
+    val wrapped = intercept[DeltaIllegalStateException] {
+      DeltaErrors.throwChangelogReadFailed("PLAN_INPUT_PARTITIONS", new RuntimeException("boom"))
+    }
+    checkError(wrapped, "DELTA_CHANGELOG_READ_FAILED.PLAN_INPUT_PARTITIONS", "XXKDS",
+      Map.empty[String, String])
+  }
+
   private def setCustomContext(session: SparkSession, context: SparkContext): Unit = {
     val scField = session.getClass.getDeclaredField("sparkContext")
     scField.setAccessible(true)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -2957,24 +2957,6 @@ trait DeltaErrorsSuiteBase
     }
   }
 
-  test("throwChangelogReadFailed preserves SparkThrowable cause and wraps others") {
-    // A cause that already carries a Spark error class is rethrown unchanged.
-    val sparkThrowableCause = new DeltaAnalysisException(
-      errorClass = "DELTA_CHANGELOG_UNBOUNDED_RANGE",
-      messageParameters = Array.empty[String])
-    val passed = intercept[DeltaAnalysisException] {
-      DeltaErrors.throwChangelogReadFailed("PROCESS_COMMIT_ACTIONS", sparkThrowableCause)
-    }
-    assert(passed eq sparkThrowableCause)
-
-    // Any other cause is wrapped in a DELTA_CHANGELOG_READ_FAILED sub-class.
-    val wrapped = intercept[DeltaIllegalStateException] {
-      DeltaErrors.throwChangelogReadFailed("PLAN_INPUT_PARTITIONS", new RuntimeException("boom"))
-    }
-    checkError(wrapped, "DELTA_CHANGELOG_READ_FAILED.PLAN_INPUT_PARTITIONS", "XXKDS",
-      Map.empty[String, String])
-  }
-
   private def setCustomContext(session: SparkSession, context: SparkContext): Unit = {
     val scField = session.getClass.getDeclaredField("sparkContext")
     scField.setAccessible(true)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -2963,17 +2963,16 @@ trait DeltaErrorsSuiteBase
       errorClass = "DELTA_CHANGELOG_UNBOUNDED_RANGE",
       messageParameters = Array.empty[String])
     val passed = intercept[DeltaAnalysisException] {
-      DeltaErrors.throwChangelogReadFailed("processing commit actions", sparkThrowableCause)
+      DeltaErrors.throwChangelogReadFailed("PROCESS_COMMIT_ACTIONS", sparkThrowableCause)
     }
     assert(passed eq sparkThrowableCause)
 
-    // Any other cause is wrapped in DELTA_CHANGELOG_READ_FAILED.
+    // Any other cause is wrapped in a DELTA_CHANGELOG_READ_FAILED sub-class.
     val wrapped = intercept[DeltaIllegalStateException] {
-      DeltaErrors.throwChangelogReadFailed(
-        "planning input partitions", new RuntimeException("boom"))
+      DeltaErrors.throwChangelogReadFailed("PLAN_INPUT_PARTITIONS", new RuntimeException("boom"))
     }
-    checkError(wrapped, "DELTA_CHANGELOG_READ_FAILED", "XXKDS",
-      Map("context" -> "planning input partitions"))
+    checkError(wrapped, "DELTA_CHANGELOG_READ_FAILED.PLAN_INPUT_PARTITIONS", "XXKDS",
+      Map.empty[String, String])
   }
 
   private def setCustomContext(session: SparkSession, context: SparkContext): Unit = {

--- a/spark/v2/src/main/java-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogBatch.java
+++ b/spark/v2/src/main/java-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogBatch.java
@@ -46,6 +46,14 @@ import org.apache.spark.sql.types.StructType;
 import org.apache.spark.unsafe.types.UTF8String;
 import scala.Tuple2;
 
+/**
+ * Batch implementation for read-time CDF that turns a commit range into CDC input partitions. It
+ * iterates the AddFile, RemoveFile and Metadata actions of each commit in the range, emitting one
+ * partition per data-changing file (RemoveFiles before AddFiles per commit), and rejects ranges
+ * whose schema or row-tracking state is not stable. {@link #createReaderFactory()} wraps the Parquet
+ * reader with {@link CDCPartitionReaderFactory} to append the CDC tail columns ({@code _change_type},
+ * {@code _commit_version}, {@code _commit_timestamp}).
+ */
 public class DeltaChangelogBatch implements Batch {
   private static final Set<DeltaLogActionUtils.DeltaAction> CHANGELOG_ACTION_SET =
       Set.of(

--- a/spark/v2/src/main/java-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogBatch.java
+++ b/spark/v2/src/main/java-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogBatch.java
@@ -34,6 +34,7 @@ import org.apache.spark.sql.connector.read.InputPartition;
 import org.apache.spark.sql.connector.read.PartitionReader;
 import org.apache.spark.sql.connector.read.PartitionReaderFactory;
 import org.apache.spark.sql.delta.DefaultRowCommitVersion$;
+import org.apache.spark.sql.delta.DeltaConfigs$;
 import org.apache.spark.sql.delta.DeltaErrors;
 import org.apache.spark.sql.delta.RowId$;
 import org.apache.spark.sql.execution.datasources.FilePartition;
@@ -155,9 +156,11 @@ public class DeltaChangelogBatch implements Batch {
                 if (!SchemaUtils.isReadCompatible(commitSchema, endDataSchema)) {
                   DeltaErrors.throwChangelogSchemaChangeInRange(commit.getVersion());
                 }
-                String rtValue = md.getConfiguration().get("delta.enableRowTracking");
-                // Absent key means the prior value persists (no change at this commit).
-                boolean rowTrackingEnabled = rtValue == null || "true".equalsIgnoreCase(rtValue);
+                String rtValue =
+                    md.getConfiguration().get(DeltaConfigs$.MODULE$.ROW_TRACKING_ENABLED().key());
+                // A new Metadata action fully replaces the prior configuration, so an absent
+                // row-tracking key means the table default (disabled), not an inherited value.
+                boolean rowTrackingEnabled = "true".equalsIgnoreCase(rtValue);
                 if (!rowTrackingEnabled) {
                   DeltaErrors.throwChangelogRowTrackingDisabledInRange(commit.getVersion());
                 }

--- a/spark/v2/src/main/java-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogBatch.java
+++ b/spark/v2/src/main/java-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogBatch.java
@@ -235,7 +235,7 @@ public class DeltaChangelogBatch implements Batch {
         scala.collection.immutable.Map$.MODULE$.empty();
     SQLConf sqlConf = SQLConf.get();
 
-    // Read-time Auto-CDF: tail columns are added by CDCPartitionReaderFactory below, so
+    // Read-time CDF: tail columns are added by CDCPartitionReaderFactory below, so
     // isWriteTimeCDCRead stays false (write-time streaming is the only true caller).
     PartitionReaderFactory delegate =
         PartitionUtils.createDeltaParquetReaderFactory(

--- a/spark/v2/src/main/java-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogBatch.java
+++ b/spark/v2/src/main/java-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogBatch.java
@@ -170,10 +170,9 @@ public class DeltaChangelogBatch implements Batch {
         } catch (RuntimeException e) {
           throw e;
         } catch (Exception e) {
-          // Include the inner message so AnalysisException error classes
-          // (e.g. DELTA_CHANGELOG_ROW_TRACKING_DISABLED_IN_RANGE) reach the user.
-          throw new RuntimeException(
-              "Failed to process CDC commit actions: " + e.getMessage(), e);
+          // Delta error-class exceptions raised above are rethrown unchanged; other checked
+          // exceptions are wrapped in a Delta error class rather than a bare RuntimeException.
+          DeltaErrors.throwChangelogReadFailed("processing commit actions", e);
         }
         partitions.addAll(commitRemoves);
         partitions.addAll(commitAdds);
@@ -181,8 +180,7 @@ public class DeltaChangelogBatch implements Batch {
     } catch (RuntimeException e) {
       throw e;
     } catch (Exception e) {
-      throw new RuntimeException(
-          "Failed to plan CDC input partitions: " + e.getMessage(), e);
+      DeltaErrors.throwChangelogReadFailed("planning input partitions", e);
     }
     return partitions.toArray(new InputPartition[0]);
   }

--- a/spark/v2/src/main/java-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogBatch.java
+++ b/spark/v2/src/main/java-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogBatch.java
@@ -25,7 +25,6 @@ import java.util.Set;
 import java.util.function.Supplier;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
-import org.apache.spark.SparkThrowable;
 import org.apache.spark.paths.SparkPath;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
@@ -37,7 +36,6 @@ import org.apache.spark.sql.connector.read.PartitionReader;
 import org.apache.spark.sql.connector.read.PartitionReaderFactory;
 import org.apache.spark.sql.delta.DefaultRowCommitVersion$;
 import org.apache.spark.sql.delta.DeltaErrors;
-import org.apache.spark.sql.delta.DeltaIllegalStateException;
 import org.apache.spark.sql.delta.RowId$;
 import org.apache.spark.sql.execution.datasources.FilePartition;
 import org.apache.spark.sql.execution.datasources.PartitionedFile;
@@ -171,13 +169,15 @@ public class DeltaChangelogBatch implements Batch {
             }
           }
         } catch (Exception e) {
-          throwReadFailed("PROCESS_COMMIT_ACTIONS", e);
+          // A cause that already carries a Spark error class is rethrown unchanged by
+          // throwChangelogReadFailed; anything else is wrapped in a Delta error class.
+          DeltaErrors.throwChangelogReadFailed("PROCESS_COMMIT_ACTIONS", e);
         }
         partitions.addAll(commitRemoves);
         partitions.addAll(commitAdds);
       }
     } catch (Exception e) {
-      throwReadFailed("PLAN_INPUT_PARTITIONS", e);
+      DeltaErrors.throwChangelogReadFailed("PLAN_INPUT_PARTITIONS", e);
     }
     return partitions.toArray(new InputPartition[0]);
   }
@@ -190,26 +190,6 @@ public class DeltaChangelogBatch implements Batch {
     if (!SchemaUtils.isReadCompatible(schema, endDataSchema)) {
       DeltaErrors.throwChangelogSchemaChangeInRange(version);
     }
-  }
-
-  /**
-   * Surfaces a changelog read failure. A cause that already carries a Spark error class (e.g. an
-   * in-range schema/row-tracking rejection) is rethrown unchanged so its user-facing error class is
-   * preserved; anything else (e.g. a low-level IO error from the kernel) is wrapped in a
-   * {@code DELTA_CHANGELOG_READ_FAILED} sub-class.
-   */
-  private static void throwReadFailed(String errorSubClass, Exception cause) {
-    if (cause instanceof SparkThrowable) {
-      throw sneakyThrow(cause);
-    }
-    throw new DeltaIllegalStateException(
-        "DELTA_CHANGELOG_READ_FAILED." + errorSubClass, new String[0], cause);
-  }
-
-  /** Rethrows {@code e} as-is without declaring it, so a checked cause keeps its concrete type. */
-  @SuppressWarnings("unchecked")
-  private static <E extends Throwable> RuntimeException sneakyThrow(Throwable e) throws E {
-    throw (E) e;
   }
 
   /**

--- a/spark/v2/src/main/java-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogBatch.java
+++ b/spark/v2/src/main/java-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogBatch.java
@@ -168,20 +168,16 @@ public class DeltaChangelogBatch implements Batch {
               }
             }
           }
-        } catch (RuntimeException e) {
-          throw e;
         } catch (Exception e) {
-          // Delta error-class exceptions raised above are rethrown unchanged; other checked
-          // exceptions are wrapped in a Delta error class rather than a bare RuntimeException.
-          DeltaErrors.throwChangelogReadFailed("processing commit actions", e);
+          // A cause that already carries a Spark error class is rethrown unchanged by
+          // throwChangelogReadFailed; anything else is wrapped in a Delta error class.
+          DeltaErrors.throwChangelogReadFailed("PROCESS_COMMIT_ACTIONS", e);
         }
         partitions.addAll(commitRemoves);
         partitions.addAll(commitAdds);
       }
-    } catch (RuntimeException e) {
-      throw e;
     } catch (Exception e) {
-      DeltaErrors.throwChangelogReadFailed("planning input partitions", e);
+      DeltaErrors.throwChangelogReadFailed("PLAN_INPUT_PARTITIONS", e);
     }
     return partitions.toArray(new InputPartition[0]);
   }

--- a/spark/v2/src/main/java-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogBatch.java
+++ b/spark/v2/src/main/java-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogBatch.java
@@ -6,6 +6,7 @@ import io.delta.kernel.Snapshot;
 import io.delta.kernel.data.ColumnarBatch;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.internal.DeltaLogActionUtils;
+import io.delta.kernel.internal.TableConfig;
 import io.delta.kernel.internal.actions.AddFile;
 import io.delta.kernel.internal.actions.DeletionVectorDescriptor;
 import io.delta.kernel.internal.actions.Metadata;
@@ -34,7 +35,6 @@ import org.apache.spark.sql.connector.read.InputPartition;
 import org.apache.spark.sql.connector.read.PartitionReader;
 import org.apache.spark.sql.connector.read.PartitionReaderFactory;
 import org.apache.spark.sql.delta.DefaultRowCommitVersion$;
-import org.apache.spark.sql.delta.DeltaConfigs$;
 import org.apache.spark.sql.delta.DeltaErrors;
 import org.apache.spark.sql.delta.RowId$;
 import org.apache.spark.sql.execution.datasources.FilePartition;
@@ -89,10 +89,7 @@ public class DeltaChangelogBatch implements Batch {
     // Pre-check catches schema drift between start and end. The per-commit loop below catches
     // in-range Metadata commits.
     StructType startSchema = SchemaUtils.convertKernelSchemaToSparkSchema(snapshot.getSchema());
-    if (!SchemaUtils.isReadCompatible(startSchema, endDataSchema)) {
-      DeltaErrors.throwChangelogSchemaChangeInRange(
-          ((CommitRangeImpl) commitRange).getStartVersion());
-    }
+    requireReadCompatible(startSchema, ((CommitRangeImpl) commitRange).getStartVersion());
 
     // TODO: Remove StreamingHelper usage. The helper is generic, only the class name is
     // streaming-flavored.
@@ -161,14 +158,10 @@ public class DeltaChangelogBatch implements Batch {
                 Metadata md = metadataOpt.get();
                 StructType commitSchema =
                     SchemaUtils.convertKernelSchemaToSparkSchema(md.getSchema());
-                if (!SchemaUtils.isReadCompatible(commitSchema, endDataSchema)) {
-                  DeltaErrors.throwChangelogSchemaChangeInRange(commit.getVersion());
-                }
-                String rtValue =
-                    md.getConfiguration().get(DeltaConfigs$.MODULE$.ROW_TRACKING_ENABLED().key());
+                requireReadCompatible(commitSchema, commit.getVersion());
                 // A new Metadata action fully replaces the prior configuration, so an absent
                 // row-tracking key means the table default (disabled), not an inherited value.
-                boolean rowTrackingEnabled = "true".equalsIgnoreCase(rtValue);
+                boolean rowTrackingEnabled = TableConfig.ROW_TRACKING_ENABLED.fromMetadata(md);
                 if (!rowTrackingEnabled) {
                   DeltaErrors.throwChangelogRowTrackingDisabledInRange(commit.getVersion());
                 }
@@ -191,6 +184,16 @@ public class DeltaChangelogBatch implements Batch {
       DeltaErrors.throwChangelogReadFailed("planning input partitions", e);
     }
     return partitions.toArray(new InputPartition[0]);
+  }
+
+  /**
+   * Rejects a schema at {@code version} that the end schema cannot read. Used for both the
+   * start/end pre-check and each in-range Metadata action.
+   */
+  private void requireReadCompatible(StructType schema, long version) {
+    if (!SchemaUtils.isReadCompatible(schema, endDataSchema)) {
+      DeltaErrors.throwChangelogSchemaChangeInRange(version);
+    }
   }
 
   /**

--- a/spark/v2/src/main/java-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogBatch.java
+++ b/spark/v2/src/main/java-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogBatch.java
@@ -80,7 +80,7 @@ public class DeltaChangelogBatch implements Batch {
     // Pre-check catches schema drift between start and end. The per-commit loop below catches
     // in-range Metadata commits.
     StructType startSchema = SchemaUtils.convertKernelSchemaToSparkSchema(snapshot.getSchema());
-    if (!startSchema.equals(endDataSchema)) {
+    if (!SchemaUtils.isReadCompatible(startSchema, endDataSchema)) {
       DeltaErrors.throwChangelogSchemaChangeInRange(
           ((CommitRangeImpl) commitRange).getStartVersion());
     }
@@ -152,7 +152,7 @@ public class DeltaChangelogBatch implements Batch {
                 Metadata md = metadataOpt.get();
                 StructType commitSchema =
                     SchemaUtils.convertKernelSchemaToSparkSchema(md.getSchema());
-                if (!commitSchema.equals(endDataSchema)) {
+                if (!SchemaUtils.isReadCompatible(commitSchema, endDataSchema)) {
                   DeltaErrors.throwChangelogSchemaChangeInRange(commit.getVersion());
                 }
                 String rtValue = md.getConfiguration().get("delta.enableRowTracking");

--- a/spark/v2/src/main/java-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogBatch.java
+++ b/spark/v2/src/main/java-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogBatch.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import java.util.function.Supplier;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
+import org.apache.spark.SparkThrowable;
 import org.apache.spark.paths.SparkPath;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
@@ -36,6 +37,7 @@ import org.apache.spark.sql.connector.read.PartitionReader;
 import org.apache.spark.sql.connector.read.PartitionReaderFactory;
 import org.apache.spark.sql.delta.DefaultRowCommitVersion$;
 import org.apache.spark.sql.delta.DeltaErrors;
+import org.apache.spark.sql.delta.DeltaIllegalStateException;
 import org.apache.spark.sql.delta.RowId$;
 import org.apache.spark.sql.execution.datasources.FilePartition;
 import org.apache.spark.sql.execution.datasources.PartitionedFile;
@@ -169,15 +171,13 @@ public class DeltaChangelogBatch implements Batch {
             }
           }
         } catch (Exception e) {
-          // A cause that already carries a Spark error class is rethrown unchanged by
-          // throwChangelogReadFailed; anything else is wrapped in a Delta error class.
-          DeltaErrors.throwChangelogReadFailed("PROCESS_COMMIT_ACTIONS", e);
+          throwReadFailed("PROCESS_COMMIT_ACTIONS", e);
         }
         partitions.addAll(commitRemoves);
         partitions.addAll(commitAdds);
       }
     } catch (Exception e) {
-      DeltaErrors.throwChangelogReadFailed("PLAN_INPUT_PARTITIONS", e);
+      throwReadFailed("PLAN_INPUT_PARTITIONS", e);
     }
     return partitions.toArray(new InputPartition[0]);
   }
@@ -190,6 +190,26 @@ public class DeltaChangelogBatch implements Batch {
     if (!SchemaUtils.isReadCompatible(schema, endDataSchema)) {
       DeltaErrors.throwChangelogSchemaChangeInRange(version);
     }
+  }
+
+  /**
+   * Surfaces a changelog read failure. A cause that already carries a Spark error class (e.g. an
+   * in-range schema/row-tracking rejection) is rethrown unchanged so its user-facing error class is
+   * preserved; anything else (e.g. a low-level IO error from the kernel) is wrapped in a
+   * {@code DELTA_CHANGELOG_READ_FAILED} sub-class.
+   */
+  private static void throwReadFailed(String errorSubClass, Exception cause) {
+    if (cause instanceof SparkThrowable) {
+      throw sneakyThrow(cause);
+    }
+    throw new DeltaIllegalStateException(
+        "DELTA_CHANGELOG_READ_FAILED." + errorSubClass, new String[0], cause);
+  }
+
+  /** Rethrows {@code e} as-is without declaring it, so a checked cause keeps its concrete type. */
+  @SuppressWarnings("unchecked")
+  private static <E extends Throwable> RuntimeException sneakyThrow(Throwable e) throws E {
+    throw (E) e;
   }
 
   /**

--- a/spark/v2/src/main/java-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogBatch.java
+++ b/spark/v2/src/main/java-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogBatch.java
@@ -56,19 +56,19 @@ public class DeltaChangelogBatch implements Batch {
 
   private final CommitRange commitRange;
   private final Engine engine;
-  private final StructType dataSchema;
+  private final StructType endDataSchema;
   private final Snapshot snapshot;
   private final Configuration hadoopConf;
 
   public DeltaChangelogBatch(
       CommitRange commitRange,
       Engine engine,
-      StructType dataSchema,
+      StructType endDataSchema,
       Snapshot snapshot,
       Configuration hadoopConf) {
     this.commitRange = commitRange;
     this.engine = engine;
-    this.dataSchema = dataSchema;
+    this.endDataSchema = endDataSchema;
     this.snapshot = snapshot;
     this.hadoopConf = hadoopConf;
   }
@@ -80,7 +80,7 @@ public class DeltaChangelogBatch implements Batch {
     // Pre-check catches schema drift between start and end. The per-commit loop below catches
     // in-range Metadata commits.
     StructType startSchema = SchemaUtils.convertKernelSchemaToSparkSchema(snapshot.getSchema());
-    if (!startSchema.equals(dataSchema)) {
+    if (!startSchema.equals(endDataSchema)) {
       DeltaErrors.throwChangelogSchemaChangeInRange(
           ((CommitRangeImpl) commitRange).getStartVersion());
     }
@@ -152,7 +152,7 @@ public class DeltaChangelogBatch implements Batch {
                 Metadata md = metadataOpt.get();
                 StructType commitSchema =
                     SchemaUtils.convertKernelSchemaToSparkSchema(md.getSchema());
-                if (!commitSchema.equals(dataSchema)) {
+                if (!commitSchema.equals(endDataSchema)) {
                   DeltaErrors.throwChangelogSchemaChangeInRange(commit.getVersion());
                 }
                 String rtValue = md.getConfiguration().get("delta.enableRowTracking");
@@ -229,7 +229,7 @@ public class DeltaChangelogBatch implements Batch {
   public PartitionReaderFactory createReaderFactory() {
     StructType partitionSchema = new StructType();
     StructType readDataSchema =
-        dataSchema.add(DeltaChangelog.METADATA_COLUMN, DeltaChangelog.METADATA_STRUCT, false);
+        endDataSchema.add(DeltaChangelog.METADATA_COLUMN, DeltaChangelog.METADATA_STRUCT, false);
     Filter[] dataFilters = new Filter[0];
     scala.collection.immutable.Map<String, String> scalaOptions =
         scala.collection.immutable.Map$.MODULE$.empty();
@@ -240,7 +240,7 @@ public class DeltaChangelogBatch implements Batch {
     PartitionReaderFactory delegate =
         PartitionUtils.createDeltaParquetReaderFactory(
             snapshot,
-            dataSchema,
+            endDataSchema,
             partitionSchema,
             readDataSchema,
             /* ddlOrderedReadOutputSchema */ readDataSchema,

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
@@ -318,7 +318,7 @@ public class DeltaV2Table
   }
 
   /**
-   * Returns the snapshot manager backing this table. Catalog-driven features such as Auto-CDF
+   * Returns the snapshot manager backing this table. Catalog-driven features such as read-time CDF
    * (TableCatalog.loadChangelog) use this to resolve versions, timestamps, and snapshots without
    * having to build their own snapshot manager.
    */

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2Batch.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2Batch.java
@@ -99,7 +99,7 @@ class DeltaV2Batch implements Batch {
   @Override
   public PartitionReaderFactory createReaderFactory() {
     // Non-CDC plain table scan. Write-time CDF streaming reads route through
-    // SparkMicroBatchStream; read-time Auto-CDF batch reads route through DeltaChangelogBatch.
+    // SparkMicroBatchStream; read-time CDF batch reads route through DeltaChangelogBatch.
     return PartitionUtils.createDeltaParquetReaderFactory(
         snapshot,
         dataSchema,

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/PartitionUtils.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/PartitionUtils.java
@@ -309,8 +309,8 @@ public class PartitionUtils {
    * @param isWriteTimeCDCRead If {@code true}, this is a write-time CDF read (streaming reads of
    *     the legacy {@code .option("readChangeFeed")} format): the read schema is augmented with CDC
    *     tail columns and the reader is wrapped with {@link CDCReadFunction}. If {@code false}, this
-   *     is a plain table scan or a read-time Auto-CDF read; CDC handling is left to the caller in
-   *     that case (Auto-CDF's outer {@code CDCPartitionReaderFactory} injects the tail columns as
+   *     is a plain table scan or a read-time CDF read; CDC handling is left to the caller in
+   *     that case (read-time CDF's outer {@code CDCPartitionReaderFactory} injects the tail columns as
    *     per-partition constants instead).
    */
   public static PartitionReaderFactory createDeltaParquetReaderFactory(
@@ -359,7 +359,7 @@ public class PartitionUtils {
 
     // For write-time CDF reads (streaming with readChangeFeed=true), build the schema context
     // and augment readDataSchema with CDC tail columns before DV wrapping so that DV column
-    // indices account for them. Read-time CDF (Auto-CDF, via DeltaChangelogBatch) does not go
+    // indices account for them. Read-time CDF (via DeltaChangelogBatch) does not go
     // through this path: DeltaChangelogBatch's outer CDCPartitionReaderFactory injects the
     // tail columns as per-partition constants instead.
     Optional<CDCSchemaContext> cdcSchemaContext =

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/PartitionUtils.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/PartitionUtils.java
@@ -309,8 +309,8 @@ public class PartitionUtils {
    * @param isWriteTimeCDCRead If {@code true}, this is a write-time CDF read (streaming reads of
    *     the legacy {@code .option("readChangeFeed")} format): the read schema is augmented with CDC
    *     tail columns and the reader is wrapped with {@link CDCReadFunction}. If {@code false}, this
-   *     is a plain table scan or a read-time CDF read; CDC handling is left to the caller in
-   *     that case (read-time CDF's outer {@code CDCPartitionReaderFactory} injects the tail columns as
+   *     is a plain table scan or a read-time CDF read; CDC handling is left to the caller in that
+   *     case (read-time CDF's outer {@code CDCPartitionReaderFactory} injects the tail columns as
    *     per-partition constants instead).
    */
   public static PartitionReaderFactory createDeltaParquetReaderFactory(

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/SchemaUtils.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/SchemaUtils.java
@@ -172,18 +172,18 @@ public class SchemaUtils {
       org.apache.spark.sql.types.StructType endSchema) {
     requireNonNull(existingSchema, "existingSchema is null");
     requireNonNull(endSchema, "endSchema is null");
-    org.apache.spark.sql.delta.schema.SchemaUtils$ schemaUtils =
-        org.apache.spark.sql.delta.schema.SchemaUtils$.MODULE$;
-    return schemaUtils.isReadCompatible(
+    scala.collection.immutable.Seq<String> noPartitionColumns =
+        scala.collection.immutable.Seq$.MODULE$.<String>empty();
+    return org.apache.spark.sql.delta.schema.SchemaUtils$.MODULE$.isReadCompatible(
         existingSchema,
         endSchema,
         /* forbidTightenNullability */ true,
-        schemaUtils.isReadCompatible$default$4(),
+        /* allowMissingColumns */ false,
         /* typeWideningMode */ org.apache.spark.sql.delta.TypeWideningMode.AllTypeWidening$.MODULE$,
-        schemaUtils.isReadCompatible$default$6(),
-        schemaUtils.isReadCompatible$default$7(),
-        schemaUtils.isReadCompatible$default$8(),
-        schemaUtils.isReadCompatible$default$9());
+        /* newPartitionColumns */ noPartitionColumns,
+        /* oldPartitionColumns */ noPartitionColumns,
+        /* caseSensitive */ true,
+        /* allowVoidTypeChange */ false);
   }
 
   //////////////////////

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/SchemaUtils.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/SchemaUtils.java
@@ -181,8 +181,7 @@ public class SchemaUtils {
         delta.isReadCompatible$default$5(),
         delta.isReadCompatible$default$6(),
         delta.isReadCompatible$default$7(),
-        delta.isReadCompatible$default$8(),
-        delta.isReadCompatible$default$9());
+        delta.isReadCompatible$default$8());
   }
 
   //////////////////////

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/SchemaUtils.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/SchemaUtils.java
@@ -160,6 +160,31 @@ public class SchemaUtils {
         ordered.toArray(new org.apache.spark.sql.types.StructField[0]));
   }
 
+  /**
+   * Whether data written under {@code existingSchema} can be read using {@code endSchema}. Backed by
+   * Delta's read-compatibility check, which accepts additive changes (new columns, relaxed
+   * nullability) and ignores internal field metadata, unlike strict equality. Nullability tightening
+   * is rejected because older data may contain nulls.
+   */
+  public static boolean isReadCompatible(
+      org.apache.spark.sql.types.StructType existingSchema,
+      org.apache.spark.sql.types.StructType endSchema) {
+    requireNonNull(existingSchema, "existingSchema is null");
+    requireNonNull(endSchema, "endSchema is null");
+    org.apache.spark.sql.delta.schema.SchemaUtils$ delta =
+        org.apache.spark.sql.delta.schema.SchemaUtils$.MODULE$;
+    return delta.isReadCompatible(
+        existingSchema,
+        endSchema,
+        /* forbidTightenNullability */ true,
+        delta.isReadCompatible$default$4(),
+        delta.isReadCompatible$default$5(),
+        delta.isReadCompatible$default$6(),
+        delta.isReadCompatible$default$7(),
+        delta.isReadCompatible$default$8(),
+        delta.isReadCompatible$default$9());
+  }
+
   //////////////////////
   // Spark --> Kernel //
   //////////////////////

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/SchemaUtils.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/SchemaUtils.java
@@ -163,27 +163,26 @@ public class SchemaUtils {
   /**
    * Whether data written under {@code existingSchema} can be read using {@code endSchema}. Backed
    * by Delta's read-compatibility check, which accepts additive changes (new columns, relaxed
-   * nullability), supported type widening (e.g. INT to LONG; the reader upcasts older data to the
-   * end type), and ignores internal field metadata, unlike strict equality. Nullability tightening
-   * is rejected because older data may contain nulls.
+   * nullability) and ignores internal field metadata, unlike strict equality. Nullability
+   * tightening is rejected because older data may contain nulls.
    */
   public static boolean isReadCompatible(
       org.apache.spark.sql.types.StructType existingSchema,
       org.apache.spark.sql.types.StructType endSchema) {
     requireNonNull(existingSchema, "existingSchema is null");
     requireNonNull(endSchema, "endSchema is null");
-    scala.collection.immutable.Seq<String> noPartitionColumns =
-        scala.collection.immutable.Seq$.MODULE$.<String>empty();
-    return org.apache.spark.sql.delta.schema.SchemaUtils$.MODULE$.isReadCompatible(
+    org.apache.spark.sql.delta.schema.SchemaUtils$ delta =
+        org.apache.spark.sql.delta.schema.SchemaUtils$.MODULE$;
+    return delta.isReadCompatible(
         existingSchema,
         endSchema,
         /* forbidTightenNullability */ true,
-        /* allowMissingColumns */ false,
-        /* typeWideningMode */ org.apache.spark.sql.delta.TypeWideningMode.AllTypeWidening$.MODULE$,
-        /* newPartitionColumns */ noPartitionColumns,
-        /* oldPartitionColumns */ noPartitionColumns,
-        /* caseSensitive */ true,
-        /* allowVoidTypeChange */ false);
+        delta.isReadCompatible$default$4(),
+        delta.isReadCompatible$default$5(),
+        delta.isReadCompatible$default$6(),
+        delta.isReadCompatible$default$7(),
+        delta.isReadCompatible$default$8(),
+        delta.isReadCompatible$default$9());
   }
 
   //////////////////////

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/SchemaUtils.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/SchemaUtils.java
@@ -163,26 +163,27 @@ public class SchemaUtils {
   /**
    * Whether data written under {@code existingSchema} can be read using {@code endSchema}. Backed
    * by Delta's read-compatibility check, which accepts additive changes (new columns, relaxed
-   * nullability) and ignores internal field metadata, unlike strict equality. Nullability
-   * tightening is rejected because older data may contain nulls.
+   * nullability), supported type widening (e.g. INT to LONG; the reader upcasts older data to the
+   * end type), and ignores internal field metadata, unlike strict equality. Nullability tightening
+   * is rejected because older data may contain nulls.
    */
   public static boolean isReadCompatible(
       org.apache.spark.sql.types.StructType existingSchema,
       org.apache.spark.sql.types.StructType endSchema) {
     requireNonNull(existingSchema, "existingSchema is null");
     requireNonNull(endSchema, "endSchema is null");
-    org.apache.spark.sql.delta.schema.SchemaUtils$ delta =
+    org.apache.spark.sql.delta.schema.SchemaUtils$ schemaUtils =
         org.apache.spark.sql.delta.schema.SchemaUtils$.MODULE$;
-    return delta.isReadCompatible(
+    return schemaUtils.isReadCompatible(
         existingSchema,
         endSchema,
         /* forbidTightenNullability */ true,
-        delta.isReadCompatible$default$4(),
-        delta.isReadCompatible$default$5(),
-        delta.isReadCompatible$default$6(),
-        delta.isReadCompatible$default$7(),
-        delta.isReadCompatible$default$8(),
-        delta.isReadCompatible$default$9());
+        schemaUtils.isReadCompatible$default$4(),
+        /* typeWideningMode */ org.apache.spark.sql.delta.TypeWideningMode.AllTypeWidening$.MODULE$,
+        schemaUtils.isReadCompatible$default$6(),
+        schemaUtils.isReadCompatible$default$7(),
+        schemaUtils.isReadCompatible$default$8(),
+        schemaUtils.isReadCompatible$default$9());
   }
 
   //////////////////////

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/SchemaUtils.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/SchemaUtils.java
@@ -161,10 +161,10 @@ public class SchemaUtils {
   }
 
   /**
-   * Whether data written under {@code existingSchema} can be read using {@code endSchema}. Backed by
-   * Delta's read-compatibility check, which accepts additive changes (new columns, relaxed
-   * nullability) and ignores internal field metadata, unlike strict equality. Nullability tightening
-   * is rejected because older data may contain nulls.
+   * Whether data written under {@code existingSchema} can be read using {@code endSchema}. Backed
+   * by Delta's read-compatibility check, which accepts additive changes (new columns, relaxed
+   * nullability) and ignores internal field metadata, unlike strict equality. Nullability
+   * tightening is rejected because older data may contain nulls.
    */
   public static boolean isReadCompatible(
       org.apache.spark.sql.types.StructType existingSchema,

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/PartitionUtilsTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/PartitionUtilsTest.java
@@ -265,7 +265,7 @@ public class PartitionUtilsTest extends DeltaV2TestBase {
   }
 
   /**
-   * Read-time Auto-CDF calls into PartitionUtils with {@code isWriteTimeCDCRead=false}. The factory
+   * Read-time CDF calls into PartitionUtils with {@code isWriteTimeCDCRead=false}. The factory
    * is then a plain Parquet reader factory: PartitionUtils does not augment {@code readDataSchema}
    * with CDC tail columns and does not wrap the reader with {@code CDCReadFunction}. The tail
    * columns are added by {@code DeltaChangelogBatch.CDCPartitionReaderFactory} as per-partition

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/PartitionUtilsTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/PartitionUtilsTest.java
@@ -265,8 +265,8 @@ public class PartitionUtilsTest extends DeltaV2TestBase {
   }
 
   /**
-   * Read-time CDF calls into PartitionUtils with {@code isWriteTimeCDCRead=false}. The factory
-   * is then a plain Parquet reader factory: PartitionUtils does not augment {@code readDataSchema}
+   * Read-time CDF calls into PartitionUtils with {@code isWriteTimeCDCRead=false}. The factory is
+   * then a plain Parquet reader factory: PartitionUtils does not augment {@code readDataSchema}
    * with CDC tail columns and does not wrap the reader with {@code CDCReadFunction}. The tail
    * columns are added by {@code DeltaChangelogBatch.CDCPartitionReaderFactory} as per-partition
    * constants instead.

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/SchemaUtilsTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/SchemaUtilsTest.java
@@ -17,6 +17,7 @@
 package io.delta.spark.internal.v2.utils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -369,5 +370,49 @@ public class SchemaUtilsTest {
         kernelMetadata, SchemaUtils.convertSparkMetadataToKernelFieldMetadata(sparkMetadata));
     assertEquals(
         sparkMetadata, SchemaUtils.convertKernelFieldMetadataToSparkMetadata(kernelMetadata));
+  }
+
+  @Test
+  public void isReadCompatibleAcceptsAdditiveColumn() {
+    org.apache.spark.sql.types.StructType existing =
+        new org.apache.spark.sql.types.StructType().add("id", DataTypes.LongType);
+    org.apache.spark.sql.types.StructType end =
+        new org.apache.spark.sql.types.StructType()
+            .add("id", DataTypes.LongType)
+            .add("name", DataTypes.StringType);
+    assertTrue(SchemaUtils.isReadCompatible(existing, end));
+  }
+
+  @Test
+  public void isReadCompatibleRejectsDroppedColumn() {
+    org.apache.spark.sql.types.StructType existing =
+        new org.apache.spark.sql.types.StructType()
+            .add("id", DataTypes.LongType)
+            .add("name", DataTypes.StringType);
+    org.apache.spark.sql.types.StructType end =
+        new org.apache.spark.sql.types.StructType().add("id", DataTypes.LongType);
+    assertFalse(SchemaUtils.isReadCompatible(existing, end));
+  }
+
+  @Test
+  public void isReadCompatibleRejectsTightenedNullability() {
+    org.apache.spark.sql.types.StructType existing =
+        new org.apache.spark.sql.types.StructType()
+            .add("id", DataTypes.LongType, /* nullable */ true);
+    org.apache.spark.sql.types.StructType end =
+        new org.apache.spark.sql.types.StructType()
+            .add("id", DataTypes.LongType, /* nullable */ false);
+    assertFalse(SchemaUtils.isReadCompatible(existing, end));
+  }
+
+  @Test
+  public void isReadCompatibleAcceptsRelaxedNullability() {
+    org.apache.spark.sql.types.StructType existing =
+        new org.apache.spark.sql.types.StructType()
+            .add("id", DataTypes.LongType, /* nullable */ false);
+    org.apache.spark.sql.types.StructType end =
+        new org.apache.spark.sql.types.StructType()
+            .add("id", DataTypes.LongType, /* nullable */ true);
+    assertTrue(SchemaUtils.isReadCompatible(existing, end));
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Follow-up cleanup for the read-time CDF (changelog) reader added in #6794 / #6830 / #6886, addressing reviewer feedback. The changelog V2 reader is gated behind the `changelogV2.enabled` SQL conf (default off) and only exists in the Spark 4.2 shim.

Changes, each in its own commit:

- **Terminology**: rename "Auto-CDF" to "read-time CDF" across changelog comments, docs and config descriptions (comment/string text only). ([comment](https://github.com/delta-io/delta/pull/6794#discussion_r3257012470))
- **Schema check**: replace strict schema equality in `DeltaChangelogBatch` with `SchemaUtils.isReadCompatible`, so additive, read-compatible changes (new columns, relaxed nullability) are accepted and internal field metadata is ignored. The check is wrapped in a small `isReadCompatible` helper on the v2 `SchemaUtils` (`forbidTightenNullability = true`, matching `CDCReaderBase`). Type changes are not read compatible and stay rejected. ([comment](https://github.com/delta-io/delta/pull/6794#discussion_r3257394771))
- **Naming**: rename the ambiguous `dataSchema` field to `endDataSchema`. ([comment](https://github.com/delta-io/delta/pull/6794#discussion_r3257394771))
- **Row-tracking detection**: a `Metadata` action fully replaces the prior table configuration, so an absent row-tracking key now means the table default (disabled) rather than an inherited value. The flag is read via the kernel `TableConfig.ROW_TRACKING_ENABLED` helper instead of a string literal. This makes the in-range row-tracking-disabled check correct; the boundary case is already caught earlier in `DeltaChangelogScanBuilder`. ([supersedes](https://github.com/delta-io/delta/pull/6794#discussion_r3257421996), [config helper](https://github.com/delta-io/delta/pull/6794#discussion_r3257418528), [in-range check](https://github.com/delta-io/delta/pull/6794#discussion_r3247979894))
- **Exceptions**: replace generic `RuntimeException` wrapping in the changelog read path with a `DELTA_CHANGELOG_READ_FAILED` error class (with `PLAN_INPUT_PARTITIONS` and `PROCESS_COMMIT_ACTIONS` sub-classes). Causes that already carry a Spark error class are rethrown unchanged so their user-facing class is preserved. ([comment](https://github.com/delta-io/delta/pull/6830/files#r3301759577), [comment](https://github.com/delta-io/delta/pull/6886#discussion_r3309976424))
- **Docs**: add a class-level comment describing the `DeltaChangelogBatch` read flow.

## How was this patch tested?

Existing unit and integration tests in `DeltaChangelogCatalogIntegrationTest` and `SchemaUtilsTest`, extended for this change:

- `SchemaUtilsTest` covers the `isReadCompatible` helper: additive column and relaxed nullability are accepted, dropped column and tightened nullability are rejected.
- `DeltaChangelogCatalogIntegrationTest` was refactored onto managed tables (single `withTable` wrapper), and gains coverage for schema/row-tracking changes across the requested range: row tracking toggled off before or after the range is allowed, an additive schema change mid-range is allowed and the pre-change rows read back under the end schema, and a dropped column, tightened nullability, or type change mid-range is rejected with `DELTA_CHANGELOG_SCHEMA_CHANGE_IN_RANGE`. Positive tests assert the actual row values, not just the row count.

## Does this PR introduce _any_ user-facing changes?
No
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->