### PR TITLE
[Spark] Improve DELTA_INVALID_COLUMN_NAMES_WHEN_REMOVING_COLUMN_MAPPING error tests

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/columnmapping/DropColumnMappingFeatureSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/columnmapping/DropColumnMappingFeatureSuite.scala
@@ -73,10 +73,12 @@ class DropColumnMappingFeatureSuite extends RemoveColumnMappingSuiteUtils {
   }
 
   test("invalid column names") {
-    val invalidColName1 = colName("col1")
-    val invalidColName2 = colName("col2")
+    val invalidColName1 = "col1()"
+    val invalidColName2 = "col2{}"
+    val validColName = "col3"
     sql(
-      s"""CREATE TABLE $testTableName (a INT, `$invalidColName1` INT, `$invalidColName2` INT)
+      s"""CREATE TABLE $testTableName (a INT, `$invalidColName1` INT, `$invalidColName2` INT,
+         |`$validColName` INT)
          |USING delta
          |TBLPROPERTIES ('delta.columnMapping.mode' = 'name')
          |""".stripMargin)
@@ -86,8 +88,7 @@ class DropColumnMappingFeatureSuite extends RemoveColumnMappingSuiteUtils {
     }
     checkError(e,
       "DELTA_INVALID_COLUMN_NAMES_WHEN_REMOVING_COLUMN_MAPPING",
-      parameters = Map("invalidColumnNames" ->
-        "col1 with special chars ,;{}()\n\t=, col2 with special chars ,;{}()\n\t="))
+      parameters = Map("invalidColumnNames" -> s"$invalidColName1, $invalidColName2"))
   }
 
   test("drop column mapping from a table without table feature") {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/columnmapping/RemoveColumnMappingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/columnmapping/RemoveColumnMappingSuite.scala
@@ -58,10 +58,12 @@ class RemoveColumnMappingSuite extends RemoveColumnMappingSuiteUtils {
   }
 
   test("invalid column names") {
-    val invalidColName1 = colName("col1")
-    val invalidColName2 = colName("col2")
+    val invalidColName1 = "col1()"
+    val invalidColName2 = "col2{}"
+    val validColName = "col3"
     sql(
-      s"""CREATE TABLE $testTableName (a INT, `$invalidColName1` INT, `$invalidColName2` INT)
+      s"""CREATE TABLE $testTableName (a INT, `$invalidColName1` INT, `$invalidColName2` INT,
+         |`$validColName` INT)
          |USING delta
          |TBLPROPERTIES ('delta.columnMapping.mode' = 'name')
          |""".stripMargin)
@@ -106,12 +108,14 @@ class RemoveColumnMappingSuite extends RemoveColumnMappingSuiteUtils {
   }
 
   test("ALTER TABLE UNSET column mapping with invalid column names") {
-    val invalidColName1 = colName("col1")
-    val invalidColName2 = colName("col2")
+    val invalidColName1 = "col1()"
+    val invalidColName2 = "col2{}"
+    val validColName = "col3"
     val propertyToKeep = "acme"
     val propertyToUnset = "acme2"
     sql(
-      s"""CREATE TABLE $testTableName (a INT, `$invalidColName1` INT, `$invalidColName2` INT)
+      s"""CREATE TABLE $testTableName (a INT, `$invalidColName1` INT, `$invalidColName2` INT,
+         |`$validColName` INT)
          |USING delta
          |TBLPROPERTIES ('${DeltaConfigs.COLUMN_MAPPING_MODE.key}' = 'name',
          |'$propertyToKeep' = '1234', '$propertyToUnset' = '1234')


### PR DESCRIPTION

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

The DELTA_INVALID_COLUMN_NAMES_WHEN_REMOVING_COLUMN_MAPPING error message template already lists the invalid characters, so the column-mapping tests should assert on plain column names rather than the noisy names produced by the shared colName(...) helper (which appended "with special chars ,;{}()\n\t=", rendering raw control characters in the message and duplicating the template).

Update the three affected tests in DropColumnMappingFeatureSuite and RemoveColumnMappingSuite to use readable invalid names ("col1()", "col2{}") plus a valid "col3" column, verifying valid columns are excluded from the reported names.

## How was this patch tested?

Test-only change.

## Does this PR introduce _any_ user-facing changes?

No.
