### PR TITLE
[Spark] Wire up time travel in catalog and add tests

### DIFF
--- a/spark-unified/src/main/java/org/apache/spark/sql/delta/catalog/DeltaCatalog.java
+++ b/spark-unified/src/main/java/org/apache/spark/sql/delta/catalog/DeltaCatalog.java
@@ -17,7 +17,10 @@
 package org.apache.spark.sql.delta.catalog;
 
 import io.delta.spark.internal.v2.catalog.DeltaV2Table;
+import io.delta.spark.internal.v2.exception.TimestampOutOfRangeException;
+import io.delta.spark.internal.v2.exception.VersionNotFoundException;
 import org.apache.spark.sql.delta.DeltaV2Mode;
+import org.apache.spark.sql.delta.v2.interop.DeltaV2ErrorInterop$;
 import java.util.HashMap;
 import java.util.function.Supplier;
 import org.apache.hadoop.fs.Path;
@@ -103,6 +106,62 @@ public class DeltaCatalog extends AbstractDeltaCatalog implements ChangelogSuppo
         // delta.`/path/to/table`, where ident.name() is `/path/to/table`
         () -> new DeltaV2Table(ident, ident.name()),
         () -> super.loadPathTable(ident));
+  }
+
+  /**
+   * Loads a Delta table pinned to a specific version.
+   *
+   * <p>Routing logic based on {@link DeltaV2Mode}:
+   * <ul>
+   *   <li>V2 connector: pins a {@link DeltaV2Table}</li>
+   *   <li>V1 connector (default): delegates to the {@code AbstractDeltaCatalog} time travel path</li>
+   * </ul>
+   *
+   * @param ident The identifier of the table in the catalog.
+   * @param version The table version to load.
+   * @return Table instance pinned to {@code version}.
+   */
+  @Override
+  public Table loadTable(Identifier ident, String version) {
+    Table table = loadTable(ident);
+    if (table instanceof DeltaV2Table) {
+      try {
+        return ((DeltaV2Table) table).withVersion(Long.parseLong(version));
+      } catch (VersionNotFoundException e) {
+        // throwAsDeltaError always throws; the trailing throw is unreachable but satisfies javac.
+        DeltaV2ErrorInterop$.MODULE$.throwAsDeltaError(e);
+        throw new IllegalStateException("unreachable");
+      }
+    }
+    return super.loadTable(ident, version);
+  }
+
+  /**
+   * Loads a Delta table pinned to the snapshot active at a specific timestamp.
+   *
+   * <p>Routing logic based on {@link DeltaV2Mode}:
+   * <ul>
+   *   <li>V2 connector: pins a {@link DeltaV2Table}.</li>
+   *   <li>V1 connector (default): delegates to the {@code AbstractDeltaCatalog} time travel path</li>
+   * </ul>
+   *
+   * @param ident The identifier of the table in the catalog.
+   * @param timestamp The timestamp to load the table at, in microseconds since the epoch.
+   * @return Table instance pinned to the snapshot active at {@code timestamp}.
+   */
+  @Override
+  public Table loadTable(Identifier ident, long timestamp) {
+    Table table = loadTable(ident);
+    if (table instanceof DeltaV2Table) {
+      try {
+        return ((DeltaV2Table) table).withTimestamp(timestamp);
+      } catch (TimestampOutOfRangeException e) {
+        // throwAsDeltaError always throws; the trailing throw is unreachable but satisfies javac.
+        DeltaV2ErrorInterop$.MODULE$.throwAsDeltaError(e);
+        throw new IllegalStateException("unreachable");
+      }
+    }
+    return super.loadTable(ident, timestamp);
   }
 
   /**

--- a/spark-unified/src/main/scala-shims/spark-4.2/io/delta/internal/ResolveTableChangesV2.scala
+++ b/spark-unified/src/main/scala-shims/spark-4.2/io/delta/internal/ResolveTableChangesV2.scala
@@ -58,10 +58,12 @@ class ResolveTableChangesV2(session: SparkSession) extends Rule[LogicalPlan] {
         }
 
       // `.option("readChangeFeed", "true").table(name)` where the catalog returned DeltaV2Table
-      // (no `TableChanges` wrapper -- the relation flows straight into the query).
-      case DataSourceV2RelationShim(_: DeltaV2Table,
-      _, Some(catalog: ChangelogSupport), Some(ident), options)
+      // (no `TableChanges` wrapper -- the relation flows straight into the query). Check for a
+      // `timeTravelSpec` to see if this is a time travel query.
+      case DataSourceV2Relation(_: DeltaV2Table,
+      _, Some(catalog: ChangelogSupport), Some(ident), options, timeTravelSpec)
         if CDCReader.isCDCRead(options) =>
+        rejectTimeTravelWithCDF(timeTravelSpec.isDefined)
         buildChangelogRelation(catalog, ident, options)
     }
   }
@@ -100,6 +102,15 @@ class ResolveTableChangesV2(session: SparkSession) extends Rule[LogicalPlan] {
       "endingBoundInclusive")
     unsupportedOptions.foreach { key =>
       if (options.containsKey(key)) throw DeltaErrors.changelogUnsupportedOption(key)
+    }
+  }
+
+  /**
+   * Block combining a CDF read with a time travel pin.
+   */
+  private def rejectTimeTravelWithCDF(hasTimeTravelSpec: Boolean): Unit = {
+    if (hasTimeTravelSpec) {
+      throw DeltaErrors.timeTravelNotSupportedException
     }
   }
 }

