### PR TITLE
[Spark][4.3] Fix OAuth case-sensitivity bug in UCTokenBasedRestClientFactory

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorBuilder.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorBuilder.scala
@@ -306,7 +306,7 @@ object UCTokenBasedRestClientFactory extends UCClientFactory {
       throw new IllegalArgumentException(s"UC config must contain '$URI_KEY'"))
 
     val authConfig = extractAuthConfig(ucConfig)
-    val tokenProvider = TokenProvider.create(authConfig.asJava)
+    val tokenProvider = TokenProvider.create(authConfig)
 
     val className =
       if (ucConfig.getOrDefault(DELTA_REST_API_ENABLED_KEY, "true").toBoolean) {
@@ -344,26 +344,48 @@ object UCTokenBasedRestClientFactory extends UCClientFactory {
   }
 
   /**
+   * Extracts entries from `ucConfig` whose keys (compared case-insensitively) start with
+   * `prefix`, strips the prefix, and returns the result as a plain [[java.util.Map]].
+   * Uses the case-preserving view of the input when available so the returned map retains
+   * original key casing (e.g. `oauth.clientId` rather than `oauth.clientid`).
+   * Callers decide whether to wrap in [[CaseInsensitiveStringMap]].
+   */
+  private[coordinatedcommits] def filterByPrefix(
+      ucConfig: java.util.Map[String, String],
+      prefix: String): java.util.Map[String, String] = {
+    val prefixLower = prefix.toLowerCase(java.util.Locale.ROOT)
+    val sourceEntries = ucConfig match {
+      case cism: CaseInsensitiveStringMap => cism.asCaseSensitiveMap().entrySet()
+      case m => m.entrySet()
+    }
+    val result = new java.util.HashMap[String, String]()
+    sourceEntries.forEach { e =>
+      if (e.getKey.toLowerCase(java.util.Locale.ROOT).startsWith(prefixLower)) {
+        result.put(e.getKey.substring(prefixLower.length), e.getValue)
+      }
+    }
+    result
+  }
+
+  /**
    * Extracts authentication configuration from ucConfig.
    * Prefers `auth.*` keys; falls back to legacy `token` key.
+   *
+   * Returns a [[CaseInsensitiveStringMap]] so that downstream consumers (e.g.
+   * [[TokenProvider.create]]) can look up camelCase keys like `oauth.clientId`
+   * regardless of what casing the source map provides.
    */
   private[coordinatedcommits] def extractAuthConfig(
-      ucConfig: java.util.Map[String, String]): Map[String, String] = {
-    val authPrefixLower = AUTH_PREFIX.toLowerCase(java.util.Locale.ROOT)
-    val authConfig = ucConfig.entrySet().asScala.iterator
-      .collect {
-        case e if e.getKey.toLowerCase(java.util.Locale.ROOT).startsWith(authPrefixLower) =>
-          val suffix = e.getKey.substring(authPrefixLower.length)
-          suffix -> e.getValue
-      }
-      .toMap
-
-    if (authConfig.nonEmpty) {
-      authConfig
+      ucConfig: java.util.Map[String, String]): CaseInsensitiveStringMap = {
+    val filtered = filterByPrefix(ucConfig, AUTH_PREFIX)
+    if (!filtered.isEmpty) {
+      new CaseInsensitiveStringMap(filtered)
     } else {
       Option(ucConfig.get("token")) match {
-        case Some(token) => Map("type" -> "static", "token" -> token)
-        case None => Map.empty
+        case Some(token) =>
+          new CaseInsensitiveStringMap(
+            java.util.Map.of("type", "static", "token", token))
+        case None => CaseInsensitiveStringMap.empty()
       }
     }
   }
@@ -374,13 +396,7 @@ object UCTokenBasedRestClientFactory extends UCClientFactory {
    */
   private[coordinatedcommits] def extractAppVersions(
       ucConfig: java.util.Map[String, String]): Map[String, String] = {
-    val appPrefixLower = APP_VERSIONS_PREFIX.toLowerCase(java.util.Locale.ROOT)
-    val extra = ucConfig.entrySet().asScala.iterator
-      .collect {
-        case e if e.getKey.toLowerCase(java.util.Locale.ROOT).startsWith(appPrefixLower) =>
-          e.getKey.substring(appPrefixLower.length) -> e.getValue
-      }
-      .toMap
+    val extra = filterByPrefix(ucConfig, APP_VERSIONS_PREFIX).asScala.toMap
     defaultAppVersions ++ extra
   }
 
@@ -409,6 +425,6 @@ case class UCCatalogConfig(catalogName: String, ucConfig: Map[String, String]) {
    * Returns the authentication config suitable for [[TokenProvider.create]].
    * Prefers `auth.*` keys; falls back to legacy `token` key.
    */
-  def authConfig: Map[String, String] =
+  def authConfig: CaseInsensitiveStringMap =
     UCTokenBasedRestClientFactory.extractAuthConfig(ucConfig.asJava)
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorBuilderSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorBuilderSuite.scala
@@ -18,13 +18,17 @@ package org.apache.spark.sql.delta.coordinatedcommits
 
 import scala.collection.JavaConverters._
 
+import io.delta.kernel.unitycatalog.UCTableIdentifier
+import io.delta.spark.internal.v2.snapshot.unitycatalog.UCTableInfo
 import io.delta.storage.commit.uccommitcoordinator.{UCClient, UCCommitCoordinatorClient}
+import io.unitycatalog.client.auth.TokenProvider
 import org.mockito.{Mock, Mockito}
 import org.mockito.ArgumentMatchers.{any, eq => meq}
 import org.mockito.Mockito.{mock, never, times, verify, when}
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 class UCCommitCoordinatorBuilderSuite extends SparkFunSuite with SharedSparkSession {
 
@@ -424,8 +428,8 @@ class UCCommitCoordinatorBuilderSuite extends SparkFunSuite with SharedSparkSess
       assert(ucConfig("token") == legacyToken)
 
       val catalogConfig = UCCatalogConfig(catalogName, ucConfig)
-      assert(catalogConfig.authConfig("type") == "static")
-      assert(catalogConfig.authConfig("token") == newToken)
+      assert(catalogConfig.authConfig.get("type") == "static")
+      assert(catalogConfig.authConfig.get("token") == newToken)
     }
   }
 
@@ -464,8 +468,8 @@ class UCCommitCoordinatorBuilderSuite extends SparkFunSuite with SharedSparkSess
       "auth.token" -> "new-token"
     )
     val auth = UCTokenBasedRestClientFactory.extractAuthConfig(ucConfig.asJava)
-    assert(auth("type") == "static")
-    assert(auth("token") == "new-token")
+    assert(auth.get("type") == "static")
+    assert(auth.get("token") == "new-token")
   }
 
   test("extractAuthConfig falls back to legacy token") {
@@ -474,8 +478,8 @@ class UCCommitCoordinatorBuilderSuite extends SparkFunSuite with SharedSparkSess
       "token" -> "legacy-token"
     )
     val auth = UCTokenBasedRestClientFactory.extractAuthConfig(ucConfig.asJava)
-    assert(auth("type") == "static")
-    assert(auth("token") == "legacy-token")
+    assert(auth.get("type") == "static")
+    assert(auth.get("token") == "legacy-token")
   }
 
   test("buildForCatalog with legacy token format") {
@@ -535,6 +539,103 @@ class UCCommitCoordinatorBuilderSuite extends SparkFunSuite with SharedSparkSess
       UCCommitCoordinatorBuilder.buildForCatalog(spark, "non_existent_catalog")
     }
     assert(exception.getMessage.contains("not found"))
