### PR TITLE
[Spark][kernel] Translate "no schema should throw an exception" mismatch from #5900

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/exceptions/TableNotFoundException.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/exceptions/TableNotFoundException.java
@@ -25,22 +25,39 @@ import io.delta.kernel.annotation.Evolving;
 @Evolving
 public class TableNotFoundException extends KernelException {
 
+  /** Indicates why no Delta table was found at the given location. */
+  public enum Reason {
+    NO_DELTA_FILES_FOUND,
+    UNKNOWN
+  }
+
   private final String tablePath;
+  private final Reason reason;
 
   public TableNotFoundException(String tablePath) {
     this(tablePath, null);
   }
 
   public TableNotFoundException(String tablePath, String context) {
+    this(tablePath, context, Reason.UNKNOWN);
+  }
+
+  public TableNotFoundException(String tablePath, String context, Reason reason) {
     super(
         String.format(
             "Delta table at path `%s` is not found.%s",
             tablePath, context == null ? "" : " Context: " + context));
     this.tablePath = tablePath;
+    this.reason = reason == null ? Reason.UNKNOWN : reason;
   }
 
   /** @return the provided path where no Delta table was found */
   public String getTablePath() {
     return tablePath;
+  }
+
+  /** @return the reason this location was considered not to contain a Delta table */
+  public Reason getReason() {
+    return reason;
   }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
@@ -294,7 +294,9 @@ public class SnapshotManager {
       }
     }
     throw new TableNotFoundException(
-        tablePath.toString(), format("No delta files found in the directory: %s", logPath));
+        tablePath.toString(),
+        format("No delta files found in the directory: %s", logPath),
+        TableNotFoundException.Reason.NO_DELTA_FILES_FOUND);
   }
 
   /**

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/exceptions/ExceptionSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/exceptions/ExceptionSuite.scala
@@ -82,6 +82,28 @@ class ExceptionSuite extends AnyFunSuite {
     assert(ex.getMessage.contains("version 7"))
   }
 
+  test("TableNotFoundException - reason defaults to UNKNOWN") {
+    val tablePath = "/path/to/table"
+
+    assert(new TableNotFoundException(tablePath).getReason == TableNotFoundException.Reason.UNKNOWN)
+    assert(
+      new TableNotFoundException(tablePath, "some context").getReason
+        == TableNotFoundException.Reason.UNKNOWN)
+  }
+
+  test("TableNotFoundException - reason is preserved") {
+    val tablePath = "/path/to/table"
+
+    val ex = new TableNotFoundException(
+      tablePath,
+      "No delta files found in the directory",
+      TableNotFoundException.Reason.NO_DELTA_FILES_FOUND)
+
+    assert(ex.getTablePath == tablePath)
+    assert(ex.getReason == TableNotFoundException.Reason.NO_DELTA_FILES_FOUND)
+    assert(ex.getMessage.contains("is not found"))
+  }
+
   test("CommitRangeNotFoundException - with start and end version") {
     val tablePath = "/path/to/table"
     val startVersion = 5L

--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSuite.scala
@@ -145,6 +145,7 @@ object DeltaV2SourceSuite {
     "deltaSourceIgnoreDeleteError contains removeFile, version, tablePath",
     "deltaSourceIgnoreChangesError contains changeInfo, version, tablePath",
     "excludeRegex throws good error on bad regex pattern",
+    "no schema should throw an exception",
 
     // ========== Misc tests ==========
     "a fast writer should not starve a Delta source",
@@ -181,8 +182,6 @@ object DeltaV2SourceSuite {
     "incremental: commit file gap between versions, failOnDataLoss=false succeeds",
 
     // === Misc ===
-    // TODO(#5900): fix exception mismatch
-    "no schema should throw an exception",
     // TODO(#5900): fix exception mismatch
     "Delta sources should verify the protocol reader version",
     // TODO(#5895): gracefully handle corrupt checkpoint

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -1389,6 +1389,14 @@ trait DeltaErrorsBase
     )
   }
 
+  /**
+   * Throws [[schemaNotSetException]]. Returns `Nothing` so Java callers can invoke it as a
+   * statement to raise the checked [[DeltaAnalysisException]].
+   */
+  def throwSchemaNotSet(): Nothing = {
+    throw schemaNotSetException
+  }
+
   def specifySchemaAtReadTimeException: Throwable = {
     new DeltaAnalysisException(
       errorClass = "DELTA_UNSUPPORTED_SCHEMA_DURING_READ",

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
@@ -23,6 +23,7 @@ import static java.util.Objects.requireNonNull;
 import io.delta.kernel.Snapshot;
 import io.delta.kernel.defaults.engine.DefaultEngine;
 import io.delta.kernel.engine.Engine;
+import io.delta.kernel.exceptions.TableNotFoundException;
 import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.internal.rowtracking.RowTracking;
 import io.delta.spark.internal.v2.read.MetadataEvolutionHandler;
@@ -44,6 +45,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.catalog.CatalogTable;
@@ -62,6 +64,7 @@ import org.apache.spark.sql.connector.read.ScanBuilder;
 import org.apache.spark.sql.connector.read.Statistics;
 import org.apache.spark.sql.connector.write.LogicalWriteInfo;
 import org.apache.spark.sql.connector.write.WriteBuilder;
+import org.apache.spark.sql.delta.DeltaErrors;
 import org.apache.spark.sql.delta.DeltaTableUtils;
 import org.apache.spark.sql.delta.RowCommitVersion$;
 import org.apache.spark.sql.delta.RowId$;
@@ -199,7 +202,18 @@ public class DeltaV2Table
     this.kernelEngine = DefaultEngine.create(this.hadoopConf);
     this.snapshotManager = SnapshotManagerFactory.create(tablePath, kernelEngine, catalogTable);
     // Load the initial snapshot through the manager
-    this.initialSnapshot = snapshotManager.loadLatestSnapshot();
+    Snapshot loadedSnapshot;
+    try {
+      loadedSnapshot = snapshotManager.loadLatestSnapshot();
+    } catch (TableNotFoundException e) {
+      // The _delta_log directory exists but holds no commits: the location is an initialized but
+      // empty Delta table.
+      if (deltaLogDirExists()) {
+        DeltaErrors.throwSchemaNotSet();
+      }
+      throw e;
+    }
+    this.initialSnapshot = loadedSnapshot;
 
     this.isCDCRead = CDCReader.isCDCRead(new CaseInsensitiveStringMap(this.options));
 
@@ -224,6 +238,17 @@ public class DeltaV2Table
     // Schema-related metadata is lazily computed on first access within SchemaProvider
     this.schemaProvider =
         new SchemaProvider(SparkSession.active(), rawSchema, partitionColumnNames);
+  }
+
+  /** Returns whether the table's {@code _delta_log} directory exists. */
+  private boolean deltaLogDirExists() {
+    try {
+      Path logPath = new Path(tablePath, "_delta_log");
+      FileSystem fs = logPath.getFileSystem(hadoopConf);
+      return fs.exists(logPath);
+    } catch (Exception ioe) {
+      return false;
+    }
   }
 
   /**

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
@@ -45,7 +45,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.catalog.CatalogTable;
@@ -206,9 +205,8 @@ public class DeltaV2Table
     try {
       loadedSnapshot = snapshotManager.loadLatestSnapshot();
     } catch (TableNotFoundException e) {
-      // The _delta_log directory exists but holds no commits: the location is an initialized but
-      // empty Delta table.
-      if (deltaLogDirExists()) {
+      // No Delta log files at the location.
+      if (e.getReason() == TableNotFoundException.Reason.NO_DELTA_FILES_FOUND) {
         DeltaErrors.throwSchemaNotSet();
       }
       throw e;
@@ -238,17 +236,6 @@ public class DeltaV2Table
     // Schema-related metadata is lazily computed on first access within SchemaProvider
     this.schemaProvider =
         new SchemaProvider(SparkSession.active(), rawSchema, partitionColumnNames);
-  }
-
-  /** Returns whether the table's {@code _delta_log} directory exists. */
-  private boolean deltaLogDirExists() {
-    try {
-      Path logPath = new Path(tablePath, "_delta_log");
-      FileSystem fs = logPath.getFileSystem(hadoopConf);
-      return fs.exists(logPath);
-    } catch (Exception ioe) {
-      return false;
-    }
   }
 
   /**


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Resolves #5900 (partly, other part in #7071)
(Scoped down from #7025)

When using DSv2 connector, a streaming read surfaces Kernel-native exceptions instead of the Spark/Delta exceptions the DSv1 path raises. This PR translates one of them at its surfacing points to be consistent with DSv1:
Reading a path whose `_delta_log` directory exists but contains no commits now throws `org.apache.spark.sql.AnalysisException` (`DELTA_SCHEMA_NOT_SET`) instead of Kernel's `TableNotFoundException`.

The translations are inline as such:
- `DeltaErrors` gains `throwSchemaNotSet()`.
- `DeltaV2Table` translates `TableNotFoundException` on initial snapshot load.


## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

Enabled the previously expected-to-fail test in `DeltaV2SourceSuite`:
- `no schema should throw an exception`

All test runs still passed after.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No