### PR TITLE
[kernel-spark] Support DSv2 streaming sink append mode

### DIFF
--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SinkSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SinkSuite.scala
@@ -1,0 +1,91 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.test
+
+import org.apache.spark.sql.delta.DeltaSinkSuite
+import org.scalatest.time.SpanSugar._
+
+/**
+ * Test suite that runs DeltaSinkSuite using the V2 connector (V2_ENABLE_MODE=STRICT).
+ */
+class DeltaV2SinkSuite extends DeltaSinkSuite with V2ForceTest {
+
+  // Route helper-based writes/reads through the catalog by name (.toTable / spark.read.table) so
+  // that, combined with V2_ENABLE_MODE=STRICT (from V2ForceTest), they exercise the V2 Kernel sink.
+  // Without this the base suite defaults to path-based access, which bypasses the catalog and runs
+  // on the V1 sink even under STRICT.
+  override protected def useDsv2: Boolean = true
+
+  // `toTable` runs a one-time CreateTable before the query starts (~10s); per-batch writes are
+  // unchanged. That fixed overhead makes the 60s default too tight under CI contention. Matches
+  // DeltaSinkNameBasedSuite, which sets the same timeout for the same reason.
+  override val streamingTimeout = 90.seconds
+
+  override protected def shouldPassTests: Set[String] = DeltaV2SinkSuite.PassingTests
+
+  override protected def shouldFailTests: Set[String] = DeltaV2SinkSuite.FailingTests
+}
+
+/**
+ * Shared V2-connector test classifications for `DeltaSinkSuite`.
+ */
+object DeltaV2SinkSuite {
+
+  // Tests migrated to name-based access (.toTable / spark.read.table) that route through the
+  // catalog to the V2 Kernel sink under STRICT and pass. Path-based tests are NOT here: under
+  // STRICT they still hit the V1 sink (bypassing the catalog), so they go in FailingTests (ignored)
+  // rather than duplicate DeltaSinkSuite's V1 run.
+  val PassingTests: Set[String] = Set(
+    "append mode",
+    "work with aggregation + watermark",
+    "do not trust user nullability, so that parquet files aren't corrupted",
+    "can't write out with all columns being partition columns"
+  )
+
+  val FailingTests: Set[String] = Set(
+    // ---- Path-based / V1-only: bypass the catalog under STRICT, so they'd duplicate the V1 run.
+    "path not specified",
+    "DeltaSink.catalogTable is correctly populated - path-based table",
+    "incompatible schema merging throws errors - first streaming then batch",
+    "DeltaSink.deltaLog is not initialized in DeltaSink constructor",
+    // Path-based schema evolution: under STRICT these still hit the V1 sink (no catalog), so they
+    // would duplicate the base suite's V1 run rather than exercise the V2 Kernel sink.
+    "allow schema evolution after dropping column",
+    "allow schema evolution after renaming column",
+
+    // ---- Genuine V2-sink gaps (name-based, route to V2, fail there) ----
+    // No partition support: the V2 write rejects a partitioned target, surfaced as an async
+    // StreamingQueryException, not the outcome these tests expect.
+    "partitioned writing and batch reading",
+    "SPARK-21167: encode and decode path correctly",
+    "throw exception when users are trying to write in batch with different partitioning",
+    // Kernel sink dropped the V1 NullType guard, so a UDT containing NullType is not rejected.
+    "DeltaSink rejects DataFrame with UDT containing NullType",
+    // Kernel commit does not set isBlindAppend=true in CommitInfo.
+    "streaming write correctly sets isBlindAppend in CommitInfo",
+    // userMetadata is rejected (it's in UNSUPPORTED_STREAMING_OPTIONS), so the query throws at
+    // start; the test expects the metadata recorded in history, not a failure.
+    "history includes user-defined metadata for DataFrame.writeStream API",
+    // Update/Complete ARE rejected on V2 (builder has neither SupportsStreamingUpdateAsAppend nor
+    // SupportsTruncate), but as an async IllegalArgumentException on the query thread, not the sync
+    // start-time AnalysisException these tests expect.
+    "update mode: not supported",
+    "complete mode",
+    // Pattern-matches the V1 WriteToMicroBatchDataSourceV1/DeltaSink plan; MatchError under V2.
+    "DeltaSink.catalogTable is correctly populated - catalog-based table"
+  )
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSinkSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSinkSuite.scala
@@ -136,17 +136,20 @@ class DeltaSinkSuite
       withSinkTarget { (target, checkpointDir) =>
         val inputData = MemoryStream[Int]
         val df = inputData.toDF()
-        val query = startStream(
+        def startAppendQuery(): StreamingQuery = startStream(
           df.writeStream
             .option("checkpointLocation", checkpointDir.getCanonicalPath)
             .format("delta"),
           target)
+        // `var` so the restart phase below can swap in a fresh query on the same checkpoint while
+        // the `finally` still stops whichever query is currently running.
+        var query = startAppendQuery()
         val log = deltaLogForTarget(target)
         try {
           inputData.addData(1)
           query.processAllAvailable()
 
-          val outputDf = readTarget(target)
+          def outputDf: DataFrame = readTarget(target)
           checkDatasetUnorderly(outputDf.as[Int], 1)
           assert(log.update().transactions.head == (query.id.toString -> 0L))
 
@@ -161,6 +164,28 @@ class DeltaSinkSuite
 
           checkDatasetUnorderly(outputDf.as[Int], 1, 2, 3)
           assert(log.update().transactions.head == (query.id.toString -> 2L))
+
+          // Restart the query from the same checkpoint. This exercises the sink's exactly-once
+          // recovery: the restarted query resumes from the checkpoint's committed offset, so the
+          // already-committed batches (1, 2, 3) must NOT be re-appended, and the streaming
+          // transaction id (appId = query.id) is preserved across the restart.
+          val queryId = query.id
+          query.stop()
+          query = startAppendQuery()
+          query.processAllAvailable()
+
+          // No data was reprocessed: the target still holds exactly the pre-restart rows, the
+          // stable query id is retained, and the last committed batch id is unchanged.
+          checkDatasetUnorderly(outputDf.as[Int], 1, 2, 3)
+          assert(query.id == queryId)
+          assert(log.update().transactions.head == (queryId.toString -> 2L))
+
+          // New data after the restart continues with the next batch id and appends correctly.
+          inputData.addData(4)
+          query.processAllAvailable()
+
+          checkDatasetUnorderly(outputDf.as[Int], 1, 2, 3, 4)
+          assert(log.update().transactions.head == (queryId.toString -> 3L))
         } finally {
           query.stop()
         }

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
@@ -98,7 +98,8 @@ public class DeltaV2Table
         EnumSet.of(
             TableCapability.BATCH_READ,
             TableCapability.MICRO_BATCH_READ,
-            TableCapability.BATCH_WRITE);
+            TableCapability.BATCH_WRITE,
+            TableCapability.STREAMING_WRITE);
     scala.Option<TableCapability> schemaEvolution =
         SparkTableShims$.MODULE$.schemaEvolutionCapability();
     if (schemaEvolution.isDefined()) {
@@ -515,7 +516,14 @@ public class DeltaV2Table
   @Override
   public WriteBuilder newWriteBuilder(LogicalWriteInfo info) {
     requireNonNull(info, "write info is null");
-    return new DeltaV2WriteBuilder(kernelEngine, tablePath, hadoopConf, initialSnapshot, info);
+    return new DeltaV2WriteBuilder(
+        kernelEngine,
+        tablePath,
+        hadoopConf,
+        initialSnapshot,
+        snapshotManager,
+        schemaProvider.getDataSchema(),
+        info);
   }
 
   /**

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2BatchWrite.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2BatchWrite.java
@@ -33,6 +33,7 @@ import org.apache.spark.sql.connector.write.LogicalWriteInfo;
 import org.apache.spark.sql.connector.write.PhysicalWriteInfo;
 import org.apache.spark.sql.connector.write.Write;
 import org.apache.spark.sql.connector.write.WriterCommitMessage;
+import org.apache.spark.sql.types.StructType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,9 +63,11 @@ class DeltaV2BatchWrite implements Write, BatchWrite {
       Configuration hadoopConf,
       String tablePath,
       Snapshot initialSnapshot,
+      StructType dataSchema,
       LogicalWriteInfo writeInfo) {
     this.context =
-        DeltaV2BatchWriteContext.create(engine, hadoopConf, tablePath, initialSnapshot, writeInfo);
+        DeltaV2BatchWriteContext.create(
+            engine, hadoopConf, tablePath, initialSnapshot, dataSchema, writeInfo);
     this.targetDirectory = context.getTargetDirectory(Collections.emptyMap());
   }
 

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2BatchWriteContext.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2BatchWriteContext.java
@@ -21,97 +21,33 @@ import io.delta.kernel.Transaction;
 import io.delta.kernel.data.Row;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.expressions.Literal;
-import io.delta.spark.internal.v2.read.DeltaParquetFileFormatV2;
-import io.delta.spark.internal.v2.utils.PartitionUtils;
-import io.delta.spark.internal.v2.utils.ScalaUtils;
-import io.delta.spark.internal.v2.utils.SchemaUtils;
 import io.delta.spark.internal.v2.utils.SerializableKernelRowWrapper;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.time.ZoneId;
-import java.util.Collections;
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.mapreduce.Job;
-import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.connector.write.LogicalWriteInfo;
-import org.apache.spark.sql.execution.datasources.OutputWriterFactory;
 import org.apache.spark.sql.types.StructType;
-import org.apache.spark.util.SerializableConfiguration;
-import scala.Option;
 
-/** Shared driver-side setup for Delta DSv2 batch writes. */
-class DeltaV2BatchWriteContext {
-
-  /** Returns the engine info string for Delta commit metadata. */
-  static String getEngineInfo() {
-    return "Apache-Spark/"
-        + org.apache.spark.package$.MODULE$.SPARK_VERSION()
-        + " Delta-Lake/"
-        + io.delta.package$.MODULE$.VERSION();
-  }
+/**
+ * Driver-side context for a Delta DSv2 <b>batch</b> write. Extends {@link DeltaV2WriteContext} with
+ * the batch transaction lifecycle: it creates a single {@code Operation.WRITE} transaction off
+ * {@code initialSnapshot} and eagerly serializes its transaction state (the batch commits once, off
+ * this transaction). The operation-independent write state (Parquet factory, schema split, Hadoop
+ * conf) is built by the superclass.
+ */
+class DeltaV2BatchWriteContext extends DeltaV2WriteContext {
 
   private final Transaction transaction;
-  private final Engine engine;
   private final SerializableKernelRowWrapper serializedTxnState;
-  private final StructType dataSchema;
-  private final StructType partitionSchema;
-  private final io.delta.kernel.types.StructType kernelTableSchema;
-  private final OutputWriterFactory outputWriterFactory;
-  private final SerializableConfiguration serializableHadoopConf;
-  private final String sessionTimeZone;
 
   static DeltaV2BatchWriteContext create(
       Engine engine,
       Configuration hadoopConf,
       String tablePath,
       Snapshot initialSnapshot,
+      StructType dataSchema,
       LogicalWriteInfo writeInfo) {
-    return new DeltaV2BatchWriteContext(engine, hadoopConf, tablePath, initialSnapshot, writeInfo);
-  }
-
-  private static void verifySchemaForWrite(DeltaParquetFileFormatV2 format, StructType dataSchema) {
-    try {
-      org.apache.spark.sql.execution.datasources.DataSourceUtils.class
-          .getMethod(
-              "verifySchema",
-              org.apache.spark.sql.execution.datasources.FileFormat.class,
-              StructType.class,
-              boolean.class)
-          .invoke(null, format, dataSchema, false);
-    } catch (NoSuchMethodException e) {
-      invokeLegacyVerifySchema(format, dataSchema);
-    } catch (java.lang.reflect.InvocationTargetException e) {
-      throwUnchecked(e.getCause());
-    } catch (IllegalAccessException e) {
-      throw new IllegalStateException("Unable to verify Parquet write schema", e);
-    }
-  }
-
-  private static void invokeLegacyVerifySchema(
-      DeltaParquetFileFormatV2 format, StructType dataSchema) {
-    try {
-      org.apache.spark.sql.execution.datasources.DataSourceUtils.class
-          .getMethod(
-              "verifySchema",
-              org.apache.spark.sql.execution.datasources.FileFormat.class,
-              StructType.class)
-          .invoke(null, format, dataSchema);
-    } catch (java.lang.reflect.InvocationTargetException e) {
-      throwUnchecked(e.getCause());
-    } catch (ReflectiveOperationException e) {
-      throw new IllegalStateException("Unable to verify Parquet write schema", e);
-    }
-  }
-
-  private static void throwUnchecked(Throwable cause) {
-    if (cause instanceof RuntimeException) {
-      throw (RuntimeException) cause;
-    }
-    if (cause instanceof Error) {
-      throw (Error) cause;
-    }
-    throw new IllegalStateException("Unable to verify Parquet write schema", cause);
+    return new DeltaV2BatchWriteContext(
+        engine, hadoopConf, tablePath, initialSnapshot, dataSchema, writeInfo);
   }
 
   private DeltaV2BatchWriteContext(
@@ -119,107 +55,27 @@ class DeltaV2BatchWriteContext {
       Configuration hadoopConf,
       String tablePath,
       Snapshot initialSnapshot,
+      StructType dataSchema,
       LogicalWriteInfo writeInfo) {
-    this.engine = engine;
+    super(engine, hadoopConf, tablePath, initialSnapshot, dataSchema, writeInfo);
     this.transaction =
         initialSnapshot
             .buildUpdateTableTransaction(getEngineInfo(), Operation.WRITE)
-            .build(this.engine);
-    Row txnState = transaction.getTransactionState(this.engine);
+            .build(getEngine());
+    Row txnState = transaction.getTransactionState(getEngine());
     this.serializedTxnState = new SerializableKernelRowWrapper(txnState);
-
-    this.kernelTableSchema = initialSnapshot.getSchema();
-    StructType tableSchema = SchemaUtils.convertKernelSchemaToSparkSchema(kernelTableSchema);
-    java.util.Set<String> partitionCols =
-        new java.util.HashSet<>(initialSnapshot.getPartitionColumnNames());
-    this.partitionSchema =
-        partitionCols.isEmpty()
-            ? new StructType()
-            : new StructType(
-                java.util.Arrays.stream(tableSchema.fields())
-                    .filter(field -> partitionCols.contains(field.name()))
-                    .toArray(org.apache.spark.sql.types.StructField[]::new));
-    this.dataSchema =
-        partitionCols.isEmpty()
-            ? tableSchema
-            : new StructType(
-                java.util.Arrays.stream(tableSchema.fields())
-                    .filter(field -> !partitionCols.contains(field.name()))
-                    .toArray(org.apache.spark.sql.types.StructField[]::new));
-
-    SparkSession session =
-        SparkSession.getActiveSession()
-            .getOrElse(
-                () -> {
-                  throw new IllegalStateException(
-                      "SparkSession not active (batch write needs it for Parquet)");
-                });
-    this.sessionTimeZone = session.sessionState().conf().sessionLocalTimeZone();
-
-    Job job;
-    try {
-      job = Job.getInstance(hadoopConf);
-    } catch (IOException e) {
-      throw new UncheckedIOException("Failed to create Hadoop job for Parquet write", e);
-    }
-    DeltaParquetFileFormatV2 format =
-        PartitionUtils.createDeltaParquetFileFormat(
-            initialSnapshot,
-            tablePath,
-            /* optimizationsEnabled */ true,
-            /* useMetadataRowIndex */ Option.empty(),
-            /* isCDCRead */ false);
-    verifySchemaForWrite(format, dataSchema);
-    org.apache.spark.sql.execution.datasources.DataSourceUtils.checkFieldNames(format, dataSchema);
-    Map<String, String> options = writeInfo.options().asCaseSensitiveMap();
-    scala.collection.immutable.Map<String, String> scalaOpts =
-        ScalaUtils.toScalaMap(options != null ? options : Collections.emptyMap());
-    this.outputWriterFactory = format.prepareWrite(session, job, scalaOpts, dataSchema);
-    this.serializableHadoopConf = new SerializableConfiguration(job.getConfiguration());
   }
 
   Transaction getTransaction() {
     return transaction;
   }
 
-  Engine getEngine() {
-    return engine;
-  }
-
   String getTargetDirectory(Map<String, Literal> partitionLiterals) {
-    return Transaction.getWriteContext(engine, serializedTxnState.getRow(), partitionLiterals)
+    return Transaction.getWriteContext(getEngine(), serializedTxnState.getRow(), partitionLiterals)
         .getTargetDirectory();
   }
 
   SerializableKernelRowWrapper getSerializedTxnState() {
     return serializedTxnState;
-  }
-
-  StructType getDataSchema() {
-    return dataSchema;
-  }
-
-  StructType getPartitionSchema() {
-    return partitionSchema;
-  }
-
-  io.delta.kernel.types.StructType getKernelTableSchema() {
-    return kernelTableSchema;
-  }
-
-  OutputWriterFactory getOutputWriterFactory() {
-    return outputWriterFactory;
-  }
-
-  SerializableConfiguration getSerializableHadoopConf() {
-    return serializableHadoopConf;
-  }
-
-  ZoneId getSessionTimeZone() {
-    return ZoneId.of(sessionTimeZone);
-  }
-
-  String getSessionTimeZoneId() {
-    return sessionTimeZone;
   }
 }

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2DataWriterFactory.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2DataWriterFactory.java
@@ -20,15 +20,20 @@ import java.io.Serializable;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.write.DataWriter;
 import org.apache.spark.sql.connector.write.DataWriterFactory;
+import org.apache.spark.sql.connector.write.streaming.StreamingDataWriterFactory;
 import org.apache.spark.sql.execution.datasources.OutputWriterFactory;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.util.SerializableConfiguration;
 
 /**
  * Serializable factory sent to executors to create {@link DeltaV2DataWriter} instances. Carries the
- * serialized Hadoop config and Kernel transaction state needed by each writer.
+ * serialized Hadoop config and Kernel transaction state needed by each writer. Serves both batch
+ * and streaming writes -- the {@link DeltaV2DataWriter} is epoch-agnostic, so the streaming
+ * overload ignores {@code epochId} (the epoch only scopes the driver-side commit, not the per-task
+ * write).
  */
-class DeltaV2DataWriterFactory implements DataWriterFactory, Serializable {
+class DeltaV2DataWriterFactory
+    implements DataWriterFactory, StreamingDataWriterFactory, Serializable {
 
   private final String targetDirectory;
   private final SerializableConfiguration hadoopConf;
@@ -59,5 +64,10 @@ class DeltaV2DataWriterFactory implements DataWriterFactory, Serializable {
         outputWriterFactory,
         partitionId,
         taskId);
+  }
+
+  @Override
+  public DataWriter<InternalRow> createWriter(int partitionId, long taskId, long epochId) {
+    return createWriter(partitionId, taskId);
   }
 }

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2StreamingWrite.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2StreamingWrite.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.write;
+
+import static java.util.Objects.requireNonNull;
+
+import io.delta.kernel.Operation;
+import io.delta.kernel.Snapshot;
+import io.delta.kernel.Transaction;
+import io.delta.kernel.data.Row;
+import io.delta.kernel.engine.Engine;
+import io.delta.kernel.exceptions.ConcurrentTransactionException;
+import io.delta.kernel.internal.SnapshotImpl;
+import io.delta.kernel.internal.actions.Protocol;
+import io.delta.kernel.types.StructType;
+import io.delta.kernel.utils.CloseableIterable;
+import io.delta.spark.internal.v2.snapshot.DeltaSnapshotManager;
+import java.util.function.Function;
+import org.apache.spark.sql.connector.write.PhysicalWriteInfo;
+import org.apache.spark.sql.connector.write.WriterCommitMessage;
+import org.apache.spark.sql.connector.write.streaming.StreamingDataWriterFactory;
+import org.apache.spark.sql.connector.write.streaming.StreamingWrite;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * StreamingWrite for DSv2 streaming <b>Append</b>. Spark's {@code V2Writes} rebuilds this per
+ * micro-batch; {@link DeltaV2Write} supplies the executor write state ({@link
+ * DeltaV2DataWriterFactory}), built from a throwaway transaction whose operation-independent
+ * context is serialized into the factory. This class adds only the driver-side commit.
+ *
+ * <p>{@link #commit} builds its transaction from a freshly reloaded snapshot (so it commits at
+ * {@code latest+1}), mirroring V1's per-batch {@code deltaLog.startTransaction()}.
+ *
+ * <p><b>Idempotency:</b> {@code withTransactionId(queryId, epochId)} records a {@code
+ * SetTransaction}; {@link #commit} pre-checks the committed epoch for {@code queryId} and skips a
+ * replay, as V1 ({@code txn.txnVersion}) does. A concurrent same-epoch commit that races the
+ * pre-check is still caught as {@link ConcurrentTransactionException} and skipped.
+ *
+ * <p><b>Schema/protocol guard:</b> {@link #commit} fails the query if the reloaded snapshot's
+ * schema or protocol has diverged from the write state's, since Kernel does not re-validate the
+ * executor-written files at commit. TODO(#7140): rebuild the write state against the new
+ * schema/protocol so a compatible change (e.g. an added nullable column) is tolerated instead of
+ * forcing a query restart.
+ */
+class DeltaV2StreamingWrite implements StreamingWrite {
+
+  private static final Logger logger = LoggerFactory.getLogger(DeltaV2StreamingWrite.class);
+
+  private final Engine engine;
+  private final DeltaSnapshotManager snapshotManager;
+  private final String queryId;
+  private final DeltaV2DataWriterFactory dataWriterFactory;
+  // The write state's schema/protocol baseline; the per-epoch guard fails if the table diverges.
+  private final StructType writeSchema;
+  private final Protocol writeProtocol;
+
+  /**
+   * @param engine Kernel engine (driver-only)
+   * @param initialSnapshot the batch's planned snapshot; write-state source and guard baseline
+   * @param snapshotManager reloads the latest snapshot per epoch (see {@link #commit})
+   * @param queryId streaming query id; the transaction application id for cross-restart idempotency
+   * @param dataWriterFactoryBuilder builds the executor write state; supplied by {@link
+   *     DeltaV2Write} to share construction with the batch path
+   */
+  DeltaV2StreamingWrite(
+      Engine engine,
+      Snapshot initialSnapshot,
+      DeltaSnapshotManager snapshotManager,
+      String queryId,
+      Function<Transaction, DeltaV2DataWriterFactory> dataWriterFactoryBuilder) {
+    this.engine = requireNonNull(engine, "engine is null");
+    requireNonNull(initialSnapshot, "initialSnapshot is null");
+    this.snapshotManager = requireNonNull(snapshotManager, "snapshotManager is null");
+    this.queryId = requireNonNull(queryId, "queryId is null");
+    requireNonNull(dataWriterFactoryBuilder, "dataWriterFactoryBuilder is null");
+    this.writeSchema = initialSnapshot.getSchema();
+    this.writeProtocol = ((SnapshotImpl) initialSnapshot).getProtocol();
+    // We only need this transaction's serialized write context for the factory, not the commit
+    // (commit() builds its own per epoch).
+    Transaction stateTxn =
+        initialSnapshot
+            .buildUpdateTableTransaction(DeltaV2Write.getEngineInfo(), Operation.STREAMING_UPDATE)
+            .build(engine);
+    this.dataWriterFactory = dataWriterFactoryBuilder.apply(stateTxn);
+  }
+
+  @Override
+  public StreamingDataWriterFactory createStreamingWriterFactory(PhysicalWriteInfo info) {
+    return dataWriterFactory;
+  }
+
+  @Override
+  public boolean useCommitCoordinator() {
+    return false;
+  }
+
+  @Override
+  public void commit(long epochId, WriterCommitMessage[] messages) {
+    // Refresh so this epoch commits at latest+1.
+    Snapshot latestSnapshot = snapshotManager.loadLatestSnapshot();
+
+    // Fail loudly on a concurrent schema/protocol change.
+    assertSchemaAndProtocolUnchanged(latestSnapshot);
+
+    // TODO(#7140): no self-scan guard. A stream reading and writing the same table commits
+    //  as a blind append, skipping the conflict check V1 gets via readWholeTable().
+
+    // Skip an already-committed epoch. Its executor-written files are then orphaned (VACUUM'd).
+    long committedEpoch =
+        ((SnapshotImpl) latestSnapshot).getLatestTransactionVersion(engine, queryId).orElse(-1L);
+    if (committedEpoch >= epochId) {
+      logger.info("Skipping already committed epoch {} for query {}", epochId, queryId);
+      return;
+    }
+
+    try {
+      Transaction txn =
+          latestSnapshot
+              .buildUpdateTableTransaction(DeltaV2Write.getEngineInfo(), Operation.STREAMING_UPDATE)
+              .withTransactionId(queryId, epochId)
+              .build(engine);
+      CloseableIterable<Row> dataActions = DeltaV2WriterCommitMessage.toDataActions(messages);
+      long version = txn.commit(engine, dataActions).getVersion();
+      logger.info(
+          "DSv2 streaming epoch {} for query {} committed at version {}",
+          epochId,
+          queryId,
+          version);
+    } catch (ConcurrentTransactionException e) {
+      // Backstop for a concurrent writer racing the same epoch between the pre-check and commit.
+      logger.info("Skipping already committed epoch {} for query {}", epochId, queryId);
+    }
+  }
+
+  /** Fails the epoch if the fresh snapshot's schema/protocol diverged from the write's baseline. */
+  private void assertSchemaAndProtocolUnchanged(Snapshot latestSnapshot) {
+    if (!writeSchema.equals(latestSnapshot.getSchema())) {
+      throw new IllegalStateException(
+          "DSv2 streaming write to query "
+              + queryId
+              + " cannot continue: the table schema changed after the stream started. Restart the "
+              + "query to pick up the new schema.");
+    }
+    if (!writeProtocol.equals(((SnapshotImpl) latestSnapshot).getProtocol())) {
+      throw new IllegalStateException(
+          "DSv2 streaming write to query "
+              + queryId
+              + " cannot continue: the table protocol changed after the stream started. Restart "
+              + "the query to pick up the new protocol.");
+    }
+  }
+
+  @Override
+  public void abort(long epochId, WriterCommitMessage[] messages) {
+    logger.warn(
+        "DSv2 streaming epoch {} for query {} aborted; {} task message(s) not committed. "
+            + "Orphaned data files will be cleaned up by VACUUM.",
+        epochId,
+        queryId,
+        messages != null ? messages.length : 0);
+  }
+}

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2StreamingWrite.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2StreamingWrite.java
@@ -113,7 +113,8 @@ class DeltaV2StreamingWrite implements StreamingWrite {
     // Refresh so this epoch commits at latest+1.
     Snapshot latestSnapshot = snapshotManager.loadLatestSnapshot();
 
-    // Fail loudly on a concurrent schema/protocol change.
+    // TODO(#7140): no implicit type cast and mergeSchema. Fail loudly on a concurrent
+    // schema/protocol change.
     assertSchemaAndProtocolUnchanged(latestSnapshot);
 
     // TODO(#7140): no self-scan guard. A stream reading and writing the same table commits

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2Write.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2Write.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.write;
+
+import static java.util.Objects.requireNonNull;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.delta.kernel.Snapshot;
+import io.delta.kernel.engine.Engine;
+import io.delta.spark.internal.v2.snapshot.DeltaSnapshotManager;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.spark.sql.connector.write.BatchWrite;
+import org.apache.spark.sql.connector.write.LogicalWriteInfo;
+import org.apache.spark.sql.connector.write.Write;
+import org.apache.spark.sql.connector.write.streaming.StreamingWrite;
+import org.apache.spark.sql.delta.DeltaOptions;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+
+/**
+ * The DSv2 {@link Write} for Delta. Holds the table-level write context (engine, Hadoop conf, table
+ * path, snapshot, data schema, write info) and dispatches to a mode-specific implementation: {@link
+ * #toBatch} builds a {@link DeltaV2BatchWrite} (which owns its own driver-side context and
+ * single-transaction commit off {@code initialSnapshot}), and {@link #toStreaming} builds a {@link
+ * DeltaV2StreamingWrite} (per-epoch commit off a reloaded snapshot).
+ *
+ * <p>Both modes obtain their executor-side write state -- a {@link DeltaV2DataWriterFactory} --
+ * from the shared {@link DeltaV2WriteContext#buildDataWriterFactory}, which keeps the
+ * operation-independent executor-state construction (schema / protocol / path, not the {@code
+ * Operation}) separate from the mode-specific transaction lifecycle.
+ *
+ * <p>Only append is supported: the builder advertises no overwrite capability, so Spark does not
+ * route overwrite, truncate, Complete, or Update here.
+ */
+class DeltaV2Write implements Write {
+
+  // Streaming-write options the sink does not honor; rejected rather than silently ignored.
+  // DeltaV2WriteTest asserts over this exact list instead of a drifting copy. Referencing the
+  // DeltaOptions constants keeps these names in sync with the canonical option definitions.
+  @VisibleForTesting
+  static final List<String> UNSUPPORTED_STREAMING_OPTIONS =
+      Arrays.asList(
+          DeltaOptions.MERGE_SCHEMA_OPTION(),
+          DeltaOptions.OVERWRITE_SCHEMA_OPTION(),
+          DeltaOptions.REPLACE_WHERE_OPTION(),
+          DeltaOptions.REPLACE_ON_OPTION(),
+          DeltaOptions.REPLACE_USING_OPTION(),
+          DeltaOptions.PARTITION_OVERWRITE_MODE_OPTION(),
+          DeltaOptions.TXN_APP_ID(),
+          DeltaOptions.TXN_VERSION(),
+          DeltaOptions.USER_METADATA_OPTION());
+
+  private final Engine engine;
+  private final Configuration hadoopConf;
+  private final String tablePath;
+  private final Snapshot initialSnapshot;
+  private final DeltaSnapshotManager snapshotManager;
+  private final StructType dataSchema;
+  private final String queryId;
+  private final LogicalWriteInfo writeInfo;
+
+  /**
+   * @param initialSnapshot the batch's planned snapshot the write state is built from (and the
+   *     streaming guard's schema/protocol baseline)
+   * @param snapshotManager reloads the latest snapshot per epoch on the streaming path; unused by
+   *     the batch path (a single commit off {@code initialSnapshot})
+   */
+  DeltaV2Write(
+      Engine engine,
+      Configuration hadoopConf,
+      String tablePath,
+      Snapshot initialSnapshot,
+      DeltaSnapshotManager snapshotManager,
+      StructType dataSchema,
+      LogicalWriteInfo writeInfo) {
+    this.engine = requireNonNull(engine, "engine is null");
+    this.hadoopConf = requireNonNull(hadoopConf, "hadoopConf is null");
+    this.tablePath = requireNonNull(tablePath, "tablePath is null");
+    this.initialSnapshot = requireNonNull(initialSnapshot, "initialSnapshot is null");
+    this.snapshotManager = requireNonNull(snapshotManager, "snapshotManager is null");
+    this.dataSchema = requireNonNull(dataSchema, "dataSchema is null");
+    this.writeInfo = requireNonNull(writeInfo, "writeInfo is null");
+    this.queryId = requireNonNull(writeInfo.queryId(), "queryId is null");
+    rejectPartitionedTable();
+  }
+
+  /**
+   * Rejects partitioned tables (batch and streaming). The write always targets the table root with
+   * empty partition values, so a partitioned target would misplace every file -- silent corruption.
+   */
+  private void rejectPartitionedTable() {
+    List<String> partitionColumns = initialSnapshot.getPartitionColumnNames();
+    if (!partitionColumns.isEmpty()) {
+      throw new UnsupportedOperationException(
+          "DSv2 writes to Delta do not support partitioned tables (partition columns: "
+              + partitionColumns
+              + "). Use the V1 write path (format(\"delta\")) instead.");
+    }
+  }
+
+  /**
+   * Returns the engine info string for Delta commit metadata. Delegates to {@link
+   * DeltaV2WriteContext#getEngineInfo} so batch and streaming share a single source of truth.
+   */
+  static String getEngineInfo() {
+    return DeltaV2WriteContext.getEngineInfo();
+  }
+
+  @Override
+  public BatchWrite toBatch() {
+    // The batch path builds its own driver-side context (DeltaV2BatchWriteContext) and commits a
+    // single transaction off initialSnapshot.
+    return new DeltaV2BatchWrite(
+        engine, hadoopConf, tablePath, initialSnapshot, dataSchema, writeInfo);
+  }
+
+  @Override
+  public StreamingWrite toStreaming() {
+    rejectUnsupportedStreamingOptions();
+    // Build the operation-independent write context once; the streaming write drives its own
+    // per-epoch transactions (Operation.STREAMING_UPDATE) and reuses buildDataWriterFactory to
+    // produce the executor write state -- the same setup the batch path uses, no duplication.
+    DeltaV2WriteContext context =
+        DeltaV2WriteContext.create(
+            engine, hadoopConf, tablePath, initialSnapshot, dataSchema, writeInfo);
+    return new DeltaV2StreamingWrite(
+        engine, initialSnapshot, snapshotManager, queryId, context::buildDataWriterFactory);
+  }
+
+  /**
+   * Rejects streaming-write options the sink does not honor (schema evolution, overwrite/replace,
+   * idempotent-txn overrides, user metadata) so a user gets a clear error rather than silent
+   * ignore. Append is the only supported mode.
+   */
+  private void rejectUnsupportedStreamingOptions() {
+    CaseInsensitiveStringMap options = writeInfo.options();
+    List<String> rejected = new ArrayList<>();
+    for (String key : UNSUPPORTED_STREAMING_OPTIONS) {
+      if (options.containsKey(key)) {
+        rejected.add(key);
+      }
+    }
+    if (!rejected.isEmpty()) {
+      throw new UnsupportedOperationException(
+          "DSv2 streaming writes to Delta do not support the option(s): "
+              + rejected
+              + ". Use the V1 write path (format(\"delta\")) if you need them.");
+    }
+  }
+}

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2WriteBuilder.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2WriteBuilder.java
@@ -21,6 +21,7 @@ import io.delta.kernel.Snapshot;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.internal.util.ColumnMapping;
 import io.delta.kernel.internal.util.ColumnMapping.ColumnMappingMode;
+import io.delta.spark.internal.v2.snapshot.DeltaSnapshotManager;
 import io.delta.spark.internal.v2.utils.SchemaUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.spark.sql.connector.write.LogicalWriteInfo;
@@ -46,6 +47,8 @@ public class DeltaV2WriteBuilder implements WriteBuilder {
   private final String tablePath;
   private final Configuration hadoopConf;
   private final Snapshot initialSnapshot;
+  private final DeltaSnapshotManager snapshotManager;
+  private final StructType dataSchema;
   private final LogicalWriteInfo writeInfo;
 
   /**
@@ -53,6 +56,9 @@ public class DeltaV2WriteBuilder implements WriteBuilder {
    * @param tablePath filesystem path to the Delta table root
    * @param hadoopConf Hadoop configuration (with merged table options)
    * @param initialSnapshot Kernel snapshot loaded at table construction time
+   * @param snapshotManager reloads the latest snapshot; used by the streaming write to build each
+   *     epoch's commit against the current table state (see {@link DeltaV2StreamingWrite})
+   * @param dataSchema the table's data (non-partition) schema, from DeltaV2Table's SchemaProvider
    * @param writeInfo Spark's logical write info (schema, queryId, options)
    */
   public DeltaV2WriteBuilder(
@@ -60,11 +66,15 @@ public class DeltaV2WriteBuilder implements WriteBuilder {
       String tablePath,
       Configuration hadoopConf,
       Snapshot initialSnapshot,
+      DeltaSnapshotManager snapshotManager,
+      StructType dataSchema,
       LogicalWriteInfo writeInfo) {
     this.engine = requireNonNull(engine, "engine is null");
     this.tablePath = requireNonNull(tablePath, "tablePath is null");
     this.hadoopConf = requireNonNull(hadoopConf, "hadoopConf is null");
     this.initialSnapshot = requireNonNull(initialSnapshot, "initialSnapshot is null");
+    this.snapshotManager = requireNonNull(snapshotManager, "snapshotManager is null");
+    this.dataSchema = requireNonNull(dataSchema, "dataSchema is null");
     this.writeInfo = requireNonNull(writeInfo, "writeInfo is null");
   }
 
@@ -85,7 +95,11 @@ public class DeltaV2WriteBuilder implements WriteBuilder {
 
     validateDataSchema(initialSnapshot, writeInfo.schema());
 
-    return new DeltaV2BatchWrite(engine, hadoopConf, tablePath, initialSnapshot, writeInfo);
+    // Returns a mode-dispatching Write: toBatch() -> DeltaV2BatchWrite (batch commit off
+    // initialSnapshot), toStreaming() -> DeltaV2StreamingWrite (per-epoch commit off the latest
+    // snapshot via snapshotManager). Both modes share the executor-side write-state construction.
+    return new DeltaV2Write(
+        engine, hadoopConf, tablePath, initialSnapshot, snapshotManager, dataSchema, writeInfo);
   }
 
   static void validateDataSchema(Snapshot initialSnapshot, StructType dataSchema) {

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2WriteContext.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2WriteContext.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.write;
+
+import io.delta.kernel.Snapshot;
+import io.delta.kernel.Transaction;
+import io.delta.kernel.data.Row;
+import io.delta.kernel.engine.Engine;
+import io.delta.spark.internal.v2.read.DeltaParquetFileFormatV2;
+import io.delta.spark.internal.v2.utils.PartitionUtils;
+import io.delta.spark.internal.v2.utils.ScalaUtils;
+import io.delta.spark.internal.v2.utils.SchemaUtils;
+import io.delta.spark.internal.v2.utils.SerializableKernelRowWrapper;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.time.ZoneId;
+import java.util.Collections;
+import java.util.Map;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.connector.write.LogicalWriteInfo;
+import org.apache.spark.sql.execution.datasources.OutputWriterFactory;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.util.SerializableConfiguration;
+import scala.Option;
+
+/**
+ * Shared driver-side setup for Delta DSv2 writes, independent of the write mode's {@code
+ * Operation}. Builds the operation-independent write state -- schema split (data / partition),
+ * Spark Parquet {@link OutputWriterFactory}, serializable Hadoop conf, session time zone -- once,
+ * from the table snapshot. The mode-specific transaction lifecycle lives in subclasses: {@link
+ * DeltaV2BatchWriteContext} (batch, {@code Operation.WRITE}) for the batch path, while the
+ * streaming path drives per-epoch transactions and reuses only {@link #buildDataWriterFactory}.
+ *
+ * <p>{@link #buildDataWriterFactory} turns a caller-supplied {@link Transaction} into the executor
+ * write state ({@link DeltaV2DataWriterFactory}); it is the single reuse point so batch and
+ * streaming never duplicate the Parquet / schema setup.
+ */
+class DeltaV2WriteContext {
+
+  /** Returns the engine info string for Delta commit metadata. */
+  static String getEngineInfo() {
+    return "Apache-Spark/"
+        + org.apache.spark.package$.MODULE$.SPARK_VERSION()
+        + " Delta-Lake/"
+        + io.delta.package$.MODULE$.VERSION();
+  }
+
+  private final Engine engine;
+  private final StructType dataSchema;
+  private final StructType partitionSchema;
+  private final io.delta.kernel.types.StructType kernelTableSchema;
+  private final OutputWriterFactory outputWriterFactory;
+  private final SerializableConfiguration serializableHadoopConf;
+  private final String sessionTimeZone;
+
+  static DeltaV2WriteContext create(
+      Engine engine,
+      Configuration hadoopConf,
+      String tablePath,
+      Snapshot initialSnapshot,
+      StructType dataSchema,
+      LogicalWriteInfo writeInfo) {
+    return new DeltaV2WriteContext(
+        engine, hadoopConf, tablePath, initialSnapshot, dataSchema, writeInfo);
+  }
+
+  private static void verifySchemaForWrite(DeltaParquetFileFormatV2 format, StructType dataSchema) {
+    try {
+      org.apache.spark.sql.execution.datasources.DataSourceUtils.class
+          .getMethod(
+              "verifySchema",
+              org.apache.spark.sql.execution.datasources.FileFormat.class,
+              StructType.class,
+              boolean.class)
+          .invoke(null, format, dataSchema, false);
+    } catch (NoSuchMethodException e) {
+      invokeLegacyVerifySchema(format, dataSchema);
+    } catch (java.lang.reflect.InvocationTargetException e) {
+      throwUnchecked(e.getCause());
+    } catch (IllegalAccessException e) {
+      throw new IllegalStateException("Unable to verify Parquet write schema", e);
+    }
+  }
+
+  private static void invokeLegacyVerifySchema(
+      DeltaParquetFileFormatV2 format, StructType dataSchema) {
+    try {
+      org.apache.spark.sql.execution.datasources.DataSourceUtils.class
+          .getMethod(
+              "verifySchema",
+              org.apache.spark.sql.execution.datasources.FileFormat.class,
+              StructType.class)
+          .invoke(null, format, dataSchema);
+    } catch (java.lang.reflect.InvocationTargetException e) {
+      throwUnchecked(e.getCause());
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException("Unable to verify Parquet write schema", e);
+    }
+  }
+
+  private static void throwUnchecked(Throwable cause) {
+    if (cause instanceof RuntimeException) {
+      throw (RuntimeException) cause;
+    }
+    if (cause instanceof Error) {
+      throw (Error) cause;
+    }
+    throw new IllegalStateException("Unable to verify Parquet write schema", cause);
+  }
+
+  protected DeltaV2WriteContext(
+      Engine engine,
+      Configuration hadoopConf,
+      String tablePath,
+      Snapshot initialSnapshot,
+      StructType dataSchema,
+      LogicalWriteInfo writeInfo) {
+    this.engine = engine;
+    // dataSchema is wired in from DeltaV2Table's SchemaProvider (which already split off the
+    // partition columns) rather than re-derived here, so the schema split lives in one place.
+    this.dataSchema = dataSchema;
+
+    this.kernelTableSchema = initialSnapshot.getSchema();
+    StructType tableSchema = SchemaUtils.convertKernelSchemaToSparkSchema(kernelTableSchema);
+    java.util.Set<String> partitionCols =
+        new java.util.HashSet<>(initialSnapshot.getPartitionColumnNames());
+    this.partitionSchema =
+        partitionCols.isEmpty()
+            ? new StructType()
+            : new StructType(
+                java.util.Arrays.stream(tableSchema.fields())
+                    .filter(field -> partitionCols.contains(field.name()))
+                    .toArray(org.apache.spark.sql.types.StructField[]::new));
+
+    SparkSession session =
+        SparkSession.getActiveSession()
+            .getOrElse(
+                () -> {
+                  throw new IllegalStateException(
+                      "SparkSession not active (write needs it for Parquet)");
+                });
+    this.sessionTimeZone = session.sessionState().conf().sessionLocalTimeZone();
+
+    Job job;
+    try {
+      job = Job.getInstance(hadoopConf);
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to create Hadoop job for Parquet write", e);
+    }
+    DeltaParquetFileFormatV2 format =
+        PartitionUtils.createDeltaParquetFileFormat(
+            initialSnapshot,
+            tablePath,
+            /* optimizationsEnabled */ true,
+            /* useMetadataRowIndex */ Option.empty(),
+            /* isCDCRead */ false);
+    verifySchemaForWrite(format, dataSchema);
+    org.apache.spark.sql.execution.datasources.DataSourceUtils.checkFieldNames(format, dataSchema);
+    Map<String, String> options = writeInfo.options().asCaseSensitiveMap();
+    scala.collection.immutable.Map<String, String> scalaOpts =
+        ScalaUtils.toScalaMap(options != null ? options : Collections.emptyMap());
+    this.outputWriterFactory = format.prepareWrite(session, job, scalaOpts, dataSchema);
+    this.serializableHadoopConf = new SerializableConfiguration(job.getConfiguration());
+  }
+
+  /**
+   * Builds the executor-side write state from {@code transaction}: the serialized transaction state
+   * and target directory (from a Kernel write context), packaged with the shared Parquet {@link
+   * OutputWriterFactory}, Hadoop conf, and data schema into a {@link DeltaV2DataWriterFactory}.
+   *
+   * <p>Operation-independent, so any write mode (batch {@code Operation.WRITE}, streaming {@code
+   * Operation.STREAMING_UPDATE}) can build its factory from its own transaction without duplicating
+   * the driver-side Parquet / schema setup done in the constructor.
+   */
+  DeltaV2DataWriterFactory buildDataWriterFactory(Transaction transaction) {
+    Row txnState = transaction.getTransactionState(engine);
+    SerializableKernelRowWrapper serializedTxnState = new SerializableKernelRowWrapper(txnState);
+    // TODO(#7140): pass real partitionValues to support partitioned writes.
+    String targetDirectory =
+        Transaction.getWriteContext(engine, txnState, /* partitionValues */ Collections.emptyMap())
+            .getTargetDirectory();
+    return new DeltaV2DataWriterFactory(
+        targetDirectory,
+        serializableHadoopConf,
+        serializedTxnState,
+        dataSchema,
+        outputWriterFactory);
+  }
+
+  Engine getEngine() {
+    return engine;
+  }
+
+  StructType getDataSchema() {
+    return dataSchema;
+  }
+
+  StructType getPartitionSchema() {
+    return partitionSchema;
+  }
+
+  io.delta.kernel.types.StructType getKernelTableSchema() {
+    return kernelTableSchema;
+  }
+
+  OutputWriterFactory getOutputWriterFactory() {
+    return outputWriterFactory;
+  }
+
+  SerializableConfiguration getSerializableHadoopConf() {
+    return serializableHadoopConf;
+  }
+
+  ZoneId getSessionTimeZone() {
+    return ZoneId.of(sessionTimeZone);
+  }
+
+  String getSessionTimeZoneId() {
+    return sessionTimeZone;
+  }
+}

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/write/DeltaV2BatchWriteTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/write/DeltaV2BatchWriteTest.java
@@ -163,6 +163,6 @@ public class DeltaV2BatchWriteTest extends DeltaV2TestBase {
     LogicalWriteInfo info =
         WriteTestUtils.logicalWriteInfo(TABLE_SCHEMA, CaseInsensitiveStringMap.empty());
     return new DeltaV2BatchWrite(
-        defaultEngine, spark.sessionState().newHadoopConf(), path, snapshot, info);
+        defaultEngine, spark.sessionState().newHadoopConf(), path, snapshot, TABLE_SCHEMA, info);
   }
 }

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/write/DeltaV2StreamingWriteTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/write/DeltaV2StreamingWriteTest.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.write;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.delta.kernel.Snapshot;
+import io.delta.spark.internal.v2.DeltaV2TestBase;
+import io.delta.spark.internal.v2.InternalRowTestUtils;
+import io.delta.spark.internal.v2.snapshot.PathBasedSnapshotManager;
+import java.io.File;
+import java.util.List;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.connector.write.DataWriter;
+import org.apache.spark.sql.connector.write.LogicalWriteInfo;
+import org.apache.spark.sql.connector.write.WriterCommitMessage;
+import org.apache.spark.sql.connector.write.streaming.StreamingDataWriterFactory;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Unit tests for {@link DeltaV2StreamingWrite}; the streaming counterpart of DeltaV2BatchWriteTest.
+ */
+public class DeltaV2StreamingWriteTest extends DeltaV2TestBase {
+
+  private static final StructType TABLE_SCHEMA =
+      DataTypes.createStructType(
+          new StructField[] {
+            DataTypes.createStructField("id", DataTypes.IntegerType, true),
+            DataTypes.createStructField("name", DataTypes.StringType, true)
+          });
+
+  @Test
+  public void testUseCommitCoordinator_isFalse(@TempDir File tempDir) {
+    DeltaV2StreamingWrite write = newWrite(createTable(tempDir, "streaming_no_coordinator"));
+    assertFalse(write.useCommitCoordinator());
+  }
+
+  @Test
+  public void testCreateStreamingWriterFactory_returnsDeltaV2DataWriterFactory(
+      @TempDir File tempDir) {
+    DeltaV2StreamingWrite write = newWrite(createTable(tempDir, "streaming_factory_type"));
+    StreamingDataWriterFactory factory =
+        write.createStreamingWriterFactory(WriteTestUtils.physicalWriteInfo(1));
+    assertTrue(factory instanceof DeltaV2DataWriterFactory);
+  }
+
+  /**
+   * Distinct epochs each append: epoch 0 and epoch 1 accumulate, and the rows are the ones written.
+   */
+  @Test
+  public void testCommit_distinctEpochsAppend(@TempDir File tempDir) throws Exception {
+    String path = createTable(tempDir, "streaming_distinct_epochs");
+    DeltaV2StreamingWrite write = newWrite(path);
+
+    write.commit(0L, new WriterCommitMessage[] {writeEpoch(write, 0L, 1, "Alice", 2, "Bob")});
+    write.commit(1L, new WriterCommitMessage[] {writeEpoch(write, 1L, 3, "Carol", 4, "Dave")});
+
+    List<Row> rows = spark.read().format("delta").load(path).orderBy("id").collectAsList();
+    assertEquals(4, rows.size(), "distinct epochs must accumulate");
+    assertEquals("Alice", rows.get(0).getString(1));
+    assertEquals("Bob", rows.get(1).getString(1));
+    assertEquals("Carol", rows.get(2).getString(1));
+    assertEquals("Dave", rows.get(3).getString(1));
+  }
+
+  /**
+   * A concurrent data-only append must not break the stream: the per-epoch snapshot refresh picks
+   * it up and this epoch commits on top of it rather than clobbering it.
+   */
+  @Test
+  public void testCommit_toleratesConcurrentDataAppend(@TempDir File tempDir) throws Exception {
+    String path = createTable(tempDir, "streaming_concurrent_append");
+    DeltaV2StreamingWrite write = newWrite(path);
+
+    // A concurrent writer appends to the same table after the streaming write was constructed.
+    spark.sql("INSERT INTO delta.`" + path + "` VALUES (99, 'Concurrent')");
+
+    write.commit(0L, new WriterCommitMessage[] {writeEpoch(write, 0L, 1, "Alice")});
+
+    List<Row> rows = spark.read().format("delta").load(path).orderBy("id").collectAsList();
+    assertEquals(2, rows.size(), "epoch must commit on top of the concurrent append, not clobber");
+    assertEquals("Alice", rows.get(0).getString(1));
+    assertEquals("Concurrent", rows.get(1).getString(1));
+  }
+
+  /**
+   * A schema change after the stream started must fail the epoch loudly (the guard), not silently
+   * append files written against the stale schema.
+   */
+  @Test
+  public void testCommit_failsOnConcurrentSchemaChange(@TempDir File tempDir) throws Exception {
+    String path = createTable(tempDir, "streaming_schema_change");
+    DeltaV2StreamingWrite write = newWrite(path);
+    WriterCommitMessage[] messages = {writeEpoch(write, 0L, 1, "Alice", 2, "Bob")};
+
+    // Concurrent column add, after the write's schema was frozen at construction.
+    spark.sql("ALTER TABLE delta.`" + path + "` ADD COLUMN (extra STRING)");
+
+    IllegalStateException e =
+        assertThrows(IllegalStateException.class, () -> write.commit(0L, messages));
+    assertTrue(
+        e.getMessage().contains("schema changed"),
+        "guard should report the schema change: " + e.getMessage());
+    // Nothing was appended: the guard fired before the commit.
+    assertEquals(0L, spark.read().format("delta").load(path).count());
+  }
+
+  /**
+   * A protocol change after the stream started must fail the epoch loudly (the guard). Enabling row
+   * tracking adds a writer feature (a protocol change Kernel can still read) without touching the
+   * schema, so only the protocol branch can fire.
+   */
+  @Test
+  public void testCommit_failsOnConcurrentProtocolChange(@TempDir File tempDir) throws Exception {
+    String path = createTable(tempDir, "streaming_protocol_change");
+    DeltaV2StreamingWrite write = newWrite(path);
+    WriterCommitMessage[] messages = {writeEpoch(write, 0L, 1, "Alice", 2, "Bob")};
+
+    // Concurrent protocol upgrade (adds the rowTracking writer feature), after the write's protocol
+    // was frozen at construction.
+    spark.sql(
+        "ALTER TABLE delta.`" + path + "` SET TBLPROPERTIES ('delta.enableRowTracking' = 'true')");
+
+    IllegalStateException e =
+        assertThrows(IllegalStateException.class, () -> write.commit(0L, messages));
+    assertTrue(
+        e.getMessage().contains("protocol changed"),
+        "guard should report the protocol change: " + e.getMessage());
+    // Nothing was appended: the guard fired before the commit.
+    assertEquals(0L, spark.read().format("delta").load(path).count());
+  }
+
+  /**
+   * Replaying an already-committed epoch must be an idempotent no-op: the data is committed once,
+   * and re-committing the same epoch does not duplicate it (the {@code withTransactionId} guard).
+   */
+  @Test
+  public void testCommit_isIdempotentOnEpochReplay(@TempDir File tempDir) throws Exception {
+    String path = createTable(tempDir, "streaming_idempotent_replay");
+    DeltaV2StreamingWrite write = newWrite(path);
+
+    write.commit(0L, new WriterCommitMessage[] {writeEpoch(write, 0L, 1, "Alice", 2, "Bob")});
+    long rowsAfterFirstCommit = spark.read().format("delta").load(path).count();
+    long versionsAfterFirstCommit = spark.sql("DESCRIBE HISTORY delta.`" + path + "`").count();
+
+    // Replay epoch 0 with a FRESH executor write (new UUID file paths, as a real retry produces).
+    // Replaying the same commit message would keep the row count at 2 via Delta's path dedup even
+    // if the guard never fired; fresh paths make the row-count assertion itself prove the skip.
+    write.commit(0L, new WriterCommitMessage[] {writeEpoch(write, 0L, 3, "Carol", 4, "Dave")});
+    long rowsAfterReplay = spark.read().format("delta").load(path).count();
+
+    assertEquals(2L, rowsAfterFirstCommit);
+    assertEquals(
+        2L,
+        rowsAfterReplay,
+        "replaying an already-committed epoch (with freshly written files) must not add data");
+    // Also assert no new table version: a redundant (even empty) re-commit would advance it, which
+    // row count alone can't detect.
+    assertEquals(
+        versionsAfterFirstCommit,
+        spark.sql("DESCRIBE HISTORY delta.`" + path + "`").count(),
+        "replaying an already-committed epoch must not create a new table version");
+  }
+
+  /**
+   * Aborting an epoch commits nothing: the written files are left orphaned, not added to the table.
+   */
+  @Test
+  public void testAbort_doesNotCommit(@TempDir File tempDir) throws Exception {
+    String path = createTable(tempDir, "streaming_abort");
+    DeltaV2StreamingWrite write = newWrite(path);
+    // Stage a real file so the abort has data to discard, not a trivial no-op.
+    WriterCommitMessage[] messages = {writeEpoch(write, 0L, 1, "Alice", 2, "Bob")};
+    long versionsBefore = spark.sql("DESCRIBE HISTORY delta.`" + path + "`").count();
+
+    write.abort(0L, messages);
+
+    assertEquals(0L, spark.read().format("delta").load(path).count(), "abort must not commit data");
+    // Also assert no new table version (row count is 0 either way; matches DeltaV2BatchWriteTest).
+    assertEquals(
+        versionsBefore,
+        spark.sql("DESCRIBE HISTORY delta.`" + path + "`").count(),
+        "abort must not create a new table version");
+  }
+
+  /**
+   * Runs the executor-side writer for one epoch and returns its commit message. {@code idNamePairs}
+   * is a flat list of (int id, String name) values.
+   */
+  private WriterCommitMessage writeEpoch(
+      DeltaV2StreamingWrite write, long epochId, Object... idNamePairs) throws Exception {
+    DataWriter<InternalRow> writer =
+        write
+            .createStreamingWriterFactory(WriteTestUtils.physicalWriteInfo(1))
+            .createWriter(0, 0L, epochId);
+    for (int i = 0; i < idNamePairs.length; i += 2) {
+      writer.write(InternalRowTestUtils.row(idNamePairs[i], idNamePairs[i + 1]));
+    }
+    return writer.commit();
+  }
+
+  private String createTable(File tempDir, String tableName) {
+    String path = tempDir.getAbsolutePath();
+    spark.sql(
+        String.format(
+            "CREATE TABLE %s (id INT, name STRING) USING delta LOCATION '%s'", tableName, path));
+    return path;
+  }
+
+  private DeltaV2StreamingWrite newWrite(String path) {
+    PathBasedSnapshotManager snapshotManager =
+        new PathBasedSnapshotManager(path, spark.sessionState().newHadoopConf());
+    Snapshot snapshot = snapshotManager.loadLatestSnapshot();
+    LogicalWriteInfo info =
+        WriteTestUtils.logicalWriteInfo(TABLE_SCHEMA, CaseInsensitiveStringMap.empty());
+    DeltaV2Write write =
+        new DeltaV2Write(
+            defaultEngine,
+            spark.sessionState().newHadoopConf(),
+            path,
+            snapshot,
+            snapshotManager,
+            TABLE_SCHEMA,
+            info);
+    return (DeltaV2StreamingWrite) write.toStreaming();
+  }
+}

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/write/DeltaV2WriteContextTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/write/DeltaV2WriteContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (2025) The Delta Lake Project Authors.
+ * Copyright (2026) The Delta Lake Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,13 +17,14 @@ package io.delta.spark.internal.v2.write;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.delta.kernel.Operation;
 import io.delta.kernel.Snapshot;
 import io.delta.kernel.TableManager;
+import io.delta.kernel.Transaction;
 import io.delta.kernel.defaults.engine.DefaultEngine;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.utils.CloseableIterable;
@@ -40,10 +41,15 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-public class DeltaV2BatchWriteContextTest extends DeltaV2TestBase {
+/**
+ * Unit tests for {@link DeltaV2WriteContext}, the operation-independent base context shared by the
+ * batch and streaming write paths. {@link DeltaV2BatchWriteContextTest} covers the batch subclass;
+ * this exercises the base directly (the streaming path builds a bare {@code DeltaV2WriteContext}).
+ */
+public class DeltaV2WriteContextTest extends DeltaV2TestBase {
 
   @Test
-  public void createInitializesDriverWriteState(@TempDir File tempDir) throws Exception {
+  public void createInitializesOperationIndependentState(@TempDir File tempDir) throws Exception {
     String path = tempDir.getAbsolutePath();
     StructType tableSchema = tableSchema();
     Configuration hadoopConf = spark.sessionState().newHadoopConf();
@@ -51,35 +57,52 @@ public class DeltaV2BatchWriteContextTest extends DeltaV2TestBase {
     createKernelTable(path, tableSchema, engine);
     Snapshot snapshot = TableManager.loadSnapshot(path).build(engine);
 
-    DeltaV2BatchWriteContext context =
-        DeltaV2BatchWriteContext.create(
+    DeltaV2WriteContext context =
+        DeltaV2WriteContext.create(
             engine, hadoopConf, path, snapshot, tableSchema, new TestLogicalWriteInfo(tableSchema));
 
     assertSame(engine, context.getEngine());
-    assertNotNull(context.getTransaction());
-    assertNotNull(context.getSerializedTxnState());
-    assertNotNull(context.getSerializedTxnState().getRow());
     assertNotNull(context.getOutputWriterFactory());
     assertNotNull(context.getSerializableHadoopConf());
     assertNotNull(context.getSerializableHadoopConf().value());
 
+    // dataSchema is wired through unchanged (not re-derived from the snapshot); the (unpartitioned)
+    // table has no partition columns.
     assertArrayEquals(tableSchema.fieldNames(), context.getDataSchema().fieldNames());
     assertEquals(0, context.getPartitionSchema().fields().length);
-    assertEquals(snapshot.getSchema().length(), context.getKernelTableSchema().length());
 
     String sessionTimeZone = spark.sessionState().conf().sessionLocalTimeZone();
     assertEquals(sessionTimeZone, context.getSessionTimeZoneId());
     assertEquals(ZoneId.of(sessionTimeZone), context.getSessionTimeZone());
+  }
 
-    String targetDirectory = context.getTargetDirectory(Collections.emptyMap());
-    assertNotNull(targetDirectory);
-    assertFalse(targetDirectory.isEmpty());
-    assertTrue(targetDirectory.contains(path));
+  @Test
+  public void buildDataWriterFactoryProducesExecutorState(@TempDir File tempDir) throws Exception {
+    String path = tempDir.getAbsolutePath();
+    StructType tableSchema = tableSchema();
+    Configuration hadoopConf = spark.sessionState().newHadoopConf();
+    Engine engine = DefaultEngine.create(hadoopConf);
+    createKernelTable(path, tableSchema, engine);
+    Snapshot snapshot = TableManager.loadSnapshot(path).build(engine);
+
+    DeltaV2WriteContext context =
+        DeltaV2WriteContext.create(
+            engine, hadoopConf, path, snapshot, tableSchema, new TestLogicalWriteInfo(tableSchema));
+
+    // The base is operation-independent: any transaction (here a WRITE txn off the snapshot) can be
+    // turned into the executor-side factory. A real factory with a serialized txn state proves the
+    // shared setup produced usable state.
+    Transaction txn =
+        snapshot
+            .buildUpdateTableTransaction(DeltaV2WriteContext.getEngineInfo(), Operation.WRITE)
+            .build(engine);
+    DeltaV2DataWriterFactory factory = context.buildDataWriterFactory(txn);
+    assertNotNull(factory);
   }
 
   @Test
   public void engineInfoUsesExpectedPrefix() {
-    assertTrue(DeltaV2BatchWriteContext.getEngineInfo().startsWith("Apache-Spark/"));
+    assertTrue(DeltaV2WriteContext.getEngineInfo().startsWith("Apache-Spark/"));
   }
 
   private static void createKernelTable(String path, StructType schema, Engine engine) {

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/write/DeltaV2WriteTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/write/DeltaV2WriteTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.write;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.delta.kernel.Snapshot;
+import io.delta.spark.internal.v2.DeltaV2TestBase;
+import io.delta.spark.internal.v2.snapshot.PathBasedSnapshotManager;
+import java.io.File;
+import java.util.Map;
+import org.apache.spark.sql.connector.write.LogicalWriteInfo;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/** Unit tests for {@link DeltaV2Write}. */
+public class DeltaV2WriteTest extends DeltaV2TestBase {
+
+  private static final StructType TABLE_SCHEMA =
+      DataTypes.createStructType(
+          new StructField[] {
+            DataTypes.createStructField("id", DataTypes.IntegerType, true),
+            DataTypes.createStructField("name", DataTypes.StringType, true)
+          });
+
+  @Test
+  public void testToBatch_returnsDeltaV2BatchWrite(@TempDir File tempDir) {
+    String path = createTable(tempDir, "write_to_batch");
+    DeltaV2Write write = newWrite(path, CaseInsensitiveStringMap.empty());
+
+    assertTrue(write.toBatch() instanceof DeltaV2BatchWrite);
+  }
+
+  @Test
+  public void testToStreaming_returnsDeltaV2StreamingWrite(@TempDir File tempDir) {
+    String path = createTable(tempDir, "write_to_streaming");
+    DeltaV2Write write = newWrite(path, CaseInsensitiveStringMap.empty());
+
+    assertTrue(write.toStreaming() instanceof DeltaV2StreamingWrite);
+  }
+
+  @Test
+  public void testToStreaming_rejectsUnsupportedOptions(@TempDir File tempDir) {
+    String path = createTable(tempDir, "write_rejects_options");
+
+    // Iterate the production list so a change there (add/remove an option) is covered without
+    // updating a separate copy here.
+    for (String option : DeltaV2Write.UNSUPPORTED_STREAMING_OPTIONS) {
+      CaseInsensitiveStringMap options = new CaseInsensitiveStringMap(Map.of(option, "x"));
+      DeltaV2Write write = newWrite(path, options);
+      assertThrows(
+          UnsupportedOperationException.class,
+          write::toStreaming,
+          "streaming write should reject option: " + option);
+    }
+  }
+
+  private String createTable(File tempDir, String tableName) {
+    String path = tempDir.getAbsolutePath();
+    spark.sql(
+        String.format(
+            "CREATE TABLE %s (id INT, name STRING) USING delta LOCATION '%s'", tableName, path));
+    return path;
+  }
+
+  private DeltaV2Write newWrite(String path, CaseInsensitiveStringMap options) {
+    PathBasedSnapshotManager snapshotManager =
+        new PathBasedSnapshotManager(path, spark.sessionState().newHadoopConf());
+    Snapshot snapshot = snapshotManager.loadLatestSnapshot();
+    LogicalWriteInfo info = WriteTestUtils.logicalWriteInfo(TABLE_SCHEMA, options);
+    return new DeltaV2Write(
+        defaultEngine,
+        spark.sessionState().newHadoopConf(),
+        path,
+        snapshot,
+        snapshotManager,
+        TABLE_SCHEMA,
+        info);
+  }
+}

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/write/DeltaV2WriterCommitMessageTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/write/DeltaV2WriterCommitMessageTest.java
@@ -128,6 +128,7 @@ public class DeltaV2WriterCommitMessageTest extends DeltaV2TestBase {
             spark.sessionState().newHadoopConf(),
             path,
             snapshot,
+            TABLE_SCHEMA,
             WriteTestUtils.logicalWriteInfo(TABLE_SCHEMA, CaseInsensitiveStringMap.empty()));
     return (DeltaV2DataWriterFactory)
         write.createBatchWriterFactory(WriteTestUtils.physicalWriteInfo(1));


### PR DESCRIPTION
## Description

Adds basic **Append-mode streaming write** support to the Kernel-based DSv2 Delta connector (`DeltaV2Table`).

- New `DeltaV2StreamingWrite` (`StreamingWrite`): each epoch's commit builds its transaction off a freshly reloaded snapshot (commits at `latest+1`), with idempotent epoch commits via `withTransactionId(queryId, epochId)` (a pre-check plus a `ConcurrentTransactionException` backstop), and a schema/protocol guard that fails the query if the table diverged after the stream started.
- `DeltaV2Table` advertises the `STREAMING_WRITE` capability; `DeltaV2Write.toStreaming()` constructs the streaming write and rejects unsupported streaming options (`mergeSchema`, `replaceWhere`, `txnAppId`, `userMetadata`, etc.) with a clear error instead of silently ignoring them.
- `DeltaV2DataWriterFactory` now also implements `StreamingDataWriterFactory` (epoch-agnostic — the per-task executor write is shared with the batch path).
- Threads `DeltaSnapshotManager` through `DeltaV2WriteBuilder` -> `DeltaV2Write` so the streaming write can reload the latest snapshot per epoch.

## How was this patch tested?

- New `DeltaV2StreamingWriteTest` (JUnit): distinct epochs append, tolerates a concurrent data append, fails loudly on a concurrent schema change, idempotent epoch replay (with freshly written files), and abort commits nothing.
- New `DeltaV2SinkSuite` runs the existing `DeltaSinkSuite` with the V2 sink enabled via a new `V2ForceTest` trait, with each base test explicitly classified as passing (routes to the V2 sink) or failing/ignored (path-based V1-only, or genuine V2-sink gaps).
- Extended `DeltaSinkSuite` with restart / exactly-once recovery coverage (committed batches not re-appended; stable query id and transaction version preserved across restart).
- Updated existing V2 write unit tests for the new `snapshotManager` constructor argument.

## Does this PR introduce _any_ user-facing changes?

No.
