### PR TITLE
[Kernel] Fix newline check in column-mapping schema validation

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaUtils.java
@@ -93,7 +93,7 @@ public class SchemaUtils {
       // when column mapping is enabled, just check the name contains no new line in it.
       flattenColNames.forEach(
           name -> {
-            if (name.contains("\\n")) {
+            if (name.contains("\n")) {
               throw invalidColumnName(name, "\\n");
             }
           });

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/SchemaUtilsSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/SchemaUtilsSuite.scala
@@ -358,12 +358,22 @@ class SchemaUtilsSuite extends AnyFunSuite {
         }
 
         if (char != '\n') {
-          // with column mapping disabled this should be a valid name
+          // with column mapping enabled only a new line is rejected, so this is a valid name
           validateSchema(
             schema,
             isColumnMappingEnabled = true,
             isColumnDefaultEnabled = false,
             isIcebergCompatV3Enabled = false)
+        } else {
+          // with column mapping enabled a new line in the name must still be rejected
+          val cmError = intercept[KernelException] {
+            validateSchema(
+              schema,
+              isColumnMappingEnabled = true,
+              isColumnDefaultEnabled = false,
+              isIcebergCompatV3Enabled = false)
+          }
+          assert(cmError.getMessage.contains("contains one of the unsupported"))
         }
 
         assert(e.getMessage.contains("contains one of the unsupported"))


### PR DESCRIPTION

#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)


When column mapping is enabled, `SchemaUtils.validateSchema` is meant to reject
column names that contain a newline (see the comment "just check the name
contains no new line in it").

The check was `name.contains("\\n")`. In Java the string literal `"\\n"` is the
two characters backslash and `n`, and `String.contains` does a literal substring
match, not a regex match. So the guard only fired when a column name literally
contained the two-character text `\n`, and it never fired on an actual newline
character. Two consequences under column mapping:

- a logical column name containing a real newline was silently accepted into the
  schema, and
- a benign name that happened to contain the substring `\n` was wrongly rejected.

This is inconsistent with the non-column-mapping path in the same method,
`validParquetColumnNames`, whose regex `".*[ ,;{}()\n\t=].*"` uses a real newline
(and so correctly matches one), and with the Delta Spark `SchemaUtils` reference,
whose `badChars` list includes a real `'\n'`.

The fix changes the check to `name.contains("\n")` so it matches a real newline.
The error-message argument is intentionally kept as the readable `"\\n"` to match
the sibling `validParquetColumnNames` call site (passing a real newline would embed
an invisible control character in the user-facing error text).

## How was this patch tested?

Extended the existing `SchemaUtilsSuite` test "check non alphanumeric column
characters". That test iterates over bad characters (which already include `\n`)
and previously asserted, for every non-newline bad character, that the name is
accepted with column mapping enabled. It now also asserts the newline case: with
column mapping enabled, a name containing a real newline is rejected with a
`KernelException` whose message contains "contains one of the unsupported".

Verified red -> green: with only the source change reverted, the extended test
fails (a real newline slips through under column mapping, so no exception is
thrown); with the fix applied, the full suite passes (59 tests).

Run locally with JDK 21:

```
build/sbt "kernelApi/testOnly *SchemaUtilsSuite*"
```

`kernelApi/javafmtCheckAll` and `kernelApi/scalafmtCheckAll` also pass.

## Does this PR introduce _any_ user-facing changes?

Yes, a validation correctness change on the table create/write path when column
mapping is enabled:

- Before: a column name containing a real newline was accepted; a column name
  containing the literal two-character substring `\n` was rejected.
- After: a column name containing a real newline is rejected (as intended); a
  column name containing the literal substring `\n` is now accepted.

This aligns Kernel's column-mapping validation with its own non-column-mapping
path and with Delta Spark.
