### PR TITLE
[Spark] Provide default implementations for SnapshotDescriptor.dataPath, numDeltaFiles, and totalDeltaFilesByteSize

### DIFF
--- a/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingUtils.scala
+++ b/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingUtils.scala
@@ -304,7 +304,7 @@ object DeltaSharingUtils extends Logging {
       localDeltaLog,
       new SnapshotDescriptor {
         val deltaLog: DeltaLog = localDeltaLog
-        val dataPath: Path = localDeltaLog.dataPath
+        override val dataPath: Path = localDeltaLog.dataPath
         val logPath: Path = localDeltaLog.logPath
         val metadata: Metadata = deltaSharingTableMetadata.metadata.deltaMetadata
         val protocol: Protocol = deltaSharingTableMetadata.protocol.deltaProtocol

--- a/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
@@ -67,8 +67,14 @@ trait SnapshotDescriptor extends DeltaLoggingProvider {
 
   def schema: StructType = metadata.schema
 
-  def dataPath: Path
+  def dataPath: Path =
+    throw new UnsupportedOperationException("dataPath is not implemented for this descriptor")
   def logPath: Path
+  def numDeltaFiles: Long =
+    throw new UnsupportedOperationException("numDeltaFiles is not implemented for this descriptor")
+  def totalDeltaFilesByteSize: Long =
+    throw new UnsupportedOperationException(
+      "totalDeltaFilesByteSize is not implemented for this descriptor")
 
   protected[delta] def numOfFilesIfKnown: Option[Long]
   protected[delta] def sizeInBytesIfKnown: Option[Long]

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
@@ -153,7 +153,7 @@ trait DeltaSourceBase extends Source
       // Construct a snapshot descriptor with custom schema inline
       new SnapshotDescriptor {
         val deltaLog: DeltaLog = snapshotAtSourceInit.deltaLog
-        val dataPath: Path = snapshotAtSourceInit.dataPath
+        override val dataPath: Path = snapshotAtSourceInit.dataPath
         val logPath: Path = snapshotAtSourceInit.logPath
         val metadata: Metadata =
           snapshotAtSourceInit.metadata.copy(


### PR DESCRIPTION
## Description

`SnapshotDescriptor` declared `dataPath` as an abstract member, requiring every implementor to define it. This change makes `dataPath` a default implementation that throws `UnsupportedOperationException`, and adds `numDeltaFiles` and `totalDeltaFilesByteSize` as members with the same default.

Implementors that can supply these values override them; those that cannot no longer need stub overrides. The two inline `SnapshotDescriptor` instances that define `dataPath` (`DeltaSource.readSnapshotDescriptor` and `DeltaSharingUtils`) now mark it as an `override`, since the trait member is no longer abstract.

## How was this patch tested?

Existing tests. This refactors trait member declarations; the throw-default bodies preserve behavior for callers that already implement these members.

## Does this PR introduce _any_ user-facing changes?

No.