### PR TITLE
Add DeltaV2Snapshot wrapping a Kernel snapshot

### DIFF
--- a/spark-unified/src/main/scala/org/apache/spark/sql/delta/v2/interop/DeltaV2Snapshot.scala
+++ b/spark-unified/src/main/scala/org/apache/spark/sql/delta/v2/interop/DeltaV2Snapshot.scala
@@ -1,0 +1,140 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.v2.interop
+
+import org.apache.spark.sql.delta.{
+  CheckpointProvider,
+  DeltaColumnMappingMode,
+  DeltaLogFileIndex,
+  Snapshot,
+  VersionChecksum
+}
+import org.apache.spark.sql.delta.actions.{
+  AddFile,
+  Metadata,
+  Protocol,
+  RemoveFile,
+  SingleAction
+}
+import org.apache.spark.sql.delta.coordinatedcommits.TableCommitCoordinatorClient
+import org.apache.spark.sql.delta.stats.DeltaStatsColumnSpec
+import org.apache.hadoop.fs.Path
+import io.delta.kernel.internal.{SnapshotImpl => KernelSnapshot}
+
+import org.apache.spark.sql.{DataFrame, Dataset, SparkSession}
+
+/**
+ * Snapshot backed by Delta Kernel to be used in v2 Connector.
+ *
+ * Construction strategy:
+ *   - Passes `null` for both [[Snapshot.logSegment]] and `deltaLog` (guardrail): the Kernel path
+ *     has no V1 LogSegment or DeltaLog. The construction-path overrides above ensure these nulls
+ *     are never dereferenced while building the snapshot.
+ *   - All data/state members (metadata, protocol, allFiles, stateDF, ...) are unimplemented for
+ *     now and fail loudly, so unmigrated callers cannot silently read empty V1 state.
+ */
+private[v2] class DeltaV2Snapshot(
+    // Typed as the internal SnapshotImpl (aliased KernelSnapshot), not the public Kernel
+    // `Snapshot` interface: the decoded data path is only exposed on SnapshotImpl in the
+    // OSS-published Kernel. The public io.delta.kernel.Snapshot has no `getDataPath`, and its
+    // `getPath` is URL-encoded, which breaks Hadoop `Path` for table roots containing spaces.
+    kernelSnapshot: KernelSnapshot,
+    sparkSession: SparkSession)
+  extends Snapshot(
+    // toString keeps this compiling across Kernel versions: getDataPath returns String in the
+    // currently pinned Kernel and io.delta.kernel.internal.fs.Path in newer Kernels.
+    path = new Path(kernelSnapshot.getDataPath.toString),
+    version = kernelSnapshot.getVersion,
+    // The Kernel-backed snapshot must not depend on the V1 LogSegment or DeltaLog. Both are null;
+    // the construction-path members that would otherwise dereference them are overridden below, so
+    // the nulls are never dereferenced on the scan path.
+    logSegment = null,
+    deltaLog = null,
+    checksumOpt = None) {
+
+  override protected def spark: SparkSession = sparkSession
+
+  // --- logSegment/deltaLog = null guardrail: construction-path overrides ----------------------
+  // These are the members dereferenced while the super `Snapshot` constructor runs (init() and the
+  // "Created snapshot" logInfo at the end of the Snapshot body), plus the eager
+  // tableCommitCoordinatorClientOpt base val. They must have real, V1-storage-free implementations
+  // so a DeltaV2Snapshot can be constructed; everything else stays unimplemented.
+
+  // Opt out of the base Snapshot invariant that requires a non-null logSegment/deltaLog: the
+  // Kernel-backed snapshot has neither (see class doc).
+  override protected def allowNullLogSegmentAndDeltaLog: Boolean = true
+
+  // Kernel already validated protocol + feature support when it loaded the snapshot, so the V1
+  // init() re-validation (which derefs the null deltaLog) is redundant and skipped.
+  override protected def init(): Unit = ()
+
+  // A Kernel-backed snapshot has no V1 commit coordinator. Override the compute hook (not the
+  // `val`, whose base initializer still runs during super construction) so the lookup that derefs
+  // the null deltaLog / unimplemented metadata is skipped.
+  override protected def computeTableCommitCoordinatorClientOpt
+      : Option[TableCommitCoordinatorClient] = None
+
+  // The base toString references `metadata` (unimplemented here) and is evaluated eagerly by the
+  // "Created snapshot" logInfo during super construction; keep it to the wired-up members only.
+  override def toString: String = s"DeltaV2Snapshot(path=$path, version=$version)"
+
+  // The "Created snapshot" logInfo reads the table id from the V1 deltaLog during super
+  // construction; this Kernel-backed snapshot has none, so report an empty id.
+  override protected def tableId: String = ""
+
+  // No V1 LogSegment, so there is no backfilled-version tracking; report the sentinel rather than
+  // dereferencing the null logSegment.
+  override protected def initialLastKnownBackfilledVersion: Long = -1L
+
+
+  // --- SnapshotDescriptor / state surface ----------------------------------------------------
+
+  override lazy val metadata: Metadata = unimplemented
+
+  override lazy val protocol: Protocol = unimplemented
+
+  override def columnMappingMode: DeltaColumnMappingMode = unimplemented
+
+  override def numOfFiles: Long = unimplemented
+
+  override protected[delta] def numOfFilesIfKnown: Option[Long] = unimplemented
+
+  override protected[delta] def sizeInBytesIfKnown: Option[Long] = unimplemented
+
+  override protected[delta] lazy val deltaFileIndexOpt: Option[DeltaLogFileIndex] = unimplemented
+
+  override lazy val checkpointProvider: CheckpointProvider = unimplemented
+
+  // --- Files surfaced via Kernel scan ---------------------------------------------------------
+
+  override lazy val allFiles: Dataset[AddFile] = unimplemented
+
+  // --- StatisticsCollection ------------------------------------------------------------------
+
+  override lazy val statsColumnSpec: DeltaStatsColumnSpec = unimplemented
+
+  // --- V1 state-reconstruction paths: fail loudly ---------------------------------------------
+
+  override def stateDF: DataFrame = unimplemented
+  override def stateDS: Dataset[SingleAction] = unimplemented
+  override def tombstones: Dataset[RemoveFile] = unimplemented
+  override def computeChecksum: VersionChecksum = unimplemented
+
+  private def unimplemented: Nothing =
+    throw new UnsupportedOperationException(
+      "This member is not yet supported on a Kernel-backed DeltaV2Snapshot")
+}

