### PR TITLE
[Spark] Parse AddFile/RemoveFile stats with the shared JsonUtils mapper

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -840,7 +840,7 @@ trait HasNumRecords {
   @transient
   protected lazy val parsedStatsFields: Option[ParsedStatsFields] = Option(stats).collect {
     case stats if stats.nonEmpty =>
-      val node = new ObjectMapper().readTree(stats)
+      val node = JsonUtils.mapper.readTree(stats)
       val numLogicalRecords = if (node.has("numRecords")) {
         Some(node.get("numRecords")).filterNot(_.isNull).map(_.asLong())
           .map(_ - numDeletedRecords)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/actions/AddFileSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/actions/AddFileSuite.scala
@@ -20,6 +20,8 @@ import org.apache.spark.sql.delta.{DeltaConfigs, DeltaLog, DeltaRuntimeException
 import org.apache.spark.sql.delta.DeltaTestUtils.BOOLEAN_DOMAIN
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.delta.util.JsonUtils
+import com.fasterxml.jackson.core.StreamReadConstraints
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.catalyst.expressions.{Cast, Literal}
@@ -605,5 +607,32 @@ class AddFileSuite extends SparkFunSuite with SharedSparkSession with DeltaSQLCo
         }
       }
     }
+  }
+
+  test("parsedStatsFields reads stats with a min/max bound longer than the default " +
+    "Jackson string length limit") {
+    // A single string value in the per-file stats (for example a wide string min/max bound)
+    // can exceed Jackson's default maxStringLength (20MB, since Jackson 2.15). The Delta log is
+    // read through JsonUtils.mapper, which lifts this limit, so stats parsing must do the same.
+    val largeBound = "a" * (StreamReadConstraints.DEFAULT_MAX_STRING_LEN + 1)
+
+    val statsNode = JsonUtils.mapper.createObjectNode()
+    statsNode.put("numRecords", 3L)
+    statsNode.put("tightBounds", true)
+    val maxValues = statsNode.putObject("maxValues")
+    maxValues.put("stringCol", largeBound)
+    val stats = JsonUtils.mapper.writeValueAsString(statsNode)
+
+    val file = AddFile(
+      path = "test.parquet",
+      partitionValues = Map.empty,
+      size = 100,
+      modificationTime = 0,
+      dataChange = true,
+      stats = stats)
+
+    assert(file.numLogicalRecords.contains(3L))
+    assert(file.numPhysicalRecords.contains(3L))
+    assert(file.tightBounds.contains(true))
   }
 }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

`HasNumRecords.parsedStatsFields` (`spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala`) parses the per-file `stats` string with a default `new ObjectMapper()`:

```scala
val node = new ObjectMapper().readTree(stats)
```

Since Jackson 2.15, a default `ObjectMapper` enforces `StreamReadConstraints.maxStringLength = 20,000,000` chars on any single string value. If the `stats` payload contains one min/max string bound longer than 20M chars, `readTree` throws `StreamConstraintsException`, which breaks `numLogicalRecords`, `numPhysicalRecords`, `tightBounds`, `estLogicalFileSize` and `logicalToPhysicalRecordsRatio` for that `AddFile` / `RemoveFile`, even though the rest of the same Delta log is read successfully.

Delta already created a shared mapper specifically to lift this limit: `JsonUtils.mapper` (`spark/src/main/scala/org/apache/spark/sql/delta/util/JsonUtils.scala`) sets `StreamReadConstraints.maxStringLength(Int.MaxValue)` on its factory, with the note that Delta log and table-data JSON strings must not be length-limited. The sibling method `AddFile.withoutTightBoundStats` in the same file already parses the same `stats` string through `JsonUtils.mapper`. This call site simply predates the override and was missed.

This change uses `JsonUtils.mapper` for stats parsing here too, so all `stats` parsing is consistent with how the rest of the Delta log is read. `JsonUtils` is already imported in `actions.scala`, so the main-source change is a single line.

This is the same class of problem as #2565, the origin of the `JsonUtils.mapper` `maxStringLength` override. #2565 itself is about the whole-log-line reader (`commitInfo.operationParameters.predicate`) and its reported path is already handled. This PR covers the remaining per-file `stats` call site, so it does not close #2565.

## How was this patch tested?

Added a regression test in `spark/src/test/scala/org/apache/spark/sql/delta/actions/AddFileSuite.scala`: `parsedStatsFields reads stats with a min/max bound longer than the default Jackson string length limit`. It builds a `stats` payload whose `maxValues` string bound is `StreamReadConstraints.DEFAULT_MAX_STRING_LEN + 1` chars long, constructs an `AddFile` with it, and asserts `numLogicalRecords`, `numPhysicalRecords` and `tightBounds` are read back correctly.

- With the fix: `build/sbt "spark/testOnly org.apache.spark.sql.delta.actions.AddFileSuite"` passes 22/22, including the new test.
- Without the fix, reverting the line to `new ObjectMapper()`, the new test fails with `com.fasterxml.jackson.core.exc.StreamConstraintsException: String value length (20000001) exceeds the maximum allowed (20000000, from StreamReadConstraints.getMaxStringLength())`.
- `spark/scalastyle` and `spark/test:scalastyle` both report 0 errors / 0 warnings.

## Does this PR introduce _any_ user-facing changes?

Yes. Before this change, reading the record counts / tight-bounds metadata for a file whose `stats` contained a single string bound longer than 20,000,000 chars threw `StreamConstraintsException`. After this change, such files are parsed successfully, the same as the rest of the Delta log. There is no behavior change for stats within the default limit.
