### PR TITLE
[Spark] Improve the message of DELTA_CANNOT_SET_LOCATION_MULTIPLE_TIMES error class

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -311,7 +311,7 @@
   },
   "DELTA_CANNOT_SET_LOCATION_MULTIPLE_TIMES" : {
     "message" : [
-      "Can't set location multiple times. Found <location>"
+      "Can't set location multiple times. Found locations: <locations>."
     ],
     "sqlState" : "XXKDS"
   },

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -2005,7 +2005,7 @@ trait DeltaErrorsBase
   def cannotSetLocationMultipleTimes(locations : Seq[String]) : Throwable = {
     new DeltaIllegalArgumentException(
       errorClass = "DELTA_CANNOT_SET_LOCATION_MULTIPLE_TIMES",
-      messageParameters = Array(s"${locations}")
+      messageParameters = Array(locations.mkString(", "))
     )
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -2429,7 +2429,7 @@ trait DeltaErrorsSuiteBase
         throw DeltaErrors.cannotSetLocationMultipleTimes(locations)
       }
       checkError(e, "DELTA_CANNOT_SET_LOCATION_MULTIPLE_TIMES", "XXKDS",
-        Map("location" -> "List(location1, location2)"))
+        Map("locations" -> "location1, location2"))
     }
     {
       val e = intercept[DeltaIllegalStateException] {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
The `DELTA_CANNOT_SET_LOCATION_MULTIPLE_TIMES` error class previously formatted its location parameter by relying on `Seq.toString`, which leaked the collection type into the user-facing message (e.g. `Found List(location1, location2)`).

This change:
- Formats the locations by joining them with `", "` instead of relying on `Seq.toString`.
- Rewords the message to `Found locations: <locations>` and renames the message parameter from `<location>` to `<locations>` to reflect that it holds multiple paths.
- Updates the existing assertion in `DeltaErrorsSuite` accordingly.

## How was this patch tested?

Updated the pre-existing unit tests.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, any user encountering the error will see a slightly different error message. 

Instead of 

> "Can't set location multiple times. Found CollectionType(location1, location2)"

the user will see

> "Can't set location multiple times. Found locations: location1, location2."