### PR TITLE
[Spark] Render table_changes timestamp args in the session time zone

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTableValueFunctions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTableValueFunctions.scala
@@ -32,9 +32,11 @@ import org.apache.spark.sql.catalyst.FunctionIdentifier
 import org.apache.spark.sql.catalyst.analysis.{FunctionRegistryBase, NamedRelation, TableFunctionRegistry, UnresolvedLeafNode, UnresolvedRelation}
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, ExpressionInfo, Literal, StringLiteral}
 import org.apache.spark.sql.catalyst.plans.logical.{LeafNode, LogicalPlan, UnaryNode}
+import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.connector.catalog.V1Table
 import org.apache.spark.sql.execution.datasources.LogicalRelation
 import org.apache.spark.sql.execution.datasources.v2.{DataSourceV2Relation, DataSourceV2RelationShim}
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{IntegerType, LongType, StringType, TimestampType}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
@@ -127,6 +129,10 @@ trait CDCStatementBase extends DeltaTableValueFunction {
         case _: StringType => (keyPrefix + "Timestamp") -> evaluated
         case _: TimestampType => (keyPrefix + "Timestamp") -> {
           val fmt = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS")
+          // The formatted string carries no zone, and it is re-parsed in the session time zone
+          // (see DeltaTimeTravelSpec.getTimestamp). Format in the session time zone as well so the
+          // rendered wall-clock refers to the same instant on both sides.
+          fmt.setTimeZone(DateTimeUtils.getTimeZone(SQLConf.get.sessionLocalTimeZone))
           // when evaluated the time is represented with microseconds, which needs to be trimmed.
           fmt.format(new Date(evaluated.toLong / 1000))
         }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCDCSQLSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCDCSQLSuite.scala
@@ -28,6 +28,7 @@ import org.apache.spark.sql.{AnalysisException, DataFrame}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.util.DateTimeTestUtils._
 import org.apache.spark.sql.functions._
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.LongType
 
 class DeltaCDCSQLSuite extends DeltaCDCSuiteBase with DeltaColumnMappingTestUtils {
@@ -371,6 +372,47 @@ class DeltaCDCSQLSuite extends DeltaCDCSuiteBase with DeltaColumnMappingTestUtil
             .withColumn("_change_type", lit("insert"))
             .withColumn("_commit_version", (col("id") / 10).cast(LongType))
         )
+      }
+    }
+  }
+
+  test("timestamp arguments use the session time zone, not the JVM default") {
+    // The starting/ending TimestampType arguments of table_changes are rendered to the CDC
+    // timestamp option and re-parsed in the session time zone. Rendering them in a different
+    // (JVM default) time zone would shift the CDC window by the zone offset. Pin the session
+    // time zone to UTC and run under a different JVM default zone to guard against that.
+    val hour = 60L * 60L * 1000L
+    val day = 24L * hour
+    Seq(UTC, LA).foreach { jvmZone =>
+      withDefaultTimeZone(jvmZone) {
+        withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> "UTC") {
+          withTable("tbl") {
+            createTblWithThreeVersions(tblName = Some("tbl"))
+            val deltaLog = DeltaLog.forTable(spark, TableIdentifier("tbl"))
+
+            // Keep the commits within the deleted-file retention window (7 days).
+            val base = System.currentTimeMillis() - 5 * day
+            modifyCommitTimestamp(deltaLog, 0, base)
+            modifyCommitTimestamp(deltaLog, 1, base + day)
+            modifyCommitTimestamp(deltaLog, 2, base + 2 * day)
+            DeltaLog.clearCache()
+
+            // Start at version 0's commit and end just after version 1, so the window is
+            // versions 0 and 1. A boundary rendered in the JVM zone instead of the session
+            // zone would be off by hours and select the wrong versions.
+            val startMillis = base
+            val endMillis = base + day + hour
+            val readDf = sql(
+              s"SELECT * FROM table_changes('tbl', timestamp_millis($startMillis), " +
+                s"timestamp_millis($endMillis))")
+            checkCDCAnswer(
+              DeltaLog.forTable(spark, TableIdentifier("tbl")),
+              readDf,
+              spark.range(20)
+                .withColumn("_change_type", lit("insert"))
+                .withColumn("_commit_version", (col("id") / 10).cast(LongType)))
+          }
+        }
       }
     }
   }


