### PR TITLE
[kernel-spark] Refactor DeltaV2BatchWrite into DeltaV2Write + DeltaV2BatchWrite

### DIFF
--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
@@ -481,7 +481,8 @@ public class DeltaV2Table
   @Override
   public WriteBuilder newWriteBuilder(LogicalWriteInfo info) {
     requireNonNull(info, "write info is null");
-    return new DeltaV2WriteBuilder(kernelEngine, tablePath, hadoopConf, initialSnapshot, info);
+    return new DeltaV2WriteBuilder(
+        kernelEngine, tablePath, hadoopConf, initialSnapshot, schemaProvider.getDataSchema(), info);
   }
 
   /**

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2BatchWrite.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2BatchWrite.java
@@ -21,159 +21,66 @@ import io.delta.kernel.Transaction;
 import io.delta.kernel.TransactionCommitResult;
 import io.delta.kernel.data.Row;
 import io.delta.kernel.engine.Engine;
-import io.delta.kernel.internal.util.Utils;
 import io.delta.kernel.utils.CloseableIterable;
-import io.delta.spark.internal.v2.read.DeltaParquetFileFormatV2;
-import io.delta.spark.internal.v2.utils.PartitionUtils;
-import io.delta.spark.internal.v2.utils.ScalaUtils;
-import io.delta.spark.internal.v2.utils.SchemaUtils;
-import io.delta.spark.internal.v2.utils.SerializableKernelRowWrapper;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.mapreduce.Job;
-import org.apache.spark.sql.SparkSession;
+import java.util.function.Function;
 import org.apache.spark.sql.connector.write.BatchWrite;
 import org.apache.spark.sql.connector.write.DataWriterFactory;
-import org.apache.spark.sql.connector.write.LogicalWriteInfo;
 import org.apache.spark.sql.connector.write.PhysicalWriteInfo;
-import org.apache.spark.sql.connector.write.Write;
 import org.apache.spark.sql.connector.write.WriterCommitMessage;
-import org.apache.spark.sql.execution.datasources.OutputWriterFactory;
-import org.apache.spark.sql.types.StructType;
-import org.apache.spark.util.SerializableConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import scala.Option;
 
 /**
- * BatchWrite for DSv2 batch append using Spark's Parquet path. Creates a Kernel transaction on the
- * driver, obtains the target directory from the Kernel write context, creates a Spark Parquet
- * OutputWriterFactory via the shared {@link PartitionUtils#createDeltaParquetFileFormat} factory,
- * and serializes everything into a {@link DeltaV2DataWriterFactory} for executor transport.
+ * BatchWrite for DSv2 batch append. Owns the Kernel transaction lifecycle: it creates the single
+ * {@link Operation#WRITE} transaction, builds the executor write state ({@link
+ * DeltaV2DataWriterFactory}) from it via the builder supplied by {@link DeltaV2Write}, and commits
+ * that transaction over the {@code AddFile} actions reported by the writers.
  *
- * <p>The {@link Transaction} object lives only on the driver and is never serialized. Executors
- * receive only serializable state: transaction state row, Hadoop conf, OutputWriterFactory, schema,
- * and target directory.
+ * <p>The {@code engine} and {@code transaction} are driver-only state and are never serialized to
+ * executors -- only the (serializable) {@link DeltaV2DataWriterFactory} is shipped.
  */
