### PR TITLE
feat: recognize delta.checkpoint.writeStatsAsStruct/writeStatsAsJson in TableConfig

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
@@ -73,6 +73,33 @@ public class TableConfig<T> {
           "needs to be a string and one of 'classic' or 'v2'.",
           true);
 
+  /**
+   * Whether to write per-file statistics as a struct column in checkpoint files. Recognized so
+   * connectors can set it (e.g. {@code v2Checkpoint} tables require it), but Kernel does not yet
+   * act on it when writing checkpoints.
+   */
+  public static final TableConfig<Boolean> CHECKPOINT_WRITE_STATS_AS_STRUCT =
+      new TableConfig<>(
+          "delta.checkpoint.writeStatsAsStruct",
+          "false",
+          Boolean::valueOf,
+          value -> true,
+          "needs to be a boolean.",
+          true);
+
+  /**
+   * Whether to write per-file statistics as JSON in checkpoint files. Recognized so connectors can
+   * set it, but Kernel does not yet act on it when writing checkpoints.
+   */
+  public static final TableConfig<Boolean> CHECKPOINT_WRITE_STATS_AS_JSON =
+      new TableConfig<>(
+          "delta.checkpoint.writeStatsAsJson",
+          "true",
+          Boolean::valueOf,
+          value -> true,
+          "needs to be a boolean.",
+          true);
+
   /** Whether commands modifying this Delta table are allowed to create new deletion vectors. */
   public static final TableConfig<Boolean> DELETION_VECTORS_CREATION_ENABLED =
       new TableConfig<>(
@@ -460,6 +487,8 @@ public class TableConfig<T> {
 
               // The below configs do not yet have their behavior correctly implemented in Kernel.
               addConfig(this, DATA_SKIPPING_STATS_COLUMNS);
+              addConfig(this, CHECKPOINT_WRITE_STATS_AS_STRUCT);
+              addConfig(this, CHECKPOINT_WRITE_STATS_AS_JSON);
             }
           });
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/types/DataTypeJsonSerDe.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/types/DataTypeJsonSerDe.java
@@ -83,6 +83,25 @@ public class DataTypeJsonSerDe {
   }
 
   /**
+   * Serializes a single {@link StructField} to a JSON string according to the Delta Protocol, i.e.
+   * an object with {@code name}, {@code type}, {@code nullable}, and {@code metadata}.
+   *
+   * @param structField the field to serialize
+   * @return JSON string representing the field
+   */
+  public static String serializeStructField(StructField structField) {
+    try {
+      StringWriter stringWriter = new StringWriter();
+      JsonGenerator generator = OBJECT_MAPPER.createGenerator(stringWriter);
+      writeStructField(generator, structField);
+      generator.flush();
+      return stringWriter.toString();
+    } catch (IOException ex) {
+      throw new KernelException("Could not serialize StructField to JSON", ex);
+    }
+  }
+
+  /**
    * Deserializes a JSON string representing a Delta data type to a {@link DataType}.
    *
    * @param structTypeJson JSON string representing a {@link StructType} data type

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/types/DataTypeJsonSerDe.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/types/DataTypeJsonSerDe.java
@@ -83,8 +83,8 @@ public class DataTypeJsonSerDe {
   }
 
   /**
-   * Serializes a single {@link StructField} to a JSON string according to the Delta Protocol, i.e.
-   * an object with {@code name}, {@code type}, {@code nullable}, and {@code metadata}.
+   * Serializes a single {@link StructField} to a JSON string as an object with {@code name}, {@code
+   * type}, {@code nullable}, and {@code metadata}.
    *
    * @param structField the field to serialize
    * @return JSON string representing the field

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/types/DataTypeJsonSerDeSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/types/DataTypeJsonSerDeSuite.scala
@@ -611,6 +611,46 @@ class DataTypeJsonSerDeSuite extends AnyFunSuite {
       "0",
       "Could not parse the following JSON as a valid Delta data type")
   }
+
+  // serializeStructField must emit the full per-field object ({name, type, nullable, metadata}).
+  // Assert the object shape and a round-trip through deserializeStructType.
+  Seq(
+    ("primitive", IntegerType.INTEGER),
+    ("decimal", new DecimalType(10, 2)),
+    ("array", new ArrayType(IntegerType.INTEGER, true)),
+    ("map", new MapType(StringType.STRING, IntegerType.INTEGER, true)),
+    ("struct", new StructType().add("x", IntegerType.INTEGER, true))).foreach {
+    case (name, dataType) =>
+      test(s"serializeStructField: emits per-field object for $name type") {
+        val field = new StructField("c", dataType, false)
+        val node = objectMapper.readTree(DataTypeJsonSerDe.serializeStructField(field))
+
+        assert(node.has("name") && node.get("name").asText === "c")
+        assert(node.has("nullable") && !node.get("nullable").asBoolean)
+        assert(node.has("metadata"))
+        assert(node.has("type") && parse(node.get("type").toString) === dataType)
+
+        val roundTripped =
+          DataTypeJsonSerDe.deserializeStructType(
+            structTypeJson(Seq(DataTypeJsonSerDe.serializeStructField(field))))
+        assert(roundTripped === new StructType().add(field))
+      }
+  }
+
+  test("serializeStructField: preserves field metadata") {
+    val field = new StructField(
+      "c",
+      IntegerType.INTEGER,
+      true,
+      FieldMetadata.builder().putLong("int", 0).build())
+    val node = objectMapper.readTree(DataTypeJsonSerDe.serializeStructField(field))
+
+    assert(node.get("metadata").get("int").asLong === 0L)
+    assert(
+      DataTypeJsonSerDe.deserializeStructType(
+        structTypeJson(Seq(DataTypeJsonSerDe.serializeStructField(field))))
+        === new StructType().add(field))
+  }
 }
 
 object DataTypeJsonSerDeSuite {

--- a/kernel/unitycatalog/src/main/java/io/delta/kernel/unitycatalog/UnityCatalogUtils.java
+++ b/kernel/unitycatalog/src/main/java/io/delta/kernel/unitycatalog/UnityCatalogUtils.java
@@ -311,7 +311,7 @@ public class UnityCatalogUtils {
               f.getName(),
               toUCTypeName(f.getDataType()),
               f.getDataType().toString(),
-              DataTypeJsonSerDe.serializeDataType(f.getDataType()),
+              DataTypeJsonSerDe.serializeStructField(f),
               f.isNullable(),
               i));
     }

--- a/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/UnityCatalogUtilsSuite.scala
+++ b/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/UnityCatalogUtilsSuite.scala
@@ -381,4 +381,25 @@ class UnityCatalogUtilsSuite
       assert(result.getDomainMetadatas.isEmpty)
     }
   }
+
+  test("toColumnDefs: typeJson is the full per-field object, not the bare data type") {
+    val schema = new StructType()
+      .add("id", IntegerType.INTEGER, false)
+      .add("name", StringType.STRING, true)
+    val defs = UnityCatalogUtils.toColumnDefs(schema).asScala
+
+    assert(defs.map(_.getName) === Seq("id", "name"))
+    assert(defs.map(_.getPosition) === Seq(0, 1))
+    assert(defs.map(_.isNullable) === Seq(false, true))
+    assert(defs.map(_.getTypeName) === Seq("INT", "STRING"))
+
+    val mapper = new com.fasterxml.jackson.databind.ObjectMapper()
+    defs.foreach { d =>
+      val node = mapper.readTree(d.getTypeJson)
+      assert(node.has("name"), s"typeJson missing 'name' for ${d.getName}: ${d.getTypeJson}")
+      assert(node.get("name").asText === d.getName)
+      assert(node.has("type") && node.has("nullable") && node.has("metadata"))
+      assert(node.get("nullable").asBoolean === d.isNullable)
+    }
+  }
 }


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/7194/files/0543c4b3bcd9b2c37c5206049489052ba49f368e..125b50e1df555bc7340ca31399b9049cc1061d59) to review incremental changes.
- [stack/create-table-typejson-fix](https://github.com/delta-io/delta/pull/7161) [[Files changed](https://github.com/delta-io/delta/pull/7161/files)]
  - [**stack/kernel-tableconfig-fix**](https://github.com/delta-io/delta/pull/7194) [[Files changed](https://github.com/delta-io/delta/pull/7194/files/0543c4b3bcd9b2c37c5206049489052ba49f368e..125b50e1df555bc7340ca31399b9049cc1061d59)] ← _this PR_
    - [stack/drc-api-integration](https://github.com/delta-io/delta/pull/7159) [[Files changed](https://github.com/delta-io/delta/pull/7159/files/125b50e1df555bc7340ca31399b9049cc1061d59..2acf7f40d157367a771ba8e89b5941ffc06aab9d)]

---------
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?

Kernel


## Description

Kernel did not recognize the checkpoint stats-encoding table properties `delta.checkpoint.writeStatsAsStruct` and `delta.checkpoint.writeStatsAsJson`, so any attempt to set them failed. This change adds both properties so kernel accepts and persists them into `Metadata.configuration`.

One CUJ that breaks today: create a Delta table with writeStatsAsStruct=true , then checkpoint it using Kernel. Kernel will pass its write-support check, write a checkpoint with JSON only stats, and ignore writeStatsAsStruct=true with no warning. Note: the Delta protocol doesn't mandate writeStatsAsStruct=true for a v2 checkpoint.

## How was this patch tested?

1. existing `TableConfigSuite` passes.
2. downstream UC Delta-Tables E2E tests now pass, not included in this PR.

## Does this PR introduce _any_ user-facing changes?

No
