### PR TITLE
[Spark] Tighten UCDeltaTableReadTest managed-table path-access error assertion

### DIFF
--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableReadTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableReadTest.java
@@ -16,6 +16,8 @@
 
 package io.sparkuctest;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.util.List;
 import org.junit.jupiter.api.Assertions;
 
@@ -117,10 +119,9 @@ public class UCDeltaTableReadTest extends UCDeltaTableIntegrationBaseTest {
 
           // Path-based access isn't supported for catalog-owned (MANAGED) tables.
           if (tableType == TableType.MANAGED) {
-            Assertions.assertThrows(
-                Exception.class,
-                () -> sql("SELECT * FROM delta.`%s`", tablePath),
-                "For managed tables, path-based access should fail");
+            assertThatThrownBy(() -> sql("SELECT * FROM delta.`%s`", tablePath))
+                .as("For managed tables, path-based access should fail")
+                .hasMessageContaining("DELTA_PATH_BASED_ACCESS_TO_CATALOG_MANAGED_TABLE_BLOCKED");
           } else {
             // For EXTERNAL tables, path-based access should work
             S3CredentialFileSystem.credentialCheckEnabled = false;


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Tighten UCDeltaTableReadTest managed-table path-access check to assert the specific `DELTA_PATH_BASED_ACCESS_TO_CATALOG_MANAGED_TABLE_BLOCKED` error instead of any exception.

## How was this patch tested?
CI

## Does this PR introduce _any_ user-facing changes?
No.