--- a/spark-unified/src/main/scala/org/apache/spark/sql/delta/v2/interop/DeltaV2ErrorInterop.scala
+++ b/spark-unified/src/main/scala/org/apache/spark/sql/delta/v2/interop/DeltaV2ErrorInterop.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.v2.interop
+
+import java.sql.Timestamp
+
+import org.apache.spark.sql.delta.{DeltaErrors, VersionNotFoundException => V1VersionNotFoundException}
+import org.apache.spark.sql.delta.util.{DateTimeUtils, TimestampFormatter}
+import io.delta.spark.internal.v2.exception.{TimestampOutOfRangeException, VersionNotFoundException}
+
+import org.apache.spark.sql.internal.SQLConf
+
+/**
+ * Maps V2 connector exceptions to their V1 [[DeltaErrors]] equivalents.
+ *
+ * Each method throws the mapped V1 error (never returns). The V1 errors are checked
+ * `AnalysisException`s, so throwing them from a Scala file lets the caller propagate them without
+ * a `throws` clause.
+ */
+object DeltaV2ErrorInterop {
+
+  def throwAsDeltaError(e: TimestampOutOfRangeException): Nothing = {
+    val userTs = new Timestamp(e.getUserMillis)
+    val commitTs = new Timestamp(e.getCommitMillis)
+    val tsString = DateTimeUtils.timestampToString(
+      TimestampFormatter(DateTimeUtils.getTimeZone(SQLConf.get.sessionLocalTimeZone)),
+      DateTimeUtils.fromJavaTimestamp(commitTs))
+    if (e.isAfterLatest) {
+      throw DeltaErrors.timestampGreaterThanLatestCommit(userTs, commitTs, tsString)
+    } else {
+      throw DeltaErrors.TimestampEarlierThanCommitRetentionException(userTs, commitTs, tsString)
+    }
+  }
+
+  def throwAsDeltaError(e: VersionNotFoundException): Nothing =
+    throw V1VersionNotFoundException(e.getUserVersion, e.getEarliest, e.getLatest)
+}

