### PR TITLE
[Delta][UniForm] Suppress Iceberg row-id reassignment in V3

### DIFF
--- a/icebergShaded/src/main/java/org/apache/iceberg/Delegates.java
+++ b/icebergShaded/src/main/java/org/apache/iceberg/Delegates.java
@@ -25,7 +25,7 @@ import java.util.Set;
 
 /**
  * This class is directly copied from iceberg repo 1.11.0 with the following change:
- * Changes: suppressFirstRowId returns the file directly instead of nulling out its first_row_id.
+ * Changes: L40: suppressFirstRowId returns the file directly instead of nulling out its first_row_id.
  *          UniForm assigns each Iceberg data file's first_row_id from the Delta baseRowId; the
  *          upstream behavior of suppressing the explicitly-set first_row_id for newly-added
  *          DataFiles (forcing Iceberg to re-assign sequentially) would drop that value and break

--- a/icebergShaded/src/main/java/org/apache/iceberg/Delegates.java
+++ b/icebergShaded/src/main/java/org/apache/iceberg/Delegates.java
@@ -1,0 +1,294 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * This class is directly copied from iceberg repo 1.11.0 with the following change:
+ * Changes: suppressFirstRowId returns the file directly instead of nulling out its first_row_id.
+ *          UniForm assigns each Iceberg data file's first_row_id from the Delta baseRowId; the
+ *          upstream behavior of suppressing the explicitly-set first_row_id for newly-added
+ *          DataFiles (forcing Iceberg to re-assign sequentially) would drop that value and break
+ *          row-tracking preservation. Keeping the explicit first_row_id makes the conversion
+ *          deterministic and aligned with Delta row IDs.
+ */
+class Delegates {
+  private Delegates() {}
+
+  @SuppressWarnings("unchecked")
+  static <F extends ContentFile<F>> F suppressFirstRowId(F file) {
+    return file;
+  }
+
+  static DeleteFile pendingDeleteFile(DeleteFile file, Long dataSequenceNumber) {
+    return new PendingDeleteFile(file, dataSequenceNumber);
+  }
+
+  static class PendingDeleteFile extends DelegatingDeleteFile {
+    private final Long dataSequenceNumber;
+
+    PendingDeleteFile(DeleteFile file, Long dataSequenceNumber) {
+      super(file);
+      this.dataSequenceNumber = dataSequenceNumber;
+    }
+
+    @Override
+    DeleteFile wrap(DeleteFile file) {
+      return new PendingDeleteFile(file, dataSequenceNumber);
+    }
+
+    @Override
+    public Long dataSequenceNumber() {
+      return dataSequenceNumber;
+    }
+  }
+
+  static class DelegatingDataFile extends DelegatingContentFile<DataFile> implements DataFile {
+    private DataFile wrappedAsDataFile;
+
+    DelegatingDataFile(DataFile wrapped) {
+      super(wrapped);
+      this.wrappedAsDataFile = wrapped;
+    }
+
+    DataFile wrap(DataFile file) {
+      setWrapped(file);
+      this.wrappedAsDataFile = file;
+      return this;
+    }
+
+    @Override
+    public DataFile copy() {
+      return wrap(wrappedAsDataFile.copy());
+    }
+
+    @Override
+    public DataFile copyWithStats(Set<Integer> requestedColumnIds) {
+      return wrap(wrappedAsDataFile.copyWithStats(requestedColumnIds));
+    }
+
+    @Override
+    public DataFile copyWithoutStats() {
+      return wrap(wrappedAsDataFile.copyWithoutStats());
+    }
+
+    @Override
+    public DataFile copy(boolean withStats) {
+      return wrap(wrappedAsDataFile.copy(withStats));
+    }
+  }
+
+  static class DelegatingDeleteFile extends DelegatingContentFile<DeleteFile>
+      implements DeleteFile {
+    private DeleteFile wrappedAsDeleteFile;
+
+    DelegatingDeleteFile(DeleteFile wrapped) {
+      super(wrapped);
+      this.wrappedAsDeleteFile = wrapped;
+    }
+
+    DeleteFile wrap(DeleteFile file) {
+      setWrapped(file);
+      this.wrappedAsDeleteFile = file;
+      return this;
+    }
+
+    @Override
+    public String referencedDataFile() {
+      return wrappedAsDeleteFile.referencedDataFile();
+    }
+
+    @Override
+    public Long contentOffset() {
+      return wrappedAsDeleteFile.contentOffset();
+    }
+
+    @Override
+    public Long contentSizeInBytes() {
+      return wrappedAsDeleteFile.contentSizeInBytes();
+    }
+
+    @Override
+    public DeleteFile copy() {
+      return wrap(wrappedAsDeleteFile.copy());
+    }
+
+    @Override
+    public DeleteFile copyWithStats(Set<Integer> requestedColumnIds) {
+      return wrap(wrappedAsDeleteFile.copyWithStats(requestedColumnIds));
+    }
+
+    @Override
+    public DeleteFile copyWithoutStats() {
+      return wrap(wrappedAsDeleteFile.copyWithoutStats());
+    }
+
+    @Override
+    public DeleteFile copy(boolean withStats) {
+      return wrap(wrappedAsDeleteFile.copy(withStats));
+    }
+  }
+
+  @SuppressWarnings("VisibilityModifier")
+  static class DelegatingContentFile<F extends ContentFile<F>> implements ContentFile<F> {
+    protected ContentFile<F> wrapped;
+
+    DelegatingContentFile(F wrapped) {
+      this.wrapped = wrapped;
+    }
+
+    protected void setWrapped(F wrapped) {
+      this.wrapped = wrapped;
+    }
+
+    @Override
+    public String manifestLocation() {
+      return wrapped.manifestLocation();
+    }
+
+    @Override
+    public Long pos() {
+      return wrapped.pos();
+    }
+
+    @Override
+    public int specId() {
+      return wrapped.specId();
+    }
+
+    @Override
+    public FileContent content() {
+      return wrapped.content();
+    }
+
+    @Override
+    public CharSequence path() {
+      return wrapped.location();
+    }
+
+    @Override
+    public String location() {
+      return wrapped.location();
+    }
+
+    @Override
+    public FileFormat format() {
+      return wrapped.format();
+    }
+
+    @Override
+    public StructLike partition() {
+      return wrapped.partition();
+    }
+
+    @Override
+    public long recordCount() {
+      return wrapped.recordCount();
+    }
+
+    @Override
+    public long fileSizeInBytes() {
+      return wrapped.fileSizeInBytes();
+    }
+
+    @Override
+    public Map<Integer, Long> columnSizes() {
+      return wrapped.columnSizes();
+    }
+
+    @Override
+    public Map<Integer, Long> valueCounts() {
+      return wrapped.valueCounts();
+    }
+
+    @Override
+    public Map<Integer, Long> nullValueCounts() {
+      return wrapped.nullValueCounts();
+    }
+
+    @Override
+    public Map<Integer, Long> nanValueCounts() {
+      return wrapped.nanValueCounts();
+    }
+
+    @Override
+    public Map<Integer, ByteBuffer> lowerBounds() {
+      return wrapped.lowerBounds();
+    }
+
+    @Override
+    public Map<Integer, ByteBuffer> upperBounds() {
+      return wrapped.upperBounds();
+    }
+
+    @Override
+    public ByteBuffer keyMetadata() {
+      return wrapped.keyMetadata();
+    }
+
+    @Override
+    public List<Long> splitOffsets() {
+      return wrapped.splitOffsets();
+    }
+
+    @Override
+    public List<Integer> equalityFieldIds() {
+      return wrapped.equalityFieldIds();
+    }
+
+    @Override
+    public Integer sortOrderId() {
+      return wrapped.sortOrderId();
+    }
+
+    @Override
+    public Long dataSequenceNumber() {
+      return wrapped.dataSequenceNumber();
+    }
+
+    @Override
+    public Long fileSequenceNumber() {
+      return wrapped.fileSequenceNumber();
+    }
+
+    @Override
+    public Long firstRowId() {
+      return wrapped.firstRowId();
+    }
+
+    @Override
+    public F copy() {
+      throw new IllegalArgumentException("Cannot copy wrapped DataFile");
+    }
+
+    @Override
+    public F copyWithStats(Set<Integer> requestedColumnIds) {
+      throw new IllegalArgumentException("Cannot copy wrapped DataFile");
+    }
+
+    @Override
+    public F copyWithoutStats() {
+      throw new IllegalArgumentException("Cannot copy wrapped DataFile");
+    }
+  }
+}

