### PR TITLE
Build per-file Iceberg-to-Delta stats with a mutable map to reduce allocation overhead

### DIFF
--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/IcebergStatsUtils.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/IcebergStatsUtils.scala
@@ -21,6 +21,7 @@ import java.nio.ByteBuffer
 import java.util.{Map => JMap}
 
 import scala.collection.JavaConverters._
+import scala.collection.mutable
 import scala.util.control.NonFatal
 
 import org.apache.spark.sql.delta.metering.DeltaLogging
@@ -228,24 +229,35 @@ object IcebergStatsUtils extends DeltaLogging {
         fields: java.util.List[NestedField],
         valueMap: Map[JInt, Any],
         deserializer: (IcebergType, Any) => Any,
-        statsAllowTypes: Set[TypeID]): Map[String, Any] = {
-      fields.asScala.flatMap { field =>
+        statsAllowTypes: Set[TypeID]): mutable.Map[String, Any] = {
+      // Accumulate into a mutable map and iterate the Java field list directly (no
+      // JavaConverters wrapping). This avoids the immutable HAMT node reallocation
+      // (BitmapIndexedMapNode) that a per-column insert into a Scala immutable Map incurs,
+      // and the per-call JListWrapper allocation from fields.asScala.
+      val stats = mutable.LinkedHashMap.empty[String, Any]
+      val it = fields.iterator()
+      while (it.hasNext) {
+        val field = it.next()
         field.`type`() match {
           case st: IcebergStructType =>
-            Some(field.name ->
-              collectStats(st.fields, valueMap, deserializer, statsAllowTypes))
+            stats += field.name ->
+              collectStats(st.fields, valueMap, deserializer, statsAllowTypes)
           case pt: IcebergPrimitiveType
             if valueMap.contains(field.fieldId) && statsAllowTypes.contains(pt.typeId) =>
-            Option(deserializer(pt, valueMap(field.fieldId))).map(field.name -> _)
+            val value = deserializer(pt, valueMap(field.fieldId))
+            if (value != null) stats += field.name -> value
           case pt: IcebergListType
             if valueMap.contains(field.fieldId) && statsAllowTypes.contains(pt.typeId) =>
-            Option(deserializer(pt, valueMap(field.fieldId))).map(field.name -> _)
+            val value = deserializer(pt, valueMap(field.fieldId))
+            if (value != null) stats += field.name -> value
           case pt: IcebergMapType
             if valueMap.contains(field.fieldId) && statsAllowTypes.contains(pt.typeId) =>
-            Option(deserializer(pt, valueMap(field.fieldId))).map(field.name -> _)
-          case _ => None
+            val value = deserializer(pt, valueMap(field.fieldId))
+            if (value != null) stats += field.name -> value
+          case _ => // Not a stats-bearing field: skip.
         }
-      }.toMap
+      }
+      stats
     }
 
     JsonUtils.toJson(


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [ ] Spark
- [x] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Refactors `IcebergStatsUtils.collectStats` to accumulate per-column statistics into a mutable `LinkedHashMap` and iterate the Iceberg `NestedField` list directly, instead of building an immutable `Map` via `fields.asScala.flatMap { ... }.toMap`.

The previous approach allocated an intermediate `JListWrapper` for each `fields.asScala` call and reallocated immutable HAMT nodes (`BitmapIndexedMapNode`) on every per-column insert. For files with many columns this added avoidable GC and CPU pressure on the stats-conversion path. Iterating the Java list directly and inserting into a single mutable map avoids both, while preserving iteration order and identical output.

No behavior change: the set of emitted column statistics and their values are unchanged.

## How was this patch tested?

Existing `IcebergStatsUtils` unit tests continue to pass. The change is a pure refactor of the stats-collection helper with no change to emitted values.

## Does this PR introduce _any_ user-facing changes?

No.