### PR DESCRIPTION

#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)


The CDF table-valued function `table_changes(tbl, <start>, <end>)` handles a
`TimestampType` boundary argument in a way that is not time-zone symmetric
between how the boundary is written and how it is later read.

On the write side, `CDCStatementBase` (in `DeltaTableValueFunctions.scala`)
evaluates a `TimestampType` argument to epoch microseconds and renders it into
the CDC `startingTimestamp` / `endingTimestamp` option string with a
`SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS")` that has no time zone set:

```scala
case _: TimestampType => (keyPrefix + "Timestamp") -> {
  val fmt = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS")
  // when evaluated the time is represented with microseconds, which needs to be trimmed.
  fmt.format(new Date(evaluated.toLong / 1000))
}
```

A `SimpleDateFormat` with no `setTimeZone` formats in the JVM default time zone,
and the pattern carries no offset, so the produced string is a bare wall-clock in
the JVM default zone.

That option string is then re-parsed in the Spark **session** time zone:
`CDCReader` builds a `DeltaTimeTravelSpec` from the option and resolves it via
`DeltaTimeTravelSpec.getTimestamp`, which casts with
`Option(conf.sessionLocalTimeZone)`.

So the write side uses `TimeZone.getDefault()` and the read side uses
`spark.sql.session.timeZone`. When those two differ (common in production, e.g.
the session pinned to UTC while the JVM runs in a local zone, or vice versa), the
CDC starting/ending boundary is shifted by the zone-offset difference, and
`table_changes` silently returns the wrong window of change rows (missing or
extra rows). The result is wrong but no error is raised.

This is the only timestamp path in this area that does not thread the session
zone. Every other Delta timestamp path already does (for example
`DeltaTimeTravelSpec.parseTimestamp`, `DelayedCommitProtocol`, and
`DeltaHistoryManager`). The fix sets the formatter's time zone to the session
time zone so the rendered wall-clock refers to the same instant on both the write
and read sides:

```scala
val fmt = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS")
fmt.setTimeZone(DateTimeUtils.getTimeZone(SQLConf.get.sessionLocalTimeZone))
```

`SQLConf.get` is the thread-local active conf, i.e. the same session conf the read
side later resolves against. The `StringType` boundary path is unaffected: that
raw string passes through untouched and is already parsed once in the session
zone.

## How was this patch tested?

Added a regression test in `DeltaCDCSQLSuite`,
`"timestamp arguments use the session time zone, not the JVM default"`. It pins
`spark.sql.session.timeZone` to UTC, runs under two different JVM default zones
(`UTC` and `America/Los_Angeles`), and reads `table_changes` with genuine
`TimestampType` boundaries built via `timestamp_millis(...)` (so it exercises the
`TimestampType` branch specifically rather than the string path). It asserts the
returned change rows are exactly versions 0 and 1. Before the fix, under the
`America/Los_Angeles` JVM zone the boundary shifts by the offset and the test
fails (the window collapses to a single version); after the fix it passes under
both zones.

Run with JDK 21:

```
build/sbt "spark/testOnly org.apache.spark.sql.delta.DeltaCDCSQLSuite"
build/sbt "spark/testOnly org.apache.spark.sql.delta.DeltaCDCScalaSuite"
```

- `DeltaCDCSQLSuite`: 57 succeeded, 0 failed (includes the new test).
- `DeltaCDCScalaSuite`: 55 succeeded, 0 failed (covers the shared `getOptions`
  path including the String and Version branches).
- `spark/scalastyle` and `spark/test:scalastyle`: 0 errors.

## Does this PR introduce _any_ user-facing changes?

Yes, a behavior fix, only when the JVM default time zone differs from
`spark.sql.session.timeZone`. Previously a `TimestampType` boundary passed to
`table_changes` was interpreted in the JVM default zone on the write side but in
the session zone on the read side, so the selected change-data window was off by
the zone offset. After this change the boundary is interpreted consistently in
the session time zone, which matches how `StringType` boundaries and Delta SQL
time-travel already behave. Queries whose JVM zone and session zone are the same
are unaffected. This is a change relative to released Delta Lake versions for the
misconfigured-zone case; the previous behavior returned an incorrect window, so
it is unlikely anything correct depended on it.
