### PR TITLE
Uniform: Pass full table config to Uniform enforcement on v1 saveAsTable overwrite

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
@@ -349,12 +349,15 @@ case class CreateDeltaTableCommand(
       )
       (taggedCommitData, op)
     }
-    // On a V1 saveAsTable overwrite we skip replaceMetadataIfNecessary, so
-    // deltaWriter.configuration only has writer/catalog options, not table properties kept
-    // in the Delta log (e.g. delta.enableIcebergCompatV3 set via ALTER TABLE). Merge the
-    // snapshot config in so the enforcement check below sees the full config; without it the
-    // check thinks IcebergCompat is off and fails the write with
-    // "IcebergCompat cannot be disabled".
+    // A V1 saveAsTable overwrite only overwrites data: it skips replaceMetadataIfNecessary, so
+    // table properties are left untouched, the committed config stays the snapshot's, and
+    // deltaWriter.configuration (writer/catalog options only) never persists. We pass
+    // snapshot ++ writer to the enforcement check below only so it sees that committed (snapshot)
+    // config -- which includes properties kept solely in the Delta log (e.g.
+    // delta.enableIcebergCompatV3 set via ALTER TABLE). Without it the check reads
+    // deltaWriter.configuration alone, misses the snapshot's flag, and wrongly fails the write with
+    // "IcebergCompat cannot be disabled". (V2 createOrReplace / SQL REPLACE do redefine properties,
+    // via replaceMetadataIfNecessary.)
     val writerConfiguration = if (isV1WriterSaveAsTableOverwrite) {
       txn.snapshot.metadata.configuration ++ deltaWriter.configuration
     } else deltaWriter.configuration

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
@@ -349,10 +349,19 @@ case class CreateDeltaTableCommand(
       )
       (taggedCommitData, op)
     }
+    // On a V1 saveAsTable overwrite we skip replaceMetadataIfNecessary, so
+    // deltaWriter.configuration only has writer/catalog options, not table properties kept
+    // in the Delta log (e.g. delta.enableIcebergCompatV3 set via ALTER TABLE). Merge the
+    // snapshot config in so the enforcement check below sees the full config; without it the
+    // check thinks IcebergCompat is off and fails the write with
+    // "IcebergCompat cannot be disabled".
+    val writerConfiguration = if (isV1WriterSaveAsTableOverwrite) {
+      txn.snapshot.metadata.configuration ++ deltaWriter.configuration
+    } else deltaWriter.configuration
     val updatedConfiguration = UniversalFormat.enforceDependenciesInConfiguration(
       sparkSession,
       tableWithLocation,
-      deltaWriter.configuration,
+      writerConfiguration,
       txn.snapshot
     )
     val updatedWriter = deltaWriter.withNewWriterConfiguration(updatedConfiguration)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/UniversalFormatSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/UniversalFormatSuiteBase.scala
@@ -505,6 +505,19 @@ trait UniversalFormatMiscSuiteBase extends IcebergCompatUtilsBase with Universal
     }
   }
 
+  test("saveAsTable overwrite preserves Delta-log-only IcebergCompatV3 properties") {
+    withTempTableAndDir { case (id, _) =>
+      executeSql(s"""CREATE TABLE $id (id INT, name STRING) USING DELTA TBLPROPERTIES (
+        'delta.columnMapping.mode' = 'name')""")
+      executeSql(s"INSERT INTO $id VALUES (1, 'a')")
+      executeSql(s"ALTER TABLE $id SET TBLPROPERTIES ('delta.enableIcebergCompatV3' = 'true')")
+
+      spark.read.table(id).write.mode("overwrite").saveAsTable(id)
+
+      val (_, snapshot) = DeltaLog.forTableWithSnapshot(spark, TableIdentifier(id))
+      assert(snapshot.metadata.configuration.get("delta.enableIcebergCompatV3") === Some("true"))
+    }
+  }
   test("UniForm config validation") {
     Seq("ICEBERG", "iceberg,iceberg", "iceber", "paimon").foreach { invalidConf =>
       withTempTableAndDir { case (id, loc) =>

--- a/spark/src/test/scala/org/apache/spark/sql/delta/UniversalFormatSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/UniversalFormatSuiteBase.scala
@@ -17,6 +17,7 @@
 package org.apache.spark.sql.delta
 
 import org.apache.spark.sql.delta.actions.AddFile
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 import org.apache.spark.sql.delta.util.Utils.try_element_at
 
@@ -273,6 +274,23 @@ trait UniversalFormatSuiteBase extends IcebergCompatUtilsBase
       }
     }
   }
