### PR TITLE
Include table name in DELTA_METADATA_CHANGED exception message

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -2059,7 +2059,7 @@
   },
   "DELTA_METADATA_CHANGED" : {
     "message" : [
-      "MetadataChangedException: The metadata of the Delta table has been changed by a concurrent update. Please try the operation again.<conflictingCommit>\nRefer to <docLink> for more details."
+      "MetadataChangedException: The metadata of the Delta table <tableName> has been changed by a concurrent update. Please try the operation again.<conflictingCommit>\nRefer to <docLink> for more details."
     ],
     "sqlState" : "2D521"
   },

--- a/spark/src/main/scala/io/delta/exceptions/DeltaConcurrentExceptions.scala
+++ b/spark/src/main/scala/io/delta/exceptions/DeltaConcurrentExceptions.scala
@@ -59,14 +59,24 @@ class ConcurrentWriteException(message: String)
  * @since 1.0.0
  */
 @Evolving
-class MetadataChangedException(message: String)
+class MetadataChangedException private (
+    message: String,
+    messageParameters: Array[String])
   extends org.apache.spark.sql.delta.MetadataChangedException(message)
     with DeltaThrowable {
+  def this(message: String) = this(message, Array.empty)
   def this(messageParameters: Array[String]) = {
-    this(DeltaThrowableHelper.getMessage("DELTA_METADATA_CHANGED", messageParameters))
+    this(
+      DeltaThrowableHelper.getMessage("DELTA_METADATA_CHANGED", messageParameters),
+      messageParameters)
   }
   override def getErrorClass: String = "DELTA_METADATA_CHANGED"
   override def getMessage: String = message
+
+  override def getMessageParameters: java.util.Map[String, String] = {
+    DeltaThrowableHelper.getMessageParameters(
+      "DELTA_METADATA_CHANGED", errorSubClass = null, messageParameters)
+  }
 }
 
 /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
@@ -649,7 +649,8 @@ private[delta] class ConflictChecker(
       if (winningCommitSummary.identityOnlyMetadataUpdate) {
         IdentityColumn.logTransactionAbort(deltaLog)
       }
-      throw DeltaErrors.metadataChangedException(winningCommitSummary.commitInfo)
+      throw DeltaErrors.metadataChangedException(
+        getTableNameOrPath, winningCommitSummary.commitInfo)
     }
   }
 
