### PR TITLE
[PROTOCOL] Interval Types RFC

### DIFF
--- a/protocol_rfcs/README.md
+++ b/protocol_rfcs/README.md
@@ -25,6 +25,7 @@ Here is the history of all the RFCs propose/accepted/rejected since Feb 6, 2024,
 | 2025-05-19    | [iceberg-compat-v3.md](https://github.com/delta-io/delta/blob/master/protocol_rfcs/iceberg-compat-v3.md)                         | https://github.com/delta-io/delta/issues/4574 | IcebergCompatV3                        |
 | 2025-11-20    | [materialize-partition-columns.md](https://github.com/delta-io/delta/blob/master/protocol_rfcs/materialize-partition-columns.md)                         | https://github.com/delta-io/delta/issues/5555 | Materialize Partition Columns                      |
 | 2026-04-22    | [iceberg-v4-metadata.md](https://github.com/delta-io/delta/blob/master/protocol_rfcs/iceberg-v4-metadata.md)                     | https://github.com/delta-io/delta/issues/6640 | Iceberg V4 Adaptive Metadata Tree      |
+| 2026-06-23    | [interval-types.md](https://github.com/delta-io/delta/blob/master/protocol_rfcs/interval-types.md)                                         | https://github.com/delta-io/delta/issues/7077 | Interval Types                         |
 
 ### Accepted RFCs
 

--- a/protocol_rfcs/interval-types.md
+++ b/protocol_rfcs/interval-types.md
@@ -30,6 +30,26 @@ In the schema, interval types are serialized in `Metadata.schemaString` as
 
 These are the canonical type-name strings. ANSI SQL also permits narrowed spellings that denote the same two types: for year-month, `interval year` and `interval month`; for day-second, `interval day`, `interval hour`, `interval minute`, `interval second`, and any `<start> to <end>` range between those fields (e.g. `interval day to minute`, `interval hour to second`). Mixed-family spellings (e.g. `interval month to day`) are not valid. Tables written by existing engines may use these narrowed spellings.
 
+Regardless of which spelling is used, the stored value is the same: every year-month spelling stores a signed count of months, and every day-second spelling stores a signed count of microseconds. The spelling affects only how a value is displayed, not how it is stored.
+
+Interval types are permitted anywhere a primitive type is permitted: as top-level columns, as nested struct fields, as array element types, and as map key or value types. For example:
+
+```
+{
+  "type": "struct",
+  "fields": [
+    { "name": "duration_ym", "type": "interval year to month", "nullable": true, "metadata": {} },
+    { "name": "duration_dt", "type": "interval day to second", "nullable": false, "metadata": {} },
+    {
+      "name": "durations",
+      "type": { "type": "array", "elementType": "interval day to second", "containsNull": true },
+      "nullable": true,
+      "metadata": {}
+    }
+  ]
+}
+```
+
 ### Reader Requirements
 
 When this table feature is supported, readers must:
@@ -42,6 +62,7 @@ When this table feature is supported, readers must:
 When this table feature is supported, writers must:
 
 - Serialize an interval field's type in `Metadata.schemaString` using the canonical `interval year to month` or `interval day to second` form.
+- Ensure the `intervalTypes` feature is present in the table `protocol`'s `readerFeatures` and `writerFeatures` whenever the table schema contains an interval type. The feature is enabled automatically by the presence of an interval-typed column; there is no separate table property to set (analogous to `timestampNtz`).
 
 ## Partition Value Serialization
 
@@ -54,17 +75,32 @@ Interval Day Second: "INTERVAL '7 12:34:56.123456' DAY TO SECOND"
 
 Where `'1-0'` refers to `years-months` and `'7 12:34:56.123456'` refers to `days hours:minutes:seconds.microseconds`.
 
+Interval partition values must not be used for partition pruning. Consistent with the data-skipping restriction for interval columns (see [Per-file Statistics](#per-file-statistics)), readers must not eliminate files based on interval partition values.
+
 ## Per-file Statistics
 
 Interval columns do not support `minValues`/`maxValues` statistics or data skipping. Writers must not record `minValues` or `maxValues` for interval columns, and readers must not perform data skipping over interval columns. The per-column `nullCount` and the per-file `numRecords` statistics are unaffected and are still recorded as normal, since they do not require interpreting interval values. This is consistent with existing tables that contain interval types, which do not record `minValues`/`maxValues` for these columns.
 
 ## Parquet Format
 
-We use raw `int32` values to represent year-month intervals and raw `int64` values to represent day-second intervals in Parquet. This allows us to support signed intervals & microsecond precision while matching existing interval types.
+Interval values are stored using a raw Parquet physical type with no logical-type annotation:
+
+- `interval year to month` is stored as a Parquet `int32` holding the signed count of months.
+- `interval day to second` is stored as a Parquet `int64` holding the signed count of microseconds.
+
+Because no Parquet logical type is written, an interval column is physically indistinguishable from a Parquet `int32`/`int64` (i.e. a Delta `integer`/`long`); the interval semantics are carried solely by the Delta schema in `Metadata.schemaString`. This representation supports signed intervals and microsecond precision while matching the physical layout of existing interval tables.
 
 ## Feature Interactions
 
-Beyond the partition-value and statistics behavior described above, interval types have no special interactions with other table features.
+Beyond the partition-value and statistics behavior described above, and the restrictions listed in [Error Conditions](#error-conditions), interval types have no special interactions with other table features.
+
+## Error Conditions
+
+- **Unrecognized type-name strings.** Type-name matching is case-sensitive. A reader that encounters an interval type-name string that is not one of the recognized canonical or narrowed spellings, including a mixed-family spelling such as `interval month to day`, or a case variant such as `INTERVAL Year To Month`, must reject the schema with an error rather than silently coercing it to a supported type.
+- **Feature not present.** A writer must add `intervalTypes` to the table `protocol`'s `readerFeatures` and `writerFeatures` whenever it writes a schema containing an interval type (see [Writer Requirements](#writer-requirements)). A reader that encounters an interval type in the schema while `intervalTypes` is absent from `readerFeatures` must reject the table.
+- **Value overflow on write.** An `interval year to month` value must fit in a signed `int32` count of months, and an `interval day to second` value must fit in a signed `int64` count of microseconds. A writer must reject any value that overflows these bounds.
+- **Malformed or out-of-range partition values.** When reading, a partition value that is not a valid ANSI interval literal, or whose decoded value does not fit the column's underlying `int32`/`int64` range, must be rejected with an error.
+- **IcebergCompat incompatibility.** Apache Iceberg has no interval type. When any of the `icebergCompatV1`, `icebergCompatV2`, or `icebergCompatV3` features is enabled, a writer must reject — at schema validation — any schema containing an interval type.
 
 > ***Add new rows to the [Primitive Types](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#primitive-types) table.***
 
@@ -72,6 +108,13 @@ Beyond the partition-value and statistics behavior described above, interval typ
 | --- | --- |
 | interval year to month | Signed duration in the precision of months |
 | interval day to second | Signed duration in the precision of microseconds |
+
+> ***Add new rows to the [Delta Data Type to Parquet Type Mappings](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#delta-data-type-to-parquet-type-mappings) table.***
+
+| Delta Type Name | Parquet Physical Type | Parquet Logical Type |
+| --- | --- | --- |
+| interval year to month | `int32` | |
+| interval day to second | `int64` | |
 
 # References
 

--- a/protocol_rfcs/interval-types.md
+++ b/protocol_rfcs/interval-types.md
@@ -1,0 +1,68 @@
+# Interval Types
+**Associated Github issue for discussions: https://github.com/delta-io/delta/issues/7077**
+
+This protocol change adds support for interval types. It consists of two changes to the protocol:
+
+- One new reader/writer table feature
+- Two new primitive types (year-month and day-second)
+
+--------
+
+> ***Add a new section in front of the [Primitive Types](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#primitive-types) section.***
+
+# Interval Types Table Feature
+
+This table feature (`intervalTypes`) adds the year-month and day-time interval types from ANSI SQL:
+
+1. **interval year to month**: A signed number of months, e.g. `INTERVAL '1-6' YEAR TO MONTH` represents 18 (1 year + 6 months = 18 months).
+2. **interval day to second**: A signed number of microseconds, e.g. `INTERVAL '1 00:00:01.000000' DAY TO SECOND` represents 86,401,000,000 (1 day + 1 second = 86,400,000,000 + 1,000,000 μs).
+
+To support this feature:
+- The table must be on **Reader Version 3** and **Writer Version 7**.
+- The feature `intervalTypes` must be listed in the table `protocol`'s `readerFeatures` and `writerFeatures`.
+
+## Type Definitions
+
+In the schema, interval types are serialized as
+
+- `interval year to month`
+- `interval day to second`
+
+When this table feature is supported:
+
+- Readers must interpret `interval year to month` and `interval day to second` as signed counts of months and microseconds, respectively.
+- Writers must serialize an interval field's type in `Metadata.schemaString` as `interval year to month` or `interval day to second`.
+
+## Partition Value Serialization
+
+Intervals can be a partition value, so we define Partition Value Serialization as the ANSI literal form for interval types as defined by the Spark SQL guide [1]. We provide an example below:
+
+```
+Interval Year Month: "INTERVAL '1-0' YEAR TO MONTH"
+Interval Day Second: "INTERVAL '7 12:34:56.123456' DAY TO SECOND"
+```
+
+Where `'1-0'` refers to `years-months` and `'7 12:34:56.123456'` refers to `days hours:minutes:seconds.microseconds`.
+
+## Per-file Statistics
+
+Interval types do not support per-file statistics or data skipping. Writers must not record `minValues` or `maxValues` statistics for interval columns, and readers must not perform data skipping over interval columns. This is consistent with existing tables that contain interval types, which do not support per-file statistics for these columns.
+
+## Parquet Format
+
+We use raw `int32` values to represent year-month intervals and raw `int64` values to represent day-time intervals in Parquet. This allows us to support signed intervals and microsecond precision.
+
+The choice of underlying Parquet representation involves design trade-offs that are still under discussion; these design decisions are tracked in the associated GitHub issue [2].
+
+> ***Add new rows to the [Primitive Types](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#primitive-types) table.***
+
+| Type Name | Description |
+| --- | --- |
+| interval year to month | Signed duration in the precision of months |
+| interval day to second | Signed duration in the precision of microseconds |
+
+# References
+
+[1] https://spark.apache.org/docs/latest/sql-ref-literals.html#interval-literal
+
+[2] https://github.com/delta-io/delta/issues/7077

--- a/protocol_rfcs/interval-types.md
+++ b/protocol_rfcs/interval-types.md
@@ -12,7 +12,7 @@ This protocol change adds support for interval types. It consists of two changes
 
 # Interval Types Table Feature
 
-This table feature (`intervalTypes`) adds the year-month and day-time interval types from ANSI SQL:
+This table feature (`intervalTypes`) adds the year-month and day-second interval types from ANSI SQL:
 
 1. **interval year to month**: A signed number of months, e.g. `INTERVAL '1-6' YEAR TO MONTH` represents 18 (1 year + 6 months = 18 months).
 2. **interval day to second**: A signed number of microseconds, e.g. `INTERVAL '1 00:00:01.000000' DAY TO SECOND` represents 86,401,000,000 (1 day + 1 second = 86,400,000,000 + 1,000,000 μs).
@@ -23,15 +23,25 @@ To support this feature:
 
 ## Type Definitions
 
-In the schema, interval types are serialized as
+In the schema, interval types are serialized in `Metadata.schemaString` as
 
 - `interval year to month`
 - `interval day to second`
 
-When this table feature is supported:
+These are the canonical type-name strings. ANSI SQL also permits narrowed spellings that denote the same two types: for year-month, `interval year` and `interval month`; for day-second, `interval day`, `interval hour`, `interval minute`, `interval second`, and any `<start> to <end>` range between those fields (e.g. `interval day to minute`, `interval hour to second`). Mixed-family spellings (e.g. `interval month to day`) are not valid. Tables written by existing engines may use these narrowed spellings.
 
-- Readers must interpret `interval year to month` and `interval day to second` as signed counts of months and microseconds, respectively.
-- Writers must serialize an interval field's type in `Metadata.schemaString` as `interval year to month` or `interval day to second`.
+### Reader Requirements
+
+When this table feature is supported, readers must:
+
+- Interpret `interval year to month` as a signed count of months, and `interval day to second` as a signed count of microseconds.
+- Accept the narrowed spellings above and normalize each to its family: any year-month spelling is treated as `interval year to month`, and any day-second spelling is treated as `interval day to second`.
+
+### Writer Requirements
+
+When this table feature is supported, writers must:
+
+- Serialize an interval field's type in `Metadata.schemaString` using the canonical `interval year to month` or `interval day to second` form.
 
 ## Partition Value Serialization
 
@@ -46,13 +56,15 @@ Where `'1-0'` refers to `years-months` and `'7 12:34:56.123456'` refers to `days
 
 ## Per-file Statistics
 
-Interval types do not support per-file statistics or data skipping. Writers must not record `minValues` or `maxValues` statistics for interval columns, and readers must not perform data skipping over interval columns. This is consistent with existing tables that contain interval types, which do not support per-file statistics for these columns.
+Interval columns do not support `minValues`/`maxValues` statistics or data skipping. Writers must not record `minValues` or `maxValues` for interval columns, and readers must not perform data skipping over interval columns. The per-column `nullCount` and the per-file `numRecords` statistics are unaffected and are still recorded as normal, since they do not require interpreting interval values. This is consistent with existing tables that contain interval types, which do not record `minValues`/`maxValues` for these columns.
 
 ## Parquet Format
 
-We use raw `int32` values to represent year-month intervals and raw `int64` values to represent day-time intervals in Parquet. This allows us to support signed intervals and microsecond precision.
+We use raw `int32` values to represent year-month intervals and raw `int64` values to represent day-second intervals in Parquet. This allows us to support signed intervals & microsecond precision while matching existing interval types.
 
-The choice of underlying Parquet representation involves design trade-offs that are still under discussion; these design decisions are tracked in the associated GitHub issue [2].
+## Feature Interactions
+
+Beyond the partition-value and statistics behavior described above, interval types have no special interactions with other table features.
 
 > ***Add new rows to the [Primitive Types](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#primitive-types) table.***
 

--- a/protocol_rfcs/interval-types.md
+++ b/protocol_rfcs/interval-types.md
@@ -64,7 +64,7 @@ When this table feature is supported, readers must:
 When this table feature is supported, writers must:
 
 - Serialize an interval field's type in `Metadata.schemaString` using the canonical `interval year to month` or `interval day to second` form.
-- Never write an interval type to a table unless the `intervalTypes` feature is present in the table `protocol`'s `readerFeatures` and `writerFeatures`. When a writer introduces an interval-typed column to a table that does not yet have the feature, it must add `intervalTypes` to both lists in the same commit, so the feature and the column are committed together. There is no separate table property to enable the feature; adding it to the reader and writer feature lists is what enables it (analogous to `timestampNtz`).
+- Never write an interval type to a table unless the `intervalTypes` feature is present in the table `protocol`'s `readerFeatures` and `writerFeatures`. When a writer introduces an interval type into the schema of a table that does not yet support the feature — whether at table creation or via schema evolution — it must add `intervalTypes` to both lists in the same commit, so that the feature and the interval type are committed together.
 
 ## Partition Value Serialization
 
@@ -101,8 +101,8 @@ Beyond the partition-value and statistics behavior described above, and the rest
 ## Error Conditions
 
 - **Unrecognized type-name strings.** Type-name matching is case-sensitive. A reader that encounters an interval type-name string that is not one of the recognized canonical or narrowed spellings, including a multi-family spelling such as `interval month to second`, or a case variant such as `INTERVAL Year To Month`, must reject the schema with an error rather than silently coercing it to a supported type.
-- **Feature not present.** A writer must add `intervalTypes` to the table `protocol`'s `readerFeatures` and `writerFeatures` whenever it writes a schema containing an interval type (see [Writer Requirements](#writer-requirements)).
-- **Value overflow on write.** An `interval year to month` value must fit in a signed `int32` count of months, and an `interval day to second` value must fit in a signed `int64` count of microseconds. A writer must reject any value that overflows these bounds.
+- **Feature not present.** A writer must add `intervalTypes` to the table `protocol`'s `readerFeatures` and `writerFeatures` whenever it introduces an interval type into the table's schema — whether at table creation or via schema evolution — if the feature is not already present, committing the feature and the interval type together (see [Writer Requirements](#writer-requirements)). Re-serializing an already-committed schema, such as when writing a checkpoint, does not introduce an interval type and must not add the `intervalTypes` feature.
+- **Value overflow on write.** An `interval year to month` value is stored as a signed `int32` count of months, so it must lie in the inclusive range `INTERVAL '-178956970-8' YEAR TO MONTH` to `INTERVAL '178956970-7' YEAR TO MONTH` (roughly ±179 million years). An `interval day to second` value is stored as a signed `int64` count of microseconds, so it must lie in the inclusive range `INTERVAL '-106751991 04:00:54.775808' DAY TO SECOND` to `INTERVAL '106751991 04:00:54.775807' DAY TO SECOND` (roughly ±106,751,991 days, or about 292 thousand years). A writer must reject any value that falls outside these bounds.
 - **Malformed or out-of-range partition values.** When reading, a partition value that is not a valid ANSI interval literal, or whose decoded value does not fit the column's underlying `int32`/`int64` range, must be rejected with an error.
 - **IcebergCompat incompatibility.** Apache Iceberg has no interval type. When any of the `icebergCompatV1`, `icebergCompatV2`, or `icebergCompatV3` features is enabled, a writer must reject any schema containing an interval type.
 

--- a/protocol_rfcs/interval-types.md
+++ b/protocol_rfcs/interval-types.md
@@ -4,7 +4,7 @@
 This protocol change adds support for interval types (as defined [here](https://spark.apache.org/docs/latest/sql-ref-datatypes.html)). It consists of two changes to the protocol:
 
 - One new reader/writer table feature
-- Two new primitive types (year-month and day-second)
+- Two distinct new primitive types (year-month and day-second)
 
 --------
 
@@ -12,10 +12,12 @@ This protocol change adds support for interval types (as defined [here](https://
 
 # Interval Types Table Feature
 
-This table feature (`intervalTypes`) adds the year-month and day-second [interval types](https://spark.apache.org/docs/latest/sql-ref-datatypes.html) from ANSI SQL:
+This table feature (`intervalTypes`) adds two distinct Delta logical types, one for each [ANSI SQL interval type](https://spark.apache.org/docs/latest/sql-ref-datatypes.html) family:
 
 1. **interval year to month**: A signed number of months, e.g. `INTERVAL '1-6' YEAR TO MONTH` represents 18 (1 year + 6 months = 18 months).
 2. **interval day to second**: A signed number of microseconds, e.g. `INTERVAL '1 12:24:36.000022' DAY TO SECOND` represents 131,076,000,022 (1 day + 12 hours + 24 minutes + 36 seconds + 22 microseconds = 86,400,000,000 + 43,200,000,000 + 1,440,000,000 + 36,000,000 + 22 = 131,076,000,022).
+
+These are separate logical types with different units and physical encodings, rather than parameters of a single interval type. Each supported interval type-name spelling described below resolves to exactly one of these two logical types.
 
 To support this feature:
 - The table must be on Reader Version 3 and Writer Version 7.
@@ -23,14 +25,16 @@ To support this feature:
 
 ## Type Definitions
 
-In the schema, interval types are serialized in `Metadata.schemaString` (case-sensitive) as
+Interval type names in `Metadata.schemaString` are case-sensitive. The canonical type-name strings are:
 
 - `interval year to month`
 - `interval day to second`
 
-Intervals have two families: year-month (made up of the fields `year` and `month`) and day-second (made up of the fields `day`, `hour`, `minute`, and `second`). `interval year to month` and `interval day to second` are the canonical type-name strings for these two families.
+Intervals have two families: year-month (made up of the fields `year` and `month`) and day-second (made up of the fields `day`, `hour`, `minute`, and `second`).
 
 ANSI SQL also permits narrowed spellings that denote the same two families: for year-month, `interval year` and `interval month`; for day-second, `interval day`, `interval hour`, `interval minute`, `interval second`, and any `<start> to <end>` range over the ordered fields `day`, `hour`, `minute`, `second` (e.g. `interval day to minute`, `interval hour to second`). A spelling is not valid if it is multi-family — that is, it combines fields from both families (for example, `interval month to second`). A spelling is also not valid if its fields are in the wrong order, going from a shorter unit to a longer one (for example, `interval second to day` or `interval month to year`).
+
+Both the canonical names and all valid narrowed spellings listed above are permitted in `Metadata.schemaString`. Readers must accept every permitted spelling, while writers must always serialize the corresponding canonical name.
 
 Regardless of which spelling is used, the stored value is the same: every year-month spelling stores a signed count of months, and every day-second spelling stores a signed count of microseconds. The spelling affects only how a value is displayed, not how it is stored.
 

--- a/protocol_rfcs/interval-types.md
+++ b/protocol_rfcs/interval-types.md
@@ -12,27 +12,29 @@ This protocol change adds support for interval types (as defined [here](https://
 
 # Interval Types Table Feature
 
-This table feature (`intervalTypes`) adds the year-month and day-second interval types from ANSI SQL:
+This table feature (`intervalTypes`) adds the year-month and day-second [interval types](https://spark.apache.org/docs/latest/sql-ref-datatypes.html) from ANSI SQL:
 
 1. **interval year to month**: A signed number of months, e.g. `INTERVAL '1-6' YEAR TO MONTH` represents 18 (1 year + 6 months = 18 months).
-2. **interval day to second**: A signed number of microseconds, e.g. `INTERVAL '1 00:00:01.000000' DAY TO SECOND` represents 86,401,000,000 (1 day + 1 second = 86,400,000,000 + 1,000,000 μs).
+2. **interval day to second**: A signed number of microseconds, e.g. `INTERVAL '1 12:24:36.000022' DAY TO SECOND` represents 131,076,000,022 (1 day + 12 hours + 24 minutes + 36 seconds + 22 microseconds = 86,400,000,000 + 43,200,000,000 + 1,440,000,000 + 36,000,000 + 22 = 131,076,000,022).
 
 To support this feature:
-- The table must be on **Reader Version 3** and **Writer Version 7**.
+- The table must be on Reader Version 3 and Writer Version 7.
 - The feature `intervalTypes` must be listed in the table `protocol`'s `readerFeatures` and `writerFeatures`.
 
 ## Type Definitions
 
-In the schema, interval types are serialized in `Metadata.schemaString` as
+In the schema, interval types are serialized in `Metadata.schemaString` (case-sensitive) as
 
 - `interval year to month`
 - `interval day to second`
 
-These are the canonical type-name strings. ANSI SQL also permits narrowed spellings that denote the same two types: for year-month, `interval year` and `interval month`; for day-second, `interval day`, `interval hour`, `interval minute`, `interval second`, and any `<start> to <end>` range between those fields (e.g. `interval day to minute`, `interval hour to second`). Mixed-family spellings (e.g. `interval month to day`) are not valid. Tables written by existing engines may use these narrowed spellings.
+Intervals have two families: year-month (made up of the fields `year` and `month`) and day-second (made up of the fields `day`, `hour`, `minute`, and `second`). `interval year to month` and `interval day to second` are the canonical type-name strings for these two families.
+
+ANSI SQL also permits narrowed spellings that denote the same two families: for year-month, `interval year` and `interval month`; for day-second, `interval day`, `interval hour`, `interval minute`, `interval second`, and any `<start> to <end>` range over the ordered fields `day`, `hour`, `minute`, `second` (e.g. `interval day to minute`, `interval hour to second`). A spelling is not valid if it is multi-family — that is, it combines fields from both families (for example, `interval month to second`). A spelling is also not valid if its fields are in the wrong order, going from a shorter unit to a longer one (for example, `interval second to day` or `interval month to year`).
 
 Regardless of which spelling is used, the stored value is the same: every year-month spelling stores a signed count of months, and every day-second spelling stores a signed count of microseconds. The spelling affects only how a value is displayed, not how it is stored.
 
-Interval types are permitted anywhere a primitive type is permitted: as top-level columns, as nested struct fields, as array element types, and as map key or value types. For example:
+Interval types are permitted anywhere a primitive type is permitted: as a top-level column, as a nested struct field, as an array element type, and as a map key or value type. For example:
 
 ```
 {
@@ -62,7 +64,7 @@ When this table feature is supported, readers must:
 When this table feature is supported, writers must:
 
 - Serialize an interval field's type in `Metadata.schemaString` using the canonical `interval year to month` or `interval day to second` form.
-- Ensure the `intervalTypes` feature is present in the table `protocol`'s `readerFeatures` and `writerFeatures` whenever the table schema contains an interval type. The feature is enabled automatically by the presence of an interval-typed column; there is no separate table property to set (analogous to `timestampNtz`).
+- Never write an interval type to a table unless the `intervalTypes` feature is present in the table `protocol`'s `readerFeatures` and `writerFeatures`. When a writer introduces an interval-typed column to a table that does not yet have the feature, it must add `intervalTypes` to both lists in the same commit, so the feature and the column are committed together. There is no separate table property to enable the feature; adding it to the reader and writer feature lists is what enables it (analogous to `timestampNtz`).
 
 ## Partition Value Serialization
 
@@ -81,6 +83,8 @@ Interval partition values must not be used for partition pruning. Consistent wit
 
 Interval columns do not support `minValues`/`maxValues` statistics or data skipping. Writers must not record `minValues` or `maxValues` for interval columns, and readers must not perform data skipping over interval columns. The per-column `nullCount` and the per-file `numRecords` statistics are unaffected and are still recorded as normal, since they do not require interpreting interval values.
 
+Since clustered tables require per-column statistics, including `minValues` and `maxValues`, a writer must not use an interval column as a clustering column.
+
 ## Parquet Format
 
 Interval values are stored using a raw Parquet physical type with no logical-type annotation:
@@ -96,7 +100,7 @@ Beyond the partition-value and statistics behavior described above, and the rest
 
 ## Error Conditions
 
-- **Unrecognized type-name strings.** Type-name matching is case-sensitive. A reader that encounters an interval type-name string that is not one of the recognized canonical or narrowed spellings, including a mixed-family spelling such as `interval month to day` (neither `year to month` nor `day to second`), or a case variant such as `INTERVAL Year To Month`, must reject the schema with an error rather than silently coercing it to a supported type.
+- **Unrecognized type-name strings.** Type-name matching is case-sensitive. A reader that encounters an interval type-name string that is not one of the recognized canonical or narrowed spellings, including a multi-family spelling such as `interval month to second`, or a case variant such as `INTERVAL Year To Month`, must reject the schema with an error rather than silently coercing it to a supported type.
 - **Feature not present.** A writer must add `intervalTypes` to the table `protocol`'s `readerFeatures` and `writerFeatures` whenever it writes a schema containing an interval type (see [Writer Requirements](#writer-requirements)).
 - **Value overflow on write.** An `interval year to month` value must fit in a signed `int32` count of months, and an `interval day to second` value must fit in a signed `int64` count of microseconds. A writer must reject any value that overflows these bounds.
 - **Malformed or out-of-range partition values.** When reading, a partition value that is not a valid ANSI interval literal, or whose decoded value does not fit the column's underlying `int32`/`int64` range, must be rejected with an error.

--- a/protocol_rfcs/interval-types.md
+++ b/protocol_rfcs/interval-types.md
@@ -97,10 +97,10 @@ Beyond the partition-value and statistics behavior described above, and the rest
 ## Error Conditions
 
 - **Unrecognized type-name strings.** Type-name matching is case-sensitive. A reader that encounters an interval type-name string that is not one of the recognized canonical or narrowed spellings, including a mixed-family spelling such as `interval month to day` (neither `year to month` nor `day to second`), or a case variant such as `INTERVAL Year To Month`, must reject the schema with an error rather than silently coercing it to a supported type.
-- **Feature not present.** A writer must add `intervalTypes` to the table `protocol`'s `readerFeatures` and `writerFeatures` whenever it writes a schema containing an interval type (see [Writer Requirements](#writer-requirements)). A reader that encounters an interval type in the schema while `intervalTypes` is absent from `readerFeatures` must reject the table.
+- **Feature not present.** A writer must add `intervalTypes` to the table `protocol`'s `readerFeatures` and `writerFeatures` whenever it writes a schema containing an interval type (see [Writer Requirements](#writer-requirements)).
 - **Value overflow on write.** An `interval year to month` value must fit in a signed `int32` count of months, and an `interval day to second` value must fit in a signed `int64` count of microseconds. A writer must reject any value that overflows these bounds.
 - **Malformed or out-of-range partition values.** When reading, a partition value that is not a valid ANSI interval literal, or whose decoded value does not fit the column's underlying `int32`/`int64` range, must be rejected with an error.
-- **IcebergCompat incompatibility.** Apache Iceberg has no interval type. When any of the `icebergCompatV1`, `icebergCompatV2`, or `icebergCompatV3` features is enabled, a writer must reject — at schema validation — any schema containing an interval type.
+- **IcebergCompat incompatibility.** Apache Iceberg has no interval type. When any of the `icebergCompatV1`, `icebergCompatV2`, or `icebergCompatV3` features is enabled, a writer must reject any schema containing an interval type.
 
 > ***Add new rows to the [Primitive Types](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#primitive-types) table.***
 

--- a/protocol_rfcs/interval-types.md
+++ b/protocol_rfcs/interval-types.md
@@ -1,7 +1,7 @@
 # Interval Types
 **Associated Github issue for discussions: https://github.com/delta-io/delta/issues/7077**
 
-This protocol change adds support for interval types. It consists of two changes to the protocol:
+This protocol change adds support for interval types (as defined [here](https://spark.apache.org/docs/latest/sql-ref-datatypes.html)). It consists of two changes to the protocol:
 
 - One new reader/writer table feature
 - Two new primitive types (year-month and day-second)
@@ -79,7 +79,7 @@ Interval partition values must not be used for partition pruning. Consistent wit
 
 ## Per-file Statistics
 
-Interval columns do not support `minValues`/`maxValues` statistics or data skipping. Writers must not record `minValues` or `maxValues` for interval columns, and readers must not perform data skipping over interval columns. The per-column `nullCount` and the per-file `numRecords` statistics are unaffected and are still recorded as normal, since they do not require interpreting interval values. This is consistent with existing tables that contain interval types, which do not record `minValues`/`maxValues` for these columns.
+Interval columns do not support `minValues`/`maxValues` statistics or data skipping. Writers must not record `minValues` or `maxValues` for interval columns, and readers must not perform data skipping over interval columns. The per-column `nullCount` and the per-file `numRecords` statistics are unaffected and are still recorded as normal, since they do not require interpreting interval values.
 
 ## Parquet Format
 
@@ -88,7 +88,7 @@ Interval values are stored using a raw Parquet physical type with no logical-typ
 - `interval year to month` is stored as a Parquet `int32` holding the signed count of months.
 - `interval day to second` is stored as a Parquet `int64` holding the signed count of microseconds.
 
-Because no Parquet logical type is written, an interval column is physically indistinguishable from a Parquet `int32`/`int64` (i.e. a Delta `integer`/`long`); the interval semantics are carried solely by the Delta schema in `Metadata.schemaString`. This representation supports signed intervals and microsecond precision while matching the physical layout of existing interval tables.
+Because no Parquet logical type is written, an interval column is physically indistinguishable from a Parquet `int32`/`int64` (i.e. a Delta `integer`/`long`); the interval semantics are carried solely by the Delta schema in `Metadata.schemaString`. This representation supports signed intervals and microsecond precision. 
 
 ## Feature Interactions
 
@@ -96,7 +96,7 @@ Beyond the partition-value and statistics behavior described above, and the rest
 
 ## Error Conditions
 
-- **Unrecognized type-name strings.** Type-name matching is case-sensitive. A reader that encounters an interval type-name string that is not one of the recognized canonical or narrowed spellings, including a mixed-family spelling such as `interval month to day`, or a case variant such as `INTERVAL Year To Month`, must reject the schema with an error rather than silently coercing it to a supported type.
+- **Unrecognized type-name strings.** Type-name matching is case-sensitive. A reader that encounters an interval type-name string that is not one of the recognized canonical or narrowed spellings, including a mixed-family spelling such as `interval month to day` (neither `year to month` nor `day to second`), or a case variant such as `INTERVAL Year To Month`, must reject the schema with an error rather than silently coercing it to a supported type.
 - **Feature not present.** A writer must add `intervalTypes` to the table `protocol`'s `readerFeatures` and `writerFeatures` whenever it writes a schema containing an interval type (see [Writer Requirements](#writer-requirements)). A reader that encounters an interval type in the schema while `intervalTypes` is absent from `readerFeatures` must reject the table.
 - **Value overflow on write.** An `interval year to month` value must fit in a signed `int32` count of months, and an `interval day to second` value must fit in a signed `int64` count of microseconds. A writer must reject any value that overflows these bounds.
 - **Malformed or out-of-range partition values.** When reading, a partition value that is not a valid ANSI interval literal, or whose decoded value does not fit the column's underlying `int32`/`int64` range, must be rejected with an error.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

This change introduces an RFC proposal for interval types. It introduces native support for storing year-month and day-time interval types in Delta tables. It includes updates to the Delta protocol to add a new reader-writer table feature for interval types. It does not include adding support for statistics.

Design Decision documented in https://github.com/delta-io/delta/issues/7077.

## How was this patch tested?

N/A

## Does this PR introduce _any_ user-facing changes?

No