### PR TITLE
[Spark] Handle UncheckedIOException(FileNotFoundException) as missing path (#6707)

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
@@ -387,7 +387,7 @@ trait Checkpoints extends DeltaLogging {
       try {
         Some(unsafeLoadMetadataFromFile())
       } catch {
-        case _: FileNotFoundException =>
+        case e if DeltaFileOperations.isFileNotFoundException(e) =>
           None
         case NonFatal(e) if tries < 3 =>
           logWarning(log"Failed to parse ${MDC(DeltaLogKeys.PATH, LAST_CHECKPOINT)}. " +

--- a/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
@@ -35,6 +35,7 @@ import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.{Utils => DeltaUtils}
+import org.apache.spark.sql.delta.util.DeltaFileOperations
 import org.apache.spark.sql.delta.util.FileNames._
 import org.apache.spark.sql.delta.util.JsonUtils
 import org.apache.spark.sql.delta.util.threads.DeltaThreadPool
@@ -121,7 +122,7 @@ trait SnapshotManagement { self: DeltaLog =>
     val filesOpt = try {
       Some(listFrom(startVersion)).filterNot(_.isEmpty)
     } catch {
-      case _: FileNotFoundException => None
+      case e if DeltaFileOperations.isFileNotFoundException(e) => None
     }
     val files =
       filesOpt.map {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/DeltaFileOperations.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/DeltaFileOperations.scala
@@ -16,7 +16,7 @@
 
 package org.apache.spark.sql.delta.util
 
-import java.io.{FileNotFoundException, IOException}
+import java.io.{FileNotFoundException, IOException, UncheckedIOException}
 import java.net.URI
 import java.util.Locale
 
@@ -119,6 +119,21 @@ object DeltaFileOperations extends DeltaLogging {
   /** Check if the thrown exception is a throttling error. */
   private def isThrottlingError(t: Throwable): Boolean = {
     Option(t.getMessage).exists(_.toLowerCase(Locale.ROOT).contains("slow down"))
+  }
+
+  /**
+   * Check whether the thrown exception represents a "file not found" condition, including the
+   * case where it is wrapped in an [[UncheckedIOException]]. Some Hadoop connectors (e.g. GCS)
+   * open input streams lazily and surface the missing-path `FileNotFoundException` only on the
+   * first read, at which point [[io.delta.storage.LineCloseableIterator]] rethrows it wrapped in
+   * an `UncheckedIOException`. Callers that treat a missing path as "expected" (such as a
+   * brand-new table with no `_last_checkpoint` or `_delta_log`) should use this to recognize both
+   * forms.
+   */
+  def isFileNotFoundException(t: Throwable): Boolean = t match {
+    case _: FileNotFoundException => true
+    case e: UncheckedIOException if e.getCause != null => isFileNotFoundException(e.getCause)
+    case _ => false
   }
 
   private def randomBackoff(

--- a/spark/src/test/scala/org/apache/spark/sql/delta/LazyFileNotFoundLogStoreSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/LazyFileNotFoundLogStoreSuite.scala
@@ -1,0 +1,115 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import java.io.{FileNotFoundException, IOException, Reader, UncheckedIOException}
+
+import org.apache.spark.sql.delta.storage.LocalLogStore
+import org.apache.spark.sql.delta.storage.LogStore.logStoreClassConfKey
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.delta.util.DeltaFileOperations
+import io.delta.storage.LineCloseableIterator
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileStatus, Path}
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.test.SharedSparkSession
+
+/**
+ * A [[Reader]] that always throws [[FileNotFoundException]] on the first read, imitating Hadoop
+ * connectors (e.g. GCS) that open input streams lazily and only surface a missing path when the
+ * stream is first read rather than when it is opened.
+ */
+private class FileNotFoundReader(message: String) extends Reader {
+  override def read(cbuf: Array[Char], off: Int, len: Int): Int =
+    throw new FileNotFoundException(message)
+  override def close(): Unit = {}
+}
+
+/**
+ * A [[LocalLogStore]] that reproduces the behavior of a lazy-listing filesystem such as GCS: a
+ * missing path is surfaced as a `FileNotFoundException` wrapped in an [[UncheckedIOException]]
+ * instead of a bare `FileNotFoundException`. `read` routes through the real
+ * [[LineCloseableIterator]] so the wrapping happens exactly as it does in production; `listFrom`
+ * throws the wrapped form directly.
+ */
+class LazyFileNotFoundLogStore(sparkConf: SparkConf, defaultHadoopConf: Configuration)
+  extends LocalLogStore(sparkConf, defaultHadoopConf) {
+
+  private def exists(path: Path, hadoopConf: Configuration): Boolean = {
+    val fs = path.getFileSystem(hadoopConf)
+    fs.exists(path)
+  }
+
+  override def read(path: Path, hadoopConf: Configuration): Seq[String] = {
+    if (!exists(path, hadoopConf)) {
+      // Drive the production iterator to force the same UncheckedIOException(FileNotFoundException)
+      // that a lazily-opened GCS stream produces on the first read.
+      val iter = new LineCloseableIterator(
+        new FileNotFoundReader(s"Item not found: '$path'."))
+      try {
+        iter.hasNext
+      } finally {
+        iter.close()
+      }
+    }
+    super.read(path, hadoopConf)
+  }
+
+  override def listFrom(path: Path, hadoopConf: Configuration): Iterator[FileStatus] = {
+    if (!exists(path.getParent, hadoopConf)) {
+      throw new UncheckedIOException(
+        new FileNotFoundException(s"Item not found: '${path.getParent}'."))
+    }
+    super.listFrom(path, hadoopConf)
+  }
+}
+
+/**
+ * Regression coverage for writes to brand-new Delta paths on lazy-listing filesystems (e.g. GCS on
+ * Dataproc). The missing `_last_checkpoint` / `_delta_log` of a new table surfaces as a
+ * `FileNotFoundException` wrapped in an [[UncheckedIOException]], which must be treated the same as
+ * a bare `FileNotFoundException` when probing a not-yet-existing table.
+ */
+class LazyFileNotFoundLogStoreSuite extends QueryTest
+  with SharedSparkSession
+  with DeltaSQLCommandTest {
+
+  override def sparkConf: SparkConf = {
+    super.sparkConf.set(logStoreClassConfKey, classOf[LazyFileNotFoundLogStore].getName)
+  }
+
+  test("write to a brand-new Delta path succeeds when a missing path surfaces as " +
+      "UncheckedIOException(FileNotFoundException)") {
+    withTempDir { dir =>
+      val path = new Path(dir.getCanonicalPath, "new_table").toString
+      spark.range(10).write.format("delta").mode("overwrite").save(path)
+      checkAnswer(spark.read.format("delta").load(path), spark.range(10).toDF())
+    }
+  }
+
+  test("isFileNotFoundException recognizes bare and UncheckedIOException-wrapped forms") {
+    val bare = new FileNotFoundException("missing")
+    assert(DeltaFileOperations.isFileNotFoundException(bare))
+    assert(DeltaFileOperations.isFileNotFoundException(new UncheckedIOException(bare)))
+    // A non-FileNotFound IOException wrapped in UncheckedIOException is not treated as missing.
+    assert(!DeltaFileOperations.isFileNotFoundException(
+      new UncheckedIOException(new IOException("boom"))))
+    assert(!DeltaFileOperations.isFileNotFoundException(new RuntimeException("unrelated")))
+  }
+}


### PR DESCRIPTION

#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)


Resolves #6707.

Writes to a brand-new Delta path fail with `java.io.UncheckedIOException` on
lazy-listing filesystems (reported on the GCS connector under Dataproc
Serverless 3.0: Spark 4.0.1 + delta-spark 4.0.0). A minimal repro:

```scala
spark.range(10).write.format("delta").mode("overwrite").save("gs://bucket/brand_new_path")
// java.io.UncheckedIOException: java.io.FileNotFoundException:
//   Item not found: 'gs://.../_delta_log/_last_checkpoint'
//   at io.delta.storage.LineCloseableIterator.hasNext(LineCloseableIterator.java:72)
//   at ...Checkpoints.unsafeLoadMetadataFromFile(Checkpoints.scala)
//   at ...SnapshotManagement.createSnapshotAtInit(SnapshotManagement.scala)
```

Root cause: when a table is brand new, Delta probes for `_last_checkpoint` and
`_delta_log`, which do not exist yet, and treats the resulting
`FileNotFoundException` as "expected". Some Hadoop connectors (notably GCS) open
input streams lazily and only raise that `FileNotFoundException` on the first
read rather than on `open`. In that case the exception surfaces from
`io.delta.storage.LineCloseableIterator.hasNext`, whose only `catch (IOException e)`
rethrows it as `new UncheckedIOException(e)`. `FileNotFoundException` is an
`IOException`, so the missing-path signal arrives wrapped in an
`UncheckedIOException` (a `RuntimeException`) instead of as a bare
`FileNotFoundException`.

The two "missing path is expected for a new table" branches only match the bare
form:

- `Checkpoints.loadMetadataFromFile` catches `case _: FileNotFoundException => None`.
  The wrapped form bypasses it, is caught by the `NonFatal(e) if tries < 3` branch
  (retries the read three times), then falls back to a listing that hits the same
  wrapped `FileNotFoundException` on the not-yet-existing `_delta_log` directory.
- `SnapshotManagement.listFromFileSystemInternal` catches
  `case _: FileNotFoundException => None`. The wrapped form bypasses it too and
  propagates fatally out of `createSnapshotAtInit`.

The net effect is that every brand-new Delta write to a lazy-listing filesystem
fails. HDFS and local filesystems are unaffected because `FileSystem.open` there
throws the bare `FileNotFoundException` up front, which the existing catches
already handle.

Fix (caller-side, minimal): add `DeltaFileOperations.isFileNotFoundException`,
which recognizes both a bare `FileNotFoundException` and one wrapped in an
`UncheckedIOException` (unwrapping via `getCause`), and use it in those two
"missing path is expected" catches. This is a strict superset of the previous
bare-`FileNotFoundException` matching and is evaluated before the retry and
corrupt-checkpoint branches, so the only newly diverted exception is
`UncheckedIOException(FileNotFoundException)`, which is exactly the reported bug.
Every other exception keeps its existing route.

`LineCloseableIterator` is intentionally left unchanged: `hasNext` (the
`Iterator` interface) cannot throw a checked exception, and `io.delta:delta-storage`
is a separately published artifact consumed by multiple connectors, so callers
would still have to recognize an unchecked wrapper regardless.

## How was this patch tested?

New suite `LazyFileNotFoundLogStoreSuite` (`spark/src/test/scala/org/apache/spark/sql/delta`):

- A `LocalLogStore` subclass reproduces a lazy-listing filesystem. Its `read`
  drives the real `LineCloseableIterator` over a reader that throws
  `FileNotFoundException` on the first read (so the production
  `UncheckedIOException` wrapping happens exactly as in the field), and its
  `listFrom` throws the wrapped form for a missing parent directory.
- Test 1 writes to a brand-new Delta path and reads it back; it fails on `master`
  with `UncheckedIOException: FileNotFoundException ... /_delta_log` (the #6707
  signature) and passes with this change.
- Test 2 is a focused unit test of `isFileNotFoundException` covering the bare
  form, the `UncheckedIOException`-wrapped form, a non-`FileNotFound`
  `IOException` wrapped in `UncheckedIOException` (must be false), and an
  unrelated `RuntimeException` (must be false).

Commands (JDK 21; `-DuseDefaultUnityCatalogReleaseVersion=true`):

- `build/sbt spark/compile` - success.
- `build/sbt "spark/testOnly *LazyFileNotFoundLogStoreSuite"` - 2/2 pass (and
  fails on `master` without the fix).
- `build/sbt spark/test:scalastyle` (+ `checkstyle`) - clean.
- Regression guards `build/sbt "spark/testOnly *CheckpointsSuite *SnapshotManagementSuite"`
  - 65/65 pass.

## Does this PR introduce _any_ user-facing changes?

Yes, a bug fix. Before: creating a Delta table at a brand-new path on a
lazy-listing filesystem (e.g. GCS) fails with `java.io.UncheckedIOException`
wrapping the expected `FileNotFoundException` for the missing `_last_checkpoint`
/ `_delta_log`. After: the missing path is recognized as "new table, nothing to
load" (as it already is on HDFS/local filesystems) and the write succeeds. No
API or configuration change; no effect on filesystems that raise
`FileNotFoundException` on `open`.
