### PR TITLE
[Spark][Test] Add OAuth coverage to UC connector integration tests (#7096)

### DIFF
--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaOAuthRefreshTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaOAuthRefreshTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.sparkuctest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
+
+/**
+ * Exercises OAuth access-token renewal. With a token lifetime well under the connector's ~30s
+ * renewal lead, the OAuthTokenProvider re-runs the client-credentials grant on essentially every
+ * authenticated call, so a handful of table operations must drive more than one token issuance at
+ * the broker.
+ *
+ * <p>Scope and limitation (token expiration is a deferred problem): this verifies only that the
+ * connector RE-FETCHES a token (the issued-token count grows). It is open-loop: it cannot verify
+ * that a non-renewed token would actually be rejected, nor any server-side expiry enforcement,
+ * because UC-internal tokens currently carry no exp claim and UC never expires them. The lifetime
+ * that triggers renewal here is the broker's advertised expires_in, not anything UC issues. So this
+ * proves the client renews, not that renewal is required or that expiry is enforced.
+ *
+ * <p>TODO(https://github.com/delta-io/delta/issues/7111): once UC-internal tokens carry an exp
+ * claim (and UC enforces expiry), close the loop by asserting that a non-renewed token is rejected.
+ */
+@DisabledIf(
+    value = "isUCRemoteConfigured",
+    disabledReason =
+        "Requires the local mock OAuth broker; a remote UC server has no broker to count issuance.")
+public class UCDeltaOAuthRefreshTest extends UCDeltaTableIntegrationBaseTest {
+
+  /** Cap the advertised lifetime at 1s so the token is always due for renewal. */
+  @Override
+  protected long oauthTokenMaxLifetimeSeconds() {
+    return 1;
+  }
+
+  @Test
+  public void renewsTokenAcrossOperations() throws Exception {
+    int before = oauthIssuedTokenCount();
+    // Captured mid-run (inside the lambda) to show the count keeps growing across operations.
+    int[] afterFirstOp = {0};
+
+    withNewTable(
+        "oauth_refresh_tbl",
+        "a INT, id BIGINT",
+        TableType.MANAGED,
+        fullName -> {
+          sql("INSERT INTO %s VALUES (1, 10)", fullName);
+          afterFirstOp[0] = oauthIssuedTokenCount();
+          sql("SELECT * FROM %s", fullName);
+          sql("INSERT INTO %s VALUES (2, 20)", fullName);
+          check(fullName, List.of(row("1", "10"), row("2", "20")));
+        });
+
+    int after = oauthIssuedTokenCount();
+    // With a 1s lifetime cap the connector is always past its ~30s renewal lead, so it re-runs the
+    // client-credentials grant on each authenticated call. Proving *renewal* (not a one-time issue)
+    // requires the count to grow as the connector first authenticates AND to keep growing across
+    // later operations -- i.e. the token is genuinely re-acquired, not fetched once and cached.
+    assertThat(afterFirstOp[0])
+        .as("token issued once the connector authenticates")
+        .isGreaterThan(before);
+    assertThat(after)
+        .as("token re-issued across later operations (renewal exercised)")
+        .isGreaterThan(afterFirstOp[0]);
+  }
+}

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaStaticTokenTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaStaticTokenTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.sparkuctest;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
+
+/**
+ * Smoke test for the static-token auth path. The rest of the integration suite defaults to OAUTH
+ * (server-validating), so this single test keeps the static-token path -- a local server with
+ * authorization disabled and the connector sending a static bearer -- covered end to end.
+ */
+@DisabledIf(
+    value = "isUCRemoteConfigured",
+    disabledReason =
+        "authMode()=STATIC only controls the local server; remote auth is selected by env vars, "
+            + "so this cannot force the static-token path remotely.")
+public class UCDeltaStaticTokenTest extends UCDeltaTableIntegrationBaseTest {
+
+  @Override
+  protected AuthMode authMode() {
+    return AuthMode.STATIC;
+  }
+
+  @Test
+  public void readsAndWritesWithStaticToken() throws Exception {
+    withNewTable(
+        "static_token_tbl",
+        "a INT, id BIGINT",
+        TableType.MANAGED,
+        fullName -> {
+          sql("INSERT INTO %s VALUES (1, 10)", fullName);
+          check(fullName, List.of(row("1", "10")));
+        });
+  }
+}

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableIntegrationBaseTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableIntegrationBaseTest.java
@@ -165,10 +165,22 @@ public abstract class UCDeltaTableIntegrationBaseTest extends UnityCatalogSuppor
     // Set the catalog specific configs.
     UnityCatalogInfo uc = unityCatalogInfo();
     String catalogName = uc.catalogName();
+    String catalogPrefix = "spark.sql.catalog." + catalogName;
     conf =
-        conf.set("spark.sql.catalog." + catalogName, "io.unitycatalog.spark.UCSingleCatalog")
-            .set("spark.sql.catalog." + catalogName + ".uri", uc.serverUri())
-            .set("spark.sql.catalog." + catalogName + ".token", uc.serverToken());
+        conf.set(catalogPrefix, "io.unitycatalog.spark.UCSingleCatalog")
+            .set(catalogPrefix + ".uri", uc.serverUri());
+    if (uc.oauthTokenUri() != null) {
+      // OAuth client-credentials: the connector fetches a token from the OAuth token endpoint
+      // (uc.oauthTokenUri(): the local broker, or a real IdP for remote runs) and sends it as a
+      // Bearer. No static `.token` is set.
+      conf =
+          conf.set(catalogPrefix + ".auth.type", "oauth")
+              .set(catalogPrefix + ".auth.oauth.uri", uc.oauthTokenUri())
+              .set(catalogPrefix + ".auth.oauth.clientId", uc.oauthClientId())
+              .set(catalogPrefix + ".auth.oauth.clientSecret", uc.oauthClientSecret());
+    } else {
+      conf = conf.set(catalogPrefix + ".token", uc.serverToken());
+    }
     if (!useDeltaRestApiForTests()) {
       // Default is true. Tests can opt out.
       conf =

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UnityCatalogSupport.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UnityCatalogSupport.java
@@ -17,7 +17,7 @@
 package io.sparkuctest;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableMap;
+import io.sparkuctest.mock.MockOAuthBroker;
 import io.unitycatalog.client.ApiClient;
 import io.unitycatalog.client.ApiClientBuilder;
 import io.unitycatalog.client.VersionUtils;
@@ -33,7 +33,11 @@ import java.io.IOException;
 import java.net.ServerSocket;
 import java.nio.file.Files;
 import java.util.Arrays;
+import java.util.Map;
 import java.util.Properties;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.experimental.Accessors;
 import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
 import org.junit.jupiter.api.AfterAll;
@@ -44,8 +48,11 @@ import org.junit.jupiter.api.TestInstance;
  * Abstract base class that provides Unity Catalog server integration for Delta tests.
  *
  * <p>Automatically starts a local Unity Catalog server before tests and stops it after. To use a
- * remote server instead, set {@code UC_REMOTE=true} and configure {@code UC_URI}, {@code UC_TOKEN},
- * {@code UC_CATALOG_NAME}, {@code UC_SCHEMA_NAME}, and {@code UC_BASE_TABLE_LOCATION}.
+ * remote server instead, set {@code UC_REMOTE=true} and configure {@code UC_URI}, {@code
+ * UC_CATALOG_NAME}, {@code UC_SCHEMA_NAME}, and {@code UC_BASE_TABLE_LOCATION}. Remote auth is
+ * selected by which env vars are set: set {@code UC_OAUTH_URI}, {@code UC_OAUTH_CLIENT_ID}, and
+ * {@code UC_OAUTH_CLIENT_SECRET} for client-credentials OAuth, or {@code UC_TOKEN} for a static
+ * bearer.
  *
  * <p>{@code unityCatalogInfo()} is the only API for subclasses, All other methods are internal
  * implementation details.
@@ -66,6 +73,9 @@ public abstract class UnityCatalogSupport {
 
   private static final Logger LOG = Logger.getLogger(UnityCatalogSupport.class);
 
+  @Getter
+  @Accessors(fluent = true)
+  @AllArgsConstructor
   protected static class UnityCatalogInfo {
 
     private final String serverUri;
@@ -73,51 +83,44 @@ public abstract class UnityCatalogSupport {
     private final String serverToken;
     private final String schemaName;
     private final String baseTableLocation;
+    // OAuth client-credentials config; null when the test authenticates with a static token.
+    private final String oauthTokenUri;
+    private final String oauthClientId;
+    private final String oauthClientSecret;
 
-    public UnityCatalogInfo(
-        String serverUri,
-        String catalogName,
-        String serverToken,
-        String schemaName,
-        String baseTableLocation) {
-      this.serverUri = serverUri;
-      this.catalogName = catalogName;
-      this.serverToken = serverToken;
-      this.schemaName = schemaName;
-      this.baseTableLocation = baseTableLocation;
-    }
-
-    public String serverUri() {
-      return serverUri;
-    }
-
-    public String catalogName() {
-      return catalogName;
-    }
-
-    public String serverToken() {
-      return serverToken;
-    }
-
-    public String schemaName() {
-      return schemaName;
-    }
-
-    public String baseTableLocation() {
-      return baseTableLocation;
-    }
-
-    /** Creates a configured Unity Catalog API client. */
+    /**
+     * Creates a configured Unity Catalog API client for test scaffolding (catalog/schema setup and
+     * assertions). Uses OAuth client-credentials when OAuth is configured, otherwise the static
+     * token, so the scaffolding authenticates the same way as the connector under test.
+     */
     public ApiClient createApiClient() {
+      Map<String, String> authConfig =
+          oauthTokenUri != null
+              ? Map.of(
+                  "type", "oauth",
+                  "oauth.uri", oauthTokenUri,
+                  "oauth.clientId", oauthClientId,
+                  "oauth.clientSecret", oauthClientSecret)
+              : Map.of("type", "static", "token", serverToken);
       return ApiClientBuilder.create()
           .uri(serverUri)
-          .tokenProvider(
-              TokenProvider.create(ImmutableMap.of("type", "static", "token", serverToken)))
+          .tokenProvider(TokenProvider.create(authConfig))
           .build();
     }
   }
 
   public static final String UC_STATIC_TOKEN = "static-token";
+
+  /** Authentication mode for the catalog under test. */
+  public enum AuthMode {
+    STATIC,
+    OAUTH
+  }
+
+  /** Client-credentials identity the local mock OAuth broker accepts. */
+  public static final String MOCK_OAUTH_CLIENT_ID = "test-client-id";
+
+  public static final String MOCK_OAUTH_CLIENT_SECRET = "test-client-secret";
 
   /** The fake S3 bucket name used for local integration tests. */
   static final String FAKE_S3_BUCKET = "fakeS3Bucket";
@@ -130,6 +133,12 @@ public abstract class UnityCatalogSupport {
   public static final String UC_SCHEMA_NAME = "UC_SCHEMA_NAME";
   public static final String UC_BASE_TABLE_LOCATION = "UC_BASE_TABLE_LOCATION";
 
+  // OAuth client-credentials config for a remote server (used when UC_REMOTE=true and
+  // UC_OAUTH_URI is set); point UC_OAUTH_URI at the real token endpoint (e.g. an OIDC provider).
+  public static final String UC_OAUTH_URI = "UC_OAUTH_URI";
+  public static final String UC_OAUTH_CLIENT_ID = "UC_OAUTH_CLIENT_ID";
+  public static final String UC_OAUTH_CLIENT_SECRET = "UC_OAUTH_CLIENT_SECRET";
+
   protected static boolean isUCRemoteConfigured() {
     String ucRemote = System.getenv(UC_REMOTE);
     return ucRemote != null && ucRemote.equalsIgnoreCase("true");
@@ -138,6 +147,40 @@ public abstract class UnityCatalogSupport {
   /** Subclasses can override to false for A/B comparison with the legacy path. */
   protected boolean useDeltaRestApiForTests() {
     return true;
+  }
+
+  /**
+   * Authentication mode for the LOCAL in-process server. Defaults to OAuth; subclasses override to
+   * {@link AuthMode#STATIC} to keep using a static token. OAUTH runs the full server-validating
+   * path: authorization is enabled and a {@link MockOAuthBroker} mints an id_token that UC
+   * exchanges for an internal token, which UC validates. STATIC uses a static bearer with auth
+   * disabled. This does not affect remote runs: a remote server's auth mode is selected by which
+   * env vars are set ({@code UC_OAUTH_*} vs {@code UC_TOKEN}), independent of this method.
+   */
+  protected AuthMode authMode() {
+    return AuthMode.OAUTH;
+  }
+
+  /**
+   * Maximum lifetime (seconds) the mock OAuth broker advertises in its {@code /token} response; any
+   * expires_in UC returns is capped at this value. The connector renews ~30s before expiry, so a
+   * value at or below that lead time makes it re-run the client-credentials grant (and thus
+   * re-exchange) on essentially every call; override low in a test to exercise token renewal.
+   */
+  protected long oauthTokenMaxLifetimeSeconds() {
+    return 3600;
+  }
+
+  /**
+   * Number of access tokens the local mock OAuth broker has issued. Only a local server in OAUTH
+   * mode runs the broker; remote runs authenticate against a real IdP, so there is none to count.
+   */
+  protected int oauthIssuedTokenCount() {
+    Preconditions.checkState(
+        mockOAuthBroker != null,
+        "oauthIssuedTokenCount() requires the local mock OAuth broker, which runs only for a "
+            + "local server in OAUTH mode");
+    return mockOAuthBroker.issuedTokenCount();
   }
 
   /** The Unity Catalog info instance for subclasses access */
@@ -154,6 +197,9 @@ public abstract class UnityCatalogSupport {
 
   /** The temporary directory for external table location */
   private File ucBaseTableLocation = null;
+
+  /** Mock OAuth broker (client-credentials front + OIDC IdP + exchange); started for OAUTH. */
+  private MockOAuthBroker mockOAuthBroker;
 
   /**
    * Returns the Unity Catalog configuration for use in tests.
@@ -177,16 +223,43 @@ public abstract class UnityCatalogSupport {
   private UnityCatalogInfo remoteUnityCatalogInfo() {
     String serverUri = System.getenv(UC_URI);
     String catalogName = System.getenv(UC_CATALOG_NAME);
-    String serverToken = System.getenv(UC_TOKEN);
     String schemaName = System.getenv(UC_SCHEMA_NAME);
     String baseTableLocation = System.getenv(UC_BASE_TABLE_LOCATION);
     Preconditions.checkNotNull(serverUri, "%s must be set when UC_REMOTE=true", UC_URI);
     Preconditions.checkNotNull(catalogName, "%s must be set when UC_REMOTE=true", UC_CATALOG_NAME);
-    Preconditions.checkNotNull(serverToken, "%s must be set when UC_REMOTE=true", UC_TOKEN);
     Preconditions.checkNotNull(schemaName, "%s must be set when UC_REMOTE=true", UC_SCHEMA_NAME);
     Preconditions.checkNotNull(
         baseTableLocation, "%s must be set when UC_REMOTE=true", UC_BASE_TABLE_LOCATION);
-    return new UnityCatalogInfo(serverUri, catalogName, serverToken, schemaName, baseTableLocation);
+
+    // The remote auth mode is chosen by which env vars are set, independent of authMode() (which
+    // governs only the local in-process server): set UC_OAUTH_* for client-credentials OAuth, or
+    // UC_TOKEN for a static bearer.
+    if (System.getenv(UC_OAUTH_URI) != null) {
+      // Real OAuth: the connector runs client-credentials against the configured token endpoint
+      // (e.g. an external OIDC provider) and the remote server validates the resulting bearer.
+      String oauthUri = System.getenv(UC_OAUTH_URI);
+      String oauthClientId = System.getenv(UC_OAUTH_CLIENT_ID);
+      String oauthClientSecret = System.getenv(UC_OAUTH_CLIENT_SECRET);
+      Preconditions.checkNotNull(
+          oauthClientId, "%s must be set when UC_OAUTH_URI is set", UC_OAUTH_CLIENT_ID);
+      Preconditions.checkNotNull(
+          oauthClientSecret, "%s must be set when UC_OAUTH_URI is set", UC_OAUTH_CLIENT_SECRET);
+      return new UnityCatalogInfo(
+          serverUri,
+          catalogName,
+          /* serverToken= */ null,
+          schemaName,
+          baseTableLocation,
+          oauthUri,
+          oauthClientId,
+          oauthClientSecret);
+    } else {
+      String serverToken = System.getenv(UC_TOKEN);
+      Preconditions.checkNotNull(serverToken, "%s must be set when UC_REMOTE=true", UC_TOKEN);
+      // Static-token path: no OAuth fields.
+      return new UnityCatalogInfo(
+          serverUri, catalogName, serverToken, schemaName, baseTableLocation, null, null, null);
+    }
   }
 
   private UnityCatalogInfo localUnityCatalogInfo() {
@@ -194,12 +267,28 @@ public abstract class UnityCatalogSupport {
     Preconditions.checkNotNull(
         ucBaseTableLocation, "Local Unity Catalog Temp Directory is not configured");
     // Use fake S3 bucket (backed by local filesystem via S3CredentialFileSystem).
+    // In OAUTH mode the broker was started in setUpLocalServer, so it must be present; its values
+    // drive both the Spark connector's auth config and the scaffolding client. STATIC leaves the
+    // OAuth fields null and uses the static token.
+    String oauthTokenUri = null;
+    String oauthClientId = null;
+    String oauthClientSecret = null;
+    if (authMode() == AuthMode.OAUTH) {
+      Preconditions.checkState(
+          mockOAuthBroker != null, "mock OAuth broker must be started for a local OAUTH server");
+      oauthTokenUri = mockOAuthBroker.tokenEndpoint();
+      oauthClientId = MOCK_OAUTH_CLIENT_ID;
+      oauthClientSecret = MOCK_OAUTH_CLIENT_SECRET;
+    }
     return new UnityCatalogInfo(
         String.format("http://localhost:%s/", ucServerPort),
         "unity",
         UC_STATIC_TOKEN,
         "default",
-        "s3://" + FAKE_S3_BUCKET + ucBaseTableLocation.getAbsolutePath());
+        "s3://" + FAKE_S3_BUCKET + ucBaseTableLocation.getAbsolutePath(),
+        oauthTokenUri,
+        oauthClientId,
+        oauthClientSecret);
   }
 
   /** Finds an available port for the UC server. */
@@ -264,6 +353,21 @@ public abstract class UnityCatalogSupport {
     serverProps.setProperty("s3.accessKey.0", "fakeAccessKey");
     serverProps.setProperty("s3.secretKey.0", "fakeSecretKey");
     serverProps.setProperty("s3.sessionToken.0", "fakeSessionToken");
+    if (authMode() == AuthMode.OAUTH) {
+      // Server-validating OAuth: enable authorization, trust the broker's issuer, and require the
+      // audience it mints.
+      serverProps.setProperty("server.authorization", "enable");
+      serverProps.setProperty("server.allowed-issuers", mockOAuthBroker.issuer());
+      serverProps.setProperty("server.audiences", MockOAuthBroker.AUDIENCE);
+
+      // Start the mock OAuth broker before building UnityCatalogInfo (and before
+      // serverProperties(), which reads the broker's issuer for the allowed-issuers config).
+      mockOAuthBroker =
+          new MockOAuthBroker(
+              MOCK_OAUTH_CLIENT_ID, MOCK_OAUTH_CLIENT_SECRET, oauthTokenMaxLifetimeSeconds());
+      mockOAuthBroker.start();
+      LOG.info("Mock OAuth broker started at " + mockOAuthBroker.issuer());
+    }
 
     // Start UC server with configuration
     ServerProperties initServerProperties = new ServerProperties(serverProps);
@@ -276,6 +380,11 @@ public abstract class UnityCatalogSupport {
 
     server.start();
     ucServer = server;
+
+    // Now that UC is up, let the OAuth broker reach the token-exchange endpoint.
+    if (mockOAuthBroker != null) {
+      mockOAuthBroker.setUcBaseUri(String.format("http://localhost:%s/", ucServerPort));
+    }
 
     // Poll for server readiness by checking if we can create an API client and query catalogs
     int maxRetries = 30;
@@ -330,6 +439,12 @@ public abstract class UnityCatalogSupport {
       ucServer.stop();
       LOG.info("Unity Catalog server stopped");
       ucServer = null;
+    }
+
+    if (mockOAuthBroker != null) {
+      mockOAuthBroker.stop();
+      LOG.info("Mock OAuth broker stopped");
+      mockOAuthBroker = null;
     }
 
     // Clean up uc server temporary directory

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UnityCatalogSupport.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UnityCatalogSupport.java
@@ -354,12 +354,6 @@ public abstract class UnityCatalogSupport {
     serverProps.setProperty("s3.secretKey.0", "fakeSecretKey");
     serverProps.setProperty("s3.sessionToken.0", "fakeSessionToken");
     if (authMode() == AuthMode.OAUTH) {
-      // Server-validating OAuth: enable authorization, trust the broker's issuer, and require the
-      // audience it mints.
-      serverProps.setProperty("server.authorization", "enable");
-      serverProps.setProperty("server.allowed-issuers", mockOAuthBroker.issuer());
-      serverProps.setProperty("server.audiences", MockOAuthBroker.AUDIENCE);
-
       // Start the mock OAuth broker before building UnityCatalogInfo (and before
       // serverProperties(), which reads the broker's issuer for the allowed-issuers config).
       mockOAuthBroker =
@@ -367,6 +361,12 @@ public abstract class UnityCatalogSupport {
               MOCK_OAUTH_CLIENT_ID, MOCK_OAUTH_CLIENT_SECRET, oauthTokenMaxLifetimeSeconds());
       mockOAuthBroker.start();
       LOG.info("Mock OAuth broker started at " + mockOAuthBroker.issuer());
+
+      // Server-validating OAuth: enable authorization, trust the broker's issuer, and require the
+      // audience it mints.
+      serverProps.setProperty("server.authorization", "enable");
+      serverProps.setProperty("server.allowed-issuers", mockOAuthBroker.issuer());
+      serverProps.setProperty("server.audiences", MockOAuthBroker.AUDIENCE);
     }
 
     // Start UC server with configuration

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/mock/MockHttpSupport.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/mock/MockHttpSupport.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.sparkuctest.mock;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.net.HttpHeaders;
+import com.google.common.net.MediaType;
+import com.sun.net.httpserver.HttpExchange;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Map;
+
+/** Shared helpers for the JDK-{@code HttpServer}-based OAuth/OIDC test mocks. */
+final class MockHttpSupport {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  /** The "Basic" auth-scheme prefix of an Authorization header value (RFC 7617). */
+  private static final String BASIC_AUTH_PREFIX = "Basic ";
+
+  private MockHttpSupport() {}
+
+  /**
+   * Returns true when the request carries credentials for the "Basic" HTTP authentication scheme
+   * (RFC 7617) matching the expected user-id and password. This is generic Basic authentication;
+   * OAuth's {@code client_secret_basic} client authentication reuses it with user-id=client_id and
+   * password=client_secret.
+   */
+  static boolean basicAuthMatches(
+      HttpExchange exchange, String expectedUserId, String expectedPassword) {
+    String header = exchange.getRequestHeaders().getFirst(HttpHeaders.AUTHORIZATION);
+    if (header == null || !header.startsWith(BASIC_AUTH_PREFIX)) {
+      return false;
+    }
+    String decoded =
+        new String(
+            Base64.getDecoder().decode(header.substring(BASIC_AUTH_PREFIX.length())),
+            StandardCharsets.UTF_8);
+    int colon = decoded.indexOf(':');
+    if (colon < 0) {
+      return false;
+    }
+    return expectedUserId.equals(decoded.substring(0, colon))
+        && expectedPassword.equals(decoded.substring(colon + 1));
+  }
+
+  /**
+   * Serializes the given fields to a JSON object (Jackson handles all value escaping) and writes it
+   * as the response body with the given status code.
+   */
+  static void respondJson(HttpExchange exchange, int status, Map<String, ?> fields)
+      throws IOException {
+    byte[] bytes;
+    try {
+      bytes = MAPPER.writeValueAsBytes(fields);
+    } catch (JsonProcessingException e) {
+      throw new IOException("Failed to serialize JSON response", e);
+    }
+    exchange.getResponseHeaders().set(HttpHeaders.CONTENT_TYPE, MediaType.JSON_UTF_8.toString());
+    exchange.sendResponseHeaders(status, bytes.length);
+    try (OutputStream os = exchange.getResponseBody()) {
+      os.write(bytes);
+    }
+  }
+}

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/mock/MockOAuthBroker.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/mock/MockOAuthBroker.java
@@ -1,0 +1,329 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.sparkuctest.mock;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.net.HttpHeaders;
+import com.google.common.net.MediaType;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import io.unitycatalog.control.model.GrantType;
+import io.unitycatalog.control.model.TokenType;
+import java.io.IOException;
+import java.math.BigInteger;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.security.KeyPairGenerator;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.util.Base64;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import lombok.Setter;
+
+/**
+ * Test OAuth broker that adapts the connector's client-credentials grant to UC's token-exchange
+ * grant, so server-validating OAuth tests work without modifying the connector. It fuses three
+ * roles that would be separate parties in a real deployment:
+ *
+ * <ul>
+ *   <li><b>Client-credentials token endpoint</b> (faces the connector): {@code POST /token} accepts
+ *       the connector's plain client-credentials grant.
+ *   <li><b>OIDC identity provider</b> (faces UC): {@code GET /.well-known/openid-configuration} and
+ *       {@code GET /jwks} let UC discover + trust this issuer (put it in {@code
+ *       server.allowed-issuers}), and {@code /token} mints an {@code admin} id_token signed by this
+ *       server's key.
+ *   <li><b>Token-exchange client</b> (faces UC's STS): {@code /token} exchanges that id_token at
+ *       UC's token-exchange endpoint for a UC-internal token, which it returns as {@code
+ *       access_token}.
+ * </ul>
+ *
+ * Net: the connector does a plain client-credentials call and receives a UC-acceptable token, while
+ * UC actually validates it (issuer, signature, audience, enabled principal).
+ */
+public class MockOAuthBroker {
+
+  /** Audience minted into the id_token; must match UC's {@code server.audiences}. */
+  public static final String AUDIENCE = "uc-oauth-test-audience";
+
+  /** Subject of the id_token. {@code admin} is auto-created + enabled when UC auth is on. */
+  private static final String SUBJECT = "admin";
+
+  /** Validity of the minted id_token (5 minutes); generous so the exchange completes within it. */
+  private static final long ID_TOKEN_LIFETIME_MILLIS = 300_000L;
+
+  private final String expectedClientId;
+  private final String expectedClientSecret;
+  // Maximum lifetime advertised in the /token response: any expires_in UC returns is capped at this
+  // value. The connector renews ~30s before expiry, so a value at or below that lead time makes it
+  // re-run the grant (and thus re-exchange) on each call.
+  private final long maxLifetimeSeconds;
+  private final AtomicInteger issuedTokenCount = new AtomicInteger();
+  private final ObjectMapper mapper = new ObjectMapper();
+  private final HttpClient httpClient = HttpClient.newHttpClient();
+
+  private HttpServer server;
+  private ExecutorService executor;
+  private RSAPublicKey publicKey;
+  private Algorithm algorithm;
+  private String keyId;
+
+  // UC base URI (ends with '/'); Must be set after the UC server starts so /token can call the
+  // exchange.
+  @Setter private volatile String ucBaseUri;
+
+  public MockOAuthBroker(
+      String expectedClientId, String expectedClientSecret, long maxLifetimeSeconds) {
+    this.expectedClientId = expectedClientId;
+    this.expectedClientSecret = expectedClientSecret;
+    this.maxLifetimeSeconds = maxLifetimeSeconds;
+  }
+
+  public void start() throws Exception {
+    KeyPairGenerator gen = KeyPairGenerator.getInstance("RSA");
+    gen.initialize(2048);
+    var keyPair = gen.generateKeyPair();
+    this.publicKey = (RSAPublicKey) keyPair.getPublic();
+    this.algorithm = Algorithm.RSA512(publicKey, (RSAPrivateKey) keyPair.getPrivate());
+    this.keyId = UUID.randomUUID().toString();
+
+    server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+    server.createContext("/.well-known/openid-configuration", this::handleDiscovery);
+    server.createContext("/jwks", this::handleJwks);
+    server.createContext("/token", this::handleToken);
+    // Multithreaded (daemon) executor is required: the /token handler blocks on UC's exchange
+    // call, and UC calls back into this same server for discovery + JWKS. A single-threaded
+    // executor would self-deadlock. Daemon threads let the forked test JVM exit cleanly.
+    executor =
+        Executors.newCachedThreadPool(
+            r -> {
+              Thread t = new Thread(r);
+              t.setDaemon(true);
+              return t;
+            });
+    server.setExecutor(executor);
+    server.start();
+  }
+
+  /** Issuer URL; register this exactly in UC's {@code server.allowed-issuers}. */
+  public String issuer() {
+    return "http://localhost:" + server.getAddress().getPort();
+  }
+
+  public String tokenEndpoint() {
+    return issuer() + "/token";
+  }
+
+  public int issuedTokenCount() {
+    return issuedTokenCount.get();
+  }
+
+  public void stop() {
+    if (server != null) {
+      server.stop(0);
+      server = null;
+    }
+    // HttpServer.stop() does not shut down a custom Executor, so do it here; otherwise the cached
+    // pool's (daemon) threads linger ~60s after each test class and accumulate across a run.
+    if (executor != null) {
+      executor.shutdownNow();
+      executor = null;
+    }
+  }
+
+  /**
+   * OIDC discovery document ({@code GET /.well-known/openid-configuration}): advertises this
+   * server's {@code issuer} and {@code jwks_uri} (OpenID Connect Discovery 1.0).
+   */
+  private void handleDiscovery(HttpExchange exchange) throws IOException {
+    String issuer = issuer();
+    MockHttpSupport.respondJson(
+        exchange, 200, Map.of("issuer", issuer, "jwks_uri", issuer + "/jwks"));
+  }
+
+  /**
+   * Serves the JWK Set: a {@code keys} array containing this server's RSA public signing key.
+   * Follows the standard JWKS shape (RFC 7517 section 5), with the RSA public-key parameters
+   * kty/n/e per RFC 7518 section 6.3.1 (n and e are Base64urlUInt-encoded; see toUnsignedBytes).
+   */
+  private void handleJwks(HttpExchange exchange) throws IOException {
+    Base64.Encoder enc = Base64.getUrlEncoder().withoutPadding();
+    String n = enc.encodeToString(toUnsignedBytes(publicKey.getModulus()));
+    String e = enc.encodeToString(toUnsignedBytes(publicKey.getPublicExponent()));
+    MockHttpSupport.respondJson(
+        exchange,
+        200,
+        Map.of(
+            "keys",
+            List.of(
+                Map.of("kty", "RSA", "use", "sig", "alg", "RS512", "kid", keyId, "n", n, "e", e))));
+  }
+
+  /**
+   * Token endpoint ({@code POST /token}): handles the client-credentials grant. On valid client
+   * authentication it returns an OAuth 2.0 access-token response (RFC 6749 section 5.1) whose
+   * {@code access_token} is a UC-internal token; on invalid client credentials it returns a 401
+   * {@code invalid_client} error (RFC 6749 section 5.2).
+   */
+  private void handleToken(HttpExchange exchange) throws IOException {
+    // OAuth client_secret_basic: the connector authenticates its client-credentials grant by
+    // sending client id/secret as HTTP Basic, so we match them as the Basic user-id/password.
+    if (!"POST".equalsIgnoreCase(exchange.getRequestMethod())
+        || !MockHttpSupport.basicAuthMatches(exchange, expectedClientId, expectedClientSecret)) {
+      MockHttpSupport.respondJson(exchange, 401, Map.of("error", "invalid_client"));
+      return;
+    }
+    // Drain the request body (the grant_type/scope form params) without parsing it: this mock
+    // authenticates via the Basic header above and assumes the client-credentials grant, so the
+    // body is unused. Consuming it leaves no unread request bytes on the connection when we
+    // respond.
+    exchange.getRequestBody().readAllBytes();
+    try {
+      String idToken = mintIdToken();
+      ExchangedToken exchanged = exchangeForInternalToken(idToken);
+      // Advertise the smaller of UC's expires_in (if any) and the broker's max lifetime. UC OSS
+      // returns no expires_in today, so the max is used; if a future UC returns a longer expiry the
+      // cap still applies, so a low test cap keeps forcing renewal. (The UC-internal token carries
+      // no exp claim, so server-side expiry is not testable yet; only client-side renewal is.)
+      long expiresInSeconds =
+          exchanged.expiresInSeconds != null
+              ? Math.min(exchanged.expiresInSeconds, maxLifetimeSeconds)
+              : maxLifetimeSeconds;
+      MockHttpSupport.respondJson(
+          exchange,
+          200,
+          Map.of(
+              "access_token",
+              exchanged.accessToken,
+              "token_type",
+              "Bearer",
+              "expires_in",
+              expiresInSeconds));
+      issuedTokenCount.incrementAndGet();
+    } catch (RuntimeException e) {
+      // Jackson escapes the detail value, so a raw exception message is safe to embed.
+      MockHttpSupport.respondJson(
+          exchange,
+          502,
+          Map.of("error", "exchange_failed", "detail", String.valueOf(e.getMessage())));
+    }
+  }
+
+  private String mintIdToken() {
+    return JWT.create()
+        .withSubject(SUBJECT)
+        .withIssuer(issuer())
+        .withAudience(AUDIENCE)
+        .withIssuedAt(new Date())
+        .withExpiresAt(new Date(System.currentTimeMillis() + ID_TOKEN_LIFETIME_MILLIS))
+        .withKeyId(keyId)
+        .withJWTId(UUID.randomUUID().toString())
+        .sign(algorithm);
+  }
+
+  /** A UC token-exchange result: the access token, plus its lifetime if UC advertised one. */
+  private static final class ExchangedToken {
+    final String accessToken;
+    final Long expiresInSeconds; // null when UC did not advertise an expires_in
+
+    ExchangedToken(String accessToken, Long expiresInSeconds) {
+      this.accessToken = accessToken;
+      this.expiresInSeconds = expiresInSeconds;
+    }
+  }
+
+  /**
+   * Exchanges the given id_token for a UC-internal access token at UC's token-exchange endpoint
+   * (RFC 8693). Returns the access token and, if UC advertised an {@code expires_in}, its lifetime
+   * (null otherwise). Throws if UC's base URI has not been set, or if the exchange request fails or
+   * returns no token.
+   */
+  private ExchangedToken exchangeForInternalToken(String idToken) {
+    if (ucBaseUri == null) {
+      throw new IllegalStateException("UC base URI not set on MockOAuthBroker");
+    }
+    // RFC 8693 token-exchange form. The grant and token-type URNs come from UC's own enums rather
+    // than hardcoded strings. (The model's toUrlQueryString() serializer that AuthCli uses is not
+    // in the pinned UC version, so the form is assembled here.)
+    String form =
+        "grant_type="
+            + GrantType.TOKEN_EXCHANGE.getValue()
+            + "&requested_token_type="
+            + TokenType.ACCESS_TOKEN.getValue()
+            + "&subject_token_type="
+            + TokenType.ID_TOKEN.getValue()
+            + "&subject_token="
+            + idToken;
+    HttpRequest request =
+        HttpRequest.newBuilder()
+            .uri(URI.create(ucBaseUri + "api/1.0/unity-control/auth/tokens"))
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.FORM_DATA.toString())
+            .POST(HttpRequest.BodyPublishers.ofString(form))
+            .build();
+    try {
+      HttpResponse<String> response =
+          httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+      if (response.statusCode() != 200) {
+        throw new IllegalStateException(
+            "token-exchange failed: HTTP " + response.statusCode() + " " + response.body());
+      }
+      JsonNode body = mapper.readTree(response.body());
+      JsonNode accessToken = body.get("access_token");
+      if (accessToken == null || accessToken.asText().isEmpty()) {
+        throw new IllegalStateException("token-exchange response missing access_token");
+      }
+      // UC OSS does not advertise token expiry today; take expires_in if a future version does,
+      // otherwise leave it null so the caller falls back to its own lifetime.
+      JsonNode expiresIn = body.get("expires_in");
+      Long expiresInSeconds = expiresIn != null && expiresIn.isNumber() ? expiresIn.asLong() : null;
+      return new ExchangedToken(accessToken.asText(), expiresInSeconds);
+    } catch (IOException e) {
+      throw new RuntimeException("token-exchange request failed", e);
+    } catch (InterruptedException e) {
+      // Restore the interrupt status that catching InterruptedException cleared, so the signal is
+      // not lost, then surface it as the same failure the caller turns into a 502.
+      Thread.currentThread().interrupt();
+      throw new RuntimeException("token-exchange request interrupted", e);
+    }
+  }
+
+  /**
+   * RSA modulus/exponent as big-endian bytes without a leading sign byte. {@code
+   * BigInteger.toByteArray()} prepends a 0x00 sign byte for positive values; the JWKS {@code
+   * n}/{@code e} fields are Base64urlUInt-encoded (RFC 7518 section 2), which omits it.
+   */
+  private static byte[] toUnsignedBytes(BigInteger value) {
+    byte[] bytes = value.toByteArray();
+    if (bytes.length > 1 && bytes[0] == 0) {
+      byte[] trimmed = new byte[bytes.length - 1];
+      System.arraycopy(bytes, 1, trimmed, 0, trimmed.length);
+      return trimmed;
+    }
+    return bytes;
+  }
+}


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Adds a mock OAuth broker so the local UC integration suite runs the full server-validating OAuth path with authorization enabled: it fronts a client-credentials token endpoint to the connector and token-exchanges with UC for an internal token. `authMode()` now defaults to OAUTH, `UCDeltaStaticTokenTest` keeps the static-token path covered, and remote runs select auth by env vars (`UC_OAUTH_*` vs `UC_TOKEN`). Adds `UCDeltaOAuthRefreshTest` for client-side token renewal. Test-only change.

## How was this patch tested?
It fails without the fix b0179819d4d6b018e01c6c1c02ca56624fca5981

## Does this PR introduce _any_ user-facing changes?
No.