--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaHistoryManagerV2Suite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaHistoryManagerV2Suite.scala
@@ -1,0 +1,502 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.test
+
+import java.io.{File, FileNotFoundException, IOException}
+import java.sql.Timestamp
+
+import scala.concurrent.duration._
+
+import org.apache.spark.sql.delta.{DeltaErrors, DeltaLog, DeltaTimeTravelTestHelpers, VersionNotFoundException}
+import org.apache.spark.sql.delta.DeltaTestUtils.modifyCommitTimestamp
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.util.FileNames
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.parser.ParseException
+
+/**
+ * DSv2 parity tests for time travel queries exercising the STRICT-mode Kernel-backed connector
+ * ([[io.delta.spark.internal.v2.catalog.DeltaV2Table]]).
+ *
+ * The helper infrastructure is reused from [[DeltaTimeTravelTestHelpers]].
+ */
+class DeltaHistoryManagerV2Suite extends DeltaTimeTravelTestHelpers {
+
+  import testImplicits._
+
+  override protected def sparkConf: SparkConf =
+    super.sparkConf.set(DeltaSQLConf.V2_ENABLE_MODE.key, "STRICT")
+
+  /** Runs table creation / commits on the V1 connector. */
+  private def inV1[T](f: => T): T =
+    withSQLConf(DeltaSQLConf.V2_ENABLE_MODE.key -> "NONE")(f)
+
+  test("SQL VERSION AS OF returns the historical snapshot") {
+    val tbl = "delta_tt_v2"
+    withTable(tbl) {
+      val start = System.currentTimeMillis() - 5.days.toMillis
+      inV1 { generateCommits(tbl, start, start + 20.minutes) }
+
+      checkAnswer(sql(s"SELECT * FROM $tbl FOR VERSION AS OF 0"), spark.range(0, 10).toDF())
+      checkAnswer(sql(s"SELECT * FROM $tbl VERSION AS OF 1"), spark.range(0, 20).toDF())
+    }
+  }
+
+  test("SQL VERSION AS OF past the latest version fails with DELTA_VERSION_NOT_FOUND") {
+    val tbl = "delta_tt_v2"
+    withTable(tbl) {
+      val start = System.currentTimeMillis() - 5.days.toMillis
+      inV1 { generateCommits(tbl, start, start + 20.minutes) }
+
+      val ex = intercept[VersionNotFoundException] {
+        sql(s"SELECT * FROM $tbl FOR VERSION AS OF 2").collect()
+      }
+      checkError(
+        ex,
+        "DELTA_VERSION_NOT_FOUND",
+        sqlState = "22003",
+        parameters = Map("userVersion" -> "2", "earliest" -> "0", "latest" -> "1"))
+    }
+  }
+
+  test("SQL TIMESTAMP AS OF resolves to the commit active at that time") {
+    val tbl = "delta_tt_v2"
+    withTable(tbl) {
+      val start = System.currentTimeMillis() - 5.days.toMillis
+      inV1 { generateCommits(tbl, start, start + 20.minutes, start + 40.minutes) }
+
+      // A timestamp between commits resolves to the commit active at that time.
+      checkAnswer(sql(s"SELECT count(*) FROM ${timestampAsOf(tbl, start + 10.minutes)}"), Row(10L))
+      checkAnswer(sql(s"SELECT count(*) FROM ${timestampAsOf(tbl, start + 30.minutes)}"), Row(20L))
+      // Exact commit timestamps resolve to that commit.
+      checkAnswer(sql(s"SELECT count(*) FROM ${timestampAsOf(tbl, start)}"), Row(10L))
+      checkAnswer(sql(s"SELECT count(*) FROM ${timestampAsOf(tbl, start + 20.minutes)}"), Row(20L))
+    }
+  }
+
+  test(
+    "SQL TIMESTAMP AS OF after the latest commit fails with DELTA_TIMESTAMP_GREATER_THAN_COMMIT") {
+    val tbl = "delta_tt_v2"
+    withTable(tbl) {
+      val start = 1540415658000L
+      inV1 { generateCommits(tbl, start) }
+
+      val ts = Seq(new Timestamp(start + 10.minutes)).toDF("ts")
+        .select($"ts".cast("string")).as[String].collect().map(i => s"'$i'")
+
+      val ex = intercept[DeltaErrors.TemporallyUnstableInputException] {
+        sql(s"SELECT count(*) FROM ${timestampAsOf(tbl, ts(0))}").collect()
+      }
+      checkError(
+        ex,
+        "DELTA_TIMESTAMP_GREATER_THAN_COMMIT",
+        sqlState = "42816",
+        parameters = Map(
+          "providedTimestamp" -> "2018-10-24 14:24:18.0",
+          "lastCommitTimestamp" -> "2018-10-24 14:14:18.0",
+          "maximumTimestamp" -> "2018-10-24 14:14:18"))
+    }
+  }
+
+  test("SQL TIMESTAMP AS OF before the earliest recreatable commit fails") {
+    val tbl = "delta_tt_v2_ts_recreatable"
+    withTable(tbl) {
+      val start = System.currentTimeMillis() - 5.days.toMillis
+      inV1 {
+        // v0, v1, v2. Checkpoint at v2, then delete v0's commit file.
+        generateCommits(tbl, start, start + 20.minutes, start + 40.minutes)
+        val deltaLog = DeltaLog.forTable(spark, TableIdentifier(tbl))
+        deltaLog.checkpoint(deltaLog.update())
+        new File(FileNames.unsafeDeltaFile(deltaLog.logPath, 0).toUri).delete()
+      }
+
+      val ts = Seq(new Timestamp(start)).toDF("ts")
+        .select($"ts".cast("string")).as[String].head()
+      val ex = intercept[DeltaErrors.TimestampEarlierThanCommitRetentionException] {
+        sql(s"SELECT * FROM ${timestampAsOf(tbl, s"'$ts'")}").collect()
+      }
+      assert(ex.getCondition === "DELTA_TIMESTAMP_EARLIER_THAN_COMMIT_RETENTION")
+      assert(ex.getSqlState === "42816")
+    }
+  }
+
+  test("SQL TIMESTAMP AS OF reflects the historical schema before a column was added") {
+    val tbl = "delta_tt_v2_ts_schema"
+    val start = System.currentTimeMillis() - 5.days.toMillis
+    withTable(tbl) {
+      inV1 {
+        sql(s"CREATE TABLE $tbl (id INT) USING delta")      // v0
+        sql(s"INSERT INTO $tbl VALUES (1)")                 // v1
+        sql(s"ALTER TABLE $tbl ADD COLUMNS (name STRING)")  // v2
+        sql(s"INSERT INTO $tbl VALUES (2, 'b')")            // v3
+        // Pin deterministic commit timestamps.
+        val deltaLog = DeltaLog.forTable(spark, TableIdentifier(tbl))
+        Seq(0L, 1L, 2L, 3L).foreach { v =>
+          modifyCommitTimestamp(deltaLog, v, start + v * 20.minutes)
+        }
+      }
+
+      val ts = Seq(new Timestamp(start + 30.minutes)).toDF("ts")
+        .select($"ts".cast("string")).as[String].head()
+      val atV1 = sql(s"SELECT * FROM ${timestampAsOf(tbl, s"'$ts'")}")
+      assert(atV1.schema.fieldNames.toSeq === Seq("id"))
+      checkAnswer(atV1, Row(1))
+      assert(sql(s"SELECT * FROM $tbl").schema.fieldNames.toSeq === Seq("id", "name"))
+    }
+  }
+
+  test("SQL TIMESTAMP AS OF accepts a timestamp expression") {
+    withDatabase("ttdb") {
+      sql("CREATE DATABASE ttdb")
+      withTable("ttdb.tbl") {
+        val ts = inV1 {
+          spark.range(10).write.format("delta").saveAsTable("ttdb.tbl")
+          sql("DESCRIBE HISTORY ttdb.tbl").select("timestamp").head().getTimestamp(0)
+        }
+        checkAnswer(
+          sql(s"SELECT count(*) FROM ttdb.tbl TIMESTAMP AS OF " +
+            s"coalesce(CAST ('$ts' AS TIMESTAMP), current_date())"),
+          Row(10L))
+      }
+    }
+  }
+
+  test("SQL VERSION AS OF across multiple versions in one query (relation caching)") {
+    val tbl = "delta_tt_v2_cache"
+    withTable(tbl) {
+      inV1 {
+        sql(s"CREATE TABLE $tbl USING delta AS SELECT 1 AS c")
+        sql(s"INSERT INTO $tbl SELECT 2 AS c")
+      }
+      checkAnswer(
+        sql(s"SELECT * FROM $tbl VERSION AS OF '0' UNION ALL SELECT * FROM $tbl VERSION AS OF '1'"),
+        Row(1) :: Row(1) :: Row(2) :: Nil)
+    }
+  }
+
+  test("SQL VERSION AS OF reflects historical column defaults") {
+    val tbl = "delta_tt_v2_defaults"
+    withTable(tbl) {
+      inV1 {
+        sql(s"CREATE TABLE $tbl(id long) USING delta " +
+          "TBLPROPERTIES('delta.feature.allowColumnDefaults' = 'enabled')")
+        sql(s"INSERT INTO $tbl SELECT default")
+        sql(s"ALTER TABLE $tbl ALTER COLUMN id SET DEFAULT 42")
+        sql(s"INSERT INTO $tbl SELECT default")
+      }
+      checkAnswer(sql(s"SELECT * FROM $tbl FOR VERSION AS OF 0"), Seq.empty[Row])
+      checkAnswer(sql(s"SELECT * FROM $tbl FOR VERSION AS OF 1"), Seq(Row(null)))
+      checkAnswer(sql(s"SELECT * FROM $tbl"), Seq(Row(null), Row(42L)))
+    }
+  }
+
+  test("SQL VERSION AS OF below the earliest recreatable commit fails") {
+    val tbl = "delta_tt_v2_recreatable"
+    withTable(tbl) {
+      val start = System.currentTimeMillis() - 5.days.toMillis
+      inV1 {
+        // v0, v1, v2. Checkpoint at v2, then delete v0's commit file
+        generateCommits(tbl, start, start + 20.minutes, start + 40.minutes)
+        val deltaLog = DeltaLog.forTable(spark, TableIdentifier(tbl))
+        deltaLog.checkpoint(deltaLog.update())
+        new File(FileNames.unsafeDeltaFile(deltaLog.logPath, 0).toUri).delete()
+      }
+
+      val ex = intercept[VersionNotFoundException] {
+        sql(s"SELECT * FROM $tbl VERSION AS OF 1").collect()
+      }
+      checkError(
+        ex,
+        "DELTA_VERSION_NOT_FOUND",
+        sqlState = "22003",
+        parameters = Map("userVersion" -> "1", "earliest" -> "2", "latest" -> "2"))
+    }
+  }
+
+  test("SQL VERSION AS OF a negative version is rejected by the parser") {
+    val tbl = "delta_tt_v2_negative"
+    withTable(tbl) {
+      inV1 { generateCommits(tbl, System.currentTimeMillis() - 5.days.toMillis) }
+      intercept[ParseException] {
+        sql(s"SELECT * FROM $tbl VERSION AS OF -1").collect()
+      }
+    }
+  }
+
+  test("SQL VERSION AS OF on a non-existent table fails to resolve the table") {
+    val ex = intercept[AnalysisException] {
+      sql("SELECT * FROM delta_tt_v2_missing VERSION AS OF 0").collect()
+    }
+    assert(ex.getMessage.contains("delta_tt_v2_missing"))
+  }
+
+  test("SQL VERSION AS OF reflects the historical schema before a column was added") {
+    val tbl = "delta_tt_v2_schema"
+    withTable(tbl) {
+      inV1 {
+        sql(s"CREATE TABLE $tbl (id INT) USING delta")      // v0
+        sql(s"INSERT INTO $tbl VALUES (1)")                 // v1
+        sql(s"ALTER TABLE $tbl ADD COLUMNS (name STRING)")  // v2
+        sql(s"INSERT INTO $tbl VALUES (2, 'b')")            // v3
+      }
+      assert(sql(s"SELECT * FROM $tbl VERSION AS OF 1").schema.fieldNames.toSeq === Seq("id"))
+      checkAnswer(sql(s"SELECT * FROM $tbl VERSION AS OF 1"), Row(1))
+      assert(sql(s"SELECT * FROM $tbl").schema.fieldNames.toSeq === Seq("id", "name"))
+      checkAnswer(sql(s"SELECT * FROM $tbl"), Row(1, null) :: Row(2, "b") :: Nil)
+    }
+  }
+
+  test("SQL VERSION AS OF after VACUUM removed the data files fails") {
+    val tbl = "delta_tt_v2_vacuum"
+    withTable(tbl) {
+      val start = System.currentTimeMillis() - 5.days.toMillis
+      inV1 {
+        generateCommits(tbl, start, start + 20.minutes)  // v0, v1
+        sql(s"OPTIMIZE $tbl")  // the v0/v1 data files become unreferenced
+        withSQLConf("spark.databricks.delta.retentionDurationCheck.enabled" -> "false") {
+          sql(s"VACUUM $tbl RETAIN 0 HOURS")
+        }
+      }
+      val ex = intercept[Exception] {
+        sql(s"SELECT * FROM $tbl VERSION AS OF 0").collect()
+      }
+      val causes = Iterator.iterate(ex: Throwable)(_.getCause).takeWhile(_ != null).toList
+      assert(
+        causes.exists { c =>
+          c.isInstanceOf[FileNotFoundException] || c.isInstanceOf[IOException]
+        },
+        "expected a missing-data-file read failure, got:\n" +
+          causes.map(c => s"  [${c.getClass.getName}] ${c.getMessage}").mkString("\n"))
+    }
+  }
+
+  private def readVersionAsOf(table: String, version: Long): DataFrame =
+    spark.read.option("versionAsOf", version).table(table)
+
+  private def readTimestampAsOf(table: String, ts: String): DataFrame =
+    spark.read.option("timestampAsOf", ts).table(table)
+
+  /** Formats an epoch-millis value as a Spark-cast timestamp string. */
+  private def timestampString(millis: Long): String =
+    Seq(new Timestamp(millis)).toDF("ts").select($"ts".cast("string")).as[String].head()
+
+  test("DataFrame versionAsOf returns the historical snapshot") {
+    val tbl = "delta_tt_v2_df_ver"
+    withTable(tbl) {
+      val start = System.currentTimeMillis() - 5.days.toMillis
+      inV1 { generateCommits(tbl, start, start + 20.minutes) }
+
+      checkAnswer(readVersionAsOf(tbl, 0), spark.range(0, 10).toDF())
+      checkAnswer(readVersionAsOf(tbl, 1), spark.range(0, 20).toDF())
+    }
+  }
+
+  test("DataFrame versionAsOf past the latest version fails with DELTA_VERSION_NOT_FOUND") {
+    val tbl = "delta_tt_v2_df_ver_oob"
+    withTable(tbl) {
+      val start = System.currentTimeMillis() - 5.days.toMillis
+      inV1 { generateCommits(tbl, start, start + 20.minutes) }
+
+      val ex = intercept[VersionNotFoundException] {
+        readVersionAsOf(tbl, 2).collect()
+      }
+      checkError(
+        ex,
+        "DELTA_VERSION_NOT_FOUND",
+        sqlState = "22003",
+        parameters = Map("userVersion" -> "2", "earliest" -> "0", "latest" -> "1"))
+    }
+  }
+
+  test("DataFrame versionAsOf below the earliest recreatable commit fails") {
+    val tbl = "delta_tt_v2_df_ver_recreatable"
+    withTable(tbl) {
+      val start = System.currentTimeMillis() - 5.days.toMillis
+      inV1 {
+        // v0, v1, v2. Checkpoint at v2, then delete v0's commit file.
+        generateCommits(tbl, start, start + 20.minutes, start + 40.minutes)
+        val deltaLog = DeltaLog.forTable(spark, TableIdentifier(tbl))
+        deltaLog.checkpoint(deltaLog.update())
+        new File(FileNames.unsafeDeltaFile(deltaLog.logPath, 0).toUri).delete()
+      }
+
+      val ex = intercept[VersionNotFoundException] {
+        readVersionAsOf(tbl, 1).collect()
+      }
+      checkError(
+        ex,
+        "DELTA_VERSION_NOT_FOUND",
+        sqlState = "22003",
+        parameters = Map("userVersion" -> "1", "earliest" -> "2", "latest" -> "2"))
+    }
+  }
+
+  test("DataFrame versionAsOf reflects the historical schema before a column was added") {
+    val tbl = "delta_tt_v2_df_ver_schema"
+    withTable(tbl) {
+      inV1 {
+        sql(s"CREATE TABLE $tbl (id INT) USING delta")      // v0
+        sql(s"INSERT INTO $tbl VALUES (1)")                 // v1
+        sql(s"ALTER TABLE $tbl ADD COLUMNS (name STRING)")  // v2
+        sql(s"INSERT INTO $tbl VALUES (2, 'b')")            // v3
+      }
+      val atV1 = readVersionAsOf(tbl, 1)
+      assert(atV1.schema.fieldNames.toSeq === Seq("id"))
+      checkAnswer(atV1, Row(1))
+      assert(spark.read.table(tbl).schema.fieldNames.toSeq === Seq("id", "name"))
+      checkAnswer(spark.read.table(tbl), Row(1, null) :: Row(2, "b") :: Nil)
+    }
+  }
+
+  test("DataFrame timestampAsOf resolves to the commit active at that time") {
+    val tbl = "delta_tt_v2_df_ts"
+    withTable(tbl) {
+      val start = System.currentTimeMillis() - 5.days.toMillis
+      inV1 { generateCommits(tbl, start, start + 20.minutes, start + 40.minutes) }
+
+      // A timestamp between commits resolves to the commit active at that time.
+      checkAnswer(readTimestampAsOf(tbl, timestampString(start + 10.minutes)).groupBy().count(),
+        Row(10L))
+      checkAnswer(readTimestampAsOf(tbl, timestampString(start + 30.minutes)).groupBy().count(),
+        Row(20L))
+      // Exact commit timestamps resolve to that commit.
+      checkAnswer(readTimestampAsOf(tbl, timestampString(start)).groupBy().count(), Row(10L))
+      checkAnswer(readTimestampAsOf(tbl, timestampString(start + 20.minutes)).groupBy().count(),
+        Row(20L))
+    }
+  }
+
+  test("DataFrame timestampAsOf after the latest commit fails with " +
+    "DELTA_TIMESTAMP_GREATER_THAN_COMMIT") {
+    val tbl = "delta_tt_v2_df_ts_oob"
+    withTable(tbl) {
+      val start = 1540415658000L
+      inV1 { generateCommits(tbl, start) }
+
+      val ex = intercept[DeltaErrors.TemporallyUnstableInputException] {
+        readTimestampAsOf(tbl, timestampString(start + 10.minutes)).collect()
+      }
+      checkError(
+        ex,
+        "DELTA_TIMESTAMP_GREATER_THAN_COMMIT",
+        sqlState = "42816",
+        parameters = Map(
+          "providedTimestamp" -> "2018-10-24 14:24:18.0",
+          "lastCommitTimestamp" -> "2018-10-24 14:14:18.0",
+          "maximumTimestamp" -> "2018-10-24 14:14:18"))
+    }
+  }
+
+  test("DataFrame timestampAsOf before the earliest recreatable commit fails") {
+    val tbl = "delta_tt_v2_df_ts_recreatable"
+    withTable(tbl) {
+      val start = System.currentTimeMillis() - 5.days.toMillis
+      inV1 {
+        // v0, v1, v2. Checkpoint at v2, then delete v0's commit file.
+        generateCommits(tbl, start, start + 20.minutes, start + 40.minutes)
+        val deltaLog = DeltaLog.forTable(spark, TableIdentifier(tbl))
+        deltaLog.checkpoint(deltaLog.update())
+        new File(FileNames.unsafeDeltaFile(deltaLog.logPath, 0).toUri).delete()
+      }
+
+      val ex = intercept[DeltaErrors.TimestampEarlierThanCommitRetentionException] {
+        readTimestampAsOf(tbl, timestampString(start)).collect()
+      }
+      assert(ex.getCondition === "DELTA_TIMESTAMP_EARLIER_THAN_COMMIT_RETENTION")
+      assert(ex.getSqlState === "42816")
+    }
+  }
+
+  test("DataFrame timestampAsOf reflects the historical schema before a column was added") {
+    val tbl = "delta_tt_v2_df_ts_schema"
+    val start = System.currentTimeMillis() - 5.days.toMillis
+    withTable(tbl) {
+      inV1 {
+        sql(s"CREATE TABLE $tbl (id INT) USING delta")      // v0
+        sql(s"INSERT INTO $tbl VALUES (1)")                 // v1
+        sql(s"ALTER TABLE $tbl ADD COLUMNS (name STRING)")  // v2
+        sql(s"INSERT INTO $tbl VALUES (2, 'b')")            // v3
+        val deltaLog = DeltaLog.forTable(spark, TableIdentifier(tbl))
+        Seq(0L, 1L, 2L, 3L).foreach { v =>
+          modifyCommitTimestamp(deltaLog, v, start + v * 20.minutes)
+        }
+      }
+      val atV1 = readTimestampAsOf(tbl, timestampString(start + 30.minutes))
+      assert(atV1.schema.fieldNames.toSeq === Seq("id"))
+      checkAnswer(atV1, Row(1))
+      assert(spark.read.table(tbl).schema.fieldNames.toSeq === Seq("id", "name"))
+    }
+  }
+
+  test("DataFrame versionAsOf and timestampAsOf together is rejected") {
+    val tbl = "delta_tt_v2_df_both"
+    withTable(tbl) {
+      val start = System.currentTimeMillis() - 5.days.toMillis
+      inV1 { generateCommits(tbl, start) }
+
+      val ex = intercept[AnalysisException] {
+        spark.read
+          .option("versionAsOf", 0)
+          .option("timestampAsOf", timestampString(start))
+          .table(tbl)
+          .collect()
+      }
+      checkError(ex, "INVALID_TIME_TRAVEL_SPEC", sqlState = Some("42K0E"))
+    }
+  }
+
+  test("DataFrame timestampAsOf with an invalid timestamp fails") {
+    val tbl = "delta_tt_v2_df_ts_invalid"
+    withTable(tbl) {
+      val start = System.currentTimeMillis() - 5.days.toMillis
+      inV1 { generateCommits(tbl, start) }
+
+      val ex = intercept[AnalysisException] {
+        readTimestampAsOf(tbl, "i am not a timestamp").collect()
+      }
+      assert(ex.getMessage.contains("i am not a timestamp"))
+    }
+  }
+
+  test("a streaming read reflects latest data, not a prior VERSION AS OF pin") {
+    val tbl = "delta_tt_v2_stream"
+    withTempDir { checkpoint =>
+      withTable(tbl) {
+        val start = System.currentTimeMillis() - 5.days.toMillis
+        inV1 { generateCommits(tbl, start, start + 20.minutes) }
+        checkAnswer(sql(s"SELECT count(*) FROM $tbl VERSION AS OF 0"), Row(10L))
+
+        val q = spark.readStream.format("delta").table(tbl).writeStream
+          .format("memory")
+          .queryName("tt_v2_stream_out")
+          .option("checkpointLocation", checkpoint.getCanonicalPath)
+          .start()
+        try {
+          q.processAllAvailable()
+          checkAnswer(sql("SELECT count(*) FROM tt_v2_stream_out"), Row(20L))
+        } finally {
+          q.stop()
+        }
+      }
+    }
+  }
+}

