### PR TITLE
[Spark] Use case-sensitive maps in UCDeltaCatalogClientImpl

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClient.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClient.scala
@@ -188,7 +188,7 @@ private[delta] object AbstractDeltaCatalogClient extends Logging {
       catalogName: String,
       options: CaseInsensitiveStringMap,
       fallbackLoadTableFunc: Identifier => Table): Option[AbstractDeltaCatalogClient] = {
-    val optionsMap = new util.HashMap[String, String](options.asCaseSensitiveMap())
+    val optionsMap = options.asCaseSensitiveMap()
     val key = UCTokenBasedRestClientFactory.DELTA_REST_API_ENABLED_KEY
     if (!optionsMap.getOrDefault(key, "true").toBoolean) {
       return None

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClient.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClient.scala
@@ -153,7 +153,7 @@ private[delta] trait AbstractDeltaCatalogClient {
 private[catalog] trait AbstractDeltaCatalogClientFactory {
   def fromCatalogOptions(
       catalogName: String,
-      options: CaseInsensitiveStringMap,
+      options: util.Map[String, String],
       fallbackLoadTableFunc: Identifier => Table): AbstractDeltaCatalogClient
 }
 
@@ -188,8 +188,9 @@ private[delta] object AbstractDeltaCatalogClient extends Logging {
       catalogName: String,
       options: CaseInsensitiveStringMap,
       fallbackLoadTableFunc: Identifier => Table): Option[AbstractDeltaCatalogClient] = {
+    val optionsMap = new util.HashMap[String, String](options.asCaseSensitiveMap())
     val key = UCTokenBasedRestClientFactory.DELTA_REST_API_ENABLED_KEY
-    if (!options.getBoolean(key, true)) {
+    if (!optionsMap.getOrDefault(key, "true").toBoolean) {
       return None
     }
     val factory = try {
@@ -204,6 +205,6 @@ private[delta] object AbstractDeltaCatalogClient extends Logging {
             "Ensure the implementation JAR is on the classpath, or remove " +
             s"'$key' from the catalog options to fall back to the legacy delegate.", e)
     }
-    Some(factory.fromCatalogOptions(catalogName, options, fallbackLoadTableFunc))
+    Some(factory.fromCatalogOptions(catalogName, optionsMap, fallbackLoadTableFunc))
   }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImpl.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImpl.scala
@@ -716,7 +716,7 @@ object UCDeltaCatalogClientImpl extends AbstractDeltaCatalogClientFactory with L
       .createUCClient(optionsMap)
       .asInstanceOf[UCDeltaClient]
     val sspEnabled =
-      "true".equalsIgnoreCase(optionsMap.get(ServerSidePlanningEnabledKey))
+      optionsMap.getOrDefault(ServerSidePlanningEnabledKey, "false").toBoolean
     new UCDeltaCatalogClientImpl(catalogName, ucClient, sspEnabled, fallbackLoadTableFunc)
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImpl.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImpl.scala
@@ -704,30 +704,24 @@ object UCDeltaCatalogClientImpl extends AbstractDeltaCatalogClientFactory with L
       options: CaseInsensitiveStringMap,
       fallbackLoadTableFunc: Identifier => Table): UCDeltaCatalogClientImpl = {
     // Normalize once at the Spark catalog boundary; downstream code uses a plain map only.
-    val caseSensitiveOptions =
-      new util.HashMap[String, String](options.asCaseSensitiveMap())
+    val optionsMap = new util.HashMap[String, String](options.asCaseSensitiveMap())
 
     // Pre-flight: keep our user-facing errors instead of the factory's less specific ones.
-    if (getIgnoreCase(caseSensitiveOptions, UriKey) == null) {
+    if (optionsMap.get(UriKey) == null) {
       throw new IllegalArgumentException(s"'$UriKey' is required (catalog '$catalogName')")
     }
-    validateAuthConfigured(caseSensitiveOptions, catalogName)
+    validateAuthConfigured(optionsMap, catalogName)
 
-    val merged = new util.HashMap[String, String](caseSensitiveOptions)
+    val merged = new util.HashMap[String, String](optionsMap)
     Seq(
       UCTokenBasedRestClientFactory.RENEW_CREDENTIAL_ENABLED_KEY -> "true",
       UCTokenBasedRestClientFactory.CRED_SCOPED_FS_ENABLED_KEY -> "false"
-    ).foreach { case (k, v) =>
-      if (!containsKeyIgnoreCase(merged, k)) merged.put(k, v)
-    }
-    // `createUCClient` looks up well-known keys with exact `.get(...)`; pin canonical casing
-    // so a user-supplied `URI` / `Token` still resolves after we drop the CISM wrapper.
-    canonicalTopLevelKeys.foreach(canonicalizeKey(merged, _))
+    ).foreach { case (k, v) => if (!merged.containsKey(k)) merged.put(k, v) }
     val ucClient = UCTokenBasedRestClientFactory
       .createUCClient(merged)
       .asInstanceOf[UCDeltaClient]
 
-    val sspEnabled = Option(getIgnoreCase(caseSensitiveOptions, ServerSidePlanningEnabledKey))
+    val sspEnabled = Option(optionsMap.get(ServerSidePlanningEnabledKey))
       .exists(_.equalsIgnoreCase("true"))
     new UCDeltaCatalogClientImpl(catalogName, ucClient, sspEnabled, fallbackLoadTableFunc)
   }
@@ -735,42 +729,6 @@ object UCDeltaCatalogClientImpl extends AbstractDeltaCatalogClientFactory with L
   private val UriKey: String = "uri"
   private val AuthPrefix: String = "auth."
   private val LegacyTokenKey: String = "token"
-
-  /** Keys that downstream `createUCClient` reads via exact, case-sensitive `.get(...)`. */
-  private val canonicalTopLevelKeys: Seq[String] = Seq(
-    UriKey,
-    LegacyTokenKey,
-    UCTokenBasedRestClientFactory.DELTA_REST_API_ENABLED_KEY,
-    UCTokenBasedRestClientFactory.RENEW_CREDENTIAL_ENABLED_KEY,
-    UCTokenBasedRestClientFactory.CRED_SCOPED_FS_ENABLED_KEY,
-    ServerSidePlanningEnabledKey)
-
-  /** Returns the value for `key`, matching case-insensitively on a plain map. */
-  private def getIgnoreCase(map: util.Map[String, String], key: String): String = {
-    if (map.containsKey(key)) {
-      return map.get(key)
-    }
-    val keyLower = key.toLowerCase(java.util.Locale.ROOT)
-    map.asScala.collectFirst {
-      case (k, v) if k.toLowerCase(java.util.Locale.ROOT) == keyLower => v
-    }.orNull
-  }
-
-  private def containsKeyIgnoreCase(map: util.Map[String, String], key: String): Boolean = {
-    if (map.containsKey(key)) {
-      return true
-    }
-    val keyLower = key.toLowerCase(java.util.Locale.ROOT)
-    map.asScala.keys.exists(_.toLowerCase(java.util.Locale.ROOT) == keyLower)
-  }
-
-  /** Writes `canonicalKey` into `map` using the value from any case-variant of that key. */
-  private def canonicalizeKey(map: util.HashMap[String, String], canonicalKey: String): Unit = {
-    val value = getIgnoreCase(map, canonicalKey)
-    if (value != null) {
-      map.put(canonicalKey, value)
-    }
-  }
 
   /**
    * Pre-flight: ensure at least one of `auth.*` or legacy `token` is present, so the user
@@ -780,10 +738,8 @@ object UCDeltaCatalogClientImpl extends AbstractDeltaCatalogClientFactory with L
   private[catalog] def validateAuthConfigured(
       options: util.Map[String, String],
       catalogName: String): Unit = {
-    val authPrefixLower = AuthPrefix.toLowerCase(java.util.Locale.ROOT)
-    val hasAuthPrefix = options.asScala.keys.exists(
-      _.toLowerCase(java.util.Locale.ROOT).startsWith(authPrefixLower))
-    val hasLegacyToken = getIgnoreCase(options, LegacyTokenKey) != null
+    val hasAuthPrefix = options.asScala.keys.exists(_.startsWith(AuthPrefix))
+    val hasLegacyToken = options.get(LegacyTokenKey) != null
     if (!hasAuthPrefix && !hasLegacyToken) {
       throw new IllegalArgumentException(
         s"auth configuration is required (catalog '$catalogName'). " +

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImpl.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImpl.scala
@@ -703,24 +703,27 @@ object UCDeltaCatalogClientImpl extends AbstractDeltaCatalogClientFactory with L
       catalogName: String,
       options: CaseInsensitiveStringMap,
       fallbackLoadTableFunc: Identifier => Table): UCDeltaCatalogClientImpl = {
+    // Normalize once at the Spark catalog boundary; downstream code uses a plain map only.
+    val caseSensitiveOptions =
+      new util.HashMap[String, String](options.asCaseSensitiveMap())
+
     // Pre-flight: keep our user-facing errors instead of the factory's less specific ones.
-    if (options.get(UriKey) == null) {
+    if (caseSensitiveOptions.get(UriKey) == null) {
       throw new IllegalArgumentException(s"'$UriKey' is required (catalog '$catalogName')")
     }
-    validateAuthConfigured(options, catalogName)
+    validateAuthConfigured(caseSensitiveOptions, catalogName)
 
-    // `asCaseSensitiveMap()` preserves the user's original key case; `containsKey` is
-    // case-insensitive so defaults don't create duplicate keys.
-    val merged = new java.util.HashMap[String, String](options.asCaseSensitiveMap())
+    val merged = new util.HashMap[String, String](caseSensitiveOptions)
     Seq(
       UCTokenBasedRestClientFactory.RENEW_CREDENTIAL_ENABLED_KEY -> "true",
       UCTokenBasedRestClientFactory.CRED_SCOPED_FS_ENABLED_KEY -> "false"
-    ).foreach { case (k, v) => if (!options.containsKey(k)) merged.put(k, v) }
+    ).foreach { case (k, v) => if (!merged.containsKey(k)) merged.put(k, v) }
     val ucClient = UCTokenBasedRestClientFactory
-      .createUCClient(new CaseInsensitiveStringMap(merged))
+      .createUCClient(merged)
       .asInstanceOf[UCDeltaClient]
 
-    val sspEnabled = options.getBoolean(ServerSidePlanningEnabledKey, false)
+    val sspEnabled = Option(caseSensitiveOptions.get(ServerSidePlanningEnabledKey))
+      .exists(_.equalsIgnoreCase("true"))
     new UCDeltaCatalogClientImpl(catalogName, ucClient, sspEnabled, fallbackLoadTableFunc)
   }
 
@@ -734,10 +737,14 @@ object UCDeltaCatalogClientImpl extends AbstractDeltaCatalogClientFactory with L
    * `TokenProvider.create` is handed an empty config.
    */
   private[catalog] def validateAuthConfigured(
-      options: CaseInsensitiveStringMap,
+      options: util.Map[String, String],
       catalogName: String): Unit = {
-    val hasAuthPrefix = options.entrySet().asScala.exists(_.getKey.startsWith(AuthPrefix))
-    val hasLegacyToken = options.get(LegacyTokenKey) != null
+    val authPrefixLower = AuthPrefix.toLowerCase(java.util.Locale.ROOT)
+    val hasAuthPrefix = options.asScala.keys.exists(
+      _.toLowerCase(java.util.Locale.ROOT).startsWith(authPrefixLower))
+    val hasLegacyToken = options.asScala.exists { case (k, v) =>
+      k.equalsIgnoreCase(LegacyTokenKey) && v != null
+    }
     if (!hasAuthPrefix && !hasLegacyToken) {
       throw new IllegalArgumentException(
         s"auth configuration is required (catalog '$catalogName'). " +

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImpl.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImpl.scala
@@ -56,7 +56,6 @@ import org.apache.spark.sql.delta.IcebergConstants
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.stats.FileSizeHistogram
 import org.apache.spark.sql.types.{DataType, StructType}
-import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 /**
  * [[AbstractDeltaCatalogClient]] backed by a [[UCDeltaClient]]. Owns all of the catalog-specific
@@ -701,34 +700,25 @@ object UCDeltaCatalogClientImpl extends AbstractDeltaCatalogClientFactory with L
    */
   override def fromCatalogOptions(
       catalogName: String,
-      options: CaseInsensitiveStringMap,
+      options: util.Map[String, String],
       fallbackLoadTableFunc: Identifier => Table): UCDeltaCatalogClientImpl = {
-    // Normalize once at the Spark catalog boundary; downstream code uses a plain map only.
-    val optionsMap = new util.HashMap[String, String](options.asCaseSensitiveMap())
-
-    // Pre-flight: keep our user-facing errors instead of the factory's less specific ones.
-    if (optionsMap.get(UriKey) == null) {
-      throw new IllegalArgumentException(s"'$UriKey' is required (catalog '$catalogName')")
+    if (options.get(UCTokenBasedRestClientFactory.URI_KEY) == null) {
+      throw new IllegalArgumentException(
+        s"'${UCTokenBasedRestClientFactory.URI_KEY}' is required (catalog '$catalogName')")
     }
-    validateAuthConfigured(optionsMap, catalogName)
+    validateAuthConfigured(options, catalogName)
 
-    val merged = new util.HashMap[String, String](optionsMap)
-    Seq(
-      UCTokenBasedRestClientFactory.RENEW_CREDENTIAL_ENABLED_KEY -> "true",
-      UCTokenBasedRestClientFactory.CRED_SCOPED_FS_ENABLED_KEY -> "false"
-    ).foreach { case (k, v) => if (!merged.containsKey(k)) merged.put(k, v) }
+    val optionsMap = new util.HashMap[String, String](options)
+    optionsMap.putIfAbsent(UCTokenBasedRestClientFactory.RENEW_CREDENTIAL_ENABLED_KEY, "true")
+    optionsMap.putIfAbsent(UCTokenBasedRestClientFactory.CRED_SCOPED_FS_ENABLED_KEY, "false")
+
     val ucClient = UCTokenBasedRestClientFactory
-      .createUCClient(merged)
+      .createUCClient(optionsMap)
       .asInstanceOf[UCDeltaClient]
-
-    val sspEnabled = Option(optionsMap.get(ServerSidePlanningEnabledKey))
-      .exists(_.equalsIgnoreCase("true"))
+    val sspEnabled =
+      "true".equalsIgnoreCase(optionsMap.get(ServerSidePlanningEnabledKey))
     new UCDeltaCatalogClientImpl(catalogName, ucClient, sspEnabled, fallbackLoadTableFunc)
   }
-
-  private val UriKey: String = "uri"
-  private val AuthPrefix: String = "auth."
-  private val LegacyTokenKey: String = "token"
 
   /**
    * Pre-flight: ensure at least one of `auth.*` or legacy `token` is present, so the user
@@ -738,13 +728,13 @@ object UCDeltaCatalogClientImpl extends AbstractDeltaCatalogClientFactory with L
   private[catalog] def validateAuthConfigured(
       options: util.Map[String, String],
       catalogName: String): Unit = {
-    val hasAuthPrefix = options.asScala.keys.exists(_.startsWith(AuthPrefix))
-    val hasLegacyToken = options.get(LegacyTokenKey) != null
-    if (!hasAuthPrefix && !hasLegacyToken) {
+    if (UCTokenBasedRestClientFactory.extractAuthConfig(options).isEmpty) {
+      val authPrefix = UCTokenBasedRestClientFactory.AUTH_PREFIX
+      val legacyTokenKey = UCTokenBasedRestClientFactory.LEGACY_TOKEN_KEY
       throw new IllegalArgumentException(
         s"auth configuration is required (catalog '$catalogName'). " +
-          s"Set either '${AuthPrefix}type' (with the corresponding " +
-          s"$AuthPrefix* keys) or the legacy '$LegacyTokenKey' option.")
+          s"Set either '${authPrefix}type' (with the corresponding " +
+          s"$authPrefix* keys) or the legacy '$legacyTokenKey' option.")
     }
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImpl.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImpl.scala
@@ -708,7 +708,7 @@ object UCDeltaCatalogClientImpl extends AbstractDeltaCatalogClientFactory with L
       new util.HashMap[String, String](options.asCaseSensitiveMap())
 
     // Pre-flight: keep our user-facing errors instead of the factory's less specific ones.
-    if (caseSensitiveOptions.get(UriKey) == null) {
+    if (getIgnoreCase(caseSensitiveOptions, UriKey) == null) {
       throw new IllegalArgumentException(s"'$UriKey' is required (catalog '$catalogName')")
     }
     validateAuthConfigured(caseSensitiveOptions, catalogName)
@@ -717,12 +717,17 @@ object UCDeltaCatalogClientImpl extends AbstractDeltaCatalogClientFactory with L
     Seq(
       UCTokenBasedRestClientFactory.RENEW_CREDENTIAL_ENABLED_KEY -> "true",
       UCTokenBasedRestClientFactory.CRED_SCOPED_FS_ENABLED_KEY -> "false"
-    ).foreach { case (k, v) => if (!merged.containsKey(k)) merged.put(k, v) }
+    ).foreach { case (k, v) =>
+      if (!containsKeyIgnoreCase(merged, k)) merged.put(k, v)
+    }
+    // `createUCClient` looks up well-known keys with exact `.get(...)`; pin canonical casing
+    // so a user-supplied `URI` / `Token` still resolves after we drop the CISM wrapper.
+    canonicalTopLevelKeys.foreach(canonicalizeKey(merged, _))
     val ucClient = UCTokenBasedRestClientFactory
       .createUCClient(merged)
       .asInstanceOf[UCDeltaClient]
 
-    val sspEnabled = Option(caseSensitiveOptions.get(ServerSidePlanningEnabledKey))
+    val sspEnabled = Option(getIgnoreCase(caseSensitiveOptions, ServerSidePlanningEnabledKey))
       .exists(_.equalsIgnoreCase("true"))
     new UCDeltaCatalogClientImpl(catalogName, ucClient, sspEnabled, fallbackLoadTableFunc)
   }
@@ -730,6 +735,42 @@ object UCDeltaCatalogClientImpl extends AbstractDeltaCatalogClientFactory with L
   private val UriKey: String = "uri"
   private val AuthPrefix: String = "auth."
   private val LegacyTokenKey: String = "token"
+
+  /** Keys that downstream `createUCClient` reads via exact, case-sensitive `.get(...)`. */
+  private val canonicalTopLevelKeys: Seq[String] = Seq(
+    UriKey,
+    LegacyTokenKey,
+    UCTokenBasedRestClientFactory.DELTA_REST_API_ENABLED_KEY,
+    UCTokenBasedRestClientFactory.RENEW_CREDENTIAL_ENABLED_KEY,
+    UCTokenBasedRestClientFactory.CRED_SCOPED_FS_ENABLED_KEY,
+    ServerSidePlanningEnabledKey)
+
+  /** Returns the value for `key`, matching case-insensitively on a plain map. */
+  private def getIgnoreCase(map: util.Map[String, String], key: String): String = {
+    if (map.containsKey(key)) {
+      return map.get(key)
+    }
+    val keyLower = key.toLowerCase(java.util.Locale.ROOT)
+    map.asScala.collectFirst {
+      case (k, v) if k.toLowerCase(java.util.Locale.ROOT) == keyLower => v
+    }.orNull
+  }
+
+  private def containsKeyIgnoreCase(map: util.Map[String, String], key: String): Boolean = {
+    if (map.containsKey(key)) {
+      return true
+    }
+    val keyLower = key.toLowerCase(java.util.Locale.ROOT)
+    map.asScala.keys.exists(_.toLowerCase(java.util.Locale.ROOT) == keyLower)
+  }
+
+  /** Writes `canonicalKey` into `map` using the value from any case-variant of that key. */
+  private def canonicalizeKey(map: util.HashMap[String, String], canonicalKey: String): Unit = {
+    val value = getIgnoreCase(map, canonicalKey)
+    if (value != null) {
+      map.put(canonicalKey, value)
+    }
+  }
 
   /**
    * Pre-flight: ensure at least one of `auth.*` or legacy `token` is present, so the user
@@ -742,9 +783,7 @@ object UCDeltaCatalogClientImpl extends AbstractDeltaCatalogClientFactory with L
     val authPrefixLower = AuthPrefix.toLowerCase(java.util.Locale.ROOT)
     val hasAuthPrefix = options.asScala.keys.exists(
       _.toLowerCase(java.util.Locale.ROOT).startsWith(authPrefixLower))
-    val hasLegacyToken = options.asScala.exists { case (k, v) =>
-      k.equalsIgnoreCase(LegacyTokenKey) && v != null
-    }
+    val hasLegacyToken = getIgnoreCase(options, LegacyTokenKey) != null
     if (!hasAuthPrefix && !hasLegacyToken) {
       throw new IllegalArgumentException(
         s"auth configuration is required (catalog '$catalogName'). " +

--- a/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorBuilder.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorBuilder.scala
@@ -346,7 +346,7 @@ object UCTokenBasedRestClientFactory extends UCClientFactory {
   /**
    * Extracts entries whose keys start with `prefix`, strips the prefix, and returns a plain map.
    */
-  private[delta] def filterByPrefix(
+  private[coordinatedcommits] def filterByPrefix(
       ucConfig: java.util.Map[String, String],
       prefix: String): java.util.Map[String, String] = {
     val result = new java.util.HashMap[String, String]()

--- a/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorBuilder.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorBuilder.scala
@@ -33,7 +33,6 @@ import org.apache.spark.sql.delta.metering.DeltaLogging
 import io.unitycatalog.client.auth.TokenProvider
 import org.apache.spark.internal.MDC
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.util.Utils
 
 /**
@@ -344,48 +343,35 @@ object UCTokenBasedRestClientFactory extends UCClientFactory {
   }
 
   /**
-   * Extracts entries from `ucConfig` whose keys (compared case-insensitively) start with
-   * `prefix`, strips the prefix, and returns the result as a plain [[java.util.Map]].
-   * Uses the case-preserving view of the input when available so the returned map retains
-   * original key casing (e.g. `oauth.clientId` rather than `oauth.clientid`).
-   * Callers decide whether to wrap in [[CaseInsensitiveStringMap]].
+   * Extracts entries from `ucConfig` whose keys start with `prefix`, strips the prefix, and
+   * returns the result as a plain, case-preserved [[java.util.Map]].
    */
   private[coordinatedcommits] def filterByPrefix(
       ucConfig: java.util.Map[String, String],
       prefix: String): java.util.Map[String, String] = {
-    val prefixLower = prefix.toLowerCase(java.util.Locale.ROOT)
-    val sourceEntries = ucConfig match {
-      case cism: CaseInsensitiveStringMap => cism.asCaseSensitiveMap().entrySet()
-      case m => m.entrySet()
-    }
     val result = new java.util.HashMap[String, String]()
-    sourceEntries.forEach { e =>
-      if (e.getKey.toLowerCase(java.util.Locale.ROOT).startsWith(prefixLower)) {
-        result.put(e.getKey.substring(prefixLower.length), e.getValue)
+    ucConfig.entrySet().forEach { e =>
+      if (e.getKey.startsWith(prefix)) {
+        result.put(e.getKey.substring(prefix.length), e.getValue)
       }
     }
     result
   }
 
   /**
-   * Extracts authentication configuration from ucConfig.
+   * Extracts authentication configuration from a case-preserved `ucConfig` map.
    * Prefers `auth.*` keys; falls back to legacy `token` key.
-   *
-   * Returns a [[CaseInsensitiveStringMap]] so that downstream consumers (e.g.
-   * [[TokenProvider.create]]) can look up camelCase keys like `oauth.clientId`
-   * regardless of what casing the source map provides.
    */
   private[coordinatedcommits] def extractAuthConfig(
-      ucConfig: java.util.Map[String, String]): CaseInsensitiveStringMap = {
+      ucConfig: java.util.Map[String, String]): java.util.Map[String, String] = {
     val filtered = filterByPrefix(ucConfig, AUTH_PREFIX)
     if (!filtered.isEmpty) {
-      new CaseInsensitiveStringMap(filtered)
+      filtered
     } else {
       Option(ucConfig.get("token")) match {
         case Some(token) =>
-          new CaseInsensitiveStringMap(
-            java.util.Map.of("type", "static", "token", token))
-        case None => CaseInsensitiveStringMap.empty()
+          java.util.Map.of("type", "static", "token", token)
+        case None => java.util.Collections.emptyMap()
       }
     }
   }
@@ -422,9 +408,9 @@ case class UCCatalogConfig(catalogName: String, ucConfig: Map[String, String]) {
     throw new NoSuchElementException(s"No URI in config for catalog $catalogName"))
 
   /**
-   * Returns the authentication config suitable for [[TokenProvider.create]].
-   * Prefers `auth.*` keys; falls back to legacy `token` key.
+   * Returns the authentication config with original key casing preserved (e.g. `oauth.clientId`).
+   * Prefers `auth.*` keys; falls back to the legacy `token` key.
    */
-  def authConfig: CaseInsensitiveStringMap =
+  def authConfig: java.util.Map[String, String] =
     UCTokenBasedRestClientFactory.extractAuthConfig(ucConfig.asJava)
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorBuilder.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorBuilder.scala
@@ -288,6 +288,7 @@ object UCTokenBasedRestClientFactory extends UCClientFactory {
 
   final val URI_KEY = "uri"
   final val AUTH_PREFIX = "auth."
+  final val LEGACY_TOKEN_KEY = "token"
   final val DELTA_REST_API_ENABLED_KEY = "deltaRestApi.enabled"
   final val APP_VERSIONS_PREFIX = "appVersions."
   /** Opt-in: caller wants `UCDeltaTokenBasedRestClient` constructed with credential renewal. */
@@ -343,36 +344,30 @@ object UCTokenBasedRestClientFactory extends UCClientFactory {
   }
 
   /**
-   * Extracts entries from `ucConfig` whose keys start with `prefix`, strips the prefix, and
-   * returns the result as a plain, case-preserved [[java.util.Map]].
+   * Extracts entries whose keys start with `prefix`, strips the prefix, and returns a plain map.
    */
-  private[coordinatedcommits] def filterByPrefix(
+  private[delta] def filterByPrefix(
       ucConfig: java.util.Map[String, String],
       prefix: String): java.util.Map[String, String] = {
     val result = new java.util.HashMap[String, String]()
-    ucConfig.entrySet().forEach { e =>
-      if (e.getKey.startsWith(prefix)) {
-        result.put(e.getKey.substring(prefix.length), e.getValue)
+    ucConfig.asScala.foreach { case (k, v) =>
+      if (k.startsWith(prefix)) {
+        result.put(k.substring(prefix.length), v)
       }
     }
     result
   }
 
-  /**
-   * Extracts authentication configuration from a case-preserved `ucConfig` map.
-   * Prefers `auth.*` keys; falls back to legacy `token` key.
-   */
-  private[coordinatedcommits] def extractAuthConfig(
+  /** Extracts auth config for [[TokenProvider.create]]; prefers `auth.*`, else legacy `token`. */
+  private[delta] def extractAuthConfig(
       ucConfig: java.util.Map[String, String]): java.util.Map[String, String] = {
-    val filtered = filterByPrefix(ucConfig, AUTH_PREFIX)
-    if (!filtered.isEmpty) {
-      filtered
+    val auth = filterByPrefix(ucConfig, AUTH_PREFIX)
+    if (!auth.isEmpty) {
+      auth
     } else {
-      Option(ucConfig.get("token")) match {
-        case Some(token) =>
-          java.util.Map.of("type", "static", "token", token)
-        case None => java.util.Collections.emptyMap()
-      }
+      Option(ucConfig.get(LEGACY_TOKEN_KEY))
+        .map(token => java.util.Map.of("type", "static", LEGACY_TOKEN_KEY, token))
+        .getOrElse(java.util.Collections.emptyMap())
     }
   }
 
@@ -382,8 +377,7 @@ object UCTokenBasedRestClientFactory extends UCClientFactory {
    */
   private[coordinatedcommits] def extractAppVersions(
       ucConfig: java.util.Map[String, String]): Map[String, String] = {
-    val extra = filterByPrefix(ucConfig, APP_VERSIONS_PREFIX).asScala.toMap
-    defaultAppVersions ++ extra
+    defaultAppVersions ++ filterByPrefix(ucConfig, APP_VERSIONS_PREFIX).asScala
   }
 
   private[coordinatedcommits] def defaultAppVersions: Map[String, String] = {
@@ -404,13 +398,9 @@ object UCTokenBasedRestClientFactory extends UCClientFactory {
  */
 case class UCCatalogConfig(catalogName: String, ucConfig: Map[String, String]) {
 
-  def uri: String = ucConfig.getOrElse("uri",
+  def uri: String = ucConfig.getOrElse(UCTokenBasedRestClientFactory.URI_KEY,
     throw new NoSuchElementException(s"No URI in config for catalog $catalogName"))
 
-  /**
-   * Returns the authentication config with original key casing preserved (e.g. `oauth.clientId`).
-   * Prefers `auth.*` keys; falls back to the legacy `token` key.
-   */
   def authConfig: java.util.Map[String, String] =
     UCTokenBasedRestClientFactory.extractAuthConfig(ucConfig.asJava)
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
@@ -103,6 +103,17 @@ class AbstractDeltaCatalogClientRoutingSuite extends QueryTest with DeltaSQLComm
       s"UC Delta API client should be UCDeltaCatalogClientImpl, was ${client.getClass}")
   }
 
+  test("fromCatalogOptions accepts oddly-cased top-level uri and token keys") {
+    val m = new util.HashMap[String, String]()
+    m.put("URI", "http://uc")
+    m.put("Token", "tok")
+    val result = AbstractDeltaCatalogClient.fromCatalogOptionsIfEnabled(
+      "test_cat",
+      new CaseInsensitiveStringMap(m),
+      noFallback)
+    assert(result.isDefined)
+  }
+
   test("AbstractDeltaCatalogClient.fromCatalogOptionsIfEnabled returns None when flag is off") {
     val result = AbstractDeltaCatalogClient.fromCatalogOptionsIfEnabled(
       "test_cat", options("deltaRestApi.enabled" -> "false"), noFallback)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
@@ -103,17 +103,6 @@ class AbstractDeltaCatalogClientRoutingSuite extends QueryTest with DeltaSQLComm
       s"UC Delta API client should be UCDeltaCatalogClientImpl, was ${client.getClass}")
   }
 
-  test("fromCatalogOptions accepts oddly-cased top-level uri and token keys") {
-    val m = new util.HashMap[String, String]()
-    m.put("URI", "http://uc")
-    m.put("Token", "tok")
-    val result = AbstractDeltaCatalogClient.fromCatalogOptionsIfEnabled(
-      "test_cat",
-      new CaseInsensitiveStringMap(m),
-      noFallback)
-    assert(result.isDefined)
-  }
-
   test("AbstractDeltaCatalogClient.fromCatalogOptionsIfEnabled returns None when flag is off") {
     val result = AbstractDeltaCatalogClient.fromCatalogOptionsIfEnabled(
       "test_cat", options("deltaRestApi.enabled" -> "false"), noFallback)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorBuilderSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorBuilderSuite.scala
@@ -541,22 +541,16 @@ class UCCommitCoordinatorBuilderSuite extends SparkFunSuite with SharedSparkSess
     assert(exception.getMessage.contains("not found"))
   }
 
-  test("extractAuthConfig with OAuth through CaseInsensitiveStringMap preserves keys and " +
-      "produces valid TokenProvider") {
-    val ucConfig = new CaseInsensitiveStringMap(Map(
-      "auth.type" -> "oauth",
-      "auth.oauth.clientId" -> "test-id",
-      "auth.oauth.clientSecret" -> "test-secret",
-      "auth.oauth.uri" -> "https://example.com/token",
-      "uri" -> "https://uc.example.com"
-    ).asJava)
+  test("extractAuthConfig with OAuth preserves camelCase keys and produces valid TokenProvider") {
+    val ucConfig = new java.util.HashMap[String, String]()
+    ucConfig.put("auth.type", "oauth")
+    ucConfig.put("auth.oauth.clientId", "test-id")
+    ucConfig.put("auth.oauth.clientSecret", "test-secret")
+    ucConfig.put("auth.oauth.uri", "https://example.com/token")
+    ucConfig.put("uri", "https://uc.example.com")
     val auth = UCTokenBasedRestClientFactory.extractAuthConfig(ucConfig)
-    // Key casing preservation (asCaseSensitiveMap proves original case is retained)
-    assert(auth.asCaseSensitiveMap().get("oauth.clientId") === "test-id")
-    assert(auth.asCaseSensitiveMap().get("oauth.clientSecret") === "test-secret")
-    // Case-insensitive access also works
-    assert(auth.get("oauth.CLIENTID") === "test-id")
-    // TokenProvider creation
+    assert(auth.get("oauth.clientId") === "test-id")
+    assert(auth.get("oauth.clientSecret") === "test-secret")
     val tp = TokenProvider.create(auth)
     assert(tp != null)
     assert(tp.configs().get("type") === "oauth")
@@ -572,21 +566,21 @@ class UCCommitCoordinatorBuilderSuite extends SparkFunSuite with SharedSparkSess
     assert(tp1.accessToken() === "my-token")
 
     // Sub-case 2: explicit auth.type=static
-    val explicitConfig = new CaseInsensitiveStringMap(Map(
+    val explicitConfig = Map(
       "auth.type" -> "static",
       "auth.token" -> "explicit-token"
-    ).asJava)
+    ).asJava
     val explicitAuth = UCTokenBasedRestClientFactory.extractAuthConfig(explicitConfig)
     val tp2 = TokenProvider.create(explicitAuth)
     assert(tp2.accessToken() === "explicit-token")
   }
 
   test("extractAppVersions preserves key casing and includes defaults") {
-    val ucConfig = new CaseInsensitiveStringMap(Map(
+    val ucConfig = Map(
       "appVersions.CustomEngine" -> "1.0",
       "appVersions.MyLib" -> "2.0",
       "uri" -> "https://uc.example.com"
-    ).asJava)
+    ).asJava
     val versions = UCTokenBasedRestClientFactory.extractAppVersions(ucConfig)
     assert(versions("CustomEngine") === "1.0")
     assert(versions("MyLib") === "2.0")
@@ -597,28 +591,23 @@ class UCCommitCoordinatorBuilderSuite extends SparkFunSuite with SharedSparkSess
   }
 
   test("OAuth round-trip through real UCTableInfo.toUcConfig produces valid TokenProvider") {
-    // 1. Start with camelCase OAuth config in a CaseInsensitiveStringMap
-    val originalConfig = new CaseInsensitiveStringMap(Map(
-      "uri" -> "https://uc.example.com",
-      "auth.type" -> "oauth",
-      "auth.oauth.clientId" -> "test-id",
-      "auth.oauth.clientSecret" -> "test-secret",
-      "auth.oauth.uri" -> "https://example.com/token"
-    ).asJava)
+    val originalConfig = new java.util.HashMap[String, String]()
+    originalConfig.put("uri", "https://uc.example.com")
+    originalConfig.put("auth.type", "oauth")
+    originalConfig.put("auth.oauth.clientId", "test-id")
+    originalConfig.put("auth.oauth.clientSecret", "test-secret")
+    originalConfig.put("auth.oauth.uri", "https://example.com/token")
 
-    // 2. Extract auth config (what UCTableInfo stores)
     val authMap = UCTokenBasedRestClientFactory.extractAuthConfig(originalConfig)
 
-    // 3. Build UCTableInfo and call toUcConfig() to re-prefix auth keys
     val tableInfo = new UCTableInfo(
       "table-id",
       "/path",
       new UCTableIdentifier("cat", "schema", "table"),
       "https://uc.example.com",
       authMap)
-    val roundTrippedConfig = new CaseInsensitiveStringMap(tableInfo.toUcConfig())
+    val roundTrippedConfig = tableInfo.toUcConfig()
 
-    // 4. Feed back through extractAuthConfig (as createUCClient would)
     val roundTrippedAuth = UCTokenBasedRestClientFactory.extractAuthConfig(roundTrippedConfig)
 
     // 5. Verify TokenProvider can be created (proves round-trip preserves values)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorBuilderSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/UCCommitCoordinatorBuilderSuite.scala
@@ -28,7 +28,6 @@ import org.mockito.Mockito.{mock, never, times, verify, when}
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.test.SharedSparkSession
-import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 class UCCommitCoordinatorBuilderSuite extends SparkFunSuite with SharedSparkSession {
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Here are some tips for you:
 1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
 2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
 3. Be sure to keep the PR description updated to reflect all changes.
 4. Please write your PR title to summarize what this PR proposes.
 5. If possible, provide a concise example to reproduce the issue for a faster review.
 6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Implements option 1 from #7197: consistently use a plain, case-preserved map along the UC Delta catalog client path instead of repeatedly round-tripping through `CaseInsensitiveStringMap` (which silently lower-cased camelCase sub-keys such as `oauth.clientId`).

- `AbstractDeltaCatalogClient.fromCatalogOptionsIfEnabled` converts Spark's `CaseInsensitiveStringMap` to a case-preserved map once at the boundary via `asCaseSensitiveMap()`, and the factory API (`AbstractDeltaCatalogClientFactory.fromCatalogOptions`) now takes a plain `util.Map[String, String]`.
- `UCDeltaCatalogClientImpl.fromCatalogOptions` uses that plain map for pre-flight validation, default merging (`renewCredential.enabled`, `credScopedFs.enabled`), and the `serverSidePlanning.enabled` lookup, and passes it directly to `UCTokenBasedRestClientFactory.createUCClient` (no `CaseInsensitiveStringMap` re-wrap). `validateAuthConfigured` reuses `extractAuthConfig` and accepts a plain `util.Map[String, String]`.
- `UCTokenBasedRestClientFactory.filterByPrefix` / `extractAuthConfig` now operate on and return plain maps.

Resolves #7197

## How was this patch tested?

- `spark/testOnly org.apache.spark.sql.delta.catalog.AbstractDeltaCatalogClientRoutingSuite`
- `spark/testOnly org.apache.spark.sql.delta.coordinatedcommits.UCCommitCoordinatorBuilderSuite`

## Does this PR introduce _any_ user-facing changes?

Yes. Catalog option keys consumed by the UC Delta catalog client are now matched case-sensitively instead of case-insensitively. Keys such as `uri`, `token`, `deltaRestApi.enabled`, `serverSidePlanning.enabled`, `renewCredential.enabled`, `credScopedFs.enabled`, and the `auth.*` / `appVersions.*` prefixes must now be specified using their documented casing. A mis-cased key (e.g. `renewcredential.enabled`) is no longer recognized and falls back to its default rather than taking effect. In exchange, camelCase sub-keys such as `auth.oauth.clientId` are now preserved exactly instead of being lower-cased. These keys are documented in their canonical casing, so correctly-configured catalogs are unaffected.