### PR TITLE
Drop float/double footer min/max for NaN-excluding writers

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -2355,6 +2355,18 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .booleanConf
       .createWithDefault(false)
 
+  val DELTA_COLLECT_STATS_SKIP_FLOATING_POINT_FROM_FOOTER =
+    buildConf("collectStats.skipFloatingPointFromFooter")
+      .internal()
+      .doc("If true, footer-based stats collection (CONVERT TO DELTA / CLONE, and ANALYZE TABLE " +
+        "... COMPUTE DELTA STATISTICS) drops float/double min/max for files written by writers " +
+        "that may exclude NaN from footer stats (such as parquet-cpp, Arrow, and pyarrow). Their " +
+        "finite max could otherwise hide a NaN value and make data skipping wrongly skip files " +
+        "that contain one. Stats from parquet-mr (Spark) are kept, since parquet-mr records NaN " +
+        "as the max when present.")
+      .booleanConf
+      .createWithDefault(true)
+
   val DELTA_ALTER_TABLE_CHANGE_COLUMN_CHECK_EXPRESSIONS =
     buildConf("alterTable.changeColumn.checkExpressions")
       .internal()

--- a/spark/src/main/scala/org/apache/spark/sql/delta/stats/StatsCollectionUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/stats/StatsCollectionUtils.scala
@@ -91,13 +91,18 @@ object StatsCollectionUtils
     val parquetRebaseMode =
       spark.sessionState.conf.getConf(SQLConf.PARQUET_REBASE_MODE_IN_READ).toString
 
+    val skipFloatingPointStats =
+      spark.sessionState.conf.getConf(
+        DeltaSQLConf.DELTA_COLLECT_STATS_SKIP_FLOATING_POINT_FROM_FOOTER)
+
     val statsCollector = StatsCollector(
       snapshot.columnMappingMode,
       snapshot.dataSchema,
       snapshot.statsSchema,
       parquetRebaseMode,
       ignoreMissingStats,
-      Some(stringTruncateLength))
+      Some(stringTruncateLength),
+      skipFloatingPointStats)
 
     val serializableConf = new SerializableConfiguration(conf)
     val broadcastConf = spark.sparkContext.broadcast(serializableConf)
