### PR TITLE
[Release] Set version to 4.3.2-SNAPSHOT

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "4.3.1"
+ThisBuild / version := "4.3.2-SNAPSHOT"


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/7146/files) to review incremental changes.
- [stack/release_431_snapshot](https://github.com/delta-io/delta/pull/7146) [[Files changed](https://github.com/delta-io/delta/pull/7146/files)]

---------
## Summary

Returns `branch-4.3` to snapshot development mode after the **4.3.1** release:

- **Set version to `4.3.2-SNAPSHOT`** in `version.sbt` (was `4.3.1`)

## Release workflow

Merge this PR **after** [#7145](https://github.com/delta-io/delta/pull/7145) has been merged and `4.3.1` has been tagged and published. This keeps the release branch building snapshot artifacts between release windows.

## 🥞 Stacked PR

- [stack/release_431_version](https://github.com/delta-io/delta/pull/7145) — set release version `4.3.1`
  - [**stack/release_431_snapshot**](https://github.com/delta-io/delta/pull/7146) ← _this PR_