### PR TITLE
Expose Delta V2 table metadata through marker

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaV2TableMarker.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaV2TableMarker.scala
@@ -16,6 +16,11 @@
 
 package org.apache.spark.sql.delta.catalog
 
+import java.util.Optional
+
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2RelationShim
 
@@ -23,7 +28,10 @@ import org.apache.spark.sql.execution.datasources.v2.DataSourceV2RelationShim
  * Trait allowing V1 code path to identify a V2 [[DeltaV2Table]] without taking a dependency on
  * that class that lives in a different target.
  */
-trait DeltaV2TableMarker
+trait DeltaV2TableMarker {
+  def getCatalogTable(): Optional[CatalogTable]
+  def getTablePath(): Path
+}
 
 object DeltaV2TableMarker {
 


### PR DESCRIPTION
## Description

Expose catalog metadata and table path accessors on `DeltaV2TableMarker` so code that only depends on the marker abstraction can rebuild the corresponding V1 fallback table without matching on the concrete Delta V2 table implementation.

## How was this patch tested?

CI. This is a small marker interface change.