--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaTimeTravelV2Suite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaTimeTravelV2Suite.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.test
+
+import org.apache.spark.sql.delta.DeltaTimeTravelSuite
+
+/**
+ * Runs the DSv1 [[DeltaTimeTravelSuite]] under the STRICT V2 connector.
+ *
+ * Table setup is rerouted to the V1 connector via [[DeltaTimeTravelSuite.setupSql]] /
+ * [[DeltaTimeTravelSuite.runSetup]], so the time travel read itself is what runs under V2.
+ * [[V2ForceTest]] also ensures that no test is silently executing a V1 file-source scan.
+ */
+class DeltaTimeTravelV2Suite extends DeltaTimeTravelSuite with V2ForceTest {
+
+  override protected def assertNoV1Fallback: Boolean = true
+
+  override protected def setupSql(sqlText: String): Unit = executeInV1Mode(sqlText)
+
+  override protected def runSetup[T](f: => T): T = inV1Mode(f)
+
+  override protected def shouldPassTests: Set[String] = Set(
+    // History-manager and log-deletion internals: operate on DeltaLog directly.
+    "getCommits should monotonize timestamps",
+    "describe history timestamps are adjusted according to file timestamp",
+    "should filter only delta files when computing earliest version",
+    "resolving commits should return commit before timestamp",
+    "BufferingLogDeletionIterator: iterator behavior",
+    "BufferingLogDeletionIterator: early exit while handling adjusted timestamps due to timestamp",
+    "BufferingLogDeletionIterator: early exit while handling adjusted timestamps due to version",
+    "BufferingLogDeletionIterator: multiple adjusted timestamps",
+    // Input validation that never engages the Delta connector.
+    "[SPARK-45383] Time travel on a non-existing table should throw AnalysisException",
+    "can't provide both version and timestamp in DataFrameReader",
+    "don't time travel a valid non-delta path with @ syntax",
+    // Catalog reads.
+    "SPARK-41154: Correct relation caching for queries with time travel spec",
+    "timestamp as of expression for table in database",
+    "Dataframe-based time travel works with different timestamp precisions"
+  )
+
+  override protected def shouldFailTests: Set[String] = Set(
+    // Path-based time travel not supported yet.
+    "don't time travel a valid delta path with @ syntax",
+    "scans on different versions of same table are executed correctly",
+    // Path-based schema/partition-evolution reads.
+    "time travel with schema changes - should instantiate old schema",
+    "time travel with partition changes - should instantiate old schema",
+    "as of timestamp in between commits should use commit before timestamp",
+    "as of timestamp on exact timestamp",
+    "as of timestamp on invalid timestamp",
+    "as of exact timestamp after last commit should fail",
+    "as of with versions",
+    "time travelling with adjusted timestamps",
+    // Catalog reads cross-checked against a path-based V1 oracle.
+    "time travel support in SQL",
+    // Write / maintenance surfaces not supported.
+    "Block time travel beyond deletedFileRetention",
+    "Block CDC beyond deletedFileRetention",
+    "Block restore table beyond deletedFileRetention",
+    "Block clone table beyond deletedFileRetention"
+  )
+}

