### PR TITLE
[Storage] Unwrap FilterFileSystem so delta.enableFastS3AListFrom work…

### DIFF
--- a/storage/src/main/java/io/delta/storage/internal/S3LogStoreUtil.java
+++ b/storage/src/main/java/io/delta/storage/internal/S3LogStoreUtil.java
@@ -89,13 +89,23 @@ public final class S3LogStoreUtil {
             Path parentPath) throws IOException {
         S3AFileSystem s3afs;
         try {
-             s3afs = (S3AFileSystem) fs;
+            s3afs = (S3AFileSystem) unwrap(fs);
         } catch (ClassCastException e) {
             throw new UnsupportedOperationException(
                     "The Hadoop file system used for the S3LogStore must be castable to " +
                             "org.apache.hadoop.fs.s3a.S3AFileSystem.", e);
         }
         return iteratorToStatuses(S3LogStoreUtil.s3ListFrom(s3afs, resolvedPath, parentPath));
+    }
+
+    /**
+     * Unwraps {@link FilterFileSystem} wrappers that delegate to a real {@link S3AFileSystem}.
+     */
+    static FileSystem unwrap(FileSystem fs) {
+        while (!(fs instanceof S3AFileSystem) && fs instanceof FilterFileSystem) {
+            fs = ((FilterFileSystem) fs).getRawFileSystem();
+        }
+        return fs;
     }
 
     /**

--- a/storage/src/test/scala/io/delta/storage/internal/S3LogStoreUtilTest.scala
+++ b/storage/src/test/scala/io/delta/storage/internal/S3LogStoreUtilTest.scala
@@ -1,5 +1,6 @@
 package io.delta.storage.internal
 
+import org.apache.hadoop.fs.{FilterFileSystem, Path, RawLocalFileSystem}
 import org.scalatest.funsuite.AnyFunSuite
 
 class S3LogStoreUtilTest extends AnyFunSuite {
@@ -20,5 +21,24 @@ class S3LogStoreUtilTest extends AnyFunSuite {
 
   test("keyBefore with empty key") {
     assert(null == S3LogStoreUtil.keyBefore(""))
+  }
+
+  test("unwrap peels FilterFileSystem chains to the raw delegate") {
+    val raw = new RawLocalFileSystem
+    assert(S3LogStoreUtil.unwrap(raw) eq raw)
+    assert(S3LogStoreUtil.unwrap(new FilterFileSystem(raw)) eq raw)
+    assert(S3LogStoreUtil.unwrap(new FilterFileSystem(new FilterFileSystem(raw))) eq raw)
+  }
+
+  test("s3ListFromArray throws UnsupportedOperationException for non-S3A") {
+    val raw = new RawLocalFileSystem
+    val p = new Path("s3a://bucket/_delta_log/x.json")
+    assertThrows[UnsupportedOperationException] {
+      S3LogStoreUtil.s3ListFromArray(new FilterFileSystem(raw), p, p.getParent)
+    }
+    assertThrows[UnsupportedOperationException] {
+      S3LogStoreUtil.s3ListFromArray(
+        new FilterFileSystem(new FilterFileSystem(raw)), p, p.getParent)
+    }
   }
 }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (Storage — `delta-storage` / `S3SingleDriverLogStore`)

## Description
Already merged in PR, this is to backport to branch 4.3: https://github.com/delta-io/delta/pull/7122

The `delta.enableFastS3AListFrom` optimization in `S3SingleDriverLogStore` calls `S3LogStoreUtil.s3ListFromArray`, which casts the Hadoop `FileSystem` to `org.apache.hadoop.fs.s3a.S3AFileSystem` in order to use the S3 `ListObjectsV2` `startAfter` API (listing only the log files lexicographically after a given version instead of the full directory).

When the configured filesystem is a `FilterFileSystem` decorator wrapping a real `S3AFileSystem` — for example a credential-scoping wrapper — the direct cast fails and `s3ListFromArray` throws `UnsupportedOperationException`. As a result the optimization cannot be used even though the underlying filesystem really is S3A.

This PR unwraps `FilterFileSystem` decorators (following `getRawFileSystem()`, including nested wrappers) before the cast. If the unwrapped filesystem is an `S3AFileSystem`, the fast `startAfter` listing path is used. Behavior is otherwise unchanged: a filesystem that is not — and does not wrap — an `S3AFileSystem` still throws `UnsupportedOperationException`.

## How was this patch tested?

New unit tests in `S3LogStoreUtilTest`:

- `unwrap` peels single and nested `FilterFileSystem` chains down to the raw delegate, and returns a non-wrapped filesystem unchanged.
- `s3ListFromArray` still throws `UnsupportedOperationException` for a non-S3A filesystem (including when it is wrapped in `FilterFileSystem`), preserving the existing contract.

New integration coverage in `S3LogStoreUtilIntegrationTest` (env-gated; runs against a real S3 bucket, so it does not run in CI by default): the existing `small`/`medium`/`large` cases are parameterized to also run through a `FilterFileSystem`-wrapped `S3AFileSystem`. The wrapped runs return the same listing results and issue the same (optimal) number of S3 list requests as the unwrapped runs, confirming the fast `startAfter` path is reached through the wrapper. Verified against a live S3 bucket (us-east-2): all cases passed, wrapped and unwrapped identical.

Additional local Spark SQL benchmark (~2000 commit READ):

| Script | Hadoop | Delta | Unity Catalog | Fast S3A flag | Outcome | Spark SQL time | Count |
| --- | --- | --- | --- | --- | --- | ---: | ---: |
| S3 optimized (this PR) | `3.4.2` | `4.3.0-SNAPSHOT` | `0.5.0` | `true` | Success | `12.424s` | `2129` |
| Non-optimized (built from this PR) | `3.4.2` | `4.3.0-SNAPSHOT` | `0.5.0` | `false` | Success | `126.028s` | `2129` |
| S3 optimized using released artifacts | `3.4.2` | `4.2.0` | `0.5.0` | `true` | Expected failure | N/A | N/A |
| Non-optimized using released artifacts | `3.4.2` | `4.2.0` | `0.5.0` | `false` | Success | `126.550s` | `2129` |

For the same local `4.3.0-SNAPSHOT` artifact, enabling fast S3A list reduced Spark SQL time from `~126s` to `12s`, a `110s` reduction, or about `10x` faster.

## Does this PR introduce _any_ user-facing changes?

No new or changed public APIs, configs, or defaults — `delta.enableFastS3AListFrom` and its default are unchanged. It does fix runtime behavior for one previously-failing configuration: with the flag enabled and an `S3AFileSystem` wrapped by a `FilterFileSystem`, listing previously threw `UnsupportedOperationException` and now succeeds via the fast path.