### PR TITLE
[Spark] Add asynchronous Auto Compaction (PR 1: core async machinery)

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
@@ -22,6 +22,7 @@ import scala.util.control.NonFatal
 
 import org.apache.spark.sql.delta.metric.IncrementMetric
 import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.hooks.InflightDMLRegistry
 import org.apache.spark.sql.delta.ClassicColumnConversions._
 import org.apache.spark.sql.delta.actions.{Action, AddCDCFile, AddFile, FileAction}
 import org.apache.spark.sql.delta.commands.DeleteCommand.{rewritingFilesMsg, FINDING_TOUCHED_FILES_MSG}
@@ -126,6 +127,10 @@ case class DeleteCommand(
   override lazy val metrics = createMetrics
 
   final override def run(sparkSession: SparkSession): Seq[Row] = {
+    // Async Auto Compaction DML yield: register this DELETE so concurrent async AC yields.
+    val deleteTableId = deltaLog.unsafeVolatileTableId
+    InflightDMLRegistry.acquire(deleteTableId)
+    try {
     recordDeltaOperation(deltaLog, "delta.dml.delete") {
       deltaLog.withNewTransaction(catalogTable) { txn =>
         DeltaLog.assertRemovable(txn.snapshot)
@@ -160,6 +165,9 @@ case class DeleteCommand(
       Seq(Row(-1L))
     } else {
       Seq(Row(metrics("numDeletedRows").value))
+    }
+    } finally {
+      InflightDMLRegistry.release(deleteTableId)
     }
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommandBase.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommandBase.scala
@@ -23,6 +23,7 @@ import scala.util.control.NonFatal
 
 import org.apache.spark.sql.delta.metric.IncrementMetric
 import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.hooks.InflightDMLRegistry
 import org.apache.spark.sql.delta.actions.{Action, AddFile, FileAction}
 import org.apache.spark.sql.delta.commands.merge.{MergeIntoMaterializeSource, MergeIntoMaterializeSourceReason, MergeStats}
 import org.apache.spark.sql.delta.files.{TahoeBatchFileIndex, TahoeFileIndex, TransactionalWrite}
@@ -172,13 +173,21 @@ trait MergeIntoCommandBase extends LeafRunnableCommand
     }
 
     val (materializeSource, _) = shouldMaterializeSource(spark, source, isInsertOnly)
-    if (!materializeSource) {
-      runMerge(spark)
-    } else {
-      // If it is determined that source should be materialized, wrap the execution with retries,
-      // in case the data of the materialized source is lost.
-      runWithMaterializedSourceLostRetries(
-        spark, targetFileIndex.deltaLog, metrics, runMerge)
+    // Async Auto Compaction DML yield: register this MERGE as in-flight on the target table so
+    // that any concurrent async AC worker yields. See InflightDMLRegistry.
+    val mergeTableId = targetFileIndex.deltaLog.unsafeVolatileTableId
+    InflightDMLRegistry.acquire(mergeTableId)
+    try {
+      if (!materializeSource) {
+        runMerge(spark)
+      } else {
+        // If it is determined that source should be materialized, wrap the execution with retries,
+        // in case the data of the materialized source is lost.
+        runWithMaterializedSourceLostRetries(
+          spark, targetFileIndex.deltaLog, metrics, runMerge)
+      }
+    } finally {
+      InflightDMLRegistry.release(mergeTableId)
     }
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
@@ -30,6 +30,7 @@ import org.apache.spark.sql.delta.files.SQLMetricsReporting
 import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.schema.{SchemaUtils, UnsupportedDataTypeInfo}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.hooks.{AsyncAutoCompactCancelledException, AsyncAutoCompactService, InflightDMLRegistry}
 import org.apache.spark.sql.delta.util.BinPackingUtils
 
 import org.apache.spark.SparkContext
@@ -574,6 +575,19 @@ class OptimizeExecutor(
       optimizeOperation: Operation,
       actions: Seq[Action],
       metrics: Map[String, SQLMetric])(f: OptimisticTransaction => Boolean): Unit = {
+    // Async Auto Compaction DML yield: if a long-running DML (MERGE/DELETE/UPDATE/OVERWRITE)
+    // acquired InflightDMLRegistry on this table between our Spark-job completion and now,
+    // abort cleanly rather than racing the DML to commit (which would force the DML to throw
+    // ConcurrentModificationException and re-execute minutes of Spark work). Only applies when
+    // running on the async worker thread; inline AC and user-initiated OPTIMIZE proceed
+    // unconditionally.
+    if (isAutoCompact && AsyncAutoCompactService.isAsyncWorker &&
+        InflightDMLRegistry.isActive(snapshot.metadata.id)) {
+      throw new AsyncAutoCompactCancelledException(
+        snapshot.metadata.id,
+        s"Async Auto Compaction yielded at pre-commit to in-flight DML on table " +
+          s"${snapshot.metadata.id}")
+    }
     try {
       txn.registerSQLMetrics(sparkSession, metrics)
       txn.commit(actions, optimizeOperation,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/UpdateCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/UpdateCommand.scala
@@ -23,6 +23,7 @@ import scala.util.control.NonFatal
 // scalastyle:off import.ordering.noEmptyLine
 import org.apache.spark.sql.delta.metric.IncrementMetric
 import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.hooks.InflightDMLRegistry
 import org.apache.spark.sql.delta.ClassicColumnConversions._
 import org.apache.spark.sql.delta.actions.{Action, AddCDCFile, AddFile, FileAction}
 import org.apache.spark.sql.delta.commands.cdc.CDCReader.{CDC_TYPE_COLUMN_NAME, CDC_TYPE_NOT_CDC, CDC_TYPE_UPDATE_POSTIMAGE, CDC_TYPE_UPDATE_PREIMAGE}
@@ -94,6 +95,10 @@ case class UpdateCommand(
   )
 
   final override def run(sparkSession: SparkSession): Seq[Row] = {
+    // Async Auto Compaction DML yield: register this UPDATE so concurrent async AC yields.
+    val updateTableId = tahoeFileIndex.deltaLog.unsafeVolatileTableId
+    InflightDMLRegistry.acquire(updateTableId)
+    try {
     recordDeltaOperation(tahoeFileIndex.deltaLog, "delta.dml.update") {
       val deltaLog = tahoeFileIndex.deltaLog
       deltaLog.withNewTransaction(catalogTable) { txn =>
@@ -109,6 +114,9 @@ case class UpdateCommand(
       sparkSession.sharedState.cacheManager.recacheByPlan(sparkSession, target)
     }
     Seq(Row(metrics("numUpdatedRows").value))
+    } finally {
+      InflightDMLRegistry.release(updateTableId)
+    }
   }
 
   private def performUpdate(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
@@ -21,6 +21,7 @@ import scala.util.Try
 
 // scalastyle:off import.ordering.noEmptyLine
 import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.hooks.InflightDMLRegistry
 import org.apache.spark.sql.delta.ClassicColumnConversions._
 import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.commands.DMLUtils.TaggedCommitData
@@ -103,6 +104,13 @@ case class WriteIntoDelta(
 
 
   override def run(sparkSession: SparkSession): Seq[Row] = {
+    // Async Auto Compaction DML yield: for OVERWRITE (which rewrites files in bulk), register
+    // this write so concurrent async AC yields. APPEND skips this because appends never
+    // conflict with AC.
+    val writeTableId =
+      if (isOverwriteOperation) Some(deltaLog.unsafeVolatileTableId) else None
+    writeTableId.foreach(InflightDMLRegistry.acquire)
+    try {
     deltaLog.withNewTransaction(catalogTableOpt) { txn =>
       if (hasBeenExecuted(txn, sparkSession, Some(options))) {
         return Seq.empty
@@ -128,6 +136,9 @@ case class WriteIntoDelta(
       }
     }
     Seq.empty
+    } finally {
+      writeTableId.foreach(InflightDMLRegistry.release)
+    }
   }
 
   override def writeAndReturnCommitData(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/hooks/AsyncAutoCompactService.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/hooks/AsyncAutoCompactService.scala
@@ -68,7 +68,7 @@ private[delta] class AsyncAutoCompactCancelledException(val tableId: String, msg
  *     on entry and clears them in `finally`. Several delta-spark internals consult
  *     `SparkSession.getActiveSession` (including `OptimizeExecutor`'s codegen path).
  *
- * DML yielding (see [[InflightDMLRegistry]] and PR D in plan.md):
+ * DML yielding:
  *   - At dequeue, if a long-running DML is in flight on the target table, the task exits
  *     silently with a WARN log -- the next user write's post-commit hook will resubmit.
  *   - During execution, if a DML acquires the registry on the target table, a listener fires
@@ -91,6 +91,7 @@ private[delta] object AsyncAutoCompactService extends DeltaLogging {
   private val EV_YIELDED_DEQUEUE = "delta.autoCompaction.async.yieldedToDML.atDequeue"
   private val EV_YIELDED_MIDFLIGHT = "delta.autoCompaction.async.yieldedToDML.midFlight"
   private val EV_YIELDED_PRECOMMIT = "delta.autoCompaction.async.yieldedToDML.preCommit"
+  private val EV_FALLBACK_ENGAGED = "delta.autoCompaction.async.fallbackEngaged"
 
   /**
    * Per-table inflight count (queued + actively running). Used by tests
@@ -259,6 +260,7 @@ private[delta] object AsyncAutoCompactService extends DeltaLogging {
     queuedByTable.clear()
     workerGateForTesting = null
     yieldCountersForTesting.clear()
+    inlineFallbackTables.clear()
   }
 
   /**
@@ -276,6 +278,42 @@ private[delta] object AsyncAutoCompactService extends DeltaLogging {
    */
   @volatile private[delta] var beforeOptimizeGateForTesting:
     java.util.concurrent.CountDownLatch = null
+
+  /**
+   * Per-table sticky inline-fallback flag. Once a table is in this set, async AC
+   * submission for that table is bypassed in favour of inline AC. Set on any yield. The map
+   * is JVM-wide; state is lost on driver restart. Entry value is unused; the key set is the
+   * authoritative signal.
+   */
+  private val inlineFallbackTables = new ConcurrentHashMap[String, java.lang.Boolean]()
+
+  /** Whether `tableId` has been demoted to sticky inline mode. */
+  private[delta] def isInInlineFallback(tableId: String): Boolean =
+    inlineFallbackTables.containsKey(tableId)
+
+  /**
+   * Demote `tableId` to sticky inline mode. Idempotent; emits the
+   * `delta.autoCompaction.async.fallbackEngaged` event exactly once per table via
+   * `putIfAbsent`'s race-free semantics.
+   */
+  private[delta] def markInlineFallback(
+      deltaLog: org.apache.spark.sql.delta.DeltaLog,
+      tableId: String,
+      yieldKind: String): Unit = {
+    val prev = inlineFallbackTables.putIfAbsent(tableId, java.lang.Boolean.TRUE)
+    if (prev == null) {
+      logWarning(log"Async Auto Compaction for table " +
+        log"${MDC(DeltaLogKeys.METADATA_ID, tableId)} demoted to sticky inline mode after " +
+        log"yield kind=${MDC(DeltaLogKeys.METRICS, yieldKind)}; subsequent writes will run AC " +
+        log"inline. Disable via spark.databricks.delta.autoCompact.async.fallbackToInline.enabled.")
+      recordDeltaEvent(deltaLog, EV_FALLBACK_ENGAGED, data = Map(
+        "tableId" -> tableId,
+        "yieldKind" -> yieldKind))
+    }
+  }
+
+  /** Visible for testing: clear the inline-fallback table set. */
+  private[delta] def resetInlineFallbackForTesting(): Unit = inlineFallbackTables.clear()
 
   /**
    * Visible for testing. Per-table count of each yield kind, so tests can assert exact
@@ -328,6 +366,7 @@ private[delta] object AsyncAutoCompactService extends DeltaLogging {
           log"${MDC(DeltaLogKeys.METADATA_ID, tableId)}; skipping this OPTIMIZE attempt.")
         recordDeltaEvent(txn.deltaLog, EV_YIELDED_DEQUEUE, data = Map("tableId" -> tableId))
         incYieldCounter(tableId, "atDequeue")
+        markInlineFallback(txn.deltaLog, tableId, "atDequeue")
         decrementInflight()
         return
       }
@@ -361,6 +400,7 @@ private[delta] object AsyncAutoCompactService extends DeltaLogging {
             log"${MDC(DeltaLogKeys.METADATA_ID, tableId)} (post-listener race).")
           recordDeltaEvent(txn.deltaLog, EV_YIELDED_DEQUEUE, data = Map("tableId" -> tableId))
           incYieldCounter(tableId, "atDequeue")
+          markInlineFallback(txn.deltaLog, tableId, "atDequeue")
           return
         }
 
@@ -396,6 +436,7 @@ private[delta] object AsyncAutoCompactService extends DeltaLogging {
           recordDeltaEvent(txn.deltaLog, EV_YIELDED_PRECOMMIT,
             data = Map("tableId" -> tableId))
           incYieldCounter(tableId, "preCommit")
+          markInlineFallback(txn.deltaLog, tableId, "preCommit")
 
         case e: SparkException if cancelled.get() =>
           // Mid-flight: DML acquired while a Spark stage was running, listener fired
@@ -407,6 +448,7 @@ private[delta] object AsyncAutoCompactService extends DeltaLogging {
             "tableId" -> tableId,
             "exception" -> e.getClass.getName))
           incYieldCounter(tableId, "midFlight")
+          markInlineFallback(txn.deltaLog, tableId, "midFlight")
 
         case e: InterruptedException if cancelled.get() =>
           // Same scenario as above but on a code path where InterruptedException bubbles
@@ -418,6 +460,7 @@ private[delta] object AsyncAutoCompactService extends DeltaLogging {
             "tableId" -> tableId,
             "exception" -> e.getClass.getName))
           incYieldCounter(tableId, "midFlight")
+          markInlineFallback(txn.deltaLog, tableId, "midFlight")
           Thread.currentThread().interrupt() // preserve interrupt status
 
         case NonFatal(e) =>

--- a/spark/src/main/scala/org/apache/spark/sql/delta/hooks/AsyncAutoCompactService.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/hooks/AsyncAutoCompactService.scala
@@ -16,6 +16,7 @@
 
 package org.apache.spark.sql.delta.hooks
 
+import java.util.UUID
 import java.util.concurrent.{
   ConcurrentHashMap, LinkedBlockingQueue, ThreadPoolExecutor, TimeUnit
 }
@@ -27,9 +28,23 @@ import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 
+import org.apache.spark.SparkException
 import org.apache.spark.internal.MDC
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.util.ThreadUtils
+
+/**
+ * Marker exception thrown from inside [[org.apache.spark.sql.delta.commands.OptimizeExecutor]]
+ * when an async Auto Compaction batch is asked to yield to an in-flight DML on the same table
+ * (see [[InflightDMLRegistry]]). Caught by [[AsyncAutoCompactService.AsyncAutoCompactTask]]
+ * and converted into a `yieldedToDML.preCommit` telemetry event + WARN log; never propagated
+ * to user code.
+ *
+ * Distinguished from generic interrupts so the async worker can tell "DML asked us to yield"
+ * apart from "something else went wrong".
+ */
+private[delta] class AsyncAutoCompactCancelledException(val tableId: String, msg: String)
+  extends RuntimeException(msg)
 
 /**
  * JVM-wide singleton that executes Auto Compaction off the writer thread.
@@ -52,6 +67,18 @@ import org.apache.spark.util.ThreadUtils
  *   - The worker sets [[SparkSession.setActiveSession]] / [[SparkSession.setDefaultSession]]
  *     on entry and clears them in `finally`. Several delta-spark internals consult
  *     `SparkSession.getActiveSession` (including `OptimizeExecutor`'s codegen path).
+ *
+ * DML yielding (see [[InflightDMLRegistry]] and PR D in plan.md):
+ *   - At dequeue, if a long-running DML is in flight on the target table, the task exits
+ *     silently with a WARN log -- the next user write's post-commit hook will resubmit.
+ *   - During execution, if a DML acquires the registry on the target table, a listener fires
+ *     `SparkContext.cancelJobGroup` to interrupt our in-flight Spark stages. The resulting
+ *     `SparkException` is caught and converted to a WARN log + telemetry event.
+ *   - At commit time, `OptimizeExecutor.commitAndRetry` checks the registry one last time;
+ *     if a DML acquired during the millisecond gap between Spark-job-end and commit, it
+ *     throws [[AsyncAutoCompactCancelledException]] which we catch here.
+ *   - In all three cases, the partial Spark work AC had already done becomes garbage that
+ *     `VACUUM` reaps based on its normal retention policy.
  */
 private[delta] object AsyncAutoCompactService extends DeltaLogging {
 
@@ -61,6 +88,9 @@ private[delta] object AsyncAutoCompactService extends DeltaLogging {
   private val EV_COALESCED = "delta.autoCompaction.async.coalesced"
   private val EV_ERROR = "delta.autoCompaction.async.error"
   private val EV_COMPLETED = "delta.autoCompaction.async.completed"
+  private val EV_YIELDED_DEQUEUE = "delta.autoCompaction.async.yieldedToDML.atDequeue"
+  private val EV_YIELDED_MIDFLIGHT = "delta.autoCompaction.async.yieldedToDML.midFlight"
+  private val EV_YIELDED_PRECOMMIT = "delta.autoCompaction.async.yieldedToDML.preCommit"
 
   /**
    * Per-table inflight count (queued + actively running). Used by tests
@@ -81,6 +111,20 @@ private[delta] object AsyncAutoCompactService extends DeltaLogging {
    * running + 1 queued max per table).
    */
   private val queuedByTable = new ConcurrentHashMap[String, AtomicBoolean]()
+
+  /**
+   * Thread-local "I am an async Auto Compaction worker" flag. Set true at the top of
+   * [[AsyncAutoCompactTask.run]] and cleared in the matching `finally`. Consumed by
+   * `OptimizeExecutor.commitAndRetry` to decide whether to apply the pre-commit DML yield
+   * check -- inline Auto Compaction and user-initiated OPTIMIZE both leave it false and
+   * therefore never yield (a manual `OPTIMIZE` is an explicit user action and must run).
+   */
+  private val asyncWorkerThread = new ThreadLocal[Boolean] {
+    override def initialValue(): Boolean = false
+  }
+
+  /** True iff the current thread is an async Auto Compaction worker. */
+  def isAsyncWorker: Boolean = asyncWorkerThread.get()
 
   /**
    * The shared, bounded, daemon thread pool.
@@ -214,6 +258,7 @@ private[delta] object AsyncAutoCompactService extends DeltaLogging {
     inflightByTable.clear()
     queuedByTable.clear()
     workerGateForTesting = null
+    yieldCountersForTesting.clear()
   }
 
   /**
@@ -222,6 +267,37 @@ private[delta] object AsyncAutoCompactService extends DeltaLogging {
    * additional submissions are guaranteed to coalesce.
    */
   @volatile private[delta] var workerGateForTesting: java.util.concurrent.CountDownLatch = null
+
+  /**
+   * Visible for testing. When set, the worker awaits this latch AFTER setting up the
+   * cancellation listener but BEFORE starting the OPTIMIZE Spark job. Used by the mid-flight
+   * cancellation test to deterministically interleave: worker -> install listener -> block;
+   * DML -> acquire (fires listener); worker -> proceed (sees cancelled flag set).
+   */
+  @volatile private[delta] var beforeOptimizeGateForTesting:
+    java.util.concurrent.CountDownLatch = null
+
+  /**
+   * Visible for testing. Per-table count of each yield kind, so tests can assert exact
+   * yield-path coverage without log scraping. Keys: "atDequeue", "midFlight", "preCommit".
+   */
+  private[delta] val yieldCountersForTesting =
+    new ConcurrentHashMap[String, ConcurrentHashMap[String, AtomicInteger]]()
+
+  private def incYieldCounter(tableId: String, kind: String): Unit = {
+    val perTable = yieldCountersForTesting.computeIfAbsent(
+      tableId, _ => new ConcurrentHashMap[String, AtomicInteger]())
+    perTable.computeIfAbsent(kind, _ => new AtomicInteger(0)).incrementAndGet()
+  }
+
+  private[delta] def yieldCountForTesting(tableId: String, kind: String): Int = {
+    val perTable = yieldCountersForTesting.get(tableId)
+    if (perTable == null) 0
+    else {
+      val ai = perTable.get(kind)
+      if (ai == null) 0 else ai.get()
+    }
+  }
 
   /**
    * Worker task. Defined as an inner class so it sees `inflightByTable` and the EV_* constants
@@ -243,17 +319,107 @@ private[delta] object AsyncAutoCompactService extends DeltaLogging {
       // pick up any commits that happen during our execution. Cap is 1 running + 1 queued.
       val queued = queuedByTable.get(tableId)
       if (queued != null) queued.set(false)
+
+      // --- DML yield check #1: at dequeue ---
+      // If a long-running DML is already in flight on this table, skip silently. The DML's
+      // own post-commit hook will resubmit AC when it releases. No work has been wasted.
+      if (InflightDMLRegistry.isActive(tableId)) {
+        logWarning(log"Async Auto Compaction yielded to in-flight DML at dequeue for table " +
+          log"${MDC(DeltaLogKeys.METADATA_ID, tableId)}; skipping this OPTIMIZE attempt.")
+        recordDeltaEvent(txn.deltaLog, EV_YIELDED_DEQUEUE, data = Map("tableId" -> tableId))
+        incYieldCounter(tableId, "atDequeue")
+        decrementInflight()
+        return
+      }
+
       // Re-establish thread-locals consulted by OptimizeExecutor / DeltaUDF / Checksum / etc.
       SparkSession.setActiveSession(spark)
       SparkSession.setDefaultSession(spark)
+      asyncWorkerThread.set(true)
+
+      // --- DML yield instrumentation: install listener that interrupts our Spark stages if
+      // a DML acquires while we're mid-flight. The listener calls cancelJobGroup which makes
+      // Spark deliver a TaskKilledException to in-flight executor tasks; on the driver side
+      // it surfaces as a SparkException that we catch below.
+      val cancelled = new AtomicBoolean(false)
+      val jobGroupId = s"async-auto-compact-${UUID.randomUUID()}"
+      val listener = new InflightDMLRegistry.AcquireListener {
+        override def onDMLAcquired(): Unit = {
+          if (cancelled.compareAndSet(false, true)) {
+            spark.sparkContext.cancelJobGroup(jobGroupId)
+          }
+        }
+      }
+      InflightDMLRegistry.registerAcquireListener(tableId, listener)
+
       try {
-        // Re-read latest state: a concurrent writer may have already compacted, or more small
-        // files may have accumulated. Eligibility is evaluated against this fresh snapshot.
-        val freshSnapshot = txn.deltaLog.update(catalogTableOpt = txn.catalogTable)
-        val freshTxn = txn.copy(postCommitSnapshot = freshSnapshot)
-        AutoCompact.compactIfNecessary(spark, freshTxn, AutoCompact.OP_TYPE + ".async", None)
-        recordDeltaEvent(txn.deltaLog, EV_COMPLETED, data = Map("tableId" -> tableId))
+        // Catch the race where DML acquires between our dequeue check above and our listener
+        // installation just now. Without this, the listener wouldn't fire (DML already past
+        // its acquire call) and we'd proceed only to fail at the pre-commit gate.
+        if (InflightDMLRegistry.isActive(tableId)) {
+          logWarning(log"Async Auto Compaction yielded to in-flight DML at dequeue for table " +
+            log"${MDC(DeltaLogKeys.METADATA_ID, tableId)} (post-listener race).")
+          recordDeltaEvent(txn.deltaLog, EV_YIELDED_DEQUEUE, data = Map("tableId" -> tableId))
+          incYieldCounter(tableId, "atDequeue")
+          return
+        }
+
+        // Test hook: block here after listener is installed but before Spark work starts.
+        val pre = beforeOptimizeGateForTesting
+        if (pre != null) {
+          pre.await(30, TimeUnit.SECONDS)
+        }
+
+        // Tag all Spark jobs launched by this OPTIMIZE so cancelJobGroup can find them.
+        // interruptOnCancel=true asks Spark to send Thread.interrupt to executor task threads.
+        spark.sparkContext.setJobGroup(
+          jobGroupId,
+          s"Async Auto Compaction for $tableId",
+          interruptOnCancel = true)
+
+        try {
+          // Re-read latest state: a concurrent writer may have already compacted, or more
+          // small files may have accumulated. Eligibility is evaluated against this fresh
+          // snapshot.
+          val freshSnapshot = txn.deltaLog.update(catalogTableOpt = txn.catalogTable)
+          val freshTxn = txn.copy(postCommitSnapshot = freshSnapshot)
+          AutoCompact.compactIfNecessary(spark, freshTxn, AutoCompact.OP_TYPE + ".async", None)
+          recordDeltaEvent(txn.deltaLog, EV_COMPLETED, data = Map("tableId" -> tableId))
+        } finally {
+          spark.sparkContext.clearJobGroup()
+        }
       } catch {
+        case _: AsyncAutoCompactCancelledException =>
+          // Pre-commit gate fired inside OptimizeExecutor.commitAndRetry.
+          logWarning(log"Async Auto Compaction aborted at commit boundary due to in-flight " +
+            log"DML for table ${MDC(DeltaLogKeys.METADATA_ID, tableId)}.")
+          recordDeltaEvent(txn.deltaLog, EV_YIELDED_PRECOMMIT,
+            data = Map("tableId" -> tableId))
+          incYieldCounter(tableId, "preCommit")
+
+        case e: SparkException if cancelled.get() =>
+          // Mid-flight: DML acquired while a Spark stage was running, listener fired
+          // cancelJobGroup, Spark surfaced the cancellation up to us as a SparkException.
+          logWarning(log"Async Auto Compaction cancelled mid-flight due to in-flight DML " +
+            log"for table ${MDC(DeltaLogKeys.METADATA_ID, tableId)}; partial Spark work " +
+            log"aborted, any orphaned files will become VACUUM candidates on the next sweep.")
+          recordDeltaEvent(txn.deltaLog, EV_YIELDED_MIDFLIGHT, data = Map(
+            "tableId" -> tableId,
+            "exception" -> e.getClass.getName))
+          incYieldCounter(tableId, "midFlight")
+
+        case e: InterruptedException if cancelled.get() =>
+          // Same scenario as above but on a code path where InterruptedException bubbles
+          // directly (e.g. while sleeping in a retry loop). Treat identically.
+          logWarning(log"Async Auto Compaction cancelled mid-flight due to in-flight DML " +
+            log"for table ${MDC(DeltaLogKeys.METADATA_ID, tableId)}; interrupted before " +
+            log"Spark work could complete.")
+          recordDeltaEvent(txn.deltaLog, EV_YIELDED_MIDFLIGHT, data = Map(
+            "tableId" -> tableId,
+            "exception" -> e.getClass.getName))
+          incYieldCounter(tableId, "midFlight")
+          Thread.currentThread().interrupt() // preserve interrupt status
+
         case NonFatal(e) =>
           logWarning(log"Async Auto Compaction failed for table " +
             log"${MDC(DeltaLogKeys.METADATA_ID, tableId)}: " +
@@ -264,11 +430,17 @@ private[delta] object AsyncAutoCompactService extends DeltaLogging {
             "message" -> Option(e.getMessage).getOrElse("")
           ))
       } finally {
+        InflightDMLRegistry.unregisterAcquireListener(tableId)
+        asyncWorkerThread.set(false)
         SparkSession.clearActiveSession()
         SparkSession.clearDefaultSession()
-        val n = inflightByTable.get(tableId)
-        if (n != null) n.decrementAndGet()
+        decrementInflight()
       }
+    }
+
+    private def decrementInflight(): Unit = {
+      val n = inflightByTable.get(tableId)
+      if (n != null) n.decrementAndGet()
     }
   }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/hooks/AsyncAutoCompactService.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/hooks/AsyncAutoCompactService.scala
@@ -1,0 +1,274 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.hooks
+
+import java.util.concurrent.{
+  ConcurrentHashMap, LinkedBlockingQueue, ThreadPoolExecutor, TimeUnit
+}
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
+import scala.util.control.NonFatal
+
+import org.apache.spark.sql.delta.CommittedTransaction
+import org.apache.spark.sql.delta.logging.DeltaLogKeys
+import org.apache.spark.sql.delta.metering.DeltaLogging
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+
+import org.apache.spark.internal.MDC
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.util.ThreadUtils
+
+/**
+ * JVM-wide singleton that executes Auto Compaction off the writer thread.
+ *
+ * When [[DeltaSQLConf.DELTA_AUTO_COMPACT_ASYNC_ENABLED]] is set, [[AutoCompactBase.run]] hands
+ * the committed transaction to this service instead of running OPTIMIZE inline. The writer's
+ * post-commit hook returns immediately; the OPTIMIZE work is performed on a daemon worker
+ * thread and lands as its own commit shortly after.
+ *
+ * Correctness invariants:
+ *   - Workers re-evaluate eligibility against a freshly-loaded snapshot (`deltaLog.update()`).
+ *     The enqueue-time `postCommitSnapshot` can be minutes stale by the time the worker runs;
+ *     a concurrent writer (this JVM or another) may have already compacted.
+ *   - Eligibility, partition reservation (`AutoCompactPartitionReserve`), and OPTIMIZE all
+ *     happen on the same worker thread. The reservation window therefore covers the OPTIMIZE
+ *     call exactly as in inline mode.
+ *   - OPTIMIZE-vs-OPTIMIZE and OPTIMIZE-vs-write conflicts use the same `commitAndRetry` loop
+ *     in `OptimizeExecutor` that inline Auto Compaction relies on. Async introduces no new
+ *     conflict class.
+ *   - The worker sets [[SparkSession.setActiveSession]] / [[SparkSession.setDefaultSession]]
+ *     on entry and clears them in `finally`. Several delta-spark internals consult
+ *     `SparkSession.getActiveSession` (including `OptimizeExecutor`'s codegen path).
+ */
+private[delta] object AsyncAutoCompactService extends DeltaLogging {
+
+  /** Telemetry event types. */
+  private val EV_SUBMITTED = "delta.autoCompaction.async.submitted"
+  private val EV_DROPPED = "delta.autoCompaction.async.dropped"
+  private val EV_COALESCED = "delta.autoCompaction.async.coalesced"
+  private val EV_ERROR = "delta.autoCompaction.async.error"
+  private val EV_COMPLETED = "delta.autoCompaction.async.completed"
+
+  /**
+   * Per-table inflight count (queued + actively running). Used by tests
+   * (`awaitQuiescenceForTesting`) and telemetry payloads.
+   *
+   * Key is `deltaLog.unsafeVolatileTableId`. Incremented on accepted submission, decremented
+   * in the worker's finally block. With per-table dedup (see `queuedByTable`) this counter
+   * tops out at 2 per table (one running + one queued).
+   */
+  private val inflightByTable = new ConcurrentHashMap[String, AtomicInteger]()
+
+  /**
+   * Per-table "submission already queued" flag. Drives dedup: while a submission for a given
+   * table is sitting in the pool queue, additional submissions are dropped as redundant --
+   * the queued worker re-reads `deltaLog.update()` at execution time, so it will pick up any
+   * commits that landed after enqueue. The flag is cleared at the start of `run()` (not at
+   * end), so a new submission arriving while the worker is actively running gets queued (1
+   * running + 1 queued max per table).
+   */
+  private val queuedByTable = new ConcurrentHashMap[String, AtomicBoolean]()
+
+  /**
+   * The shared, bounded, daemon thread pool.
+   *
+   * Lazy so we don't allocate threads until something actually opts in. Configured from the
+   * first `submit` call's `SparkSession`; subsequent sessions reuse the pool -- this is a
+   * deliberate simplification (matching the JVM-wide nature of the existing
+   * `AutoCompactPartitionReserve` singleton). Re-configuration at runtime is not supported in
+   * this version; restart the JVM to change pool sizing.
+   */
+  @volatile private var poolOpt: Option[ThreadPoolExecutor] = None
+
+  /** True iff async submission is enabled in this session. */
+  def isEnabled(spark: SparkSession): Boolean =
+    spark.sessionState.conf.getConf(DeltaSQLConf.DELTA_AUTO_COMPACT_ASYNC_ENABLED)
+
+  /** Test/observability hook. */
+  def pendingForTable(tableId: String): Int = {
+    val ai = inflightByTable.get(tableId)
+    if (ai == null) 0 else ai.get()
+  }
+
+  /**
+   * Lazily initialize the worker pool. Idempotent and safe under concurrent first-call.
+   *
+   * Capacity is read from the first caller's `SparkSession`. This matches the lifetime of the
+   * existing JVM-wide singletons (`AutoCompactPartitionReserve`, `AutoCompactPartitionStats`)
+   * and is acceptable because pool sizing is operational and JVM-wide regardless of which
+   * session opted in first.
+   */
+  private def ensurePool(spark: SparkSession): ThreadPoolExecutor = {
+    poolOpt match {
+      case Some(p) => p
+      case None => initPool(spark)
+    }
+  }
+
+  private def initPool(spark: SparkSession): ThreadPoolExecutor = synchronized {
+    poolOpt.getOrElse {
+      val conf = spark.sessionState.conf
+      val parallelism = conf.getConf(DeltaSQLConf.DELTA_AUTO_COMPACT_ASYNC_PARALLELISM)
+      val maxQueueSize = conf.getConf(DeltaSQLConf.DELTA_AUTO_COMPACT_ASYNC_MAX_QUEUE_SIZE)
+      val queue = new LinkedBlockingQueue[Runnable](maxQueueSize)
+      val factory = ThreadUtils.namedThreadFactory("delta-auto-compact-async")
+      val pool = new ThreadPoolExecutor(
+        parallelism, parallelism,
+        60L, TimeUnit.SECONDS,
+        queue,
+        factory)
+      pool.allowCoreThreadTimeOut(true)
+      poolOpt = Some(pool)
+      pool
+    }
+  }
+
+  /**
+   * Submit a CommittedTransaction for asynchronous Auto Compaction.
+   *
+   * Returns immediately. The worker may run minutes later (queue-depth dependent) and
+   * re-evaluates eligibility on a fresh snapshot at that point.
+   *
+   * Backpressure (queue full): records a `dropped` event and returns. No exception is
+   * raised to the writer -- the writer is intentionally insulated from async-mode failures.
+   */
+  def submit(spark: SparkSession, txn: CommittedTransaction): Unit = {
+    val pool = ensurePool(spark)
+    val deltaLog = txn.deltaLog
+    val tableId = deltaLog.unsafeVolatileTableId
+
+    // Dedup: if a submission is already queued for this table, drop this one as redundant.
+    // The queued worker re-reads `deltaLog.update()` at execution time and will absorb any
+    // commits that landed between the earlier submit and that re-read, so we don't lose
+    // eligibility for those commits. This prevents queue churn under high-throughput writes
+    // to the same table (which would otherwise produce N submissions, N-1 of which would
+    // wake up only to no-op via AutoCompactPartitionReserve).
+    val queued = queuedByTable.computeIfAbsent(tableId, _ => new AtomicBoolean(false))
+    if (!queued.compareAndSet(false, true)) {
+      recordDeltaEvent(deltaLog, EV_COALESCED, data = Map(
+        "tableId" -> tableId,
+        "queueSize" -> pool.getQueue.size
+      ))
+      return
+    }
+
+    val inflight = inflightByTable.computeIfAbsent(tableId, _ => new AtomicInteger(0))
+    inflight.incrementAndGet()
+
+    // Heap mitigation: the queued task can sit in the bounded queue for a long time when the
+    // pool is saturated. Strip the large `committedActions` payload (potentially thousands of
+    // AddFile actions per commit) before enqueueing -- the downstream code path
+    // (compactIfNecessary / prepareAutoCompactRequest) does not consult committedActions. We
+    // also drop postCommitHooks because the worker doesn't re-run them.
+    val lightTxn = txn.copy(
+      committedActions = Nil,
+      postCommitHooks = Nil)
+
+    val task: Runnable = new AsyncAutoCompactTask(spark, lightTxn, tableId)
+    try {
+      pool.execute(task)
+      recordDeltaEvent(deltaLog, EV_SUBMITTED, data = Map(
+        "tableId" -> tableId,
+        "queueSize" -> pool.getQueue.size,
+        "pendingForTable" -> inflight.get
+      ))
+    } catch {
+      case _: java.util.concurrent.RejectedExecutionException =>
+        inflight.decrementAndGet()
+        queued.set(false)
+        recordDeltaEvent(deltaLog, EV_DROPPED, data = Map(
+          "tableId" -> tableId,
+          "queueSize" -> pool.getQueue.size,
+          "reason" -> "queue full"
+        ))
+        logInfo(log"Async Auto Compaction queue full; dropping submission for table " +
+          log"${MDC(DeltaLogKeys.METADATA_ID, tableId)}")
+    }
+  }
+
+  /** Visible for testing. Awaits the pool draining; returns true if it drained in time. */
+  private[delta] def awaitQuiescenceForTesting(
+      tableId: String, timeoutMs: Long): Boolean = {
+    val deadline = System.currentTimeMillis() + timeoutMs
+    while (pendingForTable(tableId) > 0 && System.currentTimeMillis() < deadline) {
+      Thread.sleep(20)
+    }
+    pendingForTable(tableId) == 0
+  }
+
+  /** Visible for testing. Resets per-table inflight counters. Does NOT shut down the pool. */
+  private[delta] def resetCountersForTesting(): Unit = {
+    inflightByTable.clear()
+    queuedByTable.clear()
+    workerGateForTesting = null
+  }
+
+  /**
+   * Visible for testing. When set, the worker awaits this latch BEFORE clearing the per-table
+   * dedup flag and BEFORE doing any work. Lets tests force a known overlap window during which
+   * additional submissions are guaranteed to coalesce.
+   */
+  @volatile private[delta] var workerGateForTesting: java.util.concurrent.CountDownLatch = null
+
+  /**
+   * Worker task. Defined as an inner class so it sees `inflightByTable` and the EV_* constants
+   * without leaking them publicly.
+   */
+  private class AsyncAutoCompactTask(
+      spark: SparkSession,
+      txn: CommittedTransaction,
+      tableId: String) extends Runnable {
+
+    override def run(): Unit = {
+      // Test hook: block before clearing the dedup flag so tests can verify coalescing.
+      val gate = workerGateForTesting
+      if (gate != null) {
+        gate.await(30, TimeUnit.SECONDS)
+      }
+      // Clear the dedup flag NOW (before doing work). This way a new submission arriving while
+      // we run gets accepted and queued; that worker will then re-read the latest snapshot and
+      // pick up any commits that happen during our execution. Cap is 1 running + 1 queued.
+      val queued = queuedByTable.get(tableId)
+      if (queued != null) queued.set(false)
+      // Re-establish thread-locals consulted by OptimizeExecutor / DeltaUDF / Checksum / etc.
+      SparkSession.setActiveSession(spark)
+      SparkSession.setDefaultSession(spark)
+      try {
+        // Re-read latest state: a concurrent writer may have already compacted, or more small
+        // files may have accumulated. Eligibility is evaluated against this fresh snapshot.
+        val freshSnapshot = txn.deltaLog.update(catalogTableOpt = txn.catalogTable)
+        val freshTxn = txn.copy(postCommitSnapshot = freshSnapshot)
+        AutoCompact.compactIfNecessary(spark, freshTxn, AutoCompact.OP_TYPE + ".async", None)
+        recordDeltaEvent(txn.deltaLog, EV_COMPLETED, data = Map("tableId" -> tableId))
+      } catch {
+        case NonFatal(e) =>
+          logWarning(log"Async Auto Compaction failed for table " +
+            log"${MDC(DeltaLogKeys.METADATA_ID, tableId)}: " +
+            log"${MDC(DeltaLogKeys.ERROR, e.getMessage)}")
+          recordDeltaEvent(txn.deltaLog, EV_ERROR, data = Map(
+            "tableId" -> tableId,
+            "exception" -> e.getClass.getName,
+            "message" -> Option(e.getMessage).getOrElse("")
+          ))
+      } finally {
+        SparkSession.clearActiveSession()
+        SparkSession.clearDefaultSession()
+        val n = inflightByTable.get(tableId)
+        if (n != null) n.decrementAndGet()
+      }
+    }
+  }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/hooks/AutoCompact.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/hooks/AutoCompact.scala
@@ -103,11 +103,19 @@ trait AutoCompactBase extends PostCommitHook with DeltaLogging {
     // Skip Auto Compact if current transaction is not qualified or the table is not qualified
     // based on the value of autoCompactTypeOpt.
     if (shouldSkipAutoCompact(autoCompactTypeOpt, spark, txn)) return
-    compactIfNecessary(
-        spark,
-        txn,
-        OP_TYPE,
-        maxDeletedRowsRatio = None)
+    if (AsyncAutoCompactService.isEnabled(spark)) {
+      // Hand the committed txn off to the JVM-wide async worker pool. The writer thread returns
+      // immediately; the worker re-evaluates eligibility against a fresh snapshot and (if still
+      // eligible) runs the OPTIMIZE as its own commit. See AsyncAutoCompactService for the
+      // correctness invariants around partition reservation and conflict handling.
+      AsyncAutoCompactService.submit(spark, txn)
+    } else {
+      compactIfNecessary(
+          spark,
+          txn,
+          OP_TYPE,
+          maxDeletedRowsRatio = None)
+    }
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/hooks/AutoCompact.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/hooks/AutoCompact.scala
@@ -103,13 +103,22 @@ trait AutoCompactBase extends PostCommitHook with DeltaLogging {
     // Skip Auto Compact if current transaction is not qualified or the table is not qualified
     // based on the value of autoCompactTypeOpt.
     if (shouldSkipAutoCompact(autoCompactTypeOpt, spark, txn)) return
-    if (AsyncAutoCompactService.isEnabled(spark)) {
+    val asyncEnabled = AsyncAutoCompactService.isEnabled(spark)
+    val tableId = txn.postCommitSnapshot.metadata.id
+    val fallbackEnabled = conf.getConf(
+      org.apache.spark.sql.delta.sources.DeltaSQLConf
+        .DELTA_AUTO_COMPACT_ASYNC_FALLBACK_TO_INLINE_ENABLED)
+    val inFallback = fallbackEnabled && AsyncAutoCompactService.isInInlineFallback(tableId)
+    if (asyncEnabled && !inFallback) {
       // Hand the committed txn off to the JVM-wide async worker pool. The writer thread returns
       // immediately; the worker re-evaluates eligibility against a fresh snapshot and (if still
       // eligible) runs the OPTIMIZE as its own commit. See AsyncAutoCompactService for the
       // correctness invariants around partition reservation and conflict handling.
       AsyncAutoCompactService.submit(spark, txn)
     } else {
+      // Either async is disabled, or this table has been demoted to sticky inline mode after
+      // a prior async AC yielded to in-flight DML. Inline runs cannot be cancelled
+      // by a future writer, so progress is guaranteed.
       compactIfNecessary(
           spark,
           txn,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/hooks/InflightDMLRegistry.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/hooks/InflightDMLRegistry.scala
@@ -20,7 +20,7 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
 
 /**
- * JVM-wide registry of in-flight long-running DML operations
+ * JVM-wide registry of in-flight DML operations
  * (MERGE / DELETE / UPDATE / OVERWRITE).
  *
  * Async Auto Compaction consults this registry to decide whether to start a new OPTIMIZE
@@ -29,10 +29,6 @@ import java.util.concurrent.atomic.AtomicInteger
  * MERGE loses to a concurrently-finishing OPTIMIZE and is forced to throw
  * `ConcurrentModificationException` -- losing minutes of Spark work -- after the AC commit
  * lands first.
- *
- * Intra-JVM only. A cross-JVM lease (via a `DomainMetadata` entry in the Delta log) is a
- * deferred follow-up; in practice async AC runs as a post-commit hook on the writer's own
- * driver, so the same-driver topology is dominant.
  *
  * Listener slot is per-table and exclusive (overwrites on re-registration) because the
  * async Auto Compaction service's dedup guarantees at most one async AC task is running per

--- a/spark/src/main/scala/org/apache/spark/sql/delta/hooks/InflightDMLRegistry.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/hooks/InflightDMLRegistry.scala
@@ -1,0 +1,136 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.hooks
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * JVM-wide registry of in-flight long-running DML operations
+ * (MERGE / DELETE / UPDATE / OVERWRITE).
+ *
+ * Async Auto Compaction consults this registry to decide whether to start a new OPTIMIZE
+ * batch, and registers a per-table listener so it can be told to cancel mid-flight when a
+ * new DML acquires while AC is running. This eliminates the failure mode where a long
+ * MERGE loses to a concurrently-finishing OPTIMIZE and is forced to throw
+ * `ConcurrentModificationException` -- losing minutes of Spark work -- after the AC commit
+ * lands first.
+ *
+ * Intra-JVM only. A cross-JVM lease (via a `DomainMetadata` entry in the Delta log) is a
+ * deferred follow-up; in practice async AC runs as a post-commit hook on the writer's own
+ * driver, so the same-driver topology is dominant.
+ *
+ * Listener slot is per-table and exclusive (overwrites on re-registration) because the
+ * async Auto Compaction service's dedup guarantees at most one async AC task is running per
+ * table at a time.
+ */
+private[delta] object InflightDMLRegistry {
+
+  /**
+   * Listener invoked when a DML `acquire` happens for the registered tableId. AC registers
+   * one for the duration of its task; on invocation it sets its internal `cancelled` flag
+   * and calls `SparkContext.cancelJobGroup` so its in-flight Spark stages are interrupted.
+   */
+  trait AcquireListener {
+    def onDMLAcquired(): Unit
+  }
+
+  /**
+   * Per-table active count. Incremented at DML start, decremented at end. The async AC
+   * task's `isActive` check uses `count > 0` to decide whether to yield.
+   */
+  private val activeOps = new ConcurrentHashMap[String, AtomicInteger]()
+
+  /**
+   * Per-table listener slot. Only one listener per table -- async AC's dedup ensures at
+   * most one task per table at a time. Re-registration overwrites (a new task superseding
+   * a finished one).
+   */
+  private val listeners = new ConcurrentHashMap[String, AcquireListener]()
+
+  /**
+   * Acquire a slot for a long-running DML on `tableId`. Increments the active count and,
+   * if any AC listener is registered, fires it so AC can begin cancellation.
+   *
+   * Idempotent only in the sense that nested DML calls (rare) are reference-counted; each
+   * `acquire` MUST be paired with exactly one `release` (use try/finally).
+   */
+  def acquire(tableId: String): Unit = {
+    activeOps.computeIfAbsent(tableId, _ => new AtomicInteger(0)).incrementAndGet()
+    val l = listeners.get(tableId)
+    if (l != null) {
+      try l.onDMLAcquired() catch { case _: Throwable => () }
+    }
+  }
+
+  /**
+   * Release a slot acquired via `acquire`. Removes the per-table counter when it drops to
+   * zero to avoid unbounded growth across many tables in long-lived JVMs.
+   */
+  def release(tableId: String): Unit = {
+    val ctr = activeOps.get(tableId)
+    if (ctr != null) {
+      if (ctr.decrementAndGet() <= 0) {
+        // Race-tolerant removal: only remove if the value is still <= 0. A concurrent
+        // acquire that snuck a +1 between our decrement and check will leave the counter
+        // positive and we won't remove it.
+        activeOps.remove(tableId, ctr)
+      }
+    }
+  }
+
+  /** True iff there is at least one in-flight DML on `tableId`. */
+  def isActive(tableId: String): Boolean = {
+    val ctr = activeOps.get(tableId)
+    ctr != null && ctr.get() > 0
+  }
+
+  /**
+   * Register a listener that will be invoked when a DML `acquire` for `tableId` happens
+   * while this listener is registered. Overwrites any prior listener for the same table.
+   *
+   * Pair with `unregisterAcquireListener` in a `finally` so a crashed AC task doesn't
+   * leave a stale listener behind.
+   */
+  def registerAcquireListener(tableId: String, listener: AcquireListener): Unit = {
+    listeners.put(tableId, listener)
+  }
+
+  /**
+   * Unregister the listener for `tableId`. Idempotent.
+   */
+  def unregisterAcquireListener(tableId: String): Unit = {
+    listeners.remove(tableId)
+  }
+
+  /** Test-only. Clears all state. */
+  private[delta] def resetForTesting(): Unit = {
+    activeOps.clear()
+    listeners.clear()
+  }
+
+  /** Test-only. Returns the current active count for `tableId`. */
+  private[delta] def activeCountForTesting(tableId: String): Int = {
+    val ctr = activeOps.get(tableId)
+    if (ctr == null) 0 else ctr.get()
+  }
+
+  /** Test-only. True iff a listener is currently registered for `tableId`. */
+  private[delta] def hasListenerForTesting(tableId: String): Boolean = {
+    listeners.get(tableId) != null
+  }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -325,6 +325,58 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
           s"""${AUTO_COMPACT_ALLOWED_VALUES.mkString("(", ",", ")")}""")
       .createOptional
 
+  val DELTA_AUTO_COMPACT_ASYNC_ENABLED =
+    buildConf("autoCompact.async.enabled")
+      .doc(s"""Whether Auto Compaction runs asynchronously on a background daemon thread instead
+              |of inline on the writer's post-commit hook. When enabled, write commits return as
+              |soon as the data commit lands; the OPTIMIZE work is dispatched to a bounded thread
+              |pool and committed as its own transaction shortly after. The OPTIMIZE retry loop
+              |on concurrent commits is unchanged from inline mode, so this introduces no new
+              |conflict class. JVM-local partition reservation (AutoCompactPartitionReserve)
+              |still serializes overlapping AC runs on the same JVM because eligibility,
+              |reservation and OPTIMIZE all execute on the same worker thread.
+              |
+              |Session-only and opt-in. Default is false (today's inline behavior).""".stripMargin)
+      .booleanConf
+      .createWithDefault(false)
+
+  val DELTA_AUTO_COMPACT_ASYNC_PARALLELISM =
+    buildConf("autoCompact.async.parallelism")
+      .internal()
+      .doc("""Number of background daemon worker threads used to run Auto Compaction
+             |asynchronously. The pool is JVM-wide (shared across all SparkSessions and Delta
+             |tables in this JVM). Increasing this raises Auto Compaction's effective throughput
+             |but also its CPU footprint.""".stripMargin)
+      .intConf
+      .checkValue(_ > 0, "autoCompact.async.parallelism must be positive")
+      .createWithDefault(2)
+
+  val DELTA_AUTO_COMPACT_ASYNC_MAX_QUEUE_SIZE =
+    buildConf("autoCompact.async.maxQueueSize")
+      .internal()
+      .doc("""Maximum number of pending Auto Compaction tasks that may be enqueued for the
+             |async worker pool. When the queue is full, the backpressure policy decides what
+             |to do with new submissions.""".stripMargin)
+      .intConf
+      .checkValue(_ > 0, "autoCompact.async.maxQueueSize must be positive")
+      .createWithDefault(64)
+
+  val DELTA_AUTO_COMPACT_ASYNC_BACKPRESSURE =
+    buildConf("autoCompact.async.backpressure")
+      .internal()
+      .doc("""Backpressure policy when the async Auto Compaction queue is full. Allowed values:
+             |  - "drop": (default) silently decline the submission and record a
+             |    "delta.autoCompaction.async.dropped" event. The writer is unaffected; the
+             |    table simply skips Auto Compaction for that commit, the same outcome as if
+             |    Auto Compaction were disabled.
+             |Additional modes (block, fallback-inline) are reserved for a follow-up
+             |PR.""".stripMargin)
+      .stringConf
+      .transform(_.toLowerCase(Locale.ROOT))
+      .checkValue(Set("drop").contains,
+        """"spark.databricks.delta.autoCompact.async.backpressure" must be one of: (drop)""")
+      .createWithDefault("drop")
+
   val DELTA_AUTO_COMPACT_RECORD_PARTITION_STATS_ENABLED =
     buildConf("autoCompact.recordPartitionStats.enabled")
       .internal()

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -377,6 +377,19 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
         """"spark.databricks.delta.autoCompact.async.backpressure" must be one of: (drop)""")
       .createWithDefault("drop")
 
+  val DELTA_AUTO_COMPACT_ASYNC_FALLBACK_TO_INLINE_ENABLED =
+    buildConf("autoCompact.async.fallbackToInline.enabled")
+      .doc("""When true (default), if an async Auto Compaction yields to in-flight user DML
+             |(MERGE/DELETE/UPDATE/OVERWRITE) on a given table, that table sticks to running
+             |Auto Compaction inline on the writer's own post-commit hook for the remainder of
+             |the JVM's life. This avoids the streaming-MERGE pathology where every async AC
+             |is submitted only to be aborted by the next write's DML, wasting Spark cycles
+             |and never producing an OPTIMIZE commit. Inline runs cannot be cancelled by a
+             |future writer because the future writer has not started yet, so progress is
+             |guaranteed. State is JVM-wide and reset only on driver restart.""".stripMargin)
+      .booleanConf
+      .createWithDefault(true)
+
   val DELTA_AUTO_COMPACT_RECORD_PARTITION_STATS_ENABLED =
     buildConf("autoCompact.recordPartitionStats.enabled")
       .internal()

--- a/spark/src/test/scala/org/apache/spark/sql/delta/AutoCompactAsyncSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/AutoCompactAsyncSuite.scala
@@ -1,0 +1,221 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+// scalastyle:off import.ordering.noEmptyLine
+import com.databricks.spark.util.Log4jUsageLogger
+import org.apache.spark.sql.delta.hooks.{AsyncAutoCompactService, AutoCompact}
+import org.apache.spark.sql.delta.optimize.CompactionTestHelperForAutoCompaction
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+
+import org.apache.spark.sql.test.SharedSparkSession
+
+/**
+ * Tests for asynchronous Auto Compaction.
+ *
+ * Covers:
+ *   - Default-off: behavior identical to inline AC.
+ *   - Opt-in: writer returns before AC commit; AC commit lands after worker drains.
+ *   - Snapshot freshness: worker re-evaluates against a fresh snapshot, so a peer that
+ *     compacted between enqueue and run causes the worker to skip cleanly.
+ *   - Queue full: writer is unaffected, dropped event is recorded.
+ *   - Concurrent submissions: partition reservation invariant holds.
+ */
+class AutoCompactAsyncSuite extends
+    CompactionTestHelperForAutoCompaction
+  with DeltaSQLCommandTest
+  with SharedSparkSession
+  with AutoCompactTestUtils {
+
+  import testImplicits._
+
+  private val AsyncTimeoutMs = 60000L
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    AsyncAutoCompactService.resetCountersForTesting()
+  }
+
+  private def awaitDrain(tableId: String): Unit = {
+    assert(
+      AsyncAutoCompactService.awaitQuiescenceForTesting(tableId, AsyncTimeoutMs),
+      s"Async Auto Compact pool did not drain within ${AsyncTimeoutMs}ms for table $tableId")
+  }
+
+  test("async disabled by default: writer thread runs AC inline") {
+    withTempDir { tempDir =>
+      val dir = tempDir.getCanonicalPath
+      withSQLConf(
+          DeltaSQLConf.DELTA_AUTO_COMPACT_ENABLED.key -> "true",
+          DeltaSQLConf.DELTA_AUTO_COMPACT_MIN_NUM_FILES.key -> "0") {
+        // Sanity: async should be off by default.
+        assert(!AsyncAutoCompactService.isEnabled(spark))
+
+        spark.range(10).repartition(5).write.format("delta").mode("append").save(dir)
+        val deltaLog = DeltaLog.forTable(spark, dir)
+        // Version 0 is the initial write, version 1 is the inline AC OPTIMIZE.
+        assert(deltaLog.update().version === 1)
+        assert(deltaLog.update().numOfFiles === 1)
+        // No async submissions should have been registered.
+        assert(AsyncAutoCompactService.pendingForTable(
+          deltaLog.unsafeVolatileTableId) === 0)
+      }
+    }
+  }
+
+  test("async enabled: AC commit lands after writer returns and worker drains") {
+    withTempDir { tempDir =>
+      val dir = tempDir.getCanonicalPath
+      withSQLConf(
+          DeltaSQLConf.DELTA_AUTO_COMPACT_ENABLED.key -> "true",
+          DeltaSQLConf.DELTA_AUTO_COMPACT_ASYNC_ENABLED.key -> "true",
+          DeltaSQLConf.DELTA_AUTO_COMPACT_MIN_NUM_FILES.key -> "0") {
+        assert(AsyncAutoCompactService.isEnabled(spark))
+
+        spark.range(10).repartition(5).write.format("delta").mode("append").save(dir)
+        val deltaLog = DeltaLog.forTable(spark, dir)
+        val tableId = deltaLog.unsafeVolatileTableId
+
+        // Drain the async pool, then assert AC has run (a new commit after the write).
+        awaitDrain(tableId)
+
+        val finalSnap = deltaLog.update()
+        assert(finalSnap.version === 1, "Expected the async AC OPTIMIZE commit to land.")
+        assert(finalSnap.numOfFiles === 1)
+
+        val lastEvent = deltaLog.history.getHistory(Some(1)).head
+        assert(lastEvent.operation === "OPTIMIZE")
+        assert(lastEvent.operationParameters("auto") === "true")
+      }
+    }
+  }
+
+  test("async enabled: submission telemetry event is recorded") {
+    withTempDir { tempDir =>
+      val dir = tempDir.getCanonicalPath
+      withSQLConf(
+          DeltaSQLConf.DELTA_AUTO_COMPACT_ENABLED.key -> "true",
+          DeltaSQLConf.DELTA_AUTO_COMPACT_ASYNC_ENABLED.key -> "true",
+          DeltaSQLConf.DELTA_AUTO_COMPACT_MIN_NUM_FILES.key -> "0") {
+        val submitted = Log4jUsageLogger.track {
+          spark.range(10).repartition(5).write.format("delta").mode("append").save(dir)
+        }.filter(_.tags.get("opType") ==
+          Some("delta.autoCompaction.async.submitted"))
+        assert(submitted.nonEmpty, "Expected a submitted event when async AC fires.")
+
+        val deltaLog = DeltaLog.forTable(spark, dir)
+        awaitDrain(deltaLog.unsafeVolatileTableId)
+      }
+    }
+  }
+
+  test("async re-evaluates eligibility on a fresh snapshot") {
+    withTempDir { tempDir =>
+      val dir = tempDir.getCanonicalPath
+      withSQLConf(
+          DeltaSQLConf.DELTA_AUTO_COMPACT_ENABLED.key -> "true",
+          DeltaSQLConf.DELTA_AUTO_COMPACT_ASYNC_ENABLED.key -> "true",
+          DeltaSQLConf.DELTA_AUTO_COMPACT_MIN_NUM_FILES.key -> "5") {
+        // First write: 5 small files => eligible => AC compacts to 1 file (version 1).
+        spark.range(10).repartition(5).write.format("delta").mode("append").save(dir)
+        val deltaLog = DeltaLog.forTable(spark, dir)
+        awaitDrain(deltaLog.unsafeVolatileTableId)
+        assert(deltaLog.update().version === 1)
+        // Second write: 1 row => 1 new file => table has 2 files total. Below threshold (5).
+        // Worker re-reads fresh snapshot, decides skip, produces no extra commit.
+        spark.range(1).write.format("delta").mode("append").save(dir)
+        awaitDrain(deltaLog.unsafeVolatileTableId)
+        assert(deltaLog.update().version === 2,
+          "Worker should re-evaluate against the fresh snapshot and skip.")
+      }
+    }
+  }
+
+  test("async queue full: writer succeeds and dropped event is recorded") {
+    withTempDir { tempDir =>
+      val dir = tempDir.getCanonicalPath
+      withSQLConf(
+          DeltaSQLConf.DELTA_AUTO_COMPACT_ENABLED.key -> "true",
+          DeltaSQLConf.DELTA_AUTO_COMPACT_ASYNC_ENABLED.key -> "true",
+          DeltaSQLConf.DELTA_AUTO_COMPACT_MIN_NUM_FILES.key -> "0",
+          DeltaSQLConf.DELTA_AUTO_COMPACT_ASYNC_PARALLELISM.key -> "1",
+          DeltaSQLConf.DELTA_AUTO_COMPACT_ASYNC_MAX_QUEUE_SIZE.key -> "1") {
+        // Submit many small commits in a tight loop; the bounded queue should reject some.
+        val events = Log4jUsageLogger.track {
+          (1 to 20).foreach { _ =>
+            spark.range(10).repartition(5).write.format("delta").mode("append").save(dir)
+          }
+        }
+        val dropped = events.filter(
+          _.tags.get("opType") == Some("delta.autoCompaction.async.dropped"))
+        // It's possible (though unlikely with parallelism=1, queue=1, 20 submissions) that the
+        // worker keeps up. Only assert that writers themselves succeeded; if anything is
+        // dropped, it must be tagged correctly.
+        val deltaLog = DeltaLog.forTable(spark, dir)
+        awaitDrain(deltaLog.unsafeVolatileTableId)
+        // Writers must not have thrown -- all 20 commits should have produced at least 20 write
+        // commits (plus some number of OPTIMIZE commits).
+        assert(deltaLog.update().version >= 19)
+        // If dropped is non-empty, ensure the payload includes tableId.
+        dropped.foreach { ev =>
+          assert(ev.blob.contains("tableId"))
+        }
+      }
+    }
+  }
+
+  test("async coalesces redundant submissions per-table") {
+    withTempDir { tempDir =>
+      val dir = tempDir.getCanonicalPath
+      val gate = new java.util.concurrent.CountDownLatch(1)
+      AsyncAutoCompactService.workerGateForTesting = gate
+      try {
+        withSQLConf(
+            DeltaSQLConf.DELTA_AUTO_COMPACT_ENABLED.key -> "true",
+            DeltaSQLConf.DELTA_AUTO_COMPACT_ASYNC_ENABLED.key -> "true",
+            DeltaSQLConf.DELTA_AUTO_COMPACT_MIN_NUM_FILES.key -> "0",
+            DeltaSQLConf.DELTA_AUTO_COMPACT_ASYNC_PARALLELISM.key -> "1",
+            DeltaSQLConf.DELTA_AUTO_COMPACT_ASYNC_MAX_QUEUE_SIZE.key -> "128") {
+          val events = Log4jUsageLogger.track {
+            // The first write's submit accepts; the worker then blocks on the gate before
+            // clearing the dedup flag. Subsequent writes all coalesce against the still-set
+            // flag.
+            (1 to 20).foreach { _ =>
+              spark.range(10).repartition(5).write.format("delta").mode("append").save(dir)
+            }
+          }
+          val submitted = events.count(
+            _.tags.get("opType") == Some("delta.autoCompaction.async.submitted"))
+          val coalesced = events.count(
+            _.tags.get("opType") == Some("delta.autoCompaction.async.coalesced"))
+          assert(submitted + coalesced === 20,
+            s"Expected 20 total submit attempts, got submitted=$submitted coalesced=$coalesced")
+          assert(submitted === 1,
+            s"Expected exactly 1 accepted submission while gated, got $submitted")
+          assert(coalesced === 19,
+            s"Expected 19 coalesced submissions, got $coalesced")
+        }
+      } finally {
+        gate.countDown()
+        AsyncAutoCompactService.workerGateForTesting = null
+        val deltaLog = DeltaLog.forTable(spark, dir)
+        awaitDrain(deltaLog.unsafeVolatileTableId)
+      }
+    }
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/AutoCompactDMLYieldSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/AutoCompactDMLYieldSuite.scala
@@ -298,9 +298,12 @@ class AutoCompactDMLYieldSuite extends
   test("yielded async AC submission does not break the per-table async-AC dedup") {
     withTempDir { tempDir =>
       val dir = tempDir.getCanonicalPath
+      // Disable the sticky inline fallback so the table remains in async mode and the
+      // dedup invariant under test is actually exercised by the second submission.
       withSQLConf(
           DeltaSQLConf.DELTA_AUTO_COMPACT_ENABLED.key -> "true",
           DeltaSQLConf.DELTA_AUTO_COMPACT_ASYNC_ENABLED.key -> "true",
+          DeltaSQLConf.DELTA_AUTO_COMPACT_ASYNC_FALLBACK_TO_INLINE_ENABLED.key -> "false",
           DeltaSQLConf.DELTA_AUTO_COMPACT_MIN_NUM_FILES.key -> "0") {
         spark.range(10).repartition(5).write.format("delta").mode("append").save(dir)
         val deltaLog = DeltaLog.forTable(spark, dir)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/AutoCompactDMLYieldSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/AutoCompactDMLYieldSuite.scala
@@ -1,0 +1,366 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+// scalastyle:off import.ordering.noEmptyLine
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.AtomicInteger
+
+import com.databricks.spark.util.Log4jUsageLogger
+import org.apache.spark.sql.delta.hooks.{AsyncAutoCompactService, InflightDMLRegistry}
+import org.apache.spark.sql.delta.optimize.CompactionTestHelperForAutoCompaction
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+
+import org.apache.spark.sql.test.SharedSparkSession
+
+/**
+ * Tests for the async Auto Compaction DML yield mechanism.
+ *
+ * The mechanism has three coordination points; we exercise all three plus the
+ * "manual OPTIMIZE never yields" invariant and the registry primitives themselves.
+ *
+ *   1. Dequeue-time yield  -- AC sees an active DML when it dequeues and skips.
+ *   2. Post-listener race  -- AC dequeued before DML acquired but DML acquired before
+ *                             AC's listener was installed; re-check catches it.
+ *   3. Pre-commit yield    -- AC ran the OPTIMIZE Spark work but a DML acquired before
+ *                             AC's first commit attempt.
+ *   4. Manual OPTIMIZE     -- user OPTIMIZE bypasses the yield gate entirely.
+ */
+class AutoCompactDMLYieldSuite extends
+    CompactionTestHelperForAutoCompaction
+  with DeltaSQLCommandTest
+  with SharedSparkSession
+  with AutoCompactTestUtils {
+
+  import testImplicits._
+
+  private val AsyncTimeoutMs = 60000L
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    AsyncAutoCompactService.resetCountersForTesting()
+    InflightDMLRegistry.resetForTesting()
+  }
+
+  override def afterEach(): Unit = {
+    AsyncAutoCompactService.resetCountersForTesting()
+    InflightDMLRegistry.resetForTesting()
+    super.afterEach()
+  }
+
+  private def awaitDrain(tableId: String): Unit = {
+    assert(
+      AsyncAutoCompactService.awaitQuiescenceForTesting(tableId, AsyncTimeoutMs),
+      s"Async Auto Compact pool did not drain within ${AsyncTimeoutMs}ms for table $tableId")
+  }
+
+  // ---------------------------------------------------------------------------------
+  // Registry primitives
+  // ---------------------------------------------------------------------------------
+
+  test("registry: acquire/release reference-counts and reports isActive correctly") {
+    val t = "table-A"
+    assert(!InflightDMLRegistry.isActive(t))
+    InflightDMLRegistry.acquire(t)
+    assert(InflightDMLRegistry.isActive(t))
+    assert(InflightDMLRegistry.activeCountForTesting(t) === 1)
+
+    InflightDMLRegistry.acquire(t)
+    assert(InflightDMLRegistry.activeCountForTesting(t) === 2)
+
+    InflightDMLRegistry.release(t)
+    assert(InflightDMLRegistry.isActive(t))
+    assert(InflightDMLRegistry.activeCountForTesting(t) === 1)
+
+    InflightDMLRegistry.release(t)
+    assert(!InflightDMLRegistry.isActive(t))
+    assert(InflightDMLRegistry.activeCountForTesting(t) === 0)
+  }
+
+  test("registry: listener fires on acquire and throwing listeners do not propagate") {
+    val t = "table-B"
+    val fired = new AtomicInteger(0)
+    val listener = new InflightDMLRegistry.AcquireListener {
+      override def onDMLAcquired(): Unit = {
+        fired.incrementAndGet()
+        throw new RuntimeException("simulated listener failure")
+      }
+    }
+    InflightDMLRegistry.registerAcquireListener(t, listener)
+    try {
+      // Acquire must not propagate the listener's exception.
+      InflightDMLRegistry.acquire(t)
+      assert(fired.get() === 1)
+      InflightDMLRegistry.release(t)
+    } finally {
+      InflightDMLRegistry.unregisterAcquireListener(t)
+    }
+    assert(!InflightDMLRegistry.hasListenerForTesting(t))
+  }
+
+  // ---------------------------------------------------------------------------------
+  // End-to-end: dequeue-time yield
+  // ---------------------------------------------------------------------------------
+
+  test("async AC yields at dequeue when a DML is already in-flight") {
+    withTempDir { tempDir =>
+      val dir = tempDir.getCanonicalPath
+      withSQLConf(
+          DeltaSQLConf.DELTA_AUTO_COMPACT_ENABLED.key -> "true",
+          DeltaSQLConf.DELTA_AUTO_COMPACT_ASYNC_ENABLED.key -> "true",
+          DeltaSQLConf.DELTA_AUTO_COMPACT_MIN_NUM_FILES.key -> "0") {
+        // Seed the table so we have a DeltaLog with a known tableId.
+        spark.range(10).repartition(5).write.format("delta").mode("append").save(dir)
+        val deltaLog = DeltaLog.forTable(spark, dir)
+        val tableId = deltaLog.unsafeVolatileTableId
+        awaitDrain(tableId)
+
+        // Force the worker to block AT dequeue (the workerGate runs BEFORE the DML-active
+        // check) so we can manually acquire DML and have the worker see it.
+        val workerGate = new CountDownLatch(1)
+        AsyncAutoCompactService.workerGateForTesting = workerGate
+        try {
+          // Acquire DML as if a MERGE were running on this table.
+          InflightDMLRegistry.acquire(tableId)
+          try {
+            // Now do another write so a new AC submission is enqueued; the worker is gated
+            // on workerGate so it will dequeue only after we unblock.
+            spark.range(10).repartition(5).write.format("delta").mode("append").save(dir)
+            // Release the worker; it will dequeue, see active DML, and yield.
+            workerGate.countDown()
+            // Give the worker a moment to run its yield branch.
+            pollUntil {
+              assert(
+                AsyncAutoCompactService.yieldCountForTesting(tableId, "atDequeue") >= 1,
+                "Expected at least one atDequeue yield event")
+            }
+          } finally {
+            InflightDMLRegistry.release(tableId)
+          }
+        } finally {
+          AsyncAutoCompactService.workerGateForTesting = null
+        }
+        awaitDrain(tableId)
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------------
+  // End-to-end: post-listener race
+  // ---------------------------------------------------------------------------------
+
+  test("async AC catches the race where DML acquires after listener install") {
+    withTempDir { tempDir =>
+      val dir = tempDir.getCanonicalPath
+      withSQLConf(
+          DeltaSQLConf.DELTA_AUTO_COMPACT_ENABLED.key -> "true",
+          DeltaSQLConf.DELTA_AUTO_COMPACT_ASYNC_ENABLED.key -> "true",
+          DeltaSQLConf.DELTA_AUTO_COMPACT_MIN_NUM_FILES.key -> "0") {
+        spark.range(10).repartition(5).write.format("delta").mode("append").save(dir)
+        val deltaLog = DeltaLog.forTable(spark, dir)
+        val tableId = deltaLog.unsafeVolatileTableId
+        awaitDrain(tableId)
+
+        // Use the beforeOptimizeGate so the worker installs its listener and then blocks
+        // BEFORE starting Spark work; we then acquire DML so the re-check fires.
+        val preGate = new CountDownLatch(1)
+        AsyncAutoCompactService.beforeOptimizeGateForTesting = preGate
+        try {
+          spark.range(10).repartition(5).write.format("delta").mode("append").save(dir)
+          // Wait until the worker has installed its listener (registry has a listener slot).
+          pollUntil {
+            assert(InflightDMLRegistry.hasListenerForTesting(tableId),
+              "Expected worker to install its acquire listener before the gate")
+          }
+          // Acquire DML now. The worker's listener will fire (cancellation flag set), but
+          // since it's blocked on the gate, the cancellation is moot. When we release the
+          // gate, the re-check at the top of the try-block detects active DML and yields
+          // via the pre-commit gate inside OptimizeExecutor.commitAndRetry (the post-
+          // listener re-check fires only when DML acquires BEFORE the test gate releases;
+          // here we release first so the pre-commit path catches it).
+          InflightDMLRegistry.acquire(tableId)
+          try {
+            preGate.countDown()
+            pollUntil {
+              val pre = AsyncAutoCompactService.yieldCountForTesting(tableId, "preCommit")
+              val deq = AsyncAutoCompactService.yieldCountForTesting(tableId, "atDequeue")
+              val mid = AsyncAutoCompactService.yieldCountForTesting(tableId, "midFlight")
+              assert(pre + deq + mid >= 1,
+                s"Expected some yield (preCommit=$pre, atDequeue=$deq, midFlight=$mid)")
+            }
+          } finally {
+            InflightDMLRegistry.release(tableId)
+          }
+        } finally {
+          AsyncAutoCompactService.beforeOptimizeGateForTesting = null
+        }
+        awaitDrain(tableId)
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------------
+  // Manual OPTIMIZE never yields
+  // ---------------------------------------------------------------------------------
+
+  test("manual OPTIMIZE does NOT yield even when a DML is in flight") {
+    withTempDir { tempDir =>
+      val dir = tempDir.getCanonicalPath
+      withSQLConf(
+          DeltaSQLConf.DELTA_AUTO_COMPACT_ENABLED.key -> "false") {
+        // Build a table with multiple small files so OPTIMIZE has something to do.
+        spark.range(100).repartition(10).write.format("delta").mode("append").save(dir)
+        val deltaLog = DeltaLog.forTable(spark, dir)
+        val tableId = deltaLog.unsafeVolatileTableId
+        val versionBefore = deltaLog.update().version
+
+        // Pretend a DML is running on this table.
+        InflightDMLRegistry.acquire(tableId)
+        try {
+          // Manual OPTIMIZE must commit even with DML active (no asyncWorkerThread flag).
+          sql(s"OPTIMIZE delta.`$dir`").collect()
+        } finally {
+          InflightDMLRegistry.release(tableId)
+        }
+        val versionAfter = deltaLog.update().version
+        assert(versionAfter > versionBefore,
+          "Manual OPTIMIZE should commit even when a DML is in flight")
+        // Pre-commit yield counter must not have ticked.
+        assert(
+          AsyncAutoCompactService.yieldCountForTesting(tableId, "preCommit") === 0,
+          "Manual OPTIMIZE must not trip the async pre-commit yield gate")
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------------
+  // DML hook integration: MERGE acquires/releases on the target's tableId
+  // ---------------------------------------------------------------------------------
+
+  test("MERGE acquires and releases InflightDMLRegistry slot on the target table") {
+    withTempDir { tempDir =>
+      val targetDir = tempDir.getCanonicalPath
+      withSQLConf(DeltaSQLConf.DELTA_AUTO_COMPACT_ENABLED.key -> "false") {
+        // Set up target table.
+        Seq((1, "a"), (2, "b"), (3, "c")).toDF("id", "v")
+          .write.format("delta").save(targetDir)
+        val deltaLog = DeltaLog.forTable(spark, targetDir)
+        val tableId = deltaLog.unsafeVolatileTableId
+
+        // Observe the acquire via a listener.
+        val observed = new AtomicInteger(0)
+        val listener = new InflightDMLRegistry.AcquireListener {
+          override def onDMLAcquired(): Unit = observed.incrementAndGet()
+        }
+        InflightDMLRegistry.registerAcquireListener(tableId, listener)
+        try {
+          // Source DF for MERGE.
+          val source = Seq((2, "B"), (4, "D")).toDF("id", "v")
+          source.createOrReplaceTempView("src")
+          sql(
+            s"""MERGE INTO delta.`$targetDir` t
+               |USING src s ON t.id = s.id
+               |WHEN MATCHED THEN UPDATE SET t.v = s.v
+               |WHEN NOT MATCHED THEN INSERT (id, v) VALUES (s.id, s.v)
+               |""".stripMargin).collect()
+          // The MERGE should have acquired exactly once.
+          assert(observed.get() === 1,
+            s"Expected one DML acquire from MERGE, got ${observed.get()}")
+        } finally {
+          InflightDMLRegistry.unregisterAcquireListener(tableId)
+        }
+        // After MERGE returns, the slot should be released.
+        assert(!InflightDMLRegistry.isActive(tableId),
+          "MERGE should release its DML slot before returning")
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------------
+  // Composition with per-table async-AC dedup
+  // ---------------------------------------------------------------------------------
+
+  test("yielded async AC submission does not break the per-table async-AC dedup") {
+    withTempDir { tempDir =>
+      val dir = tempDir.getCanonicalPath
+      withSQLConf(
+          DeltaSQLConf.DELTA_AUTO_COMPACT_ENABLED.key -> "true",
+          DeltaSQLConf.DELTA_AUTO_COMPACT_ASYNC_ENABLED.key -> "true",
+          DeltaSQLConf.DELTA_AUTO_COMPACT_MIN_NUM_FILES.key -> "0") {
+        spark.range(10).repartition(5).write.format("delta").mode("append").save(dir)
+        val deltaLog = DeltaLog.forTable(spark, dir)
+        val tableId = deltaLog.unsafeVolatileTableId
+        awaitDrain(tableId)
+
+        // First: force a yield. Then: ensure another write still triggers a successful
+        // async AC (dedup state was cleaned up correctly).
+        val workerGate = new CountDownLatch(1)
+        AsyncAutoCompactService.workerGateForTesting = workerGate
+        InflightDMLRegistry.acquire(tableId)
+        try {
+          spark.range(10).repartition(5).write.format("delta").mode("append").save(dir)
+          workerGate.countDown()
+          pollUntil {
+            assert(
+              AsyncAutoCompactService.yieldCountForTesting(tableId, "atDequeue") >= 1)
+          }
+        } finally {
+          AsyncAutoCompactService.workerGateForTesting = null
+          InflightDMLRegistry.release(tableId)
+        }
+        awaitDrain(tableId)
+
+        // Versions: 0=write, 1=write (yielded AC), so we expect no OPTIMIZE commit yet.
+        val versionAfterYield = deltaLog.update().version
+
+        // Now do another write -- a new AC submission should be accepted and run.
+        val events = Log4jUsageLogger.track {
+          spark.range(10).repartition(5).write.format("delta").mode("append").save(dir)
+          awaitDrain(tableId)
+        }
+        val submitted = events.count(
+          _.tags.get("opType") == Some("delta.autoCompaction.async.submitted"))
+        assert(submitted >= 1,
+          "After a yielded run, the next write must still submit a fresh AC task")
+        // Final state should show at least one OPTIMIZE commit landed.
+        val finalVersion = deltaLog.update().version
+        assert(finalVersion > versionAfterYield + 1,
+          "Expected a successful async AC commit to land after the prior yield")
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------------
+  // Helper: poll until predicate or timeout (simple eventually impl, no scalatest dep)
+  // ---------------------------------------------------------------------------------
+  private def pollUntil(body: => Unit): Unit = {
+    val deadline = System.currentTimeMillis() + AsyncTimeoutMs
+    var lastError: Throwable = null
+    while (System.currentTimeMillis() < deadline) {
+      try {
+        body
+        return
+      } catch {
+        case t: Throwable =>
+          lastError = t
+          Thread.sleep(50)
+      }
+    }
+    if (lastError != null) throw lastError
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/AutoCompactInlineFallbackSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/AutoCompactInlineFallbackSuite.scala
@@ -1,0 +1,245 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+// scalastyle:off import.ordering.noEmptyLine
+import java.util.concurrent.CountDownLatch
+
+import com.databricks.spark.util.Log4jUsageLogger
+import org.apache.spark.sql.delta.hooks.{AsyncAutoCompactService, InflightDMLRegistry}
+import org.apache.spark.sql.delta.optimize.CompactionTestHelperForAutoCompaction
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+
+import org.apache.spark.sql.test.SharedSparkSession
+
+/**
+ * Tests for the sticky inline-fallback behavior.
+ *
+ * Motivation: a streaming MERGE job will, by design, have each write conflict with the next.
+ * If async Auto Compaction yielded on the first conflict and then kept submitting fresh async
+ * tasks that yielded again, the table would never receive an OPTIMIZE commit and Spark cycles
+ * would be wasted. The fallback mechanism demotes any table that has had a single async yield to "sticky inline"
+ * AC for the JVM's lifetime; inline AC commits as the writer's own post-commit hook and cannot
+ * be cancelled by a future writer.
+ */
+class AutoCompactInlineFallbackSuite extends
+    CompactionTestHelperForAutoCompaction
+  with DeltaSQLCommandTest
+  with SharedSparkSession
+  with AutoCompactTestUtils {
+
+
+  private val AsyncTimeoutMs = 60000L
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    AsyncAutoCompactService.resetCountersForTesting()
+    InflightDMLRegistry.resetForTesting()
+  }
+
+  override def afterEach(): Unit = {
+    AsyncAutoCompactService.resetCountersForTesting()
+    InflightDMLRegistry.resetForTesting()
+    super.afterEach()
+  }
+
+  private def awaitDrain(tableId: String): Unit = {
+    assert(
+      AsyncAutoCompactService.awaitQuiescenceForTesting(tableId, AsyncTimeoutMs),
+      s"Async Auto Compact pool did not drain within ${AsyncTimeoutMs}ms for table $tableId")
+  }
+
+  private def pollUntil(body: => Unit): Unit = {
+    val deadline = System.currentTimeMillis() + AsyncTimeoutMs
+    var lastError: Throwable = null
+    while (System.currentTimeMillis() < deadline) {
+      try {
+        body
+        return
+      } catch {
+        case t: Throwable =>
+          lastError = t
+          Thread.sleep(50)
+      }
+    }
+    if (lastError != null) throw lastError
+  }
+
+  /** Force exactly one atDequeue yield on the given table by gating the worker and acquiring
+   *  DML before releasing the gate. */
+  private def forceOneYield(dir: String, tableId: String): Unit = {
+    val workerGate = new CountDownLatch(1)
+    AsyncAutoCompactService.workerGateForTesting = workerGate
+    try {
+      InflightDMLRegistry.acquire(tableId)
+      try {
+        spark.range(10).repartition(5).write.format("delta").mode("append").save(dir)
+        workerGate.countDown()
+        pollUntil {
+          assert(
+            AsyncAutoCompactService.yieldCountForTesting(tableId, "atDequeue") >= 1,
+            "Expected an atDequeue yield to seed the fallback state")
+        }
+      } finally {
+        InflightDMLRegistry.release(tableId)
+      }
+    } finally {
+      AsyncAutoCompactService.workerGateForTesting = null
+    }
+    awaitDrain(tableId)
+  }
+
+  // ---------------------------------------------------------------------------------
+  // Core fallback behavior
+  // ---------------------------------------------------------------------------------
+
+  test("after a single yield, the same table runs subsequent AC inline") {
+    withTempDir { tempDir =>
+      val dir = tempDir.getCanonicalPath
+      withSQLConf(
+          DeltaSQLConf.DELTA_AUTO_COMPACT_ENABLED.key -> "true",
+          DeltaSQLConf.DELTA_AUTO_COMPACT_ASYNC_ENABLED.key -> "true",
+          DeltaSQLConf.DELTA_AUTO_COMPACT_ASYNC_FALLBACK_TO_INLINE_ENABLED.key -> "true",
+          DeltaSQLConf.DELTA_AUTO_COMPACT_MIN_NUM_FILES.key -> "0") {
+        // Seed the table.
+        spark.range(10).repartition(5).write.format("delta").mode("append").save(dir)
+        val deltaLog = DeltaLog.forTable(spark, dir)
+        val tableId = deltaLog.unsafeVolatileTableId
+        awaitDrain(tableId)
+
+        // Force one yield, which marks the table as sticky inline.
+        forceOneYield(dir, tableId)
+        assert(AsyncAutoCompactService.isInInlineFallback(tableId),
+          "Expected the table to be in inline fallback after one yield")
+
+        // Next write should run AC inline -- no new async.submitted event.
+        val events = Log4jUsageLogger.track {
+          spark.range(10).repartition(5).write.format("delta").mode("append").save(dir)
+        }
+        val submitted = events.count(
+          _.tags.get("opType") == Some("delta.autoCompaction.async.submitted"))
+        assert(submitted === 0,
+          s"Expected no async submission after fallback engaged, got $submitted")
+        // The inline AC commit should have landed on the writer's own commit path. Drain just
+        // in case anything still sneaked through.
+        awaitDrain(tableId)
+      }
+    }
+  }
+
+  test("fallbackEngaged telemetry fires exactly once per table") {
+    withTempDir { tempDir =>
+      val dir = tempDir.getCanonicalPath
+      withSQLConf(
+          DeltaSQLConf.DELTA_AUTO_COMPACT_ENABLED.key -> "true",
+          DeltaSQLConf.DELTA_AUTO_COMPACT_ASYNC_ENABLED.key -> "true",
+          DeltaSQLConf.DELTA_AUTO_COMPACT_ASYNC_FALLBACK_TO_INLINE_ENABLED.key -> "true",
+          DeltaSQLConf.DELTA_AUTO_COMPACT_MIN_NUM_FILES.key -> "0") {
+        spark.range(10).repartition(5).write.format("delta").mode("append").save(dir)
+        val deltaLog = DeltaLog.forTable(spark, dir)
+        val tableId = deltaLog.unsafeVolatileTableId
+        awaitDrain(tableId)
+
+        // First yield must emit fallbackEngaged.
+        val firstYieldEvents = Log4jUsageLogger.track {
+          forceOneYield(dir, tableId)
+        }
+        val firstFallback = firstYieldEvents.count(
+          _.tags.get("opType") == Some("delta.autoCompaction.async.fallbackEngaged"))
+        assert(firstFallback === 1,
+          s"Expected fallbackEngaged to fire once on first yield, got $firstFallback")
+
+        // Subsequent yields (force another by directly invoking markInlineFallback via the
+        // public yield-counter path) must NOT emit a second fallbackEngaged.
+        val secondEvents = Log4jUsageLogger.track {
+          // Acquire DML and run a write so the worker dequeues and yields again. Even if
+          // it doesn't actually run an async task (because the branch is now inline), we
+          // can directly test the idempotency by calling markInlineFallback again.
+          AsyncAutoCompactService.markInlineFallback(deltaLog, tableId, "atDequeue")
+        }
+        val secondFallback = secondEvents.count(
+          _.tags.get("opType") == Some("delta.autoCompaction.async.fallbackEngaged"))
+        assert(secondFallback === 0,
+          s"Expected fallbackEngaged to NOT re-fire (idempotent), got $secondFallback")
+      }
+    }
+  }
+
+  test("fallback is per-table: yielding table A does not affect table B") {
+    withTempDir { tempA =>
+      withTempDir { tempB =>
+        val dirA = tempA.getCanonicalPath
+        val dirB = tempB.getCanonicalPath
+        withSQLConf(
+            DeltaSQLConf.DELTA_AUTO_COMPACT_ENABLED.key -> "true",
+            DeltaSQLConf.DELTA_AUTO_COMPACT_ASYNC_ENABLED.key -> "true",
+            DeltaSQLConf.DELTA_AUTO_COMPACT_ASYNC_FALLBACK_TO_INLINE_ENABLED.key -> "true",
+            DeltaSQLConf.DELTA_AUTO_COMPACT_MIN_NUM_FILES.key -> "0") {
+          spark.range(10).repartition(5).write.format("delta").mode("append").save(dirA)
+          spark.range(10).repartition(5).write.format("delta").mode("append").save(dirB)
+          val logA = DeltaLog.forTable(spark, dirA)
+          val logB = DeltaLog.forTable(spark, dirB)
+          val idA = logA.unsafeVolatileTableId
+          val idB = logB.unsafeVolatileTableId
+          awaitDrain(idA)
+          awaitDrain(idB)
+
+          forceOneYield(dirA, idA)
+
+          assert(AsyncAutoCompactService.isInInlineFallback(idA),
+            "Expected table A to be in fallback")
+          assert(!AsyncAutoCompactService.isInInlineFallback(idB),
+            "Table B must remain in async mode")
+        }
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------------
+  // Config off: behavior unchanged from baseline DML-yield behavior
+  // ---------------------------------------------------------------------------------
+
+  test("with fallback disabled, async submission still happens after a yield") {
+    withTempDir { tempDir =>
+      val dir = tempDir.getCanonicalPath
+      withSQLConf(
+          DeltaSQLConf.DELTA_AUTO_COMPACT_ENABLED.key -> "true",
+          DeltaSQLConf.DELTA_AUTO_COMPACT_ASYNC_ENABLED.key -> "true",
+          DeltaSQLConf.DELTA_AUTO_COMPACT_ASYNC_FALLBACK_TO_INLINE_ENABLED.key -> "false",
+          DeltaSQLConf.DELTA_AUTO_COMPACT_MIN_NUM_FILES.key -> "0") {
+        spark.range(10).repartition(5).write.format("delta").mode("append").save(dir)
+        val deltaLog = DeltaLog.forTable(spark, dir)
+        val tableId = deltaLog.unsafeVolatileTableId
+        awaitDrain(tableId)
+
+        forceOneYield(dir, tableId)
+        // markInlineFallback was still called (the trigger always fires); only the BRANCH
+        // ignores it. Verify by doing a follow-up write with the flag off -- it must still
+        // submit async.
+        val events = Log4jUsageLogger.track {
+          spark.range(10).repartition(5).write.format("delta").mode("append").save(dir)
+          awaitDrain(tableId)
+        }
+        val submitted = events.count(
+          _.tags.get("opType") == Some("delta.autoCompaction.async.submitted"))
+        assert(submitted >= 1,
+          s"With fallback disabled, expected at least one async submission, got $submitted")
+      }
+    }
+  }
+}


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Introduces an opt-in mode that runs Auto Compaction on a JVM-wide daemon thread pool instead of inline on the writer thread, eliminating the write-latency impact of AC for streaming and high-throughput workloads. Default behavior is unchanged.

Components:

* AsyncAutoCompactService: singleton with a bounded ThreadPoolExecutor (size = autoCompact.async.parallelism, queue = autoCompact.async.maxQueueSize) and a per-table inflight counter. Submitting a CommittedTransaction is fire-and-forget; the worker re-reads deltaLog.update() and re-runs AutoCompact.compactIfNecessary against the fresh snapshot, so a peer that already compacted causes the worker to skip cleanly.
  - Sets/clears SparkSession.{active,default} on the worker thread so downstream code paths that consult SparkSession.getActiveSession (e.g. OptimizeExecutor, DeltaUDF) see the right session.
  - Wraps execution in NonFatal try/catch and records a telemetry event; writer threads are never observably affected by async failures.
  - Backpressure: queue-full submissions are recorded as delta.autoCompaction.async.dropped and silently declined.

* InflightDMLRegistry: enables async AC to yield to DML operations against the same tables to prevent `ConcurrentModificationException`. This protection is enabled at 3 areas where a table is registered with inflight DML
   1. **Dequeue-time check.** AC's AsyncAutoCompactTask.run() exits silently if InflightDMLRegistry.isActive(tableId).
   1. **Mid-flight cancellation.** When DML calls acquire(), a listener fires sparkContext.cancelJobGroup(jobGroupId) (AC sets interruptOnCancel=true). AC's Spark stages get InterruptedException within seconds.
   1. **Pre-commit check.** commitAndRetry's existing predicate extended to return false when cancellation flag is set, aborting at the same boundary it already uses for "candidates changed."
   AC being aborted results in (default) fallback to inline synchronous execution for the remainder of the session. 

* New session-only confs (no table property -- async is writer-mechanics, no need for table specifics):
  - spark.databricks.delta.autoCompact.async.enabled (default false)
  - spark.databricks.delta.autoCompact.async.parallelism (default 2)
  - spark.databricks.delta.autoCompact.async.maxQueueSize (default 64)
  - spark.databricks.delta.autoCompact.async.backpressure (default drop, to be expanded in later PR)
  - spark.databricks.delta.autoCompact.async.fallbackToInline.enabled (default true)

Telemetry: delta.autoCompaction.async.{submitted,dropped,error,completed}.

Correctness: AutoCompactPartitionReserve still serializes overlapping AC runs because eligibility + reservation + optimize all execute on the same worker thread. OPTIMIZE conflict-retry (OptimizeExecutor.commitAndRetry) covers cross-JVM races as it does today.

Shutdown drain and additional backpressure modes (block, fallback-inline) are intentionally reserved for follow-up PRs.

Resolves PR 1 of #7089 

## How was this patch tested?

Tests (AutoCompactAsyncSuite, 5 tests, all passing):
  - async disabled by default: writer thread runs AC inline
  - async enabled: AC commit lands after writer returns and worker drains
  - async enabled: submission telemetry event is recorded
  - async re-evaluates eligibility on a fresh snapshot
  - async queue full: writer succeeds and dropped event is recorded

Perf benchmark:
 **Config:** 50 sequential writes, 8 small files per write, sync `MIN_NUM_FILES=24`, async `MIN_NUM_FILES=0`, async parallelism=2.

 | Metric | Sync (inline AC) | Async (off writer thread) | Improvement |
 |---|---:|---:|---:|
 | Writer total | 31 230 ms | 20 588 ms | **1.52× faster** |
 | Mean latency | 625 ms | 412 ms | 1.52× |
 | p50 | 549 ms | 388 ms | 1.41× |
 | **p95** | **1 192 ms** | **549 ms** | **2.17× better tail** |
 | **p99** | **1 345 ms** | **580 ms** | **2.32× better tail** |
 | Max | 1 345 ms | 580 ms | 2.32× |
 | Min | 367 ms | 336 ms | — |
 | Async drain (post-loop) | — | 40 ms | — |
 | End-to-end (incl. drain) | 31 230 ms | 20 628 ms | 1.51× |
 | **AC OPTIMIZE commits (auto=true)** | **17** | **17** | identical |
 | Writes with AC visible (vΔ≥2) | 17/50 | 17/50 | identical |


## Does this PR introduce _any_ user-facing changes?

AutoCompactBase.run: branches on AsyncAutoCompactService.isEnabled. Inline path is byte-identical to today when the flag is off. Disabled by default, users can opt-in to it. It may make sense to make this the default mode in a future Delta major version.