### PR TITLE
[Spark][Type Widening] Actionable error when ALTER COLUMN TYPE is rejected because type widening is not enabled

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -71,6 +71,15 @@
     ],
     "sqlState" : "42903"
   },
+  "DELTA_ALTER_COLUMN_TYPE_WIDENING_NOT_ENABLED" : {
+    "message" : [
+      "ALTER TABLE CHANGE COLUMN is rejected because the type widening table feature is not enabled on this table.",
+      "The requested change of column <fieldPath> from <fromType> to <toType> is a supported lossless widening. To enable it, run:",
+      "  ALTER TABLE <tableName> SET TBLPROPERTIES ('delta.enableTypeWidening' = 'true')",
+      "This upgrades the table protocol so that readers on older Delta versions that do not support the typeWidening reader feature will not be able to read the table."
+    ],
+    "sqlState" : "0AKDC"
+  },
   "DELTA_ALTER_TABLE_CHANGE_COL_NOT_SUPPORTED" : {
     "message" : [
       "ALTER TABLE CHANGE COLUMN is not supported for changing column <currentType> to <newType>"

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -948,6 +948,26 @@ trait DeltaErrorsBase
     )
   }
 
+  /**
+   * Thrown by ALTER TABLE CHANGE COLUMN TYPE when the requested type change is on the supported
+   * [[TypeWidening.isTypeChangeSupported]] allow-list but the type widening table feature is not
+   * enabled on the target table. The message names the exact table property to set so the user
+   * doesn't need to consult the docs to find the remediation.
+   */
+  def alterColumnTypeWideningNotEnabledException(
+      fieldPath: String,
+      fromType: DataType,
+      toType: DataType,
+      tableName: String): Throwable =
+    new DeltaAnalysisException(
+      errorClass = "DELTA_ALTER_COLUMN_TYPE_WIDENING_NOT_ENABLED",
+      messageParameters = Array(
+        fieldPath,
+        fromType.sql,
+        toType.sql,
+        tableName)
+    )
+
   def alterTableReplaceColumnsException(
       oldSchema: StructType,
       newSchema: StructType,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
@@ -1073,16 +1073,37 @@ case class AlterTableChangeColumnDeltaCommand(
     // first (original data type is already normalized as we store char/varchar as string type with
     // special metadata in the Delta log), then apply Delta-specific checks.
     val newType = CharVarcharUtils.replaceCharVarcharWithString(newColumn.dataType)
+    val typeWideningEnabled = TypeWidening.isEnabled(txn.protocol, txn.metadata)
     if (SchemaUtils.canChangeDataType(
         originalField.dataType,
         newType,
         resolver,
         txn.metadata.columnMappingMode,
         columnPath :+ originalField.name,
-        allowTypeWidening = TypeWidening.isEnabled(txn.protocol, txn.metadata)
+        allowTypeWidening = typeWideningEnabled
       ).nonEmpty) {
+      // If the change is rejected AND type widening is disabled, check whether the requested
+      // change would have been accepted with type widening enabled. If so, surface a more
+      // actionable error that names the exact table property to set — avoids sending users to
+      // the docs to figure out `delta.enableTypeWidening`.
+      val fieldPath = UnresolvedAttribute(columnPath :+ originalField.name).name
+      if (!typeWideningEnabled &&
+          SchemaUtils.canChangeDataType(
+            originalField.dataType,
+            newType,
+            resolver,
+            txn.metadata.columnMappingMode,
+            columnPath :+ originalField.name,
+            allowTypeWidening = true
+          ).isEmpty) {
+        throw DeltaErrors.alterColumnTypeWideningNotEnabledException(
+          fieldPath = fieldPath,
+          fromType = originalField.dataType,
+          toType = newType,
+          tableName = table.name())
+      }
       throw DeltaErrors.alterTableChangeColumnException(
-        fieldPath = UnresolvedAttribute(columnPath :+ originalField.name).name,
+        fieldPath = fieldPath,
         oldField = originalField,
         newField = newColumn
       )

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -909,6 +909,26 @@ trait DeltaErrorsSuiteBase
       )
     }
     {
+      val e = intercept[DeltaAnalysisException] {
+        throw DeltaErrors.alterColumnTypeWideningNotEnabledException(
+          fieldPath = "a.b.c",
+          fromType = IntegerType,
+          toType = LongType,
+          tableName = "spark_catalog.default.t")
+      }
+      checkError(
+        e,
+        "DELTA_ALTER_COLUMN_TYPE_WIDENING_NOT_ENABLED",
+        "0AKDC",
+        Map(
+          "fieldPath" -> "a.b.c",
+          "fromType" -> "INT",
+          "toType" -> "BIGINT",
+          "tableName" -> "spark_catalog.default.t"
+        )
+      )
+    }
+    {
       val s1 = StructType(Seq(StructField("c0", IntegerType)))
       val s2 = StructType(Seq(StructField("c0", StringType)))
       val e = intercept[DeltaAnalysisException] {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningAlterColumnErrorMessageSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningAlterColumnErrorMessageSuite.scala
@@ -1,0 +1,150 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.typewidening
+
+import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+
+import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types._
+
+/**
+ * Tests that ALTER TABLE CHANGE COLUMN TYPE, when rejected on a table that does not have the
+ * type widening table feature enabled, surfaces the actionable
+ * [[DeltaErrors.alterColumnTypeWideningNotEnabledException]] whenever the requested change is on
+ * the supported [[TypeWidening.isTypeChangeSupported]] allow-list — and continues to surface the
+ * pre-existing DELTA_UNSUPPORTED_ALTER_TABLE_CHANGE_COL_OP for genuinely unsupported changes.
+ *
+ * Deliberately does NOT mix in [[TypeWideningTestMixin]] — that mixin enables type widening by
+ * default at the SparkConf level, and every case here needs to start from the default protocol
+ * (reader=1, writer=2) with type widening off.
+ */
+class TypeWideningAlterColumnErrorMessageSuite
+  extends QueryTest
+    with SharedSparkSession
+    with DeltaSQLCommandTest {
+
+  private def withDeltaTable(schema: String)(body: String => Unit): Unit = {
+    withTable("t") {
+      sql(s"CREATE TABLE t ($schema) USING delta")
+      body("t")
+    }
+  }
+
+  /** Widening pairs from [[TypeWidening.isTypeChangeSupported]] that should surface the new hint. */
+  private val supportedWideningPairs: Seq[(String, DataType, DataType)] = Seq(
+    ("byte -> short",           ByteType,             ShortType),
+    ("byte -> int",             ByteType,             IntegerType),
+    ("byte -> long",            ByteType,             LongType),
+    ("short -> int",            ShortType,            IntegerType),
+    ("short -> long",           ShortType,            LongType),
+    ("int -> long",             IntegerType,          LongType),
+    ("float -> double",         FloatType,            DoubleType),
+    ("date -> timestamp_ntz",   DateType,             TimestampNTZType),
+    ("int -> double",           IntegerType,          DoubleType),
+    ("decimal(5,2) -> decimal(10,2)", DecimalType(5, 2), DecimalType(10, 2)))
+
+  for ((label, from, to) <- supportedWideningPairs) {
+    test(s"hint fires for supported widening $label when feature is disabled") {
+      withDeltaTable(s"c ${from.sql}") { t =>
+        checkError(
+          intercept[DeltaAnalysisException] {
+            sql(s"ALTER TABLE $t CHANGE COLUMN c TYPE ${to.sql}")
+          },
+          "DELTA_ALTER_COLUMN_TYPE_WIDENING_NOT_ENABLED",
+          parameters = Map(
+            "fieldPath" -> "c",
+            "fromType"  -> from.sql,
+            "toType"    -> to.sql,
+            "tableName" -> "spark_catalog.default.t"))
+      }
+    }
+  }
+
+  test("original DELTA_UNSUPPORTED_ALTER_TABLE_CHANGE_COL_OP is preserved for non-widening " +
+      "changes that Delta rejects post-analysis") {
+    // INT -> STRING is an upcast (so Spark's analyzer allows it through to Delta) but is NOT in the
+    // TypeWidening allow-list — must fall through to the pre-existing generic error.
+    withDeltaTable("c INT") { t =>
+      checkError(
+        intercept[DeltaAnalysisException] {
+          sql(s"ALTER TABLE $t CHANGE COLUMN c TYPE STRING")
+        },
+        "DELTA_UNSUPPORTED_ALTER_TABLE_CHANGE_COL_OP",
+        parameters = Map(
+          "fieldPath" -> "c",
+          "oldField"  -> "INT",
+          "newField"  -> "STRING"))
+    }
+  }
+
+  test("ALTER succeeds when type widening is already enabled — no hint fires") {
+    withTable("t") {
+      sql("CREATE TABLE t (c INT) USING delta " +
+            "TBLPROPERTIES ('delta.enableTypeWidening' = 'true')")
+      sql("ALTER TABLE t CHANGE COLUMN c TYPE BIGINT")
+      val df = sql("DESCRIBE TABLE t")
+      // The column must now be BIGINT.
+      assert(spark.table("t").schema("c").dataType === LongType)
+      // A subsequent write of a value that would have overflowed INT succeeds.
+      sql("INSERT INTO t VALUES (9999999999)")
+      checkAnswer(sql("SELECT c FROM t"), Row(9999999999L) :: Nil)
+    }
+  }
+
+  test("hint uses the logical column name when column mapping is enabled") {
+    withTable("t") {
+      sql(
+        """
+          |CREATE TABLE t (my_col INT) USING delta
+          |TBLPROPERTIES (
+          |  'delta.columnMapping.mode' = 'name',
+          |  'delta.minReaderVersion' = '2',
+          |  'delta.minWriterVersion' = '5'
+          |)
+          |""".stripMargin)
+      checkError(
+        intercept[DeltaAnalysisException] {
+          sql("ALTER TABLE t CHANGE COLUMN my_col TYPE BIGINT")
+        },
+        "DELTA_ALTER_COLUMN_TYPE_WIDENING_NOT_ENABLED",
+        parameters = Map(
+          "fieldPath" -> "my_col",
+          "fromType"  -> "INT",
+          "toType"    -> "BIGINT",
+          "tableName" -> "spark_catalog.default.t"))
+    }
+  }
+
+  test("hint message body names the exact remediation SQL") {
+    withDeltaTable("c INT") { t =>
+      val ex = intercept[DeltaAnalysisException] {
+        sql(s"ALTER TABLE $t CHANGE COLUMN c TYPE BIGINT")
+      }
+      assert(ex.getErrorClass === "DELTA_ALTER_COLUMN_TYPE_WIDENING_NOT_ENABLED")
+      val msg = ex.getMessage
+      // Guardrail: the remediation SQL fragment must appear verbatim so users can copy-paste it.
+      assert(
+        msg.contains("SET TBLPROPERTIES ('delta.enableTypeWidening' = 'true')"),
+        s"expected remediation SQL in message, got:\n$msg")
+      // And the exact from -> to pair renders correctly.
+      assert(msg.contains("INT"), s"expected fromType INT in message, got:\n$msg")
+      assert(msg.contains("BIGINT"), s"expected toType BIGINT in message, got:\n$msg")
+    }
+  }
+}


### PR DESCRIPTION
…ected because type widening is not enabled

Today, running `ALTER TABLE t ALTER COLUMN c TYPE BIGINT` on a Delta table without the type widening table feature enabled fails with the generic DELTA_UNSUPPORTED_ALTER_TABLE_CHANGE_COL_OP — the message doesn't tell the user that (a) this widening is actually supported by Delta, (b) there's a table property that unlocks it, or (c) what SQL to run.

Users end up rewriting entire tables via 5-step ADD/UPDATE/DROP/RENAME column-swap patterns before discovering `delta.enableTypeWidening=true` would have made it a metadata-only change.

## Change

Introduce a new error class `DELTA_ALTER_COLUMN_TYPE_WIDENING_NOT_ENABLED` that fires when the requested change is on TypeWidening.isTypeChangeSupported and TypeWidening.isEnabled(protocol, metadata) returns false. The message names the exact remediation SQL:

  ALTER TABLE <table> SET TBLPROPERTIES ('delta.enableTypeWidening' = 'true')

and warns about the reader protocol upgrade.

Non-widening rejections (e.g., INT -> STRING) continue to surface the pre-existing DELTA_UNSUPPORTED_ALTER_TABLE_CHANGE_COL_OP.

## Implementation notes

- Detection: after `SchemaUtils.canChangeDataType(..., allowTypeWidening=isEnabled)` rejects, re-run with `allowTypeWidening=true`. If it accepts, the rejection was due to the feature not being on. This avoids refactoring `canChangeDataType`'s return type — the extra call only runs on the already- failing path so has no impact on the happy path.
- Zero on-disk impact. No protocol bump. Every successful ALTER continues to succeed byte-identically; every failure that used to throw generic continues to throw the same thing unless the change is on the widening allow-list.
- Follow-up (out of scope): apply the same actionable error to AlterTableReplaceColumnsDeltaCommand and to the CTAS/REPLACE COLUMNS paths that flow through ImplicitMetadataOperation.

## Tests

New suite `TypeWideningAlterColumnErrorMessageSuite`:
- Every widening pair from TypeWidening.isTypeChangeSupported fires the new error class when the feature is off.
- INT -> STRING (upcast but not a supported widening) continues to fire the pre-existing DELTA_UNSUPPORTED_ALTER_TABLE_CHANGE_COL_OP.
- ALTER succeeds when type widening is enabled, and a value that would have overflowed INT is stored correctly as BIGINT.
- Column mapping surfaces the *logical* column name (not the physical one).
- The remediation SQL appears verbatim in the message body.

Golden test added in `DeltaErrorsSuite`.

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