--- a/project/ShadedIcebergBuild.scala
+++ b/project/ShadedIcebergBuild.scala
@@ -71,6 +71,8 @@ object ShadedIcebergBuild {
    * Here's an overview:
    *  PartitionSpec: sets checkConflicts to false to honor field ID assigned by Delta
    *  HiveCatalog, HiveTableOperations: allow metadataUpdates to overwrite schema and partition spec
+   *  Delegates: does not suppress the explicit first_row_id on added DataFiles, so UniForm can
+   *    preserve Delta row IDs (baseRowId) as Iceberg first_row_id.
    */
   def updateMergeStrategy(prev: String => MergeStrategy): String => MergeStrategy = {
     case PathList("shadedForDelta", "org", "apache", "iceberg", s)
@@ -78,6 +80,9 @@ object ShadedIcebergBuild {
       MergeStrategy.first
     case PathList("shadedForDelta", "org", "apache", "iceberg", s)
       if s.matches("MetadataUpdate(\\$.*)?\\.class") =>
+      MergeStrategy.first
+    case PathList("shadedForDelta", "org", "apache", "iceberg", s)
+      if s.matches("Delegates(\\$.*)?\\.class") =>
       MergeStrategy.first
     case PathList("shadedForDelta", "org", "apache", "iceberg", "PartitionSpec$Builder.class") =>
       MergeStrategy.first


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

When converting a Delta table to UniForm Iceberg V3, the converter assigns each Iceberg data file's `first_row_id` from the corresponding Delta file's `baseRowId`, so Iceberg row lineage matches Delta row tracking.

Upstream Iceberg, however, deliberately drops that value: `Delegates.suppressFirstRowId(file)` wraps every newly-added `DataFile` so its `firstRowId()` returns `null`, forcing Iceberg to re-assign `first_row_id` sequentially at commit time (called from `GenericManifestEntry` and `MergingSnapshotProducer`). Because Iceberg then assigns ids in the order files are added — and a single commit can produce multiple data files in a non-deterministic order — the resulting per-file `first_row_id` does not reliably equal the Delta `baseRowId`. This makes row-tracking conversion non-deterministic (e.g. the `UniFormWithIcebergCompatV3Suite` "row tracking information should be converted" test flakes).

This overrides the shaded Iceberg `Delegates` class so `suppressFirstRowId` returns the file unchanged, preserving the explicitly-assigned `first_row_id`. The override uses the existing shaded-Iceberg class-replacement mechanism (the same one already used for `TableMetadata`, `MetadataUpdate`, `PartitionSpec`, and `HiveCatalog`):

- `icebergShaded/src/main/java/org/apache/iceberg/Delegates.java`: copied verbatim from Iceberg 1.11.0 (the shaded version) with the single change that `suppressFirstRowId` returns the file directly instead of nulling out an added DataFile's `first_row_id`.
- `project/ShadedIcebergBuild.scala`: register `Delegates(...).class` (including inner classes) as `MergeStrategy.first` in `updateMergeStrategy` so the customized class wins over the one from the Iceberg jar during assembly.

This makes UniForm Iceberg V3 preserve Delta row IDs deterministically, independent of file add-order or the number of files a write produces.

## How was this patch tested?

- Built the shaded jar (`icebergShaded/assembly`) and confirmed the customized `Delegates` is merged via the `first` strategy.
- Ran `iceberg/testOnly org.apache.spark.sql.delta.uniform.UniFormWithIcebergCompatV3Suite -- -z "row tracking information should be converted"` (with the original multi-row `INSERT ... VALUES (1), (2), (3)`) 6 times consecutively — all passed. The test was flaky before this change.

## Does this PR introduce _any_ user-facing changes?

No. This changes only how the shaded Iceberg library assigns data-file `first_row_id` during UniForm conversion, so the generated Iceberg metadata deterministically preserves Delta row IDs. There is no API or behavior change for Delta users beyond correct/stable row-lineage in the converted Iceberg tables.
