### PR TITLE
Add Delta ReplaceData writer primitives

### DIFF
--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/PartitionUtils.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/PartitionUtils.java
@@ -17,6 +17,7 @@ package io.delta.spark.internal.v2.utils;
 
 import io.delta.kernel.Snapshot;
 import io.delta.kernel.data.MapValue;
+import io.delta.kernel.expressions.Literal;
 import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.internal.actions.AddFile;
 import io.delta.kernel.internal.actions.DeletionVectorDescriptor;
@@ -35,6 +36,7 @@ import io.delta.spark.internal.v2.read.metadata.MetadataStructSchemaContext;
 import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -61,6 +63,8 @@ import org.apache.spark.sql.execution.datasources.PartitioningUtils;
 import org.apache.spark.sql.execution.datasources.parquet.ParquetUtils;
 import org.apache.spark.sql.internal.SQLConf;
 import org.apache.spark.sql.sources.Filter;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StringType;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
@@ -183,6 +187,65 @@ public class PartitionUtils {
       }
     }
     return new GenericInternalRow(values);
+  }
+
+  /**
+   * Convert an AddFile partition-value map keyed by physical column names into a logical-name map
+   * using the provided partition schema.
+   */
+  public static Map<String, String> getLogicalPartitionValueStrings(
+      MapValue partitionValues, StructType partitionSchema) {
+    Map<String, String> rawPartitionValues = toJavaStringStringMap(partitionValues);
+    Map<String, String> logicalPartitionValues = new LinkedHashMap<>();
+    for (StructField field : partitionSchema.fields()) {
+      String physicalName = DeltaColumnMapping.getPhysicalName(field);
+      logicalPartitionValues.put(field.name(), rawPartitionValues.get(physicalName));
+    }
+    return logicalPartitionValues;
+  }
+
+  private static Map<String, String> toJavaStringStringMap(MapValue mapValue) {
+    Map<String, String> result = new LinkedHashMap<>(mapValue.getSize());
+    for (int i = 0; i < mapValue.getSize(); i++) {
+      String value = mapValue.getValues().isNullAt(i) ? null : mapValue.getValues().getString(i);
+      result.put(mapValue.getKeys().getString(i), value);
+    }
+    return result;
+  }
+
+  /** Build a Kernel write-context partition map keyed by logical partition-column names. */
+  public static Map<String, Literal> buildKernelPartitionLiteralMap(
+      Map<String, String> logicalPartitionValueStrings,
+      StructType partitionSchema,
+      ZoneId zoneId) {
+    Map<String, Literal> partitionLiteralMap = new LinkedHashMap<>();
+    for (StructField field : partitionSchema.fields()) {
+      String logicalName = field.name();
+      String rawValue = logicalPartitionValueStrings.get(logicalName);
+      if (rawValue == null) {
+        throw new IllegalArgumentException(
+            "Null partition literals are introduced in the partition edge slice");
+      }
+      DataType dataType = field.dataType();
+      Object typedValue = PartitioningUtils.castPartValueToDesiredType(dataType, rawValue, zoneId);
+      if (dataType instanceof StringType) {
+        partitionLiteralMap.put(logicalName, Literal.ofString(typedValue.toString()));
+      } else if (dataType == DataTypes.IntegerType) {
+        partitionLiteralMap.put(logicalName, Literal.ofInt((Integer) typedValue));
+      } else if (dataType == DataTypes.LongType) {
+        partitionLiteralMap.put(logicalName, Literal.ofLong((Long) typedValue));
+      } else if (dataType == DataTypes.DateType) {
+        partitionLiteralMap.put(logicalName, Literal.ofDate((Integer) typedValue));
+      } else if (dataType == DataTypes.TimestampType) {
+        partitionLiteralMap.put(logicalName, Literal.ofTimestamp((Long) typedValue));
+      } else if (dataType == DataTypes.TimestampNTZType) {
+        partitionLiteralMap.put(logicalName, Literal.ofTimestampNtz((Long) typedValue));
+      } else {
+        throw new IllegalArgumentException(
+            "Unsupported partition literal data type before partition edge slice: " + dataType);
+      }
+    }
+    return partitionLiteralMap;
   }
 
   /**

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaReplaceDataCommitMessage.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaReplaceDataCommitMessage.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.write;
+
+import io.delta.spark.internal.v2.utils.SerializableKernelRowWrapper;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import org.apache.spark.sql.connector.write.WriterCommitMessage;
+
+/** Commit message for a ReplaceData write task. */
+class DeltaReplaceDataCommitMessage implements WriterCommitMessage {
+
+  private final List<SerializableKernelRowWrapper> addFileActionRows;
+  private final Set<String> sourceFilePaths;
+
+  DeltaReplaceDataCommitMessage(
+      List<SerializableKernelRowWrapper> addFileActionRows, Set<String> sourceFilePaths) {
+    this.addFileActionRows =
+        addFileActionRows != null ? new ArrayList<>(addFileActionRows) : Collections.emptyList();
+    this.sourceFilePaths =
+        sourceFilePaths != null ? new LinkedHashSet<>(sourceFilePaths) : Collections.emptySet();
+  }
+
+  List<SerializableKernelRowWrapper> getAddFileActionRows() {
+    return Collections.unmodifiableList(addFileActionRows);
+  }
+
+  Set<String> getSourceFilePaths() {
+    return Collections.unmodifiableSet(sourceFilePaths);
+  }
+}

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaReplaceDataWriter.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaReplaceDataWriter.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.write;
+
+import io.delta.kernel.DataWriteContext;
+import io.delta.kernel.Transaction;
+import io.delta.kernel.data.Row;
+import io.delta.kernel.defaults.engine.DefaultEngine;
+import io.delta.kernel.engine.Engine;
+import io.delta.kernel.expressions.Literal;
+import io.delta.kernel.internal.util.Preconditions;
+import io.delta.kernel.internal.util.Utils;
+import io.delta.kernel.utils.CloseableIterator;
+import io.delta.kernel.utils.DataFileStatus;
+import io.delta.spark.internal.v2.utils.PartitionUtils;
+import io.delta.spark.internal.v2.utils.SerializableKernelRowWrapper;
+import java.io.IOException;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.TaskAttemptContextImpl;
+import org.apache.hadoop.mapred.TaskAttemptID;
+import org.apache.hadoop.mapreduce.TaskType;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.connector.write.DataWriter;
+import org.apache.spark.sql.connector.write.WriterCommitMessage;
+import org.apache.spark.sql.execution.datasources.OutputWriter;
+import org.apache.spark.sql.execution.datasources.OutputWriterFactory;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.unsafe.types.UTF8String;
+import org.apache.spark.util.SerializableConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * ReplaceData writer that tracks source file metadata when Spark routes rows through
+ * DataAndMetadataWritingSparkTask.
+ */
+class DeltaReplaceDataWriter implements DataWriter<InternalRow> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DeltaReplaceDataWriter.class);
+
+  private static final int SOURCE_FILE_PATH_METADATA_INDEX = 0;
+
+  private final String targetDirectory;
+  private final SerializableConfiguration hadoopConf;
+  private final SerializableKernelRowWrapper serializedTxnState;
+  private final StructType dataSchema;
+  private final OutputWriterFactory outputWriterFactory;
+  private final StructType partitionSchema;
+  private final Map<String, String> partitionValueStrings;
+  private final String sessionTimeZone;
+  private final int partitionId;
+  private final long taskId;
+  private final Set<String> sourceFilePaths = new LinkedHashSet<>();
+
+  private OutputWriter writer;
+  private Path outputPath;
+  private long rowCount;
+
+  DeltaReplaceDataWriter(
+      String targetDirectory,
+      SerializableConfiguration hadoopConf,
+      SerializableKernelRowWrapper serializedTxnState,
+      StructType dataSchema,
+      OutputWriterFactory outputWriterFactory,
+      StructType partitionSchema,
+      Map<String, String> partitionValueStrings,
+      String sessionTimeZone,
+      int partitionId,
+      long taskId) {
+    this.targetDirectory = targetDirectory;
+    this.hadoopConf = hadoopConf;
+    this.serializedTxnState = serializedTxnState;
+    this.dataSchema = dataSchema;
+    this.outputWriterFactory = outputWriterFactory;
+    this.partitionSchema = partitionSchema;
+    this.partitionValueStrings = partitionValueStrings;
+    this.sessionTimeZone = sessionTimeZone;
+    this.partitionId = partitionId;
+    this.taskId = taskId;
+    this.rowCount = 0L;
+  }
+
+  @Override
+  public void write(InternalRow metadata, InternalRow record) throws IOException {
+    if (metadata != null && !metadata.isNullAt(SOURCE_FILE_PATH_METADATA_INDEX)) {
+      Object sourceFilePath =
+          metadata.get(SOURCE_FILE_PATH_METADATA_INDEX, DataTypes.StringType);
+      String sourceFilePathClass =
+          sourceFilePath == null ? "null" : sourceFilePath.getClass().getName();
+      Preconditions.checkArgument(
+          sourceFilePath instanceof UTF8String || sourceFilePath instanceof String,
+          "Expected source file path metadata at index %s to be a string, but found %s",
+          SOURCE_FILE_PATH_METADATA_INDEX,
+          sourceFilePathClass);
+      sourceFilePaths.add(sourceFilePath.toString());
+    }
+    write(record);
+  }
+
+  @Override
+  public void write(InternalRow record) throws IOException {
+    if (writer == null) {
+      initWriter();
+    }
+    writer.write(record);
+    rowCount++;
+  }
+
+  @Override
+  public WriterCommitMessage commit() throws IOException {
+    if (rowCount == 0) {
+      return new DeltaReplaceDataCommitMessage(Collections.emptyList(), Collections.emptySet());
+    }
+
+    writer.close();
+    writer = null;
+
+    List<SerializableKernelRowWrapper> actionRows = generateActionRows();
+    return new DeltaReplaceDataCommitMessage(actionRows, sourceFilePaths);
+  }
+
+  @Override
+  public void abort() throws IOException {
+    closeWriterQuietly();
+    tryDeleteOutputFile();
+  }
+
+  @Override
+  public void close() throws IOException {
+    closeWriterQuietly();
+  }
+
+  private List<SerializableKernelRowWrapper> generateActionRows() throws IOException {
+    Configuration conf = hadoopConf.value();
+    Engine engine = DefaultEngine.create(conf);
+    Row txnState = serializedTxnState.getRow();
+    Map<String, Literal> partitionLiterals =
+        PartitionUtils.buildKernelPartitionLiteralMap(
+            partitionValueStrings, partitionSchema, ZoneId.of(sessionTimeZone));
+    DataWriteContext writeContext =
+        Transaction.getWriteContext(engine, txnState, partitionLiterals);
+
+    FileSystem fs = outputPath.getFileSystem(conf);
+    FileStatus fileStatus = fs.getFileStatus(outputPath);
+    DataFileStatus dataFileStatus =
+        new DataFileStatus(
+            outputPath.toString(),
+            fileStatus.getLen(),
+            fileStatus.getModificationTime(),
+            Optional.empty());
+
+    CloseableIterator<DataFileStatus> dataFilesIter =
+        Utils.toCloseableIterator(Collections.singletonList(dataFileStatus).iterator());
+
+    CloseableIterator<Row> actionRowsIter =
+        Transaction.generateAppendActions(engine, txnState, dataFilesIter, writeContext);
+
+    List<SerializableKernelRowWrapper> actionRows = new ArrayList<>();
+    try {
+      while (actionRowsIter.hasNext()) {
+        actionRows.add(new SerializableKernelRowWrapper(actionRowsIter.next()));
+      }
+    } finally {
+      actionRowsIter.close();
+    }
+    return actionRows;
+  }
+
+  private void closeWriterQuietly() {
+    if (writer != null) {
+      try {
+        writer.close();
+      } catch (Exception e) {
+        LOG.debug("Best-effort close of ReplaceData Parquet writer failed", e);
+      }
+      writer = null;
+    }
+  }
+
+  private void tryDeleteOutputFile() {
+    if (outputPath != null) {
+      try {
+        FileSystem fs = outputPath.getFileSystem(hadoopConf.value());
+        fs.delete(outputPath, false);
+      } catch (Exception e) {
+        LOG.debug("Best-effort delete of partially written file {} failed", outputPath, e);
+      }
+    }
+  }
+
+  private void initWriter() {
+    Configuration conf = hadoopConf.value();
+
+    TaskAttemptContextImpl taskAttemptContext =
+        new TaskAttemptContextImpl(
+            new JobConf(conf), new TaskAttemptID("", 0, TaskType.MAP, partitionId, 0));
+
+    String ext = outputWriterFactory.getFileExtension(taskAttemptContext);
+    String fileName =
+        org.apache.spark.sql.delta.files.DelayedCommitProtocol.buildFileName(
+            partitionId, ext, /* isCdc */ false);
+    outputPath = new Path(targetDirectory, fileName);
+
+    writer = outputWriterFactory.newInstance(outputPath.toString(), dataSchema, taskAttemptContext);
+  }
+}

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaReplaceDataWriterFactory.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaReplaceDataWriterFactory.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.write;
+
+import io.delta.spark.internal.v2.utils.SerializableKernelRowWrapper;
+import java.io.Serializable;
+import java.util.Map;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.connector.write.DataWriter;
+import org.apache.spark.sql.connector.write.DataWriterFactory;
+import org.apache.spark.sql.execution.datasources.OutputWriterFactory;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.util.SerializableConfiguration;
+
+/** Serializable factory sent to executors to create ReplaceData writers. */
+class DeltaReplaceDataWriterFactory implements DataWriterFactory, Serializable {
+
+  private final String targetDirectory;
+  private final SerializableConfiguration hadoopConf;
+  private final SerializableKernelRowWrapper serializedTxnState;
+  private final StructType dataSchema;
+  private final OutputWriterFactory outputWriterFactory;
+  private final StructType partitionSchema;
+  private final Map<String, String> partitionValueStrings;
+  private final String sessionTimeZone;
+
+  DeltaReplaceDataWriterFactory(
+      String targetDirectory,
+      SerializableConfiguration hadoopConf,
+      SerializableKernelRowWrapper serializedTxnState,
+      StructType dataSchema,
+      OutputWriterFactory outputWriterFactory,
+      StructType partitionSchema,
+      Map<String, String> partitionValueStrings,
+      String sessionTimeZone) {
+    this.targetDirectory = targetDirectory;
+    this.hadoopConf = hadoopConf;
+    this.serializedTxnState = serializedTxnState;
+    this.dataSchema = dataSchema;
+    this.outputWriterFactory = outputWriterFactory;
+    this.partitionSchema = partitionSchema;
+    this.partitionValueStrings = partitionValueStrings;
+    this.sessionTimeZone = sessionTimeZone;
+  }
+
+  @Override
+  public DataWriter<InternalRow> createWriter(int partitionId, long taskId) {
+    return new DeltaReplaceDataWriter(
+        targetDirectory,
+        hadoopConf,
+        serializedTxnState,
+        dataSchema,
+        outputWriterFactory,
+        partitionSchema,
+        partitionValueStrings,
+        sessionTimeZone,
+        partitionId,
+        taskId);
+  }
+}

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/write/DeltaReplaceDataWriterTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/write/DeltaReplaceDataWriterTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.write;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.delta.kernel.data.Row;
+import io.delta.kernel.defaults.internal.json.JsonUtils;
+import io.delta.kernel.types.IntegerType;
+import io.delta.spark.internal.v2.utils.SerializableKernelRowWrapper;
+import java.util.Collections;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
+import org.apache.spark.sql.connector.write.DataWriter;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.Test;
+
+public class DeltaReplaceDataWriterTest {
+
+  @Test
+  public void commitMessageNormalizesAndProtectsCollections() {
+    DeltaReplaceDataCommitMessage message = new DeltaReplaceDataCommitMessage(null, null);
+    assertNotNull(message.getAddFileActionRows());
+    assertNotNull(message.getSourceFilePaths());
+    assertTrue(message.getAddFileActionRows().isEmpty());
+    assertTrue(message.getSourceFilePaths().isEmpty());
+    assertThrows(
+        UnsupportedOperationException.class, () -> message.getAddFileActionRows().add(null));
+    assertThrows(UnsupportedOperationException.class, () -> message.getSourceFilePaths().add("x"));
+  }
+
+  @Test
+  public void commitMessagePreservesPayloads() {
+    io.delta.kernel.types.StructType schema =
+        new io.delta.kernel.types.StructType().add("x", IntegerType.INTEGER);
+    Row row = JsonUtils.rowFromJson("{\"x\": 42}", schema);
+    SerializableKernelRowWrapper wrapper = new SerializableKernelRowWrapper(row);
+    DeltaReplaceDataCommitMessage message =
+        new DeltaReplaceDataCommitMessage(
+            Collections.singletonList(wrapper), Collections.singleton("source"));
+    assertEquals(Collections.singletonList(wrapper), message.getAddFileActionRows());
+    assertEquals(Collections.singleton("source"), message.getSourceFilePaths());
+  }
+
+  @Test
+  public void writerFactoryCreatesReplaceDataWriter() {
+    DeltaReplaceDataWriterFactory factory =
+        new DeltaReplaceDataWriterFactory(
+            null, null, null, null, null, new StructType(), Collections.emptyMap(), "UTC");
+    DataWriter<InternalRow> writer = factory.createWriter(1, 2L);
+    assertTrue(writer instanceof DeltaReplaceDataWriter);
+  }
+
+  @Test
+  public void writerRejectsNonStringSourceFilePathMetadata() {
+    DeltaReplaceDataWriterFactory factory =
+        new DeltaReplaceDataWriterFactory(
+            null, null, null, null, null, new StructType(), Collections.emptyMap(), "UTC");
+    DataWriter<InternalRow> writer = factory.createWriter(1, 2L);
+    InternalRow metadata = new GenericInternalRow(new Object[] {1});
+
+    IllegalArgumentException e =
+        assertThrows(
+            IllegalArgumentException.class, () -> writer.write(metadata, InternalRow.empty()));
+    assertTrue(e.getMessage().contains("Expected source file path metadata at index 0"));
+  }
+}


### PR DESCRIPTION
## Description

Adds the executor-side pieces of the Delta Spark DSv2 ReplaceData write path:

- commit messages that carry AddFile action rows and source file paths
- a writer factory and data writer that write replacement Parquet data files
- partition literal helpers for Kernel write contexts

This is DSv2 write-path plumbing; follow-up changes wire the driver-side commit path and row-level operations.

## How was this tested?

- `git diff --check`
- `MAVEN_MIRROR_URL=https://maven-proxy.cloud.databricks.com build/sbt "sparkV2 / Compile / javafmtCheck" "sparkV2 / Test / javafmtCheck"`
- `MAVEN_MIRROR_URL=https://maven-proxy.cloud.databricks.com MAVEN_PROXY_URL=https://maven-proxy.cloud.databricks.com build/sbt "sparkV2 / Compile / compile"`
