### PR TITLE
[Kernel][Defaults] Reuse the already-read Parquet footer in the reader

### DIFF
--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetFileReader.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetFileReader.java
@@ -33,10 +33,10 @@ import io.delta.kernel.utils.FileStatus;
 import java.io.IOException;
 import java.util.*;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.ParquetReadOptions;
 import org.apache.parquet.filter2.compat.FilterCompat;
 import org.apache.parquet.filter2.predicate.FilterPredicate;
 import org.apache.parquet.format.converter.ParquetMetadataConverter;
-import org.apache.parquet.hadoop.ParquetReader;
 import org.apache.parquet.hadoop.api.InitContext;
 import org.apache.parquet.hadoop.api.ReadSupport;
 import org.apache.parquet.hadoop.metadata.ParquetMetadata;
@@ -71,7 +71,7 @@ public class ParquetFileReader {
 
     return new CloseableIterator<ColumnarBatch>() {
       private final BatchReadSupport readSupport = new BatchReadSupport(maxBatchSize, schema);
-      private ParquetReader<Object> reader;
+      private ParquetRecordReaderWrapper<Object> reader;
       private boolean hasNotConsumedNextElement;
 
       @Override
@@ -87,8 +87,7 @@ public class ParquetFileReader {
             return true;
           }
 
-          Object next = reader.read();
-          hasNotConsumedNextElement = next != null;
+          hasNotConsumedNextElement = reader.nextKeyValue() && reader.getCurrentValue() != null;
           return hasNotConsumedNextElement;
         } catch (IOException ex) {
           throw new KernelEngineException(
@@ -134,16 +133,8 @@ public class ParquetFileReader {
             Optional<FilterPredicate> parquetPredicate =
                 predicate.flatMap(predicate -> toParquetFilter(parquetSchema, predicate));
 
-            // TODO: We can avoid reading the footer again if we can pass the footer, but there is
-            // no API to do that in the current version of parquet-mr which takes InputFile
-            // as input.
-            reader =
-                new ParquetReader.Builder<Object>(parquetInputFile) {
-                  @Override
-                  protected ReadSupport<Object> getReadSupport() {
-                    return readSupport;
-                  }
-                }.withFilter(parquetPredicate.map(FilterCompat::get).orElse(FilterCompat.NOOP))
+            ParquetReadOptions readOptions =
+                ParquetReadOptions.builder()
                     // Disable the record level filtering as the `parquet-mr` evaluates
                     // the filter once the entire record has been materialized. Instead,
                     // we use the predicate to prune the row groups which is more efficient.
@@ -154,8 +145,16 @@ public class ParquetFileReader {
                     .useBloomFilter(false)
                     .useDictionaryFilter(false)
                     .useColumnIndexFilter(false)
+                    .withRecordFilter(
+                        parquetPredicate.map(FilterCompat::get).orElse(FilterCompat.NOOP))
                     .build();
 
+            // Pass the already read footer to the reader to avoid reading it again.
+            fileReader =
+                org.apache.parquet.hadoop.ParquetFileReader.open(
+                    parquetInputFile, footer, readOptions, parquetInputFile.newStream());
+            reader = new ParquetRecordReaderWrapper<>(readSupport);
+            reader.initialize(fileReader, readOptions);
           } catch (IOException e) {
             Utils.closeCloseablesSilently(fileReader, reader);
             throw new KernelEngineException(

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetRecordReaderWrapper.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetRecordReaderWrapper.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.defaults.internal.parquet;
+
+import static java.util.Objects.requireNonNull;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import org.apache.parquet.ParquetReadOptions;
+import org.apache.parquet.hadoop.ParquetFileReader;
+import org.apache.parquet.hadoop.api.ReadSupport;
+
+/**
+ * Thin wrapper that exposes {@code parquet-mr}'s package-private {@code
+ * InternalParquetRecordReader} to Kernel, delegating each call to the underlying reader via
+ * reflection.
+ *
+ * <p>Kernel drives the low-level {@link ParquetFileReader} directly (rather than the high-level
+ * {@link org.apache.parquet.hadoop.ParquetReader}) so that it can reuse the {@link
+ * org.apache.parquet.hadoop.metadata.ParquetMetadata footer} it already read to build the row-group
+ * filter, instead of having the reader read (and parse) the footer a second time. The class that
+ * materializes rows from such a reader — {@code InternalParquetRecordReader} — is package-private,
+ * so this wrapper reaches it reflectively.
+ *
+ * <p>An earlier version of this wrapper (delta-io/delta#4429) instead <em>subclassed</em> {@code
+ * InternalParquetRecordReader} from a source file declared in package {@code
+ * org.apache.parquet.hadoop}. That was removed because it caused {@link IllegalAccessError}s when
+ * {@code parquet-mr} and Kernel are loaded by different class loaders: the JVM's package-private
+ * access check requires the same runtime package (same package name <em>and</em> same class
+ * loader), which does not hold across class loaders. Reflection with {@link
+ * java.lang.reflect.AccessibleObject#setAccessible(boolean) setAccessible(true)} disables that
+ * access check, so it works regardless of the class-loader topology.
+ *
+ * <p>Every member accessed here is {@code public} on {@code InternalParquetRecordReader}; only the
+ * class itself is package-private.
+ */
+class ParquetRecordReaderWrapper<T> implements Closeable {
+
+  private static final String INTERNAL_READER_CLASS =
+      "org.apache.parquet.hadoop.InternalParquetRecordReader";
+
+  // Reflection handles for InternalParquetRecordReader, resolved once and made accessible. They are
+  // stateless and safe to share; the reader instances they operate on are not.
+  private static final Constructor<?> CONSTRUCTOR;
+  private static final Method INITIALIZE;
+  private static final Method NEXT_KEY_VALUE;
+  private static final Method GET_CURRENT_VALUE;
+  private static final Method GET_CURRENT_ROW_INDEX;
+  private static final Method CLOSE;
+
+  static {
+    try {
+      Class<?> cls = Class.forName(INTERNAL_READER_CLASS);
+      CONSTRUCTOR = cls.getConstructor(ReadSupport.class);
+      INITIALIZE = cls.getMethod("initialize", ParquetFileReader.class, ParquetReadOptions.class);
+      NEXT_KEY_VALUE = cls.getMethod("nextKeyValue");
+      GET_CURRENT_VALUE = cls.getMethod("getCurrentValue");
+      GET_CURRENT_ROW_INDEX = cls.getMethod("getCurrentRowIndex");
+      CLOSE = cls.getMethod("close");
+      // The class is package-private, so its public members are only reachable after this.
+      CONSTRUCTOR.setAccessible(true);
+      INITIALIZE.setAccessible(true);
+      NEXT_KEY_VALUE.setAccessible(true);
+      GET_CURRENT_VALUE.setAccessible(true);
+      GET_CURRENT_ROW_INDEX.setAccessible(true);
+      CLOSE.setAccessible(true);
+    } catch (ReflectiveOperationException e) {
+      throw new ExceptionInInitializerError(
+          new IOException(
+              "Failed to set up "
+                  + INTERNAL_READER_CLASS
+                  + ". This is likely due to an incompatible version of parquet-hadoop on the"
+                  + " classpath.",
+              e));
+    }
+  }
+
+  // Thrown for an IllegalAccessException at a call site: it is effectively impossible after the
+  // static block's setAccessible(true) calls succeeded, so it signals a broken JVM/parquet
+  // environment rather than a recoverable I/O error.
+  private static final String ACCESS_BUG_MESSAGE =
+      "Unexpected reflective access failure on " + INTERNAL_READER_CLASS + " after setAccessible";
+
+  private final Object internalReader;
+
+  ParquetRecordReaderWrapper(ReadSupport<T> readSupport) throws IOException {
+    requireNonNull(readSupport, "readSupport is null");
+    try {
+      this.internalReader = CONSTRUCTOR.newInstance(readSupport);
+    } catch (InvocationTargetException e) {
+      throw rethrow(e);
+    } catch (InstantiationException | IllegalAccessException e) {
+      throw new IllegalStateException(ACCESS_BUG_MESSAGE, e);
+    }
+  }
+
+  /**
+   * Delegates to {@code InternalParquetRecordReader.initialize(ParquetFileReader,
+   * ParquetReadOptions)}.
+   */
+  void initialize(ParquetFileReader fileReader, ParquetReadOptions options) {
+    try {
+      INITIALIZE.invoke(internalReader, fileReader, options);
+    } catch (InvocationTargetException e) {
+      throw rethrowUnchecked(e);
+    } catch (IllegalAccessException e) {
+      throw new IllegalStateException(ACCESS_BUG_MESSAGE, e);
+    }
+  }
+
+  /** Delegates to {@code InternalParquetRecordReader.nextKeyValue()}. */
+  boolean nextKeyValue() throws IOException {
+    try {
+      return (Boolean) NEXT_KEY_VALUE.invoke(internalReader);
+    } catch (InvocationTargetException e) {
+      throw rethrow(e);
+    } catch (IllegalAccessException e) {
+      throw new IllegalStateException(ACCESS_BUG_MESSAGE, e);
+    }
+  }
+
+  /** Delegates to {@code InternalParquetRecordReader.getCurrentValue()}. */
+  @SuppressWarnings("unchecked")
+  T getCurrentValue() throws IOException {
+    try {
+      return (T) GET_CURRENT_VALUE.invoke(internalReader);
+    } catch (InvocationTargetException e) {
+      throw rethrow(e);
+    } catch (IllegalAccessException e) {
+      throw new IllegalStateException(ACCESS_BUG_MESSAGE, e);
+    }
+  }
+
+  /** Delegates to {@code InternalParquetRecordReader.getCurrentRowIndex()}. */
+  long getCurrentRowIndex() {
+    // Unlike the other methods, the underlying getCurrentRowIndex() declares no checked exception,
+    // so this wrapper does not declare `throws IOException` either.
+    try {
+      return (Long) GET_CURRENT_ROW_INDEX.invoke(internalReader);
+    } catch (InvocationTargetException e) {
+      throw rethrowUnchecked(e);
+    } catch (IllegalAccessException e) {
+      throw new IllegalStateException(ACCESS_BUG_MESSAGE, e);
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    try {
+      CLOSE.invoke(internalReader);
+    } catch (InvocationTargetException e) {
+      throw rethrow(e);
+    } catch (IllegalAccessException e) {
+      throw new IllegalStateException(ACCESS_BUG_MESSAGE, e);
+    }
+  }
+
+  /**
+   * Rethrows the real cause of a reflective call, preserving its type. {@link Error}s and {@link
+   * RuntimeException}s (e.g. {@code ParquetDecodingException}) are rethrown as-is so callers see
+   * the same exceptions they would from a direct call. An {@link IOException} cause is returned for
+   * the caller to throw. Any other (checked) cause is wrapped in an {@link IOException}, which
+   * mirrors {@link org.apache.parquet.hadoop.ParquetReader} that Kernel used previously.
+   */
+  private static IOException rethrow(InvocationTargetException e) {
+    Throwable cause = e.getCause();
+    if (cause instanceof Error) {
+      throw (Error) cause;
+    }
+    if (cause instanceof RuntimeException) {
+      throw (RuntimeException) cause;
+    }
+    if (cause instanceof IOException) {
+      return (IOException) cause;
+    }
+    return new IOException(cause);
+  }
+
+  /**
+   * Variant of {@link #rethrow} for methods that do not declare {@code throws IOException}. The
+   * underlying method declares no checked exception, so a checked cause would itself be a bug; wrap
+   * it in an unchecked exception.
+   */
+  private static RuntimeException rethrowUnchecked(InvocationTargetException e) {
+    Throwable cause = e.getCause();
+    if (cause instanceof Error) {
+      throw (Error) cause;
+    }
+    if (cause instanceof RuntimeException) {
+      throw (RuntimeException) cause;
+    }
+    return new RuntimeException(cause);
+  }
+}

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/parquet/ParquetFileReaderSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/parquet/ParquetFileReaderSuite.scala
@@ -16,13 +16,21 @@
 package io.delta.kernel.defaults.internal.parquet
 
 import java.math.BigDecimal
-import java.util.TimeZone
+import java.nio.file.{Files, Paths}
+import java.util.{Optional, TimeZone}
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
 
 import io.delta.golden.GoldenTableUtils.{goldenTableFile, goldenTablePath}
+import io.delta.kernel.defaults.engine.fileio.{FileIO, InputFile, OutputFile, SeekableInputStream}
+import io.delta.kernel.defaults.engine.hadoopio.HadoopFileIO
 import io.delta.kernel.defaults.utils.{ExpressionTestUtils, TestRow}
+import io.delta.kernel.expressions.Literal.ofLong
+import io.delta.kernel.expressions.Predicate
 import io.delta.kernel.test.VectorTestUtils
 import io.delta.kernel.types._
-import io.delta.kernel.utils.MetadataColumnTestUtils
+import io.delta.kernel.utils.{CloseableIterator, MetadataColumnTestUtils}
+import io.delta.kernel.utils.{FileStatus => KernelFileStatus}
 
 import org.apache.spark.sql.internal.SQLConf
 import org.scalatest.funsuite.AnyFunSuite
@@ -330,6 +338,41 @@ class ParquetFileReaderSuite extends AnyFunSuite
   }
 
   /////////////////////////////////////////////////////////////////////////////////////////////////
+  // Tests for footer reuse: the footer read up-front to build the filter is reused by the reader //
+  // instead of being read (and parsed) a second time.                                            //
+  /////////////////////////////////////////////////////////////////////////////////////////////////
+
+  test("footer is read only once when reading a Parquet file") {
+    // Multiple row groups + a predicate that prunes some of them exercises the full record-read
+    // loop (row-group iteration, stats filtering and row-index tracking) while still needing only
+    // a single footer read.
+    val filePath = getTestResourceFilePath("parquet/row_index_multiple_row_groups.parquet")
+    val readSchema = new StructType()
+      .add("id", LongType.LONG)
+      .add(ROW_INDEX)
+    val fileStatus = KernelFileStatus.of(
+      filePath,
+      Files.size(Paths.get(filePath)),
+      /* modificationTime = */ 0L)
+
+    // Read once with no predicate and once with a predicate that prunes row groups; the footer
+    // should be read exactly once in both cases.
+    Seq[Optional[Predicate]](
+      Optional.empty(),
+      Optional.of(gt(col("id"), ofLong(5000L)))).foreach { predicate =>
+      val fileIO = new FooterReadCountingFileIO(new HadoopFileIO(configuration))
+      val reader = new ParquetFileReader(fileIO)
+      // Drain the iterator (the implicit `forEach` closes it) so all row groups are read.
+      reader.read(fileStatus, readSchema, predicate).forEach(_ => ())
+
+      assert(
+        fileIO.footerReadCount(filePath) === 1,
+        s"Expected the footer to be read exactly once for predicate=$predicate, " +
+          s"but it was read ${fileIO.footerReadCount(filePath)} times")
+    }
+  }
+
+  /////////////////////////////////////////////////////////////////////////////////////////////////
   // Test compatibility with Parquet legacy format files                                         //
   /////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -385,4 +428,69 @@ class ParquetFileReaderSuite extends AnyFunSuite
       readParquetFilesUsingKernel(parquetFilePath, readSchema), /* actual */
       readParquetFilesUsingSpark(parquetFilePath, readSchema) /* expected */ )
   }
+}
+
+/**
+ * A [[FileIO]] that delegates to an underlying [[FileIO]] but counts how many times the Parquet
+ * footer is read for each file. A footer read is detected by a seek to the footer-length index
+ * (`fileLength - 8`), which is where `parquet-mr` starts reading the footer trailer.
+ */
+class FooterReadCountingFileIO(delegate: FileIO) extends FileIO {
+  private val footerReadCounts = new ConcurrentHashMap[String, AtomicInteger]()
+
+  def footerReadCount(path: String): Int =
+    Option(footerReadCounts.get(path)).map(_.get()).getOrElse(0)
+
+  private def recordFooterRead(path: String): Unit = {
+    footerReadCounts.putIfAbsent(path, new AtomicInteger(0))
+    footerReadCounts.get(path).incrementAndGet()
+  }
+
+  override def newInputFile(path: String, fileSize: Long): InputFile = {
+    val delegateInputFile = delegate.newInputFile(path, fileSize)
+    new InputFile {
+      override def length(): Long = delegateInputFile.length()
+
+      override def path(): String = delegateInputFile.path()
+
+      override def newStream(): SeekableInputStream = {
+        val delegateStream = delegateInputFile.newStream()
+        // `fileLength - 8` == fileLength - MAGIC(4) - FOOTER_LENGTH_SIZE(4), the position
+        // parquet-mr seeks to when it reads the footer.
+        val footerIndex = delegateInputFile.length() - 8
+        new SeekableInputStream {
+          override def getPos(): Long = delegateStream.getPos()
+
+          override def seek(newPos: Long): Unit = {
+            if (newPos == footerIndex) {
+              recordFooterRead(path)
+            }
+            delegateStream.seek(newPos)
+          }
+
+          override def readFully(b: Array[Byte], off: Int, len: Int): Unit =
+            delegateStream.readFully(b, off, len)
+
+          override def read(): Int = delegateStream.read()
+
+          override def read(b: Array[Byte], off: Int, len: Int): Int =
+            delegateStream.read(b, off, len)
+
+          override def close(): Unit = delegateStream.close()
+        }
+      }
+    }
+  }
+
+  // All other operations simply delegate.
+  override def listFrom(filePath: String): CloseableIterator[KernelFileStatus] =
+    delegate.listFrom(filePath)
+  override def getFileStatus(path: String): KernelFileStatus = delegate.getFileStatus(path)
+  override def resolvePath(path: String): String = delegate.resolvePath(path)
+  override def mkdirs(path: String): Boolean = delegate.mkdirs(path)
+  override def newOutputFile(path: String): OutputFile = delegate.newOutputFile(path)
+  override def delete(path: String): Boolean = delegate.delete(path)
+  override def getConf(confKey: String): Optional[String] = delegate.getConf(confKey)
+  override def copyFileAtomically(srcPath: String, destPath: String, overwrite: Boolean): Unit =
+    delegate.copyFileAtomically(srcPath, destPath, overwrite)
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

Kernel reads the Parquet footer up front to build the physical schema and the row-group filter pushed into parquet-mr, then previously handed the file to the high-level ParquetReader, which re-read (and re-parsed) the footer a second time.

Drive the low-level ParquetFileReader directly, opening it with the footer-accepting `open(InputFile, ParquetMetadata, ParquetReadOptions, SeekableInputStream)` API so the footer is read once. Records are materialized via a new ParquetRecordReaderWrapper that reaches `parquet-mr`'s package-private InternalParquetRecordReader through reflection with setAccessible(true). This restores the pre-#4429 structure without reintroducing the IllegalAccessError that subclassing caused when `parquet-mr` and Kernel load in different class loaders (reflection bypasses the package-private access check).

## How was this patch tested?

Add a test asserting the footer is read exactly once, with and without a row-group-pruning predicate.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
