### PR TITLE
[Spark] Handle ReplaceData partition edges

### DIFF
--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaScanFile.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaScanFile.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.read;
+
+import io.delta.kernel.data.MapValue;
+import io.delta.kernel.internal.actions.AddFile;
+import io.delta.kernel.internal.actions.DeletionVectorDescriptor;
+import java.util.Objects;
+import java.util.Optional;
+
+/** Narrow descriptor for a Delta file selected by a DSv2 scan. */
+public final class DeltaScanFile {
+
+  private final String path;
+  private final MapValue partitionValues;
+  private final long size;
+  private final Optional<Long> baseRowId;
+  private final Optional<Long> defaultRowCommitVersion;
+  private final Optional<DeletionVectorDescriptor> deletionVector;
+
+  DeltaScanFile(AddFile addFile) {
+    this.path = Objects.requireNonNull(addFile, "addFile is null").getPath();
+    this.partitionValues = addFile.getPartitionValues();
+    this.size = addFile.getSize();
+    this.baseRowId = addFile.getBaseRowId();
+    this.defaultRowCommitVersion = addFile.getDefaultRowCommitVersion();
+    this.deletionVector = addFile.getDeletionVector();
+  }
+
+  public String getPath() {
+    return path;
+  }
+
+  public MapValue getPartitionValues() {
+    return partitionValues;
+  }
+
+  public long getSize() {
+    return size;
+  }
+
+  public Optional<Long> getBaseRowId() {
+    return baseRowId;
+  }
+
+  public Optional<Long> getDefaultRowCommitVersion() {
+    return defaultRowCommitVersion;
+  }
+
+  public Optional<DeletionVectorDescriptor> getDeletionVector() {
+    return deletionVector;
+  }
+}

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkScan.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/SparkScan.java
@@ -85,12 +85,13 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
   private final DeltaOptions deltaOptions;
   private final ZoneId zoneId;
 
-  // Planned input files and stats
+  // Planned input files and the corresponding selected AddFile actions.
   private List<PartitionedFile> partitionedFiles = new ArrayList<>();
   // Per-file row counts, parallel to partitionedFiles. Populated only while rowCountKnown is
   // true; cleared if any AddFile lacks numRecords. Retained so totalRows can be recomputed
   // after runtime partition filtering prunes files, instead of invalidating the count.
   private List<Long> perFileRowCounts = new ArrayList<>();
+  private List<DeltaScanFile> selectedFiles = new ArrayList<>();
   private long totalBytes = 0L;
   private long totalRows = 0L;
   // true iff every AddFile in the scan had numRecords in its stats JSON.
@@ -466,6 +467,7 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
 
           totalBytes += addFile.getSize();
           partitionedFiles.add(partitionedFile);
+          selectedFiles.add(new DeltaScanFile(addFile));
 
           if (rowCountKnown) {
             Optional<Long> numRecords = addFile.getNumRecords();
@@ -509,6 +511,7 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
       }
 
       List<PartitionedFile> runtimeFilteredPartitionedFiles = new ArrayList<>();
+      List<DeltaScanFile> runtimeFilteredFiles = new ArrayList<>();
       // Parallel to runtimeFilteredPartitionedFiles; only used when rowCountKnown is true.
       List<Long> filteredRowCounts = rowCountKnown ? new ArrayList<>() : null;
       long newTotalRows = 0L;
