### PR TITLE
[Spark] Wire Delta row-level operation hooks

### DIFF
--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
@@ -31,6 +31,7 @@ import io.delta.spark.internal.v2.read.cdc.CDCSchemaContext;
 import io.delta.spark.internal.v2.snapshot.DeltaSnapshotManager;
 import io.delta.spark.internal.v2.snapshot.SnapshotManagerFactory;
 import io.delta.spark.internal.v2.utils.SchemaUtils;
+import io.delta.spark.internal.v2.write.DeltaRowLevelOperationBuilder;
 import io.delta.spark.internal.v2.write.DeltaV2WriteBuilder;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -62,6 +63,8 @@ import org.apache.spark.sql.connector.expressions.Transform;
 import org.apache.spark.sql.connector.read.ScanBuilder;
 import org.apache.spark.sql.connector.read.Statistics;
 import org.apache.spark.sql.connector.write.LogicalWriteInfo;
+import org.apache.spark.sql.connector.write.RowLevelOperationBuilder;
+import org.apache.spark.sql.connector.write.RowLevelOperationInfo;
 import org.apache.spark.sql.connector.write.WriteBuilder;
 import org.apache.spark.sql.delta.DeltaTableUtils;
 import org.apache.spark.sql.delta.RowCommitVersion$;