@@ -667,7 +668,8 @@ private[delta] class ConflictChecker(
    */
   protected def attemptToResolveMetadataConflicts(): Unit = {
     def throwMetadataChangedException(): Unit =
-      throw DeltaErrors.metadataChangedException(winningCommitSummary.commitInfo)
+      throw DeltaErrors.metadataChangedException(
+        getTableNameOrPath, winningCommitSummary.commitInfo)
 
     // If winning commit does not contain metadata update, no conflict.
     if (winningCommitSummary.metadataUpdates.isEmpty) return
@@ -1492,15 +1494,8 @@ private[delta] class ConflictChecker(
     }
   }
 
-  protected def getTableNameOrPath: String = {
-    val tableName = currentTransactionInfo.catalogTable.map(_.qualifiedName)
-      .getOrElse(currentTransactionInfo.metadata.name)
-    if (tableName != null) {
-      tableName
-    } else {
-      s"delta.`${currentTransactionInfo.readSnapshot.dataPath}`"
-    }
-  }
+  protected def getTableNameOrPath: String =
+    currentTransactionInfo.readSnapshot.tableNameOrPath(currentTransactionInfo.catalogTable)
 
   protected def recordTime[T](phase: String)(f: => T): T = {
     val startTimeNs = System.nanoTime()

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -2647,9 +2647,11 @@ trait DeltaErrorsBase
   }
 
   def metadataChangedException(
+      table: String,
       conflictingCommit: Option[CommitInfo]): io.delta.exceptions.MetadataChangedException = {
     new io.delta.exceptions.MetadataChangedException(
       Array(
+        table,
         conflictingCommit.map(ci => s"\nConflicting commit: ${JsonUtils.toJson(ci)}").getOrElse(""),
         DeltaErrors.generateDocsLink(SparkEnv.get.conf, "/concurrency-control.html"))
     )

--- a/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
@@ -157,6 +157,16 @@ class Snapshot(
   override def columnMappingMode: DeltaColumnMappingMode = metadata.columnMappingMode
 
   /**
+   * Returns the catalog-qualified table name when available, falling back to the table's metadata
+   * name and finally to its path. Intended for use in user-facing error messages.
+   */
+  def tableNameOrPath(catalogTable: Option[CatalogTable]): String = {
+    // `metadata.name` might be null, so we wrap it with an Option.
+    Option(catalogTable.map(_.qualifiedName).getOrElse(metadata.name))
+      .getOrElse(s"delta.`$dataPath`")
+  }
+
+  /**
    * Returns the timestamp of the latest commit of this snapshot.
    * For an uninitialized snapshot, this returns -1.
    *

--- a/spark/src/main/scala/org/apache/spark/sql/delta/TypeWidening.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TypeWidening.scala
@@ -58,9 +58,10 @@ object TypeWidening {
       protocol: Protocol,
       metadata: Metadata,
       otherProtocol: Protocol,
-      otherMetadata: Metadata): Unit = {
+      otherMetadata: Metadata,
+      tableNameOrPath: String): Unit = {
     if (isEnabled(protocol, metadata) != isEnabled(otherProtocol, otherMetadata)) {
-      throw DeltaErrors.metadataChangedException(None)
+      throw DeltaErrors.metadataChangedException(tableNameOrPath, None)
     }
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommand.scala
@@ -101,7 +101,8 @@ case class MergeIntoCommand(
           protocol = targetFileIndex.protocol,
           metadata = targetFileIndex.metadata,
           otherProtocol = deltaTxn.protocol,
-          otherMetadata = deltaTxn.metadata
+          otherMetadata = deltaTxn.metadata,
+          tableNameOrPath = deltaTxn.tableNameOrPath
         )
 
         if (canMergeSchema) {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommandBase.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommandBase.scala
@@ -534,7 +534,8 @@ trait MergeIntoCommandBase extends LeafRunnableCommand
           val info = IdentityColumn.getIdentityInfo(f)
           if (info.highWaterMark != gen.highWaterMarkOpt) {
             IdentityColumn.logTransactionAbort(deltaTxn.deltaLog)
-            throw DeltaErrors.metadataChangedException(conflictingCommit = None)
+            throw DeltaErrors.metadataChangedException(
+              table = deltaTxn.tableNameOrPath, conflictingCommit = None)
           }
 
         case (f, _) if ColumnWithDefaultExprUtils.isIdentityColumn(f) &&

--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/TransactionHelper.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/TransactionHelper.scala
@@ -58,6 +58,12 @@ trait TransactionHelper extends DeltaLogging {
   def protocol: Protocol
 
   /**
+   * Returns the catalog-qualified table name when available, falling back to the table's metadata
+   * name and finally to its path.
+   */
+  def tableNameOrPath: String = snapshot.tableNameOrPath(catalogTable)
+
+  /**
    * Default [[IsolationLevel]] as set in table metadata.
    */
   private[delta] def getDefaultIsolationLevel(): IsolationLevel = {

--- a/spark/src/test/scala/io/delta/exceptions/DeltaConcurrentExceptionsSuite.scala
+++ b/spark/src/test/scala/io/delta/exceptions/DeltaConcurrentExceptionsSuite.scala
@@ -45,15 +45,18 @@ class DeltaConcurrentExceptionsSuite extends SparkFunSuite with SharedSparkSessi
 
   test("test MetadataChangedException") {
     intercept[org.apache.spark.sql.delta.DeltaConcurrentModificationException] {
-      throw org.apache.spark.sql.delta.DeltaErrors.metadataChangedException(None)
+      throw org.apache.spark.sql.delta.DeltaErrors
+        .metadataChangedException("test_table", None)
     }
 
     intercept[io.delta.exceptions.DeltaConcurrentModificationException] {
-      throw org.apache.spark.sql.delta.DeltaErrors.metadataChangedException(None)
+      throw org.apache.spark.sql.delta.DeltaErrors
+        .metadataChangedException("test_table", None)
     }
 
     intercept[org.apache.spark.sql.delta.MetadataChangedException] {
-      throw org.apache.spark.sql.delta.DeltaErrors.metadataChangedException(None)
+      throw org.apache.spark.sql.delta.DeltaErrors
+        .metadataChangedException("test_table", None)
     }
 
     intercept[org.apache.spark.sql.delta.DeltaConcurrentModificationException] {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -122,7 +122,7 @@ trait DeltaErrorsSuiteBase
     "concurrentTransactionException" ->
       DeltaErrors.concurrentTransactionException(None),
     "metadataChangedException" ->
-      DeltaErrors.metadataChangedException(None),
+      DeltaErrors.metadataChangedException("test_table", None),
     "protocolChangedException" ->
       DeltaErrors.protocolChangedException(None)
   )
@@ -2909,11 +2909,14 @@ trait DeltaErrorsSuiteBase
     }
     {
       val e = intercept[io.delta.exceptions.MetadataChangedException] {
-        throw org.apache.spark.sql.delta.DeltaErrors.metadataChangedException(None)
+        throw org.apache.spark.sql.delta.DeltaErrors
+          .metadataChangedException("test_table", None)
       }
-      checkError(e, "DELTA_METADATA_CHANGED", "2D521", Map.empty[String, String])
-      assert(e.getMessage.contains("The metadata of the Delta table has been changed by a " +
-        "concurrent update."))
+      checkError(e, "DELTA_METADATA_CHANGED", "2D521",
+        Map(
+          "tableName" -> "test_table",
+          "conflictingCommit" -> "",
+          "docLink" -> generateDocsLink("/concurrency-control.html")))
     }
     {
       val e = intercept[DeltaAnalysisException] {


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other

## Description

When a concurrent transaction changes a Delta table's metadata, the resulting `MetadataChangedException` (`DELTA_METADATA_CHANGED`) message did not identify which table was affected, making conflicts harder to diagnose in multi-table workloads.

This adds a `tableName` parameter to the `DELTA_METADATA_CHANGED` error so the message names the affected table:

> `MetadataChangedException: The metadata of the Delta table <tableName> has been changed by a concurrent update. ...`

`io.delta.exceptions.MetadataChangedException` now also exposes its message parameters via `getMessageParameters` (mirroring the existing `ConcurrentAppendException`), so the parameter can be asserted directly in tests. The table name is resolved via a new `Snapshot.tableNameOrPath(catalogTable)` helper (catalog-qualified name, falling back to the metadata name and finally the table path), reused by the conflict checker and the transaction helper.

## How was this patch tested?

Updated `DeltaErrorsSuite` and `DeltaConcurrentExceptionsSuite` to assert the new `tableName` parameter via `checkError`.

## Does this PR introduce _any_ user-facing changes?

Yes. The `DELTA_METADATA_CHANGED` error message now includes the name of the affected Delta table. Previously it did not identify the table. The error condition and SQLSTATE are unchanged.