### PR TITLE
Add KernelSnapshotUtils to convert Kernel snapshot files to V1 AddFile rows

### DIFF
--- a/spark-unified/src/main/scala/org/apache/spark/sql/delta/v2/interop/KernelSnapshotUtils.scala
+++ b/spark-unified/src/main/scala/org/apache/spark/sql/delta/v2/interop/KernelSnapshotUtils.scala
@@ -1,0 +1,152 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.v2.interop
+
+import scala.collection.mutable.ArrayBuffer
+import scala.jdk.OptionConverters._
+
+import org.apache.spark.sql.delta.actions.{
+  AddFile,
+  DeletionVectorDescriptor => V1DeletionVectorDescriptor
+}
+import org.apache.spark.sql.delta.implicits._
+import io.delta.kernel.data.MapValue
+import io.delta.kernel.engine.Engine
+import io.delta.kernel.internal.{ScanImpl, SnapshotImpl}
+import io.delta.kernel.internal.actions.{AddFile => KernelAddFile}
+
+import org.apache.spark.sql.{Dataset, SparkSession}
+
+/**
+ * Helpers for code that has a Kernel snapshot but still needs V1 file actions.
+ * An AddFile action is the V1 record for one data file in a Delta table.
+ *
+ * This object does not create a SparkSession or Kernel Engine. The caller passes them in so the
+ * caller controls which Spark context and Hadoop configuration are used.
+ */
+private[delta] object KernelSnapshotUtils {
+
+  /**
+   * Reads the active files in the Kernel snapshot and returns them as V1 [[AddFile]] rows.
+   * Active files are the data files that belong to this snapshot and have not been removed.
+   *
+   * This builds the Kernel-backed version of V1 Snapshot.allFiles. Spark builds the Dataset.
+   * The Engine reads the file metadata from Kernel.
+   */
+  def buildAllFiles(
+      kernelSnapshot: SnapshotImpl,
+      spark: SparkSession,
+      engine: Engine): Dataset[AddFile] = {
+    spark.createDataset(collectV1AddFiles(kernelSnapshot, engine))
+  }
+
+  /**
+   * Reads the active file rows from Kernel and returns them as a Scala sequence.
+   *
+   * The scan asks Kernel for stats because V1 allFiles includes stats JSON on AddFile when stats
+   * are available. Kernel returns the files in batches, and this method collects them.
+   */
+  private def collectV1AddFiles(
+      kernelSnapshot: SnapshotImpl,
+      engine: Engine): Seq[AddFile] = {
+    val scan = kernelSnapshot.getScanBuilder.build().asInstanceOf[ScanImpl]
+    val scanFileBatches = scan.getScanFiles(engine, true /* includeStats */)
+    try {
+      val files = ArrayBuffer.empty[AddFile]
+      while (scanFileBatches.hasNext) {
+        val rows = scanFileBatches.next().getRows
+        try {
+          while (rows.hasNext) {
+            val kernelAddFile = new KernelAddFile(
+              rows.next().getStruct(0 /* addFileColumnOrdinal */))
+            files += toV1AddFile(kernelAddFile)
+          }
+        } finally {
+          rows.close()
+        }
+      }
+      files.toSeq
+    } finally {
+      scanFileBatches.close()
+    }
+  }
+
+  /**
+   * Builds one V1 [[AddFile]] from one Kernel AddFile.
+   *
+   * The returned AddFile keeps the path, partition values, size, modification time, stats,
+   * deletion vector, and row tracking fields from Kernel. The row tracking fields are baseRowId
+   * and defaultRowCommitVersion.
+   */
+  private def toV1AddFile(kernelAddFile: KernelAddFile): AddFile = {
+    AddFile(
+      path = kernelAddFile.getPath,
+      partitionValues = toV1PartitionValues(kernelAddFile.getPartitionValues),
+      size = kernelAddFile.getSize,
+      modificationTime = kernelAddFile.getModificationTime,
+      // V1 Snapshot.allFiles normalizes active files to dataChange = false.
+      dataChange = false,
+      stats = kernelAddFile.getStatsJson.toScala.orNull,
+      deletionVector = toV1DeletionVectorDescriptor(kernelAddFile),
+      baseRowId = kernelAddFile.getBaseRowId.toScala.map(_.longValue()),
+      defaultRowCommitVersion =
+        kernelAddFile.getDefaultRowCommitVersion.toScala.map(_.longValue()))
+  }
+
+  /**
+   * Builds the V1 deletion vector descriptor for a Kernel AddFile.
+   *
+   * A deletion vector records which rows in the file are deleted without removing the whole file.
+   * The descriptor stores where that deletion vector lives and how many rows it marks as deleted.
+   * V1 AddFile uses null when a file has no deletion vector, so this method does the same.
+   */
+  private def toV1DeletionVectorDescriptor(
+      kernelAddFile: KernelAddFile): V1DeletionVectorDescriptor = {
+    val deletionVector = kernelAddFile.getDeletionVector
+    if (deletionVector.isPresent) {
+      val kernelDeletionVector = deletionVector.get
+      V1DeletionVectorDescriptor(
+        storageType = kernelDeletionVector.getStorageType,
+        pathOrInlineDv = kernelDeletionVector.getPathOrInlineDv,
+        offset = kernelDeletionVector.getOffset.toScala.map(_.intValue()),
+        sizeInBytes = kernelDeletionVector.getSizeInBytes,
+        cardinality = kernelDeletionVector.getCardinality)
+    } else {
+      null
+    }
+  }
+
+  /**
+   * Returns the partition column values for one AddFile as a Scala map.
+   *
+   * For a table partitioned by date and country, one file may have values like
+   * `Map("date" -> "2026-06-08", "country" -> "US")`. V1 stores these values in AddFile
+   * as `Map[String, String]`, with null when a partition value is null.
+   */
+  private def toV1PartitionValues(partitionValues: MapValue): Map[String, String] = {
+    if (partitionValues != null) {
+      val keys = partitionValues.getKeys
+      val values = partitionValues.getValues
+      (0 until partitionValues.getSize).map { index =>
+        val value = if (values.isNullAt(index)) null else values.getString(index)
+        keys.getString(index) -> value
+      }.toMap
+    } else {
+      Map.empty
+    }
+  }
+}

