### PR TITLE
[Build] Bump defaultUnityCatalogReleaseVersion to 0.5.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -798,7 +798,7 @@ lazy val contribs = (project in file("contribs"))
 //
 // Override with -DunityCatalogVersion=<anything> for ad-hoc experiments.
 val unityCatalogReleaseVersion: Option[String] = None
-val defaultUnityCatalogReleaseVersion = "0.4.1"
+val defaultUnityCatalogReleaseVersion = "0.5.0"
 val useDefaultUnityCatalogReleaseVersion: Boolean =
   sys.props.getOrElse("useDefaultUnityCatalogReleaseVersion", "false").toBoolean
 val unityCatalogSetupScript = "project/scripts/setup_unitycatalog_main.sh"


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Unity Catalog 0.5.0 has been released and is the first version that
publishes per-Spark-version connector artifacts (`unitycatalog-spark_4.0`,
`unitycatalog-spark_4.1`). The old unsuffixed artifact
(`unitycatalog-spark_2.13:0.4.1`) is no longer published at 0.5.0.

Since `build.sbt` now references the suffixed artifact name
(`unitycatalog-spark_${shortVersion}`, from #6824), the fallback version
used by `-DuseDefaultUnityCatalogReleaseVersion=true` must match a release
that publishes those suffixed artifacts.

This is a single-line change: `"0.4.1"` → `"0.5.0"`.

## How was this patch tested?

Verified all UC 0.5.0 artifacts are available on Maven Central:
- `unitycatalog-spark_4.0_2.13:0.5.0` ✓
- `unitycatalog-spark_4.1_2.13:0.5.0` ✓
- `unitycatalog-client:0.5.0` ✓
- `unitycatalog-hadoop:0.5.0` ✓
- `unitycatalog-server:0.5.0` ✓

## Does this PR introduce _any_ user-facing changes?

No. This only affects the `-DuseDefaultUnityCatalogReleaseVersion=true` build path (used by doc/lint CI jobs that skip the pinned UC build).