### PR TITLE
[Storage] Fix BaseExternalLogStore releasing another writer's PathLock on interrupt

### DIFF
--- a/storage-s3-dynamodb/src/main/java/io/delta/storage/BaseExternalLogStore.java
+++ b/storage-s3-dynamodb/src/main/java/io/delta/storage/BaseExternalLogStore.java
@@ -172,20 +172,28 @@ public abstract class BaseExternalLogStore extends HadoopFileSystemLogStore {
             Configuration hadoopConf) throws IOException {
         final FileSystem fs = path.getFileSystem(hadoopConf);
         final Path resolvedPath = stripUserInfo(fs.makeQualified(path));
-        try {
-            // Prevent concurrent writers in this JVM from either
-            // a) concurrently overwriting N.json if overwrite=true
-            // b) both checking if N-1.json exists and performing a "recovery" where they both
-            //    copy T(N-1) into N-1.json
-            //
-            // Note that the mutual exclusion on writing into N.json with overwrite=false from
-            // different JVMs (which is the entire point of BaseExternalLogStore) is provided by the
-            // external cache, not by this lock, of course.
-            //
-            // Also note that this lock path (resolvedPath) is for N.json, while the lock path used
-            // below in the recovery `fixDeltaLog` path is for N-1.json. Thus, no deadlock.
-            pathLock.acquire(resolvedPath);
 
+        // Prevent concurrent writers in this JVM from either
+        // a) concurrently overwriting N.json if overwrite=true
+        // b) both checking if N-1.json exists and performing a "recovery" where they both
+        //    copy T(N-1) into N-1.json
+        //
+        // Note that the mutual exclusion on writing into N.json with overwrite=false from
+        // different JVMs (which is the entire point of BaseExternalLogStore) is provided by the
+        // external cache, not by this lock, of course.
+        //
+        // Also note that this lock path (resolvedPath) is for N.json, while the lock path used
+        // below in the recovery `fixDeltaLog` path is for N-1.json. Thus, no deadlock.
+        //
+        // The `acquire` must be outside of the try-finally below so that we only `release` a lock
+        // we actually hold. If the acquire were interrupted while waiting, `release` in `finally`
+        // would remove the lock entry owned by another writer, breaking per-JVM mutual exclusion.
+        try {
+            pathLock.acquire(resolvedPath);
+        } catch (java.lang.InterruptedException e) {
+            throw new InterruptedIOException(e.getMessage());
+        }
+        try {
             if (overwrite) {
                 writeActions(fs, path, actions);
                 return;
@@ -263,8 +271,6 @@ public abstract class BaseExternalLogStore extends HadoopFileSystemLogStore {
                     "{}: ignoring recoverable error", e.getClass().getSimpleName(), e
                 );
             }
-        } catch (java.lang.InterruptedException e) {
-            throw new InterruptedIOException(e.getMessage());
         } finally {
             pathLock.release(resolvedPath);
         }
@@ -392,9 +398,15 @@ public abstract class BaseExternalLogStore extends HadoopFileSystemLogStore {
         }
 
         final Path targetPath = entry.absoluteFilePath();
+        // The `acquire` must be outside of the try-finally below so that we only `release` a lock we
+        // actually hold. If the acquire were interrupted while waiting, `release` in `finally` would
+        // remove the lock entry owned by another thread, breaking per-JVM mutual exclusion.
         try {
             pathLock.acquire(targetPath);
-
+        } catch (java.lang.InterruptedException e) {
+            throw new InterruptedIOException(e.getMessage());
+        }
+        try {
             int retry = 0;
             boolean copied = false;
             while (true) {
@@ -421,8 +433,6 @@ public abstract class BaseExternalLogStore extends HadoopFileSystemLogStore {
                 }
                 retry += 1;
             }
-        } catch (java.lang.InterruptedException e) {
-            throw new InterruptedIOException(e.getMessage());
         } finally {
             pathLock.release(targetPath);
         }

--- a/storage-s3-dynamodb/src/test/scala/io/delta/storage/ExternalLogStoreSuite.scala
+++ b/storage-s3-dynamodb/src/test/scala/io/delta/storage/ExternalLogStoreSuite.scala
@@ -425,6 +425,131 @@ class S3DynamoDBLogStoreSuite extends AnyFunSuite {
   }
 }
 
+///////////////////////////////////////////
+// BaseExternalLogStore PathLock Behavior //
+///////////////////////////////////////////
+
+class BaseExternalLogStorePathLockSuite extends AnyFunSuite {
+
+  private def writeOverwrite(store: MemoryLogStore, path: Path): Unit = {
+    import scala.jdk.CollectionConverters._
+    val actions = Iterator("foo").asJava
+    val overwrite = true
+    store.write(path, actions, overwrite, new Configuration())
+  }
+
+  /** Block until `thread` is parked in wait()/sleep()/park() (or dead) so interrupts land. */
+  private def awaitBlocked(thread: Thread): Unit = {
+    val deadline = System.nanoTime() + java.util.concurrent.TimeUnit.SECONDS.toNanos(10)
+    while (thread.isAlive
+        && thread.getState != Thread.State.WAITING
+        && thread.getState != Thread.State.TIMED_WAITING
+        && System.nanoTime() < deadline) {
+      Thread.sleep(10)
+    }
+  }
+
+  // scalastyle:off line.size.limit
+  test("write interrupted while contending for the per-JVM lock does not break mutual exclusion") {
+    // scalastyle:on line.size.limit
+    val tempDir = java.nio.file.Files.createTempDirectory("path-lock-suite").toFile
+    try {
+      val logDir = new File(tempDir, "_delta_log")
+      logDir.mkdirs()
+      val path = new Path(new File(logDir, "00000000000000000000.json").toURI)
+
+      // The lock holder blocks inside its critical section until the test releases it. `overwrite=
+      // true` makes `write` call only `writeActions` under the lock, so blocking there
+      // deterministically holds the per-JVM PathLock (a single static instance shared by all
+      // BaseExternalLogStore instances) for `path`.
+      val holderInCriticalSection = new java.util.concurrent.CountDownLatch(1)
+      val releaseHolder = new java.util.concurrent.CountDownLatch(1)
+      val holderStore = new BlockingMemoryLogStore(
+        new Configuration(), holderInCriticalSection, releaseHolder)
+      // Other writers use a non-blocking store, so they finish as soon as they hold the lock.
+      val otherStore = new MemoryLogStore(new Configuration())
+
+      // T0 acquires the lock for `path` and parks inside the critical section.
+      val holder = new Thread(() => writeOverwrite(holderStore, path), "holder")
+      holder.start()
+      assert(holderInCriticalSection.await(10, java.util.concurrent.TimeUnit.SECONDS),
+        "holder never entered its critical section")
+
+      // T1 tries to write the same path and blocks in PathLock.acquire, then gets interrupted.
+      // Before the fix, `acquire` was inside the try whose finally released the lock, so the
+      // interrupt made T1 rip out T0's lock entry (and could NPE in release).
+      val contenderError = new java.util.concurrent.atomic.AtomicReference[Throwable]()
+      val contender = new Thread(() => {
+        try {
+          writeOverwrite(otherStore, path)
+        } catch {
+          case t: Throwable => contenderError.set(t)
+        }
+      }, "contender")
+      contender.start()
+      awaitBlocked(contender)
+      contender.interrupt()
+      contender.join(java.util.concurrent.TimeUnit.SECONDS.toMillis(10))
+      assert(!contender.isAlive, "interrupted contender did not terminate")
+
+      // The interrupt must surface as InterruptedIOException, not a NullPointerException from
+      // releasing a lock the contender never held.
+      val err = contenderError.get()
+      assert(err != null, "contender was expected to fail with an interrupt")
+      assert(err.isInstanceOf[java.io.InterruptedIOException],
+        s"expected InterruptedIOException, got $err")
+
+      // Mutual exclusion must still hold: while T0 is inside its critical section, a fresh writer
+      // for the same path must NOT be able to proceed. If T1's interrupt had freed T0's entry, this
+      // (non-blocking) writer would acquire and finish immediately.
+      val guardEntered = new java.util.concurrent.CountDownLatch(1)
+      val guard = new Thread(() => {
+        writeOverwrite(otherStore, path)
+        guardEntered.countDown()
+      }, "guard")
+      guard.start()
+      assert(!guardEntered.await(1, java.util.concurrent.TimeUnit.SECONDS),
+        "mutual exclusion was broken: a second writer acquired the lock while it was held")
+
+      // Let the holder finish; the guard writer should then be able to complete.
+      releaseHolder.countDown()
+      holder.join(java.util.concurrent.TimeUnit.SECONDS.toMillis(10))
+      assert(guardEntered.await(10, java.util.concurrent.TimeUnit.SECONDS),
+        "guard writer never completed after the holder released the lock")
+      guard.join(java.util.concurrent.TimeUnit.SECONDS.toMillis(10))
+    } finally {
+      def deleteRecursively(f: File): Unit = {
+        if (f.isDirectory) Option(f.listFiles()).foreach(_.foreach(deleteRecursively))
+        f.delete()
+      }
+      deleteRecursively(tempDir)
+    }
+  }
+}
+
+/**
+ * A [[MemoryLogStore]] whose `writeActions` blocks inside the `write` critical section until the
+ * test releases it, so a test can deterministically hold the per-JVM `PathLock` for a path.
+ */
+class BlockingMemoryLogStore(
+    hadoopConf: Configuration,
+    entered: java.util.concurrent.CountDownLatch,
+    release: java.util.concurrent.CountDownLatch) extends MemoryLogStore(hadoopConf) {
+
+  override def writeActions(
+      fs: FileSystem,
+      path: Path,
+      actions: java.util.Iterator[String]): Unit = {
+    entered.countDown()
+    try {
+      release.await()
+    } catch {
+      case _: InterruptedException => Thread.currentThread().interrupt()
+    }
+    super.writeActions(fs, path, actions)
+  }
+}
+
 ////////////////////////////////
 // File System Helper Classes //
 ////////////////////////////////

--- a/storage/src/main/java/io/delta/storage/internal/PathLock.java
+++ b/storage/src/main/java/io/delta/storage/internal/PathLock.java
@@ -22,6 +22,11 @@ public class PathLock {
     /** Release the lock for the path after writing. */
     public void release(Path resolvedPath) {
         final Object lock = pathLock.remove(resolvedPath);
+        // The path may have no entry if `acquire` never succeeded for it (e.g. it was interrupted
+        // while waiting). In that case there is nothing to release and no waiters to notify.
+        if (lock == null) {
+            return;
+        }
         synchronized(lock) {
             lock.notifyAll();
         }

--- a/storage/src/test/scala/io/delta/storage/internal/PathLockSuite.scala
+++ b/storage/src/test/scala/io/delta/storage/internal/PathLockSuite.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.internal
+
+import org.apache.hadoop.fs.Path
+import org.scalatest.funsuite.AnyFunSuite
+
+class PathLockSuite extends AnyFunSuite {
+
+  private val path = new Path("s3://bucket/_delta_log/00000000000000000000.json")
+
+  test("acquire then release round-trips and can be re-acquired") {
+    val pathLock = new PathLock()
+    pathLock.acquire(path)
+    pathLock.release(path)
+    // The path is free again, so a second acquire must not block.
+    pathLock.acquire(path)
+    pathLock.release(path)
+  }
+
+  test("release is a no-op when the path was never acquired") {
+    val pathLock = new PathLock()
+    // Previously this threw a NullPointerException from `synchronized(null)` because
+    // `remove` returned null for an absent entry.
+    pathLock.release(path)
+  }
+}


### PR DESCRIPTION

#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (Storage - S3DynamoDB / external LogStore)


`BaseExternalLogStore` is the base class of the S3 + DynamoDB multi-cluster
LogStore. To stop two writers in the same JVM from concurrently copying
`T(N) -> N.json` for the same path, `write()` and `fixDeltaLog()` guard their body
with a per-JVM `PathLock` (a single `static final` instance).

The problem: `pathLock.acquire(...)` was called *inside* a `try` whose `finally`
unconditionally calls `pathLock.release(...)`.

`PathLock.acquire()` blocks in `Object.wait()` only when another thread already
holds the path's entry (it loops on `putIfAbsent` / `wait`). If the current thread
is interrupted while waiting, `acquire` throws `InterruptedException` **without ever
having won the entry** - it does not own the lock. But the `finally` still runs
`release()`, which does `pathLock.remove(path)`. That removes the lock entry owned
by the writer that actually holds it. Two things then go wrong:

1. **Lost mutual exclusion.** The legitimate holder's entry is gone, so a thread
   waiting on that path exits its `while (pathLock.get(P) == lock)` loop and a
   second writer enters the critical region (`writeCopyTempFile` / `fixDeltaLog`
   recovery) while the first writer is still inside it - exactly what the lock
   exists to prevent.
2. **NPE that masks the interrupt.** If the entry is already absent when `release`
   runs, `remove` returns `null` and `synchronized(null)` throws
   `NullPointerException`, hiding the intended `InterruptedIOException`.

This is reachable in normal operation: Spark interrupts task threads on job
cancellation, speculative execution, and stage failure, and Delta commits run on
those threads. `write()` already anticipates this (it translated
`InterruptedException` to `InterruptedIOException`).

The fix is small and surgical:

- Move `pathLock.acquire(...)` into its own `try/catch` placed **before** the
  `try/finally`, in both `write()` and `fixDeltaLog()`. `release()` in the
  `finally` now runs only when the lock is actually held. The now-unreachable
  `catch (InterruptedException)` on the protected region is removed (acquire is the
  only call there that can throw it).
- Make `PathLock.release()` a no-op when the path has no entry (return early when
  `remove` yields `null`). This is defense in depth and correct on its own: a
  release for a path that was never acquired should do nothing, not NPE.

No public API or behavior changes for correctly-locked paths; a lock that is held
is still acquired and released exactly as before.

## How was this patch tested?

Added two tests, both confirmed to fail before the fix and pass after (red -> green):

- `storage/.../internal/PathLockSuite.scala` (new, no Spark): an acquire/release
  round-trip that can be re-acquired, and `release` when the path was never
  acquired. The second case reproduces the `NullPointerException` from
  `synchronized(null)` on the old code.
- `BaseExternalLogStorePathLockSuite` in
  `storage-s3-dynamodb/.../ExternalLogStoreSuite.scala` (new): deterministically
  parks a holder thread inside its critical section (a `BlockingMemoryLogStore`
  gated by latches) so it holds the per-JVM `PathLock`, starts a second writer for
  the same path that blocks in `acquire`, waits until it is actually in
  `WAITING`/`TIMED_WAITING`, then interrupts it. It asserts the interrupt surfaces
  as `InterruptedIOException` (not an NPE) and that a fresh writer for the same path
  still cannot proceed while the holder is inside its critical section (mutual
  exclusion intact), then that it completes once the holder releases.

Run (external LogStore suites), JDK 21:

```
build/sbt \
  "storage/testOnly io.delta.storage.internal.PathLockSuite" \
  "storageS3DynamoDB/testOnly io.delta.storage.BaseExternalLogStorePathLockSuite \
     io.delta.storage.ExternalLogStoreSuite io.delta.storage.S3DynamoDBLogStoreSuite"
```

Result: `PathLockSuite` 2/2 and the S3+DynamoDB suites 26/26 pass. Reverting only
the two source files to `master` (keeping the tests) turns both new tests red:
`PathLockSuite` fails with the `synchronized(null)` NPE and
`BaseExternalLogStorePathLockSuite` fails with "mutual exclusion was broken: a
second writer acquired the lock while it was held".

## Does this PR introduce _any_ user-facing changes?

No. This fixes an internal concurrency bug in the S3+DynamoDB (external) LogStore.
The only observable difference is on the error path: a write interrupted while
contending for the per-JVM lock now consistently raises `InterruptedIOException`
instead of sometimes surfacing a `NullPointerException`, and it no longer
corrupts another concurrent writer's lock state.
