### PR TITLE
[FLINK] Fix bounded Delta source no-more-splits subtask handling

### DIFF
--- a/connectors/flink/src/main/java/io/delta/flink/source/internal/enumerator/BoundedDeltaSourceSplitEnumerator.java
+++ b/connectors/flink/src/main/java/io/delta/flink/source/internal/enumerator/BoundedDeltaSourceSplitEnumerator.java
@@ -62,4 +62,14 @@ public class BoundedDeltaSourceSplitEnumerator extends DeltaSourceSplitEnumerato
     protected void handleNoMoreSplits(int subtaskId) {
         enumContext.signalNoMoreSplits(subtaskId);
     }
+
+    @Override
+    protected boolean removeAwaitingReaderOnNoMoreSplits() {
+        return true;
+    }
+
+    @Override
+    protected boolean continueAssigningAfterNoMoreSplits() {
+        return true;
+    }
 }

--- a/connectors/flink/src/main/java/io/delta/flink/source/internal/enumerator/DeltaSourceSplitEnumerator.java
+++ b/connectors/flink/src/main/java/io/delta/flink/source/internal/enumerator/DeltaSourceSplitEnumerator.java
@@ -19,8 +19,6 @@ import org.apache.flink.connector.file.src.assigners.FileSplitAssigner;
 import org.apache.flink.core.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import static io.delta.flink.source.internal.enumerator.DeltaSourceSplitEnumerator.AssignSplitStatus.NO_MORE_READERS;
-import static io.delta.flink.source.internal.enumerator.DeltaSourceSplitEnumerator.AssignSplitStatus.NO_MORE_SPLITS;
 
 /**
  * A base class for {@link SplitEnumerator} used by {@link io.delta.flink.source.DeltaSource}
@@ -62,7 +60,6 @@ public abstract class DeltaSourceSplitEnumerator implements
      */
     protected final LinkedHashMap<Integer, String> readersAwaitingSplit;
 
-
     protected DeltaSourceSplitEnumerator(
         Path deltaTablePath, FileSplitAssigner splitAssigner,
         SplitEnumeratorContext<DeltaSourceSplit> enumContext) {
@@ -88,12 +85,11 @@ public abstract class DeltaSourceSplitEnumerator implements
         }
 
         readersAwaitingSplit.put(subtaskId, requesterHostname);
-        assignSplits(subtaskId);
+        assignSplits();
     }
 
     @Override
     public void addSplitsBack(List<DeltaSourceSplit> splits, int subtaskId) {
-        LOG.debug("Bounded Delta Source Enumerator adds splits back: {}", splits);
         addSplits(splits);
     }
 
@@ -136,7 +132,7 @@ public abstract class DeltaSourceSplitEnumerator implements
         splitAssigner.addSplits((Collection<FileSourceSplit>) (Collection<?>) splits);
     }
 
-    protected AssignSplitStatus assignSplits() {
+    protected void assignSplits() {
         final Iterator<Entry<Integer, String>> awaitingReader =
             readersAwaitingSplit.entrySet().iterator();
 
@@ -156,27 +152,27 @@ public abstract class DeltaSourceSplitEnumerator implements
             if (nextSplit.isPresent()) {
                 FileSourceSplit split = nextSplit.get();
                 enumContext.assignSplit((DeltaSourceSplit) split, awaitingSubtask);
-                LOG.info("Assigned split to subtask {} : {}", awaitingSubtask, split);
                 awaitingReader.remove();
             } else {
                 // TODO for chunking load we will have to modify this to get a new chunk from Delta.
-                return NO_MORE_SPLITS;
+                handleNoMoreSplits(awaitingSubtask);
+
+                if (removeAwaitingReaderOnNoMoreSplits()) {
+                    awaitingReader.remove();
+                }
+
+                if (!continueAssigningAfterNoMoreSplits()) {
+                    return;
+                }
             }
         }
-
-        return NO_MORE_READERS;
     }
 