@@ -520,6 +523,7 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
                 .allMatch(predicate -> predicate.evaluator.eval(partitionValues));
         if (allMatch) {
           runtimeFilteredPartitionedFiles.add(pf);
+          runtimeFilteredFiles.add(this.selectedFiles.get(i));
           if (rowCountKnown) {
             long rc = this.perFileRowCounts.get(i);
             filteredRowCounts.add(rc);
@@ -532,6 +536,7 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
       // is filtered out
       if (runtimeFilteredPartitionedFiles.size() < this.partitionedFiles.size()) {
         this.partitionedFiles = runtimeFilteredPartitionedFiles;
+        this.selectedFiles = runtimeFilteredFiles;
         this.totalBytes =
             runtimeFilteredPartitionedFiles.stream().mapToLong(PartitionedFile::fileSize).sum();
         this.estimatedSizeInBytes = computeEstimatedSizeWithColumnProjection(this.totalBytes);
@@ -553,6 +558,19 @@ public class SparkScan implements Scan, SupportsReportStatistics, SupportsRuntim
 
   public StructType getDataSchema() {
     return dataSchema;
+  }
+
+  /**
+   * Returns the Delta files selected by this scan after pushdown and runtime filtering.
+   *
+   * <p>The returned descriptors preserve only the metadata needed by row-level ReplaceData commits
+   * to construct matching RemoveFile actions.
+   *
+   * @apiNote Internal API for the DSv2 DML write path (see {@code DeltaReplaceDataBatchWrite}).
+   */
+  public List<DeltaScanFile> getSelectedFiles() {
+    ensurePlanned();
+    return Collections.unmodifiableList(selectedFiles);
   }
 
   public StructType getPartitionSchema() {

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/PartitionUtils.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/PartitionUtils.java
@@ -17,12 +17,14 @@ package io.delta.spark.internal.v2.utils;
 
 import io.delta.kernel.Snapshot;
 import io.delta.kernel.data.MapValue;
+import io.delta.kernel.expressions.Literal;
 import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.internal.actions.AddFile;
 import io.delta.kernel.internal.actions.DeletionVectorDescriptor;
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.actions.Protocol;
 import io.delta.kernel.internal.tablefeatures.TableFeatures;
+import io.delta.kernel.internal.util.InternalUtils;
 import io.delta.spark.internal.v2.read.ColumnReorderReadFunction;
 import io.delta.spark.internal.v2.read.DeltaParquetFileFormatV2;
 import io.delta.spark.internal.v2.read.DeltaV2Reads;
@@ -32,9 +34,13 @@ import io.delta.spark.internal.v2.read.deletionvector.DeletionVectorReadFunction
 import io.delta.spark.internal.v2.read.deletionvector.DeletionVectorSchemaContext;
 import io.delta.spark.internal.v2.read.metadata.MetadataStructReadFunction;
 import io.delta.spark.internal.v2.read.metadata.MetadataStructSchemaContext;
+import java.math.BigDecimal;
+import java.sql.Date;
+import java.sql.Timestamp;
 import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -61,6 +67,7 @@ import org.apache.spark.sql.execution.datasources.PartitioningUtils;
 import org.apache.spark.sql.execution.datasources.parquet.ParquetUtils;
 import org.apache.spark.sql.internal.SQLConf;
 import org.apache.spark.sql.sources.Filter;
+import org.apache.spark.sql.types.DecimalType;
 import org.apache.spark.sql.types.StringType;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
@@ -183,6 +190,114 @@ public class PartitionUtils {
       }
     }
     return new GenericInternalRow(values);
+  }
+
+  /**
+   * Convert an AddFile partition-value map keyed by physical column names into a logical-name map
+   * using the provided partition schema.
+   */
+  public static Map<String, String> getLogicalPartitionValueStrings(
+      MapValue partitionValues, StructType partitionSchema) {
+    Map<String, String> rawPartitionValues = toJavaStringStringMap(partitionValues);
+    Map<String, String> logicalPartitionValues = new LinkedHashMap<>();
+    for (StructField field : partitionSchema.fields()) {
+      String physicalName = DeltaColumnMapping.getPhysicalName(field);
+      logicalPartitionValues.put(field.name(), rawPartitionValues.get(physicalName));
+    }
+    return logicalPartitionValues;
+  }
+
+  /**
+   * Convert a Kernel {@link MapValue} with string keys and string values into a Java map. Inlined
+   * here because the {@code VectorUtils} dropin wrapper no longer exposes {@code toJavaMap}; the
+   * iteration is trivial against {@link MapValue}'s {@code getKeys()/getValues()} column-vector
+   * API.
+   */
+  private static Map<String, String> toJavaStringStringMap(MapValue mapValue) {
+    Map<String, String> result = new LinkedHashMap<>(mapValue.getSize());
+    for (int i = 0; i < mapValue.getSize(); i++) {
+      String value = mapValue.getValues().isNullAt(i) ? null : mapValue.getValues().getString(i);
+      result.put(mapValue.getKeys().getString(i), value);
+    }
+    return result;
+  }
+
+  /** Build a Kernel write-context partition map keyed by logical partition-column names. */
+  public static Map<String, Literal> buildKernelPartitionLiteralMap(
+      Map<String, String> logicalPartitionValueStrings, StructType partitionSchema, ZoneId zoneId) {
+    Map<String, Literal> partitionLiteralMap = new LinkedHashMap<>();
+    for (StructField field : partitionSchema.fields()) {
+      String logicalName = field.name();
+      String rawValue = logicalPartitionValueStrings.get(logicalName);
+      if (rawValue == null) {
+        partitionLiteralMap.put(
+            logicalName,
+            Literal.ofNull(SchemaUtils.convertSparkDataTypeToKernelDataType(field.dataType())));
+        continue;
+      }
+      Object typedValue =
+          PartitioningUtils.castPartValueToDesiredType(field.dataType(), rawValue, zoneId);
+      partitionLiteralMap.put(
+          logicalName, convertPartitionValueToKernelLiteral(typedValue, field.dataType()));
+    }
+    return partitionLiteralMap;
+  }
+
+  private static Literal convertPartitionValueToKernelLiteral(
+      Object value, org.apache.spark.sql.types.DataType sparkDataType) {
+    if (value == null) {
+      throw new IllegalArgumentException(
+          "Partition literal conversion does not accept null values");
+    }
+    if (value instanceof Boolean) {
+      return Literal.ofBoolean((Boolean) value);
+    }
+    if (value instanceof Byte) {
+      return Literal.ofByte((Byte) value);
+    }
+    if (value instanceof Short) {
+      return Literal.ofShort((Short) value);
+    }
+    if (value instanceof Integer) {
+      return Literal.ofInt((Integer) value);
+    }
+    if (value instanceof Long) {
+      return Literal.ofLong((Long) value);
+    }
+    if (value instanceof Float) {
+      return Literal.ofFloat((Float) value);
+    }
+    if (value instanceof Double) {
+      return Literal.ofDouble((Double) value);
+    }
+    if (value instanceof BigDecimal) {
+      BigDecimal decimal = (BigDecimal) value;
+      DecimalType decimalType = (DecimalType) sparkDataType;
+      return Literal.ofDecimal(decimal, decimalType.precision(), decimalType.scale());
+    }
+    if (value instanceof org.apache.spark.sql.types.Decimal) {
+      org.apache.spark.sql.types.Decimal decimal = (org.apache.spark.sql.types.Decimal) value;
+      DecimalType decimalType = (DecimalType) sparkDataType;
+      return Literal.ofDecimal(
+          decimal.toJavaBigDecimal(), decimalType.precision(), decimalType.scale());
+    }
+    if (value instanceof UTF8String) {
+      return Literal.ofString(value.toString());
+    }
+    if (value instanceof String) {
+      return Literal.ofString((String) value);
+    }
+    if (value instanceof byte[]) {
+      return Literal.ofBinary((byte[]) value);
+    }
+    if (value instanceof Date) {
+      return Literal.ofDate(InternalUtils.daysSinceEpoch((Date) value));
+    }
+    if (value instanceof Timestamp) {
+      return Literal.ofTimestamp(InternalUtils.microsSinceEpoch((Timestamp) value));
+    }
+    throw new IllegalArgumentException(
+        "Unsupported partition literal value type: " + value.getClass().getName());
   }
 
   /**

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaReplaceDataBatchWrite.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaReplaceDataBatchWrite.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.write;
+
+import io.delta.kernel.Snapshot;
+import io.delta.kernel.TransactionCommitResult;
+import io.delta.kernel.data.Row;
+import io.delta.kernel.engine.Engine;
+import io.delta.kernel.expressions.Literal;
+import io.delta.kernel.internal.actions.GenerateIcebergCompatActionUtils;
+import io.delta.kernel.internal.actions.SingleAction;
+import io.delta.kernel.internal.util.Utils;
+import io.delta.kernel.utils.CloseableIterable;
+import io.delta.spark.internal.v2.read.DeltaScanFile;
+import io.delta.spark.internal.v2.utils.PartitionUtils;
+import io.delta.spark.internal.v2.utils.SerializableKernelRowWrapper;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Supplier;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.spark.sql.connector.write.BatchWrite;
+import org.apache.spark.sql.connector.write.DataWriterFactory;
+import org.apache.spark.sql.connector.write.LogicalWriteInfo;
+import org.apache.spark.sql.connector.write.PhysicalWriteInfo;
+import org.apache.spark.sql.connector.write.Write;
+import org.apache.spark.sql.connector.write.WriterCommitMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * BatchWrite for DSv2 ReplaceData commits.
+ *
+ * <p>On the driver this class uses {@link DeltaV2BatchWriteContext} for shared write setup, then
+ * adds ReplaceData-specific selected-file validation and RemoveFile action generation.
+ *
+ * <p>At commit time the authoritative remove-set is derived from the selected files reported by the
+ * scan — not from files the writer happens to have observed. This matters because a DELETE that
+ * fully empties a source file produces zero output rows, so the writer never reports the source
+ * path; only the scan knows which files were read. AddFile actions written by executors are paired
+ * with RemoveFile actions generated from the scan-selected files and committed together.
+ *
+ * <p>Current scope is unpartitioned tables and single-partition writes; multi-partition replace-
+ * data is rejected by {@link #resolveWritePartitionValueStrings()} until follow-up work lands.
+ */
+class DeltaReplaceDataBatchWrite implements Write, BatchWrite {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DeltaReplaceDataBatchWrite.class);
+
+  private final DeltaV2BatchWriteContext context;
+  private final String tablePath;
+  private final Supplier<List<DeltaScanFile>> selectedFilesProvider;
+
+  DeltaReplaceDataBatchWrite(
+      Engine engine,
+      Configuration hadoopConf,
+      String tablePath,
+      Snapshot initialSnapshot,
+      LogicalWriteInfo writeInfo,
+      Supplier<List<DeltaScanFile>> selectedFilesProvider) {
+    this.context =
+        DeltaV2BatchWriteContext.create(engine, hadoopConf, tablePath, initialSnapshot, writeInfo);
+    this.tablePath = Objects.requireNonNull(tablePath, "tablePath is null");
+    this.selectedFilesProvider =
+        Objects.requireNonNull(selectedFilesProvider, "selectedFilesProvider is null");
+  }
+
+  @Override
+  public BatchWrite toBatch() {
+    return this;
+  }
+
+  @Override
+  public DataWriterFactory createBatchWriterFactory(PhysicalWriteInfo physicalWriteInfo) {
+    List<DeltaScanFile> selectedFiles = getSelectedFiles();
+    Map<String, String> partitionValueStrings = resolveWritePartitionValueStrings(selectedFiles);
+    Map<String, Literal> partitionLiterals =
+        PartitionUtils.buildKernelPartitionLiteralMap(
+            partitionValueStrings, context.getPartitionSchema(), context.getSessionTimeZone());
+    String targetDirectory = context.getTargetDirectory(partitionLiterals);
+    return new DeltaReplaceDataWriterFactory(
+        targetDirectory,
+        context.getSerializableHadoopConf(),
+        context.getSerializedTxnState(),
+        context.getDataSchema(),
+        context.getOutputWriterFactory(),
+        context.getPartitionSchema(),
+        partitionValueStrings,
+        context.getSessionTimeZoneId());
+  }
+
+  @Override
+  public void commit(WriterCommitMessage[] messages) {
+    List<DeltaScanFile> selectedFiles = getSelectedFiles();
+    validateWriterSourcePaths(messages, selectedFiles);
+
+    List<Row> allActionRows = new ArrayList<>();
+    for (WriterCommitMessage message : messages) {
+      if (message instanceof DeltaReplaceDataCommitMessage) {
+        DeltaReplaceDataCommitMessage replaceDataMessage = (DeltaReplaceDataCommitMessage) message;
+        for (SerializableKernelRowWrapper wrapper : replaceDataMessage.getAddFileActionRows()) {
+          allActionRows.add(wrapper.getRow());
+        }
+      }
+    }
+
+    long removeTimestamp = System.currentTimeMillis();
+    for (DeltaScanFile selectedFile : selectedFiles) {
+      allActionRows.add(createRemoveFileActionRow(selectedFile, removeTimestamp));
+    }
+
+    if (allActionRows.isEmpty()) {
+      LOG.info("DSv2 replace-data found no selected files and no replacement files; no commit");
+      return;
+    }
+
+    CloseableIterable<Row> dataActions =
+        CloseableIterable.inMemoryIterable(Utils.toCloseableIterator(allActionRows.iterator()));
+
+    TransactionCommitResult result =
+        context.getTransaction().commit(context.getEngine(), dataActions);
+    LOG.info(
+        "DSv2 replace-data committed at version {} after rewriting {} source files",
+        result.getVersion(),
+        selectedFiles.size());
+  }
+
+  @Override
+  public void abort(WriterCommitMessage[] messages) {
+    LOG.warn(
+        "DSv2 replace-data write aborted. {} task messages will not be committed. "
+            + "Orphaned data files will be cleaned up by VACUUM.",
+        messages != null ? messages.length : 0);
+  }
+
+  private Row createRemoveFileActionRow(DeltaScanFile selectedFile, long removeTimestamp) {
+    // Master replaced AddFile.toRemoveFileRow with this dropin helper; v2 callers pass
+    // Optional.empty() for stats on the read path per its javadoc note.
+    Row removeFileRow =
+        GenerateIcebergCompatActionUtils.createRemoveFileRowWithExtendedFileMetadata(
+            selectedFile.getPath(),
+            removeTimestamp,
+            /* dataChange */ true,
+            selectedFile.getPartitionValues(),
+            selectedFile.getSize(),
+            Optional.empty(),
+            context.getKernelTableSchema(),
+            selectedFile.getBaseRowId(),
+            selectedFile.getDefaultRowCommitVersion(),
+            selectedFile.getDeletionVector());
+    return SingleAction.createRemoveFileSingleAction(removeFileRow);
+  }
+
+  private List<DeltaScanFile> getSelectedFiles() {
+    List<DeltaScanFile> selectedFiles = selectedFilesProvider.get();
+    return selectedFiles == null ? Collections.emptyList() : List.copyOf(selectedFiles);
+  }
+
+  private void validateWriterSourcePaths(
+      WriterCommitMessage[] messages, List<DeltaScanFile> selectedFiles) {
+    Set<String> selectedSourcePaths = new java.util.HashSet<>();
+    for (DeltaScanFile selectedFile : selectedFiles) {
+      selectedSourcePaths.add(selectedFile.getPath());
+      Path absolutePath = new Path(tablePath, selectedFile.getPath());
+      selectedSourcePaths.add(absolutePath.toString());
+      selectedSourcePaths.add(absolutePath.toUri().toString());
+    }
+
+    for (WriterCommitMessage message : messages) {
+      if (message instanceof DeltaReplaceDataCommitMessage) {
+        DeltaReplaceDataCommitMessage replaceDataMessage = (DeltaReplaceDataCommitMessage) message;
+        for (String sourceFilePath : replaceDataMessage.getSourceFilePaths()) {
+          if (!selectedSourcePaths.contains(sourceFilePath)) {
+            throw new IllegalStateException(
+                "Delta ReplaceData writer reported source file outside scan-selected files: "
+                    + sourceFilePath);
+          }
+        }
+      }
+    }
+  }
+
+  private Map<String, String> resolveWritePartitionValueStrings(List<DeltaScanFile> selectedFiles) {
+    if (context.getPartitionSchema().fields().length == 0) {
+      return Collections.emptyMap();
+    }
+
+    if (selectedFiles.isEmpty()) {
+      return Collections.emptyMap();
+    }
+
+    Map<String, String> resolvedPartitionValues = null;
+    for (DeltaScanFile selectedFile : selectedFiles) {
+      Map<String, String> currentPartitionValues =
+          PartitionUtils.getLogicalPartitionValueStrings(
+              selectedFile.getPartitionValues(), context.getPartitionSchema());
+      if (resolvedPartitionValues == null) {
+        resolvedPartitionValues = new LinkedHashMap<>(currentPartitionValues);
+      } else if (!resolvedPartitionValues.equals(currentPartitionValues)) {
+        throw new IllegalStateException(
+            "Delta ReplaceData currently requires scan-selected files from a single partition "
+                + "to determine the write context");
+      }
+    }
+    return resolvedPartitionValues;
+  }
+}

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaReplaceDataCommitMessage.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaReplaceDataCommitMessage.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.write;
+
+import io.delta.spark.internal.v2.utils.SerializableKernelRowWrapper;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import org.apache.spark.sql.connector.write.WriterCommitMessage;
+
+/**
+ * Commit message for a ReplaceData write task.
+ *
+ * <p>Serialised executor-to-driver envelope carrying:
+ *
+ * <ul>
+ *   <li>{@code addFileActionRows} — Kernel AddFile action rows for the new Parquet files the task
+ *       produced. Consumed by {@link DeltaReplaceDataBatchWrite#commit} on the driver.
+ *   <li>{@code sourceFilePaths} — absolute paths of the scan-side source files the task observed
+ *       via {@code _metadata.file_path}. Informational only for diagnostics today; the
+ *       authoritative remove-set comes from the captured {@code SparkScan} on the driver, not from
+ *       this set (a fully deleted file produces zero output rows, so the writer never observes its
+ *       path).
+ * </ul>
+ */
+class DeltaReplaceDataCommitMessage implements WriterCommitMessage {
+
+  private final List<SerializableKernelRowWrapper> addFileActionRows;
+  private final Set<String> sourceFilePaths;
+
+  DeltaReplaceDataCommitMessage(
+      List<SerializableKernelRowWrapper> addFileActionRows, Set<String> sourceFilePaths) {
+    this.addFileActionRows =
+        addFileActionRows != null ? new ArrayList<>(addFileActionRows) : Collections.emptyList();
+    this.sourceFilePaths =
+        sourceFilePaths != null ? new LinkedHashSet<>(sourceFilePaths) : Collections.emptySet();
+  }
+
+  List<SerializableKernelRowWrapper> getAddFileActionRows() {
+    return Collections.unmodifiableList(addFileActionRows);
+  }
+
+  Set<String> getSourceFilePaths() {
+    return Collections.unmodifiableSet(sourceFilePaths);
+  }
+}

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaReplaceDataWriteBuilder.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaReplaceDataWriteBuilder.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.write;
+
+import static java.util.Objects.requireNonNull;
+
+import io.delta.kernel.Snapshot;
+import io.delta.kernel.engine.Engine;
+import io.delta.spark.internal.v2.read.DeltaScanFile;
+import java.util.List;
+import java.util.function.Supplier;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.spark.sql.connector.write.LogicalWriteInfo;
+import org.apache.spark.sql.connector.write.Write;
+import org.apache.spark.sql.connector.write.WriteBuilder;
+
+/** WriteBuilder for Delta DSv2 ReplaceData commits backed by a configured SparkScan. */
+class DeltaReplaceDataWriteBuilder implements WriteBuilder {
+
+  private final Engine engine;
+  private final String tablePath;
+  private final Configuration hadoopConf;
+  private final Snapshot initialSnapshot;
+  private final Supplier<List<DeltaScanFile>> selectedFilesProvider;
+  private final LogicalWriteInfo writeInfo;
+
+  DeltaReplaceDataWriteBuilder(
+      Engine engine,
+      String tablePath,
+      Configuration hadoopConf,
+      Snapshot initialSnapshot,
+      Supplier<List<DeltaScanFile>> selectedFilesProvider,
+      LogicalWriteInfo writeInfo) {
+    this.engine = requireNonNull(engine, "engine is null");
+    this.tablePath = requireNonNull(tablePath, "tablePath is null");
+    this.hadoopConf = requireNonNull(hadoopConf, "hadoopConf is null");
+    this.initialSnapshot = requireNonNull(initialSnapshot, "initialSnapshot is null");
+    this.selectedFilesProvider =
+        requireNonNull(selectedFilesProvider, "selectedFilesProvider is null");
+    this.writeInfo = requireNonNull(writeInfo, "writeInfo is null");
+  }
+
+  @Override
+  public Write build() {
+    DeltaV2WriteBuilder.validateDataSchema(initialSnapshot, writeInfo.schema());
+    return new DeltaReplaceDataBatchWrite(
+        engine, hadoopConf, tablePath, initialSnapshot, writeInfo, selectedFilesProvider);
+  }
+}

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaReplaceDataWriter.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaReplaceDataWriter.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.write;
+
+import io.delta.kernel.DataWriteContext;
+import io.delta.kernel.Transaction;
+import io.delta.kernel.data.Row;
+import io.delta.kernel.defaults.engine.DefaultEngine;
+import io.delta.kernel.engine.Engine;
+import io.delta.kernel.expressions.Literal;
+import io.delta.kernel.internal.util.Utils;
+import io.delta.kernel.utils.CloseableIterator;
+import io.delta.kernel.utils.DataFileStatus;
+import io.delta.spark.internal.v2.utils.PartitionUtils;
+import io.delta.spark.internal.v2.utils.SerializableKernelRowWrapper;
+import java.io.IOException;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.TaskAttemptContextImpl;
+import org.apache.hadoop.mapred.TaskAttemptID;
+import org.apache.hadoop.mapreduce.TaskType;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.connector.write.DataWriter;
+import org.apache.spark.sql.connector.write.WriterCommitMessage;
+import org.apache.spark.sql.execution.datasources.OutputWriter;
+import org.apache.spark.sql.execution.datasources.OutputWriterFactory;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.util.SerializableConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * ReplaceData writer that tracks source file metadata when Spark routes rows through
+ * DataAndMetadataWritingSparkTask.
+ */
+class DeltaReplaceDataWriter implements DataWriter<InternalRow> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DeltaReplaceDataWriter.class);
+
+  private final String targetDirectory;
+  private final SerializableConfiguration hadoopConf;
+  private final SerializableKernelRowWrapper serializedTxnState;
+  private final StructType dataSchema;
+  private final OutputWriterFactory outputWriterFactory;
+  private final StructType partitionSchema;
+  private final Map<String, String> partitionValueStrings;
+  private final String sessionTimeZone;
+  private final int partitionId;
+  private final long taskId;
+  private final Set<String> sourceFilePaths = new LinkedHashSet<>();
+
+  private OutputWriter writer;
+  private Path outputPath;
+  private long rowCount;
+
+  DeltaReplaceDataWriter(
+      String targetDirectory,
+      SerializableConfiguration hadoopConf,
+      SerializableKernelRowWrapper serializedTxnState,
+      StructType dataSchema,
+      OutputWriterFactory outputWriterFactory,
+      StructType partitionSchema,
+      Map<String, String> partitionValueStrings,
+      String sessionTimeZone,
+      int partitionId,
+      long taskId) {
+    this.targetDirectory = targetDirectory;
+    this.hadoopConf = hadoopConf;
+    this.serializedTxnState = serializedTxnState;
+    this.dataSchema = dataSchema;
+    this.outputWriterFactory = outputWriterFactory;
+    this.partitionSchema = partitionSchema;
+    this.partitionValueStrings = partitionValueStrings;
+    this.sessionTimeZone = sessionTimeZone;
+    this.partitionId = partitionId;
+    this.taskId = taskId;
+    this.rowCount = 0L;
+  }
+
+  @Override
+  public void write(InternalRow metadata, InternalRow record) throws IOException {
+    if (metadata != null && !metadata.isNullAt(0)) {
+      sourceFilePaths.add(metadata.getUTF8String(0).toString());
+    }
+    write(record);
+  }
+
+  @Override
+  public void write(InternalRow record) throws IOException {
+    if (writer == null) {
+      initWriter();
+    }
+    writer.write(record);
+    rowCount++;
+  }
+
+  @Override
+  public WriterCommitMessage commit() throws IOException {
+    if (rowCount == 0) {
+      return new DeltaReplaceDataCommitMessage(Collections.emptyList(), Collections.emptySet());
+    }
+
+    writer.close();
+    writer = null;
+
+    List<SerializableKernelRowWrapper> actionRows = generateActionRows();
+    return new DeltaReplaceDataCommitMessage(actionRows, sourceFilePaths);
+  }
+
+  @Override
+  public void abort() throws IOException {
+    closeWriterQuietly();
+    tryDeleteOutputFile();
+  }
+
+  @Override
+  public void close() throws IOException {
+    closeWriterQuietly();
+  }
+
+  private List<SerializableKernelRowWrapper> generateActionRows() throws IOException {
+    Configuration conf = hadoopConf.value();
+    Engine engine = DefaultEngine.create(conf);
+    Row txnState = serializedTxnState.getRow();
+    Map<String, Literal> partitionLiterals =
+        PartitionUtils.buildKernelPartitionLiteralMap(
+            partitionValueStrings, partitionSchema, ZoneId.of(sessionTimeZone));
+    DataWriteContext writeContext =
+        Transaction.getWriteContext(engine, txnState, partitionLiterals);
+
+    FileSystem fs = outputPath.getFileSystem(conf);
+    FileStatus fileStatus = fs.getFileStatus(outputPath);
+    DataFileStatus dataFileStatus =
+        new DataFileStatus(
+            outputPath.toString(),
+            fileStatus.getLen(),
+            fileStatus.getModificationTime(),
+            Optional.empty());
+
+    CloseableIterator<DataFileStatus> dataFilesIter =
+        Utils.toCloseableIterator(Collections.singletonList(dataFileStatus).iterator());
+
+    CloseableIterator<Row> actionRowsIter =
+        Transaction.generateAppendActions(engine, txnState, dataFilesIter, writeContext);
+
+    List<SerializableKernelRowWrapper> actionRows = new ArrayList<>();
+    try {
+      while (actionRowsIter.hasNext()) {
+        actionRows.add(new SerializableKernelRowWrapper(actionRowsIter.next()));
+      }
+    } finally {
+      actionRowsIter.close();
+    }
+    return actionRows;
+  }
+
+  private void closeWriterQuietly() {
+    if (writer != null) {
+      try {
+        writer.close();
+      } catch (Exception e) {
+        LOG.debug("Best-effort close of ReplaceData Parquet writer failed", e);
+      }
+      writer = null;
+    }
+  }
+
+  private void tryDeleteOutputFile() {
+    if (outputPath != null) {
+      try {
+        FileSystem fs = outputPath.getFileSystem(hadoopConf.value());
+        fs.delete(outputPath, false);
+      } catch (Exception e) {
+        LOG.debug("Best-effort delete of partially written file {} failed", outputPath, e);
+      }
+    }
+  }
+
+  private void initWriter() {
+    Configuration conf = hadoopConf.value();
+
+    TaskAttemptContextImpl taskAttemptContext =
+        new TaskAttemptContextImpl(
+            new JobConf(conf), new TaskAttemptID("", 0, TaskType.MAP, partitionId, 0));
+
+    String ext = outputWriterFactory.getFileExtension(taskAttemptContext);
+    String fileName =
+        org.apache.spark.sql.delta.files.DelayedCommitProtocol.buildFileName(
+            partitionId, ext, /* isCdc */ false);
+    outputPath = new Path(targetDirectory, fileName);
+
+    writer = outputWriterFactory.newInstance(outputPath.toString(), dataSchema, taskAttemptContext);
+  }
+}

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaReplaceDataWriterFactory.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaReplaceDataWriterFactory.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.write;
+
+import io.delta.spark.internal.v2.utils.SerializableKernelRowWrapper;
+import java.io.Serializable;
+import java.util.Map;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.connector.write.DataWriter;
+import org.apache.spark.sql.connector.write.DataWriterFactory;
+import org.apache.spark.sql.execution.datasources.OutputWriterFactory;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.util.SerializableConfiguration;
+
+/**
+ * Serializable factory sent to executors to create ReplaceData writers.
+ *
+ * <p>Carries everything a task needs to write a Parquet file that will later be committed as an
+ * AddFile: target directory, Hadoop conf, serialized Kernel transaction state, data/partition
+ * schemas, the shared {@link OutputWriterFactory}, pre-resolved partition-value strings, and the
+ * session time zone for partition literal coercion. All fields are serializable; non-serializable
+ * Kernel objects (Transaction, Engine) are recreated executor-side from the transaction state.
+ */
+class DeltaReplaceDataWriterFactory implements DataWriterFactory, Serializable {
+
+  private final String targetDirectory;
+  private final SerializableConfiguration hadoopConf;
+  private final SerializableKernelRowWrapper serializedTxnState;
+  private final StructType dataSchema;
+  private final OutputWriterFactory outputWriterFactory;
+  private final StructType partitionSchema;
+  private final Map<String, String> partitionValueStrings;
+  private final String sessionTimeZone;
+
+  DeltaReplaceDataWriterFactory(
+      String targetDirectory,
+      SerializableConfiguration hadoopConf,
+      SerializableKernelRowWrapper serializedTxnState,
+      StructType dataSchema,
+      OutputWriterFactory outputWriterFactory,
+      StructType partitionSchema,
+      Map<String, String> partitionValueStrings,
+      String sessionTimeZone) {
+    this.targetDirectory = targetDirectory;
+    this.hadoopConf = hadoopConf;
+    this.serializedTxnState = serializedTxnState;
+    this.dataSchema = dataSchema;
+    this.outputWriterFactory = outputWriterFactory;
+    this.partitionSchema = partitionSchema;
+    this.partitionValueStrings = partitionValueStrings;
+    this.sessionTimeZone = sessionTimeZone;
+  }
+
+  @Override
+  public DataWriter<InternalRow> createWriter(int partitionId, long taskId) {
+    return new DeltaReplaceDataWriter(
+        targetDirectory,
+        hadoopConf,
+        serializedTxnState,
+        dataSchema,
+        outputWriterFactory,
+        partitionSchema,
+        partitionValueStrings,
+        sessionTimeZone,
+        partitionId,
+        taskId);
+  }
+}

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2BatchWrite.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2BatchWrite.java
@@ -15,7 +15,6 @@
  */
 package io.delta.spark.internal.v2.write;
 
