### PR TITLE
fix: Kernel UC createTable sends full per-field JSON for column typeJson

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/types/DataTypeJsonSerDe.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/types/DataTypeJsonSerDe.java
@@ -83,6 +83,25 @@ public class DataTypeJsonSerDe {
   }
 
   /**
+   * Serializes a single {@link StructField} to a JSON string according to the Delta Protocol, i.e.
+   * an object with {@code name}, {@code type}, {@code nullable}, and {@code metadata}.
+   *
+   * @param structField the field to serialize
+   * @return JSON string representing the field
+   */
+  public static String serializeStructField(StructField structField) {
+    try {
+      StringWriter stringWriter = new StringWriter();
+      JsonGenerator generator = OBJECT_MAPPER.createGenerator(stringWriter);
+      writeStructField(generator, structField);
+      generator.flush();
+      return stringWriter.toString();
+    } catch (IOException ex) {
+      throw new KernelException("Could not serialize StructField to JSON", ex);
+    }
+  }
+
+  /**
    * Deserializes a JSON string representing a Delta data type to a {@link DataType}.
    *
    * @param structTypeJson JSON string representing a {@link StructType} data type

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/types/DataTypeJsonSerDe.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/types/DataTypeJsonSerDe.java
@@ -83,8 +83,8 @@ public class DataTypeJsonSerDe {
   }
 
   /**
-   * Serializes a single {@link StructField} to a JSON string according to the Delta Protocol, i.e.
-   * an object with {@code name}, {@code type}, {@code nullable}, and {@code metadata}.
+   * Serializes a single {@link StructField} to a JSON string as an object with {@code name}, {@code
+   * type}, {@code nullable}, and {@code metadata}.
    *
    * @param structField the field to serialize
    * @return JSON string representing the field

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/types/DataTypeJsonSerDeSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/types/DataTypeJsonSerDeSuite.scala
@@ -611,6 +611,46 @@ class DataTypeJsonSerDeSuite extends AnyFunSuite {
       "0",
       "Could not parse the following JSON as a valid Delta data type")
   }
+
+  // serializeStructField must emit the full per-field object ({name, type, nullable, metadata}).
+  // Assert the object shape and a round-trip through deserializeStructType.
+  Seq(
+    ("primitive", IntegerType.INTEGER),
+    ("decimal", new DecimalType(10, 2)),
+    ("array", new ArrayType(IntegerType.INTEGER, true)),
+    ("map", new MapType(StringType.STRING, IntegerType.INTEGER, true)),
+    ("struct", new StructType().add("x", IntegerType.INTEGER, true))).foreach {
+    case (name, dataType) =>
+      test(s"serializeStructField: emits per-field object for $name type") {
+        val field = new StructField("c", dataType, false)
+        val node = objectMapper.readTree(DataTypeJsonSerDe.serializeStructField(field))
+
+        assert(node.has("name") && node.get("name").asText === "c")
+        assert(node.has("nullable") && !node.get("nullable").asBoolean)
+        assert(node.has("metadata"))
+        assert(node.has("type") && parse(node.get("type").toString) === dataType)
+
+        val roundTripped =
+          DataTypeJsonSerDe.deserializeStructType(
+            structTypeJson(Seq(DataTypeJsonSerDe.serializeStructField(field))))
+        assert(roundTripped === new StructType().add(field))
+      }
+  }
+
+  test("serializeStructField: preserves field metadata") {
+    val field = new StructField(
+      "c",
+      IntegerType.INTEGER,
+      true,
+      FieldMetadata.builder().putLong("int", 0).build())
+    val node = objectMapper.readTree(DataTypeJsonSerDe.serializeStructField(field))
+
+    assert(node.get("metadata").get("int").asLong === 0L)
+    assert(
+      DataTypeJsonSerDe.deserializeStructType(
+        structTypeJson(Seq(DataTypeJsonSerDe.serializeStructField(field))))
+        === new StructType().add(field))
+  }
 }
 
 object DataTypeJsonSerDeSuite {

--- a/kernel/unitycatalog/src/main/java/io/delta/kernel/unitycatalog/UnityCatalogUtils.java
+++ b/kernel/unitycatalog/src/main/java/io/delta/kernel/unitycatalog/UnityCatalogUtils.java
@@ -311,7 +311,7 @@ public class UnityCatalogUtils {
               f.getName(),
               toUCTypeName(f.getDataType()),
               f.getDataType().toString(),
-              DataTypeJsonSerDe.serializeDataType(f.getDataType()),
+              DataTypeJsonSerDe.serializeStructField(f),
               f.isNullable(),
               i));
     }

--- a/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/UnityCatalogUtilsSuite.scala
+++ b/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/UnityCatalogUtilsSuite.scala
@@ -381,4 +381,25 @@ class UnityCatalogUtilsSuite
       assert(result.getDomainMetadatas.isEmpty)
     }
   }
+
+  test("toColumnDefs: typeJson is the full per-field object, not the bare data type") {
+    val schema = new StructType()
+      .add("id", IntegerType.INTEGER, false)
+      .add("name", StringType.STRING, true)
+    val defs = UnityCatalogUtils.toColumnDefs(schema).asScala
+
+    assert(defs.map(_.getName) === Seq("id", "name"))
+    assert(defs.map(_.getPosition) === Seq(0, 1))
+    assert(defs.map(_.isNullable) === Seq(false, true))
+    assert(defs.map(_.getTypeName) === Seq("INT", "STRING"))
+
+    val mapper = new com.fasterxml.jackson.databind.ObjectMapper()
+    defs.foreach { d =>
+      val node = mapper.readTree(d.getTypeJson)
+      assert(node.has("name"), s"typeJson missing 'name' for ${d.getName}: ${d.getTypeJson}")
+      assert(node.get("name").asText === d.getName)
+      assert(node.has("type") && node.has("nullable") && node.has("metadata"))
+      assert(node.get("nullable").asBoolean === d.isNullable)
+    }
+  }
 }


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/7161/files) to review incremental changes.
- [**stack/create-table-typejson-fix**](https://github.com/delta-io/delta/pull/7161) [[Files changed](https://github.com/delta-io/delta/pull/7161/files)] ← _this PR_
  - [stack/kernel-tableconfig-fix](https://github.com/delta-io/delta/pull/7194) [[Files changed](https://github.com/delta-io/delta/pull/7194/files/0543c4b3bcd9b2c37c5206049489052ba49f368e..125b50e1df555bc7340ca31399b9049cc1061d59)]
    - [stack/drc-api-integration](https://github.com/delta-io/delta/pull/7159) [[Files changed](https://github.com/delta-io/delta/pull/7159/files/125b50e1df555bc7340ca31399b9049cc1061d59..2acf7f40d157367a771ba8e89b5941ffc06aab9d)]

---------
#### Which Delta project/connector is this regarding?
Kernel

## Description

`UnityCatalogUtils.toColumnDefs` populated each column's `typeJson` with the bare data-type JSON. UC Delta-Tables`createTable` path parses `typeJson` as a full `DeltaStructField` object (`{name, type, nullable, metadata}`). The mismatch made catalog-managed CREATE TABLE fail to deserialize the column schema. This change adds `DataTypeJsonSerDe.serializeStructField(StructField)` and switches `toColumnDefs` to use it.

Resolves https://github.com/delta-io/delta/issues/7160

## How was this patch tested?

1. new tests assert `serializeStructField` emits the full per-field object (name/type/nullable/metadata).
2. `toColumnDefs` asserts `typeJson` is the full per-field object (name/position/nullable/typeName).
3. Existing `DataTypeJsonSerDeSuite` / `UnityCatalogUtilsSuite` tests pass.

## Does this PR introduce _any_ user-facing changes?

No
