### PR TITLE
[PROTOCOL][DISCUSSION] Empty string for string type partition columns

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -2702,11 +2702,11 @@ The corresponding human-readable form is:
 
 ## Partition Value Serialization
 
-Partition values are stored as strings, using the following formats. An empty string for any type translates to a `null` partition value.
+Partition values are stored as strings, using the following formats. An empty string for any type except `string` deserialize to `null`.
 
 Type | Serialization Format
 -|-
-string | No translation required
+string | No translation required, except an empty string translates to `null`
 numeric types | The string representation of the number
 date | Encoded as `{year}-{month}-{day}`. For example, `1970-01-01`
 timestamp | Encoded as `{year}-{month}-{day} {hour}:{minute}:{second}` or `{year}-{month}-{day} {hour}:{minute}:{second}.{microsecond}`. For example: `1970-01-01 00:00:00`, or `1970-01-01 00:00:00.123456`. Timestamps may also be encoded as an ISO8601 formatted timestamp adjusted to UTC timestamp such as `1970-01-01T00:00:00.123456Z`


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (protocol)

## Description

## Note

@DrakeLin @Jameson-Crate and I found a mismatch between spark and protocol:

According the delta protocol, for string type partition columns, empty strings will be serialized as "" in json commits, and read back as null.

Spark behaves differently: serialized empty string as null. If the partition value in json commits is "", spark read back as "".

**Example 1 — write** `INSERT INTO t VALUES ('a', '')` (partition col `p = ''`):

  | | `partitionValues` in JSON commit  |
  |---|---|
  | Protocol | `{"p": ""}`  |
  | Spark| `{"p": null}` |

  **Example 2 — read** commit already has `partitionValues: {"p": ""}`, then `SELECT p`:

  | | result |
  |---|---|
  | Protocol | `null` |
  | Spark| `''` (empty string) |


I feel like we have several options:
- Change the protocol to align with spark 
  - Not breaking, but lose the ability to distinguish "" vs `null`
- Change both protocol and spark
  - For string partition columns, just leave it as it was on both read and write
    - Breaking, but provide the ability to distinguish "" vs `null`

Or maybe other solutions?


<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
