### PR TITLE
[Kernel] Use Locale.ROOT when formatting transaction-log filenames

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/FileNames.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/FileNames.java
@@ -22,6 +22,7 @@ import io.delta.kernel.internal.fs.Path;
 import io.delta.kernel.utils.FileStatus;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -194,7 +195,7 @@ public final class FileNames {
 
   /** Returns the delta (json format) path for a given delta file. */
   public static String deltaFile(Path path, long version) {
-    return String.format("%s/%020d.json", path, version);
+    return String.format(Locale.ROOT, "%s/%020d.json", path, version);
   }
 
   /** Returns the delta (json format) path for a given delta file. */
@@ -204,7 +205,8 @@ public final class FileNames {
 
   public static String stagedCommitFile(Path logPath, long version) {
     final Path stagedCommitPath = new Path(logPath, STAGED_COMMIT_DIRECTORY);
-    return String.format("%s/%020d.%s.json", stagedCommitPath, version, UUID.randomUUID());
+    return String.format(
+        Locale.ROOT, "%s/%020d.%s.json", stagedCommitPath, version, UUID.randomUUID());
   }
 
   public static String stagedCommitFile(String logPath, long version) {
@@ -218,7 +220,7 @@ public final class FileNames {
 
   /** Returns the path to the checksum file for the given version. */
   public static Path checksumFile(Path path, long version) {
-    return new Path(path, String.format("%020d.crc", version));
+    return new Path(path, String.format(Locale.ROOT, "%020d.crc", version));
   }
 
   public static long checksumVersion(Path path) {
@@ -236,7 +238,7 @@ public final class FileNames {
    * will not exist as a file.
    */
   public static String listingPrefix(Path path, long version) {
-    return String.format("%s/%020d.", path, version);
+    return String.format(Locale.ROOT, "%s/%020d.", path, version);
   }
 
   /**
@@ -245,7 +247,7 @@ public final class FileNames {
    * <p>In a future protocol version this path will stop being written.
    */
   public static Path checkpointFileSingular(Path path, long version) {
-    return new Path(path, String.format("%020d.checkpoint.parquet", version));
+    return new Path(path, String.format(Locale.ROOT, "%020d.checkpoint.parquet", version));
   }
 
   /**
@@ -255,7 +257,8 @@ public final class FileNames {
   public static Path topLevelV2CheckpointFile(
       Path path, long version, String uuid, String fileType) {
     assert (fileType.equals("json") || fileType.equals("parquet"));
-    return new Path(path, String.format("%020d.checkpoint.%s.%s", version, uuid, fileType));
+    return new Path(
+        path, String.format(Locale.ROOT, "%020d.checkpoint.%s.%s", version, uuid, fileType));
   }
 
   /** Returns the path for a V2 sidecar file with a given UUID. */
@@ -265,7 +268,9 @@ public final class FileNames {
 
   public static Path multiPartCheckpointFile(Path path, long version, int part, int numParts) {
     return new Path(
-        path, String.format("%020d.checkpoint.%010d.%010d.parquet", version, part, numParts));
+        path,
+        String.format(
+            Locale.ROOT, "%020d.checkpoint.%010d.%010d.parquet", version, part, numParts));
   }
 
   /**
@@ -293,7 +298,8 @@ public final class FileNames {
    * @param endVersion the end version for the log compaction
    */
   public static Path logCompactionPath(Path logPath, long startVersion, long endVersion) {
-    String fileName = String.format("%020d.%020d.compacted.json", startVersion, endVersion);
+    String fileName =
+        String.format(Locale.ROOT, "%020d.%020d.compacted.json", startVersion, endVersion);
     return new Path(logPath, fileName);
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/FileNames.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/FileNames.java
@@ -195,7 +195,7 @@ public final class FileNames {
 
   /** Returns the delta (json format) path for a given delta file. */
   public static String deltaFile(Path path, long version) {
-    return String.format(Locale.ROOT, "%s/%020d.json", path, version);
+    return formatRoot("%s/%020d.json", path, version);
   }
 
   /** Returns the delta (json format) path for a given delta file. */
@@ -205,8 +205,7 @@ public final class FileNames {
 
   public static String stagedCommitFile(Path logPath, long version) {
     final Path stagedCommitPath = new Path(logPath, STAGED_COMMIT_DIRECTORY);
-    return String.format(
-        Locale.ROOT, "%s/%020d.%s.json", stagedCommitPath, version, UUID.randomUUID());
+    return formatRoot("%s/%020d.%s.json", stagedCommitPath, version, UUID.randomUUID());
   }
 
   public static String stagedCommitFile(String logPath, long version) {
@@ -220,7 +219,7 @@ public final class FileNames {
 
   /** Returns the path to the checksum file for the given version. */
   public static Path checksumFile(Path path, long version) {
-    return new Path(path, String.format(Locale.ROOT, "%020d.crc", version));
+    return new Path(path, formatRoot("%020d.crc", version));
   }
 
   public static long checksumVersion(Path path) {
@@ -238,7 +237,7 @@ public final class FileNames {
    * will not exist as a file.
    */
   public static String listingPrefix(Path path, long version) {
-    return String.format(Locale.ROOT, "%s/%020d.", path, version);
+    return formatRoot("%s/%020d.", path, version);
   }
 
   /**
@@ -247,7 +246,7 @@ public final class FileNames {
    * <p>In a future protocol version this path will stop being written.
    */
   public static Path checkpointFileSingular(Path path, long version) {
-    return new Path(path, String.format(Locale.ROOT, "%020d.checkpoint.parquet", version));
+    return new Path(path, formatRoot("%020d.checkpoint.parquet", version));
   }
 
   /**
@@ -257,8 +256,7 @@ public final class FileNames {
   public static Path topLevelV2CheckpointFile(
       Path path, long version, String uuid, String fileType) {
     assert (fileType.equals("json") || fileType.equals("parquet"));
-    return new Path(
-        path, String.format(Locale.ROOT, "%020d.checkpoint.%s.%s", version, uuid, fileType));
+    return new Path(path, formatRoot("%020d.checkpoint.%s.%s", version, uuid, fileType));
   }
 
   /** Returns the path for a V2 sidecar file with a given UUID. */
@@ -268,9 +266,7 @@ public final class FileNames {
 
   public static Path multiPartCheckpointFile(Path path, long version, int part, int numParts) {
     return new Path(
-        path,
-        String.format(
-            Locale.ROOT, "%020d.checkpoint.%010d.%010d.parquet", version, part, numParts));
+        path, formatRoot("%020d.checkpoint.%010d.%010d.parquet", version, part, numParts));
   }
 
   /**
@@ -298,9 +294,12 @@ public final class FileNames {
    * @param endVersion the end version for the log compaction
    */
   public static Path logCompactionPath(Path logPath, long startVersion, long endVersion) {
-    String fileName =
-        String.format(Locale.ROOT, "%020d.%020d.compacted.json", startVersion, endVersion);
+    String fileName = formatRoot("%020d.%020d.compacted.json", startVersion, endVersion);
     return new Path(logPath, fileName);
+  }
+
+  private static String formatRoot(String format, Object... args) {
+    return String.format(Locale.ROOT, format, args);
   }
 
   /////////////////////////////

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/FileNamesSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/FileNamesSuite.scala
@@ -15,6 +15,8 @@
  */
 package io.delta.kernel.internal.util
 
+import java.util.Locale
+
 import scala.collection.JavaConverters._
 
 import io.delta.kernel.internal.fs.Path
@@ -113,6 +115,53 @@ class FileNamesSuite extends AnyFunSuite {
       new Path("/a/00000000000000000001.00000000000000000003.compacted.json"))
     assert(logCompactionPath(new Path("/a/b"), 11, 300) ==
       new Path("/a/b/00000000000000000011.00000000000000000300.compacted.json"))
+  }
+
+  test("path builders always emit ASCII digits under a non-Latin-digit default locale") {
+    // Locale.getDefault(FORMAT) governs String.format's numeric output. Under locales whose
+    // NumberFormat emits non-ASCII digits (e.g. Arabic-Indic), a version-formatting `%020d`
+    // without an explicit locale would produce a file name that the read-side `\d+` patterns
+    // (ASCII-only in Java) cannot parse, corrupting the transaction log.
+    val previousDefault = Locale.getDefault
+    try {
+      Locale.setDefault(Locale.forLanguageTag("ar-EG"))
+      val path = new Path("/a")
+      val version = 1234L
+
+      assert(deltaFile(path, version) == "/a/00000000000000001234.json")
+      assert(isCommitFile(deltaFile(path, version)))
+      assert(deltaVersion(new Path(deltaFile(path, version))) == version)
+
+      assert(listingPrefix(path, version) == "/a/00000000000000001234.")
+
+      assert(checksumFile(path, version).toString == "/a/00000000000000001234.crc")
+      assert(isChecksumFile(checksumFile(path, version).toString))
+      assert(checksumVersion(checksumFile(path, version)) == version)
+
+      assert(checkpointFileSingular(path, version).toString ==
+        "/a/00000000000000001234.checkpoint.parquet")
+      assert(isCheckpointFile(checkpointFileSingular(path, version).toString))
+      assert(checkpointVersion(checkpointFileSingular(path, version)) == version)
+
+      assert(topLevelV2CheckpointFile(path, version, "7d17ac10", "json").toString ==
+        "/a/00000000000000001234.checkpoint.7d17ac10.json")
+      assert(
+        isV2CheckpointFile(topLevelV2CheckpointFile(path, version, "7d17ac10", "json").toString))
+
+      assert(multiPartCheckpointFile(path, version, 1, 5).toString ==
+        "/a/00000000000000001234.checkpoint.0000000001.0000000005.parquet")
+      assert(isMultiPartCheckpointFile(multiPartCheckpointFile(path, version, 1, 5).toString))
+
+      assert(logCompactionPath(path, version, version + 1).toString ==
+        "/a/00000000000000001234.00000000000000001235.compacted.json")
+      assert(isLogCompactionFile(logCompactionPath(path, version, version + 1).toString))
+
+      val staged = stagedCommitFile(path, version)
+      assert(staged.startsWith("/a/_staged_commits/00000000000000001234."))
+      assert(isStagedDeltaFile(staged))
+    } finally {
+      Locale.setDefault(previousDefault)
+    }
   }
 
   ///////////////////////////////////

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/FileNamesSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/FileNamesSuite.scala
@@ -16,6 +16,7 @@
 package io.delta.kernel.internal.util
 
 import java.util.Locale
+import java.util.Locale.Category
 
 import scala.collection.JavaConverters._
 
@@ -118,13 +119,11 @@ class FileNamesSuite extends AnyFunSuite {
   }
 
   test("path builders always emit ASCII digits under a non-Latin-digit default locale") {
-    // Locale.getDefault(FORMAT) governs String.format's numeric output. Under locales whose
-    // NumberFormat emits non-ASCII digits (e.g. Arabic-Indic), a version-formatting `%020d`
-    // without an explicit locale would produce a file name that the read-side `\d+` patterns
-    // (ASCII-only in Java) cannot parse, corrupting the transaction log.
-    val previousDefault = Locale.getDefault
+    // ar-EG's NumberFormat emits non-ASCII digits, so a bare `%020d` would write a name the
+    // read-side ASCII-only `\d+` patterns can't parse.
+    val previousDefault = Locale.getDefault(Category.FORMAT)
     try {
-      Locale.setDefault(Locale.forLanguageTag("ar-EG"))
+      Locale.setDefault(Category.FORMAT, Locale.forLanguageTag("ar-EG"))
       val path = new Path("/a")
       val version = 1234L
 
@@ -160,7 +159,7 @@ class FileNamesSuite extends AnyFunSuite {
       assert(staged.startsWith("/a/_staged_commits/00000000000000001234."))
       assert(isStagedDeltaFile(staged))
     } finally {
-      Locale.setDefault(previousDefault)
+      Locale.setDefault(Category.FORMAT, previousDefault)
     }
   }
 


### PR DESCRIPTION

#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)


`FileNames` builds every versioned transaction-log path with a locale-default
`String.format("...%020d...", version)`. `String.format` without an explicit
`Locale` uses `Locale.getDefault(Locale.Category.FORMAT)`, whose `NumberFormat`
can emit non-ASCII digits. Under a non-Latin-digit default locale (for example
`ar-EG` or `fa-IR`), `"%020d.json"` formats version `42` as an
Arabic-Indic/Persian string (`٠٠...٤٢.json` / `۰۰...۴۲.json`) instead of
`00000000000000000042.json`.

The read side extracts the version with `\d`-based patterns
(`DELTA_FILE_PATTERN`, `CHECK_SUM_FILE_PATTERN`, `CHECKPOINT_FILE_PATTERN`, ...)
and with `Long.parseLong(name.split("\\.")[0])`. In Java a regex `\d` is
ASCII-only `[0-9]` (unless `UNICODE_CHARACTER_CLASS` is set, which it is not
here), and `Long.parseLong` throws on Arabic-Indic digits. So a commit written on
a JVM with such a default FORMAT locale produces a transaction-log file that
Kernel cannot list or parse, i.e. an unreadable (effectively corrupt) log.

This change passes `Locale.ROOT` to each version-formatting `String.format` call
in `FileNames` so the digits are always ASCII, matching the Delta log filename
format and the `\d+` read-side patterns. It mirrors the deliberate use of
`Locale.ROOT` already present elsewhere in the kernel (for example
`CaseInsensitiveMap`); `FileNames` was the inconsistent outlier. The `%s`-only
`String.format` calls (sidecar files, error messages) are left untouched because
they perform no numeric conversion and are not locale-sensitive.

## How was this patch tested?

Added a regression test to `FileNamesSuite` ("path builders always emit ASCII
digits under a non-Latin-digit default locale"). It sets the default locale to
`ar-EG` in a `try/finally` (restoring it afterwards) and asserts that
`deltaFile`, `stagedCommitFile`, `checksumFile`, `listingPrefix`,
`checkpointFileSingular`, `topLevelV2CheckpointFile`, `multiPartCheckpointFile`,
and `logCompactionPath` all emit ASCII digits, and that each result round-trips
through the read side (the `is<Type>File` checkers and version extractors).

Verified red -> green: with only the `FileNames.java` change reverted (test kept),
the suite fails on the Arabic-Indic output; with the change, `FileNamesSuite`
passes 15/15.

```
build/sbt "kernelApi/testOnly io.delta.kernel.internal.util.FileNamesSuite"
```

Also ran the kernel-api lint gate clean: `kernelApi/scalastyle`,
`kernelApi/test:scalastyle`, `kernelApi/checkstyle`, `kernelApi/scalafmtCheckAll`,
`kernelApi/javafmtCheckAll`.

## Does this PR introduce _any_ user-facing changes?

No. This is a correctness fix. On a JVM whose default FORMAT locale uses
non-Latin digits, transaction-log filenames were previously written with
non-ASCII digits and could not be read back; they are now always written with
ASCII digits, as the format requires. Filenames on Latin-digit locales (the
common case) are byte-for-byte unchanged.

---

## Notes / scope (not part of the PR body)
- Scope is Kernel only. The equivalent Scala Spark builder
  (`spark/src/main/scala/org/apache/spark/sql/delta/util/FileNames.scala`, which
  uses the `f"$version%020d"` interpolator and delegates to default-locale
  `String.format`) shares the same latent risk. Deliberately NOT included here to
  keep the diff surgical; a good follow-up PR.
- No existing GitHub issue to link; the PR stands on its own with the repro above.
