### PR TITLE
[Flink] Add RoaringBitmap dependency to Flink

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1685,6 +1685,11 @@ lazy val flink = (project in file("flink"))
       "com.github.ben-manes.caffeine" % "caffeine" % "3.1.8",
       "org.apache.hadoop" % "hadoop-aws" % hadoopVersion,
       "com.google.cloud.bigdataoss" % "gcs-connector" % gcsConnectorVersion % Provided classifier "shaded",
+      // kernel-api uses RoaringBitmap but ships as a shaded fat-jar that excludes it, and the
+      // unmanagedJars trick used above does not propagate kernel-api's managed deps. Declare it
+      // here too -- pinned to the same version kernel-api uses -- so our DV code under
+      // io.delta.flink.kernel.dv compiles against the same library on the classpath.
+      "org.roaringbitmap" % "RoaringBitmap" % "0.9.25",
 
       // Test dependencies
       "org.junit.jupiter" % "junit-jupiter-api" % "5.11.4" % "test",


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [x] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Adds `org.roaringbitmap:RoaringBitmap` as an explicit dependency of the Flink project.

The Flink connector's deletion-vector code (`io.delta.flink.kernel.dv`) compiles against RoaringBitmap through `kernel-api`. However, `kernel-api` is consumed as a shaded fat-jar that excludes RoaringBitmap, and the `unmanagedJars` approach used to pull `kernel-api` in does not propagate its managed transitive dependencies. As a result RoaringBitmap is not on the Flink project's classpath.

This PR declares `RoaringBitmap` directly on the Flink project, pinned to `0.9.25` (the same version `kernel-api` uses), so the DV code compiles and runs against the same library.

## How was this patch tested?

Build-only change (adds a compile/runtime dependency). Verified that the Flink project resolves and compiles the DV code under `io.delta.flink.kernel.dv` with RoaringBitmap on the classpath; existing Flink build and tests continue to pass.

## Does this PR introduce _any_ user-facing changes?

No. This only adds an internal build dependency to the Flink connector; no public API or behavior changes.
