### PR TITLE
Add AMT action schema (Checkpoint, ContentRoot, SidecarType)

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
@@ -752,9 +752,10 @@ object Checkpoints
           .where("add is not null or remove is not null")
       } else {
         // When V2 Checkpoint is disabled, the baseCheckpoint refers to the main classic checkpoint
-        // which has all actions except "commitInfo", "cdc", "checkpointMetadata", "sidecar".
+        // which has all actions except "commitInfo", "cdc", "checkpointMetadata", "sidecar",
+        // "checkpoint".
         repartitioned
-          .drop("commitInfo", "cdc", "checkpointMetadata", "sidecar")
+          .drop("commitInfo", "cdc", "checkpointMetadata", "sidecar", "checkpoint")
           .withColumn("remove", col("remove").dropFields("tags", "stats"))
       }
     }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
@@ -425,6 +425,18 @@ object TableFeature {
         TestFeatureWithTransitiveDependency,
         TestWriterFeatureWithTransitiveDependency)
     }
+    val adaptiveMetadataFeatureEnabled =
+      try {
+        SparkSession
+          .getActiveSession
+          .map(_.conf.get(DeltaSQLConf.V4_ADAPTIVE_METADATA_TABLE_PREVIEW_ENABLED))
+          .getOrElse(false)
+      } catch {
+        case _ => false
+      }
+    if (adaptiveMetadataFeatureEnabled) {
+      features += AdaptiveMetadataTableFeature
+    }
     val featureMap = features.map(f => f.name.toLowerCase(Locale.ROOT) -> f).toMap
     require(features.size == featureMap.size, "Lowercase feature names must not duplicate.")
     featureMap
@@ -905,6 +917,15 @@ object DeletionVectorsTableFeature
 
   override def preDowngradeCommand(table: DeltaTableV2): PreDowngradeTableFeatureCommand =
     DeletionVectorsPreDowngradeCommand(table)
+}
+
+object AdaptiveMetadataTableFeature
+  extends ReaderWriterFeature(name = "adaptiveMetadata-preview") {
+
+  // Iceberg v4 manifests reference columns by field ID, so column mapping must be supported on
+  // any table that enables this feature.
+  // TODO(v4amt)(LC-14962): Add other dependencies and Column mapping mode enforcement.
+  override def requiredFeatures: Set[TableFeature] = Set(ColumnMappingTableFeature)
 }
 
 object RowTrackingFeature extends WriterFeature(name = "rowTracking")

--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/InMemoryLogReplay.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/InMemoryLogReplay.scala
@@ -86,6 +86,7 @@ class InMemoryLogReplay(
         }
       case _: CommitInfo => // do nothing
       case _: AddCDCFile => // do nothing
