### PR TITLE
[Kernel] Avoid redundant exists() HEAD probe in LogStore listFrom

### DIFF
--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/logstore/LogStoreProviderSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/logstore/LogStoreProviderSuite.scala
@@ -15,10 +15,16 @@
  */
 package io.delta.kernel.defaults.internal.logstore
 
+import java.io.File
+import java.net.URI
+import java.nio.file.{AccessDeniedException, Files}
+
+import scala.collection.JavaConverters._
+
 import io.delta.storage._
 
 import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.fs.{FileStatus, Path}
+import org.apache.hadoop.fs.{FileStatus, Path, RawLocalFileSystem}
 import org.scalatest.funsuite.AnyFunSuite
 
 class LogStoreProviderSuite extends AnyFunSuite {
@@ -65,6 +71,90 @@ class LogStoreProviderSuite extends AnyFunSuite {
       LogStoreProvider.getLogStore(hadoopConf, "fake"))
     assert(e.getMessage.contains(
       "Can not instantiate `LogStore` class (from config): %s".format("java.lang.String")))
+  }
+
+  // listFrom must not HEAD the _delta_log directory: a credential scoped to LIST but not HEAD
+  // would otherwise fail a listable log.
+  Seq(
+    ("s3", classOf[S3SingleDriverLogStore]),
+    ("headdenyhdfs", classOf[HDFSLogStore])).foreach { case (scheme, storeClass) =>
+    test(s"listFrom does not HEAD the log dir ($scheme -> ${storeClass.getSimpleName})") {
+      val tableDir = Files.createTempDirectory("logstore-head-probe").toFile
+      try {
+        val deltaLog = new File(tableDir, "_delta_log")
+        assert(deltaLog.mkdir())
+        val versions = Seq("00000000000000000000.json", "00000000000000000001.json")
+        versions.foreach(n => assert(new File(deltaLog, n).createNewFile()))
+
+        val conf = new Configuration()
+        conf.set(s"fs.$scheme.impl", classOf[HeadDenyingLocalFileSystem].getName)
+        conf.setBoolean(s"fs.$scheme.impl.disable.cache", true)
+        // The HeadDenyingLocalFileSystem reports a fixed scheme, so pin the FS for every tested
+        // scheme to it and bind the scheme to the LogStore under test.
+        conf.set("fs.headdeny.scheme", scheme)
+        conf.set(LogStoreProvider.getLogStoreSchemeConfKey(scheme), storeClass.getName)
+
+        val store = LogStoreProvider.getLogStore(conf, scheme)
+        assert(store.getClass.getName === storeClass.getName)
+
+        // path inside _delta_log; its parent (the bare _delta_log dir) is HEAD-denied
+        val listingPrefix = new Path(s"$scheme://${deltaLog.getAbsolutePath}/${versions.head}")
+        val listed = store.listFrom(listingPrefix, conf).asScala.map(_.getPath.getName).toList
+        assert(listed === versions.toList)
+      } finally {
+        deleteRecursively(tableDir)
+      }
+    }
+  }
+
+  private def deleteRecursively(file: File): Unit = {
+    if (file.isDirectory) Option(file.listFiles).foreach(_.foreach(deleteRecursively))
+    file.delete()
+  }
+}
+
+/**
+ * A [[RawLocalFileSystem]] that denies a HEAD on the bare `_delta_log` directory with a
+ * non-[[java.io.FileNotFoundException]] error, mimicking an S3 403 from a credential scoped to
+ * allow LIST but not HEAD on the directory key. Both `exists` (which the LogStore probe calls)
+ * and `getFileStatus` are denied for the directory; `listStatus` (and HEADs on the version files
+ * inside the directory) are still allowed. So a correct `listFrom` that relies on `listStatus`
+ * succeeds, while one that probes the directory with `exists` fails.
+ *
+ * Note `RawLocalFileSystem` overrides `exists` to use the local file directly rather than
+ * `getFileStatus`, so the `exists` override below is what actually trips the probe.
+ *
+ * Reports a configurable scheme (default `s3`, via `fs.headdeny.scheme`) so it can stand in for
+ * different LogStore backends.
+ */
+class HeadDenyingLocalFileSystem extends RawLocalFileSystem {
+  private var uri: URI = _
+  private var scheme: String = "s3"
+
+  override def initialize(name: URI, conf: Configuration): Unit = {
+    scheme = conf.get("fs.headdeny.scheme", "s3")
+    uri = URI.create(scheme + ":///")
+    super.initialize(name, conf)
+  }
+
+  override def getScheme: String = scheme
+
+  override def getUri: URI = if (uri == null) super.getUri else uri
+
+  private def denyIfLogDir(f: Path): Unit = {
+    if (f.getName == "_delta_log") {
+      throw new AccessDeniedException(s"$f: simulated 403 Forbidden on HEAD")
+    }
+  }
+
+  override def exists(f: Path): Boolean = {
+    denyIfLogDir(f)
+    super.exists(f)
+  }
+
+  override def getFileStatus(f: Path): FileStatus = {
+    denyIfLogDir(f)
+    super.getFileStatus(f)
   }
 }
 