--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/v2/interop/DeltaV2SnapshotSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/v2/interop/DeltaV2SnapshotSuite.scala
@@ -1,0 +1,92 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.v2.interop
+
+import org.apache.spark.sql.delta.Snapshot
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.hadoop.fs.Path
+import io.delta.kernel.TableManager
+import io.delta.kernel.defaults.engine.DefaultEngine
+import io.delta.kernel.engine.Engine
+import io.delta.kernel.internal.{SnapshotImpl => KernelSnapshot}
+
+/**
+ * Tests for [[DeltaV2Snapshot]] focusing on the construction surface that is wired to the
+ * underlying Kernel snapshot: `path` (from `kernelSnapshot.getDataPath`) and `version` (from
+ * `kernelSnapshot.getVersion`). All other members are intentionally unimplemented and are expected
+ * to throw [[UnsupportedOperationException]].
+ */
+class DeltaV2SnapshotSuite extends DeltaSQLCommandTest {
+
+  // scalastyle:off deltahadoopconfiguration
+  // No DeltaLog in this test (the snapshot is loaded via Kernel), so use the session Hadoop conf.
+  private def engine: Engine = DefaultEngine.create(spark.sessionState.newHadoopConf())
+  // scalastyle:on deltahadoopconfiguration
+
+  /** Load the latest snapshot of the Delta table at `path` via Kernel. */
+  private def loadKernelSnapshot(path: String): KernelSnapshot =
+    TableManager.loadSnapshot(path).build(engine).asInstanceOf[KernelSnapshot]
+
+  test("path and version are derived from the wrapped Kernel snapshot") {
+    withTempDir { dir =>
+      val path = dir.getCanonicalPath
+      spark.range(5).write.format("delta").save(path) // version 0
+
+      val kernelSnapshot0 = loadKernelSnapshot(path)
+      val snapshot0 = new DeltaV2Snapshot(kernelSnapshot0, spark)
+      assert(snapshot0.version === kernelSnapshot0.getVersion)
+      assert(snapshot0.version === 0L)
+      assert(snapshot0.path === new Path(kernelSnapshot0.getDataPath.toString))
+
+      // version tracks the latest committed version after more commits.
+      spark.range(1).write.format("delta").mode("append").save(path) // version 1
+      spark.range(1).write.format("delta").mode("append").save(path) // version 2
+
+      val kernelSnapshot2 = loadKernelSnapshot(path)
+      val snapshot2 = new DeltaV2Snapshot(kernelSnapshot2, spark)
+      assert(snapshot2.version === 2L)
+      assert(snapshot2.version === kernelSnapshot2.getVersion)
+    }
+  }
+
+  test("unimplemented members throw UnsupportedOperationException") {
+    withTempDir { dir =>
+      val path = dir.getCanonicalPath
+      spark.range(1).write.format("delta").save(path)
+
+      val snapshot = new DeltaV2Snapshot(loadKernelSnapshot(path), spark)
+
+      // Every externally reachable data/state member must fail loudly so that an unmigrated
+      // caller cannot silently read empty V1 state.
+      intercept[UnsupportedOperationException](snapshot.metadata)
+      intercept[UnsupportedOperationException](snapshot.protocol)
+      intercept[UnsupportedOperationException](snapshot.columnMappingMode)
+      intercept[UnsupportedOperationException](snapshot.numOfFiles)
+      intercept[UnsupportedOperationException](snapshot.numOfFilesIfKnown)
+      intercept[UnsupportedOperationException](snapshot.sizeInBytesIfKnown)
+      intercept[UnsupportedOperationException](snapshot.deltaFileIndexOpt)
+      intercept[UnsupportedOperationException](snapshot.checkpointProvider)
+      intercept[UnsupportedOperationException](snapshot.allFiles)
+      intercept[UnsupportedOperationException](snapshot.statsColumnSpec)
+      intercept[UnsupportedOperationException](snapshot.stateDF)
+      intercept[UnsupportedOperationException](snapshot.stateDS)
+      intercept[UnsupportedOperationException](snapshot.tombstones)
+      intercept[UnsupportedOperationException](snapshot.computeChecksum)
+    }
+  }
+
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
@@ -130,6 +130,22 @@ class Snapshot(
   // For implicits which re-use Encoder:
   import org.apache.spark.sql.delta.implicits._
 
+  /**
+   * Whether this snapshot is allowed to be constructed without a V1 [[LogSegment]] and [[DeltaLog]]
+   * (i.e. both `logSegment` and `deltaLog` are null). Defaults to false, so every V1 snapshot is
+   * required to be backed by real V1 storage. Only the Kernel-backed [[v2.interop.DeltaV2Snapshot]]
+   * overrides this to true, since the v2 path has no V1 LogSegment/DeltaLog.
+   */
+  protected def allowNullLogSegmentAndDeltaLog: Boolean = false
+
+  // Invariant: a V1 Snapshot must always be constructed with a non-null logSegment and deltaLog.
+  // Only the Kernel-backed DeltaV2Snapshot legitimately has neither and opts out above. This guards
+  // against accidentally constructing a V1 snapshot with null storage (e.g. when v2 is disabled),
+  // which would otherwise surface as a confusing NPE deep in a scan rather than at construction.
+  require(
+    allowNullLogSegmentAndDeltaLog || (logSegment != null && deltaLog != null),
+    "A V1 Snapshot must be constructed with a non-null logSegment and deltaLog.")
+
   override def dataPath: Path = deltaLog.dataPath
   override def logPath: Path = deltaLog.logPath
 
@@ -227,8 +243,13 @@ class Snapshot(
    * indeed contains any unbackfilled commits or the LogSegment is just based on an older
    * version.
    */
-  @volatile private var lastKnownBackfilledVersion: Long =
+  // The initial last-known backfilled version comes from this snapshot's LogSegment. `protected`
+  // so a subclass without a V1 LogSegment (e.g. DeltaV2Snapshot) can override it with a sentinel
+  // rather than dereferencing a null `logSegment`.
+  protected def initialLastKnownBackfilledVersion: Long =
     logSegment.lastBackfilledVersionInSegment
+
+  @volatile private var lastKnownBackfilledVersion: Long = initialLastKnownBackfilledVersion
 
   def getLastKnownBackfilledVersion: Long = lastKnownBackfilledVersion
 
@@ -335,7 +356,12 @@ class Snapshot(
    *   [[DeltaSQLConf.COORDINATED_COMMITS_IGNORE_MISSING_COORDINATOR_IMPLEMENTATION]] to false.
    * - This must be None when coordinated commits is disabled.
    */
-  val tableCommitCoordinatorClientOpt: Option[TableCommitCoordinatorClient] = {
+  // `protected` so a subclass without a V1 deltaLog (e.g. DeltaV2Snapshot) can override this to
+  // skip the coordinator lookup, which dereferences `deltaLog`, `metadata`, and `protocol`. The
+  // backing `val` initializer runs during the superclass constructor (Scala does not skip an
+  // overridden `val`'s superclass initializer), so the hook is a `def` to dispatch to the subclass
+  // override at construction time.
+  protected def computeTableCommitCoordinatorClientOpt: Option[TableCommitCoordinatorClient] = {
     val failIfImplUnavailable =
       !spark.conf.get(DeltaSQLConf.COORDINATED_COMMITS_IGNORE_MISSING_COORDINATOR_IMPLEMENTATION)
     CoordinatedCommitsUtils.getTableCommitCoordinator(
@@ -345,6 +371,8 @@ class Snapshot(
       failIfImplUnavailable
     )
   }
+  val tableCommitCoordinatorClientOpt: Option[TableCommitCoordinatorClient] =
+    computeTableCommitCoordinatorClientOpt
 
   /**
    * Returns the [[TableCommitCoordinatorClient]] that should be used for any type of mutation
@@ -743,33 +771,33 @@ class Snapshot(
   protected def emptyDF: DataFrame =
     spark.createDataFrame(spark.sparkContext.emptyRDD[Row], logSchema)
 
+  // The "Created snapshot" logInfo at the end of this constructor runs eagerly and reads the table
+  // id from the V1 `deltaLog`, which the constructor invariant guarantees is non-null for every V1
+  // snapshot. The Kernel-backed DeltaV2Snapshot has no V1 `deltaLog` and overrides this to report
+  // an empty id.
+  protected def tableId: String = deltaLog.unsafeVolatileTableId
 
   // These logging methods must NOT read `this.metadata`: they are invoked *during* P&M
   // reconstruction (e.g. the usage log on the incremental-checksum path) and during snapshot
   // construction, where reading `metadata` re-enters the `_reconstructedProtocolMetadataAndICT`
   // lazy val on the same thread and overflows the stack. Use the DeltaLog's cached id instead.
   def logInfo(msg: MessageWithContext): Unit = {
-    val tableId = deltaLog.unsafeVolatileTableId
     super.logInfo(log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, tableId)}] " + msg)
   }
 
   def logWarning(msg: MessageWithContext): Unit = {
-    val tableId = deltaLog.unsafeVolatileTableId
     super.logWarning(log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, tableId)}] " + msg)
   }
 
   def logWarning(msg: MessageWithContext, throwable: Throwable): Unit = {
-    val tableId = deltaLog.unsafeVolatileTableId
     super.logWarning(log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, tableId)}] " + msg, throwable)
   }
 
   def logError(msg: MessageWithContext): Unit = {
-    val tableId = deltaLog.unsafeVolatileTableId
     super.logError(log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, tableId)}] " + msg)
   }
 
   def logError(msg: MessageWithContext, throwable: Throwable): Unit = {
-    val tableId = deltaLog.unsafeVolatileTableId
     super.logError(log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, tableId)}] " + msg, throwable)
   }
 


### PR DESCRIPTION
## Description

Adds `DeltaV2Snapshot`, a `Snapshot` subclass backed by a Delta Kernel snapshot, for use by the v2 connector. It derives `path` and `version` from the wrapped Kernel snapshot and is constructed without a V1 `LogSegment`/`DeltaLog`.

To support a snapshot with no V1 storage, the base `Snapshot` gains small `protected` hooks a subclass can override at construction time (rather than dereferencing a null `logSegment`/`deltaLog`):
- `allowNullLogSegmentAndDeltaLog` plus a construction invariant requiring non-null storage for V1 snapshots
- `initialLastKnownBackfilledVersion`
- `computeTableCommitCoordinatorClientOpt`
- `tableId` (the id used in log prefixes)

All data/state members (`metadata`, `protocol`, `allFiles`, `stateDF`, ...) are intentionally unimplemented for now and fail loudly with `UnsupportedOperationException`, so callers cannot silently read empty state.

## How was this patch tested?

Added `DeltaV2SnapshotSuite`, which builds a real Kernel snapshot and asserts `path`/`version` are derived correctly, and that every unimplemented member throws `UnsupportedOperationException`.

## Does this PR introduce _any_ user-facing changes?

No.
