### PR TITLE
Back the v2 connector Snapshot with Delta Kernel

### DIFF
--- a/spark-unified/src/main/scala/org/apache/spark/sql/delta/v2/interop/DeltaV2Snapshot.scala
+++ b/spark-unified/src/main/scala/org/apache/spark/sql/delta/v2/interop/DeltaV2Snapshot.scala
@@ -31,21 +31,22 @@ import org.apache.spark.sql.delta.actions.{
   SingleAction
 }
 import org.apache.spark.sql.delta.coordinatedcommits.TableCommitCoordinatorClient
-import org.apache.spark.sql.delta.stats.DeltaStatsColumnSpec
+import org.apache.spark.sql.delta.stats.{DeltaStatsColumnSpec, StatisticsCollection}
 import org.apache.hadoop.fs.Path
+import io.delta.kernel.defaults.engine.DefaultEngine
+import io.delta.kernel.engine.Engine
 import io.delta.kernel.internal.{SnapshotImpl => KernelSnapshot}
 
 import org.apache.spark.sql.{DataFrame, Dataset, SparkSession}
 
 /**
- * Snapshot backed by Delta Kernel to be used in v2 Connector.
+ * A [[Snapshot]] backed by a Delta Kernel snapshot, for the v2 Connector. It extends the V1
+ * [[Snapshot]] so the existing data-skipping read path (`filesForScan`) works unchanged, reading
+ * metadata / protocol / allFiles from Kernel.
  *
- * Construction strategy:
- *   - Passes `null` for both [[Snapshot.logSegment]] and `deltaLog` (guardrail): the Kernel path
- *     has no V1 LogSegment or DeltaLog. The construction-path overrides above ensure these nulls
- *     are never dereferenced while building the snapshot.
- *   - All data/state members (metadata, protocol, allFiles, stateDF, ...) are unimplemented for
- *     now and fail loudly, so unmigrated callers cannot silently read empty V1 state.
+ * `logSegment` and `deltaLog` are both `null` -- this snapshot has no V1 log state -- so every
+ * member the construction or scan path would dereference them through is overridden below. V1 state
+ * reconstruction (`stateDF` etc.) is not wired to Kernel yet and throws.
  */
 private[v2] class DeltaV2Snapshot(
     // Typed as the internal SnapshotImpl (aliased KernelSnapshot), not the public Kernel
@@ -53,14 +54,22 @@ private[v2] class DeltaV2Snapshot(
     // OSS-published Kernel. The public io.delta.kernel.Snapshot has no `getDataPath`, and its
     // `getPath` is URL-encoded, which breaks Hadoop `Path` for table roots containing spaces.
     kernelSnapshot: KernelSnapshot,
-    sparkSession: SparkSession)
+    sparkSession: SparkSession,
+    // Kernel engine for reading scan files and the commit timestamp -- owned and passed by the
+    // connector. The secondary constructor below builds a default one for callers without a Kernel
+    // engine of their own.
+    // The separating comma lives inside the edge block: it is only needed when the edge-only
+    // catalogTableOpt parameter follows. Without it, the OSS export would strip catalogTableOpt and
+    // leave a trailing comma that scalac accepts but scalastyle's parser rejects.
+    kernelEngine: Engine
+  )
   extends Snapshot(
     // toString keeps this compiling across Kernel versions: getDataPath returns String in the
     // currently pinned Kernel and io.delta.kernel.internal.fs.Path in newer Kernels.
     path = new Path(kernelSnapshot.getDataPath.toString),
     version = kernelSnapshot.getVersion,
-    // The Kernel-backed snapshot must not depend on the V1 LogSegment or DeltaLog. Both are null;
-    // the construction-path members that would otherwise dereference them are overridden below, so
+    // A DeltaV2Snapshot must not depend on the V1 LogSegment or DeltaLog. Both are null; the
+    // construction-path members that would otherwise dereference them are overridden below, so
     // the nulls are never dereferenced on the scan path.
     logSegment = null,
     deltaLog = null,
@@ -68,67 +77,107 @@ private[v2] class DeltaV2Snapshot(
 
   override protected def spark: SparkSession = sparkSession
 
+  /** Convenience for callers without their own Kernel engine: builds a fresh DefaultEngine. */
+  // scalastyle:off deltahadoopconfiguration
+  // No DeltaLog to source a Hadoop conf from, so use the session Hadoop conf for the engine.
+  def this(kernelSnapshot: KernelSnapshot, sparkSession: SparkSession) =
+    this(kernelSnapshot, sparkSession,
+      DefaultEngine.create(sparkSession.sessionState.newHadoopConf()))
+  // scalastyle:on deltahadoopconfiguration
+
   // --- logSegment/deltaLog = null guardrail: construction-path overrides ----------------------
   // These are the members dereferenced while the super `Snapshot` constructor runs (init() and the
   // "Created snapshot" logInfo at the end of the Snapshot body), plus the eager
   // tableCommitCoordinatorClientOpt base val. They must have real, V1-storage-free implementations
-  // so a DeltaV2Snapshot can be constructed; everything else stays unimplemented.
+  // so a DeltaV2Snapshot can be constructed.
 
-  // Opt out of the base Snapshot invariant that requires a non-null logSegment/deltaLog: the
-  // Kernel-backed snapshot has neither (see class doc).
+  // Opt out of the base Snapshot invariant that requires a non-null logSegment/deltaLog: a
+  // DeltaV2Snapshot has neither (see class doc).
   override protected def allowNullLogSegmentAndDeltaLog: Boolean = true
 
   // Kernel already validated protocol + feature support when it loaded the snapshot, so the V1
   // init() re-validation (which derefs the null deltaLog) is redundant and skipped.
   override protected def init(): Unit = ()
 
-  // A Kernel-backed snapshot has no V1 commit coordinator. Override the compute hook (not the
-  // `val`, whose base initializer still runs during super construction) so the lookup that derefs
-  // the null deltaLog / unimplemented metadata is skipped.
+  // A DeltaV2Snapshot has no V1 commit coordinator. Override the compute hook (not the `val`, whose
+  // base initializer still runs during super construction) so the lookup that derefs the null
+  // deltaLog / unimplemented metadata is skipped.
   override protected def computeTableCommitCoordinatorClientOpt
       : Option[TableCommitCoordinatorClient] = None
 
-  // The base toString references `metadata` (unimplemented here) and is evaluated eagerly by the
-  // "Created snapshot" logInfo during super construction; keep it to the wired-up members only.
+  // The base toString references `metadata` and is evaluated eagerly by the "Created snapshot"
+  // logInfo during super construction; keep it to the wired-up members only.
   override def toString: String = s"DeltaV2Snapshot(path=$path, version=$version)"
 
-  // The "Created snapshot" logInfo reads the table id from the V1 deltaLog during super
-  // construction; this Kernel-backed snapshot has none, so report an empty id.
-  override protected def tableId: String = ""
+  // The Delta table id (V1 sources the same value via deltaLog.unsafeVolatileTableId). The eager
+  // "Created snapshot" logInfo reads tableId during super construction, before the `kernelSnapshot`
+  // field is assigned; report an empty id then, the real id afterwards.
+  override protected def tableId: String = if (kernelSnapshot == null) "" else metadata.id
 
-  // No V1 LogSegment, so there is no backfilled-version tracking; report the sentinel rather than
-  // dereferencing the null logSegment.
+  // V1 seeds this from `logSegment.lastBackfilledVersionInSegment`, but it is only read on the
+  // commit / coordinated-commit paths (backfill hints, table-feature downgrade), never on the
+  // read path a DeltaV2Snapshot exercises. Report the uninitialized sentinel rather than reaching
+  // into a LogSegment we do not have.
   override protected def initialLastKnownBackfilledVersion: Long = -1L
+
+  // The table's data path, already known from Kernel (passed as `path`). Not edge-guarded: it
+  // overrides the base Snapshot.dataPath (`deltaLog.dataPath`), which exists in OSS too and would
+  // dereference the null deltaLog.
+  override def dataPath: Path = path
 
 
   // --- SnapshotDescriptor / state surface ----------------------------------------------------
 
-  override lazy val metadata: Metadata = unimplemented
+  override lazy val metadata: Metadata =
+    DeltaV2SnapshotConversionsUtils.metadataFromKernel(kernelSnapshot.getMetadata)
 
-  override lazy val protocol: Protocol = unimplemented
+  override lazy val protocol: Protocol =
+    DeltaV2SnapshotConversionsUtils.protocolFromKernel(kernelSnapshot.getProtocol)
 
-  override def columnMappingMode: DeltaColumnMappingMode = unimplemented
+  override def columnMappingMode: DeltaColumnMappingMode = metadata.columnMappingMode
 
-  override def numOfFiles: Long = unimplemented
+  override def numOfFiles: Long = numOfFilesIfKnown.getOrElse(allFiles.count())
 
-  override protected[delta] def numOfFilesIfKnown: Option[Long] = unimplemented
+  override protected[delta] def numOfFilesIfKnown: Option[Long] = {
+    None
+  }
 
-  override protected[delta] def sizeInBytesIfKnown: Option[Long] = unimplemented
+  // Kernel does not surface a cheap total table size, so report None; the data-skipping path
+  // derives the scanned size from per-file sizes instead.
+  override protected[delta] def sizeInBytesIfKnown: Option[Long] = None
 
+  // No V1 commit-file index; not used by the Kernel scan path.
   override protected[delta] lazy val deltaFileIndexOpt: Option[DeltaLogFileIndex] = unimplemented
 
+  // No V1 checkpoint provider; not used by the Kernel scan path.
   override lazy val checkpointProvider: CheckpointProvider = unimplemented
+
+  // V1 reads these from logSegment; report zero.
+  override def numDeltaFiles: Long = 0L
+  override def totalDeltaFilesByteSize: Long = 0L
+
+  // Commit timestamp of this snapshot's version, sourced from Kernel: the ICT when in-commit
+  // timestamps are enabled, otherwise the commit file's modification time -- the same semantics as
+  // the V1 `getInCommitTimestampOpt.getOrElse(logSegment.lastCommitFileModificationTimestamp)`,
+  // which a DeltaV2Snapshot cannot use directly because it has no V1 LogSegment.
+  override def timestamp: Long = kernelSnapshot.getTimestamp(kernelEngine)
 
   // --- Files surfaced via Kernel scan ---------------------------------------------------------
 
-  override lazy val allFiles: Dataset[AddFile] = unimplemented
+  override lazy val allFiles: Dataset[AddFile] =
+    KernelSnapshotUtils.buildAllFiles(kernelSnapshot, sparkSession, kernelEngine)
 
   // --- StatisticsCollection ------------------------------------------------------------------
 
-  override lazy val statsColumnSpec: DeltaStatsColumnSpec = unimplemented
+  override lazy val statsColumnSpec: DeltaStatsColumnSpec =
+    StatisticsCollection.configuredDeltaStatsColumnSpec(metadata)
 
-  // --- V1 state-reconstruction paths: fail loudly ---------------------------------------------
 
+  // --- V1 state-reconstruction paths: not yet used --------------------------------------------
+  // The DeltaV2 read path sources its files from Kernel (`allFiles`), not from V1 log-replay state
+  // reconstruction, so these members are not exercised by the data-skipping path today. They throw
+  // (rather than return empty V1 state) so that an unmigrated caller which does reach one fails
+  // loudly instead of silently reading wrong data.
   override def stateDF: DataFrame = unimplemented
   override def stateDS: Dataset[SingleAction] = unimplemented
   override def tombstones: Dataset[RemoveFile] = unimplemented

--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/v2/interop/DeltaV2SnapshotSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/v2/interop/DeltaV2SnapshotSuite.scala
@@ -16,7 +16,7 @@
 
 package org.apache.spark.sql.delta.v2.interop
 
-import org.apache.spark.sql.delta.Snapshot
+import org.apache.spark.sql.delta.{DeltaLog, Snapshot}
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.hadoop.fs.Path
 import io.delta.kernel.TableManager
@@ -26,9 +26,9 @@ import io.delta.kernel.internal.{SnapshotImpl => KernelSnapshot}
 
 /**
  * Tests for [[DeltaV2Snapshot]] focusing on the construction surface that is wired to the
- * underlying Kernel snapshot: `path` (from `kernelSnapshot.getDataPath`) and `version` (from
- * `kernelSnapshot.getVersion`). All other members are intentionally unimplemented and are expected
- * to throw [[UnsupportedOperationException]].
+ * underlying Kernel snapshot: `path` / `version`, the data members read from Kernel
+ * (`metadata`, `protocol`, `allFiles`, `timestamp`, ...), and the V1 state-reconstruction members
+ * that remain unsupported and throw [[UnsupportedOperationException]].
  */
 class DeltaV2SnapshotSuite extends DeltaSQLCommandTest {
 
@@ -63,25 +63,96 @@ class DeltaV2SnapshotSuite extends DeltaSQLCommandTest {
     }
   }
 
-  test("unimplemented members throw UnsupportedOperationException") {
+  /**
+   * Differential check: every member the DeltaV2Snapshot sources from Kernel must match what the V1
+   * `DeltaLog.snapshot` reports for the same physical table.
+   */
+  private def assertMatchesV1(path: String): Unit = {
+    val v1 = DeltaLog.forTable(spark, path).update()
+    val v2 = new DeltaV2Snapshot(loadKernelSnapshot(path), spark)
+
+    assert(v2.version === v1.version)
+    assert(v2.metadata.id === v1.metadata.id)
+    assert(v2.metadata.schemaString === v1.metadata.schemaString)
+    assert(v2.metadata.partitionColumns === v1.metadata.partitionColumns)
+    assert(v2.metadata.configuration === v1.metadata.configuration)
+    assert(v2.protocol === v1.protocol)
+    assert(v2.schema === v1.schema)
+    assert(v2.columnMappingMode === v1.columnMappingMode)
+    assert(v2.numOfFiles === v1.numOfFiles)
+    assert(v2.dataPath === v1.dataPath)
+    // With ICT disabled, both read the commit-file modification time for the same commit.
+    assert(v2.timestamp === v1.timestamp)
+
+    // allFiles is read through Kernel but must describe the same physical files as V1: same paths,
+    // sizes, and partition values (compared as a set -- ordering is not guaranteed).
+    def fileKeys(s: Snapshot) =
+      s.allFiles.collect().map(f => (f.path, f.size, f.partitionValues)).toSet
+    assert(fileKeys(v2) === fileKeys(v1))
+  }
+
+  /**
+   * A table shape to differential-test. `build` writes the table at `path` (through V1); the case
+   * exercises a distinct snapshot permutation (partitioning, multiple commits, a checkpoint, or
+   * deletion vectors).
+   */
+  private case class SnapshotCase(name: String, build: String => Unit)
+
+  private val snapshotCases: Seq[SnapshotCase] = Seq(
+    SnapshotCase("unpartitioned, single commit", path =>
+      spark.range(10).write.format("delta").save(path)),
+    SnapshotCase("unpartitioned, multiple commits", { path =>
+      spark.range(10).write.format("delta").save(path)
+      spark.range(10, 20).write.format("delta").mode("append").save(path)
+      spark.range(20, 30).write.format("delta").mode("append").save(path)
+    }),
+    SnapshotCase("partitioned", path =>
+      spark.range(20).selectExpr("id", "id % 3 as part")
+        .write.format("delta").partitionBy("part").save(path)),
+    SnapshotCase("partitioned, multiple commits", { path =>
+      spark.range(20).selectExpr("id", "id % 3 as part")
+        .write.format("delta").partitionBy("part").save(path)
+      spark.range(20, 40).selectExpr("id", "id % 3 as part")
+        .write.format("delta").partitionBy("part").mode("append").save(path)
+    }),
+    SnapshotCase("with a checkpoint", { path =>
+      spark.range(10).write.format("delta").save(path)
+      spark.range(10, 20).write.format("delta").mode("append").save(path)
+      DeltaLog.forTable(spark, path).checkpoint()
+      spark.range(20, 30).write.format("delta").mode("append").save(path)
+    }),
+    SnapshotCase("with deletion vectors", { path =>
+      spark.range(20).write.format("delta")
+        .option("delta.enableDeletionVectors", "true").save(path)
+      spark.sql(s"DELETE FROM delta.`$path` WHERE id % 4 = 0")
+    }),
+    // With in-commit timestamps enabled, `timestamp` reads the stored ICT rather than the commit
+    // file's mtime; both V1 and Kernel read the same persisted value, so they must still match.
+    SnapshotCase("with in-commit timestamps", { path =>
+      spark.range(10).write.format("delta")
+        .option("delta.enableInCommitTimestamps", "true").save(path)
+      spark.range(10, 20).write.format("delta").mode("append").save(path)
+    })
+  )
+
+  snapshotCases.foreach { c =>
+    test(s"data members match the V1 snapshot -- ${c.name}") {
+      withTempDir { dir =>
+        val path = dir.getCanonicalPath
+        c.build(path)
+        assertMatchesV1(path)
+      }
+    }
+  }
+
+  test("V1 state-reconstruction members are not yet supported on a DeltaV2 snapshot") {
     withTempDir { dir =>
       val path = dir.getCanonicalPath
       spark.range(1).write.format("delta").save(path)
 
       val snapshot = new DeltaV2Snapshot(loadKernelSnapshot(path), spark)
 
-      // Every externally reachable data/state member must fail loudly so that an unmigrated
-      // caller cannot silently read empty V1 state.
-      intercept[UnsupportedOperationException](snapshot.metadata)
-      intercept[UnsupportedOperationException](snapshot.protocol)
-      intercept[UnsupportedOperationException](snapshot.columnMappingMode)
-      intercept[UnsupportedOperationException](snapshot.numOfFiles)
-      intercept[UnsupportedOperationException](snapshot.numOfFilesIfKnown)
-      intercept[UnsupportedOperationException](snapshot.sizeInBytesIfKnown)
-      intercept[UnsupportedOperationException](snapshot.deltaFileIndexOpt)
-      intercept[UnsupportedOperationException](snapshot.checkpointProvider)
-      intercept[UnsupportedOperationException](snapshot.allFiles)
-      intercept[UnsupportedOperationException](snapshot.statsColumnSpec)
+      // These still fail loudly so an unmigrated caller cannot silently read empty V1 state.
       intercept[UnsupportedOperationException](snapshot.stateDF)
       intercept[UnsupportedOperationException](snapshot.stateDS)
       intercept[UnsupportedOperationException](snapshot.tombstones)


### PR DESCRIPTION
## Description

Implements the data and metadata surface of the v2 interop `Snapshot` on top of a Delta Kernel snapshot. `metadata`, `protocol`, column mapping mode, the file listing, the commit timestamp, and the data path are all read from Kernel, while the class continues to extend the existing `Snapshot` so the current data-skipping read path (`filesForScan`) works unchanged. Members tied to V1 log-replay state reconstruction remain unsupported and throw.

## How was this patch tested?

Adds a differential test suite that loads the same physical table through both the Kernel-backed snapshot and the log-replay snapshot, then asserts the two agree on version, metadata, protocol, schema, column mapping mode, file count, data path, timestamp, and the set of files (path, size, partition values) across unpartitioned, partitioned, multi-commit, checkpointed, deletion-vector, and in-commit-timestamp tables.

## Does this PR introduce _any_ user-facing changes?

No.
