### PR TITLE
[Build] Fix CODEOWNERS for build files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,6 +2,9 @@
 # This file defines code owners who must approve changes to specific files/directories.
 # See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
+# All files in the root directory
+/*                              @tdas
+
 # Build configuration files and directories
 /build/                         @tdas @huan233usc
 /build.sbt                      @tdas @huan233usc
@@ -11,6 +14,3 @@
 # Spark V2 and Unified modules
 /spark/v2/                      @tdas @huan233usc @TimothyW553 @raveeram-db @murali-db
 /spark-unified/                 @tdas @huan233usc @TimothyW553 @raveeram-db @murali-db
-
-# All files in the root directory
-/*                              @tdas

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,8 +3,8 @@
 # See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # Build configuration files and directories
-/build/                         @tdas
-/build.sbt                      @tdas
+/build/                         @tdas @huan233usc
+/build.sbt                      @tdas @huan233usc
 /project/                       @tdas
 /version.sbt                    @tdas
 


### PR DESCRIPTION
## Summary
- Add @huan233usc as a backup code owner for build files.
- Move the root-level fallback CODEOWNERS rule before more specific rules so build file ownership is not overridden.

## Test plan
- Not run (CODEOWNERS-only change).