### PR TITLE
Document the udt (UserDefinedType) data type disposition

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -2748,6 +2748,8 @@ See Parquet [timestamp type](https://github.com/apache/parquet-format/blob/maste
 
 Note: Existing tables may have `void` data type columns. Behavior is undefined for `void` data type columns but it is recommended to drop any `void` data type columns on reads (as is implemented by the Spark connector).
 
+Note: Existing tables may contain columns of Spark's `udt` (UserDefinedType) complex type, serialized as `{"type":"udt", "class"/"pyClass"/"serializedClass", "sqlType": <type>}`. The `class`/`pyClass` identify engine-specific (JVM/Python) deserialization code and are not part of this protocol. A reader that does not implement that engine code MUST interpret the column as its physical `sqlType`; the `sqlType` is the on-disk Parquet representation. Writers that preserve a `udt` column MUST store its data physically as `sqlType` and retain the annotation in `schemaString`.
+
 ### Struct Type
 
 A struct is used to represent both the top-level schema of the table as well as struct columns that contain nested columns. A struct is encoded as a JSON object with the following fields:


### PR DESCRIPTION
## Description

Spark writes `UserDefinedType` (`udt`) columns into `metaData.schemaString`, but the protocol's schema serialization type system does not define `udt` (only primitive / struct / array / map / variant). Such columns are therefore non-conformant today even though they already exist in tables in the wild, and a reader that rejects the unknown type fails to read the entire table.

This adds a note under **Schema Serialization Format > Primitive Types**, parallel to the existing `void` note, documenting the disposition rather than gating it behind a table feature:

> Existing tables may contain columns of Spark's `udt` (UserDefinedType) complex type... A reader that does not implement that engine code MUST interpret the column as its physical `sqlType`; the `sqlType` is the on-disk Parquet representation.

**Why no table feature:** `udt` introduces no new physical representation. It is an engine-specific annotation (`class`/`pyClass` reference JVM/Python deserialization code) over an existing physical type. A UDT-unaware reader that reads the `sqlType` reads correct data, so unlike `timestampNtz`/`variant` there is nothing for a reader to opt into. This mirrors the `void` precedent.

A companion kernel implementation (`DataType::UserDefined` read support in delta-kernel-rs) is proposed separately.

## How was this patch tested?

Documentation-only change.

## Does this PR introduce _any_ user-facing changes?

No behavioral change. Documents the disposition of an existing, previously-undocumented data type that Spark already writes.

_Authored with assistance from Claude Code._