### PR TITLE
[Kernel] Capture _last_checkpoint as opaque JSON for SnapshotHint relay

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checkpoints/CheckpointMetaData.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checkpoints/CheckpointMetaData.java
@@ -27,12 +27,17 @@ import io.delta.kernel.types.StructType;
 import java.util.*;
 
 public class CheckpointMetaData {
+  private static final int VERSION_ORDINAL = 0;
+  private static final int SIZE_ORDINAL = 1;
+  private static final int PARTS_ORDINAL = 2;
+  private static final int TAGS_ORDINAL = 3;
+
   public static CheckpointMetaData fromRow(Row row) {
     return new CheckpointMetaData(
-        row.getLong(0),
-        row.getLong(1),
-        row.isNullAt(2) ? Optional.empty() : Optional.of(row.getLong(2)),
-        row.isNullAt(3) ? Map.of() : toJavaMap(row.getMap(3)));
+        row.getLong(VERSION_ORDINAL),
+        row.getLong(SIZE_ORDINAL),
+        row.isNullAt(PARTS_ORDINAL) ? Optional.empty() : Optional.of(row.getLong(PARTS_ORDINAL)),
+        row.isNullAt(TAGS_ORDINAL) ? Map.of() : toJavaMap(row.getMap(TAGS_ORDINAL)));
   }
 
   public static StructType READ_SCHEMA =