+      case _: Checkpoint => // AMT pointer; the manifest tree is loaded separately.
       case null => // Some crazy future feature. Ignore
     }
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -1568,6 +1568,83 @@ object CommitInfo {
 sealed trait CheckpointOnlyAction extends Action
 
 /**
+ * Pointer to an Iceberg v4 root manifest produced by an AMT commit.
+ *
+ * @param path        root manifest path, relative to the table root.
+ * @param sizeInBytes size of the root manifest file in bytes.
+ */
+case class ContentRoot(
+    path: String,
+    sizeInBytes: Long)
+
+/**
+ * Closed set of values for [[SidecarFile.sidecarType]] under the `adaptiveMetadata-preview`
+ * feature. Tells a reader which slice of the checkpoint's non-content metadata a sidecar
+ * carries.
+ *
+ * Implemented as String constants because the value flows through Spark's case-class encoder
+ * (via [[SingleAction]] -> [[SidecarFile]]), and Spark cannot derive an encoder for a sealed
+ * Scala ADT. Validation belongs to whichever code paths consume the field.
+ */
+object SidecarType {
+  object Type {
+    val DomainMetadata: String = "domainMetadata"
+    val Txn: String = "txn"
+  }
+
+  /** All valid [[SidecarType]] values. */
+  val all: Set[String] = Set(Type.DomainMetadata, Type.Txn)
+
+  /** Returns the given name iff it is a known [[SidecarType]] value; throws otherwise. */
+  def validate(name: String): String = {
+    require(all.contains(name), s"Unknown sidecar type: $name")
+    name
+  }
+}
+
+/**
+ * Top-level Delta action emitted by a commit which also writes AMT.
+ * Embeds the full checkpoint state -- `contentRoot` plus the non-content metadata snapshot
+ * (protocol, metadata, domain metadata, txns, sidecars) -- that a reader needs to
+ * reconstruct the table at the recorded version without replaying earlier commits. Distinct
+ * from [[CheckpointMetadata]], which describes V2 checkpoint sidecars.
+ *
+ * For domain metadata and transaction identifiers, the data can be carried inline, in
+ * sidecars, or split across both (e.g., small changes inline with the bulk in a sidecar).
+ * A given entry must not be duplicated across inline and sidecar.
+ *
+ * @param version        version at which this checkpoint is valid. May belong to a previous
+ *                       commit (the checkpoint can lag the enclosing commit).
+ * @param contentRoot    pointer to the Iceberg v4 root manifest.
+ * @param protocol       protocol snapshot at `version`. Must be non null.
+ * @param metaData       metadata snapshot at `version`. Must be non null.
+ * @param domainMetadata all [[DomainMetadata]] entries carried inline. An empty list means
+ *                       there are no domain metadata entries inline (they may still be
+ *                       carried via sidecars).
+ * @param txns           transaction identifiers carried inline. An empty list means there are
+ *                       no transaction identifiers inline (they may still be carried via
+ *                       sidecars).
+ * @param sidecars       sidecars that carry the long tail of non-content metadata (transaction
+ *                       ids, domain metadata, ...). Empty when all non-content metadata is
+ *                       inline.
+ */
+case class Checkpoint(
+    version: Long,
+    contentRoot: ContentRoot,
+    protocol: Protocol,
+    metaData: Metadata,
+    domainMetadata: Seq[DomainMetadata],
+    txns: Seq[SetTransaction],
+    sidecars: Seq[SidecarFile]) extends Action {
+
+  // AMT checkpoint sidecars must always declare their type.
+  require(sidecars.forall(_.sidecarType.isDefined),
+    "All sidecars in a Checkpoint must have a sidecarType.")
+
+  override def wrap: SingleAction = SingleAction(checkpoint = this)
+}
+
+/**
  * An [[Action]] containing the information about a sidecar file.
  *
  * @param path - sidecar path relative to `_delta_log/_sidecar` directory
@@ -1581,8 +1658,16 @@ case class SidecarFile(
     path: String,
     sizeInBytes: Long,
     modificationTime: Long,
-    tags: Map[String, String] = null)
+    tags: Map[String, String] = null,
+    // Applicable only for AMT checkpoint sidecars.
+    // Sidecars corresponding to V2Checkpoints do not have concept of sidecarType.
+    @JsonProperty("type")
+    @JsonInclude(Include.NON_ABSENT)
+    sidecarType: Option[String] = None)
   extends CheckpointOnlyAction {
+
+  // Either no sidecarType is supplied, or it must be one of the known [[SidecarType]] values.
+  sidecarType.foreach(SidecarType.validate)
 
   override def wrap: SingleAction = SingleAction(sidecar = this)
 
@@ -1683,7 +1768,8 @@ case class SingleAction(
     checkpointMetadata: CheckpointMetadata = null,
     sidecar: SidecarFile = null,
     domainMetadata: DomainMetadata = null,
-    commitInfo: CommitInfo = null) {
+    commitInfo: CommitInfo = null,
+    checkpoint: Checkpoint = null) {
 
   def unwrap: Action = {
     if (add != null) {
@@ -1706,6 +1792,8 @@ case class SingleAction(
       domainMetadata
     } else if (commitInfo != null) {
       commitInfo
+    } else if (checkpoint != null) {
+      checkpoint
     } else {
       null
     }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -558,6 +558,17 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .booleanConf
       .createWithDefault(true)
 
+  val V4_ADAPTIVE_METADATA_TABLE_PREVIEW_ENABLED =
+    buildConf("adaptiveMetadataTree.preview.enabled")
+      .internal()
+      .doc("When false, the `adaptiveMetadata-preview` reader/writer table feature is not " +
+        "registered in this client's supported-features map. Any attempt to enable the feature " +
+        "on a table is rejected with the standard `unsupported table feature` error, and any " +
+        "table that already has the feature in its protocol fails to be read. Acts as a " +
+        "kill-switch while the feature is in preview.")
+      .booleanConf
+      .createWithDefault(true)
+
   val UNSUPPORTED_TESTING_FEATURES_ENABLED =
     buildConf("tableFeatures.dev.unsupportedTableFeatures.enabled")
       .internal()

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AdaptiveMetadataActionsSerializerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AdaptiveMetadataActionsSerializerSuite.scala
@@ -1,0 +1,400 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.amt
+
+import org.apache.spark.sql.delta.actions._
+import org.apache.spark.sql.delta.util.JsonUtils
+
+import org.apache.spark.SparkFunSuite
+
+/**
+ * JSON round-trip and invariant tests for the action-schema additions introduced for the
+ * `adaptiveMetadata-preview` feature: the new top-level [[Checkpoint]] action, the helper
+ * case classes [[ContentRoot]] / [[SidecarType]], and the optional `SidecarFile.sidecarType`
+ * field.
+ */
+class AdaptiveMetadataActionsSerializerSuite extends SparkFunSuite {
+
+  private val sampleRoot = ContentRoot(
+    path = "metadata/root-abc.parquet",
+    sizeInBytes = 4096L)
+
+  private val sampleProtocol = Protocol(minReaderVersion = 3, minWriterVersion = 7)
+  private val sampleMetadata = Metadata(id = "metadata-id", name = "t")
+
+  private def dmSidecar(path: String = "dm.parquet"): SidecarFile =
+    SidecarFile(
+      path = path,
+      sizeInBytes = 1L,
+      modificationTime = 0L,
+      sidecarType = Some(SidecarType.Type.DomainMetadata))
+
+  private def txnSidecar(path: String = "txn.parquet"): SidecarFile =
+    SidecarFile(
+      path = path,
+      sizeInBytes = 1L,
+      modificationTime = 0L,
+      sidecarType = Some(SidecarType.Type.Txn))
+
+  // ============================================================================================
+  // ContentRoot
+  // ============================================================================================
+
+  test("ContentRoot: ser-de") {
+    val root = ContentRoot(
+      path = "metadata/root-abc.parquet",
+      sizeInBytes = 4096L)
+    val json = JsonUtils.toJson(root)
+    assert(json ===
+      """{"path":"metadata/root-abc.parquet","sizeInBytes":4096}""")
+    val pretty = JsonUtils.toPrettyJson(root)
+    assert(pretty ===
+      """{
+        |  "path" : "metadata/root-abc.parquet",
+        |  "sizeInBytes" : 4096
+        |}""".stripMargin)
+    assert(JsonUtils.fromJson[ContentRoot](json) === root)
+    assert(JsonUtils.fromJson[ContentRoot](pretty) === root)
+  }
+
+  test("ContentRoot: serde handles Long.MaxValue size") {
+    val root = ContentRoot(
+      path = "metadata/root-big.parquet",
+      sizeInBytes = Long.MaxValue)
+    val json = JsonUtils.toJson(root)
+    val roundTripped = JsonUtils.fromJson[ContentRoot](json)
+    assert(roundTripped === root)
+  }
+
+  // ============================================================================================
+  // SidecarType enum
+  // ============================================================================================
+
+  test("SidecarType: check values") {
+    assert(SidecarType.Type.DomainMetadata === "domainMetadata")
+    assert(SidecarType.Type.Txn === "txn")
+  }
+
+  test("SidecarType.all contains exactly the two known values") {
+    assert(SidecarType.all === Set(
+      SidecarType.Type.DomainMetadata,
+      SidecarType.Type.Txn))
+  }
+
+  test("SidecarType.validate accepts known values and rejects unknown") {
+    Seq(SidecarType.Type.DomainMetadata, SidecarType.Type.Txn)
+      .foreach { v => assert(SidecarType.validate(v) === v) }
+    Seq("bogus", "systemDomainMetadata").foreach { bad =>
+      val ex = intercept[IllegalArgumentException] { SidecarType.validate(bad) }
+      assert(ex.getMessage.toLowerCase(java.util.Locale.ROOT).contains("unknown"))
+    }
+  }
+
+  test("SidecarFile.sidecarType: each SidecarType value round-trips through JSON") {
+    Seq(SidecarType.Type.DomainMetadata, SidecarType.Type.Txn)
+      .foreach { value =>
+        val sf = SidecarFile(
+          path = s"$value.parquet",
+          sizeInBytes = 1L,
+          modificationTime = 0L,
+          sidecarType = Some(value))
+        assert(sf.json ===
+          s"""{"sidecar":{"path":"$value.parquet","sizeInBytes":1,""" +
+            s""""modificationTime":0,"type":"$value"}}""")
+        assert(JsonUtils.toPrettyJson(sf.wrap) ===
+          s"""{
+             |  "sidecar" : {
+             |    "path" : "$value.parquet",
+             |    "sizeInBytes" : 1,
+             |    "modificationTime" : 0,
+             |    "type" : "$value"
+             |  }
+             |}""".stripMargin)
+        val parsed = Action.fromJson(sf.json).asInstanceOf[SidecarFile]
+        assert(parsed === sf)
+        assert(parsed.sidecarType.contains(value))
+      }
+  }
+
+  test("SidecarFile.sidecarType: absent from JSON when None") {
+    val sf = SidecarFile(path = "s.parquet", sizeInBytes = 1L, modificationTime = 0L)
+    assert(sf.json === """{"sidecar":{"path":"s.parquet","sizeInBytes":1,"modificationTime":0}}""")
+    assert(JsonUtils.toPrettyJson(sf.wrap) ===
+      """{
+        |  "sidecar" : {
+        |    "path" : "s.parquet",
+        |    "sizeInBytes" : 1,
+        |    "modificationTime" : 0
+        |  }
+        |}""".stripMargin)
+    assert(Action.fromJson(sf.json) === sf)
+  }
+
+  test("SidecarFile rejects unknown sidecarType values at construction") {
+    Seq("systemDomainMetadata", "bogus", "").foreach { bad =>
+      val ex = intercept[IllegalArgumentException] {
+        SidecarFile(
+          path = "x.parquet",
+          sizeInBytes = 1L,
+          modificationTime = 0L,
+          sidecarType = Some(bad))
+      }
+      assert(ex.getMessage.toLowerCase(java.util.Locale.ROOT).contains("unknown"))
+    }
+  }
+
+  test("SidecarFile accepts None sidecarType and known SidecarType values") {
+    SidecarFile(path = "x.parquet", sizeInBytes = 1L, modificationTime = 0L)
+    Seq(SidecarType.Type.DomainMetadata, SidecarType.Type.Txn).foreach { value =>
+      SidecarFile(
+        path = "x.parquet",
+        sizeInBytes = 1L,
+        modificationTime = 0L,
+        sidecarType = Some(value))
+    }
+  }
+
+  // ============================================================================================
+  // Checkpoint: ser-de
+  // ============================================================================================
+
+  test("Checkpoint: ser-de") {
+    val cp = Checkpoint(
+      version = 1L,
+      contentRoot = sampleRoot,
+      protocol = sampleProtocol,
+      metaData = sampleMetadata,
+      domainMetadata = Seq.empty,
+      txns = Seq.empty,
+      sidecars = Seq.empty)
+    assert(JsonUtils.toPrettyJson(cp.wrap) ===
+      """{
+        |  "checkpoint" : {
+        |    "version" : 1,
+        |    "contentRoot" : {
+        |      "path" : "metadata/root-abc.parquet",
+        |      "sizeInBytes" : 4096
+        |    },
+        |    "protocol" : {
+        |      "minReaderVersion" : 3,
+        |      "minWriterVersion" : 7,
+        |      "readerFeatures" : [ ],
+        |      "writerFeatures" : [ ]
+        |    },
+        |    "metaData" : {
+        |      "id" : "metadata-id",
+        |      "name" : "t",
+        |      "format" : {
+        |        "provider" : "parquet",
+        |        "options" : { }
+        |      },
+        |      "partitionColumns" : [ ],
+        |      "configuration" : { }
+        |    },
+        |    "domainMetadata" : [ ],
+        |    "txns" : [ ],
+        |    "sidecars" : [ ]
+        |  }
+        |}""".stripMargin)
+    val parsed = Action.fromJson(cp.json).asInstanceOf[Checkpoint]
+    assert(parsed === cp)
+  }
+
+  test("Checkpoint: routes through SingleAction.unwrap") {
+    val cp = Checkpoint(
+      version = 1L,
+      contentRoot = sampleRoot,
+      protocol = sampleProtocol,
+      metaData = sampleMetadata,
+      domainMetadata = Seq.empty,
+      txns = Seq.empty,
+      sidecars = Seq.empty)
+    val wrapped = cp.wrap
+    assert(wrapped.checkpoint === cp)
+    assert(wrapped.unwrap === cp)
+  }
+
+  // ============================================================================================
+  // Checkpoint: round-trip across field shapes
+  // ============================================================================================
+
+  test("Checkpoint: round-trips the full inline snapshot") {
+    val protocol = Protocol(3, 7)
+      .withReaderFeatures(Seq("deletionVectors", "v2Checkpoint"))
+      .withWriterFeatures(Seq("deletionVectors", "v2Checkpoint", "rowTracking"))
+    val dm = Seq(
+      DomainMetadata(domain = "delta.rowTracking", configuration = "{}", removed = false),
+      DomainMetadata(domain = "user.tag", configuration = "{\"k\":\"v\"}", removed = false))
+    val txns = Seq(
+      SetTransaction(appId = "app-1", version = 7L, lastUpdated = Some(100L)),
+      SetTransaction(appId = "app-2", version = 8L, lastUpdated = None))
+    val cp = Checkpoint(
+      version = 41L,
+      contentRoot = sampleRoot,
+      protocol = protocol,
+      metaData = sampleMetadata,
+      domainMetadata = dm,
+      txns = txns,
+      sidecars = Seq.empty)
+    assert(JsonUtils.toPrettyJson(cp.wrap) ===
+      """{
+        |  "checkpoint" : {
+        |    "version" : 41,
+        |    "contentRoot" : {
+        |      "path" : "metadata/root-abc.parquet",
+        |      "sizeInBytes" : 4096
+        |    },
+        |    "protocol" : {
+        |      "minReaderVersion" : 3,
+        |      "minWriterVersion" : 7,
+        |      "readerFeatures" : [ "deletionVectors", "v2Checkpoint" ],
+        |      "writerFeatures" : [ "deletionVectors", "v2Checkpoint", "rowTracking" ]
+        |    },
+        |    "metaData" : {
+        |      "id" : "metadata-id",
+        |      "name" : "t",
+        |      "format" : {
+        |        "provider" : "parquet",
+        |        "options" : { }
+        |      },
+        |      "partitionColumns" : [ ],
+        |      "configuration" : { }
+        |    },
+        |    "domainMetadata" : [ {
+        |      "domain" : "delta.rowTracking",
+        |      "configuration" : "{}",
+        |      "removed" : false
+        |    }, {
+        |      "domain" : "user.tag",
+        |      "configuration" : "{\"k\":\"v\"}",
+        |      "removed" : false
+        |    } ],
+        |    "txns" : [ {
+        |      "appId" : "app-1",
+        |      "version" : 7,
+        |      "lastUpdated" : 100
+        |    }, {
+        |      "appId" : "app-2",
+        |      "version" : 8
+        |    } ],
+        |    "sidecars" : [ ]
+        |  }
+        |}""".stripMargin)
+    val parsed = Action.fromJson(cp.json).asInstanceOf[Checkpoint]
+    assert(parsed === cp)
+  }
+
+  test("Checkpoint: round-trips with domainMetadata and txns carried via sidecars") {
+    val cp = Checkpoint(
+      version = 1L,
+      contentRoot = sampleRoot,
+      protocol = sampleProtocol,
+      metaData = sampleMetadata,
+      domainMetadata = Seq.empty,
+      txns = Seq.empty,
+      sidecars = Seq(dmSidecar(), txnSidecar()))
+    assert(JsonUtils.toPrettyJson(cp.wrap) ===
+      """{
+        |  "checkpoint" : {
+        |    "version" : 1,
+        |    "contentRoot" : {
+        |      "path" : "metadata/root-abc.parquet",
+        |      "sizeInBytes" : 4096
+        |    },
+        |    "protocol" : {
+        |      "minReaderVersion" : 3,
+        |      "minWriterVersion" : 7,
+        |      "readerFeatures" : [ ],
+        |      "writerFeatures" : [ ]
+        |    },
+        |    "metaData" : {
+        |      "id" : "metadata-id",
+        |      "name" : "t",
+        |      "format" : {
+        |        "provider" : "parquet",
+        |        "options" : { }
+        |      },
+        |      "partitionColumns" : [ ],
+        |      "configuration" : { }
+        |    },
+        |    "domainMetadata" : [ ],
+        |    "txns" : [ ],
+        |    "sidecars" : [ {
+        |      "path" : "dm.parquet",
+        |      "sizeInBytes" : 1,
+        |      "modificationTime" : 0,
+        |      "type" : "domainMetadata"
+        |    }, {
+        |      "path" : "txn.parquet",
+        |      "sizeInBytes" : 1,
+        |      "modificationTime" : 0,
+        |      "type" : "txn"
+        |    } ]
+        |  }
+        |}""".stripMargin)
+    val parsed = Action.fromJson(cp.json).asInstanceOf[Checkpoint]
+    assert(parsed === cp)
+  }
+
+  test("Checkpoint: round-trips with mixed inline-and-sidecar") {
+    val dm = Seq(
+      DomainMetadata(domain = "delta.rowTracking", configuration = "{}", removed = false))
+    val cp = Checkpoint(
+      version = 1L,
+      contentRoot = sampleRoot,
+      protocol = sampleProtocol,
+      metaData = sampleMetadata,
+      domainMetadata = dm,
+      txns = Seq.empty,
+      sidecars = Seq(dmSidecar(), txnSidecar()))
+    val parsed = Action.fromJson(cp.json).asInstanceOf[Checkpoint]
+    assert(parsed === cp)
+    assert(parsed.domainMetadata === dm)
+    assert(parsed.txns.isEmpty)
+    assert(parsed.sidecars.length === 2)
+  }
+
+  test("Checkpoint: rejects sidecar without sidecarType") {
+    val untyped = SidecarFile(path = "x.parquet", sizeInBytes = 1L, modificationTime = 0L)
+    val ex = intercept[IllegalArgumentException] {
+      Checkpoint(
+        version = 1L,
+        contentRoot = sampleRoot,
+        protocol = sampleProtocol,
+        metaData = sampleMetadata,
+        domainMetadata = Seq.empty,
+        txns = Seq.empty,
+        sidecars = Seq(untyped))
+    }
+    assert(ex.getMessage.contains("sidecarType"))
+  }
+
+  test("Checkpoint: round-trips multiple sidecars of the same type") {
+    val cp = Checkpoint(
+      version = 1L,
+      contentRoot = sampleRoot,
+      protocol = sampleProtocol,
+      metaData = sampleMetadata,
+      domainMetadata = Seq.empty,
+      txns = Seq.empty,
+      sidecars = Seq(dmSidecar("dm-1.parquet"), dmSidecar("dm-2.parquet")))
+    val parsed = Action.fromJson(cp.json).asInstanceOf[Checkpoint]
+    assert(parsed === cp)
+    assert(parsed.sidecars.length === 2)
+    assert(parsed.sidecars.forall(_.sidecarType.contains(SidecarType.Type.DomainMetadata)))
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AdaptiveMetadataTableFeatureSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AdaptiveMetadataTableFeatureSuite.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.amt
+
+import java.util.Locale
+
+import org.apache.spark.sql.delta.{
+  AdaptiveMetadataTableFeature,
+  ColumnMappingTableFeature,
+  DeltaLog,
+  DeltaTableFeatureException,
+  FeatureAutomaticallyEnabledByMetadata,
+  RemovableFeature,
+  TableFeature
+}
+import org.apache.spark.sql.delta.actions._
+import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils._
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.test.SharedSparkSession
+
+class AdaptiveMetadataTableFeatureSuite
+  extends QueryTest
+  with SharedSparkSession
+  with DeltaSQLCommandTest {
+
+  test("feature is a ReaderWriterFeature and is NOT a RemovableFeature") {
+    assert(AdaptiveMetadataTableFeature.isReaderWriterFeature)
+    // TODO(v4amt)(LC-14961): Fix this once downgrade support is added.
+    assert(!AdaptiveMetadataTableFeature.isInstanceOf[RemovableFeature])
+  }
+
+  test("feature is not automatically enabled by metadata") {
+    assert(!AdaptiveMetadataTableFeature.isInstanceOf[FeatureAutomaticallyEnabledByMetadata])
+  }
+
+  test("feature requires column mapping") {
+    assert(AdaptiveMetadataTableFeature.requiredFeatures === Set(ColumnMappingTableFeature))
+  }
+
+  test("creating a Delta table with delta.feature.adaptiveMetadata-preview=supported succeeds") {
+    withTempDir { dir =>
+      val path = dir.getCanonicalPath
+      sql(
+        s"""CREATE TABLE delta.`$path` (id INT) USING DELTA
+           |TBLPROPERTIES ('${propertyKey(AdaptiveMetadataTableFeature)}' =
+           |  '$FEATURE_PROP_SUPPORTED')""".stripMargin)
+
+      val deltaLog = DeltaLog.forTable(spark, path)
+      val protocol = deltaLog.update().protocol
+      assert(protocol.isFeatureSupported(AdaptiveMetadataTableFeature),
+        s"Protocol must record adaptiveMetadata-preview as supported. Got: $protocol")
+    }
+  }
+
+  test("enabling the feature is rejected when the kill-switch SQL conf is false") {
+    withSQLConf(DeltaSQLConf.V4_ADAPTIVE_METADATA_TABLE_PREVIEW_ENABLED.key -> "false") {
+      // The feature is unregistered, so featureNameToFeature returns None.
+      assert(TableFeature.featureNameToFeature(AdaptiveMetadataTableFeature.name).isEmpty)
+
+      withTempDir { dir =>
+        val path = dir.getCanonicalPath
+        val ex = intercept[DeltaTableFeatureException] {
+          sql(
+            s"""CREATE TABLE delta.`$path` (id INT) USING DELTA
+               |TBLPROPERTIES ('${propertyKey(AdaptiveMetadataTableFeature)}' =
+               |  '$FEATURE_PROP_SUPPORTED')""".stripMargin)
+        }
+        assert(ex.getMessage.toLowerCase(Locale.ROOT).contains("unsupported"),
+          s"Expected an unsupported-feature error, got: ${ex.getMessage}")
+      }
+    }
+  }
+}


### PR DESCRIPTION
Introduces the action-schema foundation for the adaptive metadata feature: ContentRoot, SidecarType, Checkpoint case classes, the SidecarFile.sidecarType field, and the corresponding SingleAction.checkpoint slot. Also drops the checkpoint column from classic checkpoint parquet files and adds the Checkpoint case to InMemoryLogReplay.