### PR TITLE
[Kernel] Add CRCInfo.fromRow to invert CRCInfo.toRow

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checksum/CRCInfo.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checksum/CRCInfo.java
@@ -110,7 +110,7 @@ public class CRCInfo {
                     .map(row -> DomainMetadata.fromRow((StructRow) row))
                     .collect(Collectors.toSet()));
 
-    // protocol and metadata are nullable per fromColumnVector's implementation
+    // protocol and metadata are nullable per fromColumnVector's implementation.
     if (protocol == null || metadata == null) {
       logger.warn("Invalid checksum file missing protocol and/or metadata: {}", crcFilePath);
       return Optional.empty();

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checksum/CRCInfo.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checksum/CRCInfo.java
@@ -127,6 +127,58 @@ public class CRCInfo {
             fileSizeHistogram));
   }
 
+  /**
+   * Reconstructs a {@link CRCInfo} from a {@link Row} previously produced by {@link #toRow()},
+   * inverting that serialization. Because {@code toRow()} does not carry the version (the version
+   * is derived from the {@code .crc} file name, not the row), the caller supplies it here.
+   *
+   * @param version the table version this checksum represents
+   * @param row a row with the schema {@link #CRC_FILE_SCHEMA}
+   * @return the reconstructed {@link CRCInfo}
+   */
+  public static CRCInfo fromRow(long version, Row row) {
+    requireNonNull(row, "row is null");
+    checkArgument(
+        CRC_FILE_SCHEMA.equals(row.getSchema()),
+        "Expected schema: %s, found: %s",
+        CRC_FILE_SCHEMA,
+        row.getSchema());
+
+    Metadata metadata = Metadata.fromRow(row.getStruct(getSchemaIndex(METADATA)));
+    Protocol protocol = Protocol.fromRow(row.getStruct(getSchemaIndex(PROTOCOL)));
+    long tableSizeBytes = row.getLong(getSchemaIndex(TABLE_SIZE_BYTES));
+    long numFiles = row.getLong(getSchemaIndex(NUM_FILES));
+
+    int txnIdIdx = getSchemaIndex(TXN_ID);
+    Optional<String> txnId =
+        row.isNullAt(txnIdIdx) ? Optional.empty() : Optional.of(row.getString(txnIdIdx));
+
+    int domainMetadataIdx = getSchemaIndex(DOMAIN_METADATA);
+    Optional<Set<DomainMetadata>> domainMetadata =
+        row.isNullAt(domainMetadataIdx)
+            ? Optional.empty()
+            : Optional.of(
+                VectorUtils.<Row>toJavaList(row.getArray(domainMetadataIdx)).stream()
+                    .map(DomainMetadata::fromRow)
+                    .collect(Collectors.toSet()));
+
+    int histogramIdx = getSchemaIndex(FILE_SIZE_HISTOGRAM);
+    Optional<FileSizeHistogram> fileSizeHistogram =
+        row.isNullAt(histogramIdx)
+            ? Optional.empty()
+            : FileSizeHistogram.fromRow(row.getStruct(histogramIdx));
+
+    return new CRCInfo(
+        version,
+        metadata,
+        protocol,
+        tableSizeBytes,
+        numFiles,
+        txnId,
+        domainMetadata,
+        fileSizeHistogram);
+  }
+
   private final long version;
   private final Metadata metadata;
   private final Protocol protocol;

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checksum/CRCInfo.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checksum/CRCInfo.java
@@ -180,7 +180,7 @@ public class CRCInfo {
     Optional<FileSizeHistogram> fileSizeHistogram =
         row.isNullAt(histogramIdx)
             ? Optional.empty()
-            : FileSizeHistogram.fromRow(row.getStruct(histogramIdx));
+            : Optional.of(FileSizeHistogram.fromRow(row.getStruct(histogramIdx)));
 
     return new CRCInfo(
         version,

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checksum/CRCInfo.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checksum/CRCInfo.java
@@ -110,7 +110,7 @@ public class CRCInfo {
                     .map(row -> DomainMetadata.fromRow((StructRow) row))
                     .collect(Collectors.toSet()));
 
-    //  protocol and metadata are nullable per fromColumnVector's implementation.
+    // protocol and metadata are nullable per fromColumnVector's implementation
     if (protocol == null || metadata == null) {
       logger.warn("Invalid checksum file missing protocol and/or metadata: {}", crcFilePath);
       return Optional.empty();
@@ -135,6 +135,9 @@ public class CRCInfo {
    * @param version the table version this checksum represents
    * @param row a row with the schema {@link #CRC_FILE_SCHEMA}
    * @return the reconstructed {@link CRCInfo}
+   * @throws IllegalArgumentException if {@code row}'s schema is not {@link #CRC_FILE_SCHEMA}, or if
+   *     any required field ({@code metadata}, {@code protocol}, {@code tableSizeBytes}, {@code
+   *     numFiles}) is null
    */
   public static CRCInfo fromRow(long version, Row row) {
     requireNonNull(row, "row is null");
@@ -144,10 +147,21 @@ public class CRCInfo {
         CRC_FILE_SCHEMA,
         row.getSchema());
 
-    Metadata metadata = Metadata.fromRow(row.getStruct(getSchemaIndex(METADATA)));
-    Protocol protocol = Protocol.fromRow(row.getStruct(getSchemaIndex(PROTOCOL)));
-    long tableSizeBytes = row.getLong(getSchemaIndex(TABLE_SIZE_BYTES));
-    long numFiles = row.getLong(getSchemaIndex(NUM_FILES));
+    // Required fields
+    int metadataIdx = getSchemaIndex(METADATA);
+    int protocolIdx = getSchemaIndex(PROTOCOL);
+    int tableSizeBytesIdx = getSchemaIndex(TABLE_SIZE_BYTES);
+    int numFilesIdx = getSchemaIndex(NUM_FILES);
+    Metadata metadata =
+        Metadata.fromRow(
+            InternalUtils.requireNonNull(row, metadataIdx, METADATA).getStruct(metadataIdx));
+    Protocol protocol =
+        Protocol.fromRow(
+            InternalUtils.requireNonNull(row, protocolIdx, PROTOCOL).getStruct(protocolIdx));
+    long tableSizeBytes =
+        InternalUtils.requireNonNull(row, tableSizeBytesIdx, TABLE_SIZE_BYTES)
+            .getLong(tableSizeBytesIdx);
+    long numFiles = InternalUtils.requireNonNull(row, numFilesIdx, NUM_FILES).getLong(numFilesIdx);
 
     int txnIdIdx = getSchemaIndex(TXN_ID);
     Optional<String> txnId =

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/stats/FileSizeHistogram.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/stats/FileSizeHistogram.java
@@ -63,17 +63,17 @@ public class FileSizeHistogram {
   }
 
   /** Creates a FileSizeHistogram from a {@link Row} with the schema {@link #FULL_SCHEMA}. */
-  public static Optional<FileSizeHistogram> fromRow(Row row) {
-    if (row == null) {
-      return Optional.empty();
-    }
+  public static FileSizeHistogram fromRow(Row row) {
+    requireNonNull(row);
     checkArgument(
         FULL_SCHEMA.equals(row.getSchema()),
         "Expected schema: %s, found: %s",
         FULL_SCHEMA,
         row.getSchema());
     return fromColumnVector(
-        VectorUtils.buildColumnVector(Collections.singletonList(row), FULL_SCHEMA), /* rowId */ 0);
+            VectorUtils.buildColumnVector(Collections.singletonList(row), FULL_SCHEMA),
+            /* rowId */ 0)
+        .get();
   }
 
   /** Creates a FileSizeHistogram from a column vector. */

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/stats/FileSizeHistogram.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/stats/FileSizeHistogram.java
@@ -28,7 +28,13 @@ import io.delta.kernel.metrics.FileSizeHistogramResult;
 import io.delta.kernel.types.ArrayType;
 import io.delta.kernel.types.LongType;
 import io.delta.kernel.types.StructType;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /** A histogram that tracks file size distributions and their counts. */
@@ -54,6 +60,20 @@ public class FileSizeHistogram {
     long[] zeroCounts = new long[defaultBoundaries.length];
     long[] zeroBytes = new long[defaultBoundaries.length];
     return new FileSizeHistogram(defaultBoundaries, zeroCounts, zeroBytes);
+  }
+
+  /** Creates a FileSizeHistogram from a {@link Row} with the schema {@link #FULL_SCHEMA}. */
+  public static Optional<FileSizeHistogram> fromRow(Row row) {
+    if (row == null) {
+      return Optional.empty();
+    }
+    checkArgument(
+        FULL_SCHEMA.equals(row.getSchema()),
+        "Expected schema: %s, found: %s",
+        FULL_SCHEMA,
+        row.getSchema());
+    return fromColumnVector(
+        VectorUtils.buildColumnVector(Collections.singletonList(row), FULL_SCHEMA), /* rowId */ 0);
   }
 
   /** Creates a FileSizeHistogram from a column vector. */

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/checksum/CRCInfoFromRowSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/checksum/CRCInfoFromRowSuite.scala
@@ -1,0 +1,159 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.internal.checksum
+
+import java.util
+import java.util.{Collections, Optional}
+
+import io.delta.kernel.data.Row
+import io.delta.kernel.internal.actions.{DomainMetadata, Format, Metadata, Protocol}
+import io.delta.kernel.internal.stats.FileSizeHistogram
+import io.delta.kernel.internal.types.DataTypeJsonSerDe
+import io.delta.kernel.internal.util.VectorUtils.{buildArrayValue, stringStringMapValue}
+import io.delta.kernel.types.{StringType, StructType}
+
+import org.scalatest.funsuite.AnyFunSuite
+
+/**
+ * Tests that [[CRCInfo.fromRow]] inverts [[CRCInfo.toRow]]: a CRCInfo round-tripped through its Row
+ * representation is equal to the original, across every combination of the optional fields.
+ */
+class CRCInfoFromRowSuite extends AnyFunSuite {
+
+  private val testProtocol =
+    new Protocol(1, 2, Collections.emptySet(), Collections.emptySet())
+
+  private val testMetadata = new Metadata(
+    "id",
+    Optional.of("name"),
+    Optional.of("description"),
+    new Format("parquet", Collections.emptyMap()),
+    DataTypeJsonSerDe.serializeDataType(new StructType()),
+    new StructType(),
+    buildArrayValue(util.Arrays.asList("c3"), StringType.STRING),
+    Optional.of(123),
+    stringStringMapValue(new util.HashMap[String, String]() {
+      put("delta.appendOnly", "true")
+    }))
+
+  private def createTestHistogram(fileCount: Long): FileSizeHistogram = {
+    val boundaries = Array(0L, 1024L)
+    val counts = Array(fileCount, 0L)
+    val bytes = Array(fileCount * 100, 0L)
+    new FileSizeHistogram(boundaries, counts, bytes)
+  }
+
+  private def domainMetadataSet(entries: (String, String)*): util.Set[DomainMetadata] = {
+    val set = new util.HashSet[DomainMetadata]()
+    entries.foreach { case (domain, config) =>
+      set.add(new DomainMetadata(domain, config, false))
+    }
+    set
+  }
+
+  /** Round-trips a CRCInfo through toRow -> fromRow and asserts equality. */
+  private def assertRoundTrips(crcInfo: CRCInfo): Unit = {
+    val row: Row = crcInfo.toRow()
+    val reconstructed = CRCInfo.fromRow(crcInfo.getVersion, row)
+    assert(reconstructed === crcInfo)
+  }
+
+  test("round-trips with only required fields (no optional fields)") {
+    assertRoundTrips(new CRCInfo(
+      5L,
+      testMetadata,
+      testProtocol,
+      /* tableSizeBytes */ 1000L,
+      /* numFiles */ 10L,
+      /* txnId */ Optional.empty(),
+      /* domainMetadata */ Optional.empty(),
+      /* fileSizeHistogram */ Optional.empty()))
+  }
+
+  test("round-trips with txnId present") {
+    assertRoundTrips(new CRCInfo(
+      7L,
+      testMetadata,
+      testProtocol,
+      2000L,
+      20L,
+      Optional.of("txn-abc"),
+      Optional.empty(),
+      Optional.empty()))
+  }
+
+  test("round-trips with domainMetadata present") {
+    assertRoundTrips(new CRCInfo(
+      9L,
+      testMetadata,
+      testProtocol,
+      3000L,
+      30L,
+      Optional.empty(),
+      Optional.of(domainMetadataSet("delta.rowTracking" -> "{\"hwm\":42}", "d2" -> "{}")),
+      Optional.empty()))
+  }
+
+  test("round-trips with fileSizeHistogram present") {
+    assertRoundTrips(new CRCInfo(
+      11L,
+      testMetadata,
+      testProtocol,
+      4000L,
+      40L,
+      Optional.empty(),
+      Optional.empty(),
+      Optional.of(createTestHistogram(fileCount = 40))))
+  }
+
+  test("round-trips with all optional fields present") {
+    assertRoundTrips(new CRCInfo(
+      13L,
+      testMetadata,
+      testProtocol,
+      5000L,
+      50L,
+      Optional.of("txn-xyz"),
+      Optional.of(domainMetadataSet("delta.clustering" -> "{\"cols\":[\"c1\"]}")),
+      Optional.of(createTestHistogram(fileCount = 50))))
+  }
+
+  test("preserves the supplied version, independent of the row (toRow omits version)") {
+    val crcInfo = new CRCInfo(
+      99L,
+      testMetadata,
+      testProtocol,
+      6000L,
+      60L,
+      Optional.empty(),
+      Optional.empty(),
+      Optional.empty())
+    val reconstructed = CRCInfo.fromRow(123L, crcInfo.toRow())
+    assert(reconstructed.getVersion === 123L)
+    assert(reconstructed.getMetadata === crcInfo.getMetadata)
+    assert(reconstructed.getProtocol === crcInfo.getProtocol)
+    assert(reconstructed.getTableSizeBytes === crcInfo.getTableSizeBytes)
+    assert(reconstructed.getNumFiles === crcInfo.getNumFiles)
+  }
+
+  test("rejects a row whose schema is not CRC_FILE_SCHEMA") {
+    val wrongRow: Row = testMetadata.toRow()
+    val ex = intercept[IllegalArgumentException] {
+      CRCInfo.fromRow(1L, wrongRow)
+    }
+    assert(ex.getMessage.contains("Expected schema"))
+  }
+}

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/checksum/CRCInfoFromRowSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/checksum/CRCInfoFromRowSuite.scala
@@ -20,6 +20,7 @@ import java.util.{Collections, Optional}
 
 import io.delta.kernel.data.Row
 import io.delta.kernel.internal.actions.{DomainMetadata, Format, Metadata, Protocol}
+import io.delta.kernel.internal.data.GenericRow
 import io.delta.kernel.internal.stats.FileSizeHistogram
 import io.delta.kernel.internal.types.DataTypeJsonSerDe
 import io.delta.kernel.internal.util.VectorUtils.{buildArrayValue, stringStringMapValue}
@@ -155,5 +156,66 @@ class CRCInfoFromRowSuite extends AnyFunSuite {
       CRCInfo.fromRow(1L, wrongRow)
     }
     assert(ex.getMessage.contains("Expected schema"))
+  }
+
+  test("multiple domainMetadata entries round-trip as a set (order-independent)") {
+    val entries = domainMetadataSet(
+      "delta.rowTracking" -> "{\"hwm\":42}",
+      "delta.clustering" -> "{\"cols\":[\"c1\"]}",
+      "d3" -> "{}")
+    val crcInfo = new CRCInfo(
+      15L,
+      testMetadata,
+      testProtocol,
+      7000L,
+      70L,
+      Optional.empty(),
+      Optional.of(entries),
+      Optional.empty())
+    val reconstructed = CRCInfo.fromRow(crcInfo.getVersion, crcInfo.toRow())
+    assert(reconstructed === crcInfo)
+    // The array in the row is reassembled into a Set, so all entries survive regardless of order.
+    assert(reconstructed.getDomainMetadata.isPresent)
+    assert(reconstructed.getDomainMetadata.get === entries)
+    assert(reconstructed.getDomainMetadata.get.size === 3)
+  }
+
+  // A row with CRC_FILE_SCHEMA whose fields come from `values`. Any field absent from the map reads
+  // back as null.
+  private def crcRow(values: util.Map[Integer, Object]): Row =
+    new GenericRow(CRCInfo.CRC_FILE_SCHEMA, values)
+
+  private def idx(field: String): Integer = Int.box(CRCInfo.CRC_FILE_SCHEMA.indexOf(field))
+
+  /** A value map with every required field of CRC_FILE_SCHEMA populated. */
+  private def requiredValues(): util.HashMap[Integer, Object] = {
+    val values = new util.HashMap[Integer, Object]()
+    values.put(idx("tableSizeBytes"), Long.box(1000L))
+    values.put(idx("numFiles"), Long.box(10L))
+    values.put(idx("numMetadata"), Long.box(1L))
+    values.put(idx("numProtocol"), Long.box(1L))
+    values.put(idx("metadata"), testMetadata.toRow())
+    values.put(idx("protocol"), testProtocol.toRow())
+    values
+  }
+
+  Seq("metadata", "protocol", "tableSizeBytes", "numFiles").foreach { field =>
+    test(s"throws when required field '$field' is null") {
+      val values = requiredValues()
+      values.remove(idx(field))
+      val ex = intercept[IllegalArgumentException] {
+        CRCInfo.fromRow(1L, crcRow(values))
+      }
+      assert(ex.getMessage.contains(field))
+    }
+  }
+
+  test("throws on a fully-null row (all fields null)") {
+    // Schema matches CRC_FILE_SCHEMA, but every value is absent -> null. fromRow must reject it
+    val ex = intercept[IllegalArgumentException] {
+      CRCInfo.fromRow(1L, crcRow(new util.HashMap[Integer, Object]()))
+    }
+    // The first required field
+    assert(ex.getMessage.contains("metadata"))
   }
 }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

`CRCInfo` can be serialized to a `Row` via `toRow()` (used when writing the `.crc` file), but there is no inverse. The only way to read a `CRCInfo` back is `fromColumnarBatch(...)`, which requires an engine-produced `ColumnarBatch` and is tailored to reading a `.crc` file off storage. A caller that already holds a persisted or round-tripped CRC `Row` can't rebuild the `CRCInfo` without re-reading the `.crc` file.

This adds **`CRCInfo.fromRow(long version, Row)`**, the `Row`-level counterpart to `fromColumnarBatch`, inverting `toRow()`. Because `toRow()` does not encode the version (it is derived from the `.crc` file name), `fromRow` takes it as an argument. The implementation reuses the existing `Metadata.fromRow` / `Protocol.fromRow` / `DomainMetadata.fromRow`, and adds a small **`FileSizeHistogram.fromRow(Row)`** (the one nested type).

**Motivation.** For calling `ChecksumUtils.tryBuildCrcIncrementally(engine, logSegment, priorCrc)`, we need a priorCrc (CRCInfo type) which a user with checksumOpt Json field would have a hard time obtaining without fromRow() serialization.

Also refactored FileSizeHistogram.fromRow to return a bare type instead of Optional, matching the other fromRow() methods, and moved the field-presence check up to the call site in CRCInfo.fromRow (matches style).


## How was this patch tested?

New `CRCInfoFromRowSuite` asserts `fromRow(version, crcInfo.toRow()) === crcInfo` round trip tests across every combination of the optional fields.

## Does this PR introduce _any_ user-facing changes?

No. This adds a new internal API.
