### PR TITLE
Refactor CheckpointProvider to be layout-agnostic

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/CheckpointProvider.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/CheckpointProvider.scala
@@ -20,10 +20,14 @@ import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.duration.Duration
 import scala.util.control.NonFatal
 
+import org.apache.spark.sql.delta.ClassicColumnConversions._
 import org.apache.spark.sql.delta.DataFrameUtils
+import org.apache.spark.sql.delta.DeltaLogFileIndex.COMMIT_VERSION_COLUMN
 import org.apache.spark.sql.delta.SnapshotManagement.checkpointV2ThreadPool
 import org.apache.spark.sql.delta.actions._
+import org.apache.spark.sql.delta.expressions.EncodeNestedVariantAsZ85String
 import org.apache.spark.sql.delta.metering.DeltaLogging
+import org.apache.spark.sql.delta.schema.SchemaUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.storage.LogStore
 import org.apache.spark.sql.delta.util.FileNames._
@@ -31,9 +35,10 @@ import org.apache.spark.sql.delta.util.threads.NonFateSharingFuture
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, Path}
 
-import org.apache.spark.sql.Dataset
+import org.apache.spark.sql.{Column, DataFrame, Dataset}
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.functions.{col, lit, to_json}
+import org.apache.spark.sql.types.{StructField, StructType}
 
 /**
  * Represents basic information about a checkpoint.
@@ -54,12 +59,13 @@ trait UninitializedCheckpointProvider {
   def topLevelFiles: Seq[FileStatus]
 
   /**
-   * File index which could help derive actions stored in top level files
-   * for the checkpoint.
-   * This could be used to get [[Protocol]], [[Metadata]] etc from a checkpoint.
-   * This could also be used if we want to shallow copy a checkpoint.
+   * The checkpoint's contribution to the protocol/metadata/in-commit-timestamp fast path, as a
+   * DataFrame over [[Snapshot.pAndMQuerySchema]] tagged with [[COMMIT_VERSION_COLUMN]] (None when
+   * the checkpoint is empty). Callers read their delta side with the same schema so the two
+   * DataFrames can be unioned.
    */
-  def topLevelFileIndex: Option[DeltaLogFileIndex]
+  def loadProtocolMetadataActions(
+      spark: SparkSession, deltaLog: DeltaLog): Option[DataFrame]
 }
 
 /**
@@ -71,16 +77,58 @@ trait CheckpointProvider extends UninitializedCheckpointProvider {
   def effectiveCheckpointSizeInBytes(): Long
 
   /**
-   * List of different file indexes which could help derive full state-reconstruction
-   * for the checkpoint.
-   */
-  def allActionsFileIndexes(): Seq[DeltaLogFileIndex]
-
-  /**
    * The type of checkpoint (V2 vs Classic). This will be None when no checkpoint is available.
    * This is only intended to be used for logging and metrics.
    */
