### PR TITLE
[Spark] Don't persist is_managed_location into Delta table metadata

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
@@ -187,6 +187,10 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
       case TableCatalog.PROP_COMMENT => false
       case TableCatalog.PROP_OWNER => false
       case TableCatalog.PROP_EXTERNAL => false
+      // `is_managed_location` is a reserved v2 catalog property used only to signal that the
+      // table location is system-generated (see `isManagedLocation` below). It is not a real
+      // Delta table property, so filter it out to avoid leaking it into the table metadata.
+      case TableCatalog.PROP_IS_MANAGED_LOCATION => false
       case "path" => false
       case "option.path" => false
       case _ => true

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableV2.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableV2.scala
@@ -254,6 +254,9 @@ class DeltaTableV2 private(
       if (v1Table.tableType == CatalogTableType.EXTERNAL) {
         base.put(TableCatalog.PROP_EXTERNAL, "true")
       }
+      if (v1Table.tableType == CatalogTableType.MANAGED) {
+        base.put(TableCatalog.PROP_IS_MANAGED_LOCATION, "true")
+      }
     }
     // Don't use [[PROP_CLUSTERING_COLUMNS]] from CatalogTable because it may be stale.
     // Since ALTER TABLE updates it using an async post-commit hook.

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableCreationTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableCreationTest.java
@@ -940,6 +940,15 @@ public class UCDeltaTableCreationTest extends UCDeltaTableIntegrationBaseTest {
       // Check for catalogManaged feature
       assertThat(tableProperties)
           .contains(String.format("%s=%s", DELTA_CATALOG_MANAGED_KEY, SUPPORTED));
+      // Regression: the reserved `is_managed_location` catalog property must not leak into the
+      // committed Delta metadata configuration. `DESCRIBE DETAIL`'s `properties` column is the raw
+      // `snapshot.metadata.configuration` (the commit log), unlike DESC EXTENDED / SHOW
+      // TBLPROPERTIES which surface `is_managed_location` synthesized at load time. The `Type` /
+      // `Is_managed_location` rows asserted above still reflect that this is a managed table.
+      List<String> detailRow = sql("DESCRIBE DETAIL %s", fullTableName).get(0);
+      assertThat(String.join(",", detailRow))
+          .as("is_managed_location must not be persisted in the Delta commit log")
+          .doesNotContain(TableCatalog.PROP_IS_MANAGED_LOCATION);
     } else {
       // Check for UC table ID
       assertThat(tableProperties).doesNotContain(UC_TABLE_ID_KEY);


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
`is_managed_location` is a reserved DSv2 catalog property (it marks a table location as system-generated), not a real Delta table property. When a catalog sets it on `createTable`, it leaked into the committed `Metadata.configuration` and showed up in the commit log.

- Filter `PROP_IS_MANAGED_LOCATION` out in `AbstractDeltaCatalog.createTable` so it is no longer written into the table metadata.
- Synthesize it at load in `DeltaTableV2.properties()` for managed tables (mirroring Spark's `V1Table`), so DESCRIBE / SHOW TBLPROPERTIES still report it without persisting it.

## How was this patch tested?
- Add a regression test asserting the key is absent from the on-disk `metadata.configuration` (via DESCRIBE DETAIL) while still surfaced for managed tables.

## Does this PR introduce _any_ user-facing changes?
No