### PR TITLE
[Spark] Move areAllLeavesLiteral into the DataFiltersBuilder object

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/stats/DataFiltersBuilder.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/stats/DataFiltersBuilder.scala
@@ -242,7 +242,8 @@ class DataFiltersBuilder(
       dataFilter: Expression,
       isNullExpansionDepth: Integer): Option[DataSkippingPredicate] = dataFilter match {
     // Expressions that contain only literals are not eligible for skipping.
-    case cmp: Expression if cmp.children.forall(areAllLeavesLiteral) => None
+    case cmp: Expression if cmp.children.forall(DataFiltersBuilder.areAllLeavesLiteral)
+      => None
 
     // Push skipping predicate generation through the AND:
     //
@@ -741,7 +742,10 @@ class DataFiltersBuilder(
         DataSkippingPredicate(Column(finalExpr), statsCols.toSet)
     }
   }
+}
 
+
+object DataFiltersBuilder {
   // We are doing the iterative approach because of stack depth concerns.
   private[stats] def areAllLeavesLiteral(e: Expression): Boolean = {
     val stack = scala.collection.mutable.Stack[Expression]()
@@ -760,4 +764,3 @@ class DataFiltersBuilder(
     true
   }
 }
-

--- a/spark/src/test/scala/org/apache/spark/sql/delta/stats/DataSkippingDeltaConstructDataFiltersSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/stats/DataSkippingDeltaConstructDataFiltersSuite.scala
@@ -73,11 +73,6 @@ class DataSkippingDeltaConstructDataFiltersSuite
   }
 
   test("Verify areAllLeavesLiteral can't be recursively called b/c it can cause stack overflow") {
-    val dataFilterBuilder = new DataFiltersBuilder(
-      spark,
-      DeltaDataSkippingType.dataSkippingOnlyV1,
-      getStatsColumnOpt = _ => None)
-
     // Create a deeply nested Alias expression: Alias(Alias(Alias(...), "name3"), "name2"), "name1")
     val depth = 100000 // Deep enough to cause stack overflow with default JVM stack size
     var nestedExpr: Expression = Literal.create("foo", StringType)
@@ -85,7 +80,7 @@ class DataSkippingDeltaConstructDataFiltersSuite
       nestedExpr = Alias(nestedExpr, s"name$i")()
     }
 
-    assert(dataFilterBuilder.areAllLeavesLiteral(nestedExpr))
+    assert(DataFiltersBuilder.areAllLeavesLiteral(nestedExpr))
 
     // This should cause a StackOverflowError when areAllLeavesLiteral is called recursively
     def areAllLeavesLiteral(e: Expression): Boolean = e match {


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [x] Spark

## Description

Moves the iterative `areAllLeavesLiteral` leaf-literal check onto the `DataFiltersBuilder` companion object so it lives in a single place and can be called without constructing a builder instance. `constructDataFilters` now references `DataFiltersBuilder.areAllLeavesLiteral`.

The check is iterative (explicit stack) rather than recursive, so it does not `StackOverflowError` on deeply nested expression trees.

## How was this patch tested?

Updated the existing `DataSkippingDeltaConstructDataFiltersSuite` regression test to call the object method; it asserts the iterative check handles a 100k-deep nested expression while the naive recursive form throws `StackOverflowError`.

## Does this PR introduce _any_ user-facing changes?

No.