+  }
+
+  test("extractAuthConfig with OAuth through CaseInsensitiveStringMap preserves keys and " +
+      "produces valid TokenProvider") {
+    val ucConfig = new CaseInsensitiveStringMap(Map(
+      "auth.type" -> "oauth",
+      "auth.oauth.clientId" -> "test-id",
+      "auth.oauth.clientSecret" -> "test-secret",
+      "auth.oauth.uri" -> "https://example.com/token",
+      "uri" -> "https://uc.example.com"
+    ).asJava)
+    val auth = UCTokenBasedRestClientFactory.extractAuthConfig(ucConfig)
+    // Key casing preservation (asCaseSensitiveMap proves original case is retained)
+    assert(auth.asCaseSensitiveMap().get("oauth.clientId") === "test-id")
+    assert(auth.asCaseSensitiveMap().get("oauth.clientSecret") === "test-secret")
+    // Case-insensitive access also works
+    assert(auth.get("oauth.CLIENTID") === "test-id")
+    // TokenProvider creation
+    val tp = TokenProvider.create(auth)
+    assert(tp != null)
+    assert(tp.configs().get("type") === "oauth")
+    assert(tp.configs().get("oauth.clientId") === "test-id")
+    assert(tp.configs().get("oauth.clientSecret") === "test-secret")
+  }
+
+  test("extractAuthConfig with static token produces valid TokenProvider") {
+    // Sub-case 1: legacy token key
+    val legacyConfig = Map("token" -> "my-token", "uri" -> "https://uc.example.com")
+    val legacyAuth = UCTokenBasedRestClientFactory.extractAuthConfig(legacyConfig.asJava)
+    val tp1 = TokenProvider.create(legacyAuth)
+    assert(tp1.accessToken() === "my-token")
+
+    // Sub-case 2: explicit auth.type=static
+    val explicitConfig = new CaseInsensitiveStringMap(Map(
+      "auth.type" -> "static",
+      "auth.token" -> "explicit-token"
+    ).asJava)
+    val explicitAuth = UCTokenBasedRestClientFactory.extractAuthConfig(explicitConfig)
+    val tp2 = TokenProvider.create(explicitAuth)
+    assert(tp2.accessToken() === "explicit-token")
+  }
+
+  test("extractAppVersions preserves key casing and includes defaults") {
+    val ucConfig = new CaseInsensitiveStringMap(Map(
+      "appVersions.CustomEngine" -> "1.0",
+      "appVersions.MyLib" -> "2.0",
+      "uri" -> "https://uc.example.com"
+    ).asJava)
+    val versions = UCTokenBasedRestClientFactory.extractAppVersions(ucConfig)
+    assert(versions("CustomEngine") === "1.0")
+    assert(versions("MyLib") === "2.0")
+    assert(versions("Delta") === io.delta.VERSION)
+    assert(versions("Spark") === org.apache.spark.SPARK_VERSION)
+    assert(versions("Scala") === scala.util.Properties.versionNumberString)
+    assert(versions("Java") === System.getProperty("java.version"))
+  }
+
+  test("OAuth round-trip through real UCTableInfo.toUcConfig produces valid TokenProvider") {
+    // 1. Start with camelCase OAuth config in a CaseInsensitiveStringMap
+    val originalConfig = new CaseInsensitiveStringMap(Map(
+      "uri" -> "https://uc.example.com",
+      "auth.type" -> "oauth",
+      "auth.oauth.clientId" -> "test-id",
+      "auth.oauth.clientSecret" -> "test-secret",
+      "auth.oauth.uri" -> "https://example.com/token"
+    ).asJava)
+
+    // 2. Extract auth config (what UCTableInfo stores)
+    val authMap = UCTokenBasedRestClientFactory.extractAuthConfig(originalConfig)
+
+    // 3. Build UCTableInfo and call toUcConfig() to re-prefix auth keys
+    val tableInfo = new UCTableInfo(
+      "table-id",
+      "/path",
+      new UCTableIdentifier("cat", "schema", "table"),
+      "https://uc.example.com",
+      authMap)
+    val roundTrippedConfig = new CaseInsensitiveStringMap(tableInfo.toUcConfig())
+
+    // 4. Feed back through extractAuthConfig (as createUCClient would)
+    val roundTrippedAuth = UCTokenBasedRestClientFactory.extractAuthConfig(roundTrippedConfig)
+
+    // 5. Verify TokenProvider can be created (proves round-trip preserves values)
+    val tp = TokenProvider.create(roundTrippedAuth)
+    assert(tp != null)
+    assert(tp.configs().get("oauth.clientId") === "test-id")
+    assert(tp.configs().get("oauth.clientSecret") === "test-secret")
+    assert(tp.configs().get("oauth.uri") === "https://example.com/token")
+  }
+
+  test("filterByPrefix returns empty map when no keys match") {
+    val ucConfig = Map("uri" -> "https://uc.example.com", "token" -> "my-token")
+    assert(UCTokenBasedRestClientFactory.filterByPrefix(ucConfig.asJava, "auth.").isEmpty)
+    // extractAuthConfig with no auth and no token returns empty
+    val noTokenConfig = Map("uri" -> "https://uc.example.com")
+    val auth = UCTokenBasedRestClientFactory.extractAuthConfig(noTokenConfig.asJava)
+    assert(auth.isEmpty)
   }
 
   private def getCommitCoordinatorClient(metastoreId: String) = {

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/snapshot/unitycatalog/UCUtils.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/snapshot/unitycatalog/UCUtils.java
@@ -95,7 +95,7 @@ public final class UCUtils {
             tablePath,
             extractTableIdentifier(catalogTable),
             ucUri,
-            asJava(config.authConfig()),
+            config.authConfig(),
             extractOptInFlags(asJava(config.ucConfig()))));
   }
 


### PR DESCRIPTION
Backport of #7087 to branch-4.3.

Fixes a bug where `CaseInsensitiveStringMap.entrySet()` returns lowercase keys, destroying camelCase OAuth config keys like `oauth.clientId` in the Delta REST Catalog authentication path. See #7087 for full description and reproduction steps.

Cherry-picked cleanly with no conflicts.