-class DeltaV2BatchWrite implements Write, BatchWrite {
+class DeltaV2BatchWrite implements BatchWrite {
 
-  private static final Logger LOG = LoggerFactory.getLogger(DeltaV2BatchWrite.class);
-
-  private static String getEngineInfo() {
-    return "Delta-Spark-DSv2/" + org.apache.spark.package$.MODULE$.SPARK_VERSION();
-  }
+  private static final Logger logger = LoggerFactory.getLogger(DeltaV2BatchWrite.class);
 
   private final Transaction transaction;
   private final Engine engine;
+  private final DeltaV2DataWriterFactory dataWriterFactory;
 
-  private final String targetDirectory;
-  private final SerializableConfiguration serializableHadoopConf;
-  private final SerializableKernelRowWrapper serializedTxnState;
-  private final StructType dataSchema;
-  private final OutputWriterFactory outputWriterFactory;
-
+  /**
+   * @param engine Kernel engine (driver-only)
+   * @param initialSnapshot snapshot the WRITE transaction is built from
+   * @param dataWriterFactoryBuilder builds the executor write state from the transaction created
+   *     here; supplied by {@link DeltaV2Write} so the executor-state construction stays shared
+   *     across write modes
+   */
   DeltaV2BatchWrite(
       Engine engine,
-      Configuration hadoopConf,
-      String tablePath,
       Snapshot initialSnapshot,
-      LogicalWriteInfo writeInfo) {
+      Function<Transaction, DeltaV2DataWriterFactory> dataWriterFactoryBuilder) {
     this.engine = engine;
     this.transaction =
         initialSnapshot
-            .buildUpdateTableTransaction(getEngineInfo(), Operation.WRITE)
-            .build(this.engine);
-    Row txnState = transaction.getTransactionState(this.engine);
-    this.serializedTxnState = new SerializableKernelRowWrapper(txnState);
-
-    this.targetDirectory =
-        Transaction.getWriteContext(this.engine, txnState, Collections.emptyMap())
-            .getTargetDirectory();
-
-    StructType tableSchema =
-        SchemaUtils.convertKernelSchemaToSparkSchema(initialSnapshot.getSchema());
-    java.util.Set<String> partitionCols =
-        new java.util.HashSet<>(initialSnapshot.getPartitionColumnNames());
-    this.dataSchema =
-        partitionCols.isEmpty()
-            ? tableSchema
-            : new StructType(
-                java.util.Arrays.stream(tableSchema.fields())
-                    .filter(f -> !partitionCols.contains(f.name()))
-                    .toArray(org.apache.spark.sql.types.StructField[]::new));
-
-    SparkSession session =
-        SparkSession.getActiveSession()
-            .getOrElse(
-                () -> {
-                  throw new IllegalStateException(
-                      "SparkSession not active (batch write needs it for Parquet)");
-                });
-
-    Job job;
-    try {
-      job = Job.getInstance(hadoopConf);
-    } catch (IOException e) {
-      throw new UncheckedIOException("Failed to create Hadoop job for Parquet write", e);
-    }
-    // TODO: support write-time CDF on batch writes.
-    DeltaParquetFileFormatV2 format =
-        PartitionUtils.createDeltaParquetFileFormat(
-            initialSnapshot,
-            tablePath,
-            /* optimizationsEnabled */ true,
-            /* useMetadataRowIndex */ Option.empty(),
-            /* isCDCRead */ false);
-    org.apache.spark.sql.execution.datasources.DataSourceUtils.checkFieldNames(format, dataSchema);
-    Map<String, String> options = writeInfo.options().asCaseSensitiveMap();
-    scala.collection.immutable.Map<String, String> scalaOpts =
-        ScalaUtils.toScalaMap(options != null ? options : Collections.emptyMap());
-    this.outputWriterFactory = format.prepareWrite(session, job, scalaOpts, dataSchema);
-    this.serializableHadoopConf = new SerializableConfiguration(job.getConfiguration());
-  }
-
-  @Override
-  public BatchWrite toBatch() {
-    return this;
+            .buildUpdateTableTransaction(DeltaV2Write.getEngineInfo(), Operation.WRITE)
+            .build(engine);
+    this.dataWriterFactory = dataWriterFactoryBuilder.apply(transaction);
   }
 
   @Override
   public DataWriterFactory createBatchWriterFactory(PhysicalWriteInfo physicalWriteInfo) {
-    return new DeltaV2DataWriterFactory(
-        targetDirectory,
-        serializableHadoopConf,
-        serializedTxnState,
-        dataSchema,
-        outputWriterFactory);
+    return dataWriterFactory;
   }
 
   @Override
   public void commit(WriterCommitMessage[] messages) {
-    List<Row> allActionRows = new ArrayList<>();
-    for (WriterCommitMessage msg : messages) {
-      if (msg instanceof DeltaV2WriterCommitMessage) {
-        for (SerializableKernelRowWrapper wrapper :
-            ((DeltaV2WriterCommitMessage) msg).getActionRows()) {
-          allActionRows.add(wrapper.getRow());
-        }
-      }
-    }
-
-    CloseableIterable<Row> dataActions =
-        CloseableIterable.inMemoryIterable(Utils.toCloseableIterator(allActionRows.iterator()));
-
+    CloseableIterable<Row> dataActions = DeltaV2WriterCommitMessage.toDataActions(messages);
     TransactionCommitResult result = transaction.commit(engine, dataActions);
-    LOG.info("DSv2 batch write committed at version {}", result.getVersion());
+    logger.info("DSv2 batch write committed at version {}", result.getVersion());
   }
 
   @Override
   public void abort(WriterCommitMessage[] messages) {
-    LOG.warn(
+    logger.warn(
         "DSv2 batch write aborted. {} task messages will not be committed. "
             + "Orphaned data files will be cleaned up by VACUUM.",
         messages != null ? messages.length : 0);

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2Write.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2Write.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.write;
+
+import static java.util.Objects.requireNonNull;
+
+import io.delta.kernel.Snapshot;
+import io.delta.kernel.Transaction;
+import io.delta.kernel.data.Row;
+import io.delta.kernel.engine.Engine;
+import io.delta.spark.internal.v2.read.DeltaParquetFileFormatV2;
+import io.delta.spark.internal.v2.utils.PartitionUtils;
+import io.delta.spark.internal.v2.utils.ScalaUtils;
+import io.delta.spark.internal.v2.utils.SerializableKernelRowWrapper;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Collections;
+import java.util.Map;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.connector.write.BatchWrite;
+import org.apache.spark.sql.connector.write.LogicalWriteInfo;
+import org.apache.spark.sql.connector.write.Write;
+import org.apache.spark.sql.execution.datasources.OutputWriterFactory;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.util.SerializableConfiguration;
+import scala.Option;
+
+/**
+ * The DSv2 {@link Write} for Delta. Holds the table-level write context (engine, Hadoop conf, table
+ * path, snapshot, data schema, write info) and builds the executor-side write state -- a {@link
+ * DeltaV2DataWriterFactory} (serialized transaction state, target directory, Spark Parquet {@link
+ * OutputWriterFactory}, Hadoop conf) -- from a Kernel {@link Transaction} via {@link
+ * #buildDataWriterFactory}. It passes that builder to {@link DeltaV2BatchWrite}, which owns the
+ * transaction lifecycle (create, commit).
+ *
+ * <p>Splitting {@code Write} from {@code BatchWrite} keeps the operation-independent executor-state
+ * construction (schema / protocol / path, not the {@code Operation}) separate from the
+ * mode-specific transaction lifecycle, so {@link #buildDataWriterFactory} can be reused by future
+ * write modes.
+ *
+ * <p>Only append is supported: the builder advertises no overwrite capability, so Spark does not
+ * route overwrite, truncate, Complete, or Update here.
+ */
+class DeltaV2Write implements Write {
+
+  private final Engine engine;
+  private final Configuration hadoopConf;
+  private final String tablePath;
+  private final Snapshot initialSnapshot;
+  private final StructType dataSchema;
+  private final LogicalWriteInfo writeInfo;
+
+  DeltaV2Write(
+      Engine engine,
+      Configuration hadoopConf,
+      String tablePath,
+      Snapshot initialSnapshot,
+      StructType dataSchema,
+      LogicalWriteInfo writeInfo) {
+    this.engine = requireNonNull(engine, "engine is null");
+    this.hadoopConf = requireNonNull(hadoopConf, "hadoopConf is null");
+    this.tablePath = requireNonNull(tablePath, "tablePath is null");
+    this.initialSnapshot = requireNonNull(initialSnapshot, "initialSnapshot is null");
+    this.dataSchema = requireNonNull(dataSchema, "dataSchema is null");
+    this.writeInfo = requireNonNull(writeInfo, "writeInfo is null");
+  }
+
+  static String getEngineInfo() {
+    return "Delta-Spark-DSv2/" + org.apache.spark.package$.MODULE$.SPARK_VERSION();
+  }
+
+  @Override
+  public BatchWrite toBatch() {
+    return new DeltaV2BatchWrite(engine, initialSnapshot, this::buildDataWriterFactory);
+  }
+
+  /**
+   * Builds the executor-side write state from {@code transaction}: the serialized transaction state
+   * and target directory (from a Kernel write context), the Spark Parquet {@link
+   * OutputWriterFactory}, and the Hadoop conf, packaged into a {@link DeltaV2DataWriterFactory}.
+   *
+   * <p>DSv1 has no analogue: it writes data files inside the transaction scope on the driver
+   * ({@code txn.writeFiles}), whereas DSv2 writes them on executors before the driver commits, so
+   * the write context must be extracted and serialized ahead of the commit. The extracted state is
+   * operation-independent (schema / protocol / path), so any write mode can build its factory here.
+   */
+  private DeltaV2DataWriterFactory buildDataWriterFactory(Transaction transaction) {
+    Row txnState = transaction.getTransactionState(engine);
+    SerializableKernelRowWrapper serializedTxnState = new SerializableKernelRowWrapper(txnState);
+    // TODO(#7140): pass real partitionValues to support partitioned writes.
+    String targetDirectory =
+        Transaction.getWriteContext(engine, txnState, /* partitionValues */ Collections.emptyMap())
+            .getTargetDirectory();
+
+    SparkSession session =
+        SparkSession.getActiveSession()
+            .getOrElse(
+                () -> {
+                  throw new IllegalStateException(
+                      "SparkSession not active (write needs it for Parquet)");
+                });
+
+    Job job;
+    try {
+      job = Job.getInstance(hadoopConf);
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to create Hadoop job for Parquet write", e);
+    }
+    // TODO(#7140): support write-time CDF on batch writes.
+    DeltaParquetFileFormatV2 format =
+        PartitionUtils.createDeltaParquetFileFormat(
+            initialSnapshot,
+            tablePath,
+            /* optimizationsEnabled */ true,
+            /* useMetadataRowIndex */ Option.empty(),
+            /* isCDCRead */ false);
+    org.apache.spark.sql.execution.datasources.DataSourceUtils.checkFieldNames(format, dataSchema);
+    Map<String, String> options = writeInfo.options().asCaseSensitiveMap();
+    scala.collection.immutable.Map<String, String> scalaOpts =
+        ScalaUtils.toScalaMap(options != null ? options : Collections.emptyMap());
+    OutputWriterFactory outputWriterFactory =
+        format.prepareWrite(session, job, scalaOpts, dataSchema);
+    SerializableConfiguration serializableHadoopConf =
+        new SerializableConfiguration(job.getConfiguration());
+
+    return new DeltaV2DataWriterFactory(
+        targetDirectory,
+        serializableHadoopConf,
+        serializedTxnState,
+        dataSchema,
+        outputWriterFactory);
+  }
+}

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2WriteBuilder.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2WriteBuilder.java
@@ -31,9 +31,9 @@ import org.apache.spark.sql.delta.schema.SchemaMergingUtils;
 import org.apache.spark.sql.types.StructType;
 
 /**
- * WriteBuilder for DSv2 batch writes to Delta tables. Mirrors the read-side {@code
- * SparkScanBuilder} pattern: takes table-level state and Spark's {@link LogicalWriteInfo}, and
- * builds a {@link DeltaV2BatchWrite} (which implements both Write and BatchWrite).
+ * WriteBuilder for DSv2 writes to Delta tables. Mirrors the read-side {@code SparkScanBuilder}
+ * pattern: takes table-level state and Spark's {@link LogicalWriteInfo}, and builds a {@link
+ * DeltaV2Write}.
  *
  * <p>Schema validation uses the shared V1 utility {@code SchemaMergingUtils.mergeSchemas} to check
  * type compatibility and reject duplicate columns before the write proceeds.
@@ -44,6 +44,7 @@ public class DeltaV2WriteBuilder implements WriteBuilder {
   private final String tablePath;
   private final Configuration hadoopConf;
   private final Snapshot initialSnapshot;
+  private final StructType dataSchema;
   private final LogicalWriteInfo writeInfo;
 
   /**
@@ -51,6 +52,7 @@ public class DeltaV2WriteBuilder implements WriteBuilder {
    * @param tablePath filesystem path to the Delta table root
    * @param hadoopConf Hadoop configuration (with merged table options)
    * @param initialSnapshot Kernel snapshot loaded at table construction time
+   * @param dataSchema the table's data (non-partition) schema, from DeltaV2Table's SchemaProvider
    * @param writeInfo Spark's logical write info (schema, queryId, options)
    */
   public DeltaV2WriteBuilder(
@@ -58,11 +60,13 @@ public class DeltaV2WriteBuilder implements WriteBuilder {
       String tablePath,
       Configuration hadoopConf,
       Snapshot initialSnapshot,
+      StructType dataSchema,
       LogicalWriteInfo writeInfo) {
     this.engine = requireNonNull(engine, "engine is null");
     this.tablePath = requireNonNull(tablePath, "tablePath is null");
     this.hadoopConf = requireNonNull(hadoopConf, "hadoopConf is null");
     this.initialSnapshot = requireNonNull(initialSnapshot, "initialSnapshot is null");
+    this.dataSchema = requireNonNull(dataSchema, "dataSchema is null");
     this.writeInfo = requireNonNull(writeInfo, "writeInfo is null");
   }
 
@@ -87,7 +91,7 @@ public class DeltaV2WriteBuilder implements WriteBuilder {
     // only logical types -- matches V1's dropColumnMappingMetadata call.
     StructType cleanTableSchema =
         DeltaColumnMapping.dropColumnMappingMetadata(tableSchema.asNullable());
-    StructType dataSchema = writeInfo.schema();
+    StructType writeSchema = writeInfo.schema();
 
     // Throws DeltaAnalysisException for type incompatibilities or duplicate columns.
     // Return value discarded -- we only need the validation side-effect.
@@ -95,12 +99,12 @@ public class DeltaV2WriteBuilder implements WriteBuilder {
     // schema returned here to update table metadata instead of discarding it.
     SchemaMergingUtils.mergeSchemas(
         cleanTableSchema,
-        dataSchema,
+        writeSchema,
         /* allowImplicitConversions */ false,
         /* keepExistingType */ false,
         TypeWideningMode.NoTypeWidening$.MODULE$,
         /* caseSensitive */ false);
 
-    return new DeltaV2BatchWrite(engine, hadoopConf, tablePath, initialSnapshot, writeInfo);
+    return new DeltaV2Write(engine, hadoopConf, tablePath, initialSnapshot, dataSchema, writeInfo);
   }
 }

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2WriterCommitMessage.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2WriterCommitMessage.java
@@ -15,7 +15,11 @@
  */
 package io.delta.spark.internal.v2.write;
 
+import io.delta.kernel.data.Row;
+import io.delta.kernel.internal.util.Utils;
+import io.delta.kernel.utils.CloseableIterable;
 import io.delta.spark.internal.v2.utils.SerializableKernelRowWrapper;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import org.apache.spark.sql.connector.write.WriterCommitMessage;
@@ -35,5 +39,22 @@ class DeltaV2WriterCommitMessage implements WriterCommitMessage {
 
   List<SerializableKernelRowWrapper> getActionRows() {
     return Collections.unmodifiableList(actionRows);
+  }
+
+  /**
+   * Flattens the Delta log action rows from every task's commit message into the {@link
+   * CloseableIterable} that {@link io.delta.kernel.Transaction#commit} expects.
+   */
+  static CloseableIterable<Row> toDataActions(WriterCommitMessage[] messages) {
+    List<Row> allActionRows = new ArrayList<>();
+    for (WriterCommitMessage msg : messages) {
+      if (msg instanceof DeltaV2WriterCommitMessage) {
+        DeltaV2WriterCommitMessage deltaMsg = (DeltaV2WriterCommitMessage) msg;
+        for (SerializableKernelRowWrapper wrapper : deltaMsg.actionRows) {
+          allActionRows.add(wrapper.getRow());
+        }
+      }
+    }
+    return CloseableIterable.inMemoryIterable(Utils.toCloseableIterator(allActionRows.iterator()));
   }
 }

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/write/DeltaV2BatchWriteTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/write/DeltaV2BatchWriteTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.write;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.delta.kernel.Snapshot;
+import io.delta.spark.internal.v2.DeltaV2TestBase;
+import io.delta.spark.internal.v2.InternalRowTestUtils;
+import io.delta.spark.internal.v2.snapshot.PathBasedSnapshotManager;
+import java.io.File;
+import java.util.List;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.connector.write.DataWriter;
+import org.apache.spark.sql.connector.write.DataWriterFactory;
+import org.apache.spark.sql.connector.write.LogicalWriteInfo;
+import org.apache.spark.sql.connector.write.WriterCommitMessage;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/** Unit tests for {@link DeltaV2BatchWrite}. */
+public class DeltaV2BatchWriteTest extends DeltaV2TestBase {
+
+  private static final StructType TABLE_SCHEMA =
+      DataTypes.createStructType(
+          new StructField[] {
+            DataTypes.createStructField("id", DataTypes.IntegerType, true),
+            DataTypes.createStructField("name", DataTypes.StringType, true)
+          });
+
+  @Test
+  public void testCreateBatchWriterFactory_returnsDeltaV2DataWriterFactory(@TempDir File tempDir) {
+    DeltaV2BatchWrite write = newWrite(createTable(tempDir, "batch_factory_type"));
+    assertTrue(
+        write.createBatchWriterFactory(WriteTestUtils.physicalWriteInfo(1))
+            instanceof DeltaV2DataWriterFactory);
+  }
+
+  @Test
+  public void testCommit_appendsData(@TempDir File tempDir) throws Exception {
+    String path = createTable(tempDir, "batch_commit");
+    DeltaV2BatchWrite write = newWrite(path);
+    WriterCommitMessage[] messages = {writeFile(write, 1, "Alice", 2, "Bob")};
+
+    write.commit(messages);
+
+    List<Row> rows = spark.read().format("delta").load(path).orderBy("id").collectAsList();
+    assertEquals(2, rows.size());
+    assertEquals("Alice", rows.get(0).getString(1));
+    assertEquals("Bob", rows.get(1).getString(1));
+  }
+
+  @Test
+  public void testCommit_multipleTasks_appendsAllData(@TempDir File tempDir) throws Exception {
+    String path = createTable(tempDir, "batch_commit_multi");
+    DeltaV2BatchWrite write = newWrite(path);
+    // Two tasks each write their own file; commit must flatten both tasks' AddFile actions into a
+    // single Delta commit rather than dropping all but one.
+    DataWriterFactory factory = write.createBatchWriterFactory(WriteTestUtils.physicalWriteInfo(2));
+    WriterCommitMessage[] messages = {
+      writeFile(factory, 0, 1, "Alice", 2, "Bob"), writeFile(factory, 1, 3, "Carol")
+    };
+
+    write.commit(messages);
+
+    List<Row> rows = spark.read().format("delta").load(path).orderBy("id").collectAsList();
+    assertEquals(3, rows.size());
+    assertEquals("Alice", rows.get(0).getString(1));
+    assertEquals("Bob", rows.get(1).getString(1));
+    assertEquals("Carol", rows.get(2).getString(1));
+  }
+
+  @Test
+  public void testAbort_doesNotCommit(@TempDir File tempDir) throws Exception {
+    String path = createTable(tempDir, "batch_abort");
+    DeltaV2BatchWrite write = newWrite(path);
+    // Stage a real file (writeFile runs the executor writer and produces a non-empty commit
+    // message) so the test exercises an abort that has data to discard, not a trivial no-op.
+    WriterCommitMessage[] messages = {writeFile(write, 1, "Alice", 2, "Bob")};
+    long versionsBefore = spark.sql("DESCRIBE HISTORY delta.`" + path + "`").count();
+
+    write.abort(messages);
+
+    assertEquals(0L, spark.read().format("delta").load(path).count(), "abort must not commit data");
+    // Distinguishes a correct abort from an erroneous (even empty) commit: a commit would advance
+    // the table version, so the history row count must be unchanged.
+    assertEquals(
+        versionsBefore,
+        spark.sql("DESCRIBE HISTORY delta.`" + path + "`").count(),
+        "abort must not create a new table version");
+  }
+
+  @Test
+  public void testAbort_hasNoSideEffectsOnSurroundingWrites(@TempDir File tempDir)
+      throws Exception {
+    String path = createTable(tempDir, "batch_abort_no_side_effects");
+
+    // Commit before the abort.
+    DeltaV2BatchWrite before = newWrite(path);
+    before.commit(new WriterCommitMessage[] {writeFile(before, 1, "Alice")});
+    // Abort a write that staged real data.
+    DeltaV2BatchWrite aborted = newWrite(path);
+    aborted.abort(new WriterCommitMessage[] {writeFile(aborted, 2, "Bob")});
+    // Commit after the abort.
+    DeltaV2BatchWrite after = newWrite(path);
+    after.commit(new WriterCommitMessage[] {writeFile(after, 3, "Carol")});
+
+    // Only the surrounding commits survive; the aborted row must not leak.
+    List<Row> rows = spark.read().format("delta").load(path).orderBy("id").collectAsList();
+    assertEquals(2, rows.size());
+    assertEquals("Alice", rows.get(0).getString(1));
+    assertEquals("Carol", rows.get(1).getString(1));
+  }
+
+  /** Runs the executor-side writer at partition 0 / task 0 and returns its commit message. */
+  private WriterCommitMessage writeFile(DeltaV2BatchWrite write, Object... idNamePairs)
+      throws Exception {
+    return writeFile(
+        write.createBatchWriterFactory(WriteTestUtils.physicalWriteInfo(1)), 0, idNamePairs);
+  }
+
+  /** Runs the executor-side writer for the given partition and returns its commit message. */
+  private WriterCommitMessage writeFile(
+      DataWriterFactory factory, int partitionId, Object... idNamePairs) throws Exception {
+    DataWriter<InternalRow> writer = factory.createWriter(partitionId, 0L);
+    for (int i = 0; i < idNamePairs.length; i += 2) {
+      writer.write(InternalRowTestUtils.row(idNamePairs[i], idNamePairs[i + 1]));
+    }
+    return writer.commit();
+  }
+
+  private String createTable(File tempDir, String tableName) {
+    String path = tempDir.getAbsolutePath();
+    spark.sql(
+        String.format(
+            "CREATE TABLE %s (id INT, name STRING) USING delta LOCATION '%s'", tableName, path));
+    return path;
+  }
+
+  private DeltaV2BatchWrite newWrite(String path) {
+    Snapshot snapshot =
+        new PathBasedSnapshotManager(path, spark.sessionState().newHadoopConf())
+            .loadLatestSnapshot();
+    LogicalWriteInfo info =
+        WriteTestUtils.logicalWriteInfo(TABLE_SCHEMA, CaseInsensitiveStringMap.empty());
+    DeltaV2Write write =
+        new DeltaV2Write(
+            defaultEngine,
+            spark.sessionState().newHadoopConf(),
+            path,
+            snapshot,
+            TABLE_SCHEMA,
+            info);
+    return (DeltaV2BatchWrite) write.toBatch();
+  }
+}

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/write/DeltaV2WriteTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/write/DeltaV2WriteTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.write;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.delta.kernel.Snapshot;
+import io.delta.spark.internal.v2.DeltaV2TestBase;
+import io.delta.spark.internal.v2.snapshot.PathBasedSnapshotManager;
+import java.io.File;
+import org.apache.spark.sql.connector.write.LogicalWriteInfo;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/** Unit tests for {@link DeltaV2Write}. */
+public class DeltaV2WriteTest extends DeltaV2TestBase {
+
+  private static final StructType TABLE_SCHEMA =
+      DataTypes.createStructType(
+          new StructField[] {
+            DataTypes.createStructField("id", DataTypes.IntegerType, true),
+            DataTypes.createStructField("name", DataTypes.StringType, true)
+          });
+
+  @Test
+  public void testToBatch_returnsDeltaV2BatchWrite(@TempDir File tempDir) {
+    String path = createTable(tempDir, "write_to_batch");
+    DeltaV2Write write = newWrite(path, CaseInsensitiveStringMap.empty());
+
+    assertTrue(write.toBatch() instanceof DeltaV2BatchWrite);
+  }
+
+  private String createTable(File tempDir, String tableName) {
+    String path = tempDir.getAbsolutePath();
+    spark.sql(
+        String.format(
+            "CREATE TABLE %s (id INT, name STRING) USING delta LOCATION '%s'", tableName, path));
+    return path;
+  }
+
+  private DeltaV2Write newWrite(String path, CaseInsensitiveStringMap options) {
+    Snapshot snapshot =
+        new PathBasedSnapshotManager(path, spark.sessionState().newHadoopConf())
+            .loadLatestSnapshot();
+    LogicalWriteInfo info = WriteTestUtils.logicalWriteInfo(TABLE_SCHEMA, options);
+    return new DeltaV2Write(
+        defaultEngine, spark.sessionState().newHadoopConf(), path, snapshot, TABLE_SCHEMA, info);
+  }
+}

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/write/DeltaV2WriterCommitMessageTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/write/DeltaV2WriterCommitMessageTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.write;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.delta.kernel.Snapshot;
+import io.delta.kernel.data.Row;
+import io.delta.kernel.utils.CloseableIterable;
+import io.delta.kernel.utils.CloseableIterator;
+import io.delta.spark.internal.v2.DeltaV2TestBase;
+import io.delta.spark.internal.v2.InternalRowTestUtils;
+import io.delta.spark.internal.v2.snapshot.PathBasedSnapshotManager;
+import java.io.File;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.connector.write.DataWriter;
+import org.apache.spark.sql.connector.write.WriterCommitMessage;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/** Unit tests for {@link DeltaV2WriterCommitMessage}, focused on {@code toDataActions}. */
+public class DeltaV2WriterCommitMessageTest extends DeltaV2TestBase {
+
+  private static final StructType TABLE_SCHEMA =
+      DataTypes.createStructType(
+          new StructField[] {
+            DataTypes.createStructField("id", DataTypes.IntegerType, true),
+            DataTypes.createStructField("name", DataTypes.StringType, true)
+          });
+
+  @Test
+  public void testConstructor_nullActionRows_isEmpty() {
+    assertEquals(0, new DeltaV2WriterCommitMessage(null).getActionRows().size());
+  }
+
+  @Test
+  public void testToDataActions_noMessages_isEmpty() {
+    assertEquals(
+        0, countActions(DeltaV2WriterCommitMessage.toDataActions(new WriterCommitMessage[0])));
+  }
+
+  @Test
+  public void testToDataActions_ignoresNonDeltaMessages() {
+    WriterCommitMessage other = new WriterCommitMessage() {};
+    assertEquals(
+        0,
+        countActions(DeltaV2WriterCommitMessage.toDataActions(new WriterCommitMessage[] {other})));
+  }
+
+  @Test
+  public void testToDataActions_flattensActionsFromAllMessages(@TempDir File tempDir)
+      throws Exception {
+    String path = createTable(tempDir, "commit_msg_flatten");
+    DeltaV2DataWriterFactory factory = dataWriterFactory(path);
+
+    // Two tasks, one file (one AddFile action) each; toDataActions must combine both.
+    WriterCommitMessage m1 = writeFile(factory, 0, 1, "Alice");
+    WriterCommitMessage m2 = writeFile(factory, 1, 2, "Bob");
+
+    assertEquals(
+        2,
+        countActions(DeltaV2WriterCommitMessage.toDataActions(new WriterCommitMessage[] {m1, m2})));
+  }
+
+  @Test
+  public void testToDataActions_multipleRowsPerFile(@TempDir File tempDir) throws Exception {
+    String path = createTable(tempDir, "commit_msg_multi_row");
+    DeltaV2DataWriterFactory factory = dataWriterFactory(path);
+
+    // Multiple rows in one file still yield one AddFile action (actions are per-file, not per-row).
+    WriterCommitMessage m = writeFile(factory, 0, 1, "Alice", 2, "Bob", 3, "Carol");
+
+    assertEquals(
+        1, countActions(DeltaV2WriterCommitMessage.toDataActions(new WriterCommitMessage[] {m})));
+  }
+
+  private static int countActions(CloseableIterable<Row> actions) {
+    int n = 0;
+    CloseableIterator<Row> it = actions.iterator();
+    try {
+      while (it.hasNext()) {
+        it.next();
+        n++;
+      }
+    } finally {
+      try {
+        it.close();
+      } catch (Exception ignored) {
+        // Test cleanup best-effort.
+      }
+    }
+    return n;
+  }
+
+  private WriterCommitMessage writeFile(
+      DeltaV2DataWriterFactory factory, int partitionId, Object... idNamePairs) throws Exception {
+    DataWriter<InternalRow> writer = factory.createWriter(partitionId, 0L);
+    for (int i = 0; i < idNamePairs.length; i += 2) {
+      writer.write(InternalRowTestUtils.row(idNamePairs[i], idNamePairs[i + 1]));
+    }
+    return writer.commit();
+  }
+
+  private DeltaV2DataWriterFactory dataWriterFactory(String path) {
+    Snapshot snapshot =
+        new PathBasedSnapshotManager(path, spark.sessionState().newHadoopConf())
+            .loadLatestSnapshot();
+    DeltaV2Write write =
+        new DeltaV2Write(
+            defaultEngine,
+            spark.sessionState().newHadoopConf(),
+            path,
+            snapshot,
+            TABLE_SCHEMA,
+            WriteTestUtils.logicalWriteInfo(TABLE_SCHEMA, CaseInsensitiveStringMap.empty()));
+    return (DeltaV2DataWriterFactory)
+        write.toBatch().createBatchWriterFactory(WriteTestUtils.physicalWriteInfo(1));
+  }
+
+  private String createTable(File tempDir, String tableName) {
+    String path = tempDir.getAbsolutePath();
+    spark.sql(
+        String.format(
+            "CREATE TABLE %s (id INT, name STRING) USING delta LOCATION '%s'", tableName, path));
+    return path;
+  }
+}

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/write/WriteTestUtils.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/write/WriteTestUtils.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.write;
+
+import org.apache.spark.sql.connector.write.LogicalWriteInfo;
+import org.apache.spark.sql.connector.write.PhysicalWriteInfo;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+
+/** Shared helpers for the write-side unit tests. */
+final class WriteTestUtils {
+
+  private WriteTestUtils() {}
+
+  /**
+   * Builds a {@link LogicalWriteInfo}. Spark's {@code LogicalWriteInfoImpl} is {@code private[sql]}
+   * and not reachable from this package, so we implement the interface directly.
+   */
+  static LogicalWriteInfo logicalWriteInfo(StructType schema, CaseInsensitiveStringMap options) {
+    return new LogicalWriteInfo() {
+      @Override
+      public String queryId() {
+        return "test-query-id";
+      }
+
+      @Override
+      public StructType schema() {
+        return schema;
+      }
+
+      @Override
+      public CaseInsensitiveStringMap options() {
+        return options;
+      }
+    };
+  }
+
+  static PhysicalWriteInfo physicalWriteInfo(int numPartitions) {
+    return () -> numPartitions;
+  }
+}


### PR DESCRIPTION
## Description

This PR implements the write path for the Spark DataSource V2 (DSv2) connector.

It introduces a `DeltaV2Write` implementation of Spark's `Write` interface that produces a `BatchWrite` via `toBatch()`, wiring together the engine, table snapshot, data schema, and `LogicalWriteInfo` needed to construct per-partition data writer factories. Supporting changes:

- `DeltaV2Write`: new `Write` implementation that builds the batch write and its data writer factory from the initial snapshot and logical write info.
- `DeltaV2BatchWrite`: refactored to accept a data-writer-factory builder, simplifying construction and commit handling.
- `DeltaV2WriterCommitMessage`: new `WriterCommitMessage` carrying the committed actions back to the driver.
- `DeltaV2WriteBuilder` / `DeltaV2Table`: updated to route through the new `DeltaV2Write`.

## How was this patch tested?

New unit tests are included:
- `DeltaV2WriteTest`
- `DeltaV2BatchWriteTest`
- `DeltaV2WriterCommitMessageTest`
- `WriteTestUtils` (shared test helpers)

## Does this PR introduce _any_ user-facing changes?

No.
