### PR TITLE
[Spark] [Test] Match FileSourceScanLike instead of FileSourceScanExec

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeleteSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeleteSuiteBase.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.delta.sources.DeltaSQLConf
 
 import org.apache.spark.{SparkThrowable, SparkUnsupportedOperationException}
 import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row}
-import org.apache.spark.sql.execution.FileSourceScanExec
+import org.apache.spark.sql.execution.FileSourceScanLike
 import org.apache.spark.sql.functions.{lit, struct}
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.StructType
@@ -479,7 +479,7 @@ trait DeleteBaseTests extends DeleteBaseMixin {
     }
 
     val scans = executedPlans.flatMap(_.collect {
-      case f: FileSourceScanExec => f
+      case f: FileSourceScanLike => f
     })
 
     // The first scan is for finding files to delete. We only are matching against the key
@@ -503,7 +503,7 @@ trait DeleteBaseTests extends DeleteBaseMixin {
     }
 
     val scans = executedPlans.flatMap(_.collect {
-      case f: FileSourceScanExec => f
+      case f: FileSourceScanLike => f
     })
 
     assert(scans.head.schema == StructType.fromDDL("nested STRUCT<key: int>"))

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
@@ -45,7 +45,7 @@ import org.apache.spark.sql.connector.catalog.TableCatalog
 import org.apache.spark.sql.catalyst.expressions.InSet
 import org.apache.spark.sql.catalyst.expressions.Literal.TrueLiteral
 import org.apache.spark.sql.catalyst.plans.logical.Filter
-import org.apache.spark.sql.execution.FileSourceScanExec
+import org.apache.spark.sql.execution.FileSourceScanLike
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelationWithTable}
 import org.apache.spark.sql.functions.{asc, col, expr, lit, map_values, struct}
 import org.apache.spark.sql.internal.SQLConf
@@ -122,7 +122,7 @@ class DeltaSuite extends QueryTest
       // Read only one partition
       val query = spark.read.format("delta").load(testPath).where("part = 1")
       val fileScans = query.queryExecution.executedPlan.collect {
-        case f: FileSourceScanExec => f
+        case f: FileSourceScanLike => f
       }
 
       // Force the query to read files and generate metrics

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTestUtils.scala
@@ -50,7 +50,7 @@ import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.util.{quietly, FailFastMode}
-import org.apache.spark.sql.execution.{FileSourceScanExec, QueryExecution, RDDScanExec, SparkPlan, WholeStageCodegenExec}
+import org.apache.spark.sql.execution.{FileSourceScanLike, QueryExecution, RDDScanExec, SparkPlan, WholeStageCodegenExec}
 import org.apache.spark.sql.execution.aggregate.HashAggregateExec
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.StructType
@@ -258,7 +258,7 @@ trait DeltaTestUtilsBase {
           hash.collectLeaves().size == 2 &&
             hash.collectLeaves()
               .forall { s =>
-                s.isInstanceOf[FileSourceScanExec] ||
+                s.isInstanceOf[FileSourceScanLike] ||
                   s.isInstanceOf[RDDScanExec]
               }
         case _ => false

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSQLSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSQLSuite.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.catalyst.analysis.{Analyzer, ResolveSessionCatalog}
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.catalyst.plans.logical.{DeltaMergeInto, LogicalPlan}
 import org.apache.spark.sql.catalyst.rules.Rule
-import org.apache.spark.sql.execution.FileSourceScanExec
+import org.apache.spark.sql.execution.FileSourceScanLike
 import org.apache.spark.sql.functions.udf
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
@@ -235,7 +235,7 @@ trait MergeIntoSQLTests extends MergeIntoSQLMixin {
           val df = sql(merge)
 
           val readSchema: Seq[StructType] = df.queryExecution.executedPlan.collect {
-            case f: FileSourceScanExec => f.requiredSchema
+            case f: FileSourceScanLike => f.requiredSchema
           }
           assert(readSchema.flatten.isEmpty, "column pruning does not work")
         }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/UpdateSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/UpdateSuiteBase.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.delta.test.shims.UnsupportedTableOperationErrorShims
 
 import org.apache.spark.{SparkThrowable, SparkUnsupportedOperationException}
 import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row}
-import org.apache.spark.sql.execution.FileSourceScanExec
+import org.apache.spark.sql.execution.FileSourceScanLike
 import org.apache.spark.sql.execution.datasources.FileFormat
 import org.apache.spark.sql.functions.{lit, struct}
 import org.apache.spark.sql.internal.SQLConf
@@ -843,7 +843,7 @@ trait UpdateBaseMiscTests extends UpdateBaseMixin {
     }
 
     val scans = executedPlans.flatMap(_.collect {
-      case f: FileSourceScanExec => f
+      case f: FileSourceScanLike => f
     })
     // The first scan is for finding files to update. We only are matching against the key
     // so that should be the only field in the schema.
