### PR TITLE
[Delta][UniForm] Enabling Iceberg V3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -109,7 +109,9 @@ lazy val commonSettings = Seq(
       Seq(  // For Java 17 +
         "--add-opens=java.base/java.nio=ALL-UNNAMED",
         "--add-opens=java.base/java.lang=ALL-UNNAMED",
+        "--add-opens=java.base/java.lang.invoke=ALL-UNNAMED",
         "--add-opens=java.base/java.net=ALL-UNNAMED",
+        "--add-opens=java.base/java.util=ALL-UNNAMED",
         "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED",
         "--add-opens=java.base/sun.util.calendar=ALL-UNNAMED"
       )

--- a/iceberg/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormIcebergVerifier.scala
+++ b/iceberg/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormIcebergVerifier.scala
@@ -1,0 +1,505 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.uniform
+
+import java.nio.ByteBuffer
+
+import scala.collection.JavaConverters._
+
+import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.DeltaColumnMapping._
+import org.apache.spark.sql.delta.actions._
+import org.apache.spark.sql.delta.icebergShaded._
+import org.apache.spark.sql.delta.util.JsonUtils
+import shadedForDelta.org.apache.iceberg._
+import shadedForDelta.org.apache.iceberg.hadoop.HadoopTables
+import shadedForDelta.org.apache.iceberg.types._
+import shadedForDelta.org.apache.iceberg.util.DateTimeUtil
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
+import org.apache.spark.sql.types._
+
+/**
+ * Verify that Delta tables match the UniForm Iceberg tables converted from them.
+ * NOTE: this method should avoid using existing conversion utils as much as possible, so that
+ *       we have a pair of fresh eyes reviewing the behaviors of UniForm.
+ */
+class UniFormIcebergVerifier(
+     spark: SparkSession,
+     deltaLog: DeltaLog,
+     catalogTableOpt: Option[CatalogTable],
+     icebergTable: Table) {
+
+  def this(spark: SparkSession, catalogTable: CatalogTable, icebergTable: Table) =
+    this(spark, DeltaLog.forTable(spark, catalogTable), Some(catalogTable), icebergTable)
+
+  def this(spark: SparkSession, tableName: String,
+           loadIceberg: String => Table = UniFormIcebergVerifier.loadIcebergTableFromUC) =
+    this(
+      spark,
+      spark.sessionState.catalog.getTableMetadata(TableIdentifier(tableName)),
+      loadIceberg.apply(tableName)
+    )
+
+  val compatObject: IcebergCompatBase = IcebergCompat
+    .anyEnabled(deltaLog.update(catalogTableOpt = catalogTableOpt).metadata)
+    .orNull
+
+  val deltaSnapshot = deltaLog.update(catalogTableOpt = catalogTableOpt)
+  val deltaSchema = deltaSnapshot.schema
+  val icebergSchema = icebergTable.schema()
+
+  /* =====================================
+   *  Check Switches that can be overriden
+   * ====================================== */
+  protected var enforceFieldIdCheck = true
+
+  protected var enforceTableSizeCheck = true
+
+  protected var enforceSnapshotSeqNumCheck = true
+  protected var expectedSnapshotSeqNumber: Option[Int] = None
+
+  protected var enforceDataFileStatsCheck = true
+
+
+  def withCompatVersion(condition: Int => Boolean)(f: => Unit): Unit = {
+    if (compatObject != null && condition.apply(compatObject.version)) {
+      f
+    }
+  }
+
+  def verify(): Unit = {
+    verifyMetadata()
+    verifyContent()
+  }
+
+  protected def verifyMetadata(): Unit = {
+    verifySchema()
+    verifyProperties()
+    verifyTableSummary()
+    verifyDataFiles()
+  }
+
+  protected def verifySchema(): Unit = {
+    verifySchemaFields()
+    verifyPartition()
+  }
+
+  private var propertiesToVerify: Seq[(String, String)] = Seq.empty
+
+  def includeProperties(props: Seq[(String, String)]): UniFormIcebergVerifier = {
+    propertiesToVerify = props
+    this
+  }
+
+  def assertSnapshotSeqNum(
+        expectedSnapshotSeqNumber: Int): UniFormIcebergVerifier = {
+    this.expectedSnapshotSeqNumber = Some(expectedSnapshotSeqNumber)
+    this
+  }
+
+  def bypassSnapshotSeqNumCheck(): UniFormIcebergVerifier = {
+    this.enforceSnapshotSeqNumCheck = false
+    this
+  }
+
+  def bypassDataFileStatsCheck(): UniFormIcebergVerifier = {
+    this.enforceDataFileStatsCheck = false
+    this
+  }
+
+  protected def verifyProperties(): Unit = {
+    this.propertiesToVerify.foreach { case (key, value) =>
+      val icebergValue = icebergTable.properties().get(key)
+      val deltaValue = deltaSnapshot.metadata.configuration.get(key)
+      key match {
+        case deltaKey if key.startsWith("delta") =>
+          assert(deltaValue.contains(value), key)
+        case formatVersionKey if key == "format-version" =>
+          val formatVersion = icebergTable.asInstanceOf[BaseTable]
+            .operations().current().formatVersion()
+          assert(deltaValue.contains(s"$formatVersion"))
+        case _ =>
+          assert(deltaValue.contains(icebergValue),
+            s"$key: delta -> $deltaValue, iceberg -> $icebergValue")
+      }
+    }
+  }
+
+  protected def verifySchemaFields(): Unit = {
+    // Flatten Iceberg Type to a map of path to field
+    def flattenType(rootType: Type): Map[Seq[String], Types.NestedField] = {
+      rootType match {
+        case struct: Types.StructType =>
+          struct
+            .fields()
+            .asScala
+            .flatMap(
+              f =>
+                flattenType(f.`type`()) match {
+                  case empty if empty.isEmpty => Map(Seq(f.name) -> f)
+                  case nonempty =>
+                    nonempty.map { case (key, field) => (f.name +: key, field) }.toMap
+                }
+            )
+            .toMap
+        case map: Types.MapType =>
+          val keyMap = flattenType(map.keyType()) match {
+            case empty if empty.isEmpty =>
+              Map(Seq("key") -> Types.NestedField.required(map.keyId(), "key", map.keyType()))
+            case nonempty => nonempty.map { case (key, field) => ("key" +: key, field) }.toMap
+          }
+          val valueMap = flattenType(map.valueType()) match {
+            case empty if empty.isEmpty =>
+              Map(
+                Seq("value") -> Types.NestedField
+                  .of(map.valueId(), map.isValueOptional, "value", map.valueType())
+              )
+            case nonempty => nonempty.map { case (key, field) => ("value" +: key, field) }.toMap
+          }
+          keyMap ++ valueMap
+        case list: Types.ListType =>
+          flattenType(list.elementType()) match {
+            case empty if empty.isEmpty =>
+              Map(
+                Seq("element") -> Types.NestedField
+                  .of(list.elementId(), list.isElementOptional, "element", list.elementType())
+              )
+            case nonempty => nonempty.map { case (key, field) => ("element" +: key, field) }.toMap
+          }
+        case _ => Map.empty
+      }
+    }
+
+    val pathToIcebergFields = flattenType(icebergSchema.asStruct())
+    pathToIcebergFields.foreach {
+      case (path, icebergField) =>
+        val deltaField = deltaSchema.findNestedField(path, includeCollections = true).get._2
+        if (deltaField.metadata.contains(COLUMN_MAPPING_METADATA_ID_KEY) && enforceFieldIdCheck) {
+          assert(deltaField.metadata.getLong(COLUMN_MAPPING_METADATA_ID_KEY)
+            == icebergField.fieldId())
+        }
+        verifySchemaField(deltaField, icebergField)
+    }
+  }
+
+  protected def verifySchemaField(
+      deltaField: StructField,
+      icebergField: Types.NestedField): Unit = {
+    assert(deltaField.name == icebergField.name())
+    assert(deltaField.nullable == icebergField.isOptional)
+
+    val icebergType = deltaField.dataType match {
+      case VariantType => Types.VariantType.get()
+      case _ => IcebergSchemaUtils.convertAtomic(deltaField.dataType)
+    }
+    assert(icebergType == icebergField.`type`())
+
+    withCompatVersion(_ >= 3) {
+      verifyColumnDefaults(deltaField, icebergField)
+    }
+  }
+
+  protected def verifyColumnDefaults(
+      deltaField: StructField, icebergField: Types.NestedField): Unit = {
+    val deltaDefaultValue = deltaField.getCurrentDefaultValue()
+    val icebergDefault = Option(icebergField.writeDefault()).map(_.toString)
+    assert(deltaDefaultValue == icebergDefault)
+  }
+
+  protected def verifyPartition(): Unit = {
+    val icebergPartition = icebergTable.spec()
+    val deltaPartCols = deltaLog.update(
+      catalogTableOpt = catalogTableOpt).metadata.partitionColumns
+    assert(deltaPartCols.nonEmpty == icebergPartition.isPartitioned)
+    deltaPartCols.foreach { p =>
+      assert(icebergPartition.schema().findField(p) != null)
+    }
+  }
+
+  protected def verifyTableSummary(): Unit = {
+    // Verify statistics consistency
+    val deltaSnapshot = deltaLog.update(catalogTableOpt = catalogTableOpt)
+    val deltaState = deltaSnapshot.computeChecksum
+    // Delta table size does not count in dv size
+    val dvFileSize = deltaSnapshot.allFiles
+      .collect()
+      .map(a => Option(a.deletionVector).map(_.sizeInBytes + 8).getOrElse(0))
+      .sum
+    if (icebergTable.currentSnapshot() != null) {
+      val currentSnapshotSummary = icebergTable.currentSnapshot().summary()
+      if (enforceTableSizeCheck) {
+        assert(
+          currentSnapshotSummary.get("total-files-size").toLong ==
+          deltaState.tableSizeBytes + dvFileSize,
+          "Total files size should match")
+        assert(
+          currentSnapshotSummary.get("total-data-files").toLong == deltaState.numFiles,
+          "Number of files should match")
+      }
+    }
+  }
+
+  protected def verifyDataFiles(): Unit = {
+    val deltaAllFiles = deltaLog.update(catalogTableOpt = catalogTableOpt).allFiles.collect()
+    val icebergAllFiles: Seq[DataFile] =
+      Option(icebergTable.currentSnapshot())
+        .map(_.allManifests(icebergTable.io())
+          .asScala
+          .flatMap { manifest =>
+            manifest.content() match {
+              case ManifestContent.DATA =>
+                ManifestFiles.read(manifest, icebergTable.io()).asScala.toSeq
+              case _ => Seq.empty
+            }
+          }
+          .toSeq)
+        .getOrElse(Seq.empty)
+    assert(deltaAllFiles.length == icebergAllFiles.size)
+    val deltaPathToFile = deltaAllFiles
+      .map(file => (file.absolutePath(deltaLog).toString -> file))
+      .toMap
+    val icebergPathToFile = icebergAllFiles.map(file => (file.path() -> file)).toMap
+    assert(deltaPathToFile.keySet == icebergPathToFile.keySet)
+    deltaPathToFile.keySet.foreach { key =>
+      verifyDataFile(deltaPathToFile(key), icebergPathToFile(key))
+    }
+
+    withCompatVersion(_ >= 3) {
+      verifyDeletionVectors()
+      verifyRowTrackingMetadata()
+    }
+  }
+
+  protected def verifyDeletionVectors(): Unit = {
+    val icebergDeleteFiles =
+      Option(icebergTable.currentSnapshot())
+        .map(
+          _.deleteManifests(icebergTable.io())
+            .asScala
+            .flatMap(ManifestFiles.readDeleteManifest(_, icebergTable.io(), null).asScala.toSeq)
+            .map(df => (df.referencedDataFile, df.path))
+            .toMap)
+        .getOrElse(Map.empty)
+
+    val deltaLogDeleteFiles = deltaLog.update(
+        catalogTableOpt = catalogTableOpt).allFiles.collect().collect {
+      case add: AddFile if add.deletionVector != null =>
+        (add.absolutePath(deltaLog).toString,
+          add.deletionVector.absolutePath(deltaLog.dataPath).toString)
+    }.toMap
+    assert(icebergDeleteFiles == deltaLogDeleteFiles)
+  }
+
+  protected def verifyRowTrackingMetadata(): Unit = {
+    if (icebergTable.currentSnapshot() == null) {
+      return
+    }
+    // verify high water mark equal to next row id
+    val icebergNextRowId = icebergTable.asInstanceOf[BaseTable].operations().refresh().nextRowId()
+    val deltaHighWaterMark = RowId.extractHighWatermark(
+      deltaLog.update(catalogTableOpt = catalogTableOpt)).get
+    assert(icebergNextRowId == deltaHighWaterMark + 1)
+
+    if (this.expectedSnapshotSeqNumber.nonEmpty) {
+      assert(this.expectedSnapshotSeqNumber.get
+        == icebergTable.currentSnapshot().sequenceNumber(),
+        s"expected Snapshot Seq Number ${expectedSnapshotSeqNumber.get}, " +
+          s"iceberg sequence ${icebergTable.currentSnapshot().sequenceNumber()}"
+      )
+    } else if (enforceSnapshotSeqNumCheck) {
+      // verify iceberg snapshot sequence number match latest delta version
+      assert(deltaLog.update(catalogTableOpt = catalogTableOpt).version ==
+        icebergTable.currentSnapshot().sequenceNumber(),
+        s"delta log version ${deltaLog.update(catalogTableOpt = catalogTableOpt).version}, " +
+          s"iceberg sequence ${icebergTable.currentSnapshot().sequenceNumber()}"
+      )
+    }
+  }
+
+  protected def verifyDataFile(deltaFile: AddFile, icebergFile: DataFile): Unit = {
+    verifyDataFilePartition(deltaFile, icebergFile)
+    if (enforceDataFileStatsCheck) {
+      verifyDataFileStats(deltaFile, icebergFile)
+    }
+    withCompatVersion( _ >= 3) {
+      verifyRowTrackingFileMetadata(deltaFile, icebergFile)
+    }
+  }
+
+  protected def verifyDataFilePartition(deltaFile: AddFile, icebergFile: DataFile): Unit = {
+    // Verify Partition match
+    val icebergPartitionSpec = icebergTable.specs.get(icebergFile.specId())
+
+    assert(deltaFile.partitionValues.size == icebergFile.partition().size())
+
+    val logicalToPhysicalForPartCols = IcebergTransactionUtils
+      .getPartitionPhysicalNameMapping(deltaSnapshot.metadata.partitionSchema)
+    val dataTypeByLogicalName = deltaSchema.fields.map(f => (f.name, f.dataType)).toMap
+
+    for (i <- 0 until icebergPartitionSpec.fields().size()) {
+      val icebergPartName = icebergPartitionSpec.fields().get(i).name()
+      val icebergPartValue = icebergFile.partition().asInstanceOf[PartitionData].get(i)
+
+      val logicalName = icebergPartName
+      val dataType = dataTypeByLogicalName(logicalName)
+      val stringVal = deltaFile.partitionValues(logicalToPhysicalForPartCols(logicalName))
+      val icebergPartValueFromDelta = IcebergTransactionUtils
+        .stringToIcebergPartitionValue(dataType, stringVal, 0)
+
+      assert(icebergPartValue == icebergPartValueFromDelta)
+    }
+  }
+
+  protected def verifyDataFileStats(deltaFile: AddFile, icebergFile: DataFile): Unit = {
+    val deltaStats = JsonUtils.fromJson[Map[String, Any]](deltaFile.stats)
+    val deltaNumRecords = deltaStats("numRecords").asInstanceOf[Int]
+    assert(deltaNumRecords == icebergFile.recordCount())
+
+    // Translate Iceberg partition data in ByteBuffer into Java/Scala objects
+    def deserialize(ftype: Type, value: Any): Any = {
+      (ftype, value) match {
+        case (_, null) => null
+        case (_: Types.StringType, bb: ByteBuffer) =>
+          Conversions.fromByteBuffer(ftype, bb).toString
+        case (_: Types.DateType, bb: ByteBuffer) =>
+          val daysFromEpoch = Conversions.fromByteBuffer(ftype, bb).asInstanceOf[Int]
+          DateTimeUtil.dateFromDays(daysFromEpoch).toString
+        case (tsType: Types.TimestampType, bb: ByteBuffer) =>
+          val microts = Conversions.fromByteBuffer(tsType, bb).asInstanceOf[java.lang.Long]
+          if (tsType.shouldAdjustToUTC()) {
+            DateTimeUtil.microsToIsoTimestamptz(microts)
+          } else {
+            DateTimeUtil.microsToIsoTimestamp(microts)
+          }
+        case (_, bb: java.nio.ByteBuffer) =>
+          Conversions.fromByteBuffer(ftype, bb)
+        case _ => throw new IllegalArgumentException("unable to deserialize unknown values")
+      }
+    }
+    // Collect a mapping of Delta physical name to field id
+    def collectIdToPhysicalName(root: StructType): Map[Int, String] =
+      root.fields.flatMap { field =>
+        val fieldPair = field.metadata.getLong(COLUMN_MAPPING_METADATA_ID_KEY).toInt ->
+          field.metadata.getString(COLUMN_MAPPING_PHYSICAL_NAME_KEY)
+        val subPairs = field.dataType match {
+          case struct: StructType => collectIdToPhysicalName(struct).toSeq
+          case list: ArrayType =>
+            list.elementType match {
+              case listStruct: StructType => collectIdToPhysicalName(listStruct).toSeq
+              case _ => Nil
+            }
+          case map: MapType =>
+            val mapKeyPairs = map.keyType match {
+              case keyStruct: StructType => collectIdToPhysicalName(keyStruct).toSeq
+              case _ => Nil
+            }
+            val mapValuePairs = map.valueType match {
+              case valueStruct: StructType => collectIdToPhysicalName(valueStruct).toSeq
+              case _ => Nil
+            }
+            mapKeyPairs ++ mapValuePairs
+          case _ => Nil
+        }
+        subPairs :+ fieldPair
+      }.toMap
+    // Make leveled Delta stats a flat map
+    def flattenDeltaStats(input: Map[String, Any]): Map[String, Any] =
+      input.flatMap {
+        case (key, value) =>
+          value match {
+            case nestedMap: Map[String, Any] => flattenDeltaStats(nestedMap).toSeq
+            case _ => Seq(key -> value)
+          }
+      }.toMap
+
+    val idToPhysicalName = collectIdToPhysicalName(deltaSchema)
+    val physicalNames = idToPhysicalName.values.toSet
+
+    // Filter out fields no longer in the latest schema
+    val deltaMax = flattenDeltaStats(deltaStats("maxValues").asInstanceOf[Map[String, Any]])
+      .filter { case (key, _) => physicalNames.contains(key) }
+    val icebergMax = icebergFile
+      .upperBounds()
+      .asScala
+      .collect {
+        case (id, value) if idToPhysicalName.contains(id) =>
+          idToPhysicalName(id) -> deserialize(icebergSchema.findField(id).`type`(), value)
+      }
+      .toMap
+    assert(icebergMax == deltaMax)
+
+    val deltaMin = flattenDeltaStats(deltaStats("minValues").asInstanceOf[Map[String, Any]])
+      .filter { case (key, _) => physicalNames.contains(key) }
+    val icebergMin = icebergFile
+      .lowerBounds()
+      .asScala
+      .collect {
+        case (id, value) if idToPhysicalName.contains(id) =>
+          idToPhysicalName(id) -> deserialize(icebergSchema.findField(id).`type`(), value)
+      }
+      .toMap
+    assert(icebergMin == deltaMin)
+
+    val deltaNullCount = flattenDeltaStats(deltaStats("nullCount").asInstanceOf[Map[String, Any]])
+      .filter { case (key, _) => physicalNames.contains(key) }
+    val icebergNullCount = icebergFile
+      .nullValueCounts()
+      .asScala
+      .collect {
+        case (id, value) if idToPhysicalName.contains(id) =>
+          idToPhysicalName(id) -> value
+      }
+      .toMap
+    assert(icebergNullCount == deltaNullCount)
+  }
+
+  protected def verifyRowTrackingFileMetadata(deltaFile: AddFile, icebergFile: DataFile): Unit = {
+    assert(deltaFile.baseRowId.getOrElse(null.asInstanceOf[Long])
+      == icebergFile.firstRowId(), s"delta row id ${deltaFile.baseRowId}," +
+      s"iceberg row id ${icebergFile.firstRowId()}")
+  }
+
+  protected def verifyContent(): Unit = {
+    // Do nothing for now
+  }
+}
+
+object UniFormIcebergVerifier {
+  /**
+   * Load Iceberg table from a metadata path
+   */
+  def loadIcebergTableFromPath(spark: SparkSession, metadataLocation: String): Table = {
+    // scalastyle:off deltahadoopconfiguration
+    val hadoopTables = new HadoopTables(spark.sessionState.newHadoopConf())
+    // scalastyle:on deltahadoopconfiguration
+    hadoopTables.load(metadataLocation)
+  }
+  /**
+   * Load Iceberg table from UC.
+   */
+  def loadIcebergTableFromUC(tableName: String): Table =
+    SparkSession.getActiveSession.flatMap { spark =>
+      val tableMetadata = spark.sessionState.catalog
+        .getTableMetadata(TableIdentifier(tableName))
+      tableMetadata.storage.properties
+        .get(IcebergConstants.CATALOG_TABLE_ICEBERG_METADATA_LOCATION_PROP)
+        .map(tablePath => loadIcebergTableFromPath(spark, tablePath))
+    }.getOrElse(throw new IllegalArgumentException("Spark Session not available"))
+}

--- a/iceberg/src/test/scala/org/apache/spark/sql/delta/uniform/UniversalFormatSuite.scala
+++ b/iceberg/src/test/scala/org/apache/spark/sql/delta/uniform/UniversalFormatSuite.scala
@@ -20,13 +20,17 @@ import java.util.UUID
 
 import org.apache.spark.sql.delta.{
   DeltaLog,
+  IcebergCompatBase,
   IcebergCompatUtilsBase,
+  IcebergCompatV3,
   UniFormWithIcebergCompatV1SuiteBase,
   UniFormWithIcebergCompatV2SuiteBase,
   UniversalFormatMiscSuiteBase,
   UniversalFormatSuiteBase}
+import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.commands.DeltaReorgTableCommand
 import org.apache.spark.sql.delta.icebergShaded.IcebergTransactionUtils
+import org.apache.spark.sql.delta.uniform.UniFormIcebergVerifier
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
@@ -67,3 +71,46 @@ class UniFormWithIcebergCompatV1Suite
 class UniFormWithIcebergCompatV2Suite
     extends UniversalFormatSuiteUtilsBase
     with UniFormWithIcebergCompatV2SuiteBase
+
+class UniFormWithIcebergCompatV3Suite
+  extends IcebergCompatUtilsBase
+    with WriteDeltaUCCCReadIceberg {
+
+  import org.apache.spark.sql.delta.test.DeltaTestImplicits._
+
+  override val compatObject: IcebergCompatBase = IcebergCompatV3
+
+  override def executeSql(sqlStr: String): DataFrame = write(sqlStr)
+
+  override def withTempTableAndDir(f: (String, String) => Unit): Unit = {
+    val tableId = s"testTable${UUID.randomUUID()}".replace("-", "_")
+    withTempDir { dir =>
+      val tablePath = new Path(dir.toString, "table")
+
+      withTable(tableId) {
+        f(tableId, s"'$tablePath'")
+      }
+    }
+  }
+
+  test("row tracking information should be converted") {
+    withTempTableAndDir { case (id, _) =>
+      executeSql(
+        s"""
+           |CREATE TABLE $id (ID INT) USING DELTA TBLPROPERTIES (
+           |  'delta.universalFormat.enabledFormats' = 'iceberg',
+           |  'delta.enableIcebergCompatV$compatVersion' = 'true'
+           |  $requiredTableProperties
+           |)""".stripMargin)
+      executeSql(s"insert into $id values (1), (2), (3)")
+      executeSql(s"update $id set id = 100 where id = 1")
+
+      val identifier = TableIdentifier(id)
+      val table = DeltaTableV2(spark, identifier)
+      val deltaLog = table.deltaLog
+      val icebergTable = UniFormIcebergVerifier.loadIcebergTableFromUC(id)
+
+      new UniFormIcebergVerifier(spark, deltaLog, table.catalogTable, icebergTable).verify()
+    }
+  }
+}

--- a/spark/src/main/scala-shims/spark-4.1/GeoTypesShim.scala
+++ b/spark/src/main/scala-shims/spark-4.1/GeoTypesShim.scala
@@ -41,6 +41,8 @@ object GeoTypesShim {
     case _ => false
   }
 
+  val geoTypes: Seq[Class[_]] = Seq(classOf[GeometryType], classOf[GeographyType])
+
   /**
    * If `dt` is a geospatial type with an unsupported SRID, returns `Some(srid)`. Returns
    * `None` for non-geospatial types or geospatial types with supported SRIDs.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/IcebergCompat.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/IcebergCompat.scala
@@ -23,6 +23,7 @@ import org.apache.spark.sql.delta.commands.DeletionVectorUtils
 import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.schema.SchemaUtils
+import org.apache.spark.sql.delta.shims.GeoTypesShim
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 
 import org.apache.spark.internal.MDC
@@ -81,7 +82,7 @@ object IcebergCompatV2 extends IcebergCompatBase(
 )
 object CheckTypeInV3AllowList extends CheckTypeInAllowList {
   val v3OnlyTypes = Set[Class[_]](VariantType.getClass)
-  val v3GeoSpatialTypes = Set[Class[_]]()
+  val v3GeoSpatialTypes = GeoTypesShim.geoTypes
   override val allowTypes: Set[Class[_]] =
     CheckTypeInV2AllowList.allowTypes ++ v3OnlyTypes ++ v3GeoSpatialTypes
 }
@@ -426,7 +427,7 @@ case class IcebergCompatVersionBase(knownVersions: Set[IcebergCompatBase]) {
 }
 
 object IcebergCompat extends IcebergCompatVersionBase(
-    Set(IcebergCompatV1, IcebergCompatV2)
+    Set(IcebergCompatV1, IcebergCompatV2, IcebergCompatV3)
   ) with DeltaLogging
 
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/UniversalFormat.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/UniversalFormat.scala
@@ -211,7 +211,8 @@ object UniversalFormat extends DeltaLogging {
         Option[DeltaOperations.Operation],
         Seq[Action]) => (Option[Protocol], Option[Metadata])] = Seq(
       IcebergCompatV1.enforceInvariantsAndDependencies,
-      IcebergCompatV2.enforceInvariantsAndDependencies
+      IcebergCompatV2.enforceInvariantsAndDependencies,
+      IcebergCompatV3.enforceInvariantsAndDependencies
     )
     compatChecks.foreach { compatCheck =>
       val updates = compatCheck(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -2245,7 +2245,7 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .internal()
       .doc("If true, allow users to create/upgrade Uniform Iceberg v3 tables.")
       .booleanConf
-      .createWithDefault(false)
+      .createWithDefault(true)
 
   val DELTA_UNIFORM_ICEBERG_GEOSPATIAL_ENABLED =
     buildConf("uniform.iceberg.geospatial.enabled")
@@ -3345,6 +3345,17 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
         .stripMargin)
     .booleanConf
     .createWithDefault(true)
+
+  val GUARD_VARIANT_IN_STATS_SCHEMA =
+    buildConf("variantShredding.guardVariantInStatsSchema.enabled")
+      .internal()
+      .doc("When enabled, variant columns are only included in the data skipping stats schema " +
+        "if the table's protocol supports the variantShredding (or variantShredding-preview) " +
+        "table feature. This acts as a kill switch for that gating: when disabled, variant " +
+        "columns are included in the stats schema based solely on the variant data skipping " +
+        "stats config, regardless of the table's shredding support.")
+      .booleanConf
+      .createWithDefault(true)
 
   val PARSE_FOOTER_FOR_VARIANT_DATA_SKIPPING_STATS =
     buildConf("variantShredding.parseFooterForStats")

--- a/spark/src/main/scala/org/apache/spark/sql/delta/stats/StatisticsCollection.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/stats/StatisticsCollection.scala
@@ -30,6 +30,7 @@ import org.apache.spark.sql.delta.ClassicColumnConversions._
 import org.apache.spark.sql.delta.DeltaColumnMapping.COLUMN_MAPPING_PHYSICAL_NAME_KEY
 import org.apache.spark.sql.delta.DeltaOperations.ComputeStats
 import org.apache.spark.sql.delta.OptimisticTransaction
+import org.apache.spark.sql.delta.{VariantShreddingPreviewTableFeature, VariantShreddingTableFeature}
 import org.apache.spark.sql.delta.actions.{AddFile, Metadata, Protocol}
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.commands.DeletionVectorUtils
@@ -132,6 +133,20 @@ trait StatisticsCollection extends DeltaLogging {
   protected def protocol: Protocol
 
   lazy val deletionVectorsSupported = protocol.isFeatureSupported(DeletionVectorsTableFeature)
+
+  lazy val variantShreddingSupported: Boolean =
+    protocol.isFeatureSupported(VariantShreddingTableFeature) ||
+      protocol.isFeatureSupported(VariantShreddingPreviewTableFeature)
+
+  /**
+   * Whether VARIANT columns are eligible for inclusion in the min/max data skipping stats schema.
+   * When [[DeltaSQLConf.GUARD_VARIANT_IN_STATS_SCHEMA]] is enabled (the default), variant columns
+   * are only included when the table supports variant shredding; the conf acts as a kill switch
+   * that, when disabled, restores the prior behavior of including variant columns regardless of
+   * the table's shredding support.
+   */
+  private def variantEligibleForStatsSchema: Boolean =
+    !SQLConf.get.getConf(DeltaSQLConf.GUARD_VARIANT_IN_STATS_SCHEMA) || variantShreddingSupported
 
   private def effectiveSchema: StructType = if (statsColumnSpec.numIndexedColsOpt.isDefined) {
     outputTableStatsSchema
@@ -322,11 +337,38 @@ trait StatisticsCollection extends DeltaLogging {
     // 4) omits metadata in table schema as Delta stats schema does not need the metadata
     def getMinMaxStatsSchema(schema: StructType): Option[StructType] = {
       val fields = schema.fields.flatMap {
+        // Iceberg stats require column IDs so they are propagated to the stats schema.
+        // Fields without column IDs are ignored during Delta stat to Iceberg stat conversion.
+        // As List and Map types are not skipping eligible, we do not need to handle
+        // nested field IDs here.
+        case f@StructField(_, dataType: StructType, _, _) if DeltaColumnMapping.hasColumnId(f) =>
+          getMinMaxStatsSchema(dataType).map { newDataType =>
+            StructField(
+              DeltaColumnMapping.getPhysicalName(f),
+              newDataType,
+              metadata = new MetadataBuilder()
+                .putLong(DeltaColumnMapping.COLUMN_MAPPING_METADATA_ID_KEY,
+                  DeltaColumnMapping.getColumnId(f))
+                .build()
+            )
+          }
+        case f@StructField(_, SkippingEligibleDataType(dataType), _, _)
+            if DeltaColumnMapping.hasColumnId(f) &&
+              (!dataType.isInstanceOf[VariantType] || variantEligibleForStatsSchema) =>
+          Some(StructField(
+            DeltaColumnMapping.getPhysicalName(f),
+            dataType,
+            metadata = new MetadataBuilder()
+              .putLong(DeltaColumnMapping.COLUMN_MAPPING_METADATA_ID_KEY,
+                DeltaColumnMapping.getColumnId(f))
+              .build()
+          ))
         case f@StructField(_, dataType: StructType, _, _) =>
           getMinMaxStatsSchema(dataType).map { newDataType =>
             StructField(DeltaColumnMapping.getPhysicalName(f), newDataType)
           }
-        case f@StructField(_, SkippingEligibleDataType(dataType), _, _) =>
+        case f@StructField(_, SkippingEligibleDataType(dataType), _, _)
+            if !dataType.isInstanceOf[VariantType] || variantEligibleForStatsSchema =>
           Some(StructField(DeltaColumnMapping.getPhysicalName(f), dataType))
         case _ => None
       }
@@ -338,6 +380,30 @@ trait StatisticsCollection extends DeltaLogging {
     // 4) omits metadata in table schema as Delta stats schema does not need the metadata
     def getNullCountSchema(schema: StructType): Option[StructType] = {
       val fields = schema.fields.flatMap {
+        // Iceberg stats require column IDs so they are propagated to the stats schema.
+        // Fields without column IDs are ignored during Delta stat to Iceberg stat conversion.
+        // The Iceberg stats schema does not require nested field IDs for list and map columns
+        // so we do not need to add them here.
+        case f@StructField(_, dataType: StructType, _, _) if DeltaColumnMapping.hasColumnId(f) =>
+          getNullCountSchema(dataType).map { newDataType =>
+            StructField(
+              DeltaColumnMapping.getPhysicalName(f),
+              newDataType,
+              metadata = new MetadataBuilder()
+                .putLong(DeltaColumnMapping.COLUMN_MAPPING_METADATA_ID_KEY,
+                  DeltaColumnMapping.getColumnId(f))
+                .build()
+            )
+          }
+        case f: StructField if DeltaColumnMapping.hasColumnId(f) =>
+          Some(StructField(
+            DeltaColumnMapping.getPhysicalName(f),
+            LongType,
+            metadata = new MetadataBuilder()
+              .putLong(DeltaColumnMapping.COLUMN_MAPPING_METADATA_ID_KEY,
+                DeltaColumnMapping.getColumnId(f))
+              .build()
+          ))
         case f@StructField(_, dataType: StructType, _, _) =>
           getNullCountSchema(dataType).map { newDataType =>
             StructField(DeltaColumnMapping.getPhysicalName(f), newDataType)


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Enables UniForm **IcebergCompatV3** so Delta tables can be created/upgraded to write Iceberg metadata under compat v3, and makes the surrounding pieces (type allow-list, statistics schema) v3-aware.

- **Register IcebergCompatV3** (`IcebergCompat.scala`, `UniversalFormat.scala`): add `IcebergCompatV3` to the set of known compat versions and wire its `enforceInvariantsAndDependencies` into the UniForm enforcement checks.
- **V3 type allow-list** (`IcebergCompat.scala`, `spark-4.1/GeoTypesShim.scala`): `CheckTypeInV3AllowList` now additionally allows `VariantType` and the geospatial types. `GeoTypesShim.geoTypes` exposes `GeometryType`/`GeographyType`, which feed `v3GeoSpatialTypes`.
- **Enable v3 by default** (`DeltaSQLConf.scala`): flip `uniform.iceberg.v3` (allow create/upgrade of UniForm Iceberg v3 tables) default from `false` to `true`.
- **Stats schema carries column IDs** (`StatisticsCollection.scala`): the min/max and null-count stats schemas now propagate the column-mapping field ID (`COLUMN_MAPPING_METADATA_ID_KEY`) for struct and leaf fields. Iceberg stats are keyed by field ID, so fields without a column ID are skipped during Delta -> Iceberg stats conversion.
- **Guard variant columns in the stats schema** (`DeltaSQLConf.scala`, `StatisticsCollection.scala`): new internal config `variantShredding.guardVariantInStatsSchema.enabled` (default `true`). When enabled, `VARIANT` columns are only included in the data-skipping stats schema if the table supports the `variantShredding` (or `variantShredding-preview`) table feature. The config is a kill switch that restores the prior unconditional behavior when disabled.
- **Test JVM module flags** (`build.sbt`): add `--add-opens` for `java.base/java.lang.invoke` and `java.base/java.util` (Java 17+). These are required so Spark's Kryo serializer can pre-register its built-in JDK classes (e.g. `SerializedLambda`) when a Kryo instance is constructed during shuffle setup; without them registration fails with `Unable to create serializer "FieldSerializer" for class ...`.

## How was this patch tested?

New test infrastructure and an end-to-end v3 suite under `iceberg/src/test`:

- **`UniFormIcebergVerifier`** (new): independently loads the converted Iceberg table (schema, field IDs, statistics, snapshots) through the shaded Iceberg APIs and cross-checks it against the source Delta snapshot. It deliberately avoids the production conversion utilities so it acts as an independent oracle for UniForm behavior.
- **`UniversalFormatSuite`**: adds a `UniFormWithIcebergCompatV3Suite` that creates a Delta UniForm table with `delta.enableIcebergCompatV3`, runs `INSERT` + `UPDATE` (exercising row tracking), then validates the generated Iceberg table with `UniFormIcebergVerifier`.

## Does this PR introduce _any_ user-facing changes?

Yes. UniForm Iceberg compat **v3 is now enabled by default** (`uniform.iceberg.v3` defaults to `true`). Users can create and upgrade UniForm Iceberg v3 tables without first flipping an internal flag; v3 additionally allows `Variant` and geospatial (`Geometry`/`Geography`) column types in the Iceberg type allow-list. This is a change relative to prior `master` behavior, where v3 was gated off by default. Existing v1/v2 UniForm behavior is unchanged.