+
+  test("V1 saveAsTable overwrite preserves Delta-log-only IcebergCompat property") {
+    withTempTableAndDir { case (id, _) =>
+      executeSql(s"""CREATE TABLE $id (id INT, name STRING) USING DELTA TBLPROPERTIES (
+        'delta.columnMapping.mode' = 'name')""")
+      executeSql(s"INSERT INTO $id VALUES (1, 'a')")
+      executeSql(
+        s"ALTER TABLE $id SET TBLPROPERTIES ('delta.enableIcebergCompatV$compatVersion' = 'true')")
+
+      // The overwrite does not re-pass enableIcebergCompatV$compatVersion, so it lives only in the
+      // Delta log. The write should still succeed and preserve it.
+      spark.sql("SELECT 2 AS id, 'b' AS name").write
+        .format("delta").mode("overwrite").saveAsTable(id)
+
+      assert(getProperties(id).get(s"delta.enableIcebergCompatV$compatVersion") === Some("true"))
+    }
+  }
 }
 
 trait UniFormWithIcebergCompatV1SuiteBase extends UniversalFormatSuiteBase {
@@ -505,19 +523,24 @@ trait UniversalFormatMiscSuiteBase extends IcebergCompatUtilsBase with Universal
     }
   }
 
-  test("saveAsTable overwrite preserves Delta-log-only IcebergCompatV3 properties") {
-    withTempTableAndDir { case (id, _) =>
-      executeSql(s"""CREATE TABLE $id (id INT, name STRING) USING DELTA TBLPROPERTIES (
-        'delta.columnMapping.mode' = 'name')""")
-      executeSql(s"INSERT INTO $id VALUES (1, 'a')")
-      executeSql(s"ALTER TABLE $id SET TBLPROPERTIES ('delta.enableIcebergCompatV3' = 'true')")
+  test("V1 saveAsTable overwrite preserves Delta-log-only IcebergCompatV3 property") {
+    withSQLConf(DeltaSQLConf.DELTA_UNIFORM_ICEBERG_TABLE_V3_ENABLED.key -> "true") {
+      withTempTableAndDir { case (id, _) =>
+        executeSql(s"""CREATE TABLE $id (id INT, name STRING) USING DELTA TBLPROPERTIES (
+          'delta.columnMapping.mode' = 'name')""")
+        executeSql(s"INSERT INTO $id VALUES (1, 'a')")
+        executeSql(s"ALTER TABLE $id SET TBLPROPERTIES ('delta.enableIcebergCompatV3' = 'true')")
 
-      spark.read.table(id).write.mode("overwrite").saveAsTable(id)
+        // The overwrite does not re-pass enableIcebergCompatV3, so it lives only in the Delta log.
+        // The write should still succeed and preserve it.
+        spark.sql("SELECT 2 AS id, 'b' AS name").write
+          .format("delta").mode("overwrite").saveAsTable(id)
 
-      val (_, snapshot) = DeltaLog.forTableWithSnapshot(spark, TableIdentifier(id))
-      assert(snapshot.metadata.configuration.get("delta.enableIcebergCompatV3") === Some("true"))
+        assert(getProperties(id).get("delta.enableIcebergCompatV3") === Some("true"))
+      }
     }
   }
+
   test("UniForm config validation") {
     Seq("ICEBERG", "iceberg,iceberg", "iceber", "paimon").foreach { invalidConf =>
       withTempTableAndDir { case (id, loc) =>


### PR DESCRIPTION


#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (Uniform)

## Description

When overwriting an IcebergCompat table via the DataFrameWriter V1 saveAsTable path, properties set only in the Delta log (such as delta.enableIcebergCompatV3) were dropped because dependency enforcement only saw the catalog-level writer configuration. Merge the existing snapshot configuration as a base so enforcement operates on the full table configuration.

## How was this patch tested?

Added test that fails as expected before this change and passes after

## Does this PR introduce _any_ user-facing changes?

No