@@ -470,6 +473,16 @@ public class DeltaV2Table
   public WriteBuilder newWriteBuilder(LogicalWriteInfo info) {
     requireNonNull(info, "write info is null");
     return new DeltaV2WriteBuilder(kernelEngine, tablePath, hadoopConf, initialSnapshot, info);
+  }
+
+  /**
+   * Returns a builder for Delta row-level operations. The builder currently wires Spark planning to
+   * Delta's copy-on-write operation shell; the concrete ReplaceData write path is introduced in a
+   * follow-up PR.
+   */
+  public RowLevelOperationBuilder newRowLevelOperationBuilder(RowLevelOperationInfo info) {
+    requireNonNull(info, "row-level operation info is null");
+    return new DeltaRowLevelOperationBuilder(this, kernelEngine, hadoopConf, initialSnapshot, info);
   }
 
   @Override

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaRowLevelOperationBuilder.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaRowLevelOperationBuilder.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.write;
+
+import static java.util.Objects.requireNonNull;
+
+import io.delta.kernel.Snapshot;
+import io.delta.kernel.engine.Engine;
+import io.delta.spark.internal.v2.catalog.DeltaV2Table;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.spark.sql.connector.expressions.FieldReference;
+import org.apache.spark.sql.connector.expressions.NamedReference;
+import org.apache.spark.sql.connector.read.ScanBuilder;
+import org.apache.spark.sql.connector.write.LogicalWriteInfo;
+import org.apache.spark.sql.connector.write.RowLevelOperation;
+import org.apache.spark.sql.connector.write.RowLevelOperationBuilder;
+import org.apache.spark.sql.connector.write.RowLevelOperationInfo;
+import org.apache.spark.sql.connector.write.WriteBuilder;
+import org.apache.spark.sql.execution.datasources.FileFormat$;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+
+/** Builds Delta's copy-on-write row-level operation stack. */
+public class DeltaRowLevelOperationBuilder implements RowLevelOperationBuilder {
+
+  private final DeltaV2Table table;
+  private final Engine engine;
+  private final Configuration hadoopConf;
+  private final Snapshot initialSnapshot;
+  private final RowLevelOperationInfo info;
+
+  public DeltaRowLevelOperationBuilder(
+      DeltaV2Table table,
+      Engine engine,
+      Configuration hadoopConf,
+      Snapshot initialSnapshot,
+      RowLevelOperationInfo info) {
+    this.table = requireNonNull(table, "table is null");
+    this.engine = requireNonNull(engine, "engine is null");
+    this.hadoopConf = requireNonNull(hadoopConf, "hadoopConf is null");
+    this.initialSnapshot = requireNonNull(initialSnapshot, "initialSnapshot is null");
+    this.info = requireNonNull(info, "info is null");
+  }
+
+  @Override
+  public RowLevelOperation build() {
+    return new CopyOnWriteOperation(table, engine, hadoopConf, initialSnapshot, info);
+  }
+
+  private static class CopyOnWriteOperation implements RowLevelOperation {
+
+    private final DeltaV2Table table;
+    private final Engine engine;
+    private final Configuration hadoopConf;
+    private final Snapshot initialSnapshot;
+    private final RowLevelOperationInfo info;
+
+    private CopyOnWriteOperation(
+        DeltaV2Table table,
+        Engine engine,
+        Configuration hadoopConf,
+        Snapshot initialSnapshot,
+        RowLevelOperationInfo info) {
+      this.table = requireNonNull(table, "table is null");
+      this.engine = requireNonNull(engine, "engine is null");
+      this.hadoopConf = requireNonNull(hadoopConf, "hadoopConf is null");
+      this.initialSnapshot = requireNonNull(initialSnapshot, "initialSnapshot is null");
+      this.info = requireNonNull(info, "info is null");
+    }
+
+    @Override
+    public Command command() {
+      return info.command();
+    }
+
+    @Override
+    public String description() {
+      return "DeltaCopyOnWrite(" + command() + ")";
+    }
+
+    @Override
+    public ScanBuilder newScanBuilder(CaseInsensitiveStringMap options) {
+      return table.newScanBuilder(options);
+    }
+
+    @Override
+    public WriteBuilder newWriteBuilder(LogicalWriteInfo writeInfo) {
+      requireNonNull(writeInfo, "writeInfo is null");
+      throw new UnsupportedOperationException(
+          "Delta copy-on-write write support is introduced in a follow-up change");
+    }
+
+    @Override
+    public NamedReference[] requiredMetadataAttributes() {
+      return new NamedReference[] {FieldReference.apply(FileFormat$.MODULE$.METADATA_NAME())};
+    }
+  }
+}

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/write/DeltaRowLevelOperationBuilderTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/write/DeltaRowLevelOperationBuilderTest.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.write;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.delta.kernel.Snapshot;
+import io.delta.kernel.defaults.engine.DefaultEngine;
+import io.delta.kernel.engine.Engine;
+import io.delta.spark.internal.v2.DeltaV2TestBase;
+import io.delta.spark.internal.v2.catalog.DeltaV2Table;
+import io.delta.spark.internal.v2.snapshot.PathBasedSnapshotManager;
+import java.io.File;
+import java.util.Collections;
+import java.util.Optional;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.SupportsRowLevelOperations;
+import org.apache.spark.sql.connector.expressions.NamedReference;
+import org.apache.spark.sql.connector.read.Scan;
+import org.apache.spark.sql.connector.read.ScanBuilder;
+import org.apache.spark.sql.connector.write.LogicalWriteInfo;
+import org.apache.spark.sql.connector.write.RowLevelOperation;
+import org.apache.spark.sql.connector.write.RowLevelOperationBuilder;
+import org.apache.spark.sql.connector.write.RowLevelOperationInfo;
+import org.apache.spark.sql.execution.datasources.FileFormat$;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class DeltaRowLevelOperationBuilderTest extends DeltaV2TestBase {
+
+  @Test
+  public void regularTableDoesNotExposeRowLevelOperations(@TempDir File tempDir) {
+    DeltaV2Table table = createBaseTable(tempDir);
+
+    assertFalse(table instanceof SupportsRowLevelOperations);
+  }
+
+  @Test
+  public void tableExposesRowLevelOperationBuilder(@TempDir File tempDir) {
+    DeltaV2Table table = createRowLevelTable(tempDir);
+
+    assertTrue(table instanceof SupportsRowLevelOperations);
+    RowLevelOperationBuilder builder =
+        ((SupportsRowLevelOperations) table)
+            .newRowLevelOperationBuilder(testInfo(RowLevelOperation.Command.DELETE));
+    assertTrue(builder instanceof DeltaRowLevelOperationBuilder);
+  }
+
+  @Test
+  public void buildReturnsCopyOnWriteOperation(@TempDir File tempDir) {
+    RowLevelOperation operation = createBuilder(tempDir, RowLevelOperation.Command.DELETE).build();
+
+    assertEquals(RowLevelOperation.Command.DELETE, operation.command());
+    assertEquals("DeltaCopyOnWrite(DELETE)", operation.description());
+  }
+
+  @Test
+  public void operationCommandMatchesInfo(@TempDir File tempDir) {
+    for (RowLevelOperation.Command command : RowLevelOperation.Command.values()) {
+      RowLevelOperation operation = createBuilder(tempDir, command).build();
+      assertEquals(command, operation.command());
+    }
+  }
+
+  @Test
+  public void operationScanBuilderDelegatesToTableAndCapturesScan(@TempDir File tempDir) {
+    RowLevelOperation operation = createBuilder(tempDir, RowLevelOperation.Command.DELETE).build();
+
+    ScanBuilder scanBuilder =
+        operation.newScanBuilder(new CaseInsensitiveStringMap(Collections.emptyMap()));
+    Scan scan = scanBuilder.build();
+
+    assertNotNull(scan);
+    assertTrue(scan instanceof io.delta.spark.internal.v2.read.SparkScan);
+  }
+
+  @Test
+  public void requiredMetadataAttributesIncludeMetadataColumn(@TempDir File tempDir) {
+    RowLevelOperation operation = createBuilder(tempDir, RowLevelOperation.Command.DELETE).build();
+
+    NamedReference[] metadataAttributes = operation.requiredMetadataAttributes();
+    assertEquals(1, metadataAttributes.length);
+    assertArrayEquals(
+        new String[] {FileFormat$.MODULE$.METADATA_NAME()}, metadataAttributes[0].fieldNames());
+  }
+
+  @Test
+  public void writeBuilderIsDeferredToCopyOnWriteWriterPr(@TempDir File tempDir) {
+    RowLevelOperation operation = createBuilder(tempDir, RowLevelOperation.Command.DELETE).build();
+
+    assertThrows(
+        UnsupportedOperationException.class,
+        () -> operation.newWriteBuilder(new TestLogicalWriteInfo(tableSchema())));
+  }
+
+  @Test
+  public void constructorRejectsNull(@TempDir File tempDir) {
+    DeltaV2Table table = createRowLevelTable(tempDir);
+    RowLevelOperationInfo info = testInfo(RowLevelOperation.Command.DELETE);
+    Configuration hadoopConf = spark.sessionState().newHadoopConf();
+    Engine engine = DefaultEngine.create(hadoopConf);
+    Snapshot snapshot =
+        new PathBasedSnapshotManager(tempDir.getAbsolutePath(), engine).loadLatestSnapshot();
+
+    assertThrows(
+        NullPointerException.class,
+        () -> new DeltaRowLevelOperationBuilder(null, engine, hadoopConf, snapshot, info));
+    assertThrows(
+        NullPointerException.class,
+        () -> new DeltaRowLevelOperationBuilder(table, null, hadoopConf, snapshot, info));
+    assertThrows(
+        NullPointerException.class,
+        () -> new DeltaRowLevelOperationBuilder(table, engine, null, snapshot, info));
+    assertThrows(
+        NullPointerException.class,
+        () -> new DeltaRowLevelOperationBuilder(table, engine, hadoopConf, null, info));
+    assertThrows(
+        NullPointerException.class,
+        () -> new DeltaRowLevelOperationBuilder(table, engine, hadoopConf, snapshot, null));
+  }
+
+  private DeltaV2Table createBaseTable(File tableDir) {
+    String path = tableDir.getAbsolutePath();
+    String tableName = "delta_row_level_" + System.nanoTime();
+    createEmptyTestTable(path, tableName);
+    return new DeltaV2Table(Identifier.of(new String[] {"default"}, tableName), path);
+  }
+
+  private DeltaV2Table createRowLevelTable(File tableDir) {
+    String path = tableDir.getAbsolutePath();
+    String tableName = "delta_row_level_" + System.nanoTime();
+    createEmptyTestTable(path, tableName);
+    return new RowLevelDeltaV2Table(Identifier.of(new String[] {"default"}, tableName), path);
+  }
+
+  private DeltaRowLevelOperationBuilder createBuilder(
+      File tableDir, RowLevelOperation.Command command) {
+    DeltaV2Table table = createRowLevelTable(new File(tableDir, "table_" + System.nanoTime()));
+    Configuration hadoopConf = spark.sessionState().newHadoopConf();
+    Engine engine = DefaultEngine.create(hadoopConf);
+    Snapshot snapshot =
+        new PathBasedSnapshotManager(table.getTablePath().toString(), engine).loadLatestSnapshot();
+    return new DeltaRowLevelOperationBuilder(
+        table, engine, hadoopConf, snapshot, testInfo(command));
+  }
+
+  private static class RowLevelDeltaV2Table extends DeltaV2Table
+      implements SupportsRowLevelOperations {
+    RowLevelDeltaV2Table(Identifier identifier, String tablePath) {
+      super(identifier, tablePath);
+    }
+  }
+
+  private static StructType tableSchema() {
+    return new StructType().add("id", DataTypes.IntegerType).add("name", DataTypes.StringType);
+  }
+
+  private static RowLevelOperationInfo testInfo(RowLevelOperation.Command command) {
+    return new RowLevelOperationInfo() {
+      @Override
+      public CaseInsensitiveStringMap options() {
+        return new CaseInsensitiveStringMap(Collections.emptyMap());
+      }
+
+      @Override
+      public RowLevelOperation.Command command() {
+        return command;
+      }
+    };
+  }
+
+  private static class TestLogicalWriteInfo implements LogicalWriteInfo {
+    private final StructType schema;
+
+    TestLogicalWriteInfo(StructType schema) {
+      this.schema = schema;
+    }
+
+    @Override
+    public String queryId() {
+      return "test-query-id";
+    }
+
+    @Override
+    public StructType schema() {
+      return schema;
+    }
+
+    @Override
+    public CaseInsensitiveStringMap options() {
+      return new CaseInsensitiveStringMap(Collections.emptyMap());
+    }
+
+    @Override
+    public Optional<StructType> metadataSchema() {
+      return Optional.of(
+          new StructType()
+              .add(
+                  FileFormat$.MODULE$.METADATA_NAME(),
+                  new StructType().add("file_path", DataTypes.StringType)));
+    }
+  }
+}


### PR DESCRIPTION
## Description

Wire Delta Spark DSv2 tables into Spark row-level operation planning with a small operation builder and operation shell. This sets up the planning path while keeping the concrete write implementation separate.

## How was this patch tested?

- CI