### PR TITLE
[Kernel] Link Kernel Rust from Delta Kernel page

### DIFF
--- a/docs/src/content/docs/delta-kernel-rust.mdx
+++ b/docs/src/content/docs/delta-kernel-rust.mdx
@@ -3,4 +3,4 @@ title: Delta Kernel Rust
 description: Learn how to build connectors to read and write Delta tables using Delta Kernel Rust.
 ---
 
-Work In Progress
+Delta Kernel Rust is a Rust library for building Delta connectors with native Rust APIs and C/C++ FFI support.

--- a/docs/src/content/docs/delta-kernel.mdx
+++ b/docs/src/content/docs/delta-kernel.mdx
@@ -1217,7 +1217,7 @@ Earlier when a non-existent path is passed, the API used to throw `FileNotFoundE
 
 ## Kernel Rust
 
-The Rust Kernel is a set of libraries for building Delta connectors in native languages. Work in progress.
+The [Rust Kernel](https://docs.delta.io/kernel/rust/) user guide shows how to build Delta connectors in native languages.
 
 ## More Information
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ X] Kernel
- [ ] Other (fill in here)

## Description

This is to link Kernel Rust to newly created Rust User Guide page so it's easy for users to find and use it.

## How was this patch tested?

Ran local Node server and tested empirically 

## Does this PR introduce _any_ user-facing changes?

Yes, docs
