### PR TITLE
Propagate catalog histograms through DSv2 column statistics

### DIFF
--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/StatsUtils.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/StatsUtils.java
@@ -29,6 +29,8 @@ import org.apache.spark.sql.connector.expressions.FieldReference;
 import org.apache.spark.sql.connector.expressions.NamedReference;
 import org.apache.spark.sql.connector.read.Statistics;
 import org.apache.spark.sql.connector.read.colstats.ColumnStatistics;
+import org.apache.spark.sql.connector.read.colstats.Histogram;
+import org.apache.spark.sql.connector.read.colstats.HistogramBin;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
@@ -138,6 +140,8 @@ public final class StatsUtils {
           toJavaOptional(stat.maxLen())
               .map(v -> OptionalLong.of(((Number) v).longValue()))
               .orElse(OptionalLong.empty());
+      Optional<Histogram> histogram =
+          toJavaOptional(stat.histogram()).map(StatsUtils::toV2Histogram);
 
       ColumnStatistics v2ColStats =
           new ColumnStatistics() {
@@ -170,9 +174,55 @@ public final class StatsUtils {
             public OptionalLong maxLen() {
               return maxLen;
             }
+
+            @Override
+            public Optional<Histogram> histogram() {
+              return histogram;
+            }
           };
       result.put(ref, v2ColStats);
     }
     return Collections.unmodifiableMap(result);
+  }
+
+  private static Histogram toV2Histogram(
+      org.apache.spark.sql.catalyst.plans.logical.Histogram histogram) {
+    double height = histogram.height();
+    org.apache.spark.sql.catalyst.plans.logical.HistogramBin[] catalystBins = histogram.bins();
+    HistogramBin[] v2Bins = new HistogramBin[catalystBins.length];
+    for (int i = 0; i < catalystBins.length; i++) {
+      org.apache.spark.sql.catalyst.plans.logical.HistogramBin catalystBin = catalystBins[i];
+      double lo = catalystBin.lo();
+      double hi = catalystBin.hi();
+      long ndv = catalystBin.ndv();
+      v2Bins[i] =
+          new HistogramBin() {
+            @Override
+            public double lo() {
+              return lo;
+            }
+
+            @Override
+            public double hi() {
+              return hi;
+            }
+
+            @Override
+            public long ndv() {
+              return ndv;
+            }
+          };
+    }
+    return new Histogram() {
+      @Override
+      public double height() {
+        return height;
+      }
+
+      @Override
+      public HistogramBin[] bins() {
+        return v2Bins;
+      }
+    };
   }
 }

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/StatsUtilsTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/StatsUtilsTest.java
@@ -111,6 +111,52 @@ class StatsUtilsTest {
     assertTrue(idStats.max().isPresent(), "max should be present");
     assertEquals(1, idStats.min().get(), "min should be 1");
     assertEquals(100, idStats.max().get(), "max should be 100");
+    assertFalse(idStats.histogram().isPresent(), "histogram should be empty when absent");
+  }
+
+  @Test
+  void testToV2Statistics_propagatesHistogram() {
+    StructType dataSchema = new StructType().add("id", DataTypes.IntegerType);
+    StructType partitionSchema = new StructType();
+
+    org.apache.spark.sql.catalyst.plans.logical.Histogram catalystHistogram =
+        new org.apache.spark.sql.catalyst.plans.logical.Histogram(
+            2.5D,
+            new org.apache.spark.sql.catalyst.plans.logical.HistogramBin[] {
+              new org.apache.spark.sql.catalyst.plans.logical.HistogramBin(1.0D, 5.0D, 4L),
+              new org.apache.spark.sql.catalyst.plans.logical.HistogramBin(5.0D, 10.0D, 5L)
+            });
+
+    CatalogColumnStat idColStat =
+        new CatalogColumnStat(
+            Option.apply(BigInt(10L)),
+            Option.apply("1"),
+            Option.apply("100"),
+            Option.apply(BigInt(0L)),
+            Option.apply((Object) 4L),
+            Option.apply((Object) 4L),
+            Option.apply(catalystHistogram), // histogram
+            CatalogColumnStat.VERSION());
+
+    scala.collection.immutable.Map<String, CatalogColumnStat> colStatsMap =
+        buildScalaMap(new String[] {"id"}, new CatalogColumnStat[] {idColStat});
+
+    CatalogStatistics catalogStats =
+        new CatalogStatistics(BigInt(1024L), Option.apply(BigInt(10L)), colStatsMap);
+
+    Statistics v2Stats = StatsUtils.toV2Statistics(catalogStats, dataSchema, partitionSchema);
+    ColumnStatistics idStats = v2Stats.columnStats().get(FieldReference.apply("id"));
+
+    assertTrue(idStats.histogram().isPresent(), "histogram should be present");
+    org.apache.spark.sql.connector.read.colstats.Histogram histogram = idStats.histogram().get();
+    assertEquals(2.5D, histogram.height(), 0.0D, "histogram height should match");
+    assertEquals(2, histogram.bins().length, "histogram should have 2 bins");
+    assertEquals(1.0D, histogram.bins()[0].lo(), 0.0D, "first bin lo should match");
+    assertEquals(5.0D, histogram.bins()[0].hi(), 0.0D, "first bin hi should match");
+    assertEquals(4L, histogram.bins()[0].ndv(), "first bin ndv should match");
+    assertEquals(5.0D, histogram.bins()[1].lo(), 0.0D, "second bin lo should match");
+    assertEquals(10.0D, histogram.bins()[1].hi(), 0.0D, "second bin hi should match");
+    assertEquals(5L, histogram.bins()[1].ndv(), "second bin ndv should match");
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

Delta's DSv2 catalog statistics bridge already preserves scalar column statistics (min, max, distinct count, null count, average/max length), but it left `ColumnStatistics.histogram()` at its default empty implementation. As a result, histograms collected by `ANALYZE TABLE ... FOR COLUMNS` were silently dropped when Delta V2/V3 tables surfaced catalog statistics through the DSv2 API.

This PR:

- Converts `CatalogColumnStat.histogram` into DSv2 `Histogram` / `HistogramBin` in `StatsUtils.toV2Statistics`.
- Preserves existing behavior when no histogram is present by returning an empty `Optional`.
- Keeps the change scoped to histogram propagation only.
- Adds direct `StatsUtils` coverage for both the present and absent histogram cases.

I looked at reusing Spark's generic `DataSourceV2Relation.v1StatsToV2Stats` helper instead of adding local conversion code. Spark master has that helper and it already handles histograms, but Delta master currently builds against Spark 4.0.1 / 4.1.0, where that helper is not available. Keeping the small conversion in Delta's existing bridge preserves compatibility with the supported Spark versions.

## How was this patch tested?

Added unit tests in `StatsUtilsTest` covering:

- A column with a histogram (two bins) is propagated into the DSv2 `Histogram`, with height, bin count, and each bin's `lo`/`hi`/`ndv` asserted.
- A column without a histogram surfaces an empty `Optional`.

## Does this PR introduce _any_ user-facing changes?

No. This only propagates already-collected catalog column-statistics metadata into the DSv2 statistics surface; it adds no new configuration or behavior changes for existing queries.