@@ -231,6 +236,8 @@ object ParallelFetchPool {
  * @param ignoreMissingStats Indicate whether to return partial result by ignoring missing stats
  *                           or throw an exception.
  * @param stringTruncateLength The optional max length of string stats to be truncated into.
+ * @param skipFloatingPointStats When true, drop float/double min/max for writers that may exclude
+ *                               NaN from footer stats (see writerIncludesNaNInFloatingPointStats).
  *
  * Scala Example:
  * {{{
@@ -259,7 +266,8 @@ abstract class StatsCollector(
     statsSchema: StructType,
     parquetRebaseMode: String,
     ignoreMissingStats: Boolean,
-    stringTruncateLength: Option[Int])
+    stringTruncateLength: Option[Int],
+    skipFloatingPointStats: Boolean)
   extends Serializable
 {
 
@@ -343,6 +351,10 @@ abstract class StatsCollector(
       parquetMetadata.getFileMetaData.getKeyValueMetaData.get, parquetRebaseMode)
     val dateRebaseFunc = DataSourceUtils.createDateRebaseFuncInRead(dateRebaseSpec.mode, "Parquet")
 
+    val dropFloatingPointStats = skipFloatingPointStats &&
+      !StatsCollector.writerIncludesNaNInFloatingPointStats(
+        parquetMetadata.getFileMetaData.getCreatedBy)
+
     val missingFieldCounts =
       mutable.Map(MAX -> 0L, MIN -> 0L, NULL_COUNT -> 0L, NUM_MISSING_TYPES -> 0L)
 
@@ -362,13 +374,13 @@ abstract class StatsCollector(
       case StructField(MIN, statsTypeSchema: StructType, _, _) =>
         val (minValues, numMissingFields) =
           collectStats(Seq.empty[String], statsTypeSchema, blocks, schemaPhysicalPathToParquetIndex,
-            ignoreMissingStats)(aggMaxOrMin(dateRebaseFunc, isMax = false))
+            ignoreMissingStats)(aggMaxOrMin(dateRebaseFunc, isMax = false, dropFloatingPointStats))
         missingFieldCounts(MIN) += numMissingFields
         MIN -> minValues
       case StructField(MAX, statsTypeSchema: StructType, _, _) =>
         val (maxValues, numMissingFields) =
           collectStats(Seq.empty[String], statsTypeSchema, blocks, schemaPhysicalPathToParquetIndex,
-            ignoreMissingStats)(aggMaxOrMin(dateRebaseFunc, isMax = true))
+            ignoreMissingStats)(aggMaxOrMin(dateRebaseFunc, isMax = true, dropFloatingPointStats))
         missingFieldCounts(MAX) += numMissingFields
         MAX -> maxValues
       case StructField(NULL_COUNT, statsTypeSchema: StructType, _, _) =>
@@ -478,11 +490,17 @@ abstract class StatsCollector(
    * dateRebaseFunc is used to adapt legacy date.
    */
   private def aggMaxOrMin(
-      dateRebaseFunc: Int => Int, isMax: Boolean)(
+      dateRebaseFunc: Int => Int, isMax: Boolean, dropFloatingPointStats: Boolean)(
       blocks: Seq[BlockMetaData], index: Int): Any = {
     val columnMetadata = blocks.head.getColumns.get(index)
     val primitiveType = columnMetadata.getPrimitiveType
     val logicalType = primitiveType.getLogicalTypeAnnotation
+    // None is recorded as null, which the read side treats as missing and keeps the file.
+    if (dropFloatingPointStats &&
+        (primitiveType.getPrimitiveTypeName == PrimitiveType.PrimitiveTypeName.FLOAT ||
+         primitiveType.getPrimitiveTypeName == PrimitiveType.PrimitiveTypeName.DOUBLE)) {
+      return None
+    }
     // Physical type of timestamp is INT96 in both Parquet and Delta.
     if (primitiveType.getPrimitiveTypeName == PrimitiveType.PrimitiveTypeName.INT96 ||
         logicalType.isInstanceOf[TimestampLogicalTypeAnnotation]) {
@@ -505,7 +523,6 @@ abstract class StatsCollector(
         if (aggregatedValue == None) {
           aggregatedValue = currentValue
         } else {
-          // TODO: check NaN value for floating point columns.
           val compareResult = currentValue.asInstanceOf[Comparable[Any]].compareTo(aggregatedValue)
           if ((isMax && compareResult > 0) || (!isMax && compareResult < 0)) {
             aggregatedValue = currentValue
@@ -582,20 +599,33 @@ abstract class StatsCollector(
 }
 
 object StatsCollector {
+  /**
+   * Whether a Parquet writer includes NaN in its row-group float/double min/max statistics.
+   * parquet-mr (and thus Spark) orders NaN as the greatest value, so a NaN-containing column
+   * records max = NaN; a finite max therefore proves the column has no NaN and the stat is
+   * trustworthy. Writers such as parquet-cpp / Arrow / pyarrow exclude NaN, so their finite max
+   * may hide NaN values. An unknown or missing writer is treated as unsafe.
+   */
+  private[stats] def writerIncludesNaNInFloatingPointStats(createdBy: String): Boolean =
+    createdBy != null && createdBy.startsWith("parquet-mr")
+
   def apply(
       columnMappingMode: DeltaColumnMappingMode,
       dataSchema: StructType,
       statsSchema: StructType,
       parquetRebaseMode: String,
       ignoreMissingStats: Boolean = true,
-      stringTruncateLength: Option[Int] = None): StatsCollector = {
+      stringTruncateLength: Option[Int] = None,
+      skipFloatingPointStats: Boolean = false): StatsCollector = {
     columnMappingMode match {
       case NoMapping | NameMapping =>
         StatsCollectorNameMapping(
-          dataSchema, statsSchema, parquetRebaseMode, ignoreMissingStats, stringTruncateLength)
+          dataSchema, statsSchema, parquetRebaseMode, ignoreMissingStats, stringTruncateLength,
+          skipFloatingPointStats)
       case IdMapping =>
         StatsCollectorIdMapping(
-          dataSchema, statsSchema, parquetRebaseMode, ignoreMissingStats, stringTruncateLength)
+          dataSchema, statsSchema, parquetRebaseMode, ignoreMissingStats, stringTruncateLength,
+          skipFloatingPointStats)
       case _ =>
         throw new UnsupportedOperationException(
           s"$columnMappingMode mapping is currently not supported")
@@ -607,9 +637,11 @@ object StatsCollector {
       statsSchema: StructType,
       parquetRebaseMode: String,
       ignoreMissingStats: Boolean,
-      stringTruncateLength: Option[Int])
+      stringTruncateLength: Option[Int],
+      skipFloatingPointStats: Boolean)
     extends StatsCollector(
-      dataSchema, statsSchema, parquetRebaseMode, ignoreMissingStats, stringTruncateLength) {
+      dataSchema, statsSchema, parquetRebaseMode, ignoreMissingStats, stringTruncateLength,
+      skipFloatingPointStats) {
 
     /**
      * Maps schema physical field path to parquet metadata column index via parquet metadata column
@@ -702,9 +734,11 @@ object StatsCollector {
       statsSchema: StructType,
       parquetRebaseMode: String,
       ignoreMissingStats: Boolean,
-      stringTruncateLength: Option[Int])
+      stringTruncateLength: Option[Int],
+      skipFloatingPointStats: Boolean)
     extends StatsCollector(
-      dataSchema, statsSchema, parquetRebaseMode, ignoreMissingStats, stringTruncateLength) {
+      dataSchema, statsSchema, parquetRebaseMode, ignoreMissingStats, stringTruncateLength,
+      skipFloatingPointStats) {
 
     // Define a FieldId type to better disambiguate between ids and indices in the code
     type FieldId = Int

--- a/spark/src/test/scala/org/apache/spark/sql/delta/ConvertToDeltaSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/ConvertToDeltaSuiteBase.scala
@@ -23,12 +23,21 @@ import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.{DeltaExceptionTestUtils, DeltaSQLCommandTest, DeltaSQLTestUtils}
 import org.apache.spark.sql.delta.test.shims.StreamingTestShims.MemoryStream
 import org.apache.hadoop.fs.Path
+import org.apache.parquet.bytes.{BytesInput, BytesUtils}
+import org.apache.parquet.column.Encoding
+import org.apache.parquet.column.statistics.Statistics
+import org.apache.parquet.format.Util
+import org.apache.parquet.hadoop.ParquetFileWriter
+import org.apache.parquet.hadoop.metadata.CompressionCodecName
+import org.apache.parquet.schema.{MessageType, Types}
+import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName
 
 import org.apache.spark.SparkException
 import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.functions._
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.Trigger
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
@@ -144,6 +153,125 @@ trait ConvertToDeltaSuiteBase extends ConvertToDeltaSuiteBaseCommons
             .as("stats")).select("stats.*")
         assert(statsDf.filter($"numRecords".isNotNull).count == 0)
       }
+    }
+  }
+
+  test("CONVERT TO DELTA keeps float/double stats for parquet-mr sources") {
+    // Spark writes via parquet-mr, which orders NaN greatest, so its finite float/double footer
+    // stats are trustworthy and must survive CONVERT. Only NaN-excluding writers get dropped, which
+    // Spark cannot produce here; that drop path is covered by StatsCollectionUtilsSuite. Auto
+    // compact would recompute via the native path, so pin it off to exercise the footer-copy path.
+    withSQLConf(
+        "spark.databricks.delta.autoCompact.enabled" -> "false",
+        DeltaSQLConf.DELTA_COLLECT_STATS_SKIP_FLOATING_POINT_FROM_FOOTER.key -> "true") {
+      withTempDir { dir =>
+        val tempDir = dir.getCanonicalPath
+        writeFiles(tempDir, spark.range(5).selectExpr(
+          "cast(id as int) as intCol",
+          "cast(id as double) + 0.5 as doubleCol",
+          "cast(id as float) + 0.25 as floatCol"))
+        convertToDelta(s"parquet.`$tempDir`", collectStats = true)
+        val snapshot = DeltaLog.forTable(spark, tempDir).update()
+        val stats = snapshot.allFiles
+          .select(from_json($"stats", snapshot.statsSchema).as("s")).select("s.*")
+        assert(stats.filter($"numRecords".isNull).count == 0)
+        assert(stats.filter($"maxValues.doubleCol".isNotNull).count > 0)
+        assert(stats.filter($"maxValues.floatCol".isNotNull).count > 0)
+        assert(stats.filter($"maxValues.intCol".isNotNull).count > 0)
+      }
+    }
+  }
+
+  // Writes a Parquet file with one DOUBLE column "c" containing a NaN row but a FINITE footer max -
+  // what writers such as parquet-cpp/Arrow/pyarrow produce by excluding NaN. parquet-mr cannot (it
+  // records max = NaN), so we write finite Statistics via the low-level writer, then patch the
+  // footer's created_by to a foreign writer so the writer-aware drop applies. Only the trailing
+  // footer is re-serialized; the data region (and its offsets) is untouched.
+  protected def writeNaNExcludedDoubleParquet(
+      dir: String,
+      values: Seq[Double],
+      finiteMin: Double,
+      finiteMax: Double,
+      createdBy: String = "parquet-cpp-arrow version 18.0.0"): Unit = {
+    val schema: MessageType = Types.buildMessage()
+      .required(PrimitiveTypeName.DOUBLE).named("c")
+      .named("spark_schema")
+    val path = new Path(dir, "nan-excluded.parquet")
+    // scalastyle:off deltahadoopconfiguration
+    val conf = spark.sessionState.newHadoopConf()
+    // scalastyle:on deltahadoopconfiguration
+
+    val writer = new ParquetFileWriter(conf, schema, path)
+    writer.start()
+    val buf = java.nio.ByteBuffer
+      .allocate(values.size * 8).order(java.nio.ByteOrder.LITTLE_ENDIAN)
+    values.foreach(buf.putDouble)
+    val data = BytesInput.from(buf.array())
+    val stats = Statistics.getBuilderForReading(schema.getColumns.get(0).getPrimitiveType)
+      .withMin(BytesUtils.longToBytes(java.lang.Double.doubleToLongBits(finiteMin)))
+      .withMax(BytesUtils.longToBytes(java.lang.Double.doubleToLongBits(finiteMax)))
+      .withNumNulls(0L)
+      .build()
+    writer.startBlock(values.size.toLong)
+    writer.startColumn(
+      schema.getColumns.get(0), values.size.toLong, CompressionCodecName.UNCOMPRESSED)
+    writer.writeDataPage(
+      values.size,
+      data.size().toInt,
+      data,
+      stats,
+      values.size.toLong,
+      Encoding.BIT_PACKED,
+      Encoding.BIT_PACKED,
+      Encoding.PLAIN)
+    writer.endColumn()
+    writer.endBlock()
+    writer.end(new java.util.HashMap[String, String]())
+
+    // Patch the footer's created_by. Layout: [data][footer thrift][4-byte LE footer len][PAR1].
+    val fs = path.getFileSystem(conf)
+    val fileLen = fs.getFileStatus(path).getLen.toInt
+    val bytes = new Array[Byte](fileLen)
+    val in = fs.open(path)
+    try in.readFully(bytes) finally in.close()
+    val footerLen = java.nio.ByteBuffer
+      .wrap(bytes, fileLen - 8, 4).order(java.nio.ByteOrder.LITTLE_ENDIAN).getInt
+    val footerStart = fileLen - 8 - footerLen
+    val fmd = Util.readFileMetaData(new java.io.ByteArrayInputStream(bytes, footerStart, footerLen))
+    fmd.setCreated_by(createdBy)
+    val footerOut = new java.io.ByteArrayOutputStream()
+    Util.writeFileMetaData(fmd, footerOut)
+    val newFooter = footerOut.toByteArray
+    val out = fs.create(path, true) // overwrite
+    try {
+      out.write(bytes, 0, footerStart)
+      out.write(newFooter)
+      out.write(java.nio.ByteBuffer
+        .allocate(4).order(java.nio.ByteOrder.LITTLE_ENDIAN).putInt(newFooter.length).array())
+      out.write("PAR1".getBytes(java.nio.charset.StandardCharsets.US_ASCII))
+    } finally out.close()
+  }
+
+  test("CONVERT keeps NaN rows for finite-threshold predicate (NaN-excluding writer)") {
+    // Disable Parquet pushdown so only Delta file skipping is exercised, not row-group filtering.
+    withSQLConf(
+        SQLConf.PARQUET_FILTER_PUSHDOWN_ENABLED.key -> "false",
+        "spark.databricks.delta.autoCompact.enabled" -> "false") {
+      // NaN >= 100.0 is true in Spark, so the NaN row must be returned.
+      val values = Seq(1.0, 2.0, 3.0, Double.NaN)
+
+      // Flag on: the foreign writer's float/double max is dropped, so the file is kept.
+      withSQLConf(DeltaSQLConf.DELTA_COLLECT_STATS_SKIP_FLOATING_POINT_FROM_FOOTER.key -> "true") {
+        withTempDir { dir =>
+          val tempDir = dir.getCanonicalPath
+          writeNaNExcludedDoubleParquet(tempDir, values, finiteMin = 1.0, finiteMax = 3.0)
+          convertToDelta(s"parquet.`$tempDir`", collectStats = true)
+          val kept = spark.read.format("delta").load(tempDir).where("c >= 100.0")
+          assert(kept.count() == 1)
+          assert(kept.head().getDouble(0).isNaN)
+        }
+      }
+
     }
   }
 


### PR DESCRIPTION
Footer-based stats collection can record a finite float/double max for files written by writers that exclude NaN, letting data skipping incorrectly skip files that contain NaN. This drops those stats for such writers; parquet-mr stats are kept.

Tested with new unit and conversion tests.