### PR TITLE
[Kernel] Capture _last_checkpoint checkpointSchema via a raw-JSON field marker

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checkpoints/CheckpointMetaData.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checkpoints/CheckpointMetaData.java
@@ -27,6 +27,7 @@ import io.delta.kernel.internal.data.GenericRow;
 import io.delta.kernel.internal.data.StructRow;
 import io.delta.kernel.internal.util.JsonUtils;
 import io.delta.kernel.types.ArrayType;
+import io.delta.kernel.types.FieldMetadata;
 import io.delta.kernel.types.LongType;
 import io.delta.kernel.types.MapType;
 import io.delta.kernel.types.StringType;
@@ -69,9 +70,17 @@ public class CheckpointMetaData {
           .add("v2Checkpoint", V2_CHECKPOINT_SCHEMA, true /* nullable */)
           .add("checksum", StringType.STRING, true /* nullable */)
           .add(
-              "tags",
-              new MapType(StringType.STRING, StringType.STRING, false),
-              true /* nullable */);
+              "tags", new MapType(StringType.STRING, StringType.STRING, false), true /* nullable */)
+          // `checkpointSchema` is a recursive, polymorphic schema-of-schema object (a serialized
+          // StructType) that the columnar reader cannot project into a fixed schema. It is declared
+          // as a String carrying the raw-JSON marker so the reader can capture its exact JSON text.
+          .add(
+              "checkpointSchema",
+              StringType.STRING,
+              true /* nullable */,
+              FieldMetadata.builder()
+                  .putBoolean(JsonUtils.RAW_JSON_FIELD_METADATA_KEY, true)
+                  .build());
 
   private static final int VERSION_ORDINAL = 0;
   private static final int SIZE_ORDINAL = 1;