-import io.delta.kernel.Operation;
 import io.delta.kernel.Snapshot;
 import io.delta.kernel.Transaction;
 import io.delta.kernel.TransactionCommitResult;
@@ -23,32 +22,19 @@ import io.delta.kernel.data.Row;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.internal.util.Utils;
 import io.delta.kernel.utils.CloseableIterable;
-import io.delta.spark.internal.v2.read.DeltaParquetFileFormatV2;
-import io.delta.spark.internal.v2.utils.PartitionUtils;
-import io.delta.spark.internal.v2.utils.ScalaUtils;
-import io.delta.spark.internal.v2.utils.SchemaUtils;
 import io.delta.spark.internal.v2.utils.SerializableKernelRowWrapper;
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.mapreduce.Job;
-import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.connector.write.BatchWrite;
 import org.apache.spark.sql.connector.write.DataWriterFactory;
 import org.apache.spark.sql.connector.write.LogicalWriteInfo;
 import org.apache.spark.sql.connector.write.PhysicalWriteInfo;
 import org.apache.spark.sql.connector.write.Write;
 import org.apache.spark.sql.connector.write.WriterCommitMessage;
-import org.apache.spark.sql.execution.datasources.OutputWriterFactory;
-import org.apache.spark.sql.types.StructType;
-import org.apache.spark.util.SerializableConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import scala.Option;
 
 /**
  * BatchWrite for DSv2 batch append using Spark's Parquet path. Creates a Kernel transaction on the
@@ -64,18 +50,12 @@ class DeltaV2BatchWrite implements Write, BatchWrite {
 
   private static final Logger LOG = LoggerFactory.getLogger(DeltaV2BatchWrite.class);
 
-  private static String getEngineInfo() {
-    return "Delta-Spark-DSv2/" + org.apache.spark.package$.MODULE$.SPARK_VERSION();
+  static String getEngineInfo() {
+    return DeltaV2BatchWriteContext.getEngineInfo();
   }
 
-  private final Transaction transaction;
-  private final Engine engine;
-
+  private final DeltaV2BatchWriteContext context;
   private final String targetDirectory;
-  private final SerializableConfiguration serializableHadoopConf;
-  private final SerializableKernelRowWrapper serializedTxnState;
-  private final StructType dataSchema;
-  private final OutputWriterFactory outputWriterFactory;
 
   DeltaV2BatchWrite(
       Engine engine,
@@ -83,58 +63,9 @@ class DeltaV2BatchWrite implements Write, BatchWrite {
       String tablePath,
       Snapshot initialSnapshot,
       LogicalWriteInfo writeInfo) {
-    this.engine = engine;
-    this.transaction =
-        initialSnapshot
-            .buildUpdateTableTransaction(getEngineInfo(), Operation.WRITE)
-            .build(this.engine);
-    Row txnState = transaction.getTransactionState(this.engine);
-    this.serializedTxnState = new SerializableKernelRowWrapper(txnState);
-
-    this.targetDirectory =
-        Transaction.getWriteContext(this.engine, txnState, Collections.emptyMap())
-            .getTargetDirectory();
-
-    StructType tableSchema =
-        SchemaUtils.convertKernelSchemaToSparkSchema(initialSnapshot.getSchema());
-    java.util.Set<String> partitionCols =
-        new java.util.HashSet<>(initialSnapshot.getPartitionColumnNames());
-    this.dataSchema =
-        partitionCols.isEmpty()
-            ? tableSchema
-            : new StructType(
-                java.util.Arrays.stream(tableSchema.fields())
-                    .filter(f -> !partitionCols.contains(f.name()))
-                    .toArray(org.apache.spark.sql.types.StructField[]::new));
-
-    SparkSession session =
-        SparkSession.getActiveSession()
-            .getOrElse(
-                () -> {
-                  throw new IllegalStateException(
-                      "SparkSession not active (batch write needs it for Parquet)");
-                });
-
-    Job job;
-    try {
-      job = Job.getInstance(hadoopConf);
-    } catch (IOException e) {
-      throw new UncheckedIOException("Failed to create Hadoop job for Parquet write", e);
-    }
-    // TODO: support write-time CDF on batch writes.
-    DeltaParquetFileFormatV2 format =
-        PartitionUtils.createDeltaParquetFileFormat(
-            initialSnapshot,
-            tablePath,
-            /* optimizationsEnabled */ true,
-            /* useMetadataRowIndex */ Option.empty(),
-            /* isCDCRead */ false);
-    org.apache.spark.sql.execution.datasources.DataSourceUtils.checkFieldNames(format, dataSchema);
-    Map<String, String> options = writeInfo.options().asCaseSensitiveMap();
-    scala.collection.immutable.Map<String, String> scalaOpts =
-        ScalaUtils.toScalaMap(options != null ? options : Collections.emptyMap());
-    this.outputWriterFactory = format.prepareWrite(session, job, scalaOpts, dataSchema);
-    this.serializableHadoopConf = new SerializableConfiguration(job.getConfiguration());
+    this.context =
+        DeltaV2BatchWriteContext.create(engine, hadoopConf, tablePath, initialSnapshot, writeInfo);
+    this.targetDirectory = context.getTargetDirectory(Collections.emptyMap());
   }
 
   @Override
