### PR TITLE
[Kernel] Fix NullPointerException in FieldMetadata.hashCode()

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/FieldMetadata.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/FieldMetadata.java
@@ -187,11 +187,18 @@ public final class FieldMetadata {
   public int hashCode() {
     return metadata.entrySet().stream()
         .mapToInt(
-            entry ->
-                (entry.getValue().getClass().isArray()
-                    ? (entry.getKey() == null ? 0 : entry.getKey().hashCode())
-                        ^ Arrays.hashCode((Object[]) entry.getValue())
-                    : entry.hashCode()))
+            entry -> {
+              Object value = entry.getValue();
+              int valueHash;
+              if (value == null) {
+                valueHash = 0;
+              } else if (value.getClass().isArray()) {
+                valueHash = Arrays.deepHashCode((Object[]) value);
+              } else {
+                valueHash = value.hashCode();
+              }
+              return Objects.hashCode(entry.getKey()) ^ valueHash;
+            })
         .sum();
   }
 

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/types/FieldMetadataSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/types/FieldMetadataSuite.scala
@@ -466,4 +466,41 @@ class FieldMetadataSuite extends AnyFunSuite {
     assertThat(meta.equals(null)).isFalse
     assertThat(meta.equals("not-metadata")).isFalse
   }
+
+  test("hashCode handles entries with null value") {
+    val meta1 = FieldMetadata.builder()
+      .putNull("nullKey")
+      .putString("same", "x")
+      .build()
+    val meta2 = FieldMetadata.builder()
+      .putNull("nullKey")
+      .putString("same", "x")
+      .build()
+
+    // Computing the hash of metadata with a null value must not throw.
+    val hash1 = meta1.hashCode()
+    val hash2 = meta2.hashCode()
+
+    // equal instances must have equal hash codes (equals/hashCode contract).
+    assertThat(meta1.equals(meta2)).isTrue
+    assertThat(hash1).isEqualTo(hash2)
+  }
+
+  test("hashCode is consistent with equals for arrays") {
+    val strings: Seq[java.lang.String] = Seq("x", "y", "z")
+    val inner1 = FieldMetadata.builder().putBoolean("k", true).build()
+    val inner2 = FieldMetadata.builder().putBoolean("k", true).build()
+
+    val meta1 = FieldMetadata.builder()
+      .putStringArray("stringArrayKey", strings.toArray)
+      .putFieldMetadataArray("fieldMetadataArrayKey", Array(inner1))
+      .build()
+    val meta2 = FieldMetadata.builder()
+      .putStringArray("stringArrayKey", strings.toArray)
+      .putFieldMetadataArray("fieldMetadataArrayKey", Array(inner2))
+      .build()
+
+    assertThat(meta1.equals(meta2)).isTrue
+    assertThat(meta1.hashCode()).isEqualTo(meta2.hashCode())
+  }
 }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)


`FieldMetadata.hashCode()` computed `entry.getValue().getClass().isArray()` without first checking whether the value is null. Because null values are a supported, first-class scenario, hashing a `FieldMetadata` that carries one threw a `NullPointerException`.

Null values are reachable through public API and the schema-parsing path:

- `FieldMetadata.Builder.putNull(String)` puts a null value into the map.
- `DataTypeJsonSerDe` calls `builder.putNull(key)` when deserializing a JSON-null metadata value, so a table whose schema metadata contains a JSON null produces such a `FieldMetadata`.

The crash also propagates through `StructField.hashCode()`, which delegates to `FieldMetadata.hashCode()` via `Objects.hash(..., metadata, ...)`. So hashing any `StructField` whose metadata carries a null value (for example inserting fields into a `HashSet`, using a schema as a map key, or diffing column sets) throws.

The null fixes for `equals()` (#5887) and `toString()` (#5439) were never applied to `hashCode()`. This change guards the value before calling `getClass()`, mirroring the null handling already used in `toString()` in the same file. A null value now contributes `0` to the hash. It also switches the array branch from `Arrays.hashCode` to `Arrays.deepHashCode` so array (and nested `FieldMetadata[]`) values stay consistent with `equals()`, which compares via `Objects.deepEquals`; without this the `equals`/`hashCode` contract could be violated for nested arrays.

The change is confined to the `hashCode()` body. There is no API change and no new import (`java.util.Objects` and `java.util.Arrays` are already imported).

Reproducer (throws on `master`, passes with this change):

```java
FieldMetadata metadata = FieldMetadata.builder()
    .putNull("nullKey")
    .putString("k", "v")
    .build();
metadata.hashCode(); // NullPointerException before this fix
```

Resolves #5821

## How was this patch tested?

Added two regression tests to `FieldMetadataSuite`:

- `hashCode handles entries with null value` asserts that hashing metadata with a null value does not throw and that two equal instances hash equal (the `equals`/`hashCode` contract). This is the red -> green guard: on `master` it fails with an NPE at `FieldMetadata.hashCode()`; with the fix it passes.
- `hashCode is consistent with equals for arrays` covers the `Arrays.deepHashCode` change, including nested `FieldMetadata[]` values.

Ran locally:

```
build/sbt "kernelApi/testOnly *FieldMetadataSuite*"   # 25 tests, all pass
build/sbt kernelApi/javafmtCheckAll                   # passes
```

## Does this PR introduce _any_ user-facing changes?

No. This fixes a crash (`NullPointerException`) in `FieldMetadata.hashCode()`; there is no behavior change for inputs that previously worked.
