### PR TITLE
Extract post-table-creation updates into a helper method in CreateDeltaTableCommand

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
@@ -268,7 +268,16 @@ case class CreateDeltaTableCommand(
       didNotChangeMetadata,
       createTableFunc)
 
+    runPostTableCreationUpdates(
+      sparkSession, txnUsedForCommit, deltaLog, postCommitSnapshot, tableWithLocation)
+  }
 
+  private def runPostTableCreationUpdates(
+      sparkSession: SparkSession,
+      txnUsedForCommit: OptimisticTransaction,
+      deltaLog: DeltaLog,
+      postCommitSnapshot: Snapshot,
+      tableWithLocation: CatalogTable): Unit = {
 
     if (UniversalFormat.hudiEnabled(postCommitSnapshot.metadata) &&
         !txnUsedForCommit.containsPostCommitHook(HudiConverterHook)) {


### PR DESCRIPTION
Refactors `CreateDeltaTableCommand` to move the post-commit table-creation follow-up work (the UniForm Hudi conversion) out of `runPostCommitUpdates` into a dedicated `runPostTableCreationUpdates` helper, invoked right after the catalog update. This groups the table-creation follow-up steps into a single method, making the post-commit flow easier to read and extend.

No behavior change: the same updates run in the same order after the catalog update.