### PR TITLE
[Spark] Enabling unpartitioned column mapping on batch write path in DSv2

### DIFF
--- a/spark-shared-tests/src/test/scala-shared/io/delta/tables/shared/DeltaJoinRefreshTests.scala
+++ b/spark-shared-tests/src/test/scala-shared/io/delta/tables/shared/DeltaJoinRefreshTests.scala
@@ -170,14 +170,18 @@ trait DeltaJoinRefreshTests
               condition = "AMBIGUOUS_COLUMN_OR_FIELD")
         }
       } else {
-        v2EnableMode match {
-          case "STRICT" =>
-            // Column mapping is not fully supported in V2 STRICT yet, and df1 is pinned, so the
-            // join returns no rows. TODO: once [[DeltaV2Table]] implements [[Table.version]],
-            // Spark refreshes and raises an analysis exception on the incompatible column drop
-            // (like AUTO).
-            checkAnswer(selfJoinDF, Seq.empty)
-          case "AUTO" =>
+        (v2EnableMode, sparkVersionBucket) match {
+          case ("STRICT", "4.0") =>
+            // Today 4.0 STRICT pins df1 to its analysis snapshot, so the external column drop is
+            // invisible to df1 and the join executes against the pinned rows.
+            checkAnswer(selfJoinDF, Seq(Row(1, 100, 1)))
+          case ("STRICT", _) =>
+            // 4.1+ STRICT reads unpartitioned column mapping tables, so df1 refreshes and detects
+            // the incompatible column drop, raising an analysis exception.
+            checkError(
+              exception = intercept[SparkThrowable] { selfJoinDF.collect() },
+              condition = "INCOMPATIBLE_TABLE_CHANGE_AFTER_ANALYSIS.COLUMNS_MISMATCH")
+          case ("AUTO", _) =>
             checkError(
               exception = intercept[SparkThrowable] { selfJoinDF.collect() },
               condition = "DELTA_SCHEMA_CHANGE_SINCE_ANALYSIS")
@@ -246,16 +250,21 @@ trait DeltaJoinRefreshTests
                 condition = "AMBIGUOUS_COLUMN_OR_FIELD")
           }
         } else {
-          v2EnableMode match {
-            case "STRICT" =>
-              // Column mapping is not fully supported in V2 STRICT yet, and df1 is pinned, so the
-              // join returns no rows. TODO: once [[DeltaV2Table]] implements [[Table.version]] and
-              // exposes column ids, Spark 4.1 refreshes and picks up the new schema for the
-              // same-type re-add (scenario 5, one joined row), while the different-type re-add
-              // (scenario 6) raises an analysis exception; Spark 4.2+ raises an analysis exception
-              // for both, since the re-added column gets a fresh column id.
-              checkAnswer(selfJoinDF, Seq.empty)
-            case "AUTO" =>
+          (v2EnableMode, scenario, sparkVersionBucket) match {
+            case ("STRICT", _, "4.0") =>
+              // Today 4.0 STRICT pins df1 to its analysis snapshot, so the external drop and re-add
+              // is invisible to df1. df2 reads the re-added column and the pinned rows join.
+              checkAnswer(selfJoinDF, Seq(Row(1, 100, 1, null)))
+            case ("STRICT", 5, _) =>
+              // 4.1+ STRICT refreshes and picks up the new schema for the same-type column re-add.
+              checkAnswer(selfJoinDF, Seq(Row(1, null, 1, null)))
+            case ("STRICT", _, _) =>
+              // 4.1+ STRICT: re-adding the column with a different type is an incompatible change,
+              // so df1 detects it after analysis and raises.
+              checkError(
+                exception = intercept[SparkThrowable] { selfJoinDF.collect() },
+                condition = "INCOMPATIBLE_TABLE_CHANGE_AFTER_ANALYSIS.COLUMNS_MISMATCH")
+            case ("AUTO", _, _) =>
               checkError(
                 exception = intercept[SparkThrowable] { selfJoinDF.collect() },
                 condition = "DELTA_SCHEMA_CHANGE_SINCE_ANALYSIS")

--- a/spark-shared-tests/src/test/scala-shared/io/delta/tables/shared/DeltaTableRefreshSharedBase.scala
+++ b/spark-shared-tests/src/test/scala-shared/io/delta/tables/shared/DeltaTableRefreshSharedBase.scala
@@ -125,36 +125,18 @@ trait DeltaTableRefreshSharedBase { self: AnyFunSuite =>
   }
 
   /**
-   * Seeds the initial `(1, 100)` row, returning true when the table was seeded. Under STRICT the
-   * DSv2 write path rejects writes to column-mapped tables (master's DeltaV2WriteBuilder guard), so
-   * such a table can never be seeded; in that case assert the rejection (an
-   * UnsupportedOperationException, or its SparkUnsupportedOperationException subclass over Connect)
-   * and return false so the caller skips the scenario body.
+   * Seeds the initial `(1, 100)` row and returns true. The boolean return is retained only so
+   * callers keep their `if (seedInitialRow(...))` shape. The `columnMapping` parameter is likewise
+   * retained for call-site compatibility.
    */
   private def seedInitialRow(columnMapping: Boolean): Boolean = {
-    if (columnMapping && v2EnableMode == "STRICT") {
-      val expectedError = "DSv2 writes are not supported on column-mapped Delta tables"
-      val seedError =
-        try {
-          insertInitialData("t")
-          None
-        } catch {
-          case e: UnsupportedOperationException => Option(e.getMessage)
-        }
-      assert(
-        seedError.exists(_.contains(expectedError)),
-        s"expected '$expectedError', got: $seedError")
-      false
-    } else {
-      insertInitialData("t")
-      true
-    }
+    insertInitialData("t")
+    true
   }
 
   /**
    * Runs `body` against a fresh managed catalog table `t` already holding `(1, 100)`, optionally
-   * enabling column mapping or type widening. Returns without running `body` when STRICT rejects
-   * the seed write to a column-mapped table.
+   * enabling column mapping or type widening.
    */
   protected def withInitialTable(
       columnMapping: Boolean = false,
@@ -171,8 +153,7 @@ trait DeltaTableRefreshSharedBase { self: AnyFunSuite =>
   /**
    * Runs `body` against a fresh external catalog table `t` already holding `(1, 100)`, optionally
    * enabling column mapping or type widening, passing the table's storage path so the body can
-   * stage external commits there before re-reading. Returns without running `body` when STRICT
-   * rejects the seed write to a column-mapped table.
+   * stage external commits there before re-reading.
    */
   protected def withExternalTable(
       columnMapping: Boolean = false,

--- a/spark-shared-tests/src/test/scala-shared/io/delta/tables/shared/DeltaTempViewStoredPlanRefreshTests.scala
+++ b/spark-shared-tests/src/test/scala-shared/io/delta/tables/shared/DeltaTempViewStoredPlanRefreshTests.scala
@@ -139,11 +139,9 @@ trait DeltaTempViewStoredPlanRefreshTests
       withStoredPlanView(t) {
         (sparkVersionBucket, v2EnableMode) match {
           case ("4.2+", "STRICT") | ("4.1", "STRICT") | ("4.0", "STRICT") =>
-            // TODO: column mapping is not fully supported in V2 STRICT yet. A Kernel V2 scan of a
-            // column-mapping table with a pushed filter returns no rows, so the view is empty, and
-            // the V2 session catalog reads the table schema as empty, so the DROP COLUMN itself
-            // fails with FIELD_NOT_FOUND.
-            checkAnswer(spark.table("v"), Seq.empty)
+            // STRICT: the view reads the filtered [1, 100]. TODO: the V2 STRICT ALTER COLUMN path
+            // reports the column as missing rather than performing the DROP.
+            checkAnswer(spark.table("v"), Seq(Row(1, 100)))
             checkError(
               exception = intercept[SparkThrowable] {
                 writerSql(s"ALTER TABLE $t DROP COLUMN salary")
@@ -167,10 +165,9 @@ trait DeltaTempViewStoredPlanRefreshTests
       withStoredPlanView("t") {
         (sparkVersionBucket, v2EnableMode) match {
           case ("4.2+", "STRICT") | ("4.1", "STRICT") =>
-            // TODO: column mapping is not fully supported in V2 STRICT yet. The filter-pushdown gap
-            // makes the view empty, but the external column removal is still detected against the
-            // stored plan and rejected on read.
-            checkAnswer(spark.table("v"), Seq.empty)
+            // 4.2+/4.1 STRICT: the view starts as the filtered [1, 100] and the external
+            // column removal is detected against the stored plan and rejected on read.
+            checkAnswer(spark.table("v"), Seq(Row(1, 100)))
             externalDropColumn(path, "salary")
             checkError(
               exception = intercept[SparkThrowable] { spark.table("v").collect() },
@@ -184,12 +181,10 @@ trait DeltaTempViewStoredPlanRefreshTests
               exception = intercept[SparkThrowable] { spark.table("v").collect() },
               condition = "DELTA_SCHEMA_CHANGE_SINCE_ANALYSIS")
           case ("4.0", "STRICT") =>
-            // 4.0 STRICT pins the view's snapshot, so the external removal is invisible; the
-            // filter-pushdown gap keeps the view empty. TODO: column mapping is not fully supported
-            // in V2 STRICT yet.
-            checkAnswer(spark.table("v"), Seq.empty)
+            // 4.0 STRICT pins the view's snapshot, so the external removal is invisible.
+            checkAnswer(spark.table("v"), Seq(Row(1, 100)))
             externalDropColumn(path, "salary")
-            checkAnswer(spark.table("v"), Seq.empty)
+            checkAnswer(spark.table("v"), Seq(Row(1, 100)))
         }
       }
     }
@@ -250,9 +245,9 @@ trait DeltaTempViewStoredPlanRefreshTests
       withStoredPlanView(t) {
         (sparkVersionBucket, v2EnableMode) match {
           case ("4.2+", "STRICT") | ("4.1", "STRICT") =>
-            // TODO: column mapping is not fully supported in V2 STRICT yet (filter-pushdown gap),
-            // so the view is empty before and after the drop and recreate.
-            checkAnswer(spark.table("v"), Seq.empty)
+            // 4.2+/4.1 STRICT: the view starts as the filtered [1, 100] and after the drop and
+            // recreate it re-resolves to the new empty table.
+            checkAnswer(spark.table("v"), Seq(Row(1, 100)))
             writerSql(s"DROP TABLE $t")
             writerSql(
               s"CREATE TABLE $t (id INT, salary INT) USING delta " +
@@ -272,8 +267,8 @@ trait DeltaTempViewStoredPlanRefreshTests
           case ("4.0", "STRICT") =>
             // 4.0 STRICT pins the view to the dropped table's commit, whose files the session DROP
             // physically removed, so the read fails (raw Kernel exception whose message contains
-            // "does not exist"). TODO: column mapping is not fully supported in V2 STRICT yet.
-            checkAnswer(spark.table("v"), Seq.empty)
+            // "does not exist").
+            checkAnswer(spark.table("v"), Seq(Row(1, 100)))
             writerSql(s"DROP TABLE $t")
             writerSql(
               s"CREATE TABLE $t (id INT, salary INT) USING delta " +
@@ -296,10 +291,10 @@ trait DeltaTempViewStoredPlanRefreshTests
     withExternalTable(columnMapping = true) { path =>
       withStoredPlanView("t") {
         (sparkVersionBucket, v2EnableMode) match {
-          case ("4.2+", "STRICT") | ("4.1", "STRICT") | ("4.0", "STRICT") =>
-            // TODO: column mapping is not fully supported in V2 STRICT yet (filter-pushdown gap),
-            // so the view is empty before and after the external drop and recreate.
-            checkAnswer(spark.table("v"), Seq.empty)
+          case ("4.2+", "STRICT") | ("4.1", "STRICT") =>
+            // 4.2+/4.1 STRICT: the view starts as the filtered [1, 100] and re-resolves to the new
+            // empty table after the external drop and recreate.
+            checkAnswer(spark.table("v"), Seq(Row(1, 100)))
             externalDropAndRecreate(path)
             checkAnswer(spark.table("v"), Seq.empty)
           case ("4.2+", "AUTO") | ("4.1", "AUTO") | ("4.0", "AUTO") =>
@@ -307,6 +302,12 @@ trait DeltaTempViewStoredPlanRefreshTests
             checkAnswer(spark.table("v"), Seq(Row(1, 100)))
             externalDropAndRecreate(path)
             checkAnswer(spark.table("v"), Seq.empty)
+          case ("4.0", "STRICT") =>
+            // 4.0 STRICT pins the view's snapshot (the external recreate keeps the old files), so
+            // the view still returns its original rows.
+            checkAnswer(spark.table("v"), Seq(Row(1, 100)))
+            externalDropAndRecreate(path)
+            checkAnswer(spark.table("v"), Seq(Row(1, 100)))
         }
       }
     }
@@ -317,10 +318,9 @@ trait DeltaTempViewStoredPlanRefreshTests
       withStoredPlanView(t) {
         (sparkVersionBucket, v2EnableMode) match {
           case ("4.2+", "STRICT") | ("4.1", "STRICT") | ("4.0", "STRICT") =>
-            // TODO: column mapping is not fully supported in V2 STRICT yet. The view is empty (the
-            // filter-pushdown gap) and the V2 session catalog reads the table schema as empty, so
-            // the DROP COLUMN fails with FIELD_NOT_FOUND before the column can be re-added.
-            checkAnswer(spark.table("v"), Seq.empty)
+            // STRICT: the view reads the filtered [1, 100]. TODO: the V2 STRICT ALTER COLUMN path
+            // reports the column as missing rather than performing the DROP.
+            checkAnswer(spark.table("v"), Seq(Row(1, 100)))
             checkError(
               exception = intercept[SparkThrowable] {
                 writerSql(s"ALTER TABLE $t DROP COLUMN salary")
@@ -344,11 +344,11 @@ trait DeltaTempViewStoredPlanRefreshTests
     withExternalTable(columnMapping = true) { path =>
       withStoredPlanView("t") {
         (sparkVersionBucket, v2EnableMode) match {
-          case ("4.2+", "STRICT") | ("4.1", "STRICT") | ("4.0", "STRICT") =>
-            // TODO: column mapping is not fully supported in V2 STRICT yet. The filter-pushdown gap
-            // makes the view empty; re-adding the column with the same name and type is not an
-            // incompatible change, so the view stays empty.
-            checkAnswer(spark.table("v"), Seq.empty)
+          case ("4.2+", "STRICT") | ("4.1", "STRICT") =>
+            // 4.2+/4.1 STRICT: the view starts as the filtered [1, 100]; re-adding the column is
+            // allowed but the fresh column id no longer matches the stored plan's filter, so the
+            // view reads empty afterward.
+            checkAnswer(spark.table("v"), Seq(Row(1, 100)))
             externalDropAndReAddColumn(path, "salary", IntegerType)
             checkAnswer(spark.table("v"), Seq.empty)
           case ("4.2+", "AUTO") | ("4.1", "AUTO") | ("4.0", "AUTO") =>
@@ -359,6 +359,11 @@ trait DeltaTempViewStoredPlanRefreshTests
             checkError(
               exception = intercept[SparkThrowable] { spark.table("v").collect() },
               condition = "DELTA_SCHEMA_CHANGE_SINCE_ANALYSIS")
+          case ("4.0", "STRICT") =>
+            // 4.0 STRICT pins the view's snapshot, so the external drop and re-add is invisible.
+            checkAnswer(spark.table("v"), Seq(Row(1, 100)))
+            externalDropAndReAddColumn(path, "salary", IntegerType)
+            checkAnswer(spark.table("v"), Seq(Row(1, 100)))
         }
       }
     }
@@ -369,10 +374,9 @@ trait DeltaTempViewStoredPlanRefreshTests
       withStoredPlanView(t) {
         (sparkVersionBucket, v2EnableMode) match {
           case ("4.2+", "STRICT") | ("4.1", "STRICT") | ("4.0", "STRICT") =>
-            // TODO: column mapping is not fully supported in V2 STRICT yet. The view is empty (the
-            // filter-pushdown gap) and the V2 session catalog reads the table schema as empty, so
-            // the DROP COLUMN fails with FIELD_NOT_FOUND before the column can be re-added.
-            checkAnswer(spark.table("v"), Seq.empty)
+            // STRICT: the view reads the filtered [1, 100]. TODO: the V2 STRICT ALTER COLUMN path
+            // reports the column as missing rather than performing the DROP.
+            checkAnswer(spark.table("v"), Seq(Row(1, 100)))
             checkError(
               exception = intercept[SparkThrowable] {
                 writerSql(s"ALTER TABLE $t DROP COLUMN salary")
@@ -397,10 +401,9 @@ trait DeltaTempViewStoredPlanRefreshTests
       withStoredPlanView("t") {
         (sparkVersionBucket, v2EnableMode) match {
           case ("4.2+", "STRICT") | ("4.1", "STRICT") =>
-            // TODO: column mapping is not fully supported in V2 STRICT yet. The filter-pushdown gap
-            // makes the view empty, but the external type change is still detected against the
-            // stored plan and rejected on read.
-            checkAnswer(spark.table("v"), Seq.empty)
+            // 4.2+/4.1 STRICT: the view starts as the filtered [1, 100] and the external type
+            // change is detected against the stored plan and rejected on read.
+            checkAnswer(spark.table("v"), Seq(Row(1, 100)))
             externalDropAndReAddColumn(path, "salary", StringType)
             checkError(
               exception = intercept[SparkThrowable] { spark.table("v").collect() },
@@ -414,12 +417,10 @@ trait DeltaTempViewStoredPlanRefreshTests
               exception = intercept[SparkThrowable] { spark.table("v").collect() },
               condition = "DELTA_SCHEMA_CHANGE_SINCE_ANALYSIS")
           case ("4.0", "STRICT") =>
-            // 4.0 STRICT pins the view's snapshot, so the external type change is invisible; the
-            // filter-pushdown gap keeps the view empty. TODO: column mapping is not fully supported
-            // in V2 STRICT yet.
-            checkAnswer(spark.table("v"), Seq.empty)
+            // 4.0 STRICT pins the view's snapshot, so the external type change is invisible.
+            checkAnswer(spark.table("v"), Seq(Row(1, 100)))
             externalDropAndReAddColumn(path, "salary", StringType)
-            checkAnswer(spark.table("v"), Seq.empty)
+            checkAnswer(spark.table("v"), Seq(Row(1, 100)))
         }
       }
     }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaParquetFileFormat.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaParquetFileFormat.scala
@@ -124,6 +124,13 @@ abstract class DeltaParquetFileFormatBase(
   }
 
   /**
+   * prepareSchemaForWrite converts a logical schema to the physical column mapping layout used when
+   * writing parquet data files. This is an identity transform for non-column-mapped tables.
+   */
+  def prepareSchemaForWrite(inputSchema: StructType): StructType =
+    DeltaColumnMapping.createPhysicalSchema(inputSchema, referenceSchema, columnMappingMode)
+
+  /**
    * Prepares filters so that they can be pushed down into the Parquet reader.
    *
    * If column mapping is enabled, then logical column names in the filters will be replaced with

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2WriteBuilder.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2WriteBuilder.java
@@ -19,8 +19,6 @@ import static java.util.Objects.requireNonNull;
 
 import io.delta.kernel.Snapshot;
 import io.delta.kernel.engine.Engine;
-import io.delta.kernel.internal.util.ColumnMapping;
-import io.delta.kernel.internal.util.ColumnMapping.ColumnMappingMode;
 import io.delta.spark.internal.v2.snapshot.DeltaSnapshotManager;
 import io.delta.spark.internal.v2.utils.SchemaUtils;
 import org.apache.hadoop.conf.Configuration;
@@ -80,19 +78,6 @@ public class DeltaV2WriteBuilder implements WriteBuilder {
 
   @Override
   public Write build() {
-    // Reject writes to column-mapped tables: the V2 write path writes Parquet with logical
-    // column names, but column-mapped tables store data under physical UUID-based names.
-    // The mismatch causes reads to return null for every value.
-    ColumnMappingMode cmMode =
-        ColumnMapping.getColumnMappingMode(initialSnapshot.getTableProperties());
-    if (cmMode != ColumnMappingMode.NONE) {
-      throw new UnsupportedOperationException(
-          "DSv2 writes are not supported on column-mapped Delta tables "
-              + "(delta.columnMapping.mode = "
-              + cmMode.toString()
-              + "). Use the V1 write path (format(\"delta\").write()) instead.");
-    }
-
     validateDataSchema(initialSnapshot, writeInfo.schema());
 
     // Returns a mode-dispatching Write: toBatch() -> DeltaV2BatchWrite (batch commit off

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2WriteContext.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2WriteContext.java
@@ -131,9 +131,6 @@ class DeltaV2WriteContext {
       StructType dataSchema,
       LogicalWriteInfo writeInfo) {
     this.engine = engine;
-    // dataSchema is wired in from DeltaV2Table's SchemaProvider (which already split off the
-    // partition columns) rather than re-derived here, so the schema split lives in one place.
-    this.dataSchema = dataSchema;
 
     this.kernelTableSchema = initialSnapshot.getSchema();
     StructType tableSchema = SchemaUtils.convertKernelSchemaToSparkSchema(kernelTableSchema);
@@ -169,12 +166,14 @@ class DeltaV2WriteContext {
             /* optimizationsEnabled */ true,
             /* useMetadataRowIndex */ Option.empty(),
             /* isCDCRead */ false);
-    verifySchemaForWrite(format, dataSchema);
-    org.apache.spark.sql.execution.datasources.DataSourceUtils.checkFieldNames(format, dataSchema);
+    this.dataSchema = format.prepareSchemaForWrite(dataSchema);
+    verifySchemaForWrite(format, this.dataSchema);
+    org.apache.spark.sql.execution.datasources.DataSourceUtils.checkFieldNames(
+        format, this.dataSchema);
     Map<String, String> options = writeInfo.options().asCaseSensitiveMap();
     scala.collection.immutable.Map<String, String> scalaOpts =
         ScalaUtils.toScalaMap(options != null ? options : Collections.emptyMap());
-    this.outputWriterFactory = format.prepareWrite(session, job, scalaOpts, dataSchema);
+    this.outputWriterFactory = format.prepareWrite(session, job, scalaOpts, this.dataSchema);
     this.serializableHadoopConf = new SerializableConfiguration(job.getConfiguration());
   }
 

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/catalog/DeltaV2TableTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/catalog/DeltaV2TableTest.java
@@ -560,7 +560,7 @@ public class DeltaV2TableTest extends DeltaV2TestBase {
   }
 
   @Test
-  public void testWriteBuilderRejectsColumnMappedTable(@TempDir File tempDir) {
+  public void testWriteBuilderAcceptsColumnMappedTable(@TempDir File tempDir) {
     String path = tempDir.getAbsolutePath();
     spark.sql(
         String.format(
@@ -591,16 +591,11 @@ public class DeltaV2TableTest extends DeltaV2TestBase {
           }
         };
 
-    UnsupportedOperationException e =
-        assertThrows(
-            UnsupportedOperationException.class, () -> table.newWriteBuilder(writeInfo).build());
-    assertTrue(
-        e.getMessage().contains("not supported on column-mapped"),
-        "exception message should mention column-mapped; was: " + e.getMessage());
+    assertNotNull(table.newWriteBuilder(writeInfo).build());
   }
 
   @Test
-  public void testWriteBuilderRejectsIdMappedTable(@TempDir File tempDir) {
+  public void testWriteBuilderAcceptsIdMappedTable(@TempDir File tempDir) {
     String path = tempDir.getAbsolutePath();
     spark.sql(
         String.format(
@@ -631,12 +626,7 @@ public class DeltaV2TableTest extends DeltaV2TestBase {
           }
         };
 
-    UnsupportedOperationException e =
-        assertThrows(
-            UnsupportedOperationException.class, () -> table.newWriteBuilder(writeInfo).build());
-    assertTrue(
-        e.getMessage().contains("not supported on column-mapped"),
-        "exception message should mention column-mapped; was: " + e.getMessage());
+    assertNotNull(table.newWriteBuilder(writeInfo).build());
   }
 
   @Test

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/write/V2WriteTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/write/V2WriteTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.write;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.delta.spark.internal.v2.V2TestBase;
+import java.io.File;
+import java.util.List;
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.format.converter.ParquetMetadataConverter;
+import org.apache.parquet.hadoop.ParquetFileReader;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/** E2E DSv2 batch-write tests for column-mapped tables. */
+public class V2WriteTest extends V2TestBase {
+
+  @ParameterizedTest(name = "columnMappingMode={0}")
+  @ValueSource(strings = {"name", "id"})
+  public void writeToColumnMappingTable(String mappingMode, @TempDir File deltaTablePath)
+      throws Exception {
+    String tablePath = deltaTablePath.getAbsolutePath();
+    createColumnMappingTable(tablePath, mappingMode);
+
+    spark.sql(
+        str(
+            "INSERT INTO dsv2.delta.`%s` VALUES (1, 'Alice', 100.0), (2, 'Bob', 200.0)",
+            tablePath));
+
+    check(
+        str("SELECT * FROM dsv2.delta.`%s` ORDER BY id", tablePath),
+        List.of(row(1, "Alice", 100.0), row(2, "Bob", 200.0)));
+    check(
+        str("SELECT * FROM delta.`%s` ORDER BY id", tablePath),
+        List.of(row(1, "Alice", 100.0), row(2, "Bob", 200.0)));
+
+    // Both name and id mode store data under physical col-* names.
+    assertPhysicalParquetUsesMappedColumnNames(tablePath, "id", "user_name", "amount");
+  }
+
+  @Test
+  public void writeToColumnMappingTableWithRenamedColumn(@TempDir File deltaTablePath) {
+    String tablePath = deltaTablePath.getAbsolutePath();
+    createColumnMappingTable(tablePath, "name");
+
+    spark.sql(str("INSERT INTO dsv2.delta.`%s` VALUES (1, 'Alice', 100.0)", tablePath));
+    // The physical name is unchanged after a RENAME under column mapping, so the second append
+    // must still land in the same physical columns.
+    spark.sql(str("ALTER TABLE delta.`%s` RENAME COLUMN user_name TO customer_name", tablePath));
+    spark.sql(str("INSERT INTO dsv2.delta.`%s` VALUES (2, 'Bob', 200.0)", tablePath));
+
+    check(
+        str("SELECT * FROM dsv2.delta.`%s` ORDER BY id", tablePath),
+        List.of(row(1, "Alice", 100.0), row(2, "Bob", 200.0)));
+    check(
+        str("SELECT * FROM delta.`%s` ORDER BY id", tablePath),
+        List.of(row(1, "Alice", 100.0), row(2, "Bob", 200.0)));
+  }
+
+  @Test
+  public void multipleAppendsOnColumnMappingTable(@TempDir File deltaTablePath) {
+    String tablePath = deltaTablePath.getAbsolutePath();
+    createColumnMappingTable(tablePath, "name");
+
+    // Interleave V2 and V1 writes to confirm the physical layout produced by the V2 path is
+    // consistent.
+    spark.sql(str("INSERT INTO dsv2.delta.`%s` VALUES (1, 'Alice', 100.0)", tablePath));
+    spark.sql(str("INSERT INTO delta.`%s` VALUES (2, 'Bob', 200.0)", tablePath));
+    spark.sql(str("INSERT INTO dsv2.delta.`%s` VALUES (3, 'Carol', 300.0)", tablePath));
+
+    check(
+        str("SELECT * FROM dsv2.delta.`%s` ORDER BY id", tablePath),
+        List.of(row(1, "Alice", 100.0), row(2, "Bob", 200.0), row(3, "Carol", 300.0)));
+    check(
+        str("SELECT * FROM delta.`%s` ORDER BY id", tablePath),
+        List.of(row(1, "Alice", 100.0), row(2, "Bob", 200.0), row(3, "Carol", 300.0)));
+  }
+
+  private void createColumnMappingTable(String tablePath, String mappingMode) {
+    spark.sql(
+        str(
+            "CREATE TABLE delta.`%s` (id INT, user_name STRING, amount DOUBLE) "
+                + "USING delta TBLPROPERTIES ('delta.columnMapping.mode' = '%s')",
+            tablePath, mappingMode));
+  }
+
+  /**
+   * Verifies the on-disk Parquet schema uses physical column mapping names and that every field
+   * carries a Parquet field id.
+   */
+  private void assertPhysicalParquetUsesMappedColumnNames(
+      String tablePath, String... logicalColumnNames) throws Exception {
+    File[] parquetFiles = new File(tablePath).listFiles((dir, name) -> name.endsWith(".parquet"));
+    assertNotNull(parquetFiles, "Expected parquet data files under " + tablePath);
+    assertTrue(parquetFiles.length > 0, "Expected at least one parquet data file");
+    Path parquetPath = new Path(parquetFiles[0].getAbsolutePath());
+    List<org.apache.parquet.schema.Type> fields =
+        ParquetFileReader.readFooter(
+                spark.sessionState().newHadoopConf(),
+                parquetPath,
+                ParquetMetadataConverter.NO_FILTER)
+            .getFileMetaData()
+            .getSchema()
+            .getFields();
+    List<String> parquetFieldNames =
+        fields.stream()
+            .map(org.apache.parquet.schema.Type::getName)
+            .collect(java.util.stream.Collectors.toList());
+    for (String logicalName : logicalColumnNames) {
+      assertFalse(
+          parquetFieldNames.contains(logicalName),
+          "Parquet schema should not contain logical column name '"
+              + logicalName
+              + "'; got fields: "
+              + parquetFieldNames);
+    }
+    assertTrue(
+        parquetFieldNames.stream().allMatch(name -> name.startsWith("col-")),
+        "Expected physical col-* column names in Parquet, got: " + parquetFieldNames);
+    for (org.apache.parquet.schema.Type field : fields) {
+      assertNotNull(
+          field.getId(), "Expected a Parquet field id on column '" + field.getName() + "'");
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Enables the DSv2 batch write path to write unpartitioned column-mapped tables. Removes the reject guard, adds `DeltaParquetFileFormat.prepareSchemaForWrite`, and translates the data schema to physical names before writing. Identity transform for non-column-mapped tables.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

New `V2WriteTest`: E2E `name`/`id`-mode unpartitioned column-mapped writes and then assert on-disk Parquet uses physical `col-*` names as well as round-trips on read.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No