@@ -868,7 +868,7 @@ trait UpdateBaseMiscTests extends UpdateBaseMixin {
     }
 
     val scans = executedPlans.flatMap(_.collect {
-      case f: FileSourceScanExec => f
+      case f: FileSourceScanLike => f
     })
 
     assert(scans.head.schema == StructType.fromDDL("nested STRUCT<key: int>"))

--- a/spark/src/test/scala/org/apache/spark/sql/delta/deletionvectors/DeletionVectorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/deletionvectors/DeletionVectorsSuite.scala
@@ -41,7 +41,7 @@ import org.apache.spark.SparkException
 import org.apache.spark.sql.{DataFrame, QueryTest, Row}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.plans.logical.{AppendData, Subquery}
-import org.apache.spark.sql.execution.FileSourceScanExec
+import org.apache.spark.sql.execution.FileSourceScanLike
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
@@ -1113,7 +1113,7 @@ class DeletionVectorsWithPredicatePushdownSuite extends DeletionVectorsSuite {
 
   private def assertPredicatesArePushedDown(df: DataFrame): Unit = {
     val scan = df.queryExecution.executedPlan.collectFirst {
-      case scan: FileSourceScanExec => scan
+      case scan: FileSourceScanLike => scan
     }
     assert(scan.map(_.dataFilters.nonEmpty).getOrElse(true))
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/perf/OptimizeGeneratedColumnSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/perf/OptimizeGeneratedColumnSuite.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.expressions.Expression
-import org.apache.spark.sql.execution.{FileSourceScanExec, QueryExecution}
+import org.apache.spark.sql.execution.{FileSourceScanLike, QueryExecution}
 import org.apache.spark.sql.types.TimestampType
 import org.apache.spark.util.ThreadUtils
 import org.apache.spark.util.Utils
@@ -45,7 +45,7 @@ class OptimizeGeneratedColumnSuite extends GeneratedColumnTest {
 
   private def getPushedPartitionFilters(queryExecution: QueryExecution): Seq[Expression] = {
     queryExecution.executedPlan.collectFirst {
-      case scan: FileSourceScanExec => scan.partitionFilters
+      case scan: FileSourceScanLike => scan.partitionFilters
     }.getOrElse(Nil)
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowIdSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowIdSuite.scala
@@ -34,7 +34,7 @@ import org.apache.parquet.hadoop.ParquetOutputFormat
 import org.apache.spark.SparkException
 import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row}
 import org.apache.spark.sql.catalyst.TableIdentifier
-import org.apache.spark.sql.execution.{FileSourceScanExec, SparkPlan}
+import org.apache.spark.sql.execution.{FileSourceScanLike, SparkPlan}
 import org.apache.spark.sql.execution.datasources.parquet.ParquetTest
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
@@ -926,7 +926,7 @@ class RowIdSuite extends QueryTest
   protected def checkScanMetrics(plan: SparkPlan, expectedNumOfRows: Long): Unit = {
     var numOutputRows = 0L
     plan.foreach {
-      case f: FileSourceScanExec =>
+      case f: FileSourceScanLike =>
         numOutputRows += f.metrics("numOutputRows").value
       case _ => // Not a scan node, do nothing.
     }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/test/TestsStatistics.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/test/TestsStatistics.scala
@@ -20,7 +20,7 @@ import org.apache.spark.sql.delta.DeltaLog
 import org.apache.spark.sql.delta.test.DeltaSQLTestUtils
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 
-import org.apache.spark.sql.execution.{ColumnarToRowExec, FileSourceScanExec, InputAdapter, SparkPlan}
+import org.apache.spark.sql.execution.{ColumnarToRowExec, FileSourceScanLike, InputAdapter, SparkPlan}
 import org.apache.spark.sql.functions.from_json
 import org.apache.spark.sql.{Column, DataFrame}
 
@@ -75,10 +75,10 @@ trait TestsStatistics  { self: DeltaSQLTestUtils =>
    * A util to match a physical file scan node.
    */
   object FileScanExecNode {
-    def unapply(plan: SparkPlan): Option[FileSourceScanExec] = plan match {
-      case f: FileSourceScanExec => Some(f)
-      case InputAdapter(f: FileSourceScanExec) => Some(f)
-      case ColumnarToRowExec(InputAdapter(f: FileSourceScanExec)) => Some(f)
+    def unapply(plan: SparkPlan): Option[FileSourceScanLike] = plan match {
+      case f: FileSourceScanLike => Some(f)
+      case InputAdapter(f: FileSourceScanLike) => Some(f)
+      case ColumnarToRowExec(InputAdapter(f: FileSourceScanLike)) => Some(f)
       case _ => None
     }
   }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Follow up of #7104. This applies the same change to the remaining test code.

## How was this patch tested?
Unit tests

## Does this PR introduce _any_ user-facing changes?
No