-  def checkpointPolicy: Option[CheckpointPolicy.Policy]
+  def checkpointPolicyForLogging: Option[CheckpointPolicy.Policy]
+
+  /**
+   * Writes a compatibility classic single-file checkpoint for this checkpoint at `logPath`, so a
+   * legacy reader that does not understand newer kind of checkpoints can read it and fail
+   * gracefully with a Protocol requirement failure. Only checkpoint kinds that need a compat
+   * checkpoint (i.e. V2 checkpoints) implement this; the default throws.
+   */
+  def createCompatibilityCheckpoint(
+      spark: SparkSession, deltaLog: DeltaLog, logPath: Path, hadoopConf: Configuration): Unit =
+    throw new IllegalStateException(
+      s"createCompatibilityCheckpoint is not supported for ${this.getClass.getName}.")
+
+  /**
+   * The checkpoint's full action set for state reconstruction as a single DataFrame (None when the
+   * checkpoint is empty), already carrying [[COMMIT_VERSION_COLUMN]] and
+   * [[Snapshot.ADD_STATS_TO_USE_COL_NAME]] and unioned across all underlying files. Consumers just
+   * union this with the delta DataFrames; the physical layout stays behind this method.
+   */
+  def loadActionsForStateReconstruction(
+      spark: SparkSession, deltaLog: DeltaLog): Option[DataFrame]
+}
+
+/**
+ * A trait representing [[UninitializedCheckpointProvider]] corresponding to checkpoints whose file
+ * actions are stored as flat set of parquet files.
+ */
+trait FileBasedUninitializedCheckpointProvider extends UninitializedCheckpointProvider {
+
+  /**
+   * File index which could help derive non-fileactions of a checkpoint. Note that the underlying
+   * files may contain fileactions which needs to be filtered out by the caller.
+   */
+  def topLevelFileIndex: Option[DeltaLogFileIndex]
+
+  override def loadProtocolMetadataActions(
+      spark: SparkSession, deltaLog: DeltaLog): Option[DataFrame] = {
+    topLevelFileIndex.map { index =>
+      deltaLog.loadIndex(index, Snapshot.pAndMQuerySchema)
+        .withColumn(COMMIT_VERSION_COLUMN, lit(version))
+    }
+  }
+}
+
+/**
+ * A [[CheckpointProvider]] whose file actions are stored as flat set of parquet files.
+ */
+trait FileBasedCheckpointProvider
+  extends CheckpointProvider with FileBasedUninitializedCheckpointProvider {
 
   /**
    * List of different file indexes and corresponding schemas which could help derive full
@@ -90,6 +138,44 @@ trait CheckpointProvider extends UninitializedCheckpointProvider {
    */
   def allActionsFileIndexesAndSchemas(
     spark: SparkSession, deltaLog: DeltaLog): Seq[(DeltaLogFileIndex, StructType)]
+
+  override def loadActionsForStateReconstruction(
+      spark: SparkSession, deltaLog: DeltaLog): Option[DataFrame] = {
+    val jsonStatsCol = col("add.stats")
+    val checkpointDataframes = allActionsFileIndexesAndSchemas(spark, deltaLog)
+      .map { case (index, schema) =>
+        val addSchema = schema("add").dataType.asInstanceOf[StructType]
+        val (checkpointSchemaToUse, checkpointStatsColToUse) =
+          if (addSchema.exists(_.name == "stats_parsed") && !addSchema.exists(_.name == "stats")) {
+            val statsParsedSchema = addSchema("stats_parsed").dataType.asInstanceOf[StructType]
+            val checkpointSchemaToUse =
+              Action.logSchemaWithAddStatsParsed(addSchema("stats_parsed"))
+            val statsCol = col("add.stats_parsed")
+            // Only use EncodeNestedVariantAsZ85String if the schema contains VariantType.
+            // This avoids performance overhead for tables without variant columns.
+            val encodedStatsCol =
+              if (SchemaUtils.checkForVariantTypeColumnsRecursively(statsParsedSchema)) {
+                Column(EncodeNestedVariantAsZ85String(statsCol.expr))
+              } else {
+                statsCol
+              }
+            (
+              checkpointSchemaToUse,
+              to_json(encodedStatsCol)
+            )
+          } else {
+            // Normal (JSON-like) schema suffices
+            (Action.logSchema, jsonStatsCol)
+          }
+
+        // For schema compat, make sure to discard add.stats_parsed (if present)
+        deltaLog.loadIndex(index, checkpointSchemaToUse)
+          .withColumn(COMMIT_VERSION_COLUMN, lit(version))
+          .withColumn(Snapshot.ADD_STATS_TO_USE_COL_NAME, checkpointStatsColToUse)
+          .withColumn("add", col("add").dropFields("stats_parsed"))
+      }
+    checkpointDataframes.reduceOption(_.union(_))
+  }
 }
 
 object CheckpointProvider extends DeltaLogging {
@@ -111,7 +197,7 @@ object CheckpointProvider extends DeltaLogging {
     // as it might need I/O.
     case uninitializedV2CheckpointProvider: UninitializedV2CheckpointProvider =>
       new LazyCompleteCheckpointProvider(uninitializedV2CheckpointProvider) {
-        override def createCheckpointProvider(): CheckpointProvider = {
+        override def createCheckpointProvider(): FileBasedCheckpointProvider = {
           val (checkpointMetadataOpt, sidecarFiles) =
             uninitializedV2CheckpointProvider.nonFateSharingCheckpointReadFuture.get(Duration.Inf)
           // This must be a v2 checkpoint, so checkpointMetadataOpt must be non empty.
@@ -144,7 +230,7 @@ object CheckpointProvider extends DeltaLogging {
           spark, provider.logPath, provider.fileStatus, snapshotDescriptor.deltaLog.options)
       }
       new LazyCompleteCheckpointProvider(provider) {
-        override def createCheckpointProvider(): CheckpointProvider = {
+        override def createCheckpointProvider(): FileBasedCheckpointProvider = {
           val (checkpointMetadataOpt, sidecarFiles) = future.get(Duration.Inf)
           checkpointMetadataOpt match {
             case Some(cm) =>
@@ -310,7 +396,7 @@ object CheckpointProvider extends DeltaLogging {
 case class PreloadedCheckpointProvider(
     override val topLevelFiles: Seq[FileStatus],
     lastCheckpointInfoOpt: Option[LastCheckpointInfo])
-  extends CheckpointProvider
+  extends FileBasedCheckpointProvider
   with DeltaLogging {
 
   require(topLevelFiles.nonEmpty, "There should be atleast 1 checkpoint file")
@@ -320,11 +406,10 @@ case class PreloadedCheckpointProvider(
 
   override def effectiveCheckpointSizeInBytes(): Long = fileIndex.sizeInBytes
 
-  override def allActionsFileIndexes(): Seq[DeltaLogFileIndex] = Seq(fileIndex)
-
   override lazy val topLevelFileIndex: Option[DeltaLogFileIndex] = Some(fileIndex)
 
-  override def checkpointPolicy: Option[CheckpointPolicy.Policy] = Some(CheckpointPolicy.Classic)
+  override def checkpointPolicyForLogging: Option[CheckpointPolicy.Policy] =
+    Some(CheckpointPolicy.Classic)
 
   override def allActionsFileIndexesAndSchemas(
       spark: SparkSession, deltaLog: DeltaLog): Seq[(DeltaLogFileIndex, StructType)] = {
@@ -354,15 +439,15 @@ object EmptyCheckpointProvider extends CheckpointProvider {
   override def version: Long = -1
   override def topLevelFiles: Seq[FileStatus] = Nil
   override def effectiveCheckpointSizeInBytes(): Long = 0L
-  override def allActionsFileIndexes(): Seq[DeltaLogFileIndex] = Nil
-  override def topLevelFileIndex: Option[DeltaLogFileIndex] = None
-  override def checkpointPolicy: Option[CheckpointPolicy.Policy] = None
-  override def allActionsFileIndexesAndSchemas(
-    spark: SparkSession, deltaLog: DeltaLog): Seq[(DeltaLogFileIndex, StructType)] = Nil
+  override def checkpointPolicyForLogging: Option[CheckpointPolicy.Policy] = None
+  override def loadProtocolMetadataActions(
+    spark: SparkSession, deltaLog: DeltaLog): Option[DataFrame] = None
+  override def loadActionsForStateReconstruction(
+    spark: SparkSession, deltaLog: DeltaLog): Option[DataFrame] = None
 }
 
 /** A trait representing a v2 [[UninitializedCheckpointProvider]] */
-trait UninitializedV2LikeCheckpointProvider extends UninitializedCheckpointProvider {
+trait UninitializedV2LikeCheckpointProvider extends FileBasedUninitializedCheckpointProvider {
   def fileStatus: FileStatus
   def logPath: Path
   def lastCheckpointInfoOpt: Option[LastCheckpointInfo]
@@ -453,26 +538,27 @@ case class UninitializedV2CheckpointProvider(
  * @param uninitializedCheckpointProvider the underlying [[UninitializedCheckpointProvider]]
  */
 abstract class LazyCompleteCheckpointProvider(
-    uninitializedCheckpointProvider: UninitializedCheckpointProvider)
-  extends CheckpointProvider {
+    uninitializedCheckpointProvider: FileBasedUninitializedCheckpointProvider)
+  extends FileBasedCheckpointProvider {
 
   override def version: Long = uninitializedCheckpointProvider.version
   override def topLevelFiles: Seq[FileStatus] = uninitializedCheckpointProvider.topLevelFiles
   override def topLevelFileIndex: Option[DeltaLogFileIndex] =
     uninitializedCheckpointProvider.topLevelFileIndex
 
-  protected def createCheckpointProvider(): CheckpointProvider
+  protected def createCheckpointProvider(): FileBasedCheckpointProvider
 
-  lazy val underlyingCheckpointProvider: CheckpointProvider = createCheckpointProvider()
+  lazy val underlyingCheckpointProvider: FileBasedCheckpointProvider = createCheckpointProvider()
 
   override def effectiveCheckpointSizeInBytes(): Long =
     underlyingCheckpointProvider.effectiveCheckpointSizeInBytes()
 
-  override def allActionsFileIndexes(): Seq[DeltaLogFileIndex] =
-    underlyingCheckpointProvider.allActionsFileIndexes()
+  override def checkpointPolicyForLogging: Option[CheckpointPolicy.Policy] =
+    underlyingCheckpointProvider.checkpointPolicyForLogging
 
-  override def checkpointPolicy: Option[CheckpointPolicy.Policy] =
-    underlyingCheckpointProvider.checkpointPolicy
+  override def createCompatibilityCheckpoint(
+      spark: SparkSession, deltaLog: DeltaLog, logPath: Path, hadoopConf: Configuration): Unit =
+    underlyingCheckpointProvider.createCompatibilityCheckpoint(spark, deltaLog, logPath, hadoopConf)
 
   override def allActionsFileIndexesAndSchemas(
       spark: SparkSession, deltaLog: DeltaLog): Seq[(DeltaLogFileIndex, StructType)] = {
@@ -502,7 +588,7 @@ case class V2CheckpointProvider(
     lastCheckpointInfoOpt: Option[LastCheckpointInfo],
     logPath: Path,
     sidecarSchemaFetcher: () => Option[StructType]
-  ) extends CheckpointProvider with DeltaLogging {
+  ) extends FileBasedCheckpointProvider with DeltaLogging {
 
   private[delta] def sidecarFileStatuses: Seq[FileStatus] =
     sidecarFiles.map(_.toFileStatus(logPath))
@@ -523,10 +609,23 @@ case class V2CheckpointProvider(
   override lazy val topLevelFileIndex: Option[DeltaLogFileIndex] = Some(fileIndexForV2Checkpoint)
   override def effectiveCheckpointSizeInBytes(): Long =
     sidecarFiles.map(_.sizeInBytes).sum + v2CheckpointFile.getLen
-  override def allActionsFileIndexes(): Seq[DeltaLogFileIndex] =
-    topLevelFileIndex ++: fileIndexesForSidecarFiles
 
-  override def checkpointPolicy: Option[CheckpointPolicy.Policy] = Some(CheckpointPolicy.V2)
+  override def checkpointPolicyForLogging: Option[CheckpointPolicy.Policy] =
+    Some(CheckpointPolicy.V2)
+
+  override def createCompatibilityCheckpoint(
+      spark: SparkSession, deltaLog: DeltaLog, logPath: Path, hadoopConf: Configuration): Unit = {
+    // topLevelFileIndex is non-empty for V2CheckpointProvider and
+    // represents the v2 manifest file
+    val shallowCopyDf = deltaLog.loadIndex(topLevelFileIndex.get, Action.logSchema)
+    val finalPath = checkpointFileSingular(logPath, version)
+    Checkpoints.createCheckpointV2ParquetFile(
+      spark,
+      shallowCopyDf,
+      finalPath,
+      hadoopConf,
+      useRename = false)
+  }
 
   private val v2SchemaWithCaching = new LazyCheckpointSchemaGetter {
     override def fileStatus: FileStatus = v2CheckpointFile

--- a/spark/src/main/scala/org/apache/spark/sql/delta/Checksum.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Checksum.scala
@@ -830,7 +830,7 @@ trait ValidateChecksum extends DeltaLogging { self: Snapshot =>
         "v2CheckpointEnabled" ->
           CheckpointProvider.isV2CheckpointEnabled(this),
         "checkpointProviderCheckpointPolicy" ->
-          checkpointProvider.checkpointPolicy.map(_.name).getOrElse("")
+          checkpointProvider.checkpointPolicyForLogging.map(_.name).getOrElse("")
       ) ++ contextInfo)
 
     val spark = sparkOpt.getOrElse {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/MetadataCleanup.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/MetadataCleanup.scala
@@ -333,18 +333,18 @@ trait MetadataCleanup extends DeltaLogging {
       metrics: V2CompatCheckpointMetrics): Unit = {
     // Do nothing if this table does not use V2 Checkpoints, or has no checkpoints at all.
     if (!CheckpointProvider.isV2CheckpointEnabled(snapshotToCleanup)) return
-    if (snapshotToCleanup.checkpointProvider.isEmpty) return
+    val checkpointProvider = snapshotToCleanup.checkpointProvider
+    if (checkpointProvider.isEmpty) return
 
     val startTimeMs = System.currentTimeMillis()
     val hadoopConf = newDeltaHadoopConf()
-    val checkpointInstance =
-      CheckpointInstance(snapshotToCleanup.checkpointProvider.topLevelFiles.head.getPath)
+    val checkpointInstance = CheckpointInstance(checkpointProvider.topLevelFiles.head.getPath)
     // The current checkpoint provider is already using a checkpoint with the naming
     // scheme of classic checkpoints. There is no need to create a compatibility checkpoint
     // in this case.
     if (checkpointInstance.format != CheckpointInstance.Format.V2) return
 
-    val checkpointVersion = snapshotToCleanup.checkpointProvider.version
+    val checkpointVersion = checkpointProvider.version
     val checkpoints = listFrom(checkpointVersion)
       .takeWhile(file => FileNames.getFileVersionOpt(file.getPath).exists(_ <= checkpointVersion))
       .collect {
@@ -359,17 +359,8 @@ trait MetadataCleanup extends DeltaLogging {
       return
     }
 
-    // topLevelFileIndex must be non-empty when topLevelFiles are present
-    val shallowCopyDf =
-      loadIndex(snapshotToCleanup.checkpointProvider.topLevelFileIndex.get, Action.logSchema)
-    val finalPath =
-      FileNames.checkpointFileSingular(snapshotToCleanup.logPath, checkpointVersion)
-    Checkpoints.createCheckpointV2ParquetFile(
-      spark,
-      shallowCopyDf,
-      finalPath,
-      hadoopConf,
-      useRename = false)
+    checkpointProvider.createCompatibilityCheckpoint(
+      spark, self, snapshotToCleanup.logPath, hadoopConf)
     metrics.v2CheckpointCompatLogicTimeTakenMs = System.currentTimeMillis() - startTimeMs
     metrics.checkpointVersion = checkpointVersion
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
@@ -295,11 +295,6 @@ class Snapshot(
     DeltaLogFileIndex(DeltaLogFileIndex.COMMIT_FILE_FORMAT, logSegment.deltas)
   }
 
-  protected lazy val fileIndices: Seq[DeltaLogFileIndex] = {
-    val checkpointFileIndexes = checkpointProvider.allActionsFileIndexes()
-    checkpointFileIndexes ++ deltaFileIndexOpt.toSeq
-  }
-
   /**
    * Protocol, Metadata, and In-Commit Timestamp retrieved through
    * `protocolMetadataAndICTReconstruction` which skips a full state reconstruction.
@@ -501,11 +496,9 @@ class Snapshot(
       return protocolMetadataAndIctFromCrc
     }
 
-    val schemaToUse = Action.logSchema(Set("protocol", "metaData", "commitInfo"))
-    val checkpointOpt = checkpointProvider.topLevelFileIndex.map { index =>
-      deltaLog.loadIndex(index, schemaToUse)
-        .withColumn(COMMIT_VERSION_COLUMN, lit(checkpointProvider.version))
-    }
+    val schemaToUse = Snapshot.pAndMQuerySchema
+    val checkpointOpt =
+      checkpointProvider.loadProtocolMetadataActions(spark, deltaLog)
     (checkpointOpt ++ deltaFileIndexOpt.map(deltaLog.loadIndex(_, schemaToUse)).toSeq)
       .reduceOption(_.union(_)).getOrElse(emptyDF)
       .select("protocol", "metaData", "commitInfo.inCommitTimestamp", COMMIT_VERSION_COLUMN)
@@ -591,54 +584,18 @@ class Snapshot(
    * hack.
    */
   protected def loadActions: DataFrame = {
-    if (fileIndices.isEmpty) return emptyDF
-
-    // Augment the schema with a NullType add.stats_parsed column, as a place-holder for
-    // compatibility with the checkpoint parquet. Both deltas and checkpoints generally use this
-    // schema. HOWEVER, IF (and only if) a checkpoint actually exists, AND it provides an
-    // add.stats_parsed column AND it lacks an add.stats column, THEN (and only then) the checkpoint
-    // DF includes the actual add.stats_parsed column -- not a NullType placeholder -- from which we
-    // generate the add_stats_to_use column (add.stats is unused in that case). Meanwhile, JSON
-    // deltas always map add.stats to add_stats_to_use, and always use the placeholder.
+    // The checkpoint contributes its actions as a single DataFrame, already carrying
+    // COMMIT_VERSION_COLUMN and ADD_STATS_TO_USE_COL_NAME and internally normalizing add.stats /
+    // add.stats_parsed. The physical checkpoint layout stays behind
+    // `loadActionsForStateReconstruction`. Meanwhile, JSON deltas always map add.stats to
+    // add_stats_to_use.
     val logSchemaToUse = Action.logSchema
     val jsonStatsCol = col("add.stats")
     val deltas = deltaFileIndexOpt.map(deltaLog.loadIndex(_, logSchemaToUse))
       .map(_.withColumn(ADD_STATS_TO_USE_COL_NAME, jsonStatsCol))
 
-    val checkpointDataframes = checkpointProvider
-      .allActionsFileIndexesAndSchemas(spark, deltaLog)
-      .map { case (index, schema) =>
-        val addSchema = schema("add").dataType.asInstanceOf[StructType]
-        val (checkpointSchemaToUse, checkpointStatsColToUse) =
-          if (addSchema.exists(_.name == "stats_parsed") && !addSchema.exists(_.name == "stats")) {
-            val statsParsedSchema = addSchema("stats_parsed").dataType.asInstanceOf[StructType]
-            val checkpointSchemaToUse =
-              Action.logSchemaWithAddStatsParsed(addSchema("stats_parsed"))
-            val statsCol = col("add.stats_parsed")
-            // Only use EncodeNestedVariantAsZ85String if the schema contains VariantType.
-            // This avoids performance overhead for tables without variant columns.
-            val encodedStatsCol =
-              if (SchemaUtils.checkForVariantTypeColumnsRecursively(statsParsedSchema)) {
-                Column(EncodeNestedVariantAsZ85String(statsCol.expr))
-              } else {
-                statsCol
-              }
-            (
-              checkpointSchemaToUse,
-              to_json(encodedStatsCol)
-            )
-          } else {
-            // Normal (JSON-like) schema suffices
-            (logSchemaToUse, jsonStatsCol)
-          }
-
-        // For schema compat, make sure to discard add.stats_parsed (if present)
-        deltaLog.loadIndex(index, checkpointSchemaToUse)
-          .withColumn(COMMIT_VERSION_COLUMN, lit(checkpointProvider.version))
-          .withColumn(ADD_STATS_TO_USE_COL_NAME, checkpointStatsColToUse)
-          .withColumn("add", col("add").dropFields("stats_parsed"))
-      }
-      (checkpointDataframes ++ deltas).reduce(_.union(_))
+    val checkpointDataframe = checkpointProvider.loadActionsForStateReconstruction(spark, deltaLog)
+    (checkpointDataframe.toSeq ++ deltas).reduceOption(_.union(_)).getOrElse(emptyDF)
   }
 
   /**
@@ -813,6 +770,13 @@ object Snapshot extends DeltaLogging {
 
   // Used by [[loadActions]] and [[stateReconstruction]]
   val ADD_STATS_TO_USE_COL_NAME = "add_stats_to_use"
+
+  /**
+   * Schema for the protocol/metadata/in-commit-timestamp query fast path. Shared between
+   * [[CheckpointProvider.loadProtocolMetadataActions]] (checkpoint side) and its callers'
+   * delta-side reads so the two DataFrames can be unioned.
+   */
+  val pAndMQuerySchema: StructType = Action.logSchema(Set("protocol", "metaData", "commitInfo"))
 
   private val defaultNumSnapshotPartitions: Int = 50
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuite.scala
@@ -182,8 +182,9 @@ class DeltaRetentionSuite extends QueryTest
 
   def removeFileCountFromUnderlyingCheckpoint(snapshot: Snapshot): Long = {
     val df = snapshot.checkpointProvider
-      .allActionsFileIndexes()
-      .map(snapshot.deltaLog.loadIndex(_))
+      .asInstanceOf[FileBasedCheckpointProvider]
+      .allActionsFileIndexesAndSchemas(spark, snapshot.deltaLog)
+      .map { case (index, _) => snapshot.deltaLog.loadIndex(index) }
       .reduce(_.union(_))
     df.where("remove is not null").count()
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTestUtils.scala
@@ -390,6 +390,7 @@ trait DeltaCheckpointTestUtils
     val fileActionsFileIndex = ci.format match {
       case CheckpointInstance.Format.V2 =>
         val incompleteCheckpointProvider = ci.getCheckpointProvider(log, allCheckpointFiles)
+          .asInstanceOf[FileBasedUninitializedCheckpointProvider]
         val df = log.loadIndex(incompleteCheckpointProvider.topLevelFileIndex.get, Action.logSchema)
         val sidecarFileStatuses = df.as[SingleAction].collect().map(_.unwrap).collect {
           case sf: SidecarFile => sf


### PR DESCRIPTION
## Description

Restructures `CheckpointProvider` so the base trait describes *what a reader needs* for state reconstruction (returned as DataFrames) rather than *how the checkpoint bytes are physically laid out*.

- The file-index / file-list oriented members move onto new `FileBasedCheckpointProvider` and `FileBasedUninitializedCheckpointProvider` sub-traits, which the classic (`PreloadedCheckpointProvider`) and V2 (`V2CheckpointProvider`) providers extend.
- `Snapshot` now consumes the DataFrame-returning reconstruction APIs (`loadActionsForStateReconstruction`, protocol/metadata fast path) instead of reaching for checkpoint file indexes directly.
- Compatibility single-file checkpoint creation (`createCompatCheckpoint`) moves onto `V2CheckpointProvider` (the only checkpoint kind that needs it); the base trait's default throws. `LazyCompleteCheckpointProvider` delegates to its underlying provider.
- `topLevelFiles` remains on the base trait; `EmptyCheckpointProvider` implements the base trait directly.

This is a behavior-preserving refactor for classic and V2 checkpoints, and makes the trait extensible to checkpoint layouts that are not a flat set of parquet files.

## How was this patch tested?

Existing checkpoint and snapshot suites: `CheckpointProviderSuite`, `CheckpointsSuite`, `SnapshotManagementSuite`, `DeltaRetentionSuite`, and the data-skipping suites.

## Does this PR introduce _any_ user-facing changes?

No.
