### PR TITLE
[Kernel] Add FileSystemClient.readWholeFileAsUtf8 for single-op whole-file reads

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/engine/FileSystemClient.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/engine/FileSystemClient.java
@@ -68,6 +68,26 @@ public interface FileSystemClient {
       throws IOException;
 
   /**
+   * Read the entire contents of the file at {@code path} as a UTF-8 string in a single file-system
+   * read.
+   *
+   * <p>Unlike {@link #readFiles}, the caller does not need to know the file length up front: the
+   * implementation reads to end-of-file in one pass. This lets a caller obtain a file's exact bytes
+   * without a preceding {@link #getFileStatus} call, which {@link #readFiles} would otherwise
+   * require because its {@link FileReadRequest#getReadLength()} needs the length in advance.
+   *
+   * <p>Intended for small control files (e.g. {@code _last_checkpoint}) that must be read whole and
+   * whose exact text a caller needs to re-parse in more than one way from a single, consistent
+   * snapshot. Do not use for large data files.
+   *
+   * @param path Fully qualified path to the file to read.
+   * @return The full file contents decoded as UTF-8.
+   * @throws FileNotFoundException if the file at the given path is not found.
+   * @throws IOException for any other IO error.
+   */
+  String readWholeFileAsUtf8(String path) throws IOException;
+
+  /**
    * Create a directory at the given path including parent directories. This mimicks the behavior of
    * `mkdir -p` in Unix.
    *

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/test/MockEngineUtils.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/test/MockEngineUtils.scala
@@ -166,6 +166,9 @@ trait BaseMockFileSystemClient extends FileSystemClient {
 
   override def copyFileAtomically(srcPath: String, destPath: String, overwrite: Boolean): Unit =
     throw new UnsupportedOperationException("not supported in this test suite")
+
+  override def readWholeFileAsUtf8(path: String): String =
+    throw new UnsupportedOperationException("not supported in this test suite")
 }
 
 /**

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/DefaultFileSystemClient.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/DefaultFileSystemClient.java
@@ -24,6 +24,7 @@ import io.delta.kernel.utils.CloseableIterator;
 import io.delta.kernel.utils.FileStatus;
 import io.delta.storage.LogStore;
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -100,6 +101,22 @@ public class DefaultFileSystemClient implements FileSystemClient {
   public void copyFileAtomically(String srcPath, String destPath, boolean overwrite)
       throws IOException {
     fileIO.copyFileAtomically(srcPath, destPath, overwrite);
+  }
+
+  @Override
+  public String readWholeFileAsUtf8(String path) throws IOException {
+    // Read to EOF in a single pass: unlike getStream (which readFully's an exact, caller-supplied
+    // length), this needs no prior getFileStatus, so the whole file is obtained in one FS op.
+    InputFile inputFile = this.fileIO.newInputFile(path, /* fileSize */ -1);
+    try (SeekableInputStream stream = inputFile.newStream();
+        ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+      byte[] buffer = new byte[8192];
+      int read;
+      while ((read = stream.read(buffer)) != -1) {
+        out.write(buffer, 0, read);
+      }
+      return new String(out.toByteArray(), StandardCharsets.UTF_8);
+    }
   }
 
   private ByteArrayInputStream getStream(String filePath, int offset, int size) {

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/engine/DefaultFileSystemClientSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/engine/DefaultFileSystemClientSuite.scala
@@ -163,4 +163,37 @@ class DefaultFileSystemClientSuite extends AnyFunSuite with TestUtils {
       }
     }
   }
+
+  test("readWholeFileAsUtf8 returns the full contents") {
+    withTempDir { tempDir =>
+      val path = tempDir + "/whole.txt"
+      val content = """{"version":2,"size":9,"checkpointSchema":{"type":"struct"}}"""
+      writeFile(path, content)
+      assert(fsClient.readWholeFileAsUtf8(path) == content)
+    }
+  }
+
+  test("readWholeFileAsUtf8 handles an empty file") {
+    withTempDir { tempDir =>
+      val path = tempDir + "/empty.txt"
+      writeFile(path, "")
+      assert(fsClient.readWholeFileAsUtf8(path) == "")
+    }
+  }
+
+  test("readWholeFileAsUtf8 handles multi-line / multi-byte content") {
+    withTempDir { tempDir =>
+      val path = tempDir + "/multi.txt"
+      // Multiple lines plus a multi-byte UTF-8 character to exercise byte-accurate decoding.
+      val content = "line1\nline2\néèê"
+      writeFile(path, content)
+      assert(fsClient.readWholeFileAsUtf8(path) == content)
+    }
+  }
+
+  test("readWholeFileAsUtf8 on non-existent file") {
+    intercept[FileNotFoundException] {
+      fsClient.readWholeFileAsUtf8("/non-existent-file.json")
+    }
+  }
 }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/engine/DefaultFileSystemClientSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/engine/DefaultFileSystemClientSuite.scala