--- a/storage/src/main/java/io/delta/storage/HadoopFileSystemLogStore.java
+++ b/storage/src/main/java/io/delta/storage/HadoopFileSystemLogStore.java
@@ -51,11 +51,6 @@ public abstract class HadoopFileSystemLogStore extends LogStore {
     @Override
     public Iterator<FileStatus> listFrom(Path path, Configuration hadoopConf) throws IOException {
         FileSystem fs = path.getFileSystem(hadoopConf);
-        if (!fs.exists(path.getParent())) {
-            throw new FileNotFoundException(
-                String.format("No such file or directory: %s", path.getParent())
-            );
-        }
         FileStatus[] files = fs.listStatus(path.getParent());
         return Arrays.stream(files)
             .filter(f -> f.getPath().getName().compareTo(path.getName()) >= 0)

--- a/storage/src/main/java/io/delta/storage/S3SingleDriverLogStore.java
+++ b/storage/src/main/java/io/delta/storage/S3SingleDriverLogStore.java
@@ -117,11 +117,6 @@ public class S3SingleDriverLogStore extends HadoopFileSystemLogStore {
             FileSystem fs,
             Path resolvedPath) throws IOException {
         final Path parentPath = resolvedPath.getParent();
-        if (!fs.exists(parentPath)) {
-            throw new FileNotFoundException(
-                String.format("No such file or directory: %s", parentPath)
-            );
-        }
 
         FileStatus[] statuses;
         if (
@@ -130,6 +125,15 @@ public class S3SingleDriverLogStore extends HadoopFileSystemLogStore {
         ) {
             statuses = fs.listStatus(parentPath);
         } else {
+            // Fast S3A list path (S3AFileSystem only, opt-in via delta.enableFastS3AListFrom).
+            // It returns an empty result (rather than throwing) for a missing directory, which is
+            // indistinguishable from listing past the latest version, so keep the exists() probe
+            // here to preserve listFrom's documented FileNotFoundException contract.
+            if (!fs.exists(parentPath)) {
+                throw new FileNotFoundException(
+                    String.format("No such file or directory: %s", parentPath)
+                );
+            }
             statuses = S3LogStoreUtil.s3ListFromArray(fs, resolvedPath, parentPath);
         }
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Kernel
- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Other (fill in here)

## Description

`HadoopFileSystemLogStore.listFrom` and `S3SingleDriverLogStore.listFromInternal` call `fs.exists(parent)` before listing the directory. On S3 that is a HEAD on the bare `_delta_log` directory key. A credential scoped to permit the `_delta_log/` LIST but not a HEAD on the prefix (for example a vended/scoped credential) is denied that HEAD with a 403, which surfaces as an `IOException` (not `FileNotFoundException`) and propagates as `UncheckedIOException: Failed to list the files in delta log` -- even though the immediately following LIST is permitted and would have succeeded.

The probe is redundant: `listStatus` already throws `FileNotFoundException` when the directory does not exist, which is exactly what callers rely on (in Kernel, `DeltaLogActionUtils.listLogDir` maps that to `TableNotFoundException`). This PR drops the probe from `HadoopFileSystemLogStore.listFrom` and from the non-fast S3 `listFrom` path, relying on `listStatus`. As a bonus this removes one metadata round-trip per `listFrom`.

The fast S3A list path (`S3LogStoreUtil.s3ListFromArray`, opt-in via `delta.enableFastS3AListFrom`) returns an empty result rather than throwing for a missing directory, which is indistinguishable from listing past the latest version. The `exists()` probe is therefore retained only on that branch to preserve `listFrom`'s documented `FileNotFoundException` contract.

## How was this patch tested?

Added a regression test in `LogStoreProviderSuite` that lists a log directory through a `FileSystem` which denies the directory HEAD (`exists`/`getFileStatus`) with an `AccessDeniedException` while still allowing `listStatus` -- reproducing the scoped-credential scenario. It is parameterized over `S3SingleDriverLogStore` and `HDFSLogStore`. The test fails on the previous code (with the `AccessDeniedException` surfacing) and passes with this change. `storage/compile` and the suite pass locally.

## Does this PR introduce _any_ user-facing changes?

No. Behavior is unchanged for missing tables: a missing `_delta_log` still surfaces as `FileNotFoundException` (non-fast path) or an empty listing (fast S3A path), both of which Kernel already maps to `TableNotFoundException`. The only change is the elimination of a redundant HEAD that could spuriously fail under HEAD-restricted credentials.
