### PR TITLE
[Spark] Run DeltaSinkSuite against both path-based and name-based access

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSinkSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSinkSuite.scala
@@ -27,6 +27,7 @@ import org.apache.spark.sql.delta.test.{DeltaColumnMappingSelectedTestMixin, Del
 import org.apache.spark.sql.delta.test.DeltaSQLTestUtils
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 import org.apache.spark.sql.delta.test.shims.StreamingTestShims.{MemoryStream, MicroBatchExecution, StreamingQueryWrapper}
+import io.delta.tables.DeltaTable
 import org.apache.commons.io.FileUtils
 import org.scalatest.time.SpanSugar._
 
@@ -81,21 +82,71 @@ class DeltaSinkSuite
 
   import testImplicits._
 
+  /**
+   * When false, sink tests address the target by filesystem path (the original DSv1 access path).
+   * When true, they address it by catalog name via `toTable` (required to exercise the DSv2 sink,
+   * which has no path-based seam). Overridden by [[DeltaSinkNameBasedSuite]].
+   */
+  protected def useDsv2: Boolean = false
+
+  /**
+   * Run a sink test against a target table, providing the `target` identifier in the form the
+   * current mode expects: a catalog name when [[useDsv2]] is true, otherwise a filesystem path.
+   * The companion helpers ([[startStream]], [[readTarget]], [[deltaLogForTarget]],
+   * [[deltaTableForTarget]]) interpret `target` accordingly, so a single test body covers both
+   * modes.
+   */
+  protected def withSinkTarget(f: (String, File) => Unit): Unit = {
+    withTempDir { checkpointDir =>
+      if (useDsv2) {
+        // Unique table name per invocation: the target is a managed table at a deterministic
+        // warehouse path, so a fixed name leaks state across tests (stale data / DeltaLog cache).
+        val table = "test_delta_sink_" + checkpointDir.getName.replaceAll("[^A-Za-z0-9]", "")
+        withTable(table) {
+          f(table, checkpointDir)
+        }
+      } else {
+        withTempDir { outputDir =>
+          f(outputDir.getCanonicalPath, checkpointDir)
+        }
+      }
+    }
+  }
+
+  /** Start the stream against `target`, routing to `toTable` (DSv2) or `start` (path-based). */
+  protected def startStream(writer: DataStreamWriter[_], target: String): StreamingQuery =
+    if (useDsv2) writer.toTable(target) else writer.start(target)
+
+  /** Batch-read `target`, by catalog name (DSv2) or by path (path-based). */
+  protected def readTarget(target: String): DataFrame =
+    if (useDsv2) spark.read.table(target) else spark.read.format("delta").load(target)
+
+  /** Resolve the [[DeltaLog]] for `target`, by catalog name (DSv2) or by path (path-based). */
+  protected def deltaLogForTarget(target: String): DeltaLog =
+    if (useDsv2) DeltaLog.forTable(spark, TableIdentifier(target))
+    else DeltaLog.forTable(spark, target)
+
+  /** Resolve the [[DeltaTable]] for `target`, by name (DSv2) or path. */
+  protected def deltaTableForTarget(target: String): DeltaTable =
+    if (useDsv2) DeltaTable.forName(spark, target)
+    else DeltaTable.forPath(spark, target)
+
   test("append mode") {
     failAfter(streamingTimeout) {
-      withTempDirs { (outputDir, checkpointDir) =>
+      withSinkTarget { (target, checkpointDir) =>
         val inputData = MemoryStream[Int]
         val df = inputData.toDF()
-        val query = df.writeStream
-          .option("checkpointLocation", checkpointDir.getCanonicalPath)
-          .format("delta")
-          .start(outputDir.getCanonicalPath)
-        val log = DeltaLog.forTable(spark, outputDir.getCanonicalPath)
+        val query = startStream(
+          df.writeStream
+            .option("checkpointLocation", checkpointDir.getCanonicalPath)
+            .format("delta"),
+          target)
+        val log = deltaLogForTarget(target)
         try {
           inputData.addData(1)
           query.processAllAvailable()
 
-          val outputDf = spark.read.format("delta").load(outputDir.getCanonicalPath)
+          val outputDf = readTarget(target)
           checkDatasetUnorderly(outputDf.as[Int], 1)
           assert(log.update().transactions.head == (query.id.toString -> 0L))
 
@@ -119,22 +170,23 @@ class DeltaSinkSuite
 
   test("complete mode") {
     failAfter(streamingTimeout) {
-      withTempDirs { (outputDir, checkpointDir) =>
+      withSinkTarget { (target, checkpointDir) =>
         val inputData = MemoryStream[Int]
         val df = inputData.toDF()
         val query =
-          df.groupBy().count()
-            .writeStream
-            .outputMode("complete")
-            .option("checkpointLocation", checkpointDir.getCanonicalPath)
-            .format("delta")
-            .start(outputDir.getCanonicalPath)
-        val log = DeltaLog.forTable(spark, outputDir.getCanonicalPath)
+          startStream(
+            df.groupBy().count()
+              .writeStream
+              .outputMode("complete")
+              .option("checkpointLocation", checkpointDir.getCanonicalPath)
+              .format("delta"),
+            target)
+        val log = deltaLogForTarget(target)
         try {
           inputData.addData(1)
           query.processAllAvailable()
 
-          val outputDf = spark.read.format("delta").load(outputDir.getCanonicalPath)
+          val outputDf = readTarget(target)
           checkDatasetUnorderly(outputDf.as[Long], 1L)
           assert(log.update().transactions.head == (query.id.toString -> 0L))
 
@@ -158,15 +210,16 @@ class DeltaSinkSuite
 
   test("update mode: not supported") {
     failAfter(streamingTimeout) {
-      withTempDirs { (outputDir, checkpointDir) =>
+      withSinkTarget { (target, checkpointDir) =>
         val inputData = MemoryStream[Int]
         val df = inputData.toDF()
         val e = intercept[AnalysisException] {
-          df.writeStream
-            .option("checkpointLocation", checkpointDir.getCanonicalPath)
-            .outputMode("update")
-            .format("delta")
-            .start(outputDir.getCanonicalPath)
+          startStream(
+            df.writeStream
+              .option("checkpointLocation", checkpointDir.getCanonicalPath)
+              .outputMode("update")
+              .format("delta"),
+            target)
         }
         Seq("update", "not support").foreach { msg =>
           assert(e.getMessage.toLowerCase(Locale.ROOT).contains(msg))
@@ -194,16 +247,17 @@ class DeltaSinkSuite
   }
 
   test("SPARK-21167: encode and decode path correctly") {
-    withTempDirs { (outputDir, checkpointDir) =>
+    withSinkTarget { (target, checkpointDir) =>
       val inputData = MemoryStream[String]
-      val query = inputData.toDS()
-        .map(s => (s, s.length))
-        .toDF("value", "len")
-        .writeStream
-        .partitionBy("value")
-        .option("checkpointLocation", checkpointDir.getCanonicalPath)
-        .format("delta")
-        .start(outputDir.getCanonicalPath)
+      val query = startStream(
+        inputData.toDS()
+          .map(s => (s, s.length))
+          .toDF("value", "len")
+          .writeStream
+          .partitionBy("value")
+          .option("checkpointLocation", checkpointDir.getCanonicalPath)
+          .format("delta"),
+        target)
 
       try {
         // The output is partitioned by "value", so the value will appear in the file path.
@@ -212,7 +266,7 @@ class DeltaSinkSuite
         failAfter(streamingTimeout) {
           query.processAllAvailable()
         }
-        val outputDf = spark.read.format("delta").load(outputDir.getCanonicalPath)
+        val outputDf = readTarget(target)
         checkDatasetUnorderly(outputDf.as[(String, Int)], ("hello world", "hello world".length))
       } finally {
         query.stop()
@@ -221,17 +275,18 @@ class DeltaSinkSuite
   }
 
   test("partitioned writing and batch reading") {
-    withTempDirs { (outputDir, checkpointDir) =>
+    withSinkTarget { (target, checkpointDir) =>
       val inputData = MemoryStream[Int]
       val ds = inputData.toDS()
       val query =
-        ds.map(i => (i, i * 1000))
-          .toDF("id", "value")
-          .writeStream
-          .partitionBy("id")
-          .option("checkpointLocation", checkpointDir.getCanonicalPath)
-          .format("delta")
-          .start(outputDir.getCanonicalPath)
+        startStream(
+          ds.map(i => (i, i * 1000))
+            .toDF("id", "value")
+            .writeStream
+            .partitionBy("id")
+            .option("checkpointLocation", checkpointDir.getCanonicalPath)
+            .format("delta"),
+          target)
       try {
 
         inputData.addData(1, 2, 3)
@@ -239,7 +294,7 @@ class DeltaSinkSuite
           query.processAllAvailable()
         }
 
-        val outputDf = spark.read.format("delta").load(outputDir.getCanonicalPath)
+        val outputDf = readTarget(target)
         val expectedSchema = new StructType()
           .add(StructField("id", IntegerType))
           .add(StructField("value", IntegerType))
@@ -301,7 +356,7 @@ class DeltaSinkSuite
   }
 
   test("work with aggregation + watermark") {
-    withTempDirs { (outputDir, checkpointDir) =>
+    withSinkTarget { (target, checkpointDir) =>
       val inputData = MemoryStream[Long]
       val inputDF = inputData.toDF.toDF("time")
       val outputDf = inputDF
@@ -312,10 +367,11 @@ class DeltaSinkSuite
         .select("window.start", "window.end", "count")
 
       val query =
-        outputDf.writeStream
-          .option("checkpointLocation", checkpointDir.getCanonicalPath)
-          .format("delta")
-          .start(outputDir.getCanonicalPath)
+        startStream(
+          outputDf.writeStream
+            .option("checkpointLocation", checkpointDir.getCanonicalPath)
+            .format("delta"),
+          target)
       try {
         def addTimestamp(timestampInSecs: Int*): Unit = {
           inputData.addData(timestampInSecs.map(_ * 1L): _*)
@@ -325,7 +381,7 @@ class DeltaSinkSuite
         }
 
         def check(expectedResult: ((Long, Long), Long)*): Unit = {
-          val outputDf = spark.read.format("delta").load(outputDir.getCanonicalPath)
+          val outputDf = readTarget(target)
             .selectExpr(
               "CAST(start as BIGINT) AS start",
               "CAST(end as BIGINT) AS end",
@@ -350,17 +406,18 @@ class DeltaSinkSuite
   }
 
   test("throw exception when users are trying to write in batch with different partitioning") {
-    withTempDirs { (outputDir, checkpointDir) =>
+    withSinkTarget { (target, checkpointDir) =>
       val inputData = MemoryStream[Int]
       val ds = inputData.toDS()
       val query =
-        ds.map(i => (i, i * 1000))
-          .toDF("id", "value")
-          .writeStream
-          .partitionBy("id")
-          .option("checkpointLocation", checkpointDir.getCanonicalPath)
-          .format("delta")
-          .start(outputDir.getCanonicalPath)
+        startStream(
+          ds.map(i => (i, i * 1000))
+            .toDF("id", "value")
+            .writeStream
+            .partitionBy("id")
+            .option("checkpointLocation", checkpointDir.getCanonicalPath)
+            .format("delta"),
+          target)
       try {
 
         inputData.addData(1, 2, 3)
@@ -368,16 +425,27 @@ class DeltaSinkSuite
           query.processAllAvailable()
         }
 
-        val e = intercept[AnalysisException] {
-          spark.range(100)
-            .select('id.cast("integer"), 'id % 4 as "by4", 'id.cast("integer") * 1000 as "value")
-            .write
-            .format("delta")
-            .partitionBy("id", "by4")
-            .mode("append")
-            .save(outputDir.getCanonicalPath)
+        val batchWrite = spark.range(100)
+          .select('id.cast("integer"), 'id % 4 as "by4", 'id.cast("integer") * 1000 as "value")
+          .write
+          .format("delta")
+          .partitionBy("id", "by4")
+          .mode("append")
+        if (useDsv2) {
+          // Name-based: the partition-column mismatch surfaces from the catalog as an
+          // IllegalArgumentException with a different message than the path-based DataSource.
+          val e = intercept[IllegalArgumentException] {
+            batchWrite.saveAsTable(target)
+          }
+          assert(
+            e.getMessage.contains(
+              "The provided partitioning or clustering columns do not match the existing table's"))
+        } else {
+          val e = intercept[AnalysisException] {
+            batchWrite.save(target)
+          }
+          assert(e.getMessage.contains("Partition columns do not match"))
         }
-        assert(e.getMessage.contains("Partition columns do not match"))
 
       } finally {
         query.stop()
@@ -464,41 +532,51 @@ class DeltaSinkSuite
   }
 
   test("can't write out with all columns being partition columns") {
-    withTempDirs { (outputDir, checkpointDir) =>
+    withSinkTarget { (target, checkpointDir) =>
       val inputData = MemoryStream[Int]
       val ds = inputData.toDS()
-      val query =
+      val writer =
         ds.map(i => (i, i * 1000))
           .toDF("id", "value")
           .writeStream
           .partitionBy("id", "value")
           .option("checkpointLocation", checkpointDir.getCanonicalPath)
           .format("delta")
-          .start(outputDir.getCanonicalPath)
-      val e = intercept[StreamingQueryException] {
-        inputData.addData(1)
-        query.awaitTermination(30000)
+      if (useDsv2) {
+        // Name-based: creating a table partitioned by all of its columns is rejected up front (at
+        // table creation), rather than surfacing as a StreamingQueryException once the stream runs.
+        val e = intercept[AnalysisException] {
+          writer.toTable(target)
+        }
+        assert(e.getMessage.contains("Cannot use all columns for partition columns"))
+      } else {
+        val query = writer.start(target)
+        val e = intercept[StreamingQueryException] {
+          inputData.addData(1)
+          query.awaitTermination(30000)
+        }
+        assert(e.cause.isInstanceOf[AnalysisException])
       }
-      assert(e.cause.isInstanceOf[AnalysisException])
     }
   }
 
   test("streaming write correctly sets isBlindAppend in CommitInfo") {
-    withTempDirs { (outputDir, checkpointDir) =>
+    withSinkTarget { (target, checkpointDir) =>
 
       val input = MemoryStream[Int]
       val inputDataStream = input.toDF().toDF("value")
 
-      def tableData: DataFrame = spark.read.format("delta").load(outputDir.toString)
+      def tableData: DataFrame = readTarget(target)
 
       def appendToTable(df: DataFrame): Unit = failAfter(streamingTimeout) {
         var q: StreamingQuery = null
         try {
           input.addData(0)
-          q = df.writeStream
-            .format("delta")
-            .option("checkpointLocation", checkpointDir.toString)
-            .start(outputDir.toString)
+          q = startStream(
+            df.writeStream
+              .format("delta")
+              .option("checkpointLocation", checkpointDir.toString),
+            target)
           q.processAllAvailable()
         } finally {
           if (q != null) q.stop()
@@ -507,7 +585,7 @@ class DeltaSinkSuite
 
       var lastCheckedVersion = -1L
       def isLastCommitBlindAppend: Boolean = {
-        val log = DeltaLog.forTable(spark, outputDir.toString)
+        val log = deltaLogForTarget(target)
         val lastVersion = log.update().version
         assert(lastVersion > lastCheckedVersion, "no new commit was made")
         lastCheckedVersion = lastVersion
@@ -538,48 +616,48 @@ class DeltaSinkSuite
         .add("i", IntegerType, nullable = false))
       .add("c", IntegerType, nullable = false)
 
-    withTempDir { base =>
-      val sourceDir = new File(base, "source").getCanonicalPath
-      val tableDir = new File(base, "output").getCanonicalPath
-      val chkDir = new File(base, "checkpoint").getCanonicalPath
+    withSinkTarget { (target, checkpointDir) =>
+      withTempDir { sourceDir =>
+        FileUtils.write(new File(sourceDir, "a.json"), jsonRec)
 
-      FileUtils.write(new File(sourceDir, "a.json"), jsonRec)
+        val q = startStream(
+          spark.readStream
+            .format("json")
+            .schema(schema)
+            .load(sourceDir.getCanonicalPath)
+            .withColumn("file", input_file_name()) // Not sure why needs this to reproduce
+            .writeStream
+            .format("delta")
+            .trigger(org.apache.spark.sql.streaming.Trigger.Once)
+            .option("checkpointLocation", checkpointDir.getCanonicalPath),
+          target)
 
-      val q = spark.readStream
-        .format("json")
-        .schema(schema)
-        .load(sourceDir)
-        .withColumn("file", input_file_name()) // Not sure why needs this to reproduce
-        .writeStream
-        .format("delta")
-        .trigger(org.apache.spark.sql.streaming.Trigger.Once)
-        .option("checkpointLocation", chkDir)
-        .start(tableDir)
+        q.awaitTermination()
 
-      q.awaitTermination()
-
-      checkAnswer(
-        spark.read.format("delta").load(tableDir).drop("file"),
-        Seq(Row("ss", Row("ss", null), null)))
+        checkAnswer(
+          readTarget(target).drop("file"),
+          Seq(Row("ss", Row("ss", null), null)))
+      }
     }
   }
 
   test("history includes user-defined metadata for DataFrame.writeStream API") {
     failAfter(streamingTimeout) {
-      withTempDirs { (outputDir, checkpointDir) =>
+      withSinkTarget { (target, checkpointDir) =>
         val inputData = MemoryStream[Int]
         val df = inputData.toDF()
-        val query = df.writeStream
-          .option("checkpointLocation", checkpointDir.getCanonicalPath)
-          .option("userMetadata", "testMeta!")
-          .format("delta")
-          .start(outputDir.getCanonicalPath)
-        val log = DeltaLog.forTable(spark, outputDir.getCanonicalPath)
+        val query = startStream(
+          df.writeStream
+            .option("checkpointLocation", checkpointDir.getCanonicalPath)
+            .option("userMetadata", "testMeta!")
+            .format("delta"),
+          target)
+        val log = deltaLogForTarget(target)
 
         inputData.addData(1)
         query.processAllAvailable()
 
-        val lastCommitInfo = io.delta.tables.DeltaTable.forPath(spark, outputDir.getCanonicalPath)
+        val lastCommitInfo = deltaTableForTarget(target)
             .history(1).as[DeltaHistory].head
 
         assert(lastCommitInfo.userMetadata === Some("testMeta!"))
@@ -625,7 +703,7 @@ class DeltaSinkSuite
 
   test("DeltaSink rejects DataFrame with UDT containing NullType") {
     failAfter(streamingTimeout) {
-      withTempDirs { (outputDir, checkpointDir) =>
+      withSinkTarget { (target, checkpointDir) =>
         val inputData = MemoryStream[Int]
         val ds = inputData.toDS()
         val dsWriter =
@@ -636,7 +714,7 @@ class DeltaSinkSuite
             .format("delta")
 
         val wrapperException = intercept[StreamingQueryException] {
-          val q = dsWriter.start(outputDir.getCanonicalPath)
+          val q = startStream(dsWriter, target)
           inputData.addData(42)
           q.processAllAvailable()
         }
@@ -656,6 +734,13 @@ class DeltaSinkSuite
 // testing the production-like path where streaming must read from both the commit coordinator
 // and the filesystem. This follows the same pattern as other CatalogManaged (CCv2) test suites
 // (DeltaLogSuite, DeltaSourceSuite, etc.).
+
+// Re-runs the DeltaSinkSuite tests addressing the target by catalog name (`toTable`) rather than
+// by path, exercising the same behaviors through the name-based write seam required by the DSv2
+// sink.
+class DeltaSinkNameBasedSuite extends DeltaSinkSuite {
+  override protected def useDsv2: Boolean = true
+}
 
 class DeltaSinkWithCatalogManagedBatch1Suite extends DeltaSinkSuite {
   override def catalogOwnedCoordinatorBackfillBatchSize: Option[Int] = Some(1)


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Test-only change that makes `DeltaSinkSuite` run against **both** path-based and name-based table access, rather than migrating it wholesale to name-based.

An earlier revision of this PR replaced path-based access with name-based access, which dropped the original path-based coverage. This revision parameterizes the suite instead:

- A `useDsv2` flag selects how the target is addressed:
  - `useDsv2 = false` (default) — path-based: `writeStream...start(path)`, `spark.read.format("delta").load(path)`, `DeltaLog.forTable(spark, path)`. This preserves the suite's original coverage.
  - `useDsv2 = true` — name-based: `writeStream...toTable(name)`, `spark.read.table(name)`, `DeltaLog.forTable(spark, TableIdentifier(name))`. This exercises the name-based write seam, which is the only path available to the DSv2 (Kernel) sink — `toTable` rejects path identifiers.
- A `withSinkTarget` helper plus a few small companion helpers (`startStream`, `readTarget`, `deltaLogForTarget`, `deltaTableForTarget`) interpret the `target` identifier per mode, so each test body is written once and runs both ways.
- `DeltaSinkSuite` (and its existing `CatalogManagedBatch1/2` subclasses) keep `useDsv2 = false`; a new `DeltaSinkNameBasedSuite` overrides it to `true` so both modes actually run in CI.

Two tests genuinely behave differently between the two access paths and branch internally on `useDsv2`:
- **"throw exception ... write in batch with different partitioning"** — path-based throws `AnalysisException` ("Partition columns do not match"); name-based throws `IllegalArgumentException` ("The provided partitioning or clustering columns do not match the existing table's").
- **"can't write out with all columns being partition columns"** — path-based starts the stream and then surfaces a `StreamingQueryException`; name-based rejects the all-columns partitioning up front at `toTable` with an `AnalysisException`.

A few tests remain intrinsically path-specific (e.g. `path not specified`, `incompatible schema merging ...`) and are unchanged.

Motivation (same as #7058 for the type-widening tests): unblock running these tests against the DSv2 (Kernel) connector, which has no path-based streaming write, while retaining the existing path-based coverage.

## How was this patch tested?

Test-only change. Both `DeltaSinkSuite` (path-based) and `DeltaSinkNameBasedSuite` (name-based) pass.

## Does this PR introduce _any_ user-facing changes?

No.