--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/v2/interop/KernelSnapshotUtilsSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/v2/interop/KernelSnapshotUtilsSuite.scala
@@ -1,0 +1,140 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.v2.interop
+
+import org.apache.spark.sql.delta.{DeltaConfigs, DeltaLog}
+import org.apache.spark.sql.delta.actions.AddFile
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import io.delta.kernel.TableManager
+import io.delta.kernel.defaults.engine.DefaultEngine
+import io.delta.kernel.engine.Engine
+import io.delta.kernel.internal.SnapshotImpl
+
+class KernelSnapshotUtilsSuite extends DeltaSQLCommandTest {
+
+  // scalastyle:off deltahadoopconfiguration
+  private def engine: Engine = DefaultEngine.create(spark.sessionState.newHadoopConf())
+  // scalastyle:on deltahadoopconfiguration
+
+  private def kernelSnapshotFor(path: String, engine: Engine): SnapshotImpl =
+    TableManager.loadSnapshot(path).build(engine).asInstanceOf[SnapshotImpl]
+
+  private def allFilesFor(path: String): (Array[AddFile], Array[AddFile]) = {
+    val kernelEngine = engine
+    val kernelSnapshot = kernelSnapshotFor(path, kernelEngine)
+    val kernelFiles = KernelSnapshotUtils
+      .buildAllFiles(kernelSnapshot, spark, kernelEngine)
+      .collect()
+    val v1Files = DeltaLog.forTable(spark, path).snapshot.allFiles.collect()
+    (kernelFiles, v1Files)
+  }
+
+  private def assertSameAddFilesAsV1(
+      kernelFiles: Array[AddFile],
+      v1Files: Array[AddFile]): Unit = {
+    val kernelFilesByPath = kernelFiles.map(file => file.path -> file).toMap
+    val v1FilesByPath = v1Files.map(file => file.path -> file).toMap
+
+    assert(kernelFilesByPath.size === kernelFiles.length)
+    assert(v1FilesByPath.size === v1Files.length)
+    assert(kernelFilesByPath.keySet === v1FilesByPath.keySet)
+
+    v1FilesByPath.foreach { case (path, v1File) =>
+      val kernelFile = kernelFilesByPath(path)
+      withClue(s"AddFile mismatch for $path: ") {
+        assert(kernelFile.partitionValues === v1File.partitionValues)
+        assert(kernelFile.size === v1File.size)
+        assert(kernelFile.modificationTime === v1File.modificationTime)
+        assert(kernelFile.dataChange === v1File.dataChange)
+        assert(kernelFile.stats === v1File.stats)
+        assert(kernelFile.deletionVector === v1File.deletionVector)
+        assert(kernelFile.baseRowId === v1File.baseRowId)
+        assert(kernelFile.defaultRowCommitVersion === v1File.defaultRowCommitVersion)
+      }
+    }
+  }
+
+  test("buildAllFiles returns V1 file metadata and preserves stats") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      spark.range(3).write.format("delta").save(path)
+      val (kernelFiles, v1Files) = allFilesFor(path)
+
+      assertSameAddFilesAsV1(kernelFiles, v1Files)
+      assert(kernelFiles.forall(file => !file.dataChange))
+      assert(kernelFiles.map(_.stats).forall(stat => stat != null && stat.nonEmpty))
+    }
+  }
+
+  test("buildAllFiles preserves partition values") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      spark.range(4)
+        .selectExpr("id", "CAST(id % 2 AS INT) AS part")
+        .write
+        .partitionBy("part")
+        .format("delta")
+        .save(path)
+      val (kernelFiles, v1Files) = allFilesFor(path)
+
+      assert(v1Files.map(_.partitionValues).toSet === Set(
+        Map("part" -> "0"),
+        Map("part" -> "1")))
+      assertSameAddFilesAsV1(kernelFiles, v1Files)
+    }
+  }
+
+  test("buildAllFiles preserves null partition values") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      spark.range(2)
+        .selectExpr(
+          "id",
+          "IF(id = 0, CAST(NULL AS INT), CAST(id AS INT)) AS part")
+        .write
+        .partitionBy("part")
+        .format("delta")
+        .save(path)
+      val (kernelFiles, v1Files) = allFilesFor(path)
+
+      assert(v1Files.map(_.partitionValues).toSet === Set(
+        Map("part" -> null),
+        Map("part" -> "1")))
+      assertSameAddFilesAsV1(kernelFiles, v1Files)
+    }
+  }
+
+  test("buildAllFiles preserves deletion vectors and row tracking fields") {
+    withSQLConf(
+        DeltaConfigs.ENABLE_DELETION_VECTORS_CREATION.defaultTablePropertyKey -> "true",
+        DeltaConfigs.ROW_TRACKING_ENABLED.defaultTablePropertyKey -> "true",
+        DeltaSQLConf.DELETE_USE_PERSISTENT_DELETION_VECTORS.key -> "true") {
+      withTempDir { dir =>
+        val path = dir.getAbsolutePath
+        spark.range(10).repartition(1).write.format("delta").save(path)
+        sql(s"DELETE FROM delta.`$path` WHERE id = 0")
+        val (kernelFiles, v1Files) = allFilesFor(path)
+
+        assert(v1Files.exists(_.deletionVector != null))
+        assert(v1Files.exists(_.baseRowId.nonEmpty))
+        assert(v1Files.exists(_.defaultRowCommitVersion.nonEmpty))
+        assertSameAddFilesAsV1(kernelFiles, v1Files)
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description

Adds a `KernelSnapshotUtils` helper (and its test suite) under `spark-unified` for code that has a Kernel snapshot but still needs V1 `AddFile` actions.

The helper reads the active files from a Kernel snapshot via the scan API and maps each Kernel `AddFile` to a V1 `AddFile`, preserving:

- path, partition values, size, and modification time
- stats JSON (the scan requests stats so V1 `allFiles` semantics are matched)
- deletion vector descriptor (null when a file has no deletion vector, matching V1)
- row tracking fields (`baseRowId`, `defaultRowCommitVersion`)

Active files are normalized to `dataChange = false`, matching V1 `Snapshot.allFiles`. The object does not create a `SparkSession` or Kernel `Engine`; the caller passes them in so it controls the Spark context and Hadoop configuration.

## How was this patch tested?

Added `KernelSnapshotUtilsSuite`, which builds Kernel snapshots for tables with partitions, deletion vectors, row tracking, and stats, and asserts the resulting V1 `AddFile` rows match expectations.

## Does this PR introduce _any_ user-facing changes?

No.