### PR TITLE
[Spark] Reject 'enabled' status for the CatalogManaged table

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsUtils.scala
@@ -16,6 +16,7 @@
 
 package org.apache.spark.sql.delta.coordinatedcommits
 
+import java.util.Locale
 import java.util.Optional
 
 import scala.collection.JavaConverters._
@@ -270,6 +271,19 @@ object CatalogOwnedTableUtils extends DeltaLogging {
     }
   }
 
+  private[delta] def verifyCatalogManagedStatusIsSupported(
+      propertyOverrides: Map[String, String]): Unit = {
+    val catalogManagedKey =
+      TableFeatureProtocolUtils.propertyKey(CatalogOwnedTableFeature).toLowerCase(Locale.ROOT)
+    propertyOverrides.foreach { case (key, status) =>
+      if (key.toLowerCase(Locale.ROOT) == catalogManagedKey &&
+          status.toLowerCase(Locale.ROOT) != TableFeatureProtocolUtils.FEATURE_PROP_SUPPORTED) {
+        throw DeltaErrors.unsupportedTableFeatureStatusException(
+          feature = CatalogOwnedTableFeature.name, status = status)
+      }
+    }
+  }
+
   /**
    * Validates the Catalog-Owned configurations in explicit command overrides for
    * `AlterTableSetPropertiesDeltaCommand`.
@@ -329,6 +343,13 @@ object CatalogOwnedTableUtils extends DeltaLogging {
           cmd.tablePropertyOverrides)
       case _ => (if (tableExists) "REPLACE" else "CREATE", catalogTableProperties)
     }
+    // Session default table properties (`spark.databricks.delta.properties.defaults.*`) are not
+    // part of `propertyOverrides`; they are merged into the table configuration only later in
+    // [[OptimisticTransaction]]. Merge them in here so that a default requesting CatalogManaged via
+    // the `enabled` status is rejected at creation time instead of silently producing a
+    // table that has the feature in its protocol but is not registered as CatalogManaged in UC.
+    verifyCatalogManagedStatusIsSupported(
+      DeltaConfigs.mergeGlobalConfigs(spark.sessionState.conf, propertyOverrides))
     // We do not allow users to modify [[UCCommitCoordinatorClient.UC_TABLE_ID_KEY]] and
     // [[CatalogOwnedTableFeature.name]] in any explicit overrides for REPLACE command.
     if (tableExists) {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogOwnedEnablementSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogOwnedEnablementSuite.scala
@@ -336,6 +336,23 @@ class CatalogOwnedEnablementSuite
     }
   }
 
+  test("CatalogManaged feature status must be 'supported': CREATE TABLE with 'enabled' " +
+      "is rejected") {
+    val tableName = "catalog_managed_create_enabled"
+    withTable(tableName) {
+      val error = interceptWithUnwrapping[DeltaTableFeatureException] {
+        createTable(tableName, properties = Map(
+          s"delta.feature.${CatalogOwnedTableFeature.name}" -> "enabled"))
+      }
+      checkError(
+        error,
+        "DELTA_UNSUPPORTED_FEATURE_STATUS",
+        parameters = Map(
+          "feature" -> CatalogOwnedTableFeature.name,
+          "status" -> "enabled"))
+    }
+  }
+
   test("ALTER TABLE should be blocked if attempts to downgrade Catalog-Owned") {
     withRandomTable(createCatalogOwnedTableAtInit = true)  { tableName =>
       val error = intercept[DeltaTableFeatureException] {


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

CatalogManaged only supports the 'supported' feature status; 'enabled' is not a valid status for it. 

Add verifyCatalogManagedStatusIsSupported, invoked on the CREATE path (including session-default merged properties), to reject the 'enabled' status with DELTA_UNSUPPORTED_FEATURE_STATUS.

## How was this patch tested?

Unit test in CatalogOwnedEnablementSuite

## Does this PR introduce _any_ user-facing changes?
No. Adding a better error message to fail fast.