@@ -81,6 +90,7 @@ public class CheckpointMetaData {
   private static final int V2_CHECKPOINT_ORDINAL = 5;
   private static final int CHECKSUM_ORDINAL = 6;
   private static final int TAGS_ORDINAL = 7;
+  private static final int CHECKPOINT_SCHEMA_ORDINAL = 8;
 
   public static CheckpointMetaData fromRow(Row row) {
     return new CheckpointMetaData(
@@ -102,7 +112,11 @@ public class CheckpointMetaData {
         row.isNullAt(CHECKSUM_ORDINAL)
             ? Optional.empty()
             : Optional.of(row.getString(CHECKSUM_ORDINAL)),
-        row.isNullAt(TAGS_ORDINAL) ? Map.of() : toJavaMap(row.getMap(TAGS_ORDINAL)));
+        row.isNullAt(TAGS_ORDINAL) ? Map.of() : toJavaMap(row.getMap(TAGS_ORDINAL)),
+        // Captured as raw JSON text by the reader
+        row.isNullAt(CHECKPOINT_SCHEMA_ORDINAL)
+            ? Optional.empty()
+            : Optional.of(row.getString(CHECKPOINT_SCHEMA_ORDINAL)));
   }
 
   public final long version;
@@ -113,6 +127,7 @@ public class CheckpointMetaData {
   public final Optional<Row> v2Checkpoint;
   public final Optional<String> checksum;
   public final Map<String, String> tags;
+  public final Optional<String> checkpointSchema;
 
   public CheckpointMetaData(long version, long size, Optional<Long> parts) {
     this(
@@ -123,7 +138,8 @@ public class CheckpointMetaData {
         Optional.empty() /* numOfAddFiles */,
         Optional.empty() /* v2Checkpoint */,
         Optional.empty() /* checksum */,
-        Map.of() /* tags */);
+        Map.of() /* tags */,
+        Optional.empty() /* checkpointSchema */);
   }
 
   public CheckpointMetaData(
@@ -136,7 +152,8 @@ public class CheckpointMetaData {
         Optional.empty() /* numOfAddFiles */,
         Optional.empty() /* v2Checkpoint */,
         Optional.empty() /* checksum */,
-        tags);
+        tags,
+        Optional.empty() /* checkpointSchema */);
   }
 
   public CheckpointMetaData(
@@ -148,6 +165,28 @@ public class CheckpointMetaData {
       Optional<Row> v2Checkpoint,
       Optional<String> checksum,
       Map<String, String> tags) {
+    this(
+        version,
+        size,
+        parts,
+        sizeInBytes,
+        numOfAddFiles,
+        v2Checkpoint,
+        checksum,
+        tags,
+        Optional.empty() /* checkpointSchema */);
+  }
+
+  public CheckpointMetaData(
+      long version,
+      long size,
+      Optional<Long> parts,
+      Optional<Long> sizeInBytes,
+      Optional<Long> numOfAddFiles,
+      Optional<Row> v2Checkpoint,
+      Optional<String> checksum,
+      Map<String, String> tags,
+      Optional<String> checkpointSchema) {
     this.version = version;
     this.size = size;
     this.parts = parts;
@@ -156,6 +195,7 @@ public class CheckpointMetaData {
     this.v2Checkpoint = v2Checkpoint;
     this.checksum = checksum;
     this.tags = tags;
+    this.checkpointSchema = checkpointSchema;
   }
 
   public Row toRow() {
@@ -170,6 +210,7 @@ public class CheckpointMetaData {
     if (!tags.isEmpty()) {
       dataMap.put(TAGS_ORDINAL, stringStringMapValue(tags));
     }
+    checkpointSchema.ifPresent(str -> dataMap.put(CHECKPOINT_SCHEMA_ORDINAL, str));
 
     return new GenericRow(READ_SCHEMA, dataMap);
   }
@@ -197,6 +238,8 @@ public class CheckpointMetaData {
         + checksum
         + ", tags="
         + tags
+        + ", checkpointSchema="
+        + checkpointSchema
         + '}';
   }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/JsonUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/JsonUtils.java
@@ -50,6 +50,34 @@ public class JsonUtils {
   private static final ObjectMapper MAPPER = new ObjectMapper();
   private static final JsonFactory FACTORY = new JsonFactory();
 
+  /**
+   * {@link FieldMetadata} key marking a {@link StringType} schema field whose value is a nested
+   * JSON document (an object or array), not a JSON string literal.
+   *
+   * <p>A field marked with this key is handled specially by both the reader and the writer, keeping
+   * this class free of any knowledge of specific field names:
+   *
+   * <ul>
+   *   <li><b>Read</b> (e.g. {@code DefaultJsonRow}): the field's raw JSON text is captured verbatim
+   *       into the {@code String} value, rather than type-decoded. This lets a recursive,
+   *       polymorphic JSON object (which the columnar reader cannot project into a fixed schema) be
+   *       carried through as a {@code String}.
+   *   <li><b>Write</b> ({@link #rowToJson}): the {@code String} is spliced back into the output as
+   *       raw JSON via {@link JsonGenerator#writeRawValue(String)} instead of being quoted and
+   *       escaped by {@link JsonGenerator#writeString(String)}.
+   * </ul>
+   */
+  public static final String RAW_JSON_FIELD_METADATA_KEY = "__kernel_rawJson";
+
+  /**
+   * Whether {@code field} is a raw-JSON field (see {@link #RAW_JSON_FIELD_METADATA_KEY}). Shared by
+   * the read and write paths so the two cannot disagree on which fields get raw-JSON handling.
+   */
+  public static boolean isRawJsonField(StructField field) {
+    return field.getDataType() instanceof StringType
+        && Boolean.TRUE.equals(field.getMetadata().getBoolean(RAW_JSON_FIELD_METADATA_KEY));
+  }
+
   public static JsonFactory factory() {
     return FACTORY;
   }
@@ -101,7 +129,12 @@ public class JsonUtils {
       StructField field = schema.at(ordinal);
       if (!row.isNullAt(ordinal)) {
         gen.writeFieldName(field.getName());
-        writeValue(gen, row, ordinal, field.getDataType());
+        if (isRawJsonField(field)) {
+          // Splice the string in unquoted so it stays a JSON object/array
+          gen.writeRawValue(row.getString(ordinal));
+        } else {
+          writeValue(gen, row, ordinal, field.getDataType());
+        }
       }
     }
     gen.writeEndObject();
@@ -115,7 +148,11 @@ public class JsonUtils {
       ColumnVector childVector = vector.getChild(ordinal);
       if (!childVector.isNullAt(rowId)) {
         gen.writeFieldName(field.getName());
-        writeValue(gen, childVector, rowId, field.getDataType());
+        if (isRawJsonField(field)) {
+          gen.writeRawValue(childVector.getString(rowId));
+        } else {
+          writeValue(gen, childVector, rowId, field.getDataType());
+        }
       }
     }
     gen.writeEndObject();

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/SnapshotManagerSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/SnapshotManagerSuite.scala
@@ -1169,7 +1169,8 @@ class MockReadLastCheckpointFileJsonHandler(
 
         override def getColumnVector(ordinal: Int): ColumnVector = {
           // READ_SCHEMA: version, size, parts, sizeInBytes, numOfAddFiles, v2Checkpoint, checksum,
-          // tags. This classic pointer only sets version/size/parts; the rest are null/empty.
+          // tags, checkpointSchema. This classic pointer only sets version/size/parts; the rest are
+          // null/empty.
           ordinal match {
             case 0 => longVector(Seq(lastCheckpointVersion)) /* version */
             case 1 => longVector(Seq(100)) /* size */
@@ -1186,6 +1187,7 @@ class MockReadLastCheckpointFileJsonHandler(
               }
             case 6 => stringVector(Seq(null)) /* checksum */
             case 7 => mapTypeVector(Seq(Map.empty[String, String])) /* tags */
+            case 8 => stringVector(Seq(null)) /* checkpointSchema */
           }
         }
 

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/checkpoints/CheckpointerSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/checkpoints/CheckpointerSuite.scala
@@ -354,6 +354,7 @@ object CheckpointerSuite extends VectorTestUtils {
         case 5 => nullVector(CheckpointMetaData.READ_SCHEMA.at(5).getDataType) // v2Checkpoint
         case 6 => stringVector(Seq(null)) // checksum
         case 7 => mapTypeVector(Seq(Map.empty[String, String])) // tags
+        case 8 => stringVector(Seq(null)) // checkpointSchema
       }
     }
 

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/DefaultJsonRow.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/DefaultJsonRow.java
@@ -27,6 +27,7 @@ import io.delta.kernel.data.Row;
 import io.delta.kernel.defaults.internal.DefaultKernelUtils;
 import io.delta.kernel.defaults.internal.data.vector.DefaultGenericVector;
 import io.delta.kernel.internal.util.InternalUtils;
+import io.delta.kernel.internal.util.JsonUtils;
 import io.delta.kernel.internal.util.TimestampUtils;
 import io.delta.kernel.types.*;
 import java.math.BigDecimal;
@@ -390,6 +391,10 @@ public class DefaultJsonRow implements Row {
           String.format(
               "Root node at key %s is null but field isn't nullable. Root node: %s",
               field.getName(), rootNode));
+    }
+
+    if (JsonUtils.isRawJsonField(field)) {
+      return rootNode.get(field.getName()).toString();
     }
 
     return decodeElement(rootNode.get(field.getName()), field.getDataType());

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/LastCheckpointHintSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/LastCheckpointHintSuite.scala
@@ -23,6 +23,7 @@ import io.delta.golden.GoldenTableUtils.goldenTablePath
 import io.delta.kernel.defaults.engine.DefaultEngine
 import io.delta.kernel.internal.checkpoints.Checkpointer
 import io.delta.kernel.internal.fs.Path
+import io.delta.kernel.internal.types.DataTypeJsonSerDe
 import io.delta.kernel.internal.util.JsonUtils
 
 import org.apache.hadoop.conf.Configuration
@@ -37,7 +38,8 @@ import org.scalatest.funsuite.AnyFunSuite
  * projection, nested-struct/array parsing, and JSON serialization are all exercised together.
  *
  * Note: the top-level `checkpointSchema` field is a polymorphic schema-of-schema that the columnar
- * reader cannot project, so it is not captured; `toJson` reproduces every other field.
+ * reader cannot project into a fixed schema. It is captured as raw JSON text and `toJson` splices
+ * it back in as a JSON object, so it round-trips like every other field.
  */
 class LastCheckpointHintSuite extends AnyFunSuite {
 
@@ -50,17 +52,6 @@ class LastCheckpointHintSuite extends AnyFunSuite {
     assert(
       expectedNode == actualNode,
       s"JSON mismatch.\n expected: $expectedNode\n actual:   $actualNode")
-  }
-
-  /**
-   * Returns `json` with the top-level `checkpointSchema` field removed (kernel omits it). Works
-   * through a `java.util.Map` rather than an `ObjectNode` cast so it is agnostic to whether
-   * `JsonUtils.mapper()` returns shaded or unshaded Jackson node types.
-   */
-  private def withoutCheckpointSchema(json: String): String = {
-    val map = JsonUtils.mapper().readValue(json, classOf[java.util.LinkedHashMap[String, Object]])
-    map.remove("checkpointSchema")
-    JsonUtils.mapper().writeValueAsString(map)
   }
 
   private def logPathFor(goldenTable: String): Path =
@@ -88,19 +79,18 @@ class LastCheckpointHintSuite extends AnyFunSuite {
     assert(cpm.checksum.isPresent)
     assert(!cpm.parts.isPresent, "V2 pointer has no `parts`")
     assert(cpm.v2Checkpoint.isPresent, "V2 pointer must carry the v2Checkpoint block")
+    assert(!cpm.checkpointSchema.isPresent, "this fixture carries no checkpointSchema")
 
     val actualJson = cpm.toJson()
     assert(actualJson.contains("v2Checkpoint"))
     assert(actualJson.contains("sidecarFiles"))
     assert(actualJson.contains("nonFileActions"))
     assert(actualJson.contains("checkpointMetadata"))
+    assert(!actualJson.contains("checkpointSchema"))
     assertJsonEquals(expectedJson, actualJson)
   }
 
-  test("V2 (parquet format) pointer round-trips every field except checkpointSchema") {
-    // The parquet-format golden also carries a top-level `checkpointSchema` (a recursive,
-    // polymorphic schema-of-schema object) that the columnar reader cannot project. Every other
-    // field must round-trip, and toJson must reproduce the blob with only checkpointSchema dropped.
+  test("V2 (parquet format) pointer round-trips every field including checkpointSchema") {
     val logPath = logPathFor("v2-checkpoint-parquet")
     val rawJson = readLastCheckpoint(logPath)
 
@@ -109,15 +99,21 @@ class LastCheckpointHintSuite extends AnyFunSuite {
     assert(cpm.v2Checkpoint.isPresent)
     assert(cpm.sizeInBytes.isPresent)
     assert(cpm.numOfAddFiles.isPresent)
+    assert(cpm.checkpointSchema.isPresent, "checkpointSchema must be captured")
+
+    val parsedSchema = DataTypeJsonSerDe.deserializeStructType(cpm.checkpointSchema.get())
+    assert(parsedSchema.length() > 0, "checkpointSchema should parse to a non-empty StructType")
 
     val actualJson = cpm.toJson()
-    assert(!actualJson.contains("checkpointSchema"), "kernel does not capture checkpointSchema")
-    assertJsonEquals(withoutCheckpointSchema(rawJson), actualJson)
+    // Spliced back in as a JSON object, not an escaped string literal.
+    assert(actualJson.contains("\"checkpointSchema\":{"))
+    assert(!actualJson.contains("\"checkpointSchema\":\""))
+    assertJsonEquals(rawJson, actualJson)
   }
 
   test("classic checkpoint (no v2Checkpoint) round-trips its columnar fields") {
     // A classic (non-V2) pointer that carries a top-level `checkpointSchema` but has no
-    // `v2Checkpoint`, `parts`, or `tags`. The scalar fields are captured; checkpointSchema is not.
+    // `v2Checkpoint`, `parts`, or `tags`.
     val logPath = logPathFor("spark-variant-checkpoint")
     val raw = readLastCheckpoint(logPath)
 
@@ -129,10 +125,15 @@ class LastCheckpointHintSuite extends AnyFunSuite {
     assert(cpm.checksum == Optional.of("a8d400a03ead8a86dbb412f2a693e26e"))
     assert(!cpm.parts.isPresent, "classic pointer here has no `parts`")
     assert(!cpm.v2Checkpoint.isPresent, "classic pointer has no v2Checkpoint")
+    assert(cpm.checkpointSchema.isPresent, "checkpointSchema must be captured")
+
+    val parsedSchema = DataTypeJsonSerDe.deserializeStructType(cpm.checkpointSchema.get())
+    assert(parsedSchema.length() > 0, "checkpointSchema should parse to a non-empty StructType")
 
     val actual = cpm.toJson()
-    assert(!actual.contains("checkpointSchema"), "kernel does not capture checkpointSchema")
-    // Reproduces the pointer with only checkpointSchema dropped.
-    assertJsonEquals(withoutCheckpointSchema(raw), actual)
+    assert(actual.contains("\"checkpointSchema\":{"))
+    assert(!actual.contains("\"checkpointSchema\":\""))
+    // Reproduces the pointer in full.
+    assertJsonEquals(raw, actual)
   }
 }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/data/DefaultJsonRowSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/data/DefaultJsonRowSuite.scala
@@ -143,4 +143,52 @@ class DefaultJsonRowSuite extends AnyFunSuite with TestUtils with VectorTestUtil
       assert(JsonUtils.rowToJson(actRow) === expJson.linesIterator.mkString)
     }
   }
+
+  test("DefaultJsonRow raw-JSON field: nested object captured verbatim and spliced back") {
+    // Test that the reader of a StringType field marked with the raw-JSON key
+    // captures its exact text and is spliced back (unquoted) as a JSON object.
+    val rawJson = new FieldMetadata.Builder()
+      .putBoolean(JsonUtils.RAW_JSON_FIELD_METADATA_KEY, true)
+      .build()
+    val schema = new StructType()
+      .add("plain", StringType.STRING, true)
+      .add("nested", StringType.STRING, true, rawJson)
+
+    val nestedObject = """{"type":"struct","fields":[{"name":"id","type":"long"}]}"""
+    val testJson = s"""{"plain":"hi","nested":$nestedObject}"""
+
+    val row = DefaultJsonRow.fromJsonString(testJson, schema)
+    assert(row.getString(1) === nestedObject)
+    assert(row.getString(0) === "hi")
+
+    val out = JsonUtils.rowToJson(row)
+    assert(out === s"""{"plain":"hi","nested":$nestedObject}""")
+    assert(out.contains("\"nested\":{"))
+    assert(!out.contains("\"nested\":\""))
+  }
+
+  test("DefaultJsonRow raw-JSON field: nested array captured verbatim") {
+    val rawJson = new FieldMetadata.Builder()
+      .putBoolean(JsonUtils.RAW_JSON_FIELD_METADATA_KEY, true)
+      .build()
+    val schema = new StructType().add("arr", StringType.STRING, true, rawJson)
+
+    val nestedArray = """[1,2,{"k":"v"}]"""
+    val row = DefaultJsonRow.fromJsonString(s"""{"arr":$nestedArray}""", schema)
+    assert(row.getString(0) === nestedArray)
+    assert(JsonUtils.rowToJson(row) === s"""{"arr":$nestedArray}""")
+  }
+
+  test("DefaultJsonRow raw-JSON field: absent nullable field stays null and is omitted") {
+    val rawJson = new FieldMetadata.Builder()
+      .putBoolean(JsonUtils.RAW_JSON_FIELD_METADATA_KEY, true)
+      .build()
+    val schema = new StructType()
+      .add("plain", StringType.STRING, true)
+      .add("nested", StringType.STRING, true, rawJson)
+
+    val row = DefaultJsonRow.fromJsonString("""{"plain":"hi"}""", schema)
+    assert(row.isNullAt(1))
+    assert(JsonUtils.rowToJson(row) === """{"plain":"hi"}""")
+  }
 }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other

## Description

### Context
`_last_checkpoint` may carry a top-level `checkpointSchema` field: a recursive, polymorphic schema-of-schema object (a serialized `StructType`). `CheckpointMetaData` (via `Checkpointer.readLastCheckpointFile`) currently captures every columnar field except this one, because the columnar JSON reader cannot project a polymorphic object into a fixed schema — declaring `checkpointSchema` as any concrete type makes `DefaultJsonRow` throw when it encounters the object. As a result `toJson()` reproduces the pointer with `checkpointSchema` dropped.

The goal is to capture the field in the *same single read* that produces the rest of `CheckpointMetaData`.

### What
Introduces a generic **raw-JSON field** mechanism and uses it to capture `checkpointSchema`:

- **`JsonUtils` (kernel-api)**: adds `RAW_JSON_FIELD_METADATA_KEY`, a `FieldMetadata` marker for a `StringType` field whose value is a nested JSON document, and `isRawJsonField(StructField)`, a single shared predicate. On the write path, `writeRow`/`writeStruct` splice a marked field back with `JsonGenerator.writeRawValue(...)` (unquoted object) instead of `writeString(...)` (escaped literal).
- **`DefaultJsonRow` (kernel-defaults)**: on the read path, a marked field is captured as its exact JSON text (instead of being type-decoded, which would throw on an object). `DefaultJsonRow` materializes eagerly, so the captured `String` holds no reference to the `ColumnarBatch`.
- **`CheckpointMetaData` (kernel-api)**: adds `Optional<String> checkpointSchema` and declares the `checkpointSchema` field in `READ_SCHEMA` as a `StringType` carrying the marker. A new constructor overload is added; existing constructors delegate with `Optional.empty()`, so no existing caller breaks.

The single shared `isRawJsonField` predicate keeps the read and write paths from disagreeing, and it names no specific field. The marker check is cheap and safe for every existing string field (`FieldMetadata.getBoolean` returns `null` on an absent key).

### Why
This completes single-read `_last_checkpoint` capture (follow-up to #7123): `readLastCheckpointFile(...).toJson()` now round-trips `checkpointSchema` as a JSON object, in the same read that captures every other field, with no torn-read window.

Note: like the other captured fields, re-serialization is faithful but compact (semantically identical, key order preserved, not byte-identical to on-disk whitespace).

## How was this patch tested?
- **`LastCheckpointHintSuite` (kernel-defaults)**: the golden fixtures `v2-checkpoint-parquet` and `spark-variant-checkpoint` already carry a top-level `checkpointSchema`; the two tests that previously asserted it was dropped now assert it round-trips in full, that `DataTypeJsonSerDe.deserializeStructType` parses the captured text into a non-empty `StructType`, and that `toJson` emits it as an object (`"checkpointSchema":{`) not an escaped string. The `v2-checkpoint-json` fixture (no `checkpointSchema`) asserts the optional field stays empty and is omitted.
- **`DefaultJsonRowSuite` (kernel-defaults)**: new unit tests exercising the raw-JSON marker directly (nested object/array captured verbatim, absent nullable field omitted).

## Does this PR introduce _any_ user-facing changes?

No. All changes are in `internal` packages. The new `checkpointSchema` field, the marker helpers, and the constructor overload are additive and internal; no behavior change for existing callers.