@@ -61,11 +66,11 @@ public class CheckpointMetaData {
 
   public Row toRow() {
     Map<Integer, Object> dataMap = new HashMap<>();
-    dataMap.put(0, version);
-    dataMap.put(1, size);
-    parts.ifPresent(aLong -> dataMap.put(2, aLong));
+    dataMap.put(VERSION_ORDINAL, version);
+    dataMap.put(SIZE_ORDINAL, size);
+    parts.ifPresent(aLong -> dataMap.put(PARTS_ORDINAL, aLong));
     if (!tags.isEmpty()) {
-      dataMap.put(3, stringStringMapValue(tags));
+      dataMap.put(TAGS_ORDINAL, stringStringMapValue(tags));
     }
 
     return new GenericRow(READ_SCHEMA, dataMap);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checkpoints/Checkpointer.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checkpoints/Checkpointer.java
@@ -22,6 +22,8 @@ import static io.delta.kernel.internal.snapshot.MetadataCleanup.cleanupExpiredLo
 import static io.delta.kernel.internal.tablefeatures.TableFeatures.CHECKPOINT_PROTECTION_W_FEATURE;
 import static io.delta.kernel.internal.util.Utils.singletonCloseableIterator;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import io.delta.kernel.data.ColumnarBatch;
 import io.delta.kernel.data.Row;
 import io.delta.kernel.engine.Engine;
@@ -282,6 +284,11 @@ public class Checkpointer {
     return loadMetadataFromFile(engine, 0 /* tries */);
   }
 
+  /** Reads {@code _last_checkpoint} as an opaque JSON blob. */
+  public Optional<LastCheckpointSerialized> readLastCheckpointSerialized(Engine engine) {
+    return loadSerializedFromFile(engine, 0 /* tries */);
+  }
+
   /**
    * Write the given data to last checkpoint metadata file.
    *
@@ -379,6 +386,81 @@ public class Checkpointer {
       // is to list files and find the last checkpoint file. And the `_last_checkpoint`
       // file is possibly being written to.
       return loadMetadataFromFile(engine, tries + 1);
+    }
+  }
+
+  /**
+   * Loads the opaque {@code _last_checkpoint} JSON blob via {@link LastCheckpointFileReader}.
+   *
+   * @param engine {@link Engine instance to use}
+   * @param tries Number of times already tried to load before this call.
+   */
+  private Optional<LastCheckpointSerialized> loadSerializedFromFile(Engine engine, int tries) {
+    if (tries >= READ_LAST_CHECKPOINT_FILE_MAX_RETRIES) {
+      logger.warn(
+          "Failed to load serialized last checkpoint from file {} after {} attempts.",
+          lastCheckpointFilePath,
+          READ_LAST_CHECKPOINT_FILE_MAX_RETRIES);
+      return Optional.empty();
+    }
+
+    logger.info(
+        "Loading serialized last checkpoint from the _last_checkpoint file. Attempt: {} / {}",
+        tries + 1,
+        READ_LAST_CHECKPOINT_FILE_MAX_RETRIES);
+
+    try {
+      Optional<String> jsonOpt =
+          LastCheckpointFileReader.readUtf8(engine, lastCheckpointFilePath.toString());
+      if (!jsonOpt.isPresent()) {
+        logger.warn(
+            "Last checkpoint file {} has no data. Retrying after 1sec. (current attempt = {})",
+            lastCheckpointFilePath,
+            tries);
+        try {
+          Thread.sleep(1000);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          return Optional.empty();
+        }
+        return loadSerializedFromFile(engine, tries + 1);
+      }
+
+      String json = jsonOpt.get();
+      // Detect a torn read: _last_checkpoint may be overwritten between getFileStatus (size)
+      // and readFiles (bytes).
+      validateJsonObject(json);
+      return Optional.of(new LastCheckpointSerialized(json));
+    } catch (Exception e) {
+      if (e instanceof FileNotFoundException
+          || (e instanceof KernelEngineException
+              && e.getCause() instanceof FileNotFoundException)) {
+        return Optional.empty();
+      }
+      String msg =
+          String.format(
+              "Failed to load serialized last checkpoint from file %s. "
+                  + "It must be in the process of being written. "
+                  + "Retrying after 1sec. (current attempt of %s (max 3)",
+              lastCheckpointFilePath, tries);
+      logger.warn(msg, e);
+      return loadSerializedFromFile(engine, tries + 1);
+    }
+  }
+
+  /** Syntax check for the opaque blob path: valid JSON object with a {@code version} field. */
+  private static void validateJsonObject(String json) throws IOException {
+    final JsonNode node;
+    try {
+      node = JsonUtils.mapper().readTree(json);
+    } catch (JsonProcessingException e) {
+      throw new IOException("Failed to parse _last_checkpoint as JSON", e);
+    }
+    if (node == null || !node.isObject()) {
+      throw new IOException("_last_checkpoint must be a JSON object");
+    }
+    if (!node.has("version")) {
+      throw new IOException("_last_checkpoint missing version field");
     }
   }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checkpoints/LastCheckpointFileReader.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checkpoints/LastCheckpointFileReader.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.internal.checkpoints;
+
+import static io.delta.kernel.internal.util.Preconditions.checkArgument;
+import static io.delta.kernel.internal.util.Utils.singletonCloseableIterator;
+
+import io.delta.kernel.engine.Engine;
+import io.delta.kernel.engine.FileReadRequest;
+import io.delta.kernel.engine.FileSystemClient;
+import io.delta.kernel.utils.CloseableIterator;
+import io.delta.kernel.utils.FileStatus;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+/** Reads the `_last_checkpoint` hint file as a single UTF-8 JSON blob. */
+final class LastCheckpointFileReader {
+  private LastCheckpointFileReader() {}
+
+  static Optional<String> readUtf8(Engine engine, String path) throws IOException {
+    FileSystemClient fileSystemClient = engine.getFileSystemClient();
+    final FileStatus status = fileSystemClient.getFileStatus(path);
+
+    if (status.getSize() == 0) {
+      return Optional.empty();
+    }
+
+    checkArgument(
+        status.getSize() <= Integer.MAX_VALUE,
+        "_last_checkpoint file is too large: %s bytes at %s",
+        status.getSize(),
+        path);
+
+    FileReadRequest readRequest =
+        new FileReadRequest() {
+          @Override
+          public String getPath() {
+            return path;
+          }
+
+          @Override
+          public int getStartOffset() {
+            return 0;
+          }
+
+          @Override
+          public int getReadLength() {
+            return (int) status.getSize();
+          }
+        };
+
+    try (CloseableIterator<ByteArrayInputStream> streams =
+        fileSystemClient.readFiles(singletonCloseableIterator(readRequest))) {
+      if (!streams.hasNext()) {
+        return Optional.empty();
+      }
+      try (InputStream in = streams.next()) {
+        byte[] bytes = in.readAllBytes();
+        String json = new String(bytes, StandardCharsets.UTF_8).trim();
+        return json.isEmpty() ? Optional.empty() : Optional.of(json);
+      }
+    }
+  }
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checkpoints/LastCheckpointSerialized.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checkpoints/LastCheckpointSerialized.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.internal.checkpoints;
+
+import java.nio.charset.StandardCharsets;
+
+/** Capture complete contents of a {@code _last_checkpoint} file. */
+public final class LastCheckpointSerialized {
+  private final String json;
+
+  public LastCheckpointSerialized(String json) {
+    this.json = json;
+  }
+
+  public String json() {
+    return json;
+  }
+
+  public byte[] utf8Bytes() {
+    return json.getBytes(StandardCharsets.UTF_8);
+  }
+
+  /** Returns the captured JSON blob unchanged. */
+  public String toJson() {
+    return json;
+  }
+}

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/checkpoints/CheckpointerSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/checkpoints/CheckpointerSuite.scala
@@ -15,19 +15,21 @@
  */
 package io.delta.kernel.internal.checkpoints
 
-import java.io.{FileNotFoundException, IOException}
+import java.io.{ByteArrayInputStream, FileNotFoundException, IOException}
+import java.nio.charset.StandardCharsets
 import java.util.Optional
 
 import scala.util.control.NonFatal
 
 import io.delta.kernel.data.{ColumnarBatch, ColumnVector}
+import io.delta.kernel.engine.FileReadRequest
 import io.delta.kernel.exceptions.KernelEngineException
 import io.delta.kernel.expressions.Predicate
 import io.delta.kernel.internal.checkpoints.Checkpointer.findLastCompleteCheckpointBeforeHelper
 import io.delta.kernel.internal.fs.Path
 import io.delta.kernel.internal.util.FileNames.checkpointFileSingular
 import io.delta.kernel.internal.util.Utils
-import io.delta.kernel.test.{BaseMockJsonHandler, MockFileSystemClientUtils, VectorTestUtils}
+import io.delta.kernel.test.{BaseMockFileSystemClient, BaseMockJsonHandler, MockFileSystemClientUtils, VectorTestUtils}
 import io.delta.kernel.types.StructType
 import io.delta.kernel.utils.{CloseableIterator, FileStatus}
 
@@ -39,52 +41,94 @@ class CheckpointerSuite extends AnyFunSuite with MockFileSystemClientUtils {
   //////////////////////////////////////////////////////////////////////////////////
   // readLastCheckpointFile tests
   //////////////////////////////////////////////////////////////////////////////////
+  private def mockLastCheckpointEngine(
+      maxFailures: Int): (io.delta.kernel.engine.Engine, MockLastCheckpointMetadataFileReader) = {
+    val jsonHandler = new MockLastCheckpointMetadataFileReader(maxFailures)
+    (mockEngine(jsonHandler = jsonHandler), jsonHandler)
+  }
+
+  private def mockSerializedLastCheckpointEngine(
+      maxFailures: Int): (io.delta.kernel.engine.Engine, MockLastCheckpointFileSystemClient) = {
+    val fsClient = new MockLastCheckpointFileSystemClient(maxFailures)
+    (mockEngine(fileSystemClient = fsClient), fsClient)
+  }
+
   test("load a valid last checkpoint metadata file") {
-    val jsonHandler = new MockLastCheckpointMetadataFileReader(maxFailures = 0)
+    val (engine, jsonHandler) = mockLastCheckpointEngine(maxFailures = 0)
     val lastCheckpoint = new Checkpointer(VALID_LAST_CHECKPOINT_FILE_TABLE)
-      .readLastCheckpointFile(mockEngine(jsonHandler = jsonHandler))
+      .readLastCheckpointFile(engine)
     assertValidCheckpointMetadata(lastCheckpoint)
     assert(jsonHandler.currentFailCount == 0)
   }
 
   test("load a zero-sized last checkpoint metadata file") {
-    val jsonHandler = new MockLastCheckpointMetadataFileReader(maxFailures = 0)
+    val (engine, jsonHandler) = mockLastCheckpointEngine(maxFailures = 0)
     val lastCheckpoint = new Checkpointer(ZERO_SIZED_LAST_CHECKPOINT_FILE_TABLE)
-      .readLastCheckpointFile(mockEngine(jsonHandler = jsonHandler))
+      .readLastCheckpointFile(engine)
     assert(!lastCheckpoint.isPresent)
     assert(jsonHandler.currentFailCount == 0)
   }
 
   test("load an invalid last checkpoint metadata file") {
-    val jsonHandler = new MockLastCheckpointMetadataFileReader(maxFailures = 0)
+    val (engine, jsonHandler) = mockLastCheckpointEngine(maxFailures = 0)
     val lastCheckpoint = new Checkpointer(INVALID_LAST_CHECKPOINT_FILE_TABLE)
-      .readLastCheckpointFile(mockEngine(jsonHandler = jsonHandler))
+      .readLastCheckpointFile(engine)
     assert(!lastCheckpoint.isPresent)
     assert(jsonHandler.currentFailCount == 0)
   }
 
   test("retry last checkpoint metadata loading - succeeds at third attempt") {
-    val jsonHandler = new MockLastCheckpointMetadataFileReader(maxFailures = 2)
+    val (engine, jsonHandler) = mockLastCheckpointEngine(maxFailures = 2)
     val lastCheckpoint = new Checkpointer(VALID_LAST_CHECKPOINT_FILE_TABLE)
-      .readLastCheckpointFile(mockEngine(jsonHandler = jsonHandler))
+      .readLastCheckpointFile(engine)
     assertValidCheckpointMetadata(lastCheckpoint)
     assert(jsonHandler.currentFailCount == 2)
   }
 
   test("retry last checkpoint metadata loading - exceeds max failures") {
-    val jsonHandler = new MockLastCheckpointMetadataFileReader(maxFailures = 4)
+    val (engine, jsonHandler) = mockLastCheckpointEngine(maxFailures = 4)
     val lastCheckpoint = new Checkpointer(VALID_LAST_CHECKPOINT_FILE_TABLE)
-      .readLastCheckpointFile(mockEngine(jsonHandler = jsonHandler))
+      .readLastCheckpointFile(engine)
     assert(!lastCheckpoint.isPresent)
     assert(jsonHandler.currentFailCount == 3) // 3 is the max retries
   }
 
   test("try to load last checkpoint metadata when the file is missing") {
-    val jsonHandler = new MockLastCheckpointMetadataFileReader(maxFailures = 0)
+    val (engine, jsonHandler) = mockLastCheckpointEngine(maxFailures = 0)
     val lastCheckpoint = new Checkpointer(LAST_CHECKPOINT_FILE_NOT_FOUND_TABLE)
-      .readLastCheckpointFile(mockEngine(jsonHandler = jsonHandler))
+      .readLastCheckpointFile(engine)
     assert(!lastCheckpoint.isPresent)
     assert(jsonHandler.currentFailCount == 0)
+  }
+
+  test("readLastCheckpointSerialized returns the opaque JSON blob") {
+    val (engine, fsClient) = mockSerializedLastCheckpointEngine(maxFailures = 0)
+    val serialized = new Checkpointer(VALID_LAST_CHECKPOINT_FILE_TABLE)
+      .readLastCheckpointSerialized(engine)
+    assert(serialized.isPresent)
+    assert(serialized.get().json() == SAMPLE_LAST_CHECKPOINT_JSON)
+    assert(fsClient.currentFailCount == 0)
+  }
+
+  test("readLastCheckpointSerialized rejects malformed JSON after retries") {
+    val (engine, fsClient) = mockSerializedLastCheckpointEngine(maxFailures = 0)
+    val serialized = new Checkpointer(MALFORMED_JSON_LAST_CHECKPOINT_FILE_TABLE)
+      .readLastCheckpointSerialized(engine)
+    assert(!serialized.isPresent)
+    assert(fsClient.currentFailCount == 0)
+  }
+
+  test("CheckpointMetaData round-trips classic fields through toRow -> fromRow") {
+    val cpm = new CheckpointMetaData(
+      12L,
+      34L,
+      Optional.of(2L),
+      java.util.Map.of("k", "v"))
+    val restored = CheckpointMetaData.fromRow(cpm.toRow())
+    assert(restored.version == 12L)
+    assert(restored.size == 34L)
+    assert(restored.parts == Optional.of(2L))
+    assert(restored.tags == java.util.Map.of("k", "v"))
   }
 
   //////////////////////////////////////////////////////////////////////////////////
@@ -262,7 +306,7 @@ object CheckpointerSuite extends VectorTestUtils {
       ordinal match {
         case 0 => longVector(Seq(40)) // version
         case 1 => longVector(Seq(44)) // size
-        case 2 => longVector(Seq(20)); // parts
+        case 2 => longVector(Seq(20)) // parts
         case 3 => mapTypeVector(Seq(Map.empty[String, String])) // tags
       }
     }
@@ -282,10 +326,69 @@ object CheckpointerSuite extends VectorTestUtils {
   val VALID_LAST_CHECKPOINT_FILE_TABLE = new Path("/valid")
   val ZERO_SIZED_LAST_CHECKPOINT_FILE_TABLE = new Path("/zero_sized")
   val INVALID_LAST_CHECKPOINT_FILE_TABLE = new Path("/invalid")
+  val MALFORMED_JSON_LAST_CHECKPOINT_FILE_TABLE = new Path("/malformed_json")
   val LAST_CHECKPOINT_FILE_NOT_FOUND_TABLE = new Path("/filenotfoundtable")
+
+  val SAMPLE_LAST_CHECKPOINT_JSON: String = """{"version":40,"size":44,"parts":20}"""
+  val MALFORMED_LAST_CHECKPOINT_JSON: String = """{not valid json"""
 }
 
 /** `maxFailures` allows how many times to fail before returning the valid data */
+class MockLastCheckpointFileSystemClient(maxFailures: Int) extends BaseMockFileSystemClient {
+  import CheckpointerSuite._
+  var currentFailCount = 0
+
+  private def tableFor(path: String): Path = new Path(path).getParent
+
+  override def getFileStatus(path: String): FileStatus = {
+    tableFor(path) match {
+      case LAST_CHECKPOINT_FILE_NOT_FOUND_TABLE =>
+        throw new FileNotFoundException("File not found")
+      case ZERO_SIZED_LAST_CHECKPOINT_FILE_TABLE =>
+        FileStatus.of(path, 0, 0)
+      case VALID_LAST_CHECKPOINT_FILE_TABLE | INVALID_LAST_CHECKPOINT_FILE_TABLE =>
+        FileStatus.of(
+          path,
+          SAMPLE_LAST_CHECKPOINT_JSON.getBytes(StandardCharsets.UTF_8).length,
+          0)
+      case MALFORMED_JSON_LAST_CHECKPOINT_FILE_TABLE =>
+        FileStatus.of(
+          path,
+          MALFORMED_LAST_CHECKPOINT_JSON.getBytes(StandardCharsets.UTF_8).length,
+          0)
+      case _ => throw new IOException("Unknown table")
+    }
+  }
+
+  override def readFiles(
+      readRequests: CloseableIterator[FileReadRequest]): CloseableIterator[ByteArrayInputStream] = {
+    val request = readRequests.next()
+    val table = tableFor(request.getPath)
+
+    Utils.singletonCloseableIterator(
+      try {
+        if (currentFailCount < maxFailures) {
+          currentFailCount += 1
+          throw new IOException("Retryable exception")
+        }
+
+        table match {
+          case VALID_LAST_CHECKPOINT_FILE_TABLE =>
+            new ByteArrayInputStream(
+              SAMPLE_LAST_CHECKPOINT_JSON.getBytes(StandardCharsets.UTF_8))
+          case MALFORMED_JSON_LAST_CHECKPOINT_FILE_TABLE =>
+            new ByteArrayInputStream(
+              MALFORMED_LAST_CHECKPOINT_JSON.getBytes(StandardCharsets.UTF_8))
+          case INVALID_LAST_CHECKPOINT_FILE_TABLE =>
+            throw new IOException("Invalid last checkpoint file")
+          case _ => throw new IOException("Unknown table")
+        }
+      } catch {
+        case NonFatal(e) => throw new KernelEngineException("Failed to read last checkpoint", e)
+      })
+  }
+}
+
 class MockLastCheckpointMetadataFileReader(maxFailures: Int) extends BaseMockJsonHandler {
   import CheckpointerSuite._
   var currentFailCount = 0
@@ -314,7 +417,7 @@ class MockLastCheckpointMetadataFileReader(maxFailures: Int) extends BaseMockJso
           case _ => throw new IOException("Unknown table")
         }
       } catch {
-        case NonFatal(e) => throw new KernelEngineException("Failed to read last checkpoint", e);
+        case NonFatal(e) => throw new KernelEngineException("Failed to read last checkpoint", e)
       })
   }
 }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/LastCheckpointHintSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/LastCheckpointHintSuite.scala