-    private void assignSplits(int subtaskId) {
-        AssignSplitStatus assignSplitStatus = assignSplits();
-        if (NO_MORE_SPLITS.equals(assignSplitStatus)) {
-            LOG.info("No more splits available for subtasks");
-            handleNoMoreSplits(subtaskId);
-        }
+    protected boolean removeAwaitingReaderOnNoMoreSplits() {
+        return false;
     }
 
-    public enum AssignSplitStatus {
-        NO_MORE_SPLITS,
-        NO_MORE_READERS
+    protected boolean continueAssigningAfterNoMoreSplits() {
+        return false;
     }
 }

--- a/connectors/flink/src/test/java/io/delta/flink/source/internal/enumerator/BoundedDeltaSourceSplitEnumeratorTest.java
+++ b/connectors/flink/src/test/java/io/delta/flink/source/internal/enumerator/BoundedDeltaSourceSplitEnumeratorTest.java
@@ -3,6 +3,9 @@ package io.delta.flink.source.internal.enumerator;
 import java.net.URISyntaxException;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
 
 import io.delta.flink.source.internal.DeltaSourceOptions;
 import io.delta.flink.source.internal.file.AddFileEnumerator.SplitFilter;
@@ -10,6 +13,7 @@ import io.delta.flink.source.internal.file.AddFileEnumeratorContext;
 import io.delta.flink.source.internal.state.DeltaEnumeratorStateCheckpoint;
 import io.delta.flink.source.internal.state.DeltaEnumeratorStateCheckpointBuilder;
 import io.delta.flink.source.internal.state.DeltaSourceSplit;
+import org.apache.flink.api.connector.source.ReaderInfo;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -18,6 +22,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -158,9 +163,34 @@ public class BoundedDeltaSourceSplitEnumeratorTest extends DeltaSourceSplitEnume
         verify(enumContext).signalNoMoreSplits(subtaskId);
     }
 
+    @Test
+    public void shouldSignalNoMoreSplitsForAwaitingReaderInsteadOfRequestingReader() {
+        int noMoreSubtask = 45;
+        int activeSubtask = 44;
+        String noMoreHost = "noMoreHost";
+        String activeHost = "activeHost";
+        DeltaSourceSplit split = mock(DeltaSourceSplit.class);
+        Map<Integer, ReaderInfo> registeredReaders = new LinkedHashMap<>();
+        registeredReaders.put(noMoreSubtask, readerInfo);
+        registeredReaders.put(activeSubtask, readerInfo);
+
+        enumerator = setUpEnumeratorWithHeadSnapshot();
+        when(enumContext.registeredReaders()).thenReturn(registeredReaders);
+        enumerator.readersAwaitingSplit.put(noMoreSubtask, noMoreHost);
+        when(splitAssigner.getNext(noMoreHost)).thenReturn(Optional.empty());
+        when(splitAssigner.getNext(activeHost)).thenReturn(Optional.of(split));
+
+        enumerator.handleSplitRequest(activeSubtask, activeHost);
+
+        verify(enumerator).handleNoMoreSplits(noMoreSubtask);
+        verify(enumContext).signalNoMoreSplits(noMoreSubtask);
+        verify(enumContext).assignSplit(split, activeSubtask);
+        verify(enumerator, never()).handleNoMoreSplits(activeSubtask);
+        verify(enumContext, never()).signalNoMoreSplits(activeSubtask);
+    }
+
     @Override
     protected SplitEnumeratorProvider getProvider() {
         return this.provider;
     }
 }
-


### PR DESCRIPTION
### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [x] Flink
- [ ] Kernel
- [ ] Other (fill in here)

# Description

This PR fixes bounded Delta Flink source split assignment when multiple readers are waiting for splits and one awaiting reader reaches `NoMoreSplits`.

Previously, `DeltaSourceSplitEnumerator` returned a `NO_MORE_SPLITS` status from the assignment loop and then called `handleNoMoreSplits(subtaskId)` using the subtask id from the latest split request. If there was already another reader in `readersAwaitingSplit`, this could signal `NoMoreSplits` to the wrong reader.

This PR changes the split assignment flow so that `handleNoMoreSplits(...)` is called with the actual awaiting reader being processed. For bounded sources, the enumerator now removes that no-more reader from `readersAwaitingSplit` and continues assigning splits to the remaining awaiting readers.

This prevents a bounded source from incorrectly marking an active/requesting subtask as finished when a different awaiting subtask has no splits available.

# How was this patch tested?

Added a unit test:

```text
BoundedDeltaSourceSplitEnumeratorTest#shouldSignalNoMoreSplitsForAwaitingReaderInsteadOfRequestingReader
The test covers the bug scenario:

 1.  One subtask is already in readersAwaitingSplit.
 2.  A second subtask requests a split.
 3.  The first awaiting subtask has no split available.
 4.  The second subtask has a split available.
 5.  The test verifies:

•  NoMoreSplits is signaled to the first awaiting subtask.
•  The split is assigned to the second active subtask.
•  NoMoreSplits is not incorrectly signaled to the second subtask.
Ran:

cd IdeaProjects/delta-atlassian &&
build/sbt flink/testOnly io.delta.flink.source.internal.enumerator.BoundedDeltaSourceSplitEnumeratorTest
The target test class passed:

Test BoundedDeltaSourceSplitEnumeratorTest#shouldSignalNoMoreSplitsForAwaitingReaderInsteadOfRequestingReader started
...
Test run finished: 0 failed, 0 ignored, 10 total
Note: in this local environment, the SBT command also triggers unrelated Flink integration/SQL tests, and the overall task fails because of existing unrelated failures outside this change. The targeted BoundedDeltaSourceSplitEnumeratorTest suite itself passed.
Does this PR introduce any user-facing changes?
No.