--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/V2ForceTest.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/V2ForceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (2025) The Delta Lake Project Authors.
+ * Copyright (2021) The Delta Lake Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,17 @@
 
 package org.apache.spark.sql.delta.test
 
-import org.apache.spark.SparkConf
-import org.apache.spark.sql.delta.sources.DeltaSQLConf
-import org.scalatest.Tag
-import org.scalactic.source.Position
-
 import scala.collection.mutable
+
+import org.apache.spark.sql.delta.DeltaTestUtils
+import org.apache.spark.sql.delta.files.TahoeFileIndex
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.scalactic.source.Position
+import org.scalatest.Tag
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.execution.FileSourceScanExec
+import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 
 /**
  * Trait that forces Delta V2 connector mode to STRICT, ensuring all operations
@@ -38,9 +43,15 @@ import scala.collection.mutable
  * }
  * }}}
  */
-trait V2ForceTest extends DeltaSQLCommandTest {
+trait V2ForceTest extends DeltaSQLCommandTest with AdaptiveSparkPlanHelper {
 
   private val testsRun: mutable.Set[String] = mutable.Set.empty
+
+  /**
+   * When true, each `shouldPass` test additionally asserts that it does not silently fall back to
+   * the V1 Delta file-source scan under STRICT mode. Off by default.
+   */
+  protected def assertNoV1Fallback: Boolean = false
 
   /**
    * Override `test` to apply the `shouldFail` logic.
@@ -56,7 +67,21 @@ trait V2ForceTest extends DeltaSQLCommandTest {
     } else {
       super.test(testName, testTags: _*) {
         testsRun.add(testName)
-        testFun
+        if (assertNoV1Fallback) {
+          val capturedPlans = DeltaTestUtils.withAllPlansCaptured(spark) { testFun; () }
+          val fellBackToV1Delta = capturedPlans.exists { plans =>
+            collectFirst(plans.executedPlan) {
+              case scan: FileSourceScanExec
+                  if scan.relation.location.isInstanceOf[TahoeFileIndex] => scan
+            }.isDefined
+          }
+          assert(!fellBackToV1Delta,
+            s"'$testName' produced a V1 Delta file-source scan under STRICT V2 mode, so it " +
+              "silently fell back to the V1 connector. Move it to shouldFailTests if the V2 " +
+              "connector does not support this surface yet.")
+        } else {
+          testFun
+        }
       }
     }
   }
@@ -93,17 +118,16 @@ trait V2ForceTest extends DeltaSQLCommandTest {
   }
 
   /**
-   * Run a SQL statement through the V1 connector by temporarily setting
-   * V2_ENABLE_MODE to NONE. Useful for DDL/DML that DeltaV2Table (V2) doesn't support.
+   * Run an arbitrary action through the V1 connector by temporarily setting V2_ENABLE_MODE to
+   * NONE. Useful for setup/DDL/DML that V2 doesn't support.
    */
-  protected def executeInV1Mode(sqlText: String): Unit = {
-    withSQLConf(DeltaSQLConf.V2_ENABLE_MODE.key -> "NONE") {
-      sql(sqlText)
-    }
-  }
+  protected def inV1Mode[T](f: => T): T =
+    withSQLConf(DeltaSQLConf.V2_ENABLE_MODE.key -> "NONE")(f)
+
+  /** Run a SQL statement through the V1 connector. */
+  protected def executeInV1Mode(sqlText: String): Unit = inV1Mode(sql(sqlText))
 
   override def afterAll(): Unit = {
     super.afterAll()
   }
 }
-

--- a/spark/src/test/scala-shims/spark-4.2/org/apache/spark/sql/delta/DeltaV2CDFSuite.scala
+++ b/spark/src/test/scala-shims/spark-4.2/org/apache/spark/sql/delta/DeltaV2CDFSuite.scala
@@ -17,7 +17,7 @@
 package org.apache.spark.sql.delta
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
+import org.apache.spark.sql.{QueryTest, Row}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.test.SharedSparkSession
@@ -430,14 +430,8 @@ class DeltaV2CDFSuite
     withTable(tbl) {
       createRowTrackingTable(tbl)
       withStrictV2 {
-        // In V2 mode, the catalog returns DeltaV2Table from `loadTable(ident)`. The
-        // time-travel overload `loadTable(ident, version)` falls through to the parent
-        // `TableCatalog` default after `AbstractDeltaCatalog.loadTableWithTimeTravel` sees the
-        // non-DeltaTableV2 case, which throws Spark's `UNSUPPORTED_FEATURE.TIME_TRAVEL`. This
-        // also blocks `readChangeFeed` + `versionAsOf` -- the combination never reaches our
-        // V2 CDC rule.
         checkError(
-          intercept[AnalysisException] {
+          intercept[DeltaAnalysisException] {
             spark.read.format("delta")
               .option("readChangeFeed", "true")
               .option("startingVersion", "1")
@@ -446,8 +440,7 @@ class DeltaV2CDFSuite
               .table(tbl)
               .collect()
           },
-          "UNSUPPORTED_FEATURE.TIME_TRAVEL",
-          parameters = Map("relationId" -> s"`spark_catalog`.`default`.`$tbl`"))
+          "DELTA_UNSUPPORTED_TIME_TRAVEL_VIEWS")
       }
     }
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaHistoryManagerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaHistoryManagerSuite.scala
@@ -48,8 +48,8 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.util.Utils
 
-/** A set of tests which we can open source after Spark 3.0 is released. */
-trait DeltaTimeTravelTests extends QueryTest
+/** Helper methods for Delta time travel tests, without test registrations. */
+trait DeltaTimeTravelTestHelpers extends QueryTest
     with SharedSparkSession
     with GivenWhenThen
     with DeltaSQLCommandTest
@@ -157,6 +157,10 @@ trait DeltaTimeTravelTests extends QueryTest
   protected implicit def longToTimestampExpr(value: Long): String = {
     s"cast($value / 1000 as timestamp)"
   }
+}
+
+/** Delta time travel tests, built on the shared [[DeltaTimeTravelTestHelpers]]. */
+trait DeltaTimeTravelTests extends DeltaTimeTravelTestHelpers {
 
   import testImplicits._
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTimeTravelSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTimeTravelSuite.scala
@@ -134,6 +134,12 @@ class DeltaTimeTravelSuite extends QueryTest
       .map(i => s"$i")
   }
 