@@ -146,10 +77,10 @@ class DeltaV2BatchWrite implements Write, BatchWrite {
   public DataWriterFactory createBatchWriterFactory(PhysicalWriteInfo physicalWriteInfo) {
     return new DeltaV2DataWriterFactory(
         targetDirectory,
-        serializableHadoopConf,
-        serializedTxnState,
-        dataSchema,
-        outputWriterFactory);
+        context.getSerializableHadoopConf(),
+        context.getSerializedTxnState(),
+        context.getDataSchema(),
+        context.getOutputWriterFactory());
   }
 
   @Override
@@ -167,7 +98,8 @@ class DeltaV2BatchWrite implements Write, BatchWrite {
     CloseableIterable<Row> dataActions =
         CloseableIterable.inMemoryIterable(Utils.toCloseableIterator(allActionRows.iterator()));
 
-    TransactionCommitResult result = transaction.commit(engine, dataActions);
+    TransactionCommitResult result =
+        context.getTransaction().commit(context.getEngine(), dataActions);
     LOG.info("DSv2 batch write committed at version {}", result.getVersion());
   }
 

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2BatchWriteContext.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2BatchWriteContext.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.write;
+
+import io.delta.kernel.Operation;
+import io.delta.kernel.Snapshot;
+import io.delta.kernel.Transaction;
+import io.delta.kernel.data.Row;
+import io.delta.kernel.engine.Engine;
+import io.delta.kernel.expressions.Literal;
+import io.delta.spark.internal.v2.read.DeltaParquetFileFormatV2;
+import io.delta.spark.internal.v2.utils.PartitionUtils;
+import io.delta.spark.internal.v2.utils.ScalaUtils;
+import io.delta.spark.internal.v2.utils.SchemaUtils;
+import io.delta.spark.internal.v2.utils.SerializableKernelRowWrapper;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.time.ZoneId;
+import java.util.Collections;
+import java.util.Map;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.connector.write.LogicalWriteInfo;
+import org.apache.spark.sql.execution.datasources.OutputWriterFactory;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.util.SerializableConfiguration;
+import scala.Option;
+
+/** Shared driver-side setup for Delta DSv2 batch writes. */
+class DeltaV2BatchWriteContext {
+
+  static String getEngineInfo() {
+    return "Delta-Spark-DSv2/" + org.apache.spark.package$.MODULE$.SPARK_VERSION();
+  }
+
+  private final Transaction transaction;
+  private final Engine engine;
+  private final SerializableKernelRowWrapper serializedTxnState;
+  private final StructType dataSchema;
+  private final StructType partitionSchema;
+  private final io.delta.kernel.types.StructType kernelTableSchema;
+  private final OutputWriterFactory outputWriterFactory;
+  private final SerializableConfiguration serializableHadoopConf;
+  private final String sessionTimeZone;
+
+  static DeltaV2BatchWriteContext create(
+      Engine engine,
+      Configuration hadoopConf,
+      String tablePath,
+      Snapshot initialSnapshot,
+      LogicalWriteInfo writeInfo) {
+    return new DeltaV2BatchWriteContext(engine, hadoopConf, tablePath, initialSnapshot, writeInfo);
+  }
+
+  private DeltaV2BatchWriteContext(
+      Engine engine,
+      Configuration hadoopConf,
+      String tablePath,
+      Snapshot initialSnapshot,
+      LogicalWriteInfo writeInfo) {
+    this.engine = engine;
+    this.transaction =
+        initialSnapshot
+            .buildUpdateTableTransaction(getEngineInfo(), Operation.WRITE)
+            .build(this.engine);
+    Row txnState = transaction.getTransactionState(this.engine);
+    this.serializedTxnState = new SerializableKernelRowWrapper(txnState);
+
+    this.kernelTableSchema = initialSnapshot.getSchema();
+    StructType tableSchema = SchemaUtils.convertKernelSchemaToSparkSchema(kernelTableSchema);
+    java.util.Set<String> partitionCols =
+        new java.util.HashSet<>(initialSnapshot.getPartitionColumnNames());
+    this.partitionSchema =
+        partitionCols.isEmpty()
+            ? new StructType()
+            : new StructType(
+                java.util.Arrays.stream(tableSchema.fields())
+                    .filter(field -> partitionCols.contains(field.name()))
+                    .toArray(org.apache.spark.sql.types.StructField[]::new));
+    this.dataSchema =
+        partitionCols.isEmpty()
+            ? tableSchema
+            : new StructType(
+                java.util.Arrays.stream(tableSchema.fields())
+                    .filter(field -> !partitionCols.contains(field.name()))
+                    .toArray(org.apache.spark.sql.types.StructField[]::new));
+
+    SparkSession session =
+        SparkSession.getActiveSession()
+            .getOrElse(
+                () -> {
+                  throw new IllegalStateException(
+                      "SparkSession not active (batch write needs it for Parquet)");
+                });
+    this.sessionTimeZone = session.sessionState().conf().sessionLocalTimeZone();
+
+    Job job;
+    try {
+      job = Job.getInstance(hadoopConf);
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to create Hadoop job for Parquet write", e);
+    }
+    DeltaParquetFileFormatV2 format =
+        PartitionUtils.createDeltaParquetFileFormat(
+            initialSnapshot,
+            tablePath,
+            /* optimizationsEnabled */ true,
+            /* useMetadataRowIndex */ Option.empty(),
+            /* isCDCRead */ false);
+    org.apache.spark.sql.execution.datasources.DataSourceUtils.checkFieldNames(format, dataSchema);
+    Map<String, String> options = writeInfo.options().asCaseSensitiveMap();
+    scala.collection.immutable.Map<String, String> scalaOpts =
+        ScalaUtils.toScalaMap(options != null ? options : Collections.emptyMap());
+    this.outputWriterFactory = format.prepareWrite(session, job, scalaOpts, dataSchema);
+    this.serializableHadoopConf = new SerializableConfiguration(job.getConfiguration());
+  }
+
+  Transaction getTransaction() {
+    return transaction;
+  }
+
+  Engine getEngine() {
+    return engine;
+  }
+
+  String getTargetDirectory(Map<String, Literal> partitionLiterals) {
+    return Transaction.getWriteContext(engine, serializedTxnState.getRow(), partitionLiterals)
+        .getTargetDirectory();
+  }
+
+  SerializableKernelRowWrapper getSerializedTxnState() {
+    return serializedTxnState;
+  }
+
+  StructType getDataSchema() {
+    return dataSchema;
+  }
+
+  StructType getPartitionSchema() {
+    return partitionSchema;
+  }
+
+  io.delta.kernel.types.StructType getKernelTableSchema() {
+    return kernelTableSchema;
+  }
+
+  OutputWriterFactory getOutputWriterFactory() {
+    return outputWriterFactory;
+  }
+
+  SerializableConfiguration getSerializableHadoopConf() {
+    return serializableHadoopConf;
+  }
+
+  ZoneId getSessionTimeZone() {
+    return ZoneId.of(sessionTimeZone);
+  }
+
+  String getSessionTimeZoneId() {
+    return sessionTimeZone;
+  }
+}

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2WriteBuilder.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2WriteBuilder.java
@@ -81,18 +81,25 @@ public class DeltaV2WriteBuilder implements WriteBuilder {
               + "). Use the V1 write path (format(\"delta\").write()) instead.");
     }
 
