### PR TITLE
Add overridable dataPath for transactions

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -296,6 +296,8 @@ trait OptimisticTransactionImpl extends TransactionHelper
 
   def clock: Clock = deltaLog.clock
 
+  override def dataPath: Path = deltaLog.dataPath
+
   // This would be a quick operation if we already validated the checksum
   // Otherwise, we should at least perform the validation here.
   // NOTE: When incremental commits are enabled, skip validation unless it was specifically
@@ -641,7 +643,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
     if (!identityColumnAllowed &&
         ColumnWithDefaultExprUtils.hasIdentityColumn(newMetadataTmp.schema)) {
       throw DeltaErrors.unsupportedWriterTableFeaturesInTableException(
-        deltaLog.dataPath.toString, Seq(IdentityColumnsTableFeature.name))
+        dataPath.toString, Seq(IdentityColumnsTableFeature.name))
     }
 
     val protocolBeforeUpdate = protocol
@@ -1671,9 +1673,9 @@ trait OptimisticTransactionImpl extends TransactionHelper
     // If this transaction commits to the redirect destination location, then there is no
     // need to validate the subsequent no-redirect rules.
     val configuration = deltaLog.newDeltaHadoopConf()
-    val dataPath = snapshot.dataPath.toUri.getPath
+    val tableDataPath = dataPath.toUri.getPath
     val catalog = spark.sessionState.catalog
-    val isRedirectDest = redirectConfig.spec.isRedirectDest(catalog, configuration, dataPath)
+    val isRedirectDest = redirectConfig.spec.isRedirectDest(catalog, configuration, tableDataPath)
     if (isRedirectDest) return
     // Find all rules that match with the current application name.
     // If appName is not present, its no-redirect-rule are included.
@@ -2743,7 +2745,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
 
     if (readVersion > -1 && metadata.id != snapshot.metadata.id) {
       val msg = s"Change in the table id detected in txn. Table id for txn on table at " +
-        s"${deltaLog.dataPath} was ${snapshot.metadata.id} when the txn was created and " +
+        s"${dataPath} was ${snapshot.metadata.id} when the txn was created and " +
         s"is now changed to ${metadata.id}."
       logWarning(msg)
       recordDeltaEvent(deltaLog, "delta.metadataCheck.commit", data = Map(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/TransactionHelper.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/TransactionHelper.scala
@@ -32,6 +32,7 @@ import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.stats.{FileSizeHistogram, FileSizeHistogramUtils}
 import org.apache.spark.sql.util.ScalaExtensions._
+import org.apache.hadoop.fs.Path
 
 import org.apache.spark.internal.MDC
 import org.apache.spark.sql.SparkSession
@@ -42,6 +43,14 @@ import org.apache.spark.sql.catalyst.catalog.CatalogTable
  */
 trait TransactionHelper extends DeltaLogging {
   def deltaLog: DeltaLog
+
+  /**
+   * The path to the Delta table data directory. Not implemented in the base trait; each concrete
+   * transaction supplies it.
+   */
+  def dataPath: Path =
+    throw new UnsupportedOperationException("dataPath is not implemented for this transaction")
+
   def catalogTable: Option[CatalogTable]
   def snapshot: Snapshot
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
@@ -316,6 +316,14 @@ class OptimisticTransactionSuite
     }
   }
 
+  test("dataPath resolves to deltaLog.dataPath") {
+    withTempDir { tempDir =>
+      val log = DeltaLog.forTable(spark, new Path(tempDir.getCanonicalPath))
+      val txn = log.startTransaction()
+      assert(txn.dataPath === log.dataPath)
+    }
+  }
+
   test("enabling Coordinated Commits on an existing table should create commit dir") {
     withTempDir { tempDir =>
       val log = DeltaLog.forTable(spark, new Path(tempDir.getAbsolutePath))


### PR DESCRIPTION
## Description

This introduces an overridable `dataPath` on `TransactionHelper`, mirroring the existing transaction-path seam used for log paths. It lets transaction implementations provide the current table data path directly instead of forcing helper code to reach back through `deltaLog` or `snapshot`.

- Add `TransactionHelper.dataPath` (base trait throws `UnsupportedOperationException`; concrete transactions supply it), with a concrete implementation in `OptimisticTransactionImpl` that resolves to `deltaLog.dataPath`.
- Route current-transaction data-path consumers through `dataPath`, including redirect validation, unsupported-feature errors, and table-id mismatch diagnostics.

## How was this patch tested?

Added a unit test in `OptimisticTransactionSuite` verifying `OptimisticTransaction.dataPath` resolves to the backing `DeltaLog.dataPath`.