### PR TITLE
[Spark] Fix server-side planning forcing a _delta_log read for credential-less tables

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
@@ -395,10 +395,16 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
           // tables whose filesystem isn't resolvable at load time. So gate on the cheap config
           // flag first and keep the SSP-off path returning the lazy `loadCatalogTable`, exactly
           // as before this branch existed.
+          //
+          // Pass the raw `V1Table` as the credentials source: SSP's credential check looks for
+          // `option.fs.*` properties, but `DeltaTableV2.properties()` strips `fs.*` storage
+          // properties, so checking the `DeltaTableV2` would always report "no credentials" and
+          // wrongly route credentialed UC tables through server-side planning (SSP is only meant
+          // as a fallback for tables that lack credentials).
           if (ServerSidePlannedTable.isEnabled(spark)) {
             val deltaTable = loadCatalogTable(ident, v1.catalogTable)
             ServerSidePlannedTable
-              .tryCreate(spark, ident, deltaTable, isUnityCatalog)
+              .tryCreate(spark, ident, deltaTable, isUnityCatalog, credentialsTable = v1)
               .getOrElse(deltaTable)
           } else {
             loadCatalogTable(ident, v1.catalogTable)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
@@ -396,15 +396,16 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
           // flag first and keep the SSP-off path returning the lazy `loadCatalogTable`, exactly
           // as before this branch existed.
           //
-          // Pass the raw `V1Table` as the credentials source: SSP's credential check looks for
-          // `option.fs.*` properties, but `DeltaTableV2.properties()` strips `fs.*` storage
-          // properties, so checking the `DeltaTableV2` would always report "no credentials" and
-          // wrongly route credentialed UC tables through server-side planning (SSP is only meant
-          // as a fallback for tables that lack credentials).
+          // Check credentials on the raw `V1Table`, not the `DeltaTableV2`: SSP's credential check
+          // looks for `option.fs.*` properties, but `DeltaTableV2.properties()` strips `fs.*`
+          // storage properties, so checking the `DeltaTableV2` would always report "no credentials"
+          // and wrongly route credentialed UC tables through server-side planning (SSP is only
+          // meant as a fallback for tables that lack credentials).
           if (ServerSidePlannedTable.isEnabled(spark)) {
             val deltaTable = loadCatalogTable(ident, v1.catalogTable)
             ServerSidePlannedTable
-              .tryCreate(spark, ident, deltaTable, isUnityCatalog, credentialsTable = v1)
+              .tryCreate(spark, ident, deltaTable, isUnityCatalog,
+                hasCredentials = ServerSidePlannedTable.hasCredentials(v1))
               .getOrElse(deltaTable)
           } else {
             loadCatalogTable(ident, v1.catalogTable)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
@@ -387,25 +387,27 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
           // resolver can route it correctly. Capturing those in `ServerSidePlannedTable.tryCreate`
           // would short-circuit view loading.
           //
-          // Only resolve to a `DeltaTableV2` and attempt SSP when the feature is enabled. SSP
-          // needs the real schema, which lives in the transaction log (a Delta `V1Table`'s
-          // metastore `CatalogTable` schema is empty), so it must read it from `DeltaTableV2`.
-          // But forcing that resolution on the normal (SSP-off) path would touch the `DeltaLog`
-          // / filesystem during `loadTable` -- which breaks lazy callers (e.g. time travel) and
-          // tables whose filesystem isn't resolvable at load time. So gate on the cheap config
-          // flag first and keep the SSP-off path returning the lazy `loadCatalogTable`, exactly
-          // as before this branch existed.
+          // Gate on the cheap config flag so the SSP-off path stays the lazy `loadCatalogTable`.
           //
-          // Check credentials on the raw `V1Table`, not the `DeltaTableV2`: SSP's credential check
-          // looks for `option.fs.*` properties, but `DeltaTableV2.properties()` strips `fs.*`
-          // storage properties, so checking the `DeltaTableV2` would always report "no credentials"
-          // and wrongly route credentialed UC tables through server-side planning (SSP is only
-          // meant as a fallback for tables that lack credentials).
+          // SSP is the fallback for tables with *no* vended credentials, so for the case it
+          // targets -- a credential-less UC table -- we must not force a `_delta_log` read while
+          // deciding to use it. Both inputs to `tryCreate` are therefore sourced from the raw
+          // `V1Table`, which needs no such read:
+          //   - credentials: read from the `V1Table`'s `option.fs.*` properties. (A `DeltaTableV2`
+          //     both strips `fs.*` and forces `initialSnapshot` via `properties()`.)
+          //   - schema: use the `V1Table` schema, which the delegate (UC) already populates.
+          //     Only fall back to `DeltaTableV2.schema()` when it is empty -- an HMS Delta table,
+          //     whose schema lives solely in the log, so the log is the last-resort schema source
+          //     and the read is unavoidable rather than a bet on credentials being present. (This
+          //     HMS case has credentials in practice, so the read succeeds; the "no `_delta_log`
+          //     read" guarantee holds for the credential-less UC case, not universally.)
           if (ServerSidePlannedTable.isEnabled(spark)) {
             val deltaTable = loadCatalogTable(ident, v1.catalogTable)
+            val tableSchema = if (v1.schema.nonEmpty) v1.schema else deltaTable.schema()
             ServerSidePlannedTable
               .tryCreate(spark, ident, deltaTable, isUnityCatalog,
-                hasCredentials = ServerSidePlannedTable.hasCredentials(v1))
+                hasCredentials = ServerSidePlannedTable.hasCredentials(v1),
+                tableSchema = tableSchema)
               .getOrElse(deltaTable)
           } else {
             loadCatalogTable(ident, v1.catalogTable)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/serverSidePlanning/ServerSidePlannedTable.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/serverSidePlanning/ServerSidePlannedTable.scala
@@ -93,12 +93,13 @@ object ServerSidePlannedTable extends DeltaLogging {
    * @param ident The table identifier
    * @param table The loaded table used for the planned table's schema and metadata.
    * @param isUnityCatalog Whether this is a Unity Catalog instance
-   * @param credentialsTable The table to inspect for credentials. Defaults to `table`, but callers
-   *        must override it when `table` cannot carry credentials. In particular, a `DeltaTableV2`
-   *        deliberately strips `fs.*` storage properties from `properties()` (see
-   *        `DeltaTableV2.HIDDEN_STORAGE_PROPERTY_PREFIXES`), so `hasCredentials` would always
-   *        report `false` for it -- the credential check must run against the raw `V1Table`, whose
-   *        `option.fs.*` properties are intact.
+   * @param hasCredentials Whether the table has credentials available. The caller computes this
+   *        (via [[hasCredentials]]) from the raw `V1Table` rather than letting this method read it
+   *        off `table`: `table` is a `DeltaTableV2`, whose `properties()` deliberately strips
+   *        `fs.*` storage properties (see `DeltaTableV2.HIDDEN_STORAGE_PROPERTY_PREFIXES`), so the
+   *        `option.fs.*` keys the check looks for never appear on it. We need the `DeltaTableV2`
+   *        here for its schema (a Delta `V1Table`'s metastore schema is empty), but the credential
+   *        check must run against the raw `V1Table`.
    * @return Some(ServerSidePlannedTable) if server-side planning should be used, None otherwise
    */
   def tryCreate(
@@ -106,14 +107,13 @@ object ServerSidePlannedTable extends DeltaLogging {
       ident: Identifier,
       table: Table,
       isUnityCatalog: Boolean,
-      credentialsTable: Table = null): Option[ServerSidePlannedTable] = {
+      hasCredentials: Boolean): Option[ServerSidePlannedTable] = {
     // Check if we should enable server-side planning (for testing)
     val enableServerSidePlanning = isEnabled(spark)
-    val hasTableCredentials = hasCredentials(Option(credentialsTable).getOrElse(table))
 
     // Check if we should use server-side planning
     if (shouldUseServerSidePlanning(
-        isUnityCatalog, hasTableCredentials, enableServerSidePlanning,
+        isUnityCatalog, hasCredentials, enableServerSidePlanning,
         skipUCRequirementForTests = DeltaUtils.isTesting)) {
       val namespace = ident.namespace().mkString(".")
       val tableName = ident.name()
@@ -171,7 +171,7 @@ object ServerSidePlannedTable extends DeltaLogging {
    * (see `DeltaTableV2.HIDDEN_STORAGE_PROPERTY_PREFIXES`), so the `option.fs.*` keys this method
    * looks for never appear and it would always report `false`.
    */
-  private[serverSidePlanning] def hasCredentials(table: Table): Boolean = {
+  private[delta] def hasCredentials(table: Table): Boolean = {
     val properties = table.properties()
     val keys = properties.keySet()
     val iter = keys.iterator()

--- a/spark/src/main/scala/org/apache/spark/sql/delta/serverSidePlanning/ServerSidePlannedTable.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/serverSidePlanning/ServerSidePlannedTable.scala
@@ -91,18 +91,25 @@ object ServerSidePlannedTable extends DeltaLogging {
    *
    * @param spark The SparkSession
    * @param ident The table identifier
-   * @param table The loaded table from the delegate catalog
+   * @param table The loaded table used for the planned table's schema and metadata.
    * @param isUnityCatalog Whether this is a Unity Catalog instance
+   * @param credentialsTable The table to inspect for credentials. Defaults to `table`, but callers
+   *        must override it when `table` cannot carry credentials. In particular, a `DeltaTableV2`
+   *        deliberately strips `fs.*` storage properties from `properties()` (see
+   *        `DeltaTableV2.HIDDEN_STORAGE_PROPERTY_PREFIXES`), so `hasCredentials` would always
+   *        report `false` for it -- the credential check must run against the raw `V1Table`, whose
+   *        `option.fs.*` properties are intact.
    * @return Some(ServerSidePlannedTable) if server-side planning should be used, None otherwise
    */
   def tryCreate(
       spark: SparkSession,
       ident: Identifier,
       table: Table,
-      isUnityCatalog: Boolean): Option[ServerSidePlannedTable] = {
+      isUnityCatalog: Boolean,
+      credentialsTable: Table = null): Option[ServerSidePlannedTable] = {
     // Check if we should enable server-side planning (for testing)
     val enableServerSidePlanning = isEnabled(spark)
-    val hasTableCredentials = hasCredentials(table)
+    val hasTableCredentials = hasCredentials(Option(credentialsTable).getOrElse(table))
 
     // Check if we should use server-side planning
     if (shouldUseServerSidePlanning(
@@ -158,8 +165,13 @@ object ServerSidePlannedTable extends DeltaLogging {
    * Check if a table has credentials available.
    * UC injects credentials as table properties with "option.fs.*" prefix for filesystem configs.
    * See: CredPropsUtil in UCSingleCatalog.
+   *
+   * Note: this must be called on the raw `V1Table` returned by the delegate catalog, not on a
+   * `DeltaTableV2`. `DeltaTableV2.properties()` intentionally strips `fs.*` storage properties
+   * (see `DeltaTableV2.HIDDEN_STORAGE_PROPERTY_PREFIXES`), so the `option.fs.*` keys this method
+   * looks for never appear and it would always report `false`.
    */
-  private def hasCredentials(table: Table): Boolean = {
+  private[serverSidePlanning] def hasCredentials(table: Table): Boolean = {
     val properties = table.properties()
     val keys = properties.keySet()
     val iter = keys.iterator()

--- a/spark/src/main/scala/org/apache/spark/sql/delta/serverSidePlanning/ServerSidePlannedTable.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/serverSidePlanning/ServerSidePlannedTable.scala
@@ -91,15 +91,14 @@ object ServerSidePlannedTable extends DeltaLogging {
    *
    * @param spark The SparkSession
    * @param ident The table identifier
-   * @param table The loaded table used for the planned table's schema and metadata.
+   * @param table The loaded table, used only to derive planning metadata via
+   *        [[ServerSidePlanningMetadata.fromTable]] (session conf + identifier, not schema/props).
    * @param isUnityCatalog Whether this is a Unity Catalog instance
-   * @param hasCredentials Whether the table has credentials available. The caller computes this
-   *        (via [[hasCredentials]]) from the raw `V1Table` rather than letting this method read it
-   *        off `table`: `table` is a `DeltaTableV2`, whose `properties()` deliberately strips
-   *        `fs.*` storage properties (see `DeltaTableV2.HIDDEN_STORAGE_PROPERTY_PREFIXES`), so the
-   *        `option.fs.*` keys the check looks for never appear on it. We need the `DeltaTableV2`
-   *        here for its schema (a Delta `V1Table`'s metastore schema is empty), but the credential
-   *        check must run against the raw `V1Table`.
+   * @param hasCredentials Whether the table has credentials. Supplied by the caller (computed from
+   *        the raw `V1Table`) so this method never reads it off a `DeltaTableV2` -- see the caller
+   *        in `AbstractDeltaCatalog.loadTable` for why.
+   * @param tableSchema The planned table's schema, supplied by the caller (not read via
+   *        `table.schema()`) so this method never forces a `DeltaTableV2` `_delta_log` read.
    * @return Some(ServerSidePlannedTable) if server-side planning should be used, None otherwise
    */
   def tryCreate(
@@ -107,7 +106,8 @@ object ServerSidePlannedTable extends DeltaLogging {
       ident: Identifier,
       table: Table,
       isUnityCatalog: Boolean,
-      hasCredentials: Boolean): Option[ServerSidePlannedTable] = {
+      hasCredentials: Boolean,
+      tableSchema: StructType): Option[ServerSidePlannedTable] = {
     // Check if we should enable server-side planning (for testing)
     val enableServerSidePlanning = isEnabled(spark)
 
@@ -122,7 +122,7 @@ object ServerSidePlannedTable extends DeltaLogging {
       val metadata = ServerSidePlanningMetadata.fromTable(table, spark, ident, isUnityCatalog)
 
       // Try to create ServerSidePlannedTable with server-side planning
-      val plannedTable = tryCreate(spark, namespace, tableName, table.schema(), metadata)
+      val plannedTable = tryCreate(spark, namespace, tableName, tableSchema, metadata)
       if (plannedTable.isEmpty) {
         logWarning(
           s"Server-side planning not available for catalog ${metadata.catalogName}. " +

--- a/spark/src/test/scala/org/apache/spark/sql/delta/serverSidePlanning/ServerSidePlannedTableSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/serverSidePlanning/ServerSidePlannedTableSuite.scala
@@ -17,9 +17,13 @@
 package org.apache.spark.sql.delta.serverSidePlanning
 
 import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.connector.catalog.{Identifier, V1Table}
+import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.sources.{And, EqualTo, Filter, GreaterThan, LessThan}
+import org.apache.hadoop.fs.Path
 
 /**
  * Tests for server-side planning with a mock client.
@@ -213,6 +217,52 @@ class ServerSidePlannedTableSuite extends QueryTest with DeltaSQLCommandTest {
           assert(result == expected, s"$description -> expected $expected but got $result")
         }
       }
+    }
+  }
+
+  test("hasCredentials must be read from the raw V1Table, not the DeltaTableV2") {
+    // Regression test: SSP's credential check looks for `option.fs.*` table properties. A raw
+    // `V1Table` surfaces `fs.*` storage properties as `option.fs.*` (Spark's
+    // `V1Table.addV2TableProperties`), but `DeltaTableV2.properties()` intentionally strips `fs.*`
+    // (see `DeltaTableV2.HIDDEN_STORAGE_PROPERTY_PREFIXES`). If the credential check runs against
+    // the `DeltaTableV2` it always reports "no credentials", which would wrongly route a
+    // credentialed UC table through server-side planning -- SSP is only a fallback for tables that
+    // lack credentials.
+    val ident = Identifier.of(Array("test_db"), "shared_test")
+    val baseCatalogTable =
+      spark.sessionState.catalog.getTableMetadata(TableIdentifier("shared_test", Some("test_db")))
+
+    // Simulate a UC-injected filesystem credential on the loaded table's storage properties.
+    val credentialedCatalogTable = baseCatalogTable.copy(
+      storage = baseCatalogTable.storage.copy(
+        properties = baseCatalogTable.storage.properties + ("fs.s3a.access.key" -> "secret")))
+
+    val rawV1Table = V1Table(credentialedCatalogTable)
+    val deltaTableV2 = DeltaTableV2(
+      spark,
+      new Path(credentialedCatalogTable.location),
+      catalogTable = Some(credentialedCatalogTable),
+      tableIdentifier = Some(ident.toString))
+
+    // The raw V1Table exposes the credential as `option.fs.*`...
+    assert(ServerSidePlannedTable.hasCredentials(rawV1Table),
+      "Expected the raw V1Table to expose fs.* credentials as option.fs.* properties")
+    // ...but the DeltaTableV2 strips fs.* storage properties, so it never does.
+    assert(!ServerSidePlannedTable.hasCredentials(deltaTableV2),
+      "Expected DeltaTableV2 to hide fs.* credentials, so hasCredentials must report false")
+
+    // tryCreate builds the planned table from `table` (the DeltaTableV2, for its schema) but must
+    // detect credentials from `credentialsTable` (the raw V1Table). With a real UC deployment
+    // (skipUCRequirementForTests = false) a credentialed table must NOT be routed to SSP.
+    withServerSidePlanningFactory(new TestServerSidePlanningClientFactory()) {
+      assert(
+        ServerSidePlannedTable.shouldUseServerSidePlanning(
+          isUnityCatalog = true,
+          hasCredentials = ServerSidePlannedTable.hasCredentials(rawV1Table),
+          enableServerSidePlanning = ServerSidePlannedTable.isEnabled(spark),
+          skipUCRequirementForTests = false) == false,
+        "A credentialed UC table (creds read from the raw V1Table) must not use server-side " +
+          "planning")
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/serverSidePlanning/ServerSidePlannedTableSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/serverSidePlanning/ServerSidePlannedTableSuite.scala
@@ -16,14 +16,16 @@
 
 package org.apache.spark.sql.delta.serverSidePlanning
 
-import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
-import org.apache.spark.sql.catalyst.TableIdentifier
-import org.apache.spark.sql.connector.catalog.{Identifier, V1Table}
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
-import org.apache.spark.sql.sources.{And, EqualTo, Filter, GreaterThan, LessThan}
 import org.apache.hadoop.fs.Path
+
+import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.connector.catalog.{Identifier, V1Table}
+import org.apache.spark.sql.sources.{And, EqualTo, Filter, GreaterThan, LessThan}
+import org.apache.spark.sql.types.StructType
 
 /**
  * Tests for server-side planning with a mock client.
@@ -251,9 +253,9 @@ class ServerSidePlannedTableSuite extends QueryTest with DeltaSQLCommandTest {
     assert(!ServerSidePlannedTable.hasCredentials(deltaTableV2),
       "Expected DeltaTableV2 to hide fs.* credentials, so hasCredentials must report false")
 
-    // tryCreate builds the planned table from `table` (the DeltaTableV2, for its schema) but the
-    // caller passes it the credential result computed from the raw V1Table. With a real UC
-    // deployment (skipUCRequirementForTests = false) a credentialed table must NOT be routed to SSP.
+    // tryCreate takes the credential result and the schema as explicit inputs (both computed by the
+    // caller from the raw V1Table), so it never reads them off the DeltaTableV2. With a real UC
+    // deployment (skipUCRequirementForTests = false) a credentialed table must NOT use SSP.
     withServerSidePlanningFactory(new TestServerSidePlanningClientFactory()) {
       assert(
         ServerSidePlannedTable.shouldUseServerSidePlanning(
@@ -264,6 +266,65 @@ class ServerSidePlannedTableSuite extends QueryTest with DeltaSQLCommandTest {
         "A credentialed UC table (creds read from the raw V1Table) must not use server-side " +
           "planning")
     }
+  }
+
+  test("tryCreate builds the planned table from the supplied schema, not table.schema()") {
+    // Regression test: reading DeltaTableV2.schema() (or .properties()) forces an
+    // initialSnapshot / _delta_log read, which fails in the no-credentials SSP fallback case. The
+    // caller must therefore supply the schema, and tryCreate must use it verbatim rather than
+    // calling table.schema(). We assert that by passing a schema that deliberately differs from the
+    // table's own schema and checking the planned table reflects the supplied one.
+    val ident = Identifier.of(Array("test_db"), "shared_test")
+    val ct = spark.sessionState.catalog
+      .getTableMetadata(TableIdentifier("shared_test", Some("test_db")))
+    val v1 = V1Table(ct)
+    val suppliedSchema = new StructType()
+      .add("id", "int")
+      .add("name", "string")
+
+    withServerSidePlanningFactory(new TestServerSidePlanningClientFactory()) {
+      val planned = ServerSidePlannedTable.tryCreate(
+        spark, ident, v1, isUnityCatalog = false,
+        hasCredentials = false,
+        tableSchema = suppliedSchema)
+      assert(planned.isDefined, "Expected SSP to engage in test mode")
+      assert(planned.get.schema() == suppliedSchema,
+        s"Planned table must use the supplied schema; got ${planned.get.schema()}")
+    }
+  }
+
+  test("loadTable schema selection prefers the V1Table schema, falls back only when empty") {
+    // Covers the schema-selection branch in AbstractDeltaCatalog.loadTable:
+    //   val tableSchema = if (v1.schema.nonEmpty) v1.schema else deltaTable.schema()
+    // The UC path (v1.schema populated by the delegate) must use the V1Table schema and never read
+    // DeltaTableV2.schema() (which forces a _delta_log read). Only an empty metastore schema (an
+    // HMS Delta table) falls back to the log-backed DeltaTableV2 schema. An end-to-end loadTable
+    // test of the populated case needs a UC delegate (unavailable in OSS), so we exercise the exact
+    // selection expression against both a populated and an empty V1Table.
+    val baseCt = spark.sessionState.catalog
+      .getTableMetadata(TableIdentifier("shared_test", Some("test_db")))
+    val deltaTable = DeltaTableV2(
+      spark,
+      new Path(baseCt.location),
+      catalogTable = Some(baseCt),
+      tableIdentifier = Some("test_db.shared_test"))
+
+    // Populated V1Table (mirrors what the UC delegate returns): schema is used as-is.
+    val populatedSchema = new StructType().add("id", "int").add("name", "string")
+    val populatedV1 = V1Table(baseCt.copy(schema = populatedSchema))
+    assert(populatedV1.schema.nonEmpty)
+    val selectedForUC =
+      if (populatedV1.schema.nonEmpty) populatedV1.schema else deltaTable.schema()
+    assert(selectedForUC == populatedSchema,
+      s"UC path must use the V1Table schema; got $selectedForUC")
+
+    // Empty V1Table (an HMS Delta table): falls back to the log-backed DeltaTableV2 schema.
+    val emptyV1 = V1Table(baseCt.copy(schema = new StructType()))
+    assert(emptyV1.schema.isEmpty)
+    val selectedForHms =
+      if (emptyV1.schema.nonEmpty) emptyV1.schema else deltaTable.schema()
+    assert(selectedForHms == deltaTable.schema(),
+      s"HMS path must fall back to DeltaTableV2.schema(); got $selectedForHms")
   }
 
   test("ServerSidePlannedTable is read-only") {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/serverSidePlanning/ServerSidePlannedTableSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/serverSidePlanning/ServerSidePlannedTableSuite.scala
@@ -251,9 +251,9 @@ class ServerSidePlannedTableSuite extends QueryTest with DeltaSQLCommandTest {
     assert(!ServerSidePlannedTable.hasCredentials(deltaTableV2),
       "Expected DeltaTableV2 to hide fs.* credentials, so hasCredentials must report false")
 
-    // tryCreate builds the planned table from `table` (the DeltaTableV2, for its schema) but must
-    // detect credentials from `credentialsTable` (the raw V1Table). With a real UC deployment
-    // (skipUCRequirementForTests = false) a credentialed table must NOT be routed to SSP.
+    // tryCreate builds the planned table from `table` (the DeltaTableV2, for its schema) but the
+    // caller passes it the credential result computed from the raw V1Table. With a real UC
+    // deployment (skipUCRequirementForTests = false) a credentialed table must NOT be routed to SSP.
     withServerSidePlanningFactory(new TestServerSidePlanningClientFactory()) {
       assert(
         ServerSidePlannedTable.shouldUseServerSidePlanning(


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Fixes two regressions introduced by #7039 in the Delta
server-side-planning (SSP) `loadTable` path.

#7039 started resolving a `DeltaTableV2` and passing it to
`ServerSidePlannedTable.tryCreate` (its 3rd commit, to give the planned table a
real schema once the test fixtures moved to `USING delta`). `tryCreate` then
reads two things off that `DeltaTableV2`, and both are wrong for the
no-credentials fallback case that SSP exists for:

1. **Forced `_delta_log` read (the severe one).** `tryCreate` built the
   planned table from `table.schema()`. `DeltaTableV2.schema()` forces
   `initialSnapshot`, i.e. a credentialed `_delta_log` read. SSP is precisely the
   fallback for tables with **no** vended credentials, so that read fails exactly
   when SSP is needed and `loadTable` throws instead of returning a
   `ServerSidePlannedTable`. (`DeltaTableV2.properties()` — used for the credential
   check — has the same `initialSnapshot.getProperties` problem.)

2. **Credential mis-detection.** The credential check scans `table.properties()`
   for `option.fs.*` keys. A raw `V1Table` surfaces `fs.*` storage properties as
   `option.fs.*`, but `DeltaTableV2.properties()` deliberately strips `fs.*`
   (`HIDDEN_STORAGE_PROPERTY_PREFIXES`), so `hasCredentials(DeltaTableV2)` is always
   `false`. That flips `shouldUseServerSidePlanning` from `false` to `true` for a
   Unity Catalog table that **does** have credentials, routing a credentialed table
   through SSP when SSP is only meant as a fallback.

### Fix

Source both credentials and schema from the raw `V1Table`, which needs no
`_delta_log` read (`V1Table.schema` / `.properties()` are pure `CatalogTable`
accessors), instead of from the `DeltaTableV2`:

- **Credentials:** compute `hasCredentials` from the `V1Table` and pass the boolean
  into `tryCreate`.
- **Schema:** `tryCreate` now takes the schema as an explicit `StructType`
  parameter instead of calling `table.schema()`. The caller uses the `V1Table`
  schema (which the Unity Catalog delegate already populates), falling back to
  `DeltaTableV2.schema()` only when the metastore schema is empty — an HMS Delta
  table, whose schema lives in the log; that path has credentials, so the read is
  safe:

  ```scala
  val tableSchema = if (v1.schema.nonEmpty) v1.schema else deltaTable.schema()
  ```

The SSP-off path is unchanged (still the lazy `loadCatalogTable`), and SSP is still
attempted only inside the Delta-`V1Table` branch so views / `MetadataTable` shapes
fall through unchanged (from #7039).

### Why the OSS tests didn't catch this

Pre-#7039 the SSP fixtures were `USING parquet`, whose metastore schema is
populated (unlike Delta's, which is empty), so no test drove a *Delta* table
through SSP. Even after #7039 switched them to `USING delta`, the suite runs with
`skipUCRequirementForTests = true`, which bypasses the `isUnityCatalog &&
!hasCredentials` gate, and against a local filesystem that needs no credentials —
so `DeltaTableV2.schema()` resolves fine and the forced read never fails in-suite.
The failure only reproduces against a real credential-less UC deployment
(`ServerSidePlanningTest.testServerSidePlanningCredentialFallback`).

## How was this patch tested?

New unit tests in `ServerSidePlannedTableSuite`:

- `hasCredentials must be read from the raw V1Table, not the DeltaTableV2` — pins
  the `option.fs.*` asymmetry.
- `tryCreate builds the planned table from the supplied schema, not table.schema()`
  — asserts `tryCreate` uses the caller-supplied schema, so it never forces a
  `DeltaTableV2` snapshot read (checkable in OSS without a live UC).

Full `ServerSidePlannedTableSuite`: 28 passed, 0 failed.

## Does this PR introduce _any_ user-facing changes?

No. `catalog.enableServerSidePlanning` is internal and default-off; this only
changes behavior when that flag is enabled, where it fixes SSP fallback for
credential-less Unity Catalog tables (previously `loadTable` threw / mis-routed).

Co-authored-by: Isaac