### PR TITLE
feat: support the UC Delta-Tables API in the Java kernel UC committer

### DIFF
--- a/kernel/unitycatalog/src/main/java/io/delta/kernel/unitycatalog/UCCatalogManagedClient.java
+++ b/kernel/unitycatalog/src/main/java/io/delta/kernel/unitycatalog/UCCatalogManagedClient.java
@@ -166,6 +166,7 @@ public class UCCatalogManagedClient {
                                             engine,
                                             ucTableId,
                                             tablePath,
+                                            ucTableIdentifier,
                                             logData,
                                             maxUcTableVersion));
                         snapshotBuilder =
@@ -174,7 +175,9 @@ public class UCCatalogManagedClient {
 
                       Snapshot snapshot =
                           snapshotBuilder
-                              .withCommitter(createUCCommitter(ucClient, ucTableId, tablePath))
+                              .withCommitter(
+                                  createUCCommitter(
+                                      ucClient, ucTableId, tablePath, ucTableIdentifier))
                               .withLogData(logData)
                               .withMaxCatalogVersion(maxUcTableVersion)
                               .build(engine);
@@ -243,8 +246,7 @@ public class UCCatalogManagedClient {
     Objects.requireNonNull(ucTableIdentifier, "ucTableIdentifier is null");
 
     return TableManager.buildCreateTableTransaction(tablePath, schema, engineInfo)
-        .withCommitter(
-            new UCCatalogManagedCommitter(ucClient, ucTableId, tablePath, ucTableIdentifier))
+        .withCommitter(createUCCommitter(ucClient, ucTableId, tablePath, ucTableIdentifier))
         .withTableProperties(getRequiredTablePropertiesForCreate(ucTableId));
   }
 
@@ -334,7 +336,7 @@ public class UCCatalogManagedClient {
         new Lazy<>(
             () ->
                 loadLatestSnapshotForTimestampResolution(
-                    engine, ucTableId, tablePath, logData, ucTableVersion));
+                    engine, ucTableId, tablePath, ucTableIdentifier, logData, ucTableVersion));
 
     return timeUncheckedOperation(
         logger,
@@ -384,6 +386,17 @@ public class UCCatalogManagedClient {
    */
   protected Committer createUCCommitter(UCClient ucClient, String ucTableId, String tablePath) {
     return new UCCatalogManagedCommitter(ucClient, ucTableId, tablePath);
+  }
+
+  /**
+   * Creates a UC committer that carries the three-part {@link UCTableIdentifier}.
+   *
+   * <p>The identifier is required by the UCDeltaClient, whose {@code commit} needs the {@code
+   * catalog.schema.table} name. The UCClient ignores it.
+   */
+  protected Committer createUCCommitter(
+      UCClient ucClient, String ucTableId, String tablePath, UCTableIdentifier ucTableIdentifier) {
+    return new UCCatalogManagedCommitter(ucClient, ucTableId, tablePath, ucTableIdentifier);
   }
 
   ////////////////////
@@ -555,6 +568,7 @@ public class UCCatalogManagedClient {
       Engine engine,
       String ucTableId,
       String tablePath,
+      UCTableIdentifier ucTableIdentifier,
       List<ParsedLogData> logData,
       long ucTableVersion) {
     // TODO: We can remove timeUncheckedOperation when the commitRange code integrates with metrics
@@ -564,7 +578,7 @@ public class UCCatalogManagedClient {
         ucTableId,
         () ->
             TableManager.loadSnapshot(tablePath)
-                .withCommitter(new UCCatalogManagedCommitter(ucClient, ucTableId, tablePath))
+                .withCommitter(createUCCommitter(ucClient, ucTableId, tablePath, ucTableIdentifier))
                 .withLogData(logData)
                 .withMaxCatalogVersion(ucTableVersion)
                 .build(engine));

--- a/kernel/unitycatalog/src/main/java/io/delta/kernel/unitycatalog/UCCatalogManagedCommitter.java
+++ b/kernel/unitycatalog/src/main/java/io/delta/kernel/unitycatalog/UCCatalogManagedCommitter.java
@@ -336,11 +336,9 @@ public class UCCatalogManagedCommitter implements Committer, CatalogCommitter {
 
     // The Delta-Tables API has structured fields for the last-commit timestamp and domain metadata
     // (clustering, row tracking), so it takes metadata.configuration as properties.
-    final Map<String, String> effectiveConfiguration =
-        commitMetadata.getEffectiveMetadata().getConfiguration();
     final Map<String, String> ucTableProperties =
         ucClient instanceof UCDeltaClient
-            ? (effectiveConfiguration != null ? effectiveConfiguration : Collections.emptyMap())
+            ? commitMetadata.getEffectiveMetadata().getConfiguration()
             : UnityCatalogUtils.getPropertiesForCreate(commitMetadata);
     checkState(
         commitMetadata.getCommitInfo().getInCommitTimestamp().isPresent(),

--- a/kernel/unitycatalog/src/main/java/io/delta/kernel/unitycatalog/UCCatalogManagedCommitter.java
+++ b/kernel/unitycatalog/src/main/java/io/delta/kernel/unitycatalog/UCCatalogManagedCommitter.java
@@ -29,6 +29,7 @@ import io.delta.kernel.internal.annotation.VisibleForTesting;
 import io.delta.kernel.internal.files.ParsedCatalogCommitData;
 import io.delta.kernel.internal.files.ParsedPublishedDeltaData;
 import io.delta.kernel.internal.util.FileNames;
+import io.delta.kernel.unitycatalog.adapters.DomainMetadataAdapter;
 import io.delta.kernel.unitycatalog.adapters.MetadataAdapter;
 import io.delta.kernel.unitycatalog.adapters.ProtocolAdapter;
 import io.delta.kernel.unitycatalog.adapters.UniformAdapter;
@@ -47,6 +48,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -450,6 +452,13 @@ public class UCCatalogManagedCommitter implements Committer, CatalogCommitter {
                         });
               });
 
+          // UCClient ignores the old P&M and domain metadata; UCDeltaClient compares the old and
+          // new P&M to emit set-protocol/metadata updates and forwards domain-metadata updates.
+          final List<AbstractDomainMetadata> domainMetadatas =
+              commitMetadata.getCommitDomainMetadatas().stream()
+                  .map(DomainMetadataAdapter::new)
+                  .collect(Collectors.toList());
+
           try {
             ucClient.commit(
                 ucTableId,
@@ -459,11 +468,11 @@ public class UCCatalogManagedCommitter implements Committer, CatalogCommitter {
                     .orElse(null),
                 Optional.of(getUcCommitPayload(commitMetadata, kernelStagedCommitFileStatus)),
                 commitMetadata.getMaxKnownPublishedDeltaVersion(),
-                Optional.empty() /* oldMetadata */,
+                commitMetadata.getReadMetadataOpt().map(MetadataAdapter::new),
                 generateMetadataPayloadOpt(commitMetadata).map(MetadataAdapter::new),
-                Optional.empty() /* oldProtocol */,
+                commitMetadata.getReadProtocolOpt().map(ProtocolAdapter::new),
                 commitMetadata.getNewProtocolOpt().map(ProtocolAdapter::new),
-                Collections.<AbstractDomainMetadata>emptyList(),
+                domainMetadatas,
                 uniformMetadataOpt);
             return null;
           } catch (io.delta.storage.commit.CommitFailedException cfe) {

--- a/kernel/unitycatalog/src/main/java/io/delta/kernel/unitycatalog/UCCatalogManagedCommitter.java
+++ b/kernel/unitycatalog/src/main/java/io/delta/kernel/unitycatalog/UCCatalogManagedCommitter.java
@@ -342,6 +342,7 @@ public class UCCatalogManagedCommitter implements Committer, CatalogCommitter {
           tableIdentifier.getSchemaName(),
           tablePath.toUri().toString(),
           columns,
+          new ProtocolAdapter(commitMetadata.getEffectiveProtocol()),
           ucProps);
       logger.info(
           "[{}] Finalized table creation in Unity Catalog as {}.{}.{}",

--- a/kernel/unitycatalog/src/main/java/io/delta/kernel/unitycatalog/UCCatalogManagedCommitter.java
+++ b/kernel/unitycatalog/src/main/java/io/delta/kernel/unitycatalog/UCCatalogManagedCommitter.java
@@ -42,6 +42,7 @@ import io.delta.storage.commit.TableIdentifier;
 import io.delta.storage.commit.actions.AbstractDomainMetadata;
 import io.delta.storage.commit.uccommitcoordinator.UCClient;
 import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorException;
+import io.delta.storage.commit.uccommitcoordinator.UCDeltaClient;
 import io.delta.storage.commit.uniform.UniformMetadata;
 import java.io.IOException;
 import java.util.Collections;
@@ -330,9 +331,25 @@ public class UCCatalogManagedCommitter implements Committer, CatalogCommitter {
    */
   private void finalizeTableInCatalog(CommitMetadata commitMetadata) throws CommitFailedException {
     final UCTableIdentifier tableIdentifier = ucTableIdentifier.get();
-    final Map<String, String> ucProps = UnityCatalogUtils.getPropertiesForCreate(commitMetadata);
     final List<UCClient.ColumnDef> columns =
         UnityCatalogUtils.toColumnDefs(commitMetadata.getEffectiveMetadata().getSchema());
+
+    // The Delta-Tables API has structured fields for the last-commit timestamp and domain metadata
+    // (clustering, row tracking), so it takes metadata.configuration as properties.
+    final Map<String, String> effectiveConfiguration =
+        commitMetadata.getEffectiveMetadata().getConfiguration();
+    final Map<String, String> ucTableProperties =
+        ucClient instanceof UCDeltaClient
+            ? (effectiveConfiguration != null ? effectiveConfiguration : Collections.emptyMap())
+            : UnityCatalogUtils.getPropertiesForCreate(commitMetadata);
+    checkState(
+        commitMetadata.getCommitInfo().getInCommitTimestamp().isPresent(),
+        "InCommitTimestamp must be present for version 0 catalog-managed table creation");
+    final long lastCommitTimestampMs = commitMetadata.getCommitInfo().getInCommitTimestamp().get();
+    final List<AbstractDomainMetadata> domainMetadatas =
+        commitMetadata.getCommitDomainMetadatas().stream()
+            .map(DomainMetadataAdapter::new)
+            .collect(Collectors.toList());
 
     try {
       logger.info("[{}] Finalizing table creation in Unity Catalog", ucTableId);
@@ -343,7 +360,9 @@ public class UCCatalogManagedCommitter implements Committer, CatalogCommitter {
           tablePath.toUri().toString(),
           columns,
           new ProtocolAdapter(commitMetadata.getEffectiveProtocol()),
-          ucProps);
+          ucTableProperties,
+          lastCommitTimestampMs,
+          domainMetadatas);
       logger.info(
           "[{}] Finalized table creation in Unity Catalog as {}.{}.{}",
           ucTableId,

--- a/kernel/unitycatalog/src/main/java/io/delta/kernel/unitycatalog/adapters/DomainMetadataAdapter.java
+++ b/kernel/unitycatalog/src/main/java/io/delta/kernel/unitycatalog/adapters/DomainMetadataAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (2025) The Delta Lake Project Authors.
+ * Copyright (2026) The Delta Lake Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernel/unitycatalog/src/main/java/io/delta/kernel/unitycatalog/adapters/DomainMetadataAdapter.java
+++ b/kernel/unitycatalog/src/main/java/io/delta/kernel/unitycatalog/adapters/DomainMetadataAdapter.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.kernel.unitycatalog.adapters;
+
+import io.delta.kernel.internal.actions.DomainMetadata;
+import io.delta.storage.commit.actions.AbstractDomainMetadata;
+import java.util.Objects;
+
+/**
+ * Adapter from {@link io.delta.kernel.internal.actions.DomainMetadata} to {@link
+ * io.delta.storage.commit.actions.AbstractDomainMetadata}.
+ */
+public class DomainMetadataAdapter implements AbstractDomainMetadata {
+
+  private final DomainMetadata kernelDomainMetadata;
+
+  public DomainMetadataAdapter(DomainMetadata kernelDomainMetadata) {
+    this.kernelDomainMetadata =
+        Objects.requireNonNull(kernelDomainMetadata, "kernelDomainMetadata is null");
+  }
+
+  @Override
+  public String getDomain() {
+    return kernelDomainMetadata.getDomain();
+  }
+
+  @Override
+  public String getConfiguration() {
+    return kernelDomainMetadata.getConfiguration();
+  }
+
+  @Override
+  public boolean isRemoved() {
+    return kernelDomainMetadata.isRemoved();
+  }
+}

--- a/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/InMemoryUCClient.scala
+++ b/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/InMemoryUCClient.scala
@@ -47,6 +47,13 @@ object InMemoryUCClient {
     private var currentMetadataOpt: Option[AbstractMetadata] = None
     private var currentIcebergOpt: Option[IcebergMetadata] = None
 
+    // For test only: capture the read-side (old) Protocol/Metadata and domain metadata that the
+    // last commit() call received. The UCClient ignores these; capturing them lets tests assert
+    // the committer forwards them, which is needed by the UCDeltaClient.
+    private var lastOldProtocolOpt: Option[AbstractProtocol] = None
+    private var lastOldMetadataOpt: Option[AbstractMetadata] = None
+    private var lastDomainMetadatas: List[AbstractDomainMetadata] = Nil
+
     /** @return the maximum ratified version. */
     def getMaxRatifiedVersion: Long = synchronized { maxRatifiedVersion }
 
@@ -74,6 +81,25 @@ object InMemoryUCClient {
     /** @return the current Iceberg metadata. For test only. */
     def getCurrentIcebergOpt: Option[IcebergMetadata] = synchronized {
       currentIcebergOpt
+    }
+
+    /** @return the read-side (old) protocol passed to the last commit(). For test only. */
+    def getLastOldProtocolOpt: Option[AbstractProtocol] = synchronized { lastOldProtocolOpt }
+
+    /** @return the read-side (old) metadata passed to the last commit(). For test only. */
+    def getLastOldMetadataOpt: Option[AbstractMetadata] = synchronized { lastOldMetadataOpt }
+
+    /** @return the domain metadata passed to the last commit(). For test only. */
+    def getLastDomainMetadatas: List[AbstractDomainMetadata] = synchronized { lastDomainMetadatas }
+
+    /** Records the read-side P&M and domain metadata seen by a commit(). For test only. */
+    def recordCommitInputs(
+        oldProtocol: Optional[AbstractProtocol],
+        oldMetadata: Optional[AbstractMetadata],
+        domainMetadatas: JList[AbstractDomainMetadata]): Unit = synchronized {
+      lastOldProtocolOpt = if (oldProtocol.isPresent) Some(oldProtocol.get()) else None
+      lastOldMetadataOpt = if (oldMetadata.isPresent) Some(oldMetadata.get()) else None
+      lastDomainMetadatas = domainMetadatas.asScala.toList
     }
 
     /** Updates the Iceberg metadata. */
@@ -189,6 +215,8 @@ class InMemoryUCClient(ucMetastoreId: String) extends UCClient {
     val tableData = getOrCreateTableIfNotExists(tableId)
 
     tableData.synchronized {
+      tableData.recordCommitInputs(oldProtocol, oldMetadata, transactionDomainMetadata)
+
       commitOpt.ifPresent { commit =>
         tableData.appendCommit(commit, newProtocol, newMetadata)
       }

--- a/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/InMemoryUCClient.scala
+++ b/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/InMemoryUCClient.scala
@@ -152,7 +152,9 @@ object InMemoryUCClient {
       storageLocation: String,
       columns: java.util.List[UCClient.ColumnDef],
       protocol: AbstractProtocol,
-      properties: java.util.Map[String, String])
+      properties: java.util.Map[String, String],
+      lastCommitTimestampMs: Long,
+      domainMetadata: java.util.List[AbstractDomainMetadata])
 }
 
 /**
@@ -261,7 +263,9 @@ class InMemoryUCClient(ucMetastoreId: String) extends UCClient {
       storageLocation: String,
       columns: java.util.List[UCClient.ColumnDef],
       protocol: AbstractProtocol,
-      properties: java.util.Map[String, String]): Unit = {
+      properties: java.util.Map[String, String],
+      lastCommitTimestampMs: Long,
+      domainMetadata: java.util.List[AbstractDomainMetadata]): Unit = {
     forceThrowInFinalizeCreateMethod()
     lastFinalizeCreateRecord = Some(InMemoryUCClient.FinalizeCreateRecord(
       tableName,
@@ -270,7 +274,9 @@ class InMemoryUCClient(ucMetastoreId: String) extends UCClient {
       storageLocation,
       columns,
       protocol,
-      properties))
+      properties,
+      lastCommitTimestampMs,
+      domainMetadata))
     val fqn = s"$catalogName.$schemaName.$tableName"
     Option(tables.putIfAbsent(fqn, TableData.afterCreate()))
       .foreach(_ => throw new IllegalArgumentException(s"$fqn already exists"))

--- a/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/InMemoryUCClient.scala
+++ b/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/InMemoryUCClient.scala
@@ -151,6 +151,7 @@ object InMemoryUCClient {
       schemaName: String,
       storageLocation: String,
       columns: java.util.List[UCClient.ColumnDef],
+      protocol: AbstractProtocol,
       properties: java.util.Map[String, String])
 }
 
@@ -259,6 +260,7 @@ class InMemoryUCClient(ucMetastoreId: String) extends UCClient {
       schemaName: String,
       storageLocation: String,
       columns: java.util.List[UCClient.ColumnDef],
+      protocol: AbstractProtocol,
       properties: java.util.Map[String, String]): Unit = {
     forceThrowInFinalizeCreateMethod()
     lastFinalizeCreateRecord = Some(InMemoryUCClient.FinalizeCreateRecord(
@@ -267,6 +269,7 @@ class InMemoryUCClient(ucMetastoreId: String) extends UCClient {
       schemaName,
       storageLocation,
       columns,
+      protocol,
       properties))
     val fqn = s"$catalogName.$schemaName.$tableName"
     Option(tables.putIfAbsent(fqn, TableData.afterCreate()))

--- a/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/UCCatalogManagedCommitterSuite.scala
+++ b/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/UCCatalogManagedCommitterSuite.scala
@@ -25,7 +25,7 @@ import scala.collection.mutable.ArrayBuffer
 import io.delta.kernel.commit.{CommitFailedException, CommitMetadata}
 import io.delta.kernel.commit.CommitMetadata.CommitType
 import io.delta.kernel.data.Row
-import io.delta.kernel.internal.actions.{Metadata, Protocol}
+import io.delta.kernel.internal.actions.{DomainMetadata, Metadata, Protocol}
 import io.delta.kernel.internal.tablefeatures.TableFeatures
 import io.delta.kernel.internal.util.{Tuple2 => KernelTuple2}
 import io.delta.kernel.test.{BaseMockJsonHandler, MockFileSystemClientUtils, TestFixtures, VectorTestUtils}
@@ -244,6 +244,52 @@ class UCCatalogManagedCommitterSuite
       assert(latestProtocol.getReaderFeatures === protocolUpgrade.getReaderFeatures)
       assert(latestProtocol.getWriterFeatures === protocolUpgrade.getWriterFeatures)
       assert(latestMetadata.getConfiguration === metadataUpgrade.getConfiguration)
+    }
+  }
+
+  test("CATALOG_WRITE: read-side (old) P&M and domain metadata are forwarded to UC client") {
+    withTempDirAndAllDeltaSubDirs { case (tablePath, logPath) =>
+      // ===== GIVEN =====
+      val ucClient = new InMemoryUCClient("ucMetastoreId")
+      ucClient.insertTableDataAfterCreate(testUcTableId)
+      val committer = new UCCatalogManagedCommitter(ucClient, testUcTableId, tablePath)
+
+      val readProtocol = protocolWithCatalogManagedSupport
+      val readMetadata = basicPartitionedMetadata
+      val newProtocol = readProtocol.withFeature(TableFeatures.DELETION_VECTORS_RW_FEATURE)
+      val newMetadata = readMetadata.withMergedConfiguration(Map("foo" -> "bar").asJava)
+      val liveDomain = new DomainMetadata("delta.clustering", """{"a":1}""", false)
+      val removedDomain = new DomainMetadata("delta.rowTracking", """{"b":2}""", true)
+
+      val commitMetadata = createCommitMetadata(
+        version = 1,
+        logPath = logPath,
+        commitDomainMetadatas = List(liveDomain, removedDomain),
+        readPandMOpt =
+          Optional.of(new KernelTuple2[Protocol, Metadata](readProtocol, readMetadata)),
+        newProtocolOpt = Optional.of(newProtocol),
+        newMetadataOpt = Optional.of(newMetadata))
+
+      // ===== WHEN =====
+      committer.commit(defaultEngine, emptyActionsIterator, commitMetadata)
+
+      // ===== THEN =====
+      // The committer must forward the read-side (old) P&M so the UCDeltaClient can diff
+      // old-vs-new, and forward the transaction's domain metadata. (The UCClient ignores these;
+      // asserting they arrive guards the committer's forwarding, not the UCClient's behavior.)
+      val tableData = ucClient.getTablesCopy.get(testUcTableId).get
+      assert(tableData.getLastOldProtocolOpt.isDefined, "old protocol should be forwarded")
+      assert(tableData.getLastOldMetadataOpt.isDefined, "old metadata should be forwarded")
+      assert(
+        tableData.getLastOldProtocolOpt.get.getReaderFeatures === readProtocol.getReaderFeatures)
+      assert(
+        tableData.getLastOldMetadataOpt.get.getConfiguration === readMetadata.getConfiguration)
+      val forwardedDomains = tableData.getLastDomainMetadatas
+        .map(dm => (dm.getDomain, dm.getConfiguration, dm.isRemoved))
+      assert(
+        forwardedDomains === Seq(
+          ("delta.clustering", """{"a":1}""", false),
+          ("delta.rowTracking", """{"b":2}""", true)))
     }
   }
 

--- a/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/UCDeltaClientCommitE2ESuite.scala
+++ b/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/UCDeltaClientCommitE2ESuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (2025) The Delta Lake Project Authors.
+ * Copyright (2026) The Delta Lake Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/UCDeltaClientCommitE2ESuite.scala
+++ b/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/UCDeltaClientCommitE2ESuite.scala
@@ -141,11 +141,10 @@ class UCDeltaClientCommitE2ESuite
 
       val readProtocol = protocolWithCatalogManagedSupport
       val readMetadata = basicPartitionedMetadata
-      val newMetadata = readMetadata.withMergedConfiguration(
-        Map(
-          "foo" -> "bar",
-          "delta.minReaderVersion" -> "3",
-          "delta.feature.deletionVectors" -> "supported").asJava)
+      // Kernel keeps protocol-derived keys (delta.minReaderVersion / delta.feature.*) out of
+      // metadata.configuration -- they live on the protocol action -- so the config diff carries
+      // only real user properties. Protocol changes travel via the structured set-protocol update.
+      val newMetadata = readMetadata.withMergedConfiguration(Map("foo" -> "bar").asJava)
 
       val commitMetadata = createCommitMetadata(
         version = 1,
@@ -179,24 +178,19 @@ class UCDeltaClientCommitE2ESuite
       assert(updateActions.contains("add-commit"), s"expected add-commit update: $body")
       assert(updateActions.contains("set-properties"), s"expected set-properties update: $body")
 
-      // set-properties carries the real table property but no protocol-derived properties.
+      // set-properties carries the metadata.configuration diff verbatim (no stripping); protocol
+      // changes are conveyed separately via a set-protocol update, not as properties.
       val setProps = updates
         .elements()
         .asScala
         .find(_.get("action").asText() == "set-properties")
         .map(_.get("updates"))
         .getOrElse(fail(s"missing set-properties updates map: $body"))
-      val propKeys = setProps.fieldNames().asScala.toSet
-      assert(propKeys.contains("foo"), s"expected real property 'foo': $body")
-      assert(
-        !propKeys.contains("delta.minReaderVersion"),
-        s"minReaderVersion must be stripped: $body")
-      assert(
-        !propKeys.contains("delta.minWriterVersion"),
-        s"minWriterVersion must be stripped: $body")
-      assert(
-        !propKeys.exists(_.startsWith("delta.feature.")),
-        s"delta.feature.* must be stripped: $body")
+      // Exactly the config diff, nothing else: guards against protocol-derived or other keys
+      // leaking into the property bag on the wire.
+      val actualProps =
+        setProps.fields().asScala.map(e => e.getKey -> e.getValue.asText()).toMap
+      assert(actualProps === Map("foo" -> "bar"), s"expected only 'foo' -> 'bar': $body")
     }
   }
 

--- a/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/UCDeltaClientCommitE2ESuite.scala
+++ b/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/UCDeltaClientCommitE2ESuite.scala
@@ -23,15 +23,17 @@ import java.util.{Collections, Optional}
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 
+import io.delta.kernel.internal.DeltaLogActionUtils.DeltaAction
 import io.delta.kernel.internal.actions.{Metadata, Protocol}
 import io.delta.kernel.internal.tablefeatures.TableFeatures
 import io.delta.kernel.internal.util.{Tuple2 => KernelTuple2}
 import io.delta.kernel.utils.CloseableIterable
 import io.delta.storage.commit.uccommitcoordinator.UCDeltaTokenBasedRestClient
 
+import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
 import com.sun.net.httpserver.{HttpExchange, HttpServer}
 import io.unitycatalog.client.auth.TokenProvider
-import org.scalatest.BeforeAndAfterAll
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 import org.scalatest.funsuite.AnyFunSuite
 
 /**
@@ -50,12 +52,14 @@ import org.scalatest.funsuite.AnyFunSuite
 class UCDeltaClientCommitE2ESuite
     extends AnyFunSuite
     with BeforeAndAfterAll
+    with BeforeAndAfterEach
     with UCCatalogManagedTestUtils {
 
   private val testUcTableId = "11111111-1111-1111-1111-111111111111"
 
   private var server: HttpServer = _
   private var serverUri: String = _
+  private var deltaClient: UCDeltaTokenBasedRestClient = _
   // Captures (method, path, body) of every request the UCDeltaClient sends to the stub server.
   private val requests = ArrayBuffer.empty[(String, String, String)]
 
@@ -88,6 +92,18 @@ class UCDeltaClientCommitE2ESuite
     super.afterAll()
   }
 
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    requests.synchronized { requests.clear() }
+    deltaClient =
+      new UCDeltaTokenBasedRestClient(serverUri, tokenProvider(), Collections.emptyMap())
+  }
+
+  override def afterEach(): Unit = {
+    if (deltaClient != null) deltaClient.close()
+    super.afterEach()
+  }
+
   private def loadTableJson(): String =
     s"""{"metadata":{"table-uuid":"$testUcTableId","data-source-format":"DELTA",""" +
       s""""table-type":"MANAGED","location":"s3://bucket/table",""" +
@@ -101,185 +117,204 @@ class UCDeltaClientCommitE2ESuite
     override def configs(): java.util.Map[String, String] = Collections.emptyMap()
   }
 
-  private def newUCDeltaClient(): UCDeltaTokenBasedRestClient =
-    new UCDeltaTokenBasedRestClient(serverUri, tokenProvider(), Collections.emptyMap())
+  private val jsonMapper = new ObjectMapper()
+
+  /** Finds the single captured request matching `method` and a path ending in `pathSuffix`. */
+  private def findRequest(method: String, pathSuffix: String): (String, String, String) = {
+    val sent = requests.synchronized { requests.toList }
+    sent
+      .find { case (m, p, _) => m == method && p.endsWith(pathSuffix) }
+      .getOrElse(
+        fail(s"expected a $method to ...$pathSuffix, got: ${sent.map(r => r._1 + " " + r._2)}"))
+  }
+
+  private def parseJson(body: String): JsonNode = jsonMapper.readTree(body)
 
   test("CATALOG_WRITE flows through the real UCDeltaClient to the Delta-Tables API updateTable") {
     withTempDirAndAllDeltaSubDirs { case (tablePath, logPath) =>
       // ===== GIVEN: a committer wired to the REAL UCDeltaClient (injected as a UCClient) =====
-      requests.synchronized { requests.clear() }
-      val deltaClient = newUCDeltaClient()
-      try {
-        val committer = new UCCatalogManagedCommitter(
-          deltaClient,
-          testUcTableId,
-          tablePath,
-          new UCTableIdentifier("main", "default", "t"))
+      val committer = new UCCatalogManagedCommitter(
+        deltaClient,
+        testUcTableId,
+        tablePath,
+        new UCTableIdentifier("main", "default", "t"))
 
-        val readProtocol = protocolWithCatalogManagedSupport
-        val readMetadata = basicPartitionedMetadata
-        val newMetadata = readMetadata.withMergedConfiguration(Map("foo" -> "bar").asJava)
+      val readProtocol = protocolWithCatalogManagedSupport
+      val readMetadata = basicPartitionedMetadata
+      val newMetadata = readMetadata.withMergedConfiguration(
+        Map(
+          "foo" -> "bar",
+          "delta.minReaderVersion" -> "3",
+          "delta.feature.deletionVectors" -> "supported").asJava)
 
-        val commitMetadata = createCommitMetadata(
-          version = 1,
-          logPath = logPath,
-          readPandMOpt =
-            Optional.of(new KernelTuple2[Protocol, Metadata](readProtocol, readMetadata)),
-          newProtocolOpt = Optional.empty(),
-          newMetadataOpt = Optional.of(newMetadata))
+      val commitMetadata = createCommitMetadata(
+        version = 1,
+        logPath = logPath,
+        readPandMOpt =
+          Optional.of(new KernelTuple2[Protocol, Metadata](readProtocol, readMetadata)),
+        newProtocolOpt = Optional.empty(),
+        newMetadataOpt = Optional.of(newMetadata))
 
-        // ===== WHEN =====
-        committer.commit(defaultEngine, emptyActionsIterator, commitMetadata)
+      // ===== WHEN =====
+      committer.commit(defaultEngine, emptyActionsIterator, commitMetadata)
 
-        // ===== THEN: the UCDeltaClient issued an updateTable request carrying the commit =====
-        // The Delta-Tables API updateTable endpoint is POST .../tables/{table}.
-        val sent = requests.synchronized { requests.toList }
-        val updateReq = sent.find { case (method, path, _) =>
-          method == "POST" && path.endsWith("/tables/t")
-        }
-        assert(
-          updateReq.isDefined,
-          s"expected an updateTable POST to .../tables/t, got: " +
-            s"${sent.map(r => r._1 + " " + r._2)}")
-        val body = updateReq.get._3
-        // The request body must carry the add-commit update (the staged commit) and the
-        // set-properties update derived from the old-vs-new metadata diff.
-        assert(body.contains("add-commit"), s"expected add-commit update in body: $body")
-        assert(
-          body.contains("set-properties"),
-          s"expected set-properties update from the metadata diff in body: $body")
-        assert(
-          body.contains("assert-table-uuid"),
-          s"expected table-uuid requirement in body: $body")
-        assert(body.contains(testUcTableId), s"expected the table uuid in body: $body")
-      } finally {
-        deltaClient.close()
-      }
+      // ===== THEN: the UCDeltaClient issued an updateTable request carrying the commit =====
+      // The Delta-Tables API updateTable endpoint is POST .../tables/{table}.
+      val updateReq = findRequest("POST", "/tables/t")
+      val body = parseJson(updateReq._3)
+
+      // Requirements: assert-table-uuid carrying this table's uuid.
+      val requirements = body.get("requirements")
+      assert(requirements != null && requirements.isArray, s"expected requirements array: $body")
+      val requirementActions = requirements.elements().asScala.map(_.get("type").asText()).toSet
+      assert(requirementActions.contains("assert-table-uuid"), s"expected assert-table-uuid: $body")
+      assert(
+        requirements.elements().asScala.exists(_.path("uuid").asText() == testUcTableId),
+        s"expected requirement carrying table uuid $testUcTableId: $body")
+
+      // Updates: add-commit (the staged commit) and set-properties (from the metadata diff).
+      val updates = body.get("updates")
+      assert(updates != null && updates.isArray, s"expected updates array: $body")
+      val updateActions = updates.elements().asScala.map(_.get("action").asText()).toSet
+      assert(updateActions.contains("add-commit"), s"expected add-commit update: $body")
+      assert(updateActions.contains("set-properties"), s"expected set-properties update: $body")
+
+      // set-properties carries the real table property but no protocol-derived properties.
+      val setProps = updates
+        .elements()
+        .asScala
+        .find(_.get("action").asText() == "set-properties")
+        .map(_.get("updates"))
+        .getOrElse(fail(s"missing set-properties updates map: $body"))
+      val propKeys = setProps.fieldNames().asScala.toSet
+      assert(propKeys.contains("foo"), s"expected real property 'foo': $body")
+      assert(
+        !propKeys.contains("delta.minReaderVersion"),
+        s"minReaderVersion must be stripped: $body")
+      assert(
+        !propKeys.contains("delta.minWriterVersion"),
+        s"minWriterVersion must be stripped: $body")
+      assert(
+        !propKeys.exists(_.startsWith("delta.feature.")),
+        s"delta.feature.* must be stripped: $body")
     }
   }
 
   test("CATALOG_CREATE flows through the real UCDeltaClient to the Delta-Tables API createTable") {
     withTempDirAndEngine { case (tablePathUnresolved, engine) =>
-      requests.synchronized { requests.clear() }
       val tablePath = engine.getFileSystemClient.resolvePath(tablePathUnresolved)
-      val deltaClient = newUCDeltaClient()
-      try {
-        val ucCatalogManagedClient = new UCCatalogManagedClient(deltaClient)
+      val ucCatalogManagedClient = new UCCatalogManagedClient(deltaClient)
 
-        // Real create flow: writes 000.json, then finalizeCreate -> Delta-Tables API createTable.
-        ucCatalogManagedClient
-          .buildCreateTableTransaction(
-            testUcTableId,
-            tablePath,
-            testSchema,
-            "test-engine",
-            new UCTableIdentifier("main", "default", "t"))
-          .build(engine)
-          .commit(engine, CloseableIterable.emptyIterable())
+      // Real create flow: writes 000.json, then finalizeCreate -> Delta-Tables API createTable.
+      ucCatalogManagedClient
+        .buildCreateTableTransaction(
+          testUcTableId,
+          tablePath,
+          testSchema,
+          "test-engine",
+          new UCTableIdentifier("main", "default", "t"))
+        .build(engine)
+        .commit(engine, CloseableIterable.emptyIterable())
 
-        // ===== THEN: a createTable POST .../tables was issued (finalizeCreate). =====
-        val sent = requests.synchronized { requests.toList }
-        val createReq = sent.find { case (method, path, _) =>
-          method == "POST" && path.endsWith("/tables")
-        }
-        assert(
-          createReq.isDefined,
-          s"expected a createTable POST to .../tables, got: " +
-            s"${sent.map(r => r._1 + " " + r._2)}")
-      } finally {
-        deltaClient.close()
-      }
+      // ===== THEN: a createTable POST .../tables carried the protocol as a structured field. =====
+      val createReq = findRequest("POST", "/tables")
+      val body = parseJson(createReq._3)
+
+      // Protocol is sent as a structured field (not flattened into properties).
+      val protocol = body.get("protocol")
+      assert(protocol != null && protocol.isObject, s"expected structured protocol field: $body")
+      assert(protocol.path("min-reader-version").asInt() >= 3, s"expected reader version: $body")
+      assert(protocol.path("min-writer-version").asInt() >= 7, s"expected writer version: $body")
+      val writerFeatures =
+        protocol.path("writer-features").elements().asScala.map(_.asText()).toSet
+      assert(writerFeatures.contains("catalogManaged"), s"expected catalogManaged feature: $body")
+
+      // Properties carry no protocol-derived keys (those are conveyed by the protocol field).
+      val props = Option(body.get("properties"))
+      val propKeys = props.map(_.fieldNames().asScala.toSet).getOrElse(Set.empty)
+      assert(
+        !propKeys.contains("delta.minReaderVersion"),
+        s"minReaderVersion must be stripped: $body")
+      assert(
+        !propKeys.contains("delta.minWriterVersion"),
+        s"minWriterVersion must be stripped: $body")
+      assert(
+        !propKeys.exists(_.startsWith("delta.feature.")),
+        s"delta.feature.* must be stripped: $body")
     }
   }
 
   test("loadSnapshot flows through the real UCDeltaClient to the Delta-Tables API loadTable") {
     withTempDirAndEngine { case (tablePathUnresolved, engine) =>
-      requests.synchronized { requests.clear() }
       val tablePath = engine.getFileSystemClient.resolvePath(tablePathUnresolved)
-      val deltaClient = newUCDeltaClient()
-      try {
-        val ucCatalogManagedClient = new UCCatalogManagedClient(deltaClient)
+      val ucCatalogManagedClient = new UCCatalogManagedClient(deltaClient)
 
-        // Create first so there is a real 000.json for the snapshot build to read; this also
-        // exercises createTable. Then load at version 0, which drives getCommits -> loadTable.
-        ucCatalogManagedClient
-          .buildCreateTableTransaction(
-            testUcTableId,
-            tablePath,
-            testSchema,
-            "test-engine",
-            new UCTableIdentifier("main", "default", "t"))
-          .build(engine)
-          .commit(engine, CloseableIterable.emptyIterable())
-
-        requests.synchronized { requests.clear() }
-        val snapshot = ucCatalogManagedClient.loadSnapshot(
-          engine,
+      // Create first so there is a real 000.json for the snapshot build to read; this also
+      // exercises createTable. Then load at version 0, which drives getCommits -> loadTable.
+      ucCatalogManagedClient
+        .buildCreateTableTransaction(
           testUcTableId,
           tablePath,
-          new UCTableIdentifier("main", "default", "t"),
-          Optional.of(0L),
-          Optional.empty())
+          testSchema,
+          "test-engine",
+          new UCTableIdentifier("main", "default", "t"))
+        .build(engine)
+        .commit(engine, CloseableIterable.emptyIterable())
 
-        // ===== THEN: read resolved via a Delta-Tables API loadTable GET .../tables/{table}. =====
-        assert(snapshot.getVersion === 0)
-        val sent = requests.synchronized { requests.toList }
-        val loadReq = sent.find { case (method, path, _) =>
-          method == "GET" && path.endsWith("/tables/t")
-        }
-        assert(
-          loadReq.isDefined,
-          s"expected a loadTable GET to .../tables/t, got: " +
-            s"${sent.map(r => r._1 + " " + r._2)}")
-      } finally {
-        deltaClient.close()
-      }
+      requests.synchronized { requests.clear() }
+      val snapshot = ucCatalogManagedClient.loadSnapshot(
+        engine,
+        testUcTableId,
+        tablePath,
+        new UCTableIdentifier("main", "default", "t"),
+        Optional.of(0L),
+        Optional.empty())
+
+      // ===== THEN: read resolved via a Delta-Tables API loadTable GET .../tables/{table}. =====
+      assert(snapshot.getVersion === 0)
+      findRequest("GET", "/tables/t")
     }
   }
 
   test("loadCommitRange flows through the real UCDeltaClient to the Delta-Tables API loadTable") {
     withTempDirAndEngine { case (tablePathUnresolved, engine) =>
-      requests.synchronized { requests.clear() }
       val tablePath = engine.getFileSystemClient.resolvePath(tablePathUnresolved)
-      val deltaClient = newUCDeltaClient()
-      try {
-        val ucCatalogManagedClient = new UCCatalogManagedClient(deltaClient)
+      val ucCatalogManagedClient = new UCCatalogManagedClient(deltaClient)
 
-        // Create first so there is a real 000.json to build a commit range over.
-        ucCatalogManagedClient
-          .buildCreateTableTransaction(
-            testUcTableId,
-            tablePath,
-            testSchema,
-            "test-engine",
-            new UCTableIdentifier("main", "default", "t"))
-          .build(engine)
-          .commit(engine, CloseableIterable.emptyIterable())
-
-        requests.synchronized { requests.clear() }
-        val commitRange = ucCatalogManagedClient.loadCommitRange(
-          engine,
+      // Create first so there is a real 000.json to build a commit range over.
+      ucCatalogManagedClient
+        .buildCreateTableTransaction(
           testUcTableId,
           tablePath,
-          new UCTableIdentifier("main", "default", "t"),
-          Optional.of(0L),
-          Optional.empty(),
-          Optional.of(0L),
-          Optional.empty())
+          testSchema,
+          "test-engine",
+          new UCTableIdentifier("main", "default", "t"))
+        .build(engine)
+        .commit(engine, CloseableIterable.emptyIterable())
 
-        // ===== THEN: the range resolved via a Delta-Tables API loadTable GET .../tables/t. =====
-        assert(commitRange.getStartVersion === 0)
-        val sent = requests.synchronized { requests.toList }
-        val loadReq = sent.find { case (method, path, _) =>
-          method == "GET" && path.endsWith("/tables/t")
-        }
-        assert(
-          loadReq.isDefined,
-          s"expected a loadTable GET to .../tables/t, got: " +
-            s"${sent.map(r => r._1 + " " + r._2)}")
-      } finally {
-        deltaClient.close()
-      }
+      requests.synchronized { requests.clear() }
+      val commitRange = ucCatalogManagedClient.loadCommitRange(
+        engine,
+        testUcTableId,
+        tablePath,
+        new UCTableIdentifier("main", "default", "t"),
+        Optional.of(0L),
+        Optional.empty(),
+        Optional.of(0L),
+        Optional.empty())
+
+      // ===== THEN: the range resolved via a Delta-Tables API loadTable GET .../tables/t. =====
+      findRequest("GET", "/tables/t")
+      assert(commitRange.getStartVersion === 0)
+      assert(commitRange.getEndVersion === 0)
+      val commitActions =
+        commitRange.getCommitActions(
+          engine,
+          java.util.Set.of(DeltaAction.PROTOCOL, DeltaAction.METADATA))
+      val versions =
+        try commitActions.asScala.map(_.getVersion).toList
+        finally commitActions.close()
+      assert(versions === List(0L))
     }
   }
 }

--- a/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/UCDeltaClientCommitE2ESuite.scala
+++ b/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/UCDeltaClientCommitE2ESuite.scala
@@ -1,0 +1,285 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.kernel.unitycatalog
+
+import java.net.InetSocketAddress
+import java.nio.charset.StandardCharsets
+import java.util.{Collections, Optional}
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable.ArrayBuffer
+
+import io.delta.kernel.internal.actions.{Metadata, Protocol}
+import io.delta.kernel.internal.tablefeatures.TableFeatures
+import io.delta.kernel.internal.util.{Tuple2 => KernelTuple2}
+import io.delta.kernel.utils.CloseableIterable
+import io.delta.storage.commit.uccommitcoordinator.UCDeltaTokenBasedRestClient
+
+import com.sun.net.httpserver.{HttpExchange, HttpServer}
+import io.unitycatalog.client.auth.TokenProvider
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funsuite.AnyFunSuite
+
+/**
+ * End-to-end test that drives the kernel [[UCCatalogManagedCommitter]] against the real
+ * [[UCDeltaTokenBasedRestClient]] (the `UCDeltaClient` impl) over real HTTP, backed by an embedded
+ * stub server (JDK `HttpServer`, mirroring delta-storage's `UCDeltaTokenBasedRestClientSuite`).
+ *
+ * The point is to prove two things without any live Unity Catalog server:
+ *   1. A `UCDeltaClient` (a `UCClient` subtype) can be injected into the existing
+ *      `UCCatalogManagedCommitter` with no kernel change; the committer only ever touches the
+ *      `UCClient` interface.
+ *   2. A `CATALOG_WRITE` commit flows kernel to the Delta-Tables API `updateTable` correctly: the
+ *      committer's forwarded args (staged commit, old/new P&M) become an `updateTable` request
+ *      hitting the wire.
+ */
+class UCDeltaClientCommitE2ESuite
+    extends AnyFunSuite
+    with BeforeAndAfterAll
+    with UCCatalogManagedTestUtils {
+
+  private val testUcTableId = "11111111-1111-1111-1111-111111111111"
+
+  private var server: HttpServer = _
+  private var serverUri: String = _
+  // Captures (method, path, body) of every request the UCDeltaClient sends to the stub server.
+  private val requests = ArrayBuffer.empty[(String, String, String)]
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    server = HttpServer.create(new InetSocketAddress("localhost", 0), 0)
+    server.createContext(
+      "/",
+      (exchange: HttpExchange) => {
+        val body =
+          new String(exchange.getRequestBody.readAllBytes(), StandardCharsets.UTF_8)
+        requests.synchronized {
+          requests += ((exchange.getRequestMethod, exchange.getRequestURI.getPath, body))
+        }
+        // Respond with a minimal loadTable-shaped JSON; updateTable returns the same shape.
+        val resp = loadTableJson()
+        val bytes = resp.getBytes(StandardCharsets.UTF_8)
+        exchange.getResponseHeaders.add("Content-Type", "application/json")
+        exchange.sendResponseHeaders(200, bytes.length)
+        exchange.getResponseBody.write(bytes)
+        exchange.getResponseBody.close()
+        exchange.close()
+      })
+    server.start()
+    serverUri = s"http://localhost:${server.getAddress.getPort}"
+  }
+
+  override def afterAll(): Unit = {
+    if (server != null) server.stop(0)
+    super.afterAll()
+  }
+
+  private def loadTableJson(): String =
+    s"""{"metadata":{"table-uuid":"$testUcTableId","data-source-format":"DELTA",""" +
+      s""""table-type":"MANAGED","location":"s3://bucket/table",""" +
+      s""""columns":{"type":"struct","fields":[]},"properties":{},""" +
+      s""""partition-columns":[],"created-time":1000},""" +
+      s""""commits":[],"latest-table-version":0}"""
+
+  private def tokenProvider(): TokenProvider = new TokenProvider {
+    override def accessToken(): String = "mock-token"
+    override def initialize(configs: java.util.Map[String, String]): Unit = {}
+    override def configs(): java.util.Map[String, String] = Collections.emptyMap()
+  }
+
+  private def newUCDeltaClient(): UCDeltaTokenBasedRestClient =
+    new UCDeltaTokenBasedRestClient(serverUri, tokenProvider(), Collections.emptyMap())
+
+  test("CATALOG_WRITE flows through the real UCDeltaClient to the Delta-Tables API updateTable") {
+    withTempDirAndAllDeltaSubDirs { case (tablePath, logPath) =>
+      // ===== GIVEN: a committer wired to the REAL UCDeltaClient (injected as a UCClient) =====
+      requests.synchronized { requests.clear() }
+      val deltaClient = newUCDeltaClient()
+      try {
+        val committer = new UCCatalogManagedCommitter(
+          deltaClient,
+          testUcTableId,
+          tablePath,
+          new UCTableIdentifier("main", "default", "t"))
+
+        val readProtocol = protocolWithCatalogManagedSupport
+        val readMetadata = basicPartitionedMetadata
+        val newMetadata = readMetadata.withMergedConfiguration(Map("foo" -> "bar").asJava)
+
+        val commitMetadata = createCommitMetadata(
+          version = 1,
+          logPath = logPath,
+          readPandMOpt =
+            Optional.of(new KernelTuple2[Protocol, Metadata](readProtocol, readMetadata)),
+          newProtocolOpt = Optional.empty(),
+          newMetadataOpt = Optional.of(newMetadata))
+
+        // ===== WHEN =====
+        committer.commit(defaultEngine, emptyActionsIterator, commitMetadata)
+
+        // ===== THEN: the UCDeltaClient issued an updateTable request carrying the commit =====
+        // The Delta-Tables API updateTable endpoint is POST .../tables/{table}.
+        val sent = requests.synchronized { requests.toList }
+        val updateReq = sent.find { case (method, path, _) =>
+          method == "POST" && path.endsWith("/tables/t")
+        }
+        assert(
+          updateReq.isDefined,
+          s"expected an updateTable POST to .../tables/t, got: " +
+            s"${sent.map(r => r._1 + " " + r._2)}")
+        val body = updateReq.get._3
+        // The request body must carry the add-commit update (the staged commit) and the
+        // set-properties update derived from the old-vs-new metadata diff.
+        assert(body.contains("add-commit"), s"expected add-commit update in body: $body")
+        assert(
+          body.contains("set-properties"),
+          s"expected set-properties update from the metadata diff in body: $body")
+        assert(
+          body.contains("assert-table-uuid"),
+          s"expected table-uuid requirement in body: $body")
+        assert(body.contains(testUcTableId), s"expected the table uuid in body: $body")
+      } finally {
+        deltaClient.close()
+      }
+    }
+  }
+
+  test("CATALOG_CREATE flows through the real UCDeltaClient to the Delta-Tables API createTable") {
+    withTempDirAndEngine { case (tablePathUnresolved, engine) =>
+      requests.synchronized { requests.clear() }
+      val tablePath = engine.getFileSystemClient.resolvePath(tablePathUnresolved)
+      val deltaClient = newUCDeltaClient()
+      try {
+        val ucCatalogManagedClient = new UCCatalogManagedClient(deltaClient)
+
+        // Real create flow: writes 000.json, then finalizeCreate -> Delta-Tables API createTable.
+        ucCatalogManagedClient
+          .buildCreateTableTransaction(
+            testUcTableId,
+            tablePath,
+            testSchema,
+            "test-engine",
+            new UCTableIdentifier("main", "default", "t"))
+          .build(engine)
+          .commit(engine, CloseableIterable.emptyIterable())
+
+        // ===== THEN: a createTable POST .../tables was issued (finalizeCreate). =====
+        val sent = requests.synchronized { requests.toList }
+        val createReq = sent.find { case (method, path, _) =>
+          method == "POST" && path.endsWith("/tables")
+        }
+        assert(
+          createReq.isDefined,
+          s"expected a createTable POST to .../tables, got: " +
+            s"${sent.map(r => r._1 + " " + r._2)}")
+      } finally {
+        deltaClient.close()
+      }
+    }
+  }
+
+  test("loadSnapshot flows through the real UCDeltaClient to the Delta-Tables API loadTable") {
+    withTempDirAndEngine { case (tablePathUnresolved, engine) =>
+      requests.synchronized { requests.clear() }
+      val tablePath = engine.getFileSystemClient.resolvePath(tablePathUnresolved)
+      val deltaClient = newUCDeltaClient()
+      try {
+        val ucCatalogManagedClient = new UCCatalogManagedClient(deltaClient)
+
+        // Create first so there is a real 000.json for the snapshot build to read; this also
+        // exercises createTable. Then load at version 0, which drives getCommits -> loadTable.
+        ucCatalogManagedClient
+          .buildCreateTableTransaction(
+            testUcTableId,
+            tablePath,
+            testSchema,
+            "test-engine",
+            new UCTableIdentifier("main", "default", "t"))
+          .build(engine)
+          .commit(engine, CloseableIterable.emptyIterable())
+
+        requests.synchronized { requests.clear() }
+        val snapshot = ucCatalogManagedClient.loadSnapshot(
+          engine,
+          testUcTableId,
+          tablePath,
+          new UCTableIdentifier("main", "default", "t"),
+          Optional.of(0L),
+          Optional.empty())
+
+        // ===== THEN: read resolved via a Delta-Tables API loadTable GET .../tables/{table}. =====
+        assert(snapshot.getVersion === 0)
+        val sent = requests.synchronized { requests.toList }
+        val loadReq = sent.find { case (method, path, _) =>
+          method == "GET" && path.endsWith("/tables/t")
+        }
+        assert(
+          loadReq.isDefined,
+          s"expected a loadTable GET to .../tables/t, got: " +
+            s"${sent.map(r => r._1 + " " + r._2)}")
+      } finally {
+        deltaClient.close()
+      }
+    }
+  }
+
+  test("loadCommitRange flows through the real UCDeltaClient to the Delta-Tables API loadTable") {
+    withTempDirAndEngine { case (tablePathUnresolved, engine) =>
+      requests.synchronized { requests.clear() }
+      val tablePath = engine.getFileSystemClient.resolvePath(tablePathUnresolved)
+      val deltaClient = newUCDeltaClient()
+      try {
+        val ucCatalogManagedClient = new UCCatalogManagedClient(deltaClient)
+
+        // Create first so there is a real 000.json to build a commit range over.
+        ucCatalogManagedClient
+          .buildCreateTableTransaction(
+            testUcTableId,
+            tablePath,
+            testSchema,
+            "test-engine",
+            new UCTableIdentifier("main", "default", "t"))
+          .build(engine)
+          .commit(engine, CloseableIterable.emptyIterable())
+
+        requests.synchronized { requests.clear() }
+        val commitRange = ucCatalogManagedClient.loadCommitRange(
+          engine,
+          testUcTableId,
+          tablePath,
+          new UCTableIdentifier("main", "default", "t"),
+          Optional.of(0L),
+          Optional.empty(),
+          Optional.of(0L),
+          Optional.empty())
+
+        // ===== THEN: the range resolved via a Delta-Tables API loadTable GET .../tables/t. =====
+        assert(commitRange.getStartVersion === 0)
+        val sent = requests.synchronized { requests.toList }
+        val loadReq = sent.find { case (method, path, _) =>
+          method == "GET" && path.endsWith("/tables/t")
+        }
+        assert(
+          loadReq.isDefined,
+          s"expected a loadTable GET to .../tables/t, got: " +
+            s"${sent.map(r => r._1 + " " + r._2)}")
+      } finally {
+        deltaClient.close()
+      }
+    }
+  }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/InMemoryUCClient.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/InMemoryUCClient.scala
@@ -108,7 +108,9 @@ class InMemoryUCClient(
       storageLocation: String,
       columns: java.util.List[UCClient.ColumnDef],
       protocol: AbstractProtocol,
-      properties: java.util.Map[String, String]): Unit = {}
+      properties: java.util.Map[String, String],
+      lastCommitTimestampMs: Long,
+      domainMetadata: java.util.List[AbstractDomainMetadata]): Unit = {}
 
   override def close(): Unit = {}
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/InMemoryUCClient.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/InMemoryUCClient.scala
@@ -107,6 +107,7 @@ class InMemoryUCClient(
       schemaName: String,
       storageLocation: String,
       columns: java.util.List[UCClient.ColumnDef],
+      protocol: AbstractProtocol,
       properties: java.util.Map[String, String]): Unit = {}
 
   override def close(): Unit = {}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
@@ -970,7 +970,9 @@ private abstract class ThrowingUCDeltaClient extends UCDeltaClient {
       storageLocation: String,
       columns: util.List[UCClient.ColumnDef],
       protocol: AbstractProtocol,
-      properties: util.Map[String, String]): Unit =
+      properties: util.Map[String, String],
+      lastCommitTimestampMs: Long,
+      domainMetadata: util.List[AbstractDomainMetadata]): Unit =
     throw new UnsupportedOperationException
   override def reportMetrics(
       tableId: String,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
@@ -969,6 +969,7 @@ private abstract class ThrowingUCDeltaClient extends UCDeltaClient {
       schemaName: String,
       storageLocation: String,
       columns: util.List[UCClient.ColumnDef],
+      protocol: AbstractProtocol,
       properties: util.Map[String, String]): Unit =
     throw new UnsupportedOperationException
   override def reportMetrics(

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCKernelDeltaTablesLiveE2ETest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCKernelDeltaTablesLiveE2ETest.java
@@ -31,11 +31,14 @@ import io.delta.kernel.defaults.engine.DefaultEngine;
 import io.delta.kernel.defaults.internal.data.DefaultColumnarBatch;
 import io.delta.kernel.defaults.internal.data.vector.DefaultGenericVector;
 import io.delta.kernel.engine.Engine;
+import io.delta.kernel.expressions.Column;
 import io.delta.kernel.internal.InternalScanFileUtils;
 import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.internal.actions.Protocol;
 import io.delta.kernel.internal.data.ScanStateRow;
 import io.delta.kernel.internal.util.Utils;
+import io.delta.kernel.transaction.CreateTableTransactionBuilder;
+import io.delta.kernel.transaction.DataLayoutSpec;
 import io.delta.kernel.types.IntegerType;
 import io.delta.kernel.types.StringType;
 import io.delta.kernel.types.StructType;
@@ -46,10 +49,12 @@ import io.delta.kernel.utils.CloseableIterator;
 import io.delta.kernel.utils.DataFileStatus;
 import io.delta.kernel.utils.FileStatus;
 import io.delta.storage.commit.uccommitcoordinator.UCDeltaTokenBasedRestClient;
+import io.unitycatalog.client.api.TablesApi;
 import io.unitycatalog.client.auth.TokenProvider;
 import io.unitycatalog.client.delta.api.DeltaTablesApi;
 import io.unitycatalog.client.delta.model.DeltaCreateStagingTableRequest;
 import io.unitycatalog.client.delta.model.DeltaStagingTableResponse;
+import io.unitycatalog.client.model.TableInfo;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -65,11 +70,16 @@ import org.junit.jupiter.api.Test;
 /**
  * End-to-end test that drives the kernel {@link UCCatalogManagedClient} / {@code
  * UCCatalogManagedCommitter} against a <b>real</b> Unity Catalog server over the Delta-Tables API,
- * covering create, ALTER, and insert + read-back.
+ * covering create, ALTER, insert + read-back, and clustered create.
  *
  * <p>Runs against the in-process UC server started by {@link UnityCatalogSupport} by default (no
  * env flag needed). To run against a remote server instead, set {@code UC_REMOTE=true UC_URI=...
  * UC_TOKEN=... UC_CATALOG_NAME=... UC_SCHEMA_NAME=...} (see {@link UnityCatalogSupport}).
+ *
+ * <p>This exercises Kernel APIs but lives under {@code spark/unitycatalog} because booting the
+ * in-process UC server (and its {@link UnityCatalogSupport} harness) needs the coherent Jackson +
+ * server dependency stack the Spark UC module already provides; standing that stack up under {@code
+ * kernel/unitycatalog} pulls conflicting transitive Jackson versions that crash server startup.
  */
 public class UCKernelDeltaTablesLiveE2ETest extends UnityCatalogSupport {
 
@@ -91,6 +101,28 @@ public class UCKernelDeltaTablesLiveE2ETest extends UnityCatalogSupport {
   @AfterEach
   public void restoreS3CredentialCheck() {
     S3CredentialFileSystem.credentialCheckEnabled = priorCredentialCheckEnabled;
+  }
+
+  private UnityCatalogInfo uc;
+  private Engine engine;
+  private UCDeltaTokenBasedRestClient deltaClient;
+  private UCCatalogManagedClient catalogClient;
+
+  @BeforeEach
+  public void setUpCatalogClients() {
+    uc = unityCatalogInfo();
+    engine = newEngine();
+    deltaClient = newDeltaClient(uc);
+    catalogClient = new UCCatalogManagedClient(deltaClient);
+  }
+
+  @AfterEach
+  public void closeCatalogClients() throws Exception {
+    // UCCatalogManagedClient does not own the underlying UCClient, so only the REST client is
+    // released here.
+    if (deltaClient != null) {
+      deltaClient.close();
+    }
   }
 
   private static final String ENGINE_INFO = "kernel-uc-live-e2e";
@@ -152,48 +184,70 @@ public class UCKernelDeltaTablesLiveE2ETest extends UnityCatalogSupport {
    */
   @Test
   public void createTable_sendsStructuredProtocol_andRoundTrips() throws Exception {
-    UnityCatalogInfo uc = unityCatalogInfo();
-    Engine engine = newEngine();
+    CreatedTable table = createManagedTable(uc, engine, catalogClient);
 
-    try (UCDeltaTokenBasedRestClient deltaClient = newDeltaClient(uc)) {
-      UCCatalogManagedClient catalogClient = new UCCatalogManagedClient(deltaClient);
-      CreatedTable table = createManagedTable(uc, engine, catalogClient);
+    Snapshot snapshot = loadAtVersion(catalogClient, engine, table, 0L);
+    assertThat(snapshot.getVersion()).isEqualTo(0L);
+    assertThat(snapshot.getSchema().fieldNames())
+        .containsExactlyElementsOf(TEST_SCHEMA.fieldNames());
 
-      Snapshot snapshot = loadAtVersion(catalogClient, engine, table, 0L);
-      assertThat(snapshot.getVersion()).isEqualTo(0L);
-      assertThat(snapshot.getSchema().fieldNames())
-          .containsExactlyElementsOf(TEST_SCHEMA.fieldNames());
+    Protocol protocol = ((SnapshotImpl) snapshot).getProtocol();
+    assertThat(protocol.getMinReaderVersion()).isGreaterThanOrEqualTo(3);
+    assertThat(protocol.getMinWriterVersion()).isGreaterThanOrEqualTo(7);
+    assertThat(protocol.getWriterFeatures()).contains("catalogManaged");
 
-      Protocol protocol = ((SnapshotImpl) snapshot).getProtocol();
-      assertThat(protocol.getMinReaderVersion()).isGreaterThanOrEqualTo(3);
-      assertThat(protocol.getMinWriterVersion()).isGreaterThanOrEqualTo(7);
-      assertThat(protocol.getWriterFeatures()).contains("catalogManaged");
+    assertThat(snapshot.getTableProperties()).containsAllEntriesOf(table.requiredProperties);
+  }
 
-      assertThat(snapshot.getTableProperties()).containsAllEntriesOf(table.requiredProperties);
-    }
+  /**
+   * Creates a clustered table through the kernel committer path and asserts clustering round-trips
+   * on both surfaces: (a) the catalog's raw property bag returned by the server, which carries
+   * {@code clusteringColumns} plus {@code delta.feature.clustering}; and (b) the kernel snapshot,
+   * whose clustering columns come from the clustering domain metadata in the log.
+   */
+  @Test
+  public void createClusteredTable_roundTripsClusteringColumns() throws Exception {
+    CreatedTable table =
+        createManagedTable(
+            uc, engine, catalogClient, DataLayoutSpec.clustered(List.of(new Column("id"))));
+
+    // (a) Raw catalog properties as persisted by the server.
+    TablesApi tablesApi = new TablesApi(uc.createApiClient());
+    String fullName =
+        String.format(
+            "%s.%s.%s",
+            table.identifier.getCatalogName(),
+            table.identifier.getSchemaName(),
+            table.identifier.getTableName());
+    TableInfo tableInfo = tablesApi.getTable(fullName, false, false);
+    Map<String, String> serverProps = tableInfo.getProperties();
+    assertThat(serverProps).containsEntry("delta.feature.clustering", "supported");
+    // The clusteringColumns value is a column-mapped physical reference, so assert presence only.
+    assertThat(serverProps).containsKey("clusteringColumns");
+
+    // (b) Kernel snapshot: clustering columns resolved from the clustering domain metadata.
+    Snapshot snapshot = loadAtVersion(catalogClient, engine, table, 0L);
+    Optional<List<Column>> clusteringColumns =
+        ((SnapshotImpl) snapshot).getPhysicalClusteringColumns();
+    assertThat(clusteringColumns).isPresent();
+    assertThat(clusteringColumns.get()).hasSize(1);
   }
 
   @Test
   public void alterTable_setTableProperty_roundTripsThroughUpdateTable() throws Exception {
-    UnityCatalogInfo uc = unityCatalogInfo();
-    Engine engine = newEngine();
+    CreatedTable table = createManagedTable(uc, engine, catalogClient);
 
-    try (UCDeltaTokenBasedRestClient deltaClient = newDeltaClient(uc)) {
-      UCCatalogManagedClient catalogClient = new UCCatalogManagedClient(deltaClient);
-      CreatedTable table = createManagedTable(uc, engine, catalogClient);
+    // ALTER: set a user table property on the v0 table via the update-table (V1+) path.
+    Snapshot v0 = loadAtVersion(catalogClient, engine, table, 0L);
+    v0.buildUpdateTableTransaction(ENGINE_INFO, Operation.MANUAL_UPDATE)
+        .withTablePropertiesAdded(Map.of("user.key", "user-value"))
+        .build(engine)
+        .commit(engine, CloseableIterable.emptyIterable());
 
-      // ALTER: set a user table property on the v0 table via the update-table (V1+) path.
-      Snapshot v0 = loadAtVersion(catalogClient, engine, table, 0L);
-      v0.buildUpdateTableTransaction(ENGINE_INFO, Operation.MANUAL_UPDATE)
-          .withTablePropertiesAdded(Map.of("user.key", "user-value"))
-          .build(engine)
-          .commit(engine, CloseableIterable.emptyIterable());
-
-      // Reload at the new version and assert the property is present.
-      Snapshot v1 = loadAtVersion(catalogClient, engine, table, 1L);
-      assertThat(v1.getVersion()).isEqualTo(1L);
-      assertThat(v1.getTableProperties()).containsEntry("user.key", "user-value");
-    }
+    // Reload at the new version and assert the property is present.
+    Snapshot v1 = loadAtVersion(catalogClient, engine, table, 1L);
+    assertThat(v1.getVersion()).isEqualTo(1L);
+    assertThat(v1.getTableProperties()).containsEntry("user.key", "user-value");
   }
 
   /** Holds the identifiers of a table created via {@link #createManagedTable}. */
@@ -221,6 +275,20 @@ public class UCKernelDeltaTablesLiveE2ETest extends UnityCatalogSupport {
    */
   private CreatedTable createManagedTable(
       UnityCatalogInfo uc, Engine engine, UCCatalogManagedClient catalogClient) throws Exception {
+    return createManagedTable(uc, engine, catalogClient, null);
+  }
+
+  /**
+   * Reserves a staging table and runs the kernel create-table transaction. When {@code dataLayout}
+   * is non-null it is applied to the create transaction (e.g. clustering), so the write and the
+   * Delta-Tables finalize carry the layout.
+   */
+  private CreatedTable createManagedTable(
+      UnityCatalogInfo uc,
+      Engine engine,
+      UCCatalogManagedClient catalogClient,
+      DataLayoutSpec dataLayout)
+      throws Exception {
     String tableName = "kernel_e2e_" + UUID.randomUUID().toString().replace("-", "");
     UCTableIdentifier identifier =
         new UCTableIdentifier(uc.catalogName(), uc.schemaName(), tableName);
@@ -239,11 +307,14 @@ public class UCKernelDeltaTablesLiveE2ETest extends UnityCatalogSupport {
     // Honor the server's required protocol/properties from the staging response (the OSS server
     // requires catalog-managed tables to carry features/properties beyond the defaults that
     // buildCreateTableTransaction sets).
-    catalogClient
-        .buildCreateTableTransaction(ucTableId, tablePath, TEST_SCHEMA, ENGINE_INFO, identifier)
-        .withTableProperties(requiredFeatureProperties(staging))
-        .build(engine)
-        .commit(engine, CloseableIterable.emptyIterable());
+    CreateTableTransactionBuilder createBuilder =
+        catalogClient
+            .buildCreateTableTransaction(ucTableId, tablePath, TEST_SCHEMA, ENGINE_INFO, identifier)
+            .withTableProperties(requiredFeatureProperties(staging));
+    if (dataLayout != null) {
+      createBuilder = createBuilder.withDataLayoutSpec(dataLayout);
+    }
+    createBuilder.build(engine).commit(engine, CloseableIterable.emptyIterable());
 
     // The server's required *properties* (as opposed to required features, which land in the
     // protocol) persist verbatim into table metadata, so tests can assert they round-tripped.
@@ -266,22 +337,16 @@ public class UCKernelDeltaTablesLiveE2ETest extends UnityCatalogSupport {
 
   @Test
   public void insertData_thenReadBack_roundTripsThroughUpdateTable() throws Exception {
-    UnityCatalogInfo uc = unityCatalogInfo();
-    Engine engine = newEngine();
+    CreatedTable table = createManagedTable(uc, engine, catalogClient);
 
-    try (UCDeltaTokenBasedRestClient deltaClient = newDeltaClient(uc)) {
-      UCCatalogManagedClient catalogClient = new UCCatalogManagedClient(deltaClient);
-      CreatedTable table = createManagedTable(uc, engine, catalogClient);
+    // INSERT: append 3 rows to the v0 table through the update-table (V1+) commit path.
+    Snapshot v0 = loadAtVersion(catalogClient, engine, table, 0L);
+    insertRows(engine, v0, 3);
 
-      // INSERT: append 3 rows to the v0 table through the update-table (V1+) commit path.
-      Snapshot v0 = loadAtVersion(catalogClient, engine, table, 0L);
-      insertRows(engine, v0, 3);
-
-      // READ: reload at the new version and scan the data back, asserting the exact rows written.
-      Snapshot v1 = loadAtVersion(catalogClient, engine, table, 1L);
-      assertThat(v1.getVersion()).isEqualTo(1L);
-      assertThat(readRows(engine, v1)).containsExactlyInAnyOrder("0=row-0", "1=row-1", "2=row-2");
-    }
+    // READ: reload at the new version and scan the data back, asserting the exact rows written.
+    Snapshot v1 = loadAtVersion(catalogClient, engine, table, 1L);
+    assertThat(v1.getVersion()).isEqualTo(1L);
+    assertThat(readRows(engine, v1)).containsExactlyInAnyOrder("0=row-0", "1=row-1", "2=row-2");
   }
 
   /** Appends {@code rowCount} rows of test data to {@code snapshot} via a WRITE transaction. */

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCKernelDeltaTablesLiveE2ETest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCKernelDeltaTablesLiveE2ETest.java
@@ -48,12 +48,11 @@ import io.delta.kernel.utils.CloseableIterable;
 import io.delta.kernel.utils.CloseableIterator;
 import io.delta.kernel.utils.DataFileStatus;
 import io.delta.kernel.utils.FileStatus;
+import io.delta.storage.commit.TableIdentifier;
+import io.delta.storage.commit.uccommitcoordinator.UCDeltaModels;
 import io.delta.storage.commit.uccommitcoordinator.UCDeltaTokenBasedRestClient;
 import io.unitycatalog.client.api.TablesApi;
 import io.unitycatalog.client.auth.TokenProvider;
-import io.unitycatalog.client.delta.api.DeltaTablesApi;
-import io.unitycatalog.client.delta.model.DeltaCreateStagingTableRequest;
-import io.unitycatalog.client.delta.model.DeltaStagingTableResponse;
 import io.unitycatalog.client.model.TableInfo;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -61,6 +60,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.jupiter.api.AfterEach;
@@ -84,30 +84,13 @@ public class UCKernelDeltaTablesLiveE2ETest extends UnityCatalogSupport {
     return AuthMode.STATIC;
   }
 
-  // The server vends s3://<fake-bucket>/... locations backed by local files, which the test's
-  // S3CredentialFileSystem maps to local paths.
-  private boolean priorCredentialCheckEnabled;
-
-  @BeforeEach
-  public void disableS3CredentialCheck() {
-    priorCredentialCheckEnabled = S3CredentialFileSystem.credentialCheckEnabled;
-    S3CredentialFileSystem.credentialCheckEnabled = false;
-  }
-
-  @AfterEach
-  public void restoreS3CredentialCheck() {
-    S3CredentialFileSystem.credentialCheckEnabled = priorCredentialCheckEnabled;
-  }
-
   private UnityCatalogInfo uc;
-  private Engine engine;
   private UCDeltaTokenBasedRestClient deltaClient;
   private UCCatalogManagedClient catalogClient;
 
   @BeforeEach
   public void setUpCatalogClients() {
     uc = unityCatalogInfo();
-    engine = newEngine();
     deltaClient = newDeltaClient(uc);
     catalogClient = new UCCatalogManagedClient(deltaClient);
   }
@@ -133,9 +116,17 @@ public class UCKernelDeltaTablesLiveE2ETest extends UnityCatalogSupport {
   }
 
   private Engine newEngine() {
-    // Route the s3 scheme through the test's S3CredentialFileSystem.
+    return newEngine(Collections.emptyMap());
+  }
+
+  /**
+   * Builds an engine whose Hadoop config routes {@code s3://} through the test's {@link
+   * S3CredentialFileSystem} and carries {@code storageProperties} (UC-vended credentials).
+   */
+  private Engine newEngine(Map<String, String> storageProperties) {
     Configuration conf = new Configuration();
     conf.set("fs.s3.impl", S3CredentialFileSystem.class.getName());
+    storageProperties.forEach(conf::set);
     return DefaultEngine.create(conf);
   }
 
@@ -146,17 +137,11 @@ public class UCKernelDeltaTablesLiveE2ETest extends UnityCatalogSupport {
    * delta.feature.<name>=supported}, and the server's advertised required properties are applied
    * verbatim.
    */
-  private Map<String, String> requiredFeatureProperties(DeltaStagingTableResponse staging) {
+  private Map<String, String> requiredFeatureProperties(UCDeltaModels.StagingTableInfo staging) {
     Map<String, String> props = new HashMap<>();
     if (staging.getRequiredProtocol() != null) {
-      List<String> reader =
-          staging.getRequiredProtocol().getReaderFeatures() == null
-              ? Collections.emptyList()
-              : staging.getRequiredProtocol().getReaderFeatures();
-      List<String> writer =
-          staging.getRequiredProtocol().getWriterFeatures() == null
-              ? Collections.emptyList()
-              : staging.getRequiredProtocol().getWriterFeatures();
+      Set<String> reader = staging.getRequiredProtocol().getReaderFeatures();
+      Set<String> writer = staging.getRequiredProtocol().getWriterFeatures();
       for (String feature : reader) {
         props.put("delta.feature." + feature, "supported");
       }
@@ -180,9 +165,9 @@ public class UCKernelDeltaTablesLiveE2ETest extends UnityCatalogSupport {
    */
   @Test
   public void createTable_sendsStructuredProtocol_andRoundTrips() throws Exception {
-    CreatedTable table = createManagedTable(uc, engine, catalogClient);
+    CreatedTable table = createManagedTable(uc, catalogClient);
 
-    Snapshot snapshot = loadAtVersion(catalogClient, engine, table, 0L);
+    Snapshot snapshot = loadAtVersion(catalogClient, table, 0L);
     assertThat(snapshot.getVersion()).isEqualTo(0L);
     assertThat(snapshot.getSchema().fieldNames())
         .containsExactlyElementsOf(TEST_SCHEMA.fieldNames());
@@ -204,8 +189,7 @@ public class UCKernelDeltaTablesLiveE2ETest extends UnityCatalogSupport {
   @Test
   public void createClusteredTable_roundTripsClusteringColumns() throws Exception {
     CreatedTable table =
-        createManagedTable(
-            uc, engine, catalogClient, DataLayoutSpec.clustered(List.of(new Column("id"))));
+        createManagedTable(uc, catalogClient, DataLayoutSpec.clustered(List.of(new Column("id"))));
 
     // (a) Raw catalog properties as persisted by the server.
     TablesApi tablesApi = new TablesApi(uc.createApiClient());
@@ -220,7 +204,7 @@ public class UCKernelDeltaTablesLiveE2ETest extends UnityCatalogSupport {
     assertThat(serverProps).containsEntry("delta.feature.clustering", "supported");
     assertThat(serverProps).containsKey("clusteringColumns");
 
-    Snapshot snapshot = loadAtVersion(catalogClient, engine, table, 0L);
+    Snapshot snapshot = loadAtVersion(catalogClient, table, 0L);
     Optional<List<Column>> clusteringColumns =
         ((SnapshotImpl) snapshot).getPhysicalClusteringColumns();
     assertThat(clusteringColumns).isPresent();
@@ -229,16 +213,18 @@ public class UCKernelDeltaTablesLiveE2ETest extends UnityCatalogSupport {
 
   @Test
   public void alterTable_setTableProperty_roundTripsThroughUpdateTable() throws Exception {
-    CreatedTable table = createManagedTable(uc, engine, catalogClient);
+    CreatedTable table = createManagedTable(uc, catalogClient);
 
-    // ALTER: set a user table property on the v0 table via the update-table (V1+) path.
-    Snapshot v0 = loadAtVersion(catalogClient, engine, table, 0L);
+    // ALTER: set a user table property on the v0 table via the update-table (V1+) path, using an
+    // engine configured with the vended storage credentials so the write is credential-checked.
+    Engine engine = newEngine(table.storageProperties);
+    Snapshot v0 = loadAtVersion(catalogClient, table, 0L);
     v0.buildUpdateTableTransaction(ENGINE_INFO, Operation.MANUAL_UPDATE)
         .withTablePropertiesAdded(Map.of("user.key", "user-value"))
         .build(engine)
         .commit(engine, CloseableIterable.emptyIterable());
 
-    Snapshot v1 = loadAtVersion(catalogClient, engine, table, 1L);
+    Snapshot v1 = loadAtVersion(catalogClient, table, 1L);
     assertThat(v1.getVersion()).isEqualTo(1L);
     assertThat(v1.getTableProperties()).containsEntry("user.key", "user-value");
   }
@@ -249,16 +235,20 @@ public class UCKernelDeltaTablesLiveE2ETest extends UnityCatalogSupport {
     final String tablePath;
     final UCTableIdentifier identifier;
     final Map<String, String> requiredProperties;
+    // UC-vended storage credentials from the staging response
+    final Map<String, String> storageProperties;
 
     CreatedTable(
         String ucTableId,
         String tablePath,
         UCTableIdentifier identifier,
-        Map<String, String> requiredProperties) {
+        Map<String, String> requiredProperties,
+        Map<String, String> storageProperties) {
       this.ucTableId = ucTableId;
       this.tablePath = tablePath;
       this.identifier = identifier;
       this.requiredProperties = requiredProperties;
+      this.storageProperties = storageProperties;
     }
   }
 
@@ -266,9 +256,9 @@ public class UCKernelDeltaTablesLiveE2ETest extends UnityCatalogSupport {
    * Reserves a staging table and runs the kernel create-table transaction (writes 000.json + the
    * Delta-Tables createTable finalize), honoring the server's required protocol/properties.
    */
-  private CreatedTable createManagedTable(
-      UnityCatalogInfo uc, Engine engine, UCCatalogManagedClient catalogClient) throws Exception {
-    return createManagedTable(uc, engine, catalogClient, null);
+  private CreatedTable createManagedTable(UnityCatalogInfo uc, UCCatalogManagedClient catalogClient)
+      throws Exception {
+    return createManagedTable(uc, catalogClient, null);
   }
 
   /**
@@ -277,25 +267,22 @@ public class UCKernelDeltaTablesLiveE2ETest extends UnityCatalogSupport {
    * Delta-Tables finalize carry the layout.
    */
   private CreatedTable createManagedTable(
-      UnityCatalogInfo uc,
-      Engine engine,
-      UCCatalogManagedClient catalogClient,
-      DataLayoutSpec dataLayout)
+      UnityCatalogInfo uc, UCCatalogManagedClient catalogClient, DataLayoutSpec dataLayout)
       throws Exception {
     String tableName = "kernel_e2e_" + UUID.randomUUID().toString().replace("-", "");
     UCTableIdentifier identifier =
         new UCTableIdentifier(uc.catalogName(), uc.schemaName(), tableName);
 
-    // Reserve a staging table via the Delta-Tables API to obtain the UC table id + storage
-    // location. (The legacy TablesApi staging endpoint is disabled in Delta-API-only mode.)
-    DeltaTablesApi deltaTablesApi = new DeltaTablesApi(uc.createApiClient());
-    DeltaStagingTableResponse staging =
-        deltaTablesApi.createStagingTable(
-            uc.catalogName(),
-            uc.schemaName(),
-            new DeltaCreateStagingTableRequest().name(tableName));
+    // Reserve a staging table to obtain the UC table id, storage location, and vended storage
+    // credentials. (The legacy TablesApi staging endpoint is disabled in Delta-API-only mode.)
+    UCDeltaModels.StagingTableInfo staging =
+        deltaClient.createStagingTable(
+            new TableIdentifier(uc.catalogName(), uc.schemaName(), tableName));
     String ucTableId = staging.getTableId().toString();
     String tablePath = staging.getLocation();
+    Map<String, String> storageProperties = staging.getStorageProperties();
+
+    Engine engine = newEngine(storageProperties);
 
     // Honor the server's required protocol/properties from the staging response (the OSS server
     // requires catalog-managed tables to carry features/properties beyond the defaults that
@@ -313,12 +300,14 @@ public class UCKernelDeltaTablesLiveE2ETest extends UnityCatalogSupport {
     // protocol) persist verbatim into table metadata, so tests can assert they round-tripped.
     Map<String, String> requiredProperties =
         staging.getRequiredProperties() == null ? Map.of() : staging.getRequiredProperties();
-    return new CreatedTable(ucTableId, tablePath, identifier, requiredProperties);
+    return new CreatedTable(
+        ucTableId, tablePath, identifier, requiredProperties, storageProperties);
   }
 
   /** Loads {@code table} at a specific version through the catalog client. */
   private Snapshot loadAtVersion(
-      UCCatalogManagedClient catalogClient, Engine engine, CreatedTable table, long version) {
+      UCCatalogManagedClient catalogClient, CreatedTable table, long version) throws Exception {
+    Engine engine = newEngine(table.storageProperties);
     return catalogClient.loadSnapshot(
         engine,
         table.ucTableId,
@@ -330,14 +319,15 @@ public class UCKernelDeltaTablesLiveE2ETest extends UnityCatalogSupport {
 
   @Test
   public void insertData_thenReadBack_roundTripsThroughUpdateTable() throws Exception {
-    CreatedTable table = createManagedTable(uc, engine, catalogClient);
+    CreatedTable table = createManagedTable(uc, catalogClient);
 
     // INSERT: append 3 rows to the v0 table through the update-table (V1+) commit path.
-    Snapshot v0 = loadAtVersion(catalogClient, engine, table, 0L);
+    Engine engine = newEngine(table.storageProperties);
+    Snapshot v0 = loadAtVersion(catalogClient, table, 0L);
     insertRows(engine, v0, 3);
 
     // READ: reload at the new version and scan the data back, asserting the exact rows written.
-    Snapshot v1 = loadAtVersion(catalogClient, engine, table, 1L);
+    Snapshot v1 = loadAtVersion(catalogClient, table, 1L);
     assertThat(v1.getVersion()).isEqualTo(1L);
     assertThat(readRows(engine, v1)).containsExactlyInAnyOrder("0=row-0", "1=row-1", "2=row-2");
   }

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCKernelDeltaTablesLiveE2ETest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCKernelDeltaTablesLiveE2ETest.java
@@ -72,10 +72,6 @@ import org.junit.jupiter.api.Test;
  * UCCatalogManagedCommitter} against a <b>real</b> Unity Catalog server over the Delta-Tables API,
  * covering create, ALTER, insert + read-back, and clustered create.
  *
- * <p>Runs against the in-process UC server started by {@link UnityCatalogSupport} by default (no
- * env flag needed). To run against a remote server instead, set {@code UC_REMOTE=true UC_URI=...
- * UC_TOKEN=... UC_CATALOG_NAME=... UC_SCHEMA_NAME=...} (see {@link UnityCatalogSupport}).
- *
  * <p>This exercises Kernel APIs but lives under {@code spark/unitycatalog} because booting the
  * in-process UC server (and its {@link UnityCatalogSupport} harness) needs the coherent Jackson +
  * server dependency stack the Spark UC module already provides; standing that stack up under {@code
@@ -222,10 +218,8 @@ public class UCKernelDeltaTablesLiveE2ETest extends UnityCatalogSupport {
     TableInfo tableInfo = tablesApi.getTable(fullName, false, false);
     Map<String, String> serverProps = tableInfo.getProperties();
     assertThat(serverProps).containsEntry("delta.feature.clustering", "supported");
-    // The clusteringColumns value is a column-mapped physical reference, so assert presence only.
     assertThat(serverProps).containsKey("clusteringColumns");
 
-    // (b) Kernel snapshot: clustering columns resolved from the clustering domain metadata.
     Snapshot snapshot = loadAtVersion(catalogClient, engine, table, 0L);
     Optional<List<Column>> clusteringColumns =
         ((SnapshotImpl) snapshot).getPhysicalClusteringColumns();
@@ -244,7 +238,6 @@ public class UCKernelDeltaTablesLiveE2ETest extends UnityCatalogSupport {
         .build(engine)
         .commit(engine, CloseableIterable.emptyIterable());
 
-    // Reload at the new version and assert the property is present.
     Snapshot v1 = loadAtVersion(catalogClient, engine, table, 1L);
     assertThat(v1.getVersion()).isEqualTo(1L);
     assertThat(v1.getTableProperties()).containsEntry("user.key", "user-value");

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCKernelDeltaTablesLiveE2ETest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCKernelDeltaTablesLiveE2ETest.java
@@ -1,0 +1,366 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.sparkuctest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.delta.kernel.DataWriteContext;
+import io.delta.kernel.Operation;
+import io.delta.kernel.Scan;
+import io.delta.kernel.Snapshot;
+import io.delta.kernel.Transaction;
+import io.delta.kernel.data.ColumnVector;
+import io.delta.kernel.data.ColumnarBatch;
+import io.delta.kernel.data.FilteredColumnarBatch;
+import io.delta.kernel.data.Row;
+import io.delta.kernel.defaults.engine.DefaultEngine;
+import io.delta.kernel.defaults.internal.data.DefaultColumnarBatch;
+import io.delta.kernel.defaults.internal.data.vector.DefaultGenericVector;
+import io.delta.kernel.engine.Engine;
+import io.delta.kernel.internal.InternalScanFileUtils;
+import io.delta.kernel.internal.SnapshotImpl;
+import io.delta.kernel.internal.actions.Protocol;
+import io.delta.kernel.internal.data.ScanStateRow;
+import io.delta.kernel.internal.util.Utils;
+import io.delta.kernel.types.IntegerType;
+import io.delta.kernel.types.StringType;
+import io.delta.kernel.types.StructType;
+import io.delta.kernel.unitycatalog.UCCatalogManagedClient;
+import io.delta.kernel.unitycatalog.UCTableIdentifier;
+import io.delta.kernel.utils.CloseableIterable;
+import io.delta.kernel.utils.CloseableIterator;
+import io.delta.kernel.utils.DataFileStatus;
+import io.delta.kernel.utils.FileStatus;
+import io.delta.storage.commit.uccommitcoordinator.UCDeltaTokenBasedRestClient;
+import io.unitycatalog.client.auth.TokenProvider;
+import io.unitycatalog.client.delta.api.DeltaTablesApi;
+import io.unitycatalog.client.delta.model.DeltaCreateStagingTableRequest;
+import io.unitycatalog.client.delta.model.DeltaStagingTableResponse;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end test that drives the kernel {@link UCCatalogManagedClient} / {@code
+ * UCCatalogManagedCommitter} against a <b>real</b> Unity Catalog server over the Delta-Tables API,
+ * covering create, ALTER, and insert + read-back.
+ *
+ * <p>Runs against the in-process UC server started by {@link UnityCatalogSupport} by default (no
+ * env flag needed). To run against a remote server instead, set {@code UC_REMOTE=true UC_URI=...
+ * UC_TOKEN=... UC_CATALOG_NAME=... UC_SCHEMA_NAME=...} (see {@link UnityCatalogSupport}).
+ */
+public class UCKernelDeltaTablesLiveE2ETest extends UnityCatalogSupport {
+
+  @Override
+  protected AuthMode authMode() {
+    return AuthMode.STATIC;
+  }
+
+  // The server vends s3://<fake-bucket>/... locations backed by local files, which the test's
+  // S3CredentialFileSystem maps to local paths.
+  private boolean priorCredentialCheckEnabled;
+
+  @BeforeEach
+  public void disableS3CredentialCheck() {
+    priorCredentialCheckEnabled = S3CredentialFileSystem.credentialCheckEnabled;
+    S3CredentialFileSystem.credentialCheckEnabled = false;
+  }
+
+  @AfterEach
+  public void restoreS3CredentialCheck() {
+    S3CredentialFileSystem.credentialCheckEnabled = priorCredentialCheckEnabled;
+  }
+
+  private static final String ENGINE_INFO = "kernel-uc-live-e2e";
+
+  private static final StructType TEST_SCHEMA =
+      new StructType().add("id", IntegerType.INTEGER).add("name", StringType.STRING);
+
+  private UCDeltaTokenBasedRestClient newDeltaClient(UnityCatalogInfo uc) {
+    Map<String, String> authConfig = Map.of("type", "static", "token", uc.serverToken());
+    TokenProvider tokenProvider = TokenProvider.create(authConfig);
+    return new UCDeltaTokenBasedRestClient(uc.serverUri(), tokenProvider, Collections.emptyMap());
+  }
+
+  private Engine newEngine() {
+    // Route the s3 scheme through the test's S3CredentialFileSystem.
+    Configuration conf = new Configuration();
+    conf.set("fs.s3.impl", S3CredentialFileSystem.class.getName());
+    return DefaultEngine.create(conf);
+  }
+
+  /**
+   * Table properties a connector must set to satisfy the server's create contract, beyond the
+   * catalog-managed defaults that {@code buildCreateTableTransaction} already sets. Each feature
+   * the staging response's required protocol advertises becomes {@code
+   * delta.feature.<name>=supported}, and the server's advertised required properties are applied
+   * verbatim.
+   */
+  private Map<String, String> requiredFeatureProperties(DeltaStagingTableResponse staging) {
+    Map<String, String> props = new HashMap<>();
+    if (staging.getRequiredProtocol() != null) {
+      List<String> reader =
+          staging.getRequiredProtocol().getReaderFeatures() == null
+              ? Collections.emptyList()
+              : staging.getRequiredProtocol().getReaderFeatures();
+      List<String> writer =
+          staging.getRequiredProtocol().getWriterFeatures() == null
+              ? Collections.emptyList()
+              : staging.getRequiredProtocol().getWriterFeatures();
+      for (String feature : reader) {
+        props.put("delta.feature." + feature, "supported");
+      }
+      for (String feature : writer) {
+        props.put("delta.feature." + feature, "supported");
+      }
+      if (writer.contains("inCommitTimestamp")) {
+        props.put("delta.enableInCommitTimestamps", "true");
+      }
+    }
+    if (staging.getRequiredProperties() != null) {
+      props.putAll(staging.getRequiredProperties());
+    }
+    return props;
+  }
+
+  /**
+   * Full create round-trip: reserve a staging table, run the kernel create-table transaction
+   * (writes 000.json + finalizeCreate through the Delta-Tables API), then load the table back and
+   * assert the server returned the protocol we sent.
+   */
+  @Test
+  public void createTable_sendsStructuredProtocol_andRoundTrips() throws Exception {
+    UnityCatalogInfo uc = unityCatalogInfo();
+    Engine engine = newEngine();
+
+    try (UCDeltaTokenBasedRestClient deltaClient = newDeltaClient(uc)) {
+      UCCatalogManagedClient catalogClient = new UCCatalogManagedClient(deltaClient);
+      CreatedTable table = createManagedTable(uc, engine, catalogClient);
+
+      Snapshot snapshot = loadAtVersion(catalogClient, engine, table, 0L);
+      assertThat(snapshot.getVersion()).isEqualTo(0L);
+      assertThat(snapshot.getSchema().fieldNames())
+          .containsExactlyElementsOf(TEST_SCHEMA.fieldNames());
+
+      Protocol protocol = ((SnapshotImpl) snapshot).getProtocol();
+      assertThat(protocol.getMinReaderVersion()).isGreaterThanOrEqualTo(3);
+      assertThat(protocol.getMinWriterVersion()).isGreaterThanOrEqualTo(7);
+      assertThat(protocol.getWriterFeatures()).contains("catalogManaged");
+
+      assertThat(snapshot.getTableProperties()).containsAllEntriesOf(table.requiredProperties);
+    }
+  }
+
+  @Test
+  public void alterTable_setTableProperty_roundTripsThroughUpdateTable() throws Exception {
+    UnityCatalogInfo uc = unityCatalogInfo();
+    Engine engine = newEngine();
+
+    try (UCDeltaTokenBasedRestClient deltaClient = newDeltaClient(uc)) {
+      UCCatalogManagedClient catalogClient = new UCCatalogManagedClient(deltaClient);
+      CreatedTable table = createManagedTable(uc, engine, catalogClient);
+
+      // ALTER: set a user table property on the v0 table via the update-table (V1+) path.
+      Snapshot v0 = loadAtVersion(catalogClient, engine, table, 0L);
+      v0.buildUpdateTableTransaction(ENGINE_INFO, Operation.MANUAL_UPDATE)
+          .withTablePropertiesAdded(Map.of("user.key", "user-value"))
+          .build(engine)
+          .commit(engine, CloseableIterable.emptyIterable());
+
+      // Reload at the new version and assert the property is present.
+      Snapshot v1 = loadAtVersion(catalogClient, engine, table, 1L);
+      assertThat(v1.getVersion()).isEqualTo(1L);
+      assertThat(v1.getTableProperties()).containsEntry("user.key", "user-value");
+    }
+  }
+
+  /** Holds the identifiers of a table created via {@link #createManagedTable}. */
+  private static final class CreatedTable {
+    final String ucTableId;
+    final String tablePath;
+    final UCTableIdentifier identifier;
+    final Map<String, String> requiredProperties;
+
+    CreatedTable(
+        String ucTableId,
+        String tablePath,
+        UCTableIdentifier identifier,
+        Map<String, String> requiredProperties) {
+      this.ucTableId = ucTableId;
+      this.tablePath = tablePath;
+      this.identifier = identifier;
+      this.requiredProperties = requiredProperties;
+    }
+  }
+
+  /**
+   * Reserves a staging table and runs the kernel create-table transaction (writes 000.json + the
+   * Delta-Tables createTable finalize), honoring the server's required protocol/properties.
+   */
+  private CreatedTable createManagedTable(
+      UnityCatalogInfo uc, Engine engine, UCCatalogManagedClient catalogClient) throws Exception {
+    String tableName = "kernel_e2e_" + UUID.randomUUID().toString().replace("-", "");
+    UCTableIdentifier identifier =
+        new UCTableIdentifier(uc.catalogName(), uc.schemaName(), tableName);
+
+    // Reserve a staging table via the Delta-Tables API to obtain the UC table id + storage
+    // location. (The legacy TablesApi staging endpoint is disabled in Delta-API-only mode.)
+    DeltaTablesApi deltaTablesApi = new DeltaTablesApi(uc.createApiClient());
+    DeltaStagingTableResponse staging =
+        deltaTablesApi.createStagingTable(
+            uc.catalogName(),
+            uc.schemaName(),
+            new DeltaCreateStagingTableRequest().name(tableName));
+    String ucTableId = staging.getTableId().toString();
+    String tablePath = staging.getLocation();
+
+    // Honor the server's required protocol/properties from the staging response (the OSS server
+    // requires catalog-managed tables to carry features/properties beyond the defaults that
+    // buildCreateTableTransaction sets).
+    catalogClient
+        .buildCreateTableTransaction(ucTableId, tablePath, TEST_SCHEMA, ENGINE_INFO, identifier)
+        .withTableProperties(requiredFeatureProperties(staging))
+        .build(engine)
+        .commit(engine, CloseableIterable.emptyIterable());
+
+    // The server's required *properties* (as opposed to required features, which land in the
+    // protocol) persist verbatim into table metadata, so tests can assert they round-tripped.
+    Map<String, String> requiredProperties =
+        staging.getRequiredProperties() == null ? Map.of() : staging.getRequiredProperties();
+    return new CreatedTable(ucTableId, tablePath, identifier, requiredProperties);
+  }
+
+  /** Loads {@code table} at a specific version through the catalog client. */
+  private Snapshot loadAtVersion(
+      UCCatalogManagedClient catalogClient, Engine engine, CreatedTable table, long version) {
+    return catalogClient.loadSnapshot(
+        engine,
+        table.ucTableId,
+        table.tablePath,
+        table.identifier,
+        Optional.of(version),
+        Optional.empty());
+  }
+
+  @Test
+  public void insertData_thenReadBack_roundTripsThroughUpdateTable() throws Exception {
+    UnityCatalogInfo uc = unityCatalogInfo();
+    Engine engine = newEngine();
+
+    try (UCDeltaTokenBasedRestClient deltaClient = newDeltaClient(uc)) {
+      UCCatalogManagedClient catalogClient = new UCCatalogManagedClient(deltaClient);
+      CreatedTable table = createManagedTable(uc, engine, catalogClient);
+
+      // INSERT: append 3 rows to the v0 table through the update-table (V1+) commit path.
+      Snapshot v0 = loadAtVersion(catalogClient, engine, table, 0L);
+      insertRows(engine, v0, 3);
+
+      // READ: reload at the new version and scan the data back, asserting the exact rows written.
+      Snapshot v1 = loadAtVersion(catalogClient, engine, table, 1L);
+      assertThat(v1.getVersion()).isEqualTo(1L);
+      assertThat(readRows(engine, v1)).containsExactlyInAnyOrder("0=row-0", "1=row-1", "2=row-2");
+    }
+  }
+
+  /** Appends {@code rowCount} rows of test data to {@code snapshot} via a WRITE transaction. */
+  private void insertRows(Engine engine, Snapshot snapshot, int rowCount) throws Exception {
+    Transaction txn =
+        snapshot.buildUpdateTableTransaction(ENGINE_INFO, Operation.WRITE).build(engine);
+    Row txnState = txn.getTransactionState(engine);
+
+    Object[] ids = new Object[rowCount];
+    Object[] names = new Object[rowCount];
+    for (int i = 0; i < rowCount; i++) {
+      ids[i] = i;
+      names[i] = "row-" + i;
+    }
+    ColumnVector[] vectors =
+        new ColumnVector[] {
+          DefaultGenericVector.fromArray(IntegerType.INTEGER, ids),
+          DefaultGenericVector.fromArray(StringType.STRING, names)
+        };
+    FilteredColumnarBatch batch =
+        new FilteredColumnarBatch(
+            new DefaultColumnarBatch(rowCount, TEST_SCHEMA, vectors), Optional.empty());
+
+    DataWriteContext writeContext =
+        Transaction.getWriteContext(engine, txnState, Collections.emptyMap());
+    try (CloseableIterator<FilteredColumnarBatch> logicalData =
+            Utils.toCloseableIterator(Collections.singletonList(batch).iterator());
+        CloseableIterator<FilteredColumnarBatch> physicalData =
+            Transaction.transformLogicalData(
+                engine, txnState, logicalData, Collections.emptyMap());
+        CloseableIterator<DataFileStatus> dataFiles =
+            engine
+                .getParquetHandler()
+                .writeParquetFiles(
+                    writeContext.getTargetDirectory(),
+                    physicalData,
+                    writeContext.getStatisticsColumns());
+        CloseableIterator<Row> dataActions =
+            Transaction.generateAppendActions(engine, txnState, dataFiles, writeContext)) {
+      txn.commit(engine, CloseableIterable.inMemoryIterable(dataActions));
+    }
+  }
+
+  /** Scans {@code snapshot} and returns each row rendered as {@code "<id>=<name>"}. */
+  private List<String> readRows(Engine engine, Snapshot snapshot) throws Exception {
+    Scan scan = snapshot.getScanBuilder().build();
+    Row scanState = scan.getScanState(engine);
+    StructType physicalReadSchema = ScanStateRow.getPhysicalDataReadSchema(scanState);
+
+    List<String> rows = new ArrayList<>();
+    try (CloseableIterator<FilteredColumnarBatch> scanFiles = scan.getScanFiles(engine)) {
+      while (scanFiles.hasNext()) {
+        try (CloseableIterator<Row> scanFileRows = scanFiles.next().getRows()) {
+          while (scanFileRows.hasNext()) {
+            Row scanFileRow = scanFileRows.next();
+            FileStatus fileStatus = InternalScanFileUtils.getAddFileStatus(scanFileRow);
+            try (CloseableIterator<ColumnarBatch> physicalData =
+                    engine
+                        .getParquetHandler()
+                        .readParquetFiles(
+                            Utils.singletonCloseableIterator(fileStatus),
+                            physicalReadSchema,
+                            Optional.empty())
+                        .map(r -> r.getData());
+                CloseableIterator<FilteredColumnarBatch> transformed =
+                    Scan.transformPhysicalData(engine, scanState, scanFileRow, physicalData)) {
+              while (transformed.hasNext()) {
+                try (CloseableIterator<Row> dataRows = transformed.next().getRows()) {
+                  while (dataRows.hasNext()) {
+                    Row row = dataRows.next();
+                    rows.add(row.getInt(0) + "=" + row.getString(1));
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    return rows;
+  }
+}

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UnityCatalogSupport.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UnityCatalogSupport.java
@@ -299,6 +299,22 @@ public abstract class UnityCatalogSupport {
   }
 
   /**
+   * Whether {@code t} (or anything in its cause chain) is an "address already in use" bind failure.
+   * The server's async bind surfaces it wrapped as a {@link
+   * java.util.concurrent.CompletionException} around a Netty {@code NativeIoException}, so we match
+   * by message across the chain.
+   */
+  private static boolean isAddressInUse(Throwable t) {
+    for (Throwable cause = t; cause != null; cause = cause.getCause()) {
+      final String message = cause.getMessage();
+      if (message != null && message.toLowerCase().contains("address already in use")) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
    * Starts the Unity Catalog server before all tests. IMPORTANT: Starts the server BEFORE calling
    * other setup to ensure the server is running when SharedSparkSession creates the SparkSession.
    */
@@ -361,9 +377,6 @@ public abstract class UnityCatalogSupport {
     ucBaseTableLocation = Files.createTempDirectory("base-table-location-").toFile();
     ucBaseTableLocation.deleteOnExit();
 
-    // Find an available port
-    ucServerPort = findAvailablePort();
-
     // Start the mock OAuth broker before building UnityCatalogInfo (and before serverProperties(),
     // which reads the broker's issuer for the allowed-issuers config).
     if (authMode() == AuthMode.OAUTH) {
@@ -374,17 +387,33 @@ public abstract class UnityCatalogSupport {
       LOG.info("Mock OAuth broker started at " + mockOAuthBroker.issuer());
     }
 
-    // Start UC server with configuration
+    // Start UC server with configuration. findAvailablePort() picks a free port and releases it,
+    // so a concurrently-starting suite on the same runner can grab it before this server binds.
+    // Retry with a fresh port on "address already in use" rather than failing the suite.
     ServerProperties initServerProperties = new ServerProperties(serverProperties());
-
-    UnityCatalogServer server =
-        UnityCatalogServer.builder()
-            .port(ucServerPort)
-            .serverProperties(initServerProperties)
-            .build();
-
-    server.start();
-    ucServer = server;
+    final int maxBindAttempts = 5;
+    for (int attempt = 1; ; attempt++) {
+      ucServerPort = findAvailablePort();
+      UnityCatalogServer server =
+          UnityCatalogServer.builder()
+              .port(ucServerPort)
+              .serverProperties(initServerProperties)
+              .build();
+      try {
+        server.start();
+        ucServer = server;
+        break;
+      } catch (Exception e) {
+        if (attempt < maxBindAttempts && isAddressInUse(e)) {
+          LOG.warn(
+              String.format(
+                  "UC server bind on port %d failed (address in use), retrying (attempt %d/%d)",
+                  ucServerPort, attempt, maxBindAttempts));
+          continue;
+        }
+        throw e;
+      }
+    }
 
     // Now that UC is up, let the OAuth broker reach the token-exchange endpoint.
     if (mockOAuthBroker != null) {

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCClient.java
@@ -176,6 +176,7 @@ public interface UCClient extends AutoCloseable {
    * @param schemaName parent schema name in Unity Catalog
    * @param storageLocation the storage root URL for the table
    * @param columns column definitions for the table schema
+   * @param protocol the table's protocol (min reader/writer versions and features).
    * @param properties properties to persist in UC (protocol features, metadata config, etc.)
    * @throws CommitFailedException if there is a network or server error during finalization
    */
@@ -185,6 +186,7 @@ public interface UCClient extends AutoCloseable {
       String schemaName,
       String storageLocation,
       List<ColumnDef> columns,
+      AbstractProtocol protocol,
       Map<String, String> properties) throws CommitFailedException;
 
   /**

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCClient.java
@@ -177,7 +177,11 @@ public interface UCClient extends AutoCloseable {
    * @param storageLocation the storage root URL for the table
    * @param columns column definitions for the table schema
    * @param protocol the table's protocol (min reader/writer versions and features).
-   * @param properties properties to persist in UC (protocol features, metadata config, etc.)
+   * @param properties properties to persist in UC. For Delta-Commits clients this is the flattened
+   *     bag (protocol features, metadata config, timestamp, version, clustering); for Delta-Tables
+   *     clients this is the {@code metadata.configuration}.
+   * @param lastCommitTimestampMs the Delta-log timestamp of the version-0 commit.
+   * @param domainMetadata the version-0 domain-metadata actions (e.g. clustering, row tracking).
    * @throws CommitFailedException if there is a network or server error during finalization
    */
   void finalizeCreate(
@@ -187,7 +191,9 @@ public interface UCClient extends AutoCloseable {
       String storageLocation,
       List<ColumnDef> columns,
       AbstractProtocol protocol,
-      Map<String, String> properties) throws CommitFailedException;
+      Map<String, String> properties,
+      long lastCommitTimestampMs,
+      List<AbstractDomainMetadata> domainMetadata) throws CommitFailedException;
 
   /**
    * Closes any resources used by this client.

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
@@ -918,14 +918,8 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
           .comment(newMetadata.getDescription()));
     }
 
-    Map<String, String> oldConfig =
-        oldMetadata.getConfiguration() == null
-            ? Collections.emptyMap()
-            : oldMetadata.getConfiguration();
-    Map<String, String> newConfig =
-        newMetadata.getConfiguration() == null
-            ? Collections.emptyMap()
-            : newMetadata.getConfiguration();
+    Map<String, String> oldConfig = oldMetadata.getConfiguration();
+    Map<String, String> newConfig = newMetadata.getConfiguration();
 
     if (!Objects.equals(oldConfig, newConfig)) {
       Map<String, String> toSet = new LinkedHashMap<>();

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
@@ -108,11 +108,6 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
   private static final int HTTP_CONFLICT = 409;
   private static final int HTTP_NOT_FOUND = 404;
 
-  private static final String MIN_READER_VERSION_KEY = "delta.minReaderVersion";
-  private static final String MIN_WRITER_VERSION_KEY = "delta.minWriterVersion";
-  private static final String FEATURE_PREFIX = "delta.feature.";
-  private static final String LAST_COMMIT_TIMESTAMP_KEY = "delta.lastCommitTimestamp";
-
   private DeltaTablesApi deltaTablesApi;
   private MetastoresApi metastoresApi;
   private final ApiClient apiClient;
@@ -407,7 +402,9 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
       String storageLocation,
       List<ColumnDef> columns,
       AbstractProtocol protocol,
-      Map<String, String> properties) throws CommitFailedException {
+      Map<String, String> properties,
+      long lastCommitTimestampMs,
+      List<AbstractDomainMetadata> domainMetadata) throws CommitFailedException {
     ensureOpen();
     Objects.requireNonNull(tableName, "tableName must not be null");
     Objects.requireNonNull(catalogName, "catalogName must not be null");
@@ -416,24 +413,32 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
     Objects.requireNonNull(columns, "columns must not be null");
     Objects.requireNonNull(protocol, "protocol must not be null");
     Objects.requireNonNull(properties, "properties must not be null");
-
-    // The Delta-Tables API carries the last-commit timestamp as a structured field. Callers flatten
-    // it into properties, so lift it out into the request field and drop it from properties.
-    Map<String, String> remainingProperties = withoutProtocolProperties(properties);
-    String lastCommitTimestamp = remainingProperties.remove(LAST_COMMIT_TIMESTAMP_KEY);
+    Objects.requireNonNull(domainMetadata, "domainMetadata must not be null");
 
     DeltaCreateTableRequest sdkRequest = new DeltaCreateTableRequest()
         .name(tableName)
         .location(storageLocation)
         .tableType(DeltaTableType.MANAGED)
         .protocol(toSDKDeltaProtocol(protocol))
-        .properties(remainingProperties);
-    if (lastCommitTimestamp != null) {
-      sdkRequest.lastCommitTimestampMs(parseTimestampToEpochMs(lastCommitTimestamp));
-    }
+        .properties(properties)
+        .lastCommitTimestampMs(lastCommitTimestampMs);
 
     if (!columns.isEmpty()) {
       sdkRequest.columns(UCDeltaSchemaConverter.toUCStructType(columns));
+    }
+
+    try {
+      DeltaDomainMetadataUpdates updates = toSDKDomainMetadataUpdates(domainMetadata);
+      if (updates != null) {
+        sdkRequest.domainMetadata(updates);
+      }
+    } catch (IOException e) {
+      throw new CommitFailedException(
+          false /* retryable */,
+          false /* conflict */,
+          String.format("Failed to convert domain metadata for table %s.%s.%s: %s",
+              catalogName, schemaName, tableName, e.getMessage()),
+          e);
     }
 
     try {
@@ -541,8 +546,8 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
       if (partitionColumns != null && !partitionColumns.isEmpty()) {
         sdkRequest.partitionColumns(partitionColumns);
       }
-      Map<String, String> configuration = withoutProtocolProperties(metadata.getConfiguration());
-      if (!configuration.isEmpty()) {
+      Map<String, String> configuration = metadata.getConfiguration();
+      if (configuration != null && !configuration.isEmpty()) {
         sdkRequest.properties(configuration);
       }
       DeltaDomainMetadataUpdates updates = toSDKDomainMetadataUpdates(domainMetadata);
@@ -913,8 +918,14 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
           .comment(newMetadata.getDescription()));
     }
 
-    Map<String, String> oldConfig = withoutProtocolProperties(oldMetadata.getConfiguration());
-    Map<String, String> newConfig = withoutProtocolProperties(newMetadata.getConfiguration());
+    Map<String, String> oldConfig =
+        oldMetadata.getConfiguration() == null
+            ? Collections.emptyMap()
+            : oldMetadata.getConfiguration();
+    Map<String, String> newConfig =
+        newMetadata.getConfiguration() == null
+            ? Collections.emptyMap()
+            : newMetadata.getConfiguration();
 
     if (!Objects.equals(oldConfig, newConfig)) {
       Map<String, String> toSet = new LinkedHashMap<>();
@@ -941,30 +952,6 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
             .removals(toRemove));
       }
     }
-  }
-
-  /**
-   * Returns a copy of {@code config} without protocol-derived properties
-   * ({@code delta.minReaderVersion}, {@code delta.minWriterVersion}, {@code delta.feature.*}).
-   * These describe the protocol, which the Delta-Tables API carries in its structured protocol
-   * field, so they must not be duplicated as table properties on the wire.
-   */
-  private static Map<String, String> withoutProtocolProperties(Map<String, String> config) {
-    Map<String, String> filtered = new LinkedHashMap<>();
-    if (config == null || config.isEmpty()) {
-      return filtered;
-    }
-    for (Map.Entry<String, String> entry : config.entrySet()) {
-      String key = entry.getKey();
-      boolean isProtocolProperty =
-          key.equals(MIN_READER_VERSION_KEY)
-              || key.equals(MIN_WRITER_VERSION_KEY)
-              || key.startsWith(FEATURE_PREFIX);
-      if (!isProtocolProperty) {
-        filtered.put(key, entry.getValue());
-      }
-    }
-    return filtered;
   }
 
   // ===========================

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
@@ -108,6 +108,11 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
   private static final int HTTP_CONFLICT = 409;
   private static final int HTTP_NOT_FOUND = 404;
 
+  private static final String MIN_READER_VERSION_KEY = "delta.minReaderVersion";
+  private static final String MIN_WRITER_VERSION_KEY = "delta.minWriterVersion";
+  private static final String FEATURE_PREFIX = "delta.feature.";
+  private static final String LAST_COMMIT_TIMESTAMP_KEY = "delta.lastCommitTimestamp";
+
   private DeltaTablesApi deltaTablesApi;
   private MetastoresApi metastoresApi;
   private final ApiClient apiClient;
@@ -401,6 +406,7 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
       String schemaName,
       String storageLocation,
       List<ColumnDef> columns,
+      AbstractProtocol protocol,
       Map<String, String> properties) throws CommitFailedException {
     ensureOpen();
     Objects.requireNonNull(tableName, "tableName must not be null");
@@ -408,12 +414,23 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
     Objects.requireNonNull(schemaName, "schemaName must not be null");
     Objects.requireNonNull(storageLocation, "storageLocation must not be null");
     Objects.requireNonNull(columns, "columns must not be null");
+    Objects.requireNonNull(protocol, "protocol must not be null");
     Objects.requireNonNull(properties, "properties must not be null");
+
+    // The Delta-Tables API carries the last-commit timestamp as a structured field. Callers flatten
+    // it into properties, so lift it out into the request field and drop it from properties.
+    Map<String, String> remainingProperties = withoutProtocolProperties(properties);
+    String lastCommitTimestamp = remainingProperties.remove(LAST_COMMIT_TIMESTAMP_KEY);
 
     DeltaCreateTableRequest sdkRequest = new DeltaCreateTableRequest()
         .name(tableName)
         .location(storageLocation)
-        .properties(properties);
+        .tableType(DeltaTableType.MANAGED)
+        .protocol(toSDKDeltaProtocol(protocol))
+        .properties(remainingProperties);
+    if (lastCommitTimestamp != null) {
+      sdkRequest.lastCommitTimestampMs(parseTimestampToEpochMs(lastCommitTimestamp));
+    }
 
     if (!columns.isEmpty()) {
       sdkRequest.columns(UCDeltaSchemaConverter.toUCStructType(columns));
@@ -524,8 +541,8 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
       if (partitionColumns != null && !partitionColumns.isEmpty()) {
         sdkRequest.partitionColumns(partitionColumns);
       }
-      Map<String, String> configuration = metadata.getConfiguration();
-      if (configuration != null && !configuration.isEmpty()) {
+      Map<String, String> configuration = withoutProtocolProperties(metadata.getConfiguration());
+      if (!configuration.isEmpty()) {
         sdkRequest.properties(configuration);
       }
       DeltaDomainMetadataUpdates updates = toSDKDomainMetadataUpdates(domainMetadata);
@@ -896,10 +913,8 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
           .comment(newMetadata.getDescription()));
     }
 
-    Map<String, String> oldConfig = oldMetadata.getConfiguration() != null
-        ? oldMetadata.getConfiguration() : Collections.emptyMap();
-    Map<String, String> newConfig = newMetadata.getConfiguration() != null
-        ? newMetadata.getConfiguration() : Collections.emptyMap();
+    Map<String, String> oldConfig = withoutProtocolProperties(oldMetadata.getConfiguration());
+    Map<String, String> newConfig = withoutProtocolProperties(newMetadata.getConfiguration());
 
     if (!Objects.equals(oldConfig, newConfig)) {
       Map<String, String> toSet = new LinkedHashMap<>();
@@ -926,6 +941,30 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
             .removals(toRemove));
       }
     }
+  }
+
+  /**
+   * Returns a copy of {@code config} without protocol-derived properties
+   * ({@code delta.minReaderVersion}, {@code delta.minWriterVersion}, {@code delta.feature.*}).
+   * These describe the protocol, which the Delta-Tables API carries in its structured protocol
+   * field, so they must not be duplicated as table properties on the wire.
+   */
+  private static Map<String, String> withoutProtocolProperties(Map<String, String> config) {
+    Map<String, String> filtered = new LinkedHashMap<>();
+    if (config == null || config.isEmpty()) {
+      return filtered;
+    }
+    for (Map.Entry<String, String> entry : config.entrySet()) {
+      String key = entry.getKey();
+      boolean isProtocolProperty =
+          key.equals(MIN_READER_VERSION_KEY)
+              || key.equals(MIN_WRITER_VERSION_KEY)
+              || key.startsWith(FEATURE_PREFIX);
+      if (!isProtocolProperty) {
+        filtered.put(key, entry.getValue());
+      }
+    }
+    return filtered;
   }
 
   // ===========================

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCTokenBasedRestClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCTokenBasedRestClient.java
@@ -381,6 +381,7 @@ public class UCTokenBasedRestClient implements UCClient {
       String schemaName,
       String storageLocation,
       List<UCClient.ColumnDef> columns,
+      AbstractProtocol protocol,
       Map<String, String> properties) throws CommitFailedException {
     ensureOpen();
     Objects.requireNonNull(tableName, "tableName must not be null.");
@@ -388,6 +389,7 @@ public class UCTokenBasedRestClient implements UCClient {
     Objects.requireNonNull(schemaName, "schemaName must not be null.");
     Objects.requireNonNull(storageLocation, "storageLocation must not be null.");
     Objects.requireNonNull(columns, "columns must not be null.");
+    Objects.requireNonNull(protocol, "protocol must not be null.");
     Objects.requireNonNull(properties, "properties must not be null.");
 
     List<ColumnInfo> ucColumns = columns.stream()

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCTokenBasedRestClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCTokenBasedRestClient.java
@@ -382,7 +382,9 @@ public class UCTokenBasedRestClient implements UCClient {
       String storageLocation,
       List<UCClient.ColumnDef> columns,
       AbstractProtocol protocol,
-      Map<String, String> properties) throws CommitFailedException {
+      Map<String, String> properties,
+      long lastCommitTimestampMs,
+      List<AbstractDomainMetadata> domainMetadata) throws CommitFailedException {
     ensureOpen();
     Objects.requireNonNull(tableName, "tableName must not be null.");
     Objects.requireNonNull(catalogName, "catalogName must not be null.");

--- a/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClientSuite.scala
+++ b/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClientSuite.scala
@@ -878,11 +878,9 @@ class UCDeltaTokenBasedRestClientSuite
         """{"name":"id","type":"long","nullable":false,"metadata":{}}""", false, 0),
       new UCClient.ColumnDef("name", "STRING", "string",
         """{"name":"name","type":"string","nullable":true,"metadata":{}}""", true, 1))
-    // Flattened protocol-derived keys in properties are lifted into the structured protocol field.
     val props = new java.util.HashMap[String, String]()
-    props.put("delta.minReaderVersion", "3")
-    props.put("delta.feature.deletionVectors", "supported")
     props.put("foo", "bar")
+    props.put("delta.appendOnly", "true")
 
     withClient { c =>
       c.finalizeCreate(
@@ -892,7 +890,9 @@ class UCDeltaTokenBasedRestClientSuite
         "s3://bucket/tbl",
         columns,
         protocol(3, 7, Collections.singleton("deletionVectors"), Collections.emptySet()),
-        props)
+        props,
+        0L,
+        Collections.emptyList[AbstractDomainMetadata]())
     }
 
     val json = objectMapper.readTree(captured)
@@ -902,8 +902,7 @@ class UCDeltaTokenBasedRestClientSuite
     assert(json.get("protocol").get("min-reader-version").asInt() === 3)
     assert(json.get("protocol").get("min-writer-version").asInt() === 7)
     assert(json.get("properties").get("foo").asText() === "bar")
-    assert(!json.get("properties").has("delta.minReaderVersion"))
-    assert(!json.get("properties").has("delta.feature.deletionVectors"))
+    assert(json.get("properties").get("delta.appendOnly").asText() === "true")
 
     val fields = json.get("columns").get("fields")
     assert(fields.size() === 2)
@@ -932,7 +931,9 @@ class UCDeltaTokenBasedRestClientSuite
           7,
           Collections.singleton("readerOnlyFeature"),
           Collections.singleton("writerOnlyFeature")),
-        Collections.emptyMap())
+        Collections.emptyMap(),
+        0L,
+        Collections.emptyList[AbstractDomainMetadata]())
     }
 
     val proto = objectMapper.readTree(captured).get("protocol")
@@ -942,6 +943,54 @@ class UCDeltaTokenBasedRestClientSuite
     assert(writerFeatures === Set("writerOnlyFeature"))
   }
 
+  test("finalizeCreate sends structured last-commit-timestamp and clustering domain metadata") {
+    var captured: String = null
+    deltaHandler = (exchange, body) => {
+      captured = body
+      sendJson(exchange, HttpStatus.SC_OK, loadTableJson())
+    }
+
+    withClient { c =>
+      c.finalizeCreate(
+        "t",
+        testCatalog,
+        testSchema,
+        "s3://bucket/tbl",
+        Collections.emptyList(),
+        protocol(3, 7),
+        Collections.emptyMap(),
+        1234L,
+        java.util.List.of(dm("delta.clustering", """{"clusteringColumns":[["c1"],["a","b"]]}""")))
+    }
+
+    val json = objectMapper.readTree(captured)
+    assert(json.get("last-commit-timestamp-ms").asLong() === 1234L)
+    val clusteringColumns =
+      json.get("domain-metadata").get("delta.clustering").get("clusteringColumns")
+    assert(clusteringColumns.get(0).get(0).asText() === "c1")
+    assert(clusteringColumns.get(1).get(0).asText() === "a")
+    assert(clusteringColumns.get(1).get(1).asText() === "b")
+  }
+
+  test("finalizeCreate wraps unsupported domain metadata as non-retryable CommitFailedException") {
+    withClient { c =>
+      val e = intercept[CommitFailedException] {
+        c.finalizeCreate(
+          "t",
+          testCatalog,
+          testSchema,
+          "s3://bucket/tbl",
+          Collections.emptyList(),
+          protocol(3, 7),
+          Collections.emptyMap(),
+          0L,
+          java.util.List.of(dm("delta.unknownDomain", "{}")))
+      }
+      assert(!e.getRetryable)
+      assert(!e.getConflict)
+    }
+  }
+
   test("finalizeCreate throws CommitFailedException on server error") {
     deltaHandler = (exchange, _) =>
       sendJson(exchange, HttpStatus.SC_INTERNAL_SERVER_ERROR, """{"error":"fail"}""")
@@ -949,7 +998,8 @@ class UCDeltaTokenBasedRestClientSuite
     withClient { c =>
       val e = intercept[CommitFailedException] {
         c.finalizeCreate("t", testCatalog, testSchema, "s3://b/t",
-          Collections.emptyList(), protocol(3, 7), Collections.emptyMap())
+          Collections.emptyList(), protocol(3, 7), Collections.emptyMap(),
+          0L, Collections.emptyList[AbstractDomainMetadata]())
       }
       assert(e.getRetryable)
     }
@@ -959,11 +1009,13 @@ class UCDeltaTokenBasedRestClientSuite
     withClient { c =>
       intercept[NullPointerException] {
         c.finalizeCreate(
-          null, "c", "s", "loc", Collections.emptyList(), protocol(3, 7), Collections.emptyMap())
+          null, "c", "s", "loc", Collections.emptyList(), protocol(3, 7), Collections.emptyMap(),
+          0L, Collections.emptyList[AbstractDomainMetadata]())
       }
       intercept[NullPointerException] {
         c.finalizeCreate(
-          "t", null, "s", "loc", Collections.emptyList(), protocol(3, 7), Collections.emptyMap())
+          "t", null, "s", "loc", Collections.emptyList(), protocol(3, 7), Collections.emptyMap(),
+          0L, Collections.emptyList[AbstractDomainMetadata]())
       }
     }
   }

--- a/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClientSuite.scala
+++ b/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClientSuite.scala
@@ -878,17 +878,32 @@ class UCDeltaTokenBasedRestClientSuite
         """{"name":"id","type":"long","nullable":false,"metadata":{}}""", false, 0),
       new UCClient.ColumnDef("name", "STRING", "string",
         """{"name":"name","type":"string","nullable":true,"metadata":{}}""", true, 1))
+    // Flattened protocol-derived keys in properties are lifted into the structured protocol field.
     val props = new java.util.HashMap[String, String]()
-    props.put("delta.minReaderVersion", "1")
+    props.put("delta.minReaderVersion", "3")
+    props.put("delta.feature.deletionVectors", "supported")
+    props.put("foo", "bar")
 
     withClient { c =>
-      c.finalizeCreate("my_table", testCatalog, testSchema, "s3://bucket/tbl", columns, props)
+      c.finalizeCreate(
+        "my_table",
+        testCatalog,
+        testSchema,
+        "s3://bucket/tbl",
+        columns,
+        protocol(3, 7, Collections.singleton("deletionVectors"), Collections.emptySet()),
+        props)
     }
 
     val json = objectMapper.readTree(captured)
     assert(json.get("name").asText() === "my_table")
     assert(json.get("location").asText() === "s3://bucket/tbl")
-    assert(json.get("properties").get("delta.minReaderVersion").asText() === "1")
+    // Protocol is sent as a structured field, not flattened into properties.
+    assert(json.get("protocol").get("min-reader-version").asInt() === 3)
+    assert(json.get("protocol").get("min-writer-version").asInt() === 7)
+    assert(json.get("properties").get("foo").asText() === "bar")
+    assert(!json.get("properties").has("delta.minReaderVersion"))
+    assert(!json.get("properties").has("delta.feature.deletionVectors"))
 
     val fields = json.get("columns").get("fields")
     assert(fields.size() === 2)
@@ -898,6 +913,35 @@ class UCDeltaTokenBasedRestClientSuite
     assert(fields.get(1).get("nullable").asBoolean() === true)
   }
 
+  test("finalizeCreate sends reader and writer features in the correct structured lists") {
+    var captured: String = null
+    deltaHandler = (exchange, body) => {
+      captured = body
+      sendJson(exchange, HttpStatus.SC_OK, loadTableJson())
+    }
+
+    withClient { c =>
+      c.finalizeCreate(
+        "t",
+        testCatalog,
+        testSchema,
+        "s3://bucket/tbl",
+        Collections.emptyList(),
+        protocol(
+          3,
+          7,
+          Collections.singleton("readerOnlyFeature"),
+          Collections.singleton("writerOnlyFeature")),
+        Collections.emptyMap())
+    }
+
+    val proto = objectMapper.readTree(captured).get("protocol")
+    val readerFeatures = proto.get("reader-features").elements().asScala.map(_.asText()).toSet
+    val writerFeatures = proto.get("writer-features").elements().asScala.map(_.asText()).toSet
+    assert(readerFeatures === Set("readerOnlyFeature"))
+    assert(writerFeatures === Set("writerOnlyFeature"))
+  }
+
   test("finalizeCreate throws CommitFailedException on server error") {
     deltaHandler = (exchange, _) =>
       sendJson(exchange, HttpStatus.SC_INTERNAL_SERVER_ERROR, """{"error":"fail"}""")
@@ -905,7 +949,7 @@ class UCDeltaTokenBasedRestClientSuite
     withClient { c =>
       val e = intercept[CommitFailedException] {
         c.finalizeCreate("t", testCatalog, testSchema, "s3://b/t",
-          Collections.emptyList(), Collections.emptyMap())
+          Collections.emptyList(), protocol(3, 7), Collections.emptyMap())
       }
       assert(e.getRetryable)
     }
@@ -914,10 +958,12 @@ class UCDeltaTokenBasedRestClientSuite
   test("finalizeCreate validates required parameters") {
     withClient { c =>
       intercept[NullPointerException] {
-        c.finalizeCreate(null, "c", "s", "loc", Collections.emptyList(), Collections.emptyMap())
+        c.finalizeCreate(
+          null, "c", "s", "loc", Collections.emptyList(), protocol(3, 7), Collections.emptyMap())
       }
       intercept[NullPointerException] {
-        c.finalizeCreate("t", null, "s", "loc", Collections.emptyList(), Collections.emptyMap())
+        c.finalizeCreate(
+          "t", null, "s", "loc", Collections.emptyList(), protocol(3, 7), Collections.emptyMap())
       }
     }
   }

--- a/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCTokenBasedRestClientSuite.scala
+++ b/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCTokenBasedRestClientSuite.scala
@@ -23,7 +23,7 @@ import java.util.{Collections, Optional}
 import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
 import com.sun.net.httpserver.{HttpExchange, HttpServer}
 import io.delta.storage.commit.{Commit, CommitFailedException}
-import io.delta.storage.commit.actions.{AbstractDomainMetadata, AbstractMetadata}
+import io.delta.storage.commit.actions.{AbstractDomainMetadata, AbstractMetadata, AbstractProtocol}
 import io.delta.storage.commit.uniform.{IcebergMetadata, UniformMetadata}
 import io.unitycatalog.client.auth.TokenProvider
 
@@ -45,6 +45,7 @@ class UCTokenBasedRestClientSuite
   private var serverUri: String = _
   private var metastoreHandler: HttpExchange => Unit = _
   private var commitsHandler: HttpExchange => Unit = _
+  private var tablesHandler: (HttpExchange, String) => Unit = _
   private val objectMapper = new ObjectMapper()
 
   override def beforeAll(): Unit = {
@@ -63,6 +64,12 @@ class UCTokenBasedRestClientSuite
       }
       exchange.close()
     })
+    server.createContext("/api/2.1/unity-catalog/tables", exchange => {
+      val body = readRequestBody(exchange)
+      if (tablesHandler != null) tablesHandler(exchange, body)
+      else sendJson(exchange, HttpStatus.SC_OK, "{}")
+      exchange.close()
+    })
     server.start()
     serverUri = s"http://localhost:${server.getAddress.getPort}"
   }
@@ -72,6 +79,7 @@ class UCTokenBasedRestClientSuite
   override def beforeEach(): Unit = {
     metastoreHandler = null
     commitsHandler = null
+    tablesHandler = null
   }
 
   private def readRequestBody(exchange: HttpExchange): String = {
@@ -106,6 +114,14 @@ class UCTokenBasedRestClientSuite
       new Path(s"/path/_delta_log/_staged_commits/$version.uuid.json"))
     new Commit(version, fs, System.currentTimeMillis())
   }
+
+  private def createProtocol(minReader: Int, minWriter: Int): AbstractProtocol =
+    new AbstractProtocol {
+      override def getMinReaderVersion: Int = minReader
+      override def getMinWriterVersion: Int = minWriter
+      override def getReaderFeatures: java.util.Set[String] = Collections.emptySet()
+      override def getWriterFeatures: java.util.Set[String] = Collections.emptySet()
+    }
 
   private def createMetadata(): AbstractMetadata = new AbstractMetadata {
     override def getId: String = "id"
@@ -363,5 +379,33 @@ class UCTokenBasedRestClientSuite
 
     val json = objectMapper.readTree(capturedBody)
     assert(!json.has("uniform") || json.get("uniform").isNull)
+  }
+
+  test("finalizeCreate keeps protocol flattened in properties (no structured protocol field)") {
+    var capturedBody: String = null
+    tablesHandler = (exchange, body) => {
+      capturedBody = body
+      sendJson(exchange, HttpStatus.SC_OK, "{}")
+    }
+
+    // The Delta-Commits API has no structured protocol field, so the flattened protocol keys must
+    // be forwarded as table properties unchanged and the `protocol` argument must be ignored.
+    val props = new java.util.HashMap[String, String]()
+    props.put("delta.minReaderVersion", "3")
+    props.put("delta.feature.deletionVectors", "supported")
+    props.put("foo", "bar")
+
+    withClient { client =>
+      client.finalizeCreate("t", "cat", "sch", "s3://bucket/tbl",
+        Collections.emptyList(), createProtocol(3, 7), props)
+    }
+
+    val json = objectMapper.readTree(capturedBody)
+    val properties = json.get("properties")
+    assert(properties.get("delta.minReaderVersion").asText() === "3")
+    assert(properties.get("delta.feature.deletionVectors").asText() === "supported")
+    assert(properties.get("foo").asText() === "bar")
+    // No structured protocol field on the Delta-Commits create request.
+    assert(!json.has("protocol"))
   }
 }

--- a/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCTokenBasedRestClientSuite.scala
+++ b/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCTokenBasedRestClientSuite.scala
@@ -397,7 +397,8 @@ class UCTokenBasedRestClientSuite
 
     withClient { client =>
       client.finalizeCreate("t", "cat", "sch", "s3://bucket/tbl",
-        Collections.emptyList(), createProtocol(3, 7), props)
+        Collections.emptyList(), createProtocol(3, 7), props,
+        0L, Collections.emptyList[AbstractDomainMetadata]())
     }
 
     val json = objectMapper.readTree(capturedBody)


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/7159/files/270f0ffc3d8c6bbe215ba16842121f3afc93b9d9..7459ab2b38b7373acf23ad1c3bb1faad73b0b193) to review incremental changes.
- [stack/uc-test-port-bind-fix](https://github.com/delta-io/delta/pull/7220) [[Files changed](https://github.com/delta-io/delta/pull/7220/files)]
  - [**stack/drc-api-integration**](https://github.com/delta-io/delta/pull/7159) [[Files changed](https://github.com/delta-io/delta/pull/7159/files/270f0ffc3d8c6bbe215ba16842121f3afc93b9d9..7459ab2b38b7373acf23ad1c3bb1faad73b0b193)] ← _this PR_

---------
#### Which Delta project/connector is this regarding?
Java Kernel

## Description

Unity Catalog introduced a new Delta-Tables API that connectors must migrate to. Both the Delta-Commits API and Delta-Tables APIs are implemented in delta-storage behind the shared UCClient interface.

1. This change wires the UCCatalogManagedCommitter to feed the new UCClient correctly. The committer now forwards old protocol, old metadata, and domain metadata. The 3-part UCTableIdentifier is also passed when constructing the UC committer. All new fields are no-op for the legacy client.
2. The Delta-Tables API carries the table protocol as a structured field rather than flattened into table properties. `UCClient.finalizeCreate` now takes an AbstractProtocol, so the committer forwards the protocol to both UC clients. The Delta-Tables client sends the protocol in the structured protocol field and strips the flattened protocol-derived keys `(delta.minReaderVersion, delta.minWriterVersion, delta.feature.*)` from properties.
3. The Delta-Commits (legacy) client keeps the flattened properties, since its API has no structured protocol field, and ignores the protocol argument.

## How was this patch tested?

1. Added a `UCDeltaClientCommitE2ESuite`, which tests the UC committer against `UCDeltaTokenBasedRestClient` 2. new tests asserting the UC committer forwards read (old) P&M and domain metadata to the UC client.
4. extends the in memory UC client to capture old P&M + domains.
5. existing UC related tests all pass

## Does this PR introduce _any_ user-facing changes?
No
