### PR TITLE
Reclassify streaming missing-files errors from XXKDS to 42K03

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -2135,17 +2135,9 @@
   },
   "DELTA_MISSING_FILES_UNEXPECTED_VERSION" : {
     "message" : [
-      "The stream from your Delta table was expecting process data from version <startVersion>,",
-      "but the earliest available version in the _delta_log directory is <earliestVersion>. The files",
-      "in the transaction log may have been deleted due to log cleanup. In order to avoid losing",
-      "data, we recommend that you restart your stream with a new checkpoint location and to",
-      "increase your delta.logRetentionDuration setting, if you have explicitly set it below 30",
-      "days.",
-      "If you would like to ignore the missed data and continue your stream from where it left",
-      "off, you can set the .option(\"<option>\", \"false\") as part",
-      "of your readStream statement."
+      "Delta stream cannot resume from version <startVersion>; transaction log starts at <earliestVersion>. Log files may have been deleted by log retention. Restart the stream with a new checkpoint location and consider increasing delta.logRetentionDuration. To skip missing data instead, set .option(\"<option>\", \"false\")."
     ],
-    "sqlState" : "XXKDS"
+    "sqlState" : "42K03"
   },
   "DELTA_MISSING_ICEBERG_CLASS" : {
     "message" : [
@@ -2932,11 +2924,9 @@
   },
   "DELTA_STREAMING_TRAILING_COMMIT_MISSING" : {
     "message" : [
-      "The connector discovered commits up to version <expectedVersion>, but when reading the",
-      "data, commits after version <seenVersion> are missing. The trailing commit files may",
-      "have been deleted or be transiently invisible in the _delta_log directory."
+      "Delta stream detected commits up to version <expectedVersion> but files after version <seenVersion> are missing from the transaction log."
     ],
-    "sqlState" : "XXKDS"
+    "sqlState" : "42K03"
   },
   "DELTA_TABLE_ALREADY_CONTAINS_CDC_COLUMNS" : {
     "message" : [

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -1456,7 +1456,7 @@ trait DeltaErrorsSuiteBase
       val e = intercept[DeltaIllegalStateException] {
         throw DeltaErrors.failOnDataLossException(12, 10)
       }
-      checkError(e, "DELTA_MISSING_FILES_UNEXPECTED_VERSION", "XXKDS",
+      checkError(e, "DELTA_MISSING_FILES_UNEXPECTED_VERSION", "42K03",
         Map("startVersion" -> "12", "earliestVersion" -> "10", "option" -> "failOnDataLoss"))
     }
     {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
@@ -2270,8 +2270,8 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
             val e = intercept[DeltaIllegalStateException] {
               source.getBatch(startOffsetOption = None, endOffset)
             }
-            assert(e.getMessage ===
-              DeltaErrors.streamingTrailingCommitMissing(2L, 1L).getMessage)
+            checkError(e, "DELTA_STREAMING_TRAILING_COMMIT_MISSING", "42K03",
+              Map("expectedVersion" -> "2", "seenVersion" -> "1"))
           }
         }
       }
@@ -2367,7 +2367,9 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
       if (useDsv2) {
         assert(e.getCause.getMessage.contains("no log file found for version"))
       } else {
-        assert(e.getCause.getMessage === DeltaErrors.failOnDataLossException(1L, 2L).getMessage)
+        checkError(e.getCause.asInstanceOf[DeltaIllegalStateException],
+          "DELTA_MISSING_FILES_UNEXPECTED_VERSION", "42K03",
+          Map("startVersion" -> "1", "earliestVersion" -> "2", "option" -> "failOnDataLoss"))
       }
     }
   }
@@ -2406,7 +2408,9 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
       if (useDsv2) {
         assert(e.getCause.getMessage.contains("versions are not contiguous"))
       } else {
-        assert(e.getCause.getMessage === DeltaErrors.failOnDataLossException(2L, 3L).getMessage)
+        checkError(e.getCause.asInstanceOf[DeltaIllegalStateException],
+          "DELTA_MISSING_FILES_UNEXPECTED_VERSION", "42K03",
+          Map("startVersion" -> "2", "earliestVersion" -> "3", "option" -> "failOnDataLoss"))
       }
     }
   }


### PR DESCRIPTION
## Description

`DELTA_MISSING_FILES_UNEXPECTED_VERSION` and `DELTA_STREAMING_TRAILING_COMMIT_MISSING` are raised when a streaming query tries to resume from a table version whose commit files have already been removed by log retention. This is a user-recoverable condition, not an internal engine error, but both were classified with SQLSTATE `XXKDS`, which is reserved for internal errors.

This PR reclassifies both to `42K03` (file not found), matching how other missing-file conditions in Delta are classified (e.g. `DELTA_TRUNCATED_TRANSACTION_LOG`, `DELTA_FILE_NOT_FOUND`). The messages are also tightened for clarity.

## How was this patch tested?

Updated the existing `DeltaErrorsSuite` and `DeltaSourceSuite` cases to assert the new `42K03` SQLSTATE via `checkError`.

## Does this PR introduce _any_ user-facing changes?

Yes. The SQLSTATE returned for these two streaming errors changes from `XXKDS` to `42K03`, and the error message text is shortened. Clients matching on the SQLSTATE will observe the new value.