@@ -1,0 +1,113 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.defaults
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Paths}
+import java.util.Optional
+
+import io.delta.golden.GoldenTableUtils.goldenTablePath
+import io.delta.kernel.defaults.engine.DefaultEngine
+import io.delta.kernel.internal.checkpoints.Checkpointer
+import io.delta.kernel.internal.fs.Path
+import io.delta.kernel.internal.types.DataTypeJsonSerDe
+import io.delta.kernel.internal.util.JsonUtils
+
+import org.apache.hadoop.conf.Configuration
+import org.scalatest.funsuite.AnyFunSuite
+
+/**
+ * End-to-end tests for `Checkpointer.readLastCheckpointFile` / `readLastCheckpointSerialized`.
+ *
+ * The opaque JSON blob lives in [[io.delta.kernel.internal.checkpoints.LastCheckpointSerialized]]
+ * only. [[io.delta.kernel.internal.checkpoints.CheckpointMetaData]] carries the classic columnar
+ * fields.
+ */
+class LastCheckpointHintSuite extends AnyFunSuite {
+
+  private val engine = DefaultEngine.create(new Configuration())
+
+  private def assertJsonEquals(expected: String, actual: String): Unit = {
+    val expectedNode = JsonUtils.mapper().readTree(expected)
+    val actualNode = JsonUtils.mapper().readTree(actual)
+    assert(
+      expectedNode == actualNode,
+      s"JSON mismatch.\n expected: $expectedNode\n actual:   $actualNode")
+  }
+
+  private def logPathFor(goldenTable: String): Path =
+    new Path(new Path(goldenTablePath(goldenTable)), "_delta_log")
+
+  private def readLastCheckpoint(logPath: Path): String = {
+    val bytes = Files.readAllBytes(
+      Paths.get(new Path(logPath, Checkpointer.LAST_CHECKPOINT_FILE_NAME).toString))
+    new String(bytes, StandardCharsets.UTF_8).trim
+  }
+
+  test("readLastCheckpointSerialized round-trips a V2 (json format) pointer") {
+    val logPath = logPathFor("v2-checkpoint-json")
+    val expectedJson = readLastCheckpoint(logPath)
+
+    val cpm = new Checkpointer(logPath).readLastCheckpointFile(engine).get()
+    assert(cpm.version == 2L)
+    assert(cpm.size == 9L)
+    assert(!cpm.parts.isPresent, "V2 pointer has no `parts`")
+
+    val serialized = new Checkpointer(logPath).readLastCheckpointSerialized(engine).get()
+    assertJsonEquals(expectedJson, serialized.toJson())
+  }
+
+  test("V2 (parquet format) pointer round-trips every field including checkpointSchema") {
+    val logPath = logPathFor("v2-checkpoint-parquet")
+    val rawJson = readLastCheckpoint(logPath)
+
+    val serialized = new Checkpointer(logPath).readLastCheckpointSerialized(engine).get()
+    val cpm = new Checkpointer(logPath).readLastCheckpointFile(engine).get()
+    assert(cpm.version == 2L)
+    assert(cpm.size == 9L)
+
+    val parsedSchema =
+      DataTypeJsonSerDe.deserializeStructType(
+        JsonUtils.mapper().readTree(rawJson).get("checkpointSchema").toString)
+    assert(parsedSchema.length() > 0)
+
+    assert(serialized.json() == rawJson)
+    assert(serialized.toJson().contains("\"checkpointSchema\":{"))
+    assertJsonEquals(rawJson, serialized.toJson())
+  }
+
+  test("classic checkpoint round-trips columnar fields and checkpointSchema via the blob") {
+    val logPath = logPathFor("spark-variant-checkpoint")
+    val raw = readLastCheckpoint(logPath)
+
+    val cpm = new Checkpointer(logPath).readLastCheckpointFile(engine).get()
+    assert(cpm.version == 2L)
+    assert(cpm.size == 6L)
+    assert(!cpm.parts.isPresent, "classic pointer here has no `parts`")
+
+    val serialized = new Checkpointer(logPath).readLastCheckpointSerialized(engine).get()
+    assert(serialized.toJson().contains("\"checkpointSchema\":{"))
+    assertJsonEquals(raw, serialized.toJson())
+  }
+
+  test("readLastCheckpointSerialized exposes utf8 bytes") {
+    val logPath = logPathFor("v2-checkpoint-parquet")
+    val raw = readLastCheckpoint(logPath)
+
+    val serialized = new Checkpointer(logPath).readLastCheckpointSerialized(engine).get()
+    assert(new String(serialized.utf8Bytes(), StandardCharsets.UTF_8).trim == raw)
+  }
+}


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other