+    validateDataSchema(initialSnapshot, writeInfo.schema());
+
+    return new DeltaV2BatchWrite(engine, hadoopConf, tablePath, initialSnapshot, writeInfo);
+  }
+
+  static void validateDataSchema(Snapshot initialSnapshot, StructType dataSchema) {
+    // Validate data schema against table schema using the same utility as V1
+    // (ImplicitMetadataOperation.updateMetadata -> SchemaMergingUtils.mergeSchemas).
     StructType tableSchema =
         SchemaUtils.convertKernelSchemaToSparkSchema(initialSnapshot.getSchema());
     // Strip column mapping metadata (physical names, IDs) so mergeSchemas compares
-    // only logical types -- matches V1's dropColumnMappingMetadata call.
+    // only logical types - matches V1's dropColumnMappingMetadata call.
     StructType cleanTableSchema =
         DeltaColumnMapping.dropColumnMappingMetadata(tableSchema.asNullable());
-    StructType dataSchema = writeInfo.schema();
 
     // Throws DeltaAnalysisException for type incompatibilities or duplicate columns.
-    // Return value discarded -- we only need the validation side-effect.
-    // TODO: Support schema evolution (mergeSchema option). When enabled, use the merged
-    // schema returned here to update table metadata instead of discarding it.
+    // Return value discarded - we only need the validation side-effect.
+    // TODO: Support schema evolution (mergeSchema option). When enabled, use the
+    // merged schema returned here to update table metadata instead of discarding it.
     SchemaMergingUtils.mergeSchemas(
         cleanTableSchema,
         dataSchema,
@@ -100,7 +107,5 @@ public class DeltaV2WriteBuilder implements WriteBuilder {
         /* keepExistingType */ false,
         TypeWideningMode.NoTypeWidening$.MODULE$,
         /* caseSensitive */ false);
-
-    return new DeltaV2BatchWrite(engine, hadoopConf, tablePath, initialSnapshot, writeInfo);
   }
 }

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkScanTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/SparkScanTest.java
@@ -538,6 +538,33 @@ public class SparkScanTest extends DeltaV2TestBase {
     return (List<PartitionedFile>) field.get(scan);
   }
 
