### PR TITLE
[Spark] Support loading a DSv2 (Kernel) table at a specific timestamp

### DIFF
--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
@@ -23,8 +23,10 @@ import static java.util.Objects.requireNonNull;
 import io.delta.kernel.Snapshot;
 import io.delta.kernel.defaults.engine.DefaultEngine;
 import io.delta.kernel.engine.Engine;
+import io.delta.kernel.internal.DeltaHistoryManager;
 import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.internal.rowtracking.RowTracking;
+import io.delta.spark.internal.v2.exception.TimestampOutOfRangeException;
 import io.delta.spark.internal.v2.read.MetadataEvolutionHandler;
 import io.delta.spark.internal.v2.read.SparkScanBuilder;
 import io.delta.spark.internal.v2.read.cdc.CDCSchemaContext;
@@ -334,6 +336,38 @@ public class DeltaV2Table
     return catalogTable.isPresent()
         ? new DeltaV2Table(identifier, catalogTable.get(), options, OptionalLong.of(version))
         : new DeltaV2Table(identifier, tablePath, options, OptionalLong.of(version));
+  }
+
+  /** Returns a copy of this table pinned to the snapshot active at {@code timestampMicros}. */
+  public DeltaV2Table withTimestamp(long timestampMicros) {
+    return withVersion(resolveTimestampToVersion(snapshotManager, timestampMicros));
+  }
+
+  /**
+   * Resolves a time travel timestamp to the active commit version using the Kernel snapshot
+   * manager.
+   *
+   * <p>This loads the latest snapshot more than once (here and inside the Kernel lookup), make it
+   * share a singular load once the snapshot manager exposes it TODO(#5999).
+   */
+  private static long resolveTimestampToVersion(
+      DeltaSnapshotManager manager, long timestampMicros) {
+    long timeMillis = timestampMicros / 1000;
+    DeltaHistoryManager.Commit commit =
+        manager.getActiveCommitAtTime(
+            timeMillis,
+            /* canReturnLastCommit = */ true,
+            /* mustBeRecreatable = */ true,
+            /* canReturnEarliestCommit = */ true);
+    long latestVersion = manager.loadLatestSnapshot().getVersion();
+    if (commit.getTimestamp() > timeMillis) {
+      // The earliest available commit is younger than the requested time.
+      throw new TimestampOutOfRangeException(timeMillis, commit.getTimestamp(), false);
+    } else if (commit.getVersion() == latestVersion && commit.getTimestamp() < timeMillis) {
+      // The requested time is after the latest commit.
+      throw new TimestampOutOfRangeException(timeMillis, commit.getTimestamp(), true);
+    }
+    return commit.getVersion();
   }
 
   /**

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/exception/TimestampOutOfRangeException.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/exception/TimestampOutOfRangeException.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.exception;
+
+/** Exception thrown when a requested time travel timestamp is outside the table's commit range. */
+public class TimestampOutOfRangeException extends RuntimeException {
+
+  private final long userMillis;
+  private final long commitMillis;
+  private final boolean afterLatest;
+
+  public TimestampOutOfRangeException(long userMillis, long commitMillis, boolean afterLatest) {
+    super(
+        String.format(
+            "Cannot time travel Delta table to the requested timestamp (%d ms): it is %s the "
+                + "available commit range (nearest commit at %d ms).",
+            userMillis,
+            afterLatest ? "after the latest commit" : "before the earliest commit",
+            commitMillis));
+    this.userMillis = userMillis;
+    this.commitMillis = commitMillis;
+    this.afterLatest = afterLatest;
+  }
+
+  public long getUserMillis() {
+    return userMillis;
+  }
+
+  public long getCommitMillis() {
+    return commitMillis;
+  }
+
+  /** Determines if the request is after the latest or before the earliest (recreatable) commit. */
+  public boolean isAfterLatest() {
+    return afterLatest;
+  }
+}

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/catalog/DeltaV2TableTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/catalog/DeltaV2TableTest.java
@@ -968,4 +968,56 @@ public class DeltaV2TableTest extends DeltaV2TestBase {
     assertThrows(RuntimeException.class, () -> table.withVersion(5L));
     assertThrows(RuntimeException.class, () -> table.withVersion(-1L));
   }
+
+  // ---------------------------------------------------------------------------
+  // Time travel: withTimestamp(long)
+  // ---------------------------------------------------------------------------
+
+  /** withTimestamp(t) resolves to the commit active at t and pins to that snapshot. */
+  @Test
+  public void testWithTimestampPinsToHistoricalSnapshot(@TempDir File tempDir) {
+    String path = tempDir.getAbsolutePath();
+    spark.sql(
+        String.format("CREATE TABLE test_with_timestamp (id INT) USING delta LOCATION '%s'", path));
+    spark.sql("ALTER TABLE test_with_timestamp ADD COLUMNS (name STRING)");
+
+    Identifier identifier = Identifier.of(new String[] {"default"}, "test_with_timestamp");
+    DeltaV2Table latest = new DeltaV2Table(identifier, path);
+    assertEquals(2, latest.schema().fields().length);
+
+    // The timestamp of the v0 commit resolves back to v0.
+    long v0Micros =
+        spark
+                .sql("DESCRIBE HISTORY test_with_timestamp")
+                .filter("version = 0")
+                .select("timestamp")
+                .head()
+                .getTimestamp(0)
+                .getTime()
+            * 1000L;
+
+    DeltaV2Table pinned = latest.withTimestamp(v0Micros);
+    assertEquals(1, pinned.schema().fields().length, "pinned table should see the v0 schema");
+    assertEquals("id", pinned.schema().fields()[0].name());
+
+    // The original table is unaffected.
+    assertEquals(2, latest.schema().fields().length);
+    assertNotEquals(latest, pinned);
+  }
+
+  /** withTimestamp fails when the requested timestamp is out of range. */
+  @Test
+  public void testWithTimestampRejectsOutOfRangeTimestamp(@TempDir File tempDir) {
+    String path = tempDir.getAbsolutePath();
+    spark.sql(
+        String.format(
+            "CREATE TABLE test_with_timestamp_oor (id INT) USING delta LOCATION '%s'", path));
+
+    Identifier identifier = Identifier.of(new String[] {"default"}, "test_with_timestamp_oor");
+    DeltaV2Table table = new DeltaV2Table(identifier, path);
+
+    long farFutureMicros = (System.currentTimeMillis() + 365L * 24 * 60 * 60 * 1000) * 1000L;
+    assertThrows(RuntimeException.class, () -> table.withTimestamp(farFutureMicros));
+    assertThrows(RuntimeException.class, () -> table.withTimestamp(0L));
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Adds the ability to pin a `DeltaV2Table` to the specific table version active at a given timestamp:

- New `withTimestamp(long)` method returns a table whose initial snapshot is loaded at the version active at the requested timestamp.
- Timestamp resolution goes through `resolveTimestampToVersion`, which resolves the active commit with `getActiveCommitAtTime` and validates the timestamp is within the available commit range before loading.
- A timestamp before the earliest available commit or after the latest available commit throws `TimestampOutOfRangeException`.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

Added `withTimestamp` tests in `DeltaV2TableTest.java`, additionally tested through the DSv2 connector's existing read paths.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No