### PR TITLE
Revert "[Spark] Return zero latest table version from empty getCommits (#7113)"

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/InMemoryCommitCoordinator.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/InMemoryCommitCoordinator.scala
@@ -35,7 +35,6 @@ import io.delta.storage.commit.{
   TableIdentifier
 }
 import io.delta.storage.commit.actions.{AbstractMetadata, AbstractProtocol}
-import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorClient
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, Path}
 
@@ -163,25 +162,8 @@ class InMemoryCommitCoordinator(val batchSize: Long)
       val commitsInRange = tableData.commitsMap.range(
         effectiveStartVersion, effectiveEndVersion + 1)
       new JGetCommitsResponse(
-        commitsInRange.values.toSeq.asJava,
-        latestTableVersionForGetCommits(tableDesc, tableData))
+        commitsInRange.values.toSeq.asJava, tableData.lastRatifiedCommitVersion)
     }
-  }
-
-  private def latestTableVersionForGetCommits(
-      tableDesc: TableDescriptor,
-      tableData: PerTableData): Long = {
-    if (tableData.active) {
-      tableData.lastRatifiedCommitVersion
-    } else if (isCatalogManagedTableDesc(tableDesc)) {
-      0L
-    } else {
-      -1L
-    }
-  }
-
-  private def isCatalogManagedTableDesc(tableDesc: TableDescriptor): Boolean = {
-    tableDesc.getTableConf.asScala.contains(UCCommitCoordinatorClient.UC_TABLE_ID_KEY)
   }
 
   override protected[sql] def registerBackfill(
@@ -209,11 +191,12 @@ class InMemoryCommitCoordinator(val batchSize: Long)
     val newPerTableData = new PerTableData(currentVersion + 1)
     perTableMap.compute(logPath, (_, existingData) => {
       if (existingData != null) {
-        if (existingData.active) {
+        if (existingData.lastRatifiedCommitVersion != -1) {
           throw new IllegalStateException(
             s"Table $logPath already exists in the commit-coordinator.")
         }
-        // If this inactive table was just pre-registered and there is another
+        // If lastRatifiedCommitVersion is -1 i.e. the commit-coordinator has never attempted any
+        // commit for this table => this table was just pre-registered. If there is another
         // pre-registration request for an older version, we reject it and table can't go backward.
         if (currentVersion < existingData.maxCommitVersion) {
           throw new IllegalStateException(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/InMemoryUCCommitCoordinator.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/InMemoryUCCommitCoordinator.scala
@@ -356,13 +356,13 @@ class InMemoryUCCommitCoordinator {
       endVersion: Option[Long]): JGetCommitsResponse = {
     val tableUUID = UUID.fromString(tableId)
     val path = Option(perTableMap.get(tableUUID)).map(_.path).getOrElse {
-      return new JGetCommitsResponse(Seq.empty.asJava, 0L)
+      return new JGetCommitsResponse(Seq.empty.asJava, -1)
     }
     validateTableURI(path, tableUri, UCCoordinatedCommitsRequestType.GET_COMMITS)
     withLock[JGetCommitsResponse](tableUUID) {
       val tableData = perTableMap.get(tableUUID)
       val commits = tableData.getCommits(startVersion, endVersion)
-      new JGetCommitsResponse(commits.asJava, math.max(tableData.lastRatifiedCommitVersion, 0L))
+      new JGetCommitsResponse(commits.asJava, tableData.lastRatifiedCommitVersion)
     }
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CommitCoordinatorClientImplSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CommitCoordinatorClientImplSuiteBase.scala
@@ -217,8 +217,6 @@ trait CommitCoordinatorClientImplSuiteBase extends QueryTest
     assert(resp1.getCommits == resp2.getCommits)
   }
 
-  protected def expectedEmptyGetCommitsLatestTableVersion: Long = -1
-
   test("test basic commit and backfill functionality") {
     withTempTableDir { tempDir =>
       val log = DeltaLog.forTable(spark, tempDir.toString)
@@ -231,7 +229,7 @@ trait CommitCoordinatorClientImplSuiteBase extends QueryTest
       assert(e.getMessage === "Commit version 0 must go via filesystem.")
       writeCommitZero(logPath)
       assertResponseEquals(tableCommitCoordinatorClient.getCommits(),
-        new JGetCommitsResponse(Seq.empty.asJava, expectedEmptyGetCommitsLatestTableVersion))
+        new JGetCommitsResponse(Seq.empty.asJava, -1))
       assertBackfilled(version = 0, logPath, Some(0L))
 
       // Test backfilling functionality for commits 1 - 8

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/InMemoryCommitCoordinatorSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/InMemoryCommitCoordinatorSuite.scala
@@ -16,15 +16,14 @@
 
 package org.apache.spark.sql.delta.coordinatedcommits
 
-import java.util.{Optional, UUID}
+import java.util.Optional
 
 import scala.collection.JavaConverters._
 
 import org.apache.spark.sql.delta.DeltaLog
 import org.apache.spark.sql.delta.actions.Protocol
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
-import io.delta.storage.commit.{GetCommitsResponse => JGetCommitsResponse, TableDescriptor}
-import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorClient
+import io.delta.storage.commit.{GetCommitsResponse => JGetCommitsResponse}
 import org.apache.hadoop.fs.Path
 
 abstract class InMemoryCommitCoordinatorSuite(batchSize: Int)
@@ -99,23 +98,6 @@ abstract class InMemoryCommitCoordinatorSuite(batchSize: Int)
     assert(cs3.isInstanceOf[InMemoryCommitCoordinator])
     assert(cs3.asInstanceOf[InMemoryCommitCoordinator].batchSize == 10)
     assert(cs3 ne cs2)
-  }
-
-  test("empty getCommits returns zero only for catalog-managed table descriptors") {
-    withTempTableDir { tempDir =>
-      val logPath = DeltaLog.forTable(spark, tempDir.toString).logPath
-      val coordinator = InMemoryCommitCoordinatorBuilder(batchSize).build(spark, Map.empty)
-
-      val nonUcTableDesc = new TableDescriptor(logPath, Optional.empty(), Map.empty.asJava)
-      assert(coordinator.getCommits(nonUcTableDesc, null, null).getLatestTableVersion == -1L)
-
-      val catalogManagedTableDesc = new TableDescriptor(
-        logPath,
-        Optional.empty(),
-        Map(UCCommitCoordinatorClient.UC_TABLE_ID_KEY -> UUID.randomUUID().toString).asJava)
-      assert(
-        coordinator.getCommits(catalogManagedTableDesc, null, null).getLatestTableVersion == 0L)
-    }
   }
 
   test("test commit > 1 is rejected as first commit") {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorClientSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorClientSuite.scala
@@ -104,7 +104,7 @@ class UCCommitCoordinatorClientSuite extends UCCommitCoordinatorClientSuiteBase
             startVersion: Optional[JLong],
             endVersion: Optional[JLong]): JGetCommitsResponse = {
           capturedTableIdentifier = tableIdentifier
-          new JGetCommitsResponse(Collections.emptyList(), 0L)
+          new JGetCommitsResponse(Collections.emptyList(), -1L)
         }
       }
       val tableCommitCoordinatorClient = TableCommitCoordinatorClient(

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorClientSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorClientSuiteBase.scala
@@ -62,8 +62,6 @@ trait UCCommitCoordinatorClientSuiteBase extends CommitCoordinatorClientImplSuit
 
   protected var ucCommitCoordinator: InMemoryUCCommitCoordinator = _
 
-  override protected def expectedEmptyGetCommitsLatestTableVersion: Long = 0
-
   protected override def beforeAll(): Unit = {
     val tmpDirName = System.getProperty("java.io.tmpdir")
     val tmpDir = new File(tmpDirName)

--- a/storage/src/main/java/io/delta/storage/commit/CommitCoordinatorClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/CommitCoordinatorClient.java
@@ -111,9 +111,6 @@ public interface CommitCoordinatorClient {
    * The returned latestTableVersion is the maximum commit version ratified by the commit
    * coordinator. Note that returning latestTableVersion as -1 is acceptable only if the commit
    * coordinator never ratified any version, i.e. it never accepted any unbackfilled commit.
-   * UC/catalog-managed implementations may return 0 for a newly-created table with no
-   * unbackfilled commits, because catalog-managed snapshot loading requires a non-negative max
-   * catalog version.
    *
    * @param tableDescriptor The descriptor for the table.
    * @param startVersion    The minimum version of the commit that should be returned. Can be null.


### PR DESCRIPTION
Reverts #7113 because downstream validation found a regression. A narrower forward fix can follow after the failure is understood.

No tests run; this is a direct revert of the merged change.