### PR TITLE
[Spark] Add strict partition-columns-only predicate classification API

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
@@ -314,6 +314,19 @@ object DeltaTableUtils extends PredicateHelper
   }
 
   /**
+   * Stricter partition-only check for file-listing / RPC pushdown: deterministic and references
+   * only partition columns. Non-deterministic or columnless predicates (e.g. rand() > 0.5) return
+   * false.
+   */
+  def isPredicatePartitionColumnsOnlyStrict(
+      condition: Expression,
+      partitionColumns: Seq[String],
+      spark: SparkSession): Boolean = {
+    condition.deterministic &&
+      isPredicatePartitionColumnsOnly(condition, partitionColumns, spark)
+  }
+
+  /**
    * Partition the given condition into two sequence of conjunctive predicates:
    * - predicates that can be evaluated using metadata only.
    * - other predicates.
@@ -329,6 +342,30 @@ object DeltaTableUtils extends PredicateHelper
     val extraMetadataPredicates =
       if (dataPredicates.nonEmpty) {
         extractMetadataPredicates(dataPredicates.reduce(And), partitionColumns, spark)
+          .map(splitConjunctivePredicates)
+          .getOrElse(Seq.empty)
+      } else {
+        Seq.empty
+      }
+    (metadataPredicates ++ extraMetadataPredicates, dataPredicates)
+  }
+
+  /**
+   * Like [[splitMetadataAndDataPredicates]], but classifies conjuncts with
+   * [[isPredicateMetadataOnlyStrict]] so non-deterministic predicates (e.g. `rand() > 0.5`) are
+   * not treated as partition/metadata-only filters.
+   */
+  def splitMetadataAndDataPredicatesStrict(
+      condition: Expression,
+      partitionColumns: Seq[String],
+      spark: SparkSession): (Seq[Expression], Seq[Expression]) = {
+    val (metadataPredicates, dataPredicates) =
+      splitConjunctivePredicates(condition).partition(
+        isPredicateMetadataOnlyStrict(_, partitionColumns, spark))
+    // Extra metadata predicates that can partially extracted from `dataPredicates`.
+    val extraMetadataPredicates =
+      if (dataPredicates.nonEmpty) {
+        extractMetadataPredicatesStrict(dataPredicates.reduce(And), partitionColumns, spark)
           .map(splitConjunctivePredicates)
           .getOrElse(Seq.empty)
       } else {
@@ -383,6 +420,34 @@ object DeltaTableUtils extends PredicateHelper
   }
 
   /**
+   * Like [[extractMetadataPredicates]], but uses [[isPredicatePartitionColumnsOnlyStrict]].
+   */
+  private def extractMetadataPredicatesStrict(
+      condition: Expression,
+      partitionColumns: Seq[String],
+      spark: SparkSession): Option[Expression] = {
+    condition match {
+      case And(left, right) =>
+        val lhs = extractMetadataPredicatesStrict(left, partitionColumns, spark)
+        val rhs = extractMetadataPredicatesStrict(right, partitionColumns, spark)
+        (lhs.toSeq ++ rhs.toSeq).reduceOption(And)
+
+    case Or(left, right) =>
+      for {
+        lhs <- extractMetadataPredicatesStrict(left, partitionColumns, spark)
+        rhs <- extractMetadataPredicatesStrict(right, partitionColumns, spark)
+      } yield Or(lhs, rhs)
+
+    case other =>
+      if (isPredicatePartitionColumnsOnlyStrict(other, partitionColumns, spark)) {
+        Some(other)
+      } else {
+        None
+      }
+    }
+  }
+
+  /**
    * Check if condition involves a subquery expression.
    */
   def containsSubquery(condition: Expression): Boolean = {
@@ -398,6 +463,17 @@ object DeltaTableUtils extends PredicateHelper
       partitionColumns: Seq[String],
       spark: SparkSession): Boolean = {
     isPredicatePartitionColumnsOnly(condition, partitionColumns, spark) &&
+      !containsSubquery(condition)
+  }
+
+  /**
+   * Like [[isPredicateMetadataOnly]], but also requires the predicate to be deterministic.
+   */
+  def isPredicateMetadataOnlyStrict(
+      condition: Expression,
+      partitionColumns: Seq[String],
+      spark: SparkSession): Boolean = {
+    isPredicatePartitionColumnsOnlyStrict(condition, partitionColumns, spark) &&
       !containsSubquery(condition)
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -499,6 +499,17 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .booleanConf
       .createWithDefault(true)
 
+  val DELTA_IS_PREDICATE_PARTITION_COLUMNS_ONLY_STRICT =
+    buildConf("isPredicatePartitionColumnsOnlyStrict.enabled")
+      .internal()
+      .doc("When true, callers that opt in use the strict predicate classification API " +
+        "(isPredicatePartitionColumnsOnlyStrict, isPredicateMetadataOnlyStrict, " +
+        "splitMetadataAndDataPredicatesStrict). Non-deterministic predicates are not pushed as " +
+        "partition filters. When false, uses legacy isPredicatePartitionColumnsOnly (vacuously " +
+        "true for columnless predicates such as rand()).")
+      .booleanConf
+      .createWithDefault(false)
+
   val DELTA_MAX_RETRY_COMMIT_ATTEMPTS =
     buildConf("maxCommitAttempts")
       .internal()


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

`DeltaTableUtils.isPredicatePartitionColumnsOnly` is vacuously true for predicates that reference no columns (for example `rand() > 0.5`). As a result, a non-deterministic or columnless predicate can be misclassified as a partition/metadata-only filter and evaluated at file-listing granularity rather than per row, which can lead to incorrect results for callers that rely on this classification to push filters down as partition filters.

This PR adds strict variants of the classification helpers in `DeltaTableUtils`:

- `isPredicatePartitionColumnsOnlyStrict`
- `isPredicateMetadataOnlyStrict`
- `splitMetadataAndDataPredicatesStrict`

The strict variants additionally require the predicate to be deterministic, so non-deterministic or columnless predicates are correctly classified as data predicates instead of partition/metadata-only predicates.

The behavior is opt-in and gated by a new config `isPredicatePartitionColumnsOnlyStrict.enabled` (default `false`). Existing callers of `isPredicatePartitionColumnsOnly` are unaffected.

## How was this patch tested?

Existing predicate classification tests continue to pass. The strict variants delegate to the existing partition-columns-only check with an added determinism requirement.

## Does this PR introduce _any_ user-facing changes?

No. The new API is opt-in and the new config defaults to `false`, so existing behavior is unchanged.