### PR TITLE
[Storage] Close discarded iterator on each replay retry in RetryableCloseableIterator

### DIFF
--- a/storage-s3-dynamodb/src/main/java/io/delta/storage/RetryableCloseableIterator.java
+++ b/storage-s3-dynamodb/src/main/java/io/delta/storage/RetryableCloseableIterator.java
@@ -163,14 +163,17 @@ public class RetryableCloseableIterator implements CloseableIterator<String> {
             "Caught a RemoteFileChangedException. NumRetries is {} / {}.\n{}",
             numRetries + 1, maxRetries, topLevelEx
         );
-        currentIter.close();
-
         while (numRetries < maxRetries) {
             numRetries++;
             LOG.info(
                 "Replaying until (inclusive) index {}. NumRetries is {} / {}.",
                 lastSuccessfullIndex, numRetries + 1, maxRetries
             );
+            // Close the previous iterator before reopening a new one. On the first loop this
+            // closes the iterator that just threw; on subsequent loops (when the replay below
+            // itself throws a RemoteFileChangedException and we retry) this closes the iterator
+            // opened by the previous attempt, which would otherwise leak its open input stream.
+            currentIter.close();
             currentIter = iterSupplier.get();
 
             // Last successful index replayed. Starts at -1, and not 0, because 0 means we've

--- a/storage-s3-dynamodb/src/test/scala/io/delta/storage/RetryableCloseableIteratorSuite.scala
+++ b/storage-s3-dynamodb/src/test/scala/io/delta/storage/RetryableCloseableIteratorSuite.scala
@@ -57,6 +57,25 @@ class RetryableCloseableIteratorSuite extends AnyFunSuite {
       }
     }
 
+  /**
+   * A CloseableIterator that delegates to `delegate` but records whether `close` was called. Used
+   * to assert that the retry logic closes every iterator it opens, including the ones it discards
+   * while replaying.
+   */
+  private class TrackingCloseableIterator(delegate: CloseableIterator[String])
+      extends CloseableIterator[String] {
+    var closed = false
+
+    override def close(): Unit = {
+      closed = true
+      delegate.close()
+    }
+
+    override def hasNext: Boolean = delegate.hasNext
+
+    override def next(): String = delegate.next()
+  }
+
   test("simple case - internally keeps track of the correct index") {
     val testIter = new RetryableCloseableIterator(() => getIter(0 to 100))
     assert(testIter.getLastSuccessfullIndex == -1)
@@ -128,6 +147,43 @@ class RetryableCloseableIteratorSuite extends AnyFunSuite {
     val testIter2 =
       new RetryableCloseableIterator(getFailingIterSupplier(0 to 100, Seq(50, 70, 5)))
     assert(testIter2.asScala.toList.map(_.toInt) == (0 to 100).toList)
+  }
+
+  test("closes every iterator it opens while retrying the replay (no leak)") {
+    val openedIters = scala.collection.mutable.ArrayBuffer.empty[TrackingCloseableIterator]
+
+    // Fails at index 50, then the replay itself fails at 30 and again at 20 before succeeding.
+    // Each failed replay forces another retry-loop iteration, and each iteration opens a new
+    // underlying iterator via the supplier.
+    val failIndices = Seq(50, 30, 20)
+    val supplier = new ThrowingSupplier[CloseableIterator[String], IOException] {
+      var numGetCalls = 0
+
+      override def get(): CloseableIterator[String] = {
+        val delegate =
+          if (numGetCalls < failIndices.length) getIter(0 to 100, Some(failIndices(numGetCalls)))
+          else getIter(0 to 100)
+        numGetCalls = numGetCalls + 1
+        val tracking = new TrackingCloseableIterator(delegate)
+        openedIters += tracking
+        tracking
+      }
+    }
+
+    val testIter = new RetryableCloseableIterator(supplier)
+    assert(testIter.asScala.toList.map(_.toInt) == (0 to 100).toList)
+    testIter.close()
+
+    // initial iterator + one per retry (3 retries)
+    assert(openedIters.size == 4)
+    // Every opened iterator must be closed: the ones discarded across the failed replays by the
+    // retry loop, and the final live one by close() above. Before the fix, the iterators opened
+    // during the failed replays were overwritten without being closed, leaking their streams.
+    assert(
+      openedIters.forall(_.closed),
+      s"expected all opened iterators to be closed, but only " +
+        s"${openedIters.count(_.closed)} of ${openedIters.size} were closed"
+    )
   }
 
   test("throws after maxRetries exceptions") {


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (fill in here): Storage (`storage-s3-dynamodb`, `RetryableCloseableIterator`)

## Description

`RetryableCloseableIterator` wraps an underlying `CloseableIterator` and, on a `RemoteFileChangedException`, replays a freshly reopened iterator back to the last successfully read index so the failed read can be retried. The replay happens in `replayIterToLastSuccessfulIndex`, inside a `while (numRetries < maxRetries)` loop that reopens the iterator each pass with `currentIter = iterSupplier.get()`.

The iterator was only closed once, just before the loop. If the replay itself throws a `RemoteFileChangedException`, which the method explicitly catches and retries at the top of the loop, the next loop pass overwrites `currentIter` with a new iterator without closing the one opened by the previous attempt. Each such retry therefore orphans an open iterator. For `S3DynamoDBLogStore`, the supplier is `() -> super.read(path, hadoopConf)`, which opens an S3 `FSDataInputStream` (`fs.open(path)`) wrapped in a `LineCloseableIterator` whose `close()` closes that stream, so every orphaned iterator is an open S3 input stream held until GC. Up to `maxRetries - 1` streams can leak per replay incident, and the default `maxRetries` is 3.

The fix moves the single `currentIter.close()` from just before the loop to the top of the loop body, immediately before reopening the iterator:

- On the first pass it closes the iterator that just threw the top-level `RemoteFileChangedException`, same as the removed pre-loop close.
- On subsequent passes it closes the iterator opened by the previous failed replay before it is overwritten, so nothing is orphaned.
- On success the method returns and the final live iterator is still closed once by the caller via `close()`, unchanged.
- When retries are exhausted the method rethrows and the last-opened iterator is left for the caller to close, unchanged from the original contract.

`currentIter` is always non-null at the loop-top close, because the constructor sets it and every prior loop iteration sets it, so the close is safe. As a side benefit, this also removes a latent double-close on the `maxRetries == 0` path: previously the pre-loop close ran, the loop body never ran, the method threw, and the caller closed the same iterator again. Now that iterator is closed exactly once, by the caller.

The change is limited to `replayIterToLastSuccessfulIndex`; no public API or behavior changes apart from not leaking the discarded iterators.

## How was this patch tested?

Added a regression test to `RetryableCloseableIteratorSuite`, `closes every iterator it opens while retrying the replay (no leak)`. It supplies close-tracking iterators (`TrackingCloseableIterator`) and scripts the replay to fail at index 50, then again at 30 and 20 before succeeding, forcing three retry loop iterations and four iterators opened in total. After draining the iterator and calling `close()`, it asserts every opened iterator is closed.

- With the fix: the full suite passes (9/9).
- Reverting only the `RetryableCloseableIterator.java` change and keeping the test: exactly this new test fails with `only 2 of 4 were closed`, pinning the two leaked iterators. This is a proven red -> green regression test.

Run locally with JDK 21:

```
build/sbt -DuseDefaultUnityCatalogReleaseVersion=true "storageS3DynamoDB/testOnly io.delta.storage.RetryableCloseableIteratorSuite"
```

The new test reuses the existing `getIter` / supplier scaffolding already used by the sibling `handles exceptions while retrying the replay` test; it is deterministic and adds no sleeps.

## Does this PR introduce _any_ user-facing changes?

No. This fixes an internal resource leak in the S3 + DynamoDB `LogStore` retry path; there is no API or behavior change other than that discarded iterators and their underlying S3 input streams are now closed promptly during retries instead of leaking until garbage collection.