+  /** Table-setup SQL hook. V2-force subclasses override it to run setup on the V1 connector. */
+  protected def setupSql(sqlText: String): Unit = spark.sql(sqlText)
+
+  /** Table-setup action hook. V2-force subclasses override it to run setup on the V1 connector. */
+  protected def runSetup[T](f: => T): T = f
+
   private def historyTest(testName: String)(f: (DeltaLog, ManualClock) => Unit): Unit = {
     testQuietly(testName) {
       val clock = new ManualClock()
@@ -756,8 +762,10 @@ class DeltaTimeTravelSuite extends QueryTest
     withDatabase("testDb") {
       sql("CREATE DATABASE testDb")
       withTable("tbl") {
-        spark.range(10).write.format("delta").saveAsTable("testDb.tbl")
-        val ts = sql("DESCRIBE HISTORY testDb.tbl").select("timestamp").head().getTimestamp(0)
+        val ts = runSetup {
+          spark.range(10).write.format("delta").saveAsTable("testDb.tbl")
+          sql("DESCRIBE HISTORY testDb.tbl").select("timestamp").head().getTimestamp(0)
+        }
 
         sql(s"SELECT * FROM testDb.tbl TIMESTAMP AS OF " +
           s"coalesce(CAST ('$ts' AS TIMESTAMP), current_date())")
@@ -866,8 +874,8 @@ class DeltaTimeTravelSuite extends QueryTest
   test("SPARK-41154: Correct relation caching for queries with time travel spec") {
     val tblName = "tab"
     withTable(tblName) {
-      sql(s"CREATE TABLE $tblName USING DELTA AS SELECT 1 as c")
-      sql(s"INSERT INTO $tblName SELECT 2 as c")
+      setupSql(s"CREATE TABLE $tblName USING DELTA AS SELECT 1 as c")
+      setupSql(s"INSERT INTO $tblName SELECT 2 as c")
       checkAnswer(
         sql(s"""
           |SELECT * FROM $tblName VERSION AS OF '0'
@@ -881,7 +889,7 @@ class DeltaTimeTravelSuite extends QueryTest
   test("Dataframe-based time travel works with different timestamp precisions") {
     val tblName = "test_tab"
     withTable(tblName) {
-      sql(s"CREATE TABLE spark_catalog.default.$tblName (a int) USING DELTA")
+      setupSql(s"CREATE TABLE spark_catalog.default.$tblName (a int) USING DELTA")
       // Ensure that the current timestamp is different from the one in the table.
       Thread.sleep(1000)
       // Microsecond precision timestamp.
@@ -894,7 +902,7 @@ class DeltaTimeTravelSuite extends QueryTest
       val sdf = new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
       val current_time_seconds = sdf.format(new java.sql.Timestamp(System.currentTimeMillis()))
 
-      sql(s"INSERT INTO spark_catalog.default.$tblName VALUES (1)")
+      setupSql(s"INSERT INTO spark_catalog.default.$tblName VALUES (1)")
       checkAnswer(spark.read.option("timestampAsOf", current_time_micros)
         .table(s"spark_catalog.default.$tblName"), Seq.empty)
       checkAnswer(spark.read.option("timestampAsOf", current_time_millis.toString)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Wires DSv2 (Kernel-backed) time travel through the catalog so SQL `VERSION AS OF` / `TIMESTAMP AS OF` and DataFrame `versionAsOf` / `timestampAsOf` options resolve natively when the V2 connector is enabled.
- `DeltaCatalog` now overrides `loadTable(ident, version)` and `loadTable(ident, timestamp)`.
- Added`DeltaV2ErrorInterop.scala` for translating the V2 connector exceptions to their V1 `DeltaErrors` counterparts.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

- Tests for all current entry points added in new `DeltaHistoryManagerV2Suite.scala`.
- New `DeltaTimeTravelForceV2Suite` that reruns the existing `DeltaTimeTravelV2Suite` under the V2 connector.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No