@@ -16,10 +16,14 @@
 package io.delta.kernel.defaults.engine
 
 import java.io.FileNotFoundException
+import java.util.Optional
 
 import scala.collection.mutable.ArrayBuffer
 
 import io.delta.kernel.defaults.utils.TestUtils
+import io.delta.kernel.internal.checkpoints.{Checkpointer, CheckpointMetaData}
+import io.delta.kernel.internal.fs.{Path => KernelPath}
+import io.delta.kernel.internal.util.JsonUtils
 
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.scalatest.funsuite.AnyFunSuite
@@ -194,6 +198,84 @@ class DefaultFileSystemClientSuite extends AnyFunSuite with TestUtils {
   test("readWholeFileAsUtf8 on non-existent file") {
     intercept[FileNotFoundException] {
       fsClient.readWholeFileAsUtf8("/non-existent-file.json")
+    }
+  }
+
+  test("readWholeFileAsUtf8 reads a full V2 _last_checkpoint byte-for-byte") {
+    // A real V2 pointer: deeply nested v2Checkpoint block with nonFileActions and sidecarFiles,
+    // and an embedded schemaString containing escaped quotes. Exercises that the whole-file read
+    // is byte-exact (no truncation on the large/nested content, escaped quotes preserved).
+    withTempDir { tempDir =>
+      val path = tempDir + "/v2_last_checkpoint.json"
+      // Built from short pieces so each source line stays within the 100-char limit; the
+      // concatenation is the exact _last_checkpoint content written below.
+      val checkpointPath0 =
+        "00000000000000000002.checkpoint.6374b053-df23-479b-b2cf-c9c550132b49.json"
+      val sidecar1 =
+        "00000000000000000002.checkpoint.0000000001.0000000002." +
+          "bd1885fd-6ec0-4370-b0f5-43b5162fd4de.parquet"
+      val sidecar2 =
+        "00000000000000000002.checkpoint.0000000002.0000000002." +
+          "0a8d73ee-aa83-49d0-9583-c99db75b89b2.parquet"
+      val schemaString =
+        """{\"type\":\"struct\",\"fields\":[{\"name\":\"id\",\"type\":\"long\",""" +
+          """\"nullable\":true,\"metadata\":{}}]}"""
+      val content =
+        """{"version":2,"size":9,"sizeInBytes":19554,"numOfAddFiles":4,"v2Checkpoint":{""" +
+          s""""path":"$checkpointPath0",""" +
+          """"sizeInBytes":891,"modificationTime":1714496115810,"nonFileActions":[{"protocol":{""" +
+          """"minReaderVersion":3,"minWriterVersion":7,"readerFeatures":["v2Checkpoint"],""" +
+          """"writerFeatures":["v2Checkpoint","appendOnly","invariants"]}},{"metaData":{""" +
+          """"id":"8a390218-e4ee-4341-b6de-4920e27d3f78","format":{"provider":"parquet",""" +
+          s""""options":{}},"schemaString":"$schemaString","partitionColumns":[],""" +
+          """"configuration":{"delta.checkpointInterval":"2","delta.checkpointPolicy":"v2"},""" +
+          """"createdTime":1714496114564}},{"checkpointMetadata":{"version":2}}],""" +
+          s""""sidecarFiles":[{"path":"$sidecar1","sizeInBytes":9367,""" +
+          """"modificationTime":1714496115780},""" +
+          s"""{"path":"$sidecar2","sizeInBytes":9296,"modificationTime":1714496115788}]},""" +
+          """"checksum":"d09f95a326aab562c60d415a32ddd216"}"""
+      writeFile(path, content)
+
+      val actual = fsClient.readWholeFileAsUtf8(path)
+      assert(actual == content)
+      // The escaped schemaString survives verbatim (no unescaping / byte loss).
+      assert(actual.contains("""\"type\":\"struct\""""))
+      // And it parses as valid JSON with the expected shape.
+      val node = JsonUtils.mapper().readTree(actual)
+      assert(node.get("version").asInt() == 2)
+      assert(node.get("v2Checkpoint").get("nonFileActions").size() == 3)
+      assert(node.get("v2Checkpoint").get("sidecarFiles").size() == 2)
+    }
+  }
+
+  test("readWholeFileAsUtf8 reads back a _last_checkpoint written by Checkpointer") {
+    withTempDir { tempDir =>
+      val logPath = new KernelPath(tempDir.getAbsolutePath, "_delta_log")
+      fsClient.mkdirs(logPath.toString)
+      val checkpointer = new Checkpointer(logPath)
+
+      // Write a real _last_checkpoint via the production write path.
+      val cpm = new CheckpointMetaData(2L, 6L, Optional.of(java.lang.Long.valueOf(4L)))
+      checkpointer.writeLastCheckpointFile(defaultEngine, cpm)
+
+      // The JSON the writer serializes (writeJsonFileAtomically serializes each row via rowToJson,
+      // then writes it as a line, i.e. with a trailing newline).
+      val expectedJson = JsonUtils.rowToJson(cpm.toRow())
+
+      // readWholeFileAsUtf8 returns the file's bytes verbatim (no trimming), so the whole file is
+      // the serialized JSON plus the writer's trailing newline.
+      val checkpointPath =
+        new KernelPath(logPath, Checkpointer.LAST_CHECKPOINT_FILE_NAME).toString
+      val actual = fsClient.readWholeFileAsUtf8(checkpointPath)
+      assert(actual.trim == expectedJson)
+      assert(actual == expectedJson + "\n")
+
+      // And it round-trips back through the parser to the same object.
+      val roundTripped = checkpointer.readLastCheckpointFile(defaultEngine)
+      assert(roundTripped.isPresent)
+      assert(roundTripped.get().version == 2L)
+      assert(roundTripped.get().size == 6L)
+      assert(roundTripped.get().parts == Optional.of(java.lang.Long.valueOf(4L)))
     }
   }
 }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other