## Description

SnapshotHint caching needs the full `_last_checkpoint` JSON (including `checkpointSchema` and any other on-disk fields) to round-trip unchanged. This PR captures the pointer as an opaque UTF-8 JSON blob, rather than projecting individual columnar fields onto `CheckpointMetaData`. 

The earlier field-projection approach (#7123 / #7155 / #7154) was reverted separately in #7191. This PR builds the blob capture on top of that reverted state.

- **`LastCheckpointFileReader`**: reads `_last_checkpoint` in one bounded `FileSystemClient.readFiles` call (length from `getFileStatus`), returning the raw UTF-8 blob.
- **`LastCheckpointSerialized`**: blob-only wrapper (`json()`, `utf8Bytes()`, `toJson()`); no embedded `CheckpointMetaData`.
- **`Checkpointer.readLastCheckpointSerialized()`**: returns the JSON blob and has the same retry loop as `readLastCheckpointFile`.
- **`Checkpointer.readLastCheckpointFile()`**: caller contract unchanged

### Read consistency
The bounded read avoids multi-request stitching, but it does not eliminate a stat/read TOCTOU race if the file is replaced between `getFileStatus` and `readFiles`. Retries and JSON validation handle in-flight or corrupt writes in practice.

## How was this patch tested?
- `kernelApi / testOnly io.delta.kernel.internal.checkpoints.CheckpointerSuite`
- `kernelDefaults / testOnly io.delta.kernel.defaults.LastCheckpointHintSuite` (golden tables including V2 parquet with `checkpointSchema`)

## Does this PR introduce _any_ user-facing changes?

Nope. It just adds `Checkpointer.readLastCheckpointSerialized()` and the `LastCheckpointSerialized` type. `readLastCheckpointFile()` behavior is unchanged for callers that only need the structured columnar fields.
