### PR TITLE
Add AmtSingleAction row type and AmtAction typed view for AMT manifests

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/actions.scala
@@ -1,0 +1,460 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.amt
+
+import org.apache.spark.sql.delta.actions.AddFile
+
+/**
+ * One entry in any AMT manifest file (leaf or root).
+ * Same shape for leaves and roots; `content_type` discriminates the kind
+ * of entry (data file or data-manifest pointer).
+ *
+ * @param content_type Entry-kind discriminator (0=DATA, 3=DATA_MANIFEST).
+ * @param format_version Iceberg writer format version; 4 for V4.
+ * @param location Path of the file relative to the table root, or an absolute URI.
+ * @param file_format Physical format of `location` (currently always "parquet").
+ * @param tracking Lineage envelope: status plus snapshot/sequence numbers and DV positions.
+ * @param deletion_vector Pointer to a deletion-vector blob; only on DATA entries.
+ * @param spec_id Id of the partition spec the file was written under.
+ * @param partition Partition values of the file.
+ * @param sort_order_id Id of the sort order the file was written with; only on DATA entries.
+ * @param record_count Rows in the file, or rows the manifest summarizes (for pointers).
+ * @param file_size_in_bytes On-disk size of `location` in bytes.
+ * @param content_stats Column-level statistics for the file.
+ * @param manifest_info Manifest stats plus inline DV; set iff content_type is DATA_MANIFEST.
+ * @param key_metadata Encryption key metadata for the file, if encrypted.
+ * @param split_offsets Row-group split offsets (Iceberg field 132); Delta does not generate or
+ *                      consume these, but the field is kept in the schema to carry it forward
+ *                      for tables written by both Delta and Iceberg.
+ * @param column_files Per-column file entries; only content_type in {0,3}.
+ */
+case class AmtSingleAction(
+    content_type: Int,                          // ID: 134, required.
+    format_version: Int,                        // ID: 157, required.
+    location: String,                           // ID: 100, required.
+    file_format: String,                        // ID: 101, required ("parquet" for now).
+    tracking: Tracking,                         // ID: 147, required.
+    deletion_vector: Option[DeletionVector],    // ID: 148, optional (only when content_type=0).
+    spec_id: Option[Int],                       // ID: 141, optional.
+    partition: Partition,                       // ID: 102, required.
+    sort_order_id: Option[Int],                 // ID: 140, optional (only when content_type=0).
+    record_count: Long,                         // ID: 103, required.
+    file_size_in_bytes: Long,                   // ID: 104, required.
+    content_stats: Option[ContentStats],        // ID: 146, optional.
+    manifest_info: Option[ManifestInfo],        // ID: 150, required for DATA_MANIFEST.
+    key_metadata: Option[Array[Byte]],          // ID: 131, optional.
+    split_offsets: Option[Seq[Long]],           // ID: 132, optional.
+    column_files: Option[Seq[ColumnFile]] // ID: TBD (content_type in {0,3}).
+) {
+  AmtSingleAction.validate(this)
+
+  /**
+   * Returns the strongly-typed [[AmtAction]] view of this row. The `.get` calls are
+   * safe because [[AmtSingleAction.validate]] (run at construction) guarantees the required
+   * fields are present for each kind.
+   */
+  def unwrap: AmtAction = content_type match {
+    case AmtSingleAction.ContentType.Type.Data =>
+      DataEntry(
+        location = location,
+        file_format = file_format,
+        tracking = tracking,
+        record_count = record_count,
+        file_size_in_bytes = file_size_in_bytes,
+        partition = partition,
+        deletion_vector = deletion_vector,
+        spec_id = spec_id,
+        sort_order_id = sort_order_id,
+        content_stats = content_stats,
+        key_metadata = key_metadata,
+        split_offsets = split_offsets,
+        column_files = column_files,
+        format_version = format_version)
+    case AmtSingleAction.ContentType.Type.DataManifest =>
+      DataManifestEntry(
+        location = location,
+        file_format = file_format,
+        tracking = tracking,
+        record_count = record_count,
+        file_size_in_bytes = file_size_in_bytes,
+        manifest_info = manifest_info.get,
+        partition = partition,
+        spec_id = spec_id,
+        content_stats = content_stats,
+        key_metadata = key_metadata,
+        split_offsets = split_offsets,
+        column_files = column_files,
+        format_version = format_version)
+    case other =>
+      throw new IllegalStateException(s"Unsupported content_type: $other.")
+  }
+}
+
+object AmtSingleAction {
+
+  /**
+   * Content-type metadata. The integer codes live in the nested [[ContentType.Type]]
+   * object; matching Iceberg V4 (0 = DATA, 3 = DATA_MANIFEST). Codes 2 (EQUALITY_DELETES)
+   * and 4 (DELETE_MANIFEST) are intentionally omitted: Delta writers emit neither. These
+   * are expected only when an existing Iceberg table is upgraded from v3 to v4; support
+   * will be added later if needed.
+   */
+  object ContentType {
+    object Type {
+      val Data: Int = 0
+      val DataManifest: Int = 3
+    }
+    val all: Set[Int] = Set(Type.Data, Type.DataManifest)
+    /** True iff this content type may only appear in a root manifest. */
+    def isRootOnly(t: Int): Boolean = t == Type.DataManifest
+  }
+
+  /** `format_version` value that V4 writers must emit. */
+  val FormatVersionV4: Int = 4
+  /** File format for AMT data and manifest files. */
+  val FileFormatParquet: String = "parquet"
+
+  /**
+   * Validates spec invariants. Throws `IllegalArgumentException` on any
+   * violation. Called from the case-class constructor; rejecting bad
+   * entries at construction.
+   *
+   *   - content_type in {0, 3}.
+   *   - file_format missing or "parquet".
+   *   - manifest_info MUST be set iff content_type == DATA_MANIFEST (3).
+   *   - deletion_vector MUST be null when content_type != 0.
+   *   - sort_order_id MUST be null when content_type != 0.
+   *   - tracking.sequence_number == tracking.file_sequence_number when
+   *     content_type == DATA_MANIFEST (3) and both are set.
+   */
+  def validate(action: AmtSingleAction): Unit = {
+    require(ContentType.all.contains(action.content_type),
+      s"Unsupported content_type: ${action.content_type}.")
+    require(Option(action.file_format).forall(_ == FileFormatParquet),
+      s"file_format must be missing or '$FileFormatParquet'; got ${action.file_format}.")
+    require(
+      ContentType.isRootOnly(action.content_type) == action.manifest_info.isDefined,
+      s"manifest_info must be set iff content_type is a manifest pointer; " +
+        s"got content_type=${action.content_type}, " +
+        s"manifest_info.isDefined=${action.manifest_info.isDefined}.")
+    require(action.content_type == ContentType.Type.Data || action.deletion_vector.isEmpty,
+      s"deletion_vector must be null when content_type != ${ContentType.Type.Data}; " +
+        s"got content_type=${action.content_type}.")
+    require(action.content_type == ContentType.Type.Data || action.sort_order_id.isEmpty,
+      s"sort_order_id must be null when content_type != ${ContentType.Type.Data}; " +
+        s"got content_type=${action.content_type}.")
+    if (ContentType.isRootOnly(action.content_type)) {
+      (action.tracking.sequence_number, action.tracking.file_sequence_number) match {
+        case (Some(a), Some(b)) => require(a == b,
+          s"For root entries, tracking.sequence_number must equal " +
+            s"tracking.file_sequence_number; got $a vs $b.")
+        case _ => ()
+      }
+    }
+  }
+
+  /** Creates [[AmtSingleAction]] from AddFile. */
+  def fromAddFile(add: AddFile, tracking: Tracking): AmtSingleAction =
+    DataEntry.fromAddFile(add, tracking).wrap
+}
+
+/**
+ * Strongly-typed, in-memory view of an [[AmtSingleAction]], one case class per
+ * `content_type` kind. Only [[AmtSingleAction]] is persisted; [[wrap]] flattens a
+ * kind back to it and [[AmtSingleAction.unwrap]] recovers it.
+ */
+sealed trait AmtAction {
+  /** The `content_type` discriminator this kind maps to. */
+  protected def content_type: Int
+
+  require(AmtSingleAction.ContentType.all.contains(content_type),
+    s"Unsupported content_type: $content_type.")
+
+  /** Flatten this typed view back into the on-disk [[AmtSingleAction]] row. */
+  def wrap: AmtSingleAction
+}
+
+/**
+ * A data-file entry (`content_type = 0`), used by leaves.
+ *
+ * @param location Path of the data file relative to the table root, or an absolute URI.
+ * @param file_format Physical format of `location` (currently always "parquet").
+ * @param tracking Lineage envelope: status plus snapshot/sequence numbers and DV positions.
+ * @param record_count Number of records in the data file.
+ * @param file_size_in_bytes On-disk size of `location` in bytes.
+ * @param partition Partition values of the file.
+ * @param deletion_vector Pointer to a deletion-vector blob for this data file.
+ * @param spec_id Id of the partition spec the file was written under.
+ * @param sort_order_id Id of the sort order the file was written with.
+ * @param content_stats Column-level statistics for the file.
+ * @param key_metadata Encryption key metadata for the file, if encrypted.
+ * @param split_offsets Row-group split offsets (Iceberg field 132); Delta does not generate or
+ *                      consume these, but the field is kept in the schema to carry it forward
+ *                      for tables written by both Delta and Iceberg.
+ * @param column_files Per-column file entries.
+ * @param format_version Iceberg writer format version; 4 for V4.
+ */
+case class DataEntry(
+    location: String,
+    file_format: String,
+    tracking: Tracking,
+    record_count: Long,
+    file_size_in_bytes: Long,
+    partition: Partition = Partition(),
+    deletion_vector: Option[DeletionVector] = None,
+    spec_id: Option[Int] = None,
+    sort_order_id: Option[Int] = None,
+    content_stats: Option[ContentStats] = None,
+    key_metadata: Option[Array[Byte]] = None,
+    split_offsets: Option[Seq[Long]] = None,
+    column_files: Option[Seq[ColumnFile]] = None,
+    format_version: Int = AmtSingleAction.FormatVersionV4)
+  extends AmtAction {
+
+  override protected def content_type: Int = AmtSingleAction.ContentType.Type.Data
+
+  override def wrap: AmtSingleAction = AmtSingleAction(
+    content_type = content_type,
+    format_version = format_version,
+    location = location,
+    file_format = file_format,
+    tracking = tracking,
+    deletion_vector = deletion_vector,
+    spec_id = spec_id,
+    partition = partition,
+    sort_order_id = sort_order_id,
+    record_count = record_count,
+    file_size_in_bytes = file_size_in_bytes,
+    content_stats = content_stats,
+    manifest_info = None,
+    key_metadata = key_metadata,
+    split_offsets = split_offsets,
+    column_files = column_files)
+}
+
+object DataEntry {
+  /** Creates [[DataEntry]] from AddFile. */
+  def fromAddFile(add: AddFile, tracking: Tracking): DataEntry =
+    DataEntry(
+      location = add.path,
+      file_format = AmtSingleAction.FileFormatParquet,
+      tracking = tracking,
+      // Iceberg field 103 is the physical record count of the file, not the live/logical
+      // count after deletes; throw rather than guess when the AddFile carries no stats.
+      record_count = add.numPhysicalRecords.getOrElse(
+        throw new IllegalArgumentException(
+          s"Cannot build AMT entry: AddFile has no record count (missing stats): ${add.path}.")),
+      file_size_in_bytes = add.size,
+      partition = Partition(Option(add.partitionValues).filter(_.nonEmpty)),
+      deletion_vector = None,
+      content_stats = None)
+}
+
+/**
+ * A pointer from the root to a leaf data manifest (`content_type = 3`).
+ *
+ * @param location Path of the leaf data manifest relative to the table root, or an absolute URI.
+ * @param file_format Physical format of `location` (currently always "parquet").
+ * @param tracking Lineage envelope: status plus snapshot/sequence numbers and DV positions.
+ * @param record_count Rows summarized across the referenced manifest.
+ * @param file_size_in_bytes On-disk size of the manifest file in bytes.
+ * @param manifest_info Stats for the referenced manifest, plus its inline DV.
+ * @param partition Partition values.
+ * @param spec_id Id of the partition spec the manifest was written under.
+ * @param content_stats Column-level statistics.
+ * @param key_metadata Encryption key metadata for the manifest, if encrypted.
+ * @param split_offsets Row-group split offsets (Iceberg field 132); Delta does not generate or
+ *                      consume these, but the field is kept in the schema to carry it forward
+ *                      for tables written by both Delta and Iceberg.
+ * @param column_files Per-column file entries.
+ * @param format_version Iceberg writer format version; 4 for V4.
+ */
+case class DataManifestEntry(
+    location: String,
+    file_format: String,
+    tracking: Tracking,
+    record_count: Long,
+    file_size_in_bytes: Long,
+    manifest_info: ManifestInfo,
+    partition: Partition = Partition(),
+    spec_id: Option[Int] = None,
+    content_stats: Option[ContentStats] = None,
+    key_metadata: Option[Array[Byte]] = None,
+    split_offsets: Option[Seq[Long]] = None,
+    column_files: Option[Seq[ColumnFile]] = None,
+    format_version: Int = AmtSingleAction.FormatVersionV4)
+  extends AmtAction {
+
+  override protected def content_type: Int = AmtSingleAction.ContentType.Type.DataManifest
+
+  override def wrap: AmtSingleAction = AmtSingleAction(
+    content_type = content_type,
+    format_version = format_version,
+    location = location,
+    file_format = file_format,
+    tracking = tracking,
+    deletion_vector = None,
+    spec_id = spec_id,
+    partition = partition,
+    sort_order_id = None,
+    record_count = record_count,
+    file_size_in_bytes = file_size_in_bytes,
+    content_stats = content_stats,
+    manifest_info = Some(manifest_info),
+    key_metadata = key_metadata,
+    split_offsets = split_offsets,
+    column_files = column_files)
+}
+
+/**
+ * Inheritance / lineage envelope on every [[AmtSingleAction]]. Matches the
+ * `tracking` struct in the V4 spec (field IDs in comments).
+ *
+ * @param status Entry status (0=existing, 1=added, 2=deleted, 3=replaced, 4=modified).
+ * @param snapshot_id Snapshot the file was added/deleted/replaced in; inherited from root.
+ * @param dv_snapshot_id Snapshot the DV was added in; null when the entry has no DV.
+ * @param sequence_number Data sequence number of the file.
+ * @param file_sequence_number File sequence number (when the file was added).
+ * @param first_row_id Id of the first row in the data file.
+ * @param deleted_positions Bitmap of positions deleted in this snapshot.
+ * @param replaced_positions Bitmap of positions replaced in this snapshot.
+ */
+case class Tracking(
+    status: Int,                            // ID: 0, required.
+    snapshot_id: Option[Long],              // ID: 1, optional.
+    dv_snapshot_id: Option[Long],           // ID: 5, optional.
+    sequence_number: Option[Long],          // ID: 3, optional.
+    file_sequence_number: Option[Long],     // ID: 4, optional.
+    first_row_id: Option[Long],             // ID: 142, optional.
+    deleted_positions: Option[Array[Byte]], // ID: 6, optional (bitmap).
+    replaced_positions: Option[Array[Byte]] // ID: 7, optional (bitmap).
+) {
+  require(Tracking.Status.all.contains(status),
+    s"Unsupported tracking status: $status.")
+}
+
+object Tracking {
+  /**
+   * Closed set of `status` values, matching Iceberg V4 integer codes.
+   *   0 = EXISTING, 1 = ADDED, 2 = DELETED, 3 = REPLACED, 4 = MODIFIED.
+   *
+   * REPLACED / MODIFIED come in pairs: a `REPLACED` row marks the prior
+   * tracking-snapshot-id state; a `MODIFIED` row carries the current state
+   * with updated DV info or column updates. They need not be co-located
+   * in the same manifest.
+   */
+  object Status {
+    val Existing: Int = 0
+    val Added: Int = 1
+    val Deleted: Int = 2
+    val Replaced: Int = 3
+    val Modified: Int = 4
+    val all: Set[Int] = Set(Existing, Added, Deleted, Replaced, Modified)
+  }
+}
+
+/**
+ * Partition-values carrier for [[AmtSingleAction]] (Iceberg V4 `partition`, field 102).
+ *
+ * Iceberg models `partition` as a per-table dynamic struct (one typed field per
+ * partition column); that shape cannot be expressed statically here, so this PR carries
+ * Delta's raw `AddFile.partitionValues`. The struct is present at field 102 (the spec
+ * marks it required); binary interop with a strict V4 reader that expects the typed
+ * per-column struct is deferred.
+ *
+ *
+ * @param values Raw Delta partition values (column name to value); None when unpartitioned.
+ */
+case class Partition(values: Option[Map[String, String]] = None)
+
+/**
+ * Pointer to a deletion-vector blob.
+ *
+ * @param location File path holding the DV blob.
+ * @param offset Byte offset of the DV blob within the DV blob file.
+ * @param size_in_bytes Size of the DV blob in bytes.
+ * @param cardinality Number of positions the DV marks deleted.
+ */
+case class DeletionVector(
+    location: String,         // ID: 155, required (DV blob file path).
+    offset: Long,             // ID: 144, required.
+    size_in_bytes: Long,      // ID: 145, required.
+    cardinality: Long)        // ID: 156, required.
+
+/**
+ * Statistics + inline manifest DV for a `content_type == DATA_MANIFEST (3)` root entry.
+ * Field IDs and required/optional match the V4 `manifest_info` struct verbatim.
+ *
+ * `dv` carries the inline manifest deletion-vector bitmap over leaf row
+ * positions; `dv_cardinality` is its count. Manifest DVs live INSIDE
+ * `manifest_info`, not as separate root rows -- a deliberate choice in
+ * the Combined Data + DV Entry model.
+ *
+ * @param added_files_count Count of ADDED file entries in the referenced manifest.
+ * @param existing_files_count Count of EXISTING file entries.
+ * @param deleted_files_count Count of DELETED file entries.
+ * @param replaced_files_count Count of REPLACED file entries.
+ * @param added_rows_count Rows across ADDED files.
+ * @param existing_rows_count Rows across EXISTING files.
+ * @param deleted_rows_count Rows across DELETED files.
+ * @param replaced_rows_count Rows across REPLACED files.
+ * @param min_sequence_number Minimum data sequence number across the manifest's entries.
+ * @param dv Inline manifest deletion-vector bitmap over leaf row positions.
+ * @param dv_cardinality Number of positions the inline manifest DV marks.
+ */
+case class ManifestInfo(
+    added_files_count: Int,           // ID: 504, required.
+    existing_files_count: Int,        // ID: 505, required.
+    deleted_files_count: Int,         // ID: 506, required.
+    replaced_files_count: Int,        // ID: 520, required.
+    added_rows_count: Long,           // ID: 512, required.
+    existing_rows_count: Long,        // ID: 513, required.
+    deleted_rows_count: Long,         // ID: 514, required.
+    replaced_rows_count: Long,        // ID: 521, required.
+    min_sequence_number: Long,        // ID: 516, required.
+    dv: Option[Array[Byte]],          // ID: 522, optional (inline manifest DV bitmap).
+    dv_cardinality: Option[Long])     // ID: 523, optional.
+
+/**
+ * Column-level statistics carrier. Iceberg V4 leaves the inner shape
+ * up to the caller (it depends on the table schema). A future PR introduces
+ * the Delta-stats mapping.
+ *
+ * The single nullable `raw_stats` field is deliberate: an empty case class encodes to an
+ * empty Parquet group, which the Parquet data source rejects
+ * (`EMPTY_SCHEMA_NOT_SUPPORTED_FOR_DATASOURCE`). One nullable column keeps
+ * `AmtSingleAction` Parquet-writable without committing to the final stats shape; M1
+ * writers leave it `None`.
+ *
+ *
+ * @param raw_stats Column-stats payload; M1 writers leave it None.
+ */
+case class ContentStats(raw_stats: Option[Array[Byte]] = None)
+
+/**
+ * Per-column file entries; shape TBD per the spec.
+ *
+ * The single nullable `location` field is deliberate: an empty case class encodes to an
+ * empty Parquet group, which the Parquet data source rejects
+ * (`EMPTY_SCHEMA_NOT_SUPPORTED_FOR_DATASOURCE`). One nullable column keeps
+ * `AmtSingleAction` Parquet-writable without committing to the final per-column-file
+ * shape; M1 writers leave `column_files` `None`.
+ *
+ *
+ * @param location Per-column file path; M1 writers leave it None.
+ */
+case class ColumnFile(location: Option[String] = None)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AmtSingleActionSerializerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AmtSingleActionSerializerSuite.scala
@@ -1,0 +1,298 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.amt
+
+import org.apache.spark.sql.delta.actions.AddFile
+
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.test.SharedSparkSession
+
+/**
+ * Shape, builder, invariant, and parquet round-trip tests for the AMT
+ * [[AmtSingleAction]] row record and its sub-structs. The schema is dictated by
+ * the Iceberg V4 / Adaptive Metadata Tree proposal; these tests pin the
+ * declared column list, the closed constant sets, the per-kind builders, and
+ * the constructor invariants enforced by [[AmtSingleAction.validate]].
+ */
+class AmtSingleActionSerializerSuite extends QueryTest with SharedSparkSession {
+
+  import testImplicits._
+
+  /** A minimal leaf tracking envelope (ADDED status). */
+  private def addedTracking: Tracking = Tracking(
+    status = Tracking.Status.Added,
+    snapshot_id = None,
+    dv_snapshot_id = None,
+    sequence_number = None,
+    file_sequence_number = None,
+    first_row_id = None,
+    deleted_positions = None,
+    replaced_positions = None)
+
+  /** A root tracking envelope with matching sequence numbers (valid for pointers). */
+  private def rootTracking: Tracking = Tracking(
+    status = Tracking.Status.Existing,
+    snapshot_id = Some(7L),
+    dv_snapshot_id = None,
+    sequence_number = Some(3L),
+    file_sequence_number = Some(3L),
+    first_row_id = None,
+    deleted_positions = None,
+    replaced_positions = None)
+
+  private def sampleAddFile: AddFile = AddFile(
+    path = "part-00000.parquet",
+    partitionValues = Map("p" -> "1"),
+    size = 1024L,
+    modificationTime = 100L,
+    dataChange = true,
+    stats = """{"numRecords":42}""")
+
+  private def sampleManifestInfo: ManifestInfo = ManifestInfo(
+    added_files_count = 2,
+    existing_files_count = 0,
+    deleted_files_count = 0,
+    replaced_files_count = 0,
+    added_rows_count = 42L,
+    existing_rows_count = 0L,
+    deleted_rows_count = 0L,
+    replaced_rows_count = 0L,
+    min_sequence_number = 3L,
+    dv = None,
+    dv_cardinality = None)
+
+  test("encoder schema has the expected V4 column names in order") {
+    assert(spark.emptyDataset[AmtSingleAction].schema.fieldNames.toSeq == Seq(
+      "content_type", "format_version", "location", "file_format", "tracking",
+      "deletion_vector", "spec_id", "partition", "sort_order_id", "record_count",
+      "file_size_in_bytes", "content_stats", "manifest_info", "key_metadata",
+      "split_offsets", "column_files"))
+  }
+
+  test("closed constant sets match Iceberg V4 integer codes") {
+    assert(AmtSingleAction.ContentType.all == Set(0, 3))
+    assert(AmtSingleAction.ContentType.Type.Data == 0)
+    assert(AmtSingleAction.ContentType.Type.DataManifest == 3)
+    assert(Tracking.Status.all == Set(0, 1, 2, 3, 4))
+    assert(AmtSingleAction.FormatVersionV4 == 4)
+    assert(AmtSingleAction.FileFormatParquet == "parquet")
+  }
+
+  test("fromAddFile builder produces a DATA entry from an AddFile") {
+    val add = sampleAddFile
+    val entry = AmtSingleAction.fromAddFile(add, addedTracking)
+    assert(entry.content_type == AmtSingleAction.ContentType.Type.Data)
+    assert(entry.location == add.path)
+    assert(entry.record_count == add.numPhysicalRecords.get)
+    assert(entry.file_size_in_bytes == add.size)
+    assert(entry.manifest_info.isEmpty)
+    assert(entry.tracking == addedTracking)
+  }
+
+  test("DataManifestEntry wraps to a DATA_MANIFEST root entry") {
+    val info = sampleManifestInfo
+    val entry = DataManifestEntry(
+      location = "metadata/leaf-0.parquet",
+      file_format = AmtSingleAction.FileFormatParquet,
+      tracking = rootTracking,
+      record_count = 42L,
+      file_size_in_bytes = 2048L,
+      manifest_info = info).wrap
+    assert(entry.content_type == AmtSingleAction.ContentType.Type.DataManifest)
+    assert(entry.location == "metadata/leaf-0.parquet")
+    assert(entry.file_size_in_bytes == 2048L)
+    assert(entry.record_count == 42L)
+    assert(entry.manifest_info.contains(info))
+    assert(entry.deletion_vector.isEmpty)
+    assert(entry.sort_order_id.isEmpty)
+    assert(entry.column_files.isEmpty)
+  }
+
+  /** Builds a DATA entry, overriding individual fields to probe invariants. */
+  private def mkEntry(
+      content_type: Int = AmtSingleAction.ContentType.Type.Data,
+      deletion_vector: Option[DeletionVector] = None,
+      sort_order_id: Option[Int] = None,
+      manifest_info: Option[ManifestInfo] = None,
+      tracking: Tracking = addedTracking): AmtSingleAction = AmtSingleAction(
+    content_type = content_type,
+    format_version = AmtSingleAction.FormatVersionV4,
+    location = "f.parquet",
+    file_format = AmtSingleAction.FileFormatParquet,
+    tracking = tracking,
+    deletion_vector = deletion_vector,
+    spec_id = None,
+    partition = Partition(),
+    sort_order_id = sort_order_id,
+    record_count = 1L,
+    file_size_in_bytes = 1L,
+    content_stats = None,
+    manifest_info = manifest_info,
+    key_metadata = None,
+    split_offsets = None,
+    column_files = None)
+
+  private def assertRejected(substring: String)(build: => AmtSingleAction): Unit = {
+    val ex = intercept[IllegalArgumentException](build)
+    assert(ex.getMessage.contains(substring),
+      s"expected message to contain '$substring', got '${ex.getMessage}'.")
+  }
+
+  test("validate rejects an unknown content_type") {
+    assertRejected("Unsupported content_type")(mkEntry(content_type = 5))
+  }
+
+  test("validate rejects a non-parquet file_format") {
+    assertRejected("file_format must be")(mkEntry().copy(file_format = "orc"))
+  }
+
+  test("validate rejects a manifest pointer without manifest_info") {
+    assertRejected("manifest_info must be set")(
+      mkEntry(content_type = AmtSingleAction.ContentType.Type.DataManifest, manifest_info = None))
+  }
+
+  test("validate rejects a non-pointer entry with manifest_info set") {
+    assertRejected("manifest_info must be set")(
+      mkEntry(content_type = AmtSingleAction.ContentType.Type.Data,
+        manifest_info = Some(sampleManifestInfo)))
+  }
+
+  test("validate rejects deletion_vector when content_type != 0") {
+    assertRejected("deletion_vector must be null")(
+      mkEntry(
+        content_type = AmtSingleAction.ContentType.Type.DataManifest,
+        manifest_info = Some(sampleManifestInfo),
+        deletion_vector = Some(DeletionVector("dv", 0L, 1L, 1L))))
+  }
+
+  test("validate rejects sort_order_id when content_type != 0") {
+    assertRejected("sort_order_id must be null")(
+      mkEntry(
+        content_type = AmtSingleAction.ContentType.Type.DataManifest,
+        manifest_info = Some(sampleManifestInfo),
+        sort_order_id = Some(1)))
+  }
+
+  test("validate rejects mismatched sequence numbers on a root entry") {
+    val badTracking = rootTracking.copy(
+      sequence_number = Some(3L), file_sequence_number = Some(4L))
+    assertRejected("must equal")(
+      mkEntry(
+        content_type = AmtSingleAction.ContentType.Type.DataManifest,
+        manifest_info = Some(sampleManifestInfo),
+        tracking = badTracking))
+  }
+
+  test("Tracking rejects an unknown status") {
+    assertRejected("Unsupported tracking status")(
+      // Reuse the same interceptor; build a Tracking inside a throwaway entry.
+      mkEntry(tracking = addedTracking.copy(status = 5)))
+  }
+
+  test("parquet round-trip preserves entries of every content_type") {
+    withTempDir { dir =>
+      val entries = sampleKinds.map(_.wrap) :+
+        AmtSingleAction.fromAddFile(sampleAddFile, addedTracking)
+      // Write under a fresh subpath: `withTempDir` pre-creates `dir`, and the default
+      // parquet save mode errors if the target path already exists.
+      val path = new java.io.File(dir, "all-kinds").getCanonicalPath
+      spark.createDataset(entries).write.parquet(path)
+      val read = spark.read.parquet(path).as[AmtSingleAction].collect()
+      assert(read.toSet == entries.toSet)
+    }
+  }
+
+  test("parquet round-trip preserves every binary field") {
+    // Binary columns are `Array[Byte]`, whose case-class `==` is reference equality, so this
+    // asserts the bytes structurally. Populate all five Option[Array[Byte]] fields across the
+    // row and its sub-structs on a single DATA_MANIFEST entry (the only kind that reaches
+    // `manifest_info.dv`) so none is silently dropped by wrap/unwrap or the encoder.
+    withTempDir { dir =>
+      val keyMeta = Array[Byte](1, 2, 3, 4)
+      val deletedPos = Array[Byte](5, 6)
+      val replacedPos = Array[Byte](7, 8, 9)
+      val manifestDv = Array[Byte](10, 11)
+      val rawStats = Array[Byte](12, 13, 14)
+      val entry = DataManifestEntry(
+        location = "dm.parquet",
+        file_format = AmtSingleAction.FileFormatParquet,
+        tracking = rootTracking.copy(
+          deleted_positions = Some(deletedPos), replaced_positions = Some(replacedPos)),
+        record_count = 1L,
+        file_size_in_bytes = 1L,
+        manifest_info = sampleManifestInfo.copy(dv = Some(manifestDv), dv_cardinality = Some(2L)),
+        content_stats = Some(ContentStats(Some(rawStats))),
+        key_metadata = Some(keyMeta)).wrap
+      val path = new java.io.File(dir, "binary").getCanonicalPath
+      spark.createDataset(Seq(entry)).write.parquet(path)
+      val read = spark.read.parquet(path).as[AmtSingleAction].collect()
+      assert(read.length == 1)
+      val r = read.head
+      assert(r.key_metadata.exists(_.sameElements(keyMeta)), "key_metadata did not round-trip.")
+      assert(r.tracking.deleted_positions.exists(_.sameElements(deletedPos)),
+        "tracking.deleted_positions did not round-trip.")
+      assert(r.tracking.replaced_positions.exists(_.sameElements(replacedPos)),
+        "tracking.replaced_positions did not round-trip.")
+      assert(r.manifest_info.flatMap(_.dv).exists(_.sameElements(manifestDv)),
+        "manifest_info.dv did not round-trip.")
+      assert(r.content_stats.flatMap(_.raw_stats).exists(_.sameElements(rawStats)),
+        "content_stats.raw_stats did not round-trip.")
+    }
+  }
+
+  // One sample of each kind, exercising the kind-specific fields.
+  private def sampleKinds: Seq[AmtAction] = Seq(
+    DataEntry(
+      location = "data.parquet",
+      file_format = AmtSingleAction.FileFormatParquet,
+      tracking = addedTracking,
+      record_count = 10L,
+      file_size_in_bytes = 100L,
+      deletion_vector = Some(DeletionVector("dv", 0L, 8L, 3L)),
+      sort_order_id = Some(2),
+      column_files = Some(Seq(ColumnFile(Some("c0.parquet"))))),
+    DataManifestEntry(
+      location = "dm.parquet",
+      file_format = AmtSingleAction.FileFormatParquet,
+      tracking = rootTracking,
+      record_count = 42L,
+      file_size_in_bytes = 2048L,
+      manifest_info = sampleManifestInfo))
+
+  test("unwrap returns the matching kind for each content_type") {
+    assert(DataEntry("d", "parquet", addedTracking, 1L, 1L).wrap.unwrap.isInstanceOf[DataEntry])
+    assert(DataManifestEntry("m", "parquet", rootTracking, 1L, 1L, sampleManifestInfo)
+      .wrap.unwrap.isInstanceOf[DataManifestEntry])
+  }
+
+  test("wrap then unwrap round-trips every kind") {
+    sampleKinds.foreach { k =>
+      assert(k.wrap.unwrap == k, s"kind round-trip failed for $k.")
+    }
+  }
+
+  test("unwrap then wrap round-trips the flat row for every kind") {
+    sampleKinds.foreach { k =>
+      val e = k.wrap
+      assert(e.unwrap.wrap == e, s"flat round-trip failed for content_type=${e.content_type}.")
+    }
+  }
+
+  test("fromAddFile unwraps to a DataEntry") {
+    assert(AmtSingleAction.fromAddFile(sampleAddFile, addedTracking).unwrap.isInstanceOf[DataEntry])
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Introduces `AmtSingleAction`, the flat row record for AMT (Adaptive Metadata Tree) manifest files, modeled on the Iceberg V4 content-entry schema (snake_case field names, Iceberg field IDs preserved in comments). It is the single persisted, Parquet-encoded row, discriminated by a `content_type` integer column (`0` = DATA, `3` = DATA_MANIFEST), and references the sub-structs `Tracking`, `DeletionVector`, `ManifestInfo`, `Partition`, `ContentStats`, and `ColumnFile`. Spec invariants (content_type, file_format, manifest_info presence, deletion_vector / sort_order_id gating, and root sequence-number equality) are enforced at construction by `AmtSingleAction.validate`.

`AmtAction` is a strongly-typed, in-memory view over that flat row: a sealed trait with one case class per kind (`DataEntry`, `DataManifestEntry`), each carrying only the fields valid for its `content_type`. `AmtAction.wrap` flattens a kind back to `AmtSingleAction`, and `AmtSingleAction.unwrap` recovers the kind; both directions round-trip. Only `AmtSingleAction` is encoded, so the on-disk wire format stays independent of the typed view.

This is a schema-only change: no reader or writer is added.

## How was this patch tested?

New suite `AmtSingleActionSerializerSuite` covering the encoder schema and column order, the closed `content_type` / status constant sets, the builders, all `validate` rejection cases, the `wrap` / `unwrap` round-trips, and a Parquet round-trip over every content type.