## Description

### Context
`FileSystemClient` has no way to read a whole file in a single file-system read. `readFiles` takes a `FileReadRequest` whose `getReadLength()` must be supplied up front, so a caller that does not already know the file length must call `getFileStatus` first — two file-system operations, with a window in which the file can change between the stat and the read.

This blocks capturing `_last_checkpoint`'s `checkpointSchema`. That field is a recursive, polymorphic schema-of-schema object the columnar JSON reader cannot project, so it can only be obtained from the file's raw text. The kernel's existing whole-file reader (`readJsonFiles`) streams to EOF but then discards the text, returning only a `ColumnarBatch`; and `readFiles` needs the length. So there is no way to get both the parsed row and the raw `checkpointSchema` text from one consistent single-read snapshot.

### What
Adds `String readWholeFileAsUtf8(String path)` to the `FileSystemClient` SPI:

- **Interface (`FileSystemClient`)** — a new **abstract** method, matching the all-abstract convention of this interface (e.g. the recently added `copyFileAtomically`). It is abstract on purpose: the entire point of the method is the single-read guarantee, and a defaulted `getFileStatus` + `readFiles` fallback would silently degrade to two operations — a trap for implementers who assume they are getting one read.
- **`DefaultFileSystemClient`** — reads to EOF in one pass via `newInputFile(path, -1).newStream()` (no `getFileStatus`), reusing the same open-and-stream pattern `DefaultJsonHandler.readJsonFiles` already uses.
- **`BaseMockFileSystemClient`** — throw-stub, matching its other unimplemented methods.

The method is intended for small control files (e.g. `_last_checkpoint`) whose exact text a caller needs to re-parse more than one way from a single snapshot. It is not for large data files.

### Why
It closes a genuine gap in the SPI: there is currently no single-read whole-file read. The immediate motivator is `_last_checkpoint` / `checkpointSchema` capture for `SnapshotHint` caching (follow-up to #7123) — that capture must read the file once and parse it two ways (columnar row + raw `checkpointSchema`) from one snapshot to avoid a torn read. The primitive is generally useful beyond that.

## How was this patch tested?
- `DefaultFileSystemClientSuite` (kernel-defaults): `readWholeFileAsUtf8` returns the full contents, handles an empty file, handles multi-line / multi-byte UTF-8 content, and throws `FileNotFoundException` for a missing file.

## Does this PR introduce _any_ user-facing changes?

Yes — a new abstract method `FileSystemClient.readWholeFileAsUtf8(String)` on the public (`@Evolving`) engine SPI. This is **source-incompatible** for existing external `FileSystemClient` implementations: they must add the method to compile. Flagging for maintainer preference — abstract (as here) vs a defaulted stat-then-read fallback (source-compatible, but does not provide the single-read guarantee). No behavior change for existing callers of other methods.