+  @Test
+  public void testSelectedFilesTracksPlannedAndRuntimeFilteredFiles() throws Exception {
+    SparkScanBuilder builder = (SparkScanBuilder) table.newScanBuilder(options);
+    SparkScan scan = (SparkScan) builder.build();
+
+    List<PartitionedFile> plannedFiles = getPartitionedFiles(scan);
+    List<DeltaScanFile> selectedFiles = scan.getSelectedFiles();
+    assertEquals(plannedFiles.size(), selectedFiles.size());
+    assertEquals(5, selectedFiles.size(), "test table should start with all selected files");
+    assertTrue(
+        selectedFiles.stream().allMatch(file -> file.getPath().contains("city=")),
+        "selected file descriptors should expose Delta-relative AddFile paths");
+    assertTrue(
+        selectedFiles.stream().allMatch(file -> file.getSize() > 0),
+        "selected file descriptors should expose file sizes");
+
+    scan.filter(new Predicate[] {cityPredicate});
+
+    List<PartitionedFile> filteredFiles = getPartitionedFiles(scan);
+    List<DeltaScanFile> filteredSelectedFiles = scan.getSelectedFiles();
+    assertEquals(filteredFiles.size(), filteredSelectedFiles.size());
+    assertEquals(2, filteredSelectedFiles.size(), "city=hz runtime filter should keep two files");
+    assertTrue(
+        filteredSelectedFiles.stream().allMatch(file -> file.getPath().contains("city=hz")),
+        "selected files should be pruned with runtime partition filters");
+  }
+
   private static long getTotalBytes(SparkScan scan) throws Exception {
     scan.estimateStatistics(); // ensurePlanned
     Field field = SparkScan.class.getDeclaredField("totalBytes");

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/write/DeltaReplaceDataBatchWriteTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/write/DeltaReplaceDataBatchWriteTest.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.write;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.delta.kernel.Snapshot;
+import io.delta.kernel.defaults.engine.DefaultEngine;
+import io.delta.kernel.engine.Engine;
+import io.delta.spark.internal.v2.DeltaV2TestBase;
+import io.delta.spark.internal.v2.catalog.DeltaV2Table;
+import io.delta.spark.internal.v2.read.SparkScan;
+import io.delta.spark.internal.v2.snapshot.PathBasedSnapshotManager;
+import java.io.File;
+import java.util.Collections;
+import java.util.List;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.expressions.Expression;
+import org.apache.spark.sql.connector.expressions.FieldReference;
+import org.apache.spark.sql.connector.expressions.LiteralValue;
+import org.apache.spark.sql.connector.expressions.filter.Predicate;
+import org.apache.spark.sql.connector.read.Scan;
+import org.apache.spark.sql.connector.read.ScanBuilder;
+import org.apache.spark.sql.connector.write.BatchWrite;
+import org.apache.spark.sql.connector.write.LogicalWriteInfo;
+import org.apache.spark.sql.connector.write.Write;
+import org.apache.spark.sql.connector.write.WriteBuilder;
+import org.apache.spark.sql.connector.write.WriterCommitMessage;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import scala.Option;
+
+public class DeltaReplaceDataBatchWriteTest extends DeltaV2TestBase {
+
+  @Test
+  public void commitWithNoTaskMessagesRemovesAllSelectedFiles(@TempDir File tempDir)
+      throws Exception {
+    String path = tempDir.getAbsolutePath();
+    String tableName = "replace_data_remove_all_" + System.nanoTime();
+    createTestTableWithData(path, tableName);
+
+    SparkScan scan = createScan(tableName, path);
+    DeltaReplaceDataBatchWrite batchWrite =
+        buildBatchWrite(scan, path, nonPartitionedTableSchema());
+
+    long addFilesBefore =
+        org.apache.spark.sql.delta.DeltaLog.forTable(spark, path)
+            .update(false, Option.empty(), Option.empty())
+            .allFiles()
+            .count();
+    assertTrue(addFilesBefore > 0L, "Test setup expected at least one AddFile");
+
+    batchWrite.commit(new WriterCommitMessage[0]);
+
+    assertEquals(0L, spark.read().format("delta").load(path).count());
+    // Delta-log level regression: the commit must actually have removed the scan-selected AddFiles,
+    // not just produced an empty query result by some other means.
+    long addFilesAfter =
+        org.apache.spark.sql.delta.DeltaLog.forTable(spark, path)
+            .update(false, Option.empty(), Option.empty())
+            .allFiles()
+            .count();
+    assertEquals(
+        0L,
+        addFilesAfter,
+        "Expected all AddFiles to be removed from the Delta log after ReplaceData commit");
+  }
+
+  @Test
+  public void commitUsesRuntimeFilteredScanFilesForRemoveSet(@TempDir File tempDir)
+      throws Exception {
+    String path = tempDir.getAbsolutePath();
+    String tableName = "replace_data_runtime_filter_" + System.nanoTime();
+    spark.sql(
+        String.format(
+            "CREATE TABLE %s (id INT, name STRING, city STRING) USING delta "
+                + "PARTITIONED BY (city) LOCATION '%s'",
+            tableName, path));
+    spark.sql(
+        String.format("INSERT INTO %s VALUES (1, 'Alice', 'hz'), (2, 'Bob', 'la')", tableName));
+
+    SparkScan scan = createScan(tableName, path);
+    scan.filter(
+        new Predicate[] {
+          new Predicate(
+              "=",
+              new Expression[] {
+                FieldReference.apply("city"), LiteralValue.apply("hz", DataTypes.StringType)
+              })
+        });
+
+    DeltaReplaceDataBatchWrite batchWrite = buildBatchWrite(scan, path, partitionedTableSchema());
+    batchWrite.commit(new WriterCommitMessage[0]);
+
+    List<Row> remainingRows =
+        spark.read().format("delta").load(path).select("id", "city").collectAsList();
+    assertEquals(1, remainingRows.size());
+    assertEquals(2, remainingRows.get(0).getInt(0));
+    assertEquals("la", remainingRows.get(0).getString(1));
+  }
+
+  @Test
+  public void partitionedCommitWithNoSelectedFilesIsNoOp(@TempDir File tempDir) {
+    String path = tempDir.getAbsolutePath();
+    String tableName = "replace_data_empty_partitioned_" + System.nanoTime();
+    spark.sql(
+        String.format(
+            "CREATE TABLE %s (id INT, name STRING, city STRING) USING delta "
+                + "PARTITIONED BY (city) LOCATION '%s'",
+            tableName, path));
+    spark.sql(String.format("INSERT INTO %s VALUES (1, 'Alice', 'hz')", tableName));
+
+    SparkScan scan = createScan(tableName, path);
+    scan.filter(
+        new Predicate[] {
+          new Predicate(
+              "=",
+              new Expression[] {
+                FieldReference.apply("city"), LiteralValue.apply("missing", DataTypes.StringType)
+              })
+        });
+
+    DeltaReplaceDataBatchWrite batchWrite = buildBatchWrite(scan, path, partitionedTableSchema());
+    batchWrite.commit(new WriterCommitMessage[0]);
+
+    assertEquals(1L, spark.read().format("delta").load(path).count());
+  }
+
+  @Test
+  public void createBatchWriterFactoryRejectsMultiPartitionSelection(@TempDir File tempDir) {
+    String path = tempDir.getAbsolutePath();
+    String tableName = "replace_data_multi_partition_" + System.nanoTime();
+    spark.sql(
+        String.format(
+            "CREATE TABLE %s (id INT, name STRING, city STRING) USING delta "
+                + "PARTITIONED BY (city) LOCATION '%s'",
+            tableName, path));
+    spark.sql(
+        String.format("INSERT INTO %s VALUES (1, 'Alice', 'hz'), (2, 'Bob', 'la')", tableName));
+
+    SparkScan scan = createScan(tableName, path);
+    DeltaReplaceDataBatchWrite batchWrite = buildBatchWrite(scan, path, partitionedTableSchema());
+
+    IllegalStateException e =
+        assertThrows(IllegalStateException.class, () -> batchWrite.createBatchWriterFactory(null));
+    assertTrue(e.getMessage().contains("single partition"));
+  }
+
+  @Test
+  public void commitRejectsWriterSourcePathsOutsideScanSelection(@TempDir File tempDir) {
+    String path = tempDir.getAbsolutePath();
+    String tableName = "replace_data_source_path_validation_" + System.nanoTime();
+    createTestTableWithData(path, tableName);
+
+    SparkScan scan = createScan(tableName, path);
+    DeltaReplaceDataBatchWrite batchWrite =
+        buildBatchWrite(scan, path, nonPartitionedTableSchema());
+
+    DeltaReplaceDataCommitMessage message =
+        new DeltaReplaceDataCommitMessage(
+            Collections.emptyList(),
+            Collections.singleton("file:/not-a-selected-source-file.parquet"));
+    IllegalStateException e =
+        assertThrows(
+            IllegalStateException.class,
+            () -> batchWrite.commit(new WriterCommitMessage[] {message}));
+    assertTrue(e.getMessage().contains("outside scan-selected files"));
+  }
+
+  private SparkScan createScan(String tableName, String path) {
+    DeltaV2Table table = new DeltaV2Table(Identifier.of(new String[] {"default"}, tableName), path);
+    ScanBuilder scanBuilder =
+        table.newScanBuilder(new CaseInsensitiveStringMap(Collections.emptyMap()));
+    Scan scan = scanBuilder.build();
+    assertTrue(scan instanceof SparkScan);
+    return (SparkScan) scan;
+  }
+
+  private DeltaReplaceDataBatchWrite buildBatchWrite(
+      SparkScan scan, String path, StructType schema) {
+    Configuration hadoopConf = spark.sessionState().newHadoopConf();
+    Engine engine = DefaultEngine.create(hadoopConf);
+    Snapshot initialSnapshot = new PathBasedSnapshotManager(path, engine).loadLatestSnapshot();
+    WriteBuilder writeBuilder =
+        new DeltaReplaceDataWriteBuilder(
+            engine,
+            path,
+            hadoopConf,
+            initialSnapshot,
+            scan::getSelectedFiles,
+            new TestLogicalWriteInfo(schema));
+    Write write = writeBuilder.build();
+    BatchWrite batchWrite = write.toBatch();
+    assertTrue(batchWrite instanceof DeltaReplaceDataBatchWrite);
+    return (DeltaReplaceDataBatchWrite) batchWrite;
+  }
+
+  private static StructType nonPartitionedTableSchema() {
+    return new StructType()
+        .add("id", DataTypes.IntegerType)
+        .add("name", DataTypes.StringType)
+        .add("value", DataTypes.DoubleType);
+  }
+
+  private static StructType partitionedTableSchema() {
+    return new StructType()
+        .add("id", DataTypes.IntegerType)
+        .add("name", DataTypes.StringType)
+        .add("city", DataTypes.StringType);
+  }
+
+  private static class TestLogicalWriteInfo implements LogicalWriteInfo {
+    private final StructType schema;
+
+    TestLogicalWriteInfo(StructType schema) {
+      this.schema = schema;
+    }
+
+    @Override
+    public String queryId() {
+      return "test-query-id";
+    }
+
+    @Override
+    public StructType schema() {
+      return schema;
+    }
+
+    @Override
+    public CaseInsensitiveStringMap options() {
+      return new CaseInsensitiveStringMap(Collections.emptyMap());
+    }
+  }
+}

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/write/DeltaReplaceDataWriterTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/write/DeltaReplaceDataWriterTest.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.write;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.delta.kernel.DataWriteContext;
+import io.delta.kernel.Operation;
+import io.delta.kernel.Snapshot;
+import io.delta.kernel.Transaction;
+import io.delta.kernel.data.Row;
+import io.delta.kernel.defaults.engine.DefaultEngine;
+import io.delta.kernel.defaults.internal.json.JsonUtils;
+import io.delta.kernel.engine.Engine;
+import io.delta.kernel.internal.SnapshotImpl;
+import io.delta.kernel.types.IntegerType;
+import io.delta.spark.internal.v2.DeltaV2TestBase;
+import io.delta.spark.internal.v2.read.DeltaParquetFileFormatV2;
+import io.delta.spark.internal.v2.snapshot.PathBasedSnapshotManager;
+import io.delta.spark.internal.v2.utils.ScalaUtils;
+import io.delta.spark.internal.v2.utils.SchemaUtils;
+import io.delta.spark.internal.v2.utils.SerializableKernelRowWrapper;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Collections;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
+import org.apache.spark.sql.connector.write.WriterCommitMessage;
+import org.apache.spark.sql.execution.datasources.OutputWriterFactory;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.unsafe.types.UTF8String;
+import org.apache.spark.util.SerializableConfiguration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import scala.Option;
+
+public class DeltaReplaceDataWriterTest extends DeltaV2TestBase {
+
+  @Test
+  public void twoArgWriteTracksSourceFilePaths(@TempDir File tempDir) throws Exception {
+    String path = tempDir.getAbsolutePath();
+    createEmptyTestTable(path, "replace_data_tracks_paths");
+
+    DeltaReplaceDataWriter writer = createWriter(path);
+
+    GenericInternalRow metadataRow = new GenericInternalRow(1);
+    metadataRow.update(0, UTF8String.fromString("file:/tmp/source-file.parquet"));
+    InternalRow dataRow = new GenericInternalRow(new Object[] {1, UTF8String.fromString("Alice")});
+    writer.write(metadataRow, dataRow);
+
+    DeltaReplaceDataCommitMessage message = commitAndCast(writer);
+    assertEquals(
+        Collections.singleton("file:/tmp/source-file.parquet"), message.getSourceFilePaths());
+    assertEquals(1, message.getAddFileActionRows().size());
+  }
+
+  @Test
+  public void singleArgWriteDoesNotTrackPaths(@TempDir File tempDir) throws Exception {
+    String path = tempDir.getAbsolutePath();
+    createEmptyTestTable(path, "replace_data_no_paths");
+
+    DeltaReplaceDataWriter writer = createWriter(path);
+    writer.write(new GenericInternalRow(new Object[] {1, UTF8String.fromString("Alice")}));
+
+    DeltaReplaceDataCommitMessage message = commitAndCast(writer);
+    assertTrue(message.getSourceFilePaths().isEmpty());
+    assertEquals(1, message.getAddFileActionRows().size());
+  }
+
+  @Test
+  public void commitProducesAddFileActions(@TempDir File tempDir) throws Exception {
+    String path = tempDir.getAbsolutePath();
+    createEmptyTestTable(path, "replace_data_add_file");
+
+    DeltaReplaceDataWriter writer = createWriter(path);
+    writer.write(new GenericInternalRow(new Object[] {1, UTF8String.fromString("Alice")}));
+    writer.write(new GenericInternalRow(new Object[] {2, UTF8String.fromString("Bob")}));
+
+    DeltaReplaceDataCommitMessage message = commitAndCast(writer);
+    assertEquals(1, message.getAddFileActionRows().size());
+
+    Row singleActionRow = message.getAddFileActionRows().get(0).getRow();
+    int addOrdinal = singleActionRow.getSchema().indexOf("add");
+    assertFalse(singleActionRow.isNullAt(addOrdinal));
+    Row addFileRow = singleActionRow.getStruct(addOrdinal);
+    // AddFile.path is table-relative per the Delta protocol (e.g. "part-00000-...parquet").
+    String filePath = addFileRow.getString(0);
+    long fileSize = addFileRow.getLong(2);
+    int dataChangeOrdinal = addFileRow.getSchema().indexOf("dataChange");
+    assertNotNull(filePath);
+    assertTrue(
+        filePath.endsWith(".parquet"), "Expected AddFile path to end with .parquet: " + filePath);
+    assertFalse(
+        filePath.startsWith("/") || filePath.contains("://"),
+        "AddFile path must be table-relative, not absolute: " + filePath);
+    assertTrue(fileSize > 0L);
+    assertTrue(
+        addFileRow.getBoolean(dataChangeOrdinal),
+        "ReplaceData AddFile must be marked dataChange=true");
+    // Resolve the relative path against the test-table directory and verify the file exists.
+    assertTrue(
+        Files.exists(Paths.get(path, filePath)),
+        "Expected the Parquet file referenced by the AddFile to exist on disk under " + path);
+  }
+
+  @Test
+  public void emptyWriteProducesEmptyCommit(@TempDir File tempDir) throws Exception {
+    String path = tempDir.getAbsolutePath();
+    createEmptyTestTable(path, "replace_data_empty_commit");
+
+    DeltaReplaceDataWriter writer = createWriter(path);
+
+    DeltaReplaceDataCommitMessage message = commitAndCast(writer);
+    assertTrue(message.getAddFileActionRows().isEmpty());
+    assertTrue(message.getSourceFilePaths().isEmpty());
+  }
+
+  @Test
+  public void commitMessageTreatsNullCollectionsAsEmpty() {
+    DeltaReplaceDataCommitMessage message = new DeltaReplaceDataCommitMessage(null, null);
+    assertNotNull(message.getAddFileActionRows());
+    assertNotNull(message.getSourceFilePaths());
+    assertTrue(message.getAddFileActionRows().isEmpty());
+    assertTrue(message.getSourceFilePaths().isEmpty());
+  }
+
+  @Test
+  public void commitMessageReturnsUnmodifiableViews() {
+    DeltaReplaceDataCommitMessage message =
+        new DeltaReplaceDataCommitMessage(Collections.emptyList(), Collections.emptySet());
+    assertThrows(
+        UnsupportedOperationException.class, () -> message.getAddFileActionRows().add(null));
+    assertThrows(UnsupportedOperationException.class, () -> message.getSourceFilePaths().add("x"));
+  }
+
+  @Test
+  public void commitMessagePreservesPayloads() {
+    io.delta.kernel.types.StructType schema =
+        new io.delta.kernel.types.StructType().add("x", IntegerType.INTEGER);
+    Row row = JsonUtils.rowFromJson("{\"x\": 42}", schema);
+    SerializableKernelRowWrapper wrapper = new SerializableKernelRowWrapper(row);
+    DeltaReplaceDataCommitMessage message =
+        new DeltaReplaceDataCommitMessage(
+            Collections.singletonList(wrapper), Collections.singleton("p"));
+    assertEquals(1, message.getAddFileActionRows().size());
+    assertEquals(wrapper, message.getAddFileActionRows().get(0));
+    assertEquals(Collections.singleton("p"), message.getSourceFilePaths());
+  }
+
+  private DeltaReplaceDataWriter createWriter(String path) throws Exception {
+    Configuration hadoopConf = spark.sessionState().newHadoopConf();
+    PathBasedSnapshotManager snapshotManager = new PathBasedSnapshotManager(path, hadoopConf);
+    Snapshot snapshot = snapshotManager.loadLatestSnapshot();
+    Engine engine = DefaultEngine.create(hadoopConf);
+    Transaction txn = snapshot.buildUpdateTableTransaction("test", Operation.WRITE).build(engine);
+    Row txnState = txn.getTransactionState(engine);
+    SerializableKernelRowWrapper serializedTxn = new SerializableKernelRowWrapper(txnState);
+
+    DataWriteContext writeContext =
+        Transaction.getWriteContext(engine, txnState, Collections.emptyMap());
+    String targetDir = writeContext.getTargetDirectory();
+
+    StructType dataSchema = SchemaUtils.convertKernelSchemaToSparkSchema(snapshot.getSchema());
+    Job job = Job.getInstance(hadoopConf);
+    SnapshotImpl snapshotImpl = (SnapshotImpl) snapshot;
+    DeltaParquetFileFormatV2 format =
+        new DeltaParquetFileFormatV2(
+            snapshotImpl.getProtocol(),
+            snapshotImpl.getMetadata(),
+            false,
+            false,
+            true,
+            Option.apply(path),
+            false,
+            Option.empty());
+    OutputWriterFactory outputWriterFactory =
+        format.prepareWrite(spark, job, ScalaUtils.toScalaMap(Collections.emptyMap()), dataSchema);
+    SerializableConfiguration serConf = new SerializableConfiguration(job.getConfiguration());
+
+    return new DeltaReplaceDataWriter(
+        targetDir,
+        serConf,
+        serializedTxn,
+        dataSchema,
+        outputWriterFactory,
+        new StructType(),
+        Collections.emptyMap(),
+        spark.sessionState().conf().sessionLocalTimeZone(),
+        0,
+        0);
+  }
+
+  private static DeltaReplaceDataCommitMessage commitAndCast(DeltaReplaceDataWriter writer)
+      throws Exception {
+    WriterCommitMessage message = writer.commit();
+    assertNotNull(message);
+    assertTrue(message instanceof DeltaReplaceDataCommitMessage);
+    return (DeltaReplaceDataCommitMessage) message;
+  }
+}


### PR DESCRIPTION
## Description

Add partition literal handling and validation edge coverage for the Delta Spark DSv2 ReplaceData path, including null and decimal partition values and source-file validation.

## How was this patch tested?

- Not run: formatter check is blocked because `build/sbt` could not download `sbt-launch-1.9.9.jar` from the configured Maven URLs in this environment.