### PR TITLE
[Kernel] Physical partition names for column-mapped tables

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Transaction.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Transaction.java
@@ -43,6 +43,8 @@ import io.delta.kernel.internal.fs.Path;
 import io.delta.kernel.internal.icebergcompat.IcebergCompatV2MetadataValidatorAndUpdater;
 import io.delta.kernel.internal.icebergcompat.IcebergCompatV3MetadataValidatorAndUpdater;
 import io.delta.kernel.internal.tablefeatures.TableFeatures;
+import io.delta.kernel.internal.util.ColumnMapping;
+import io.delta.kernel.internal.util.PartitionUtils;
 import io.delta.kernel.internal.util.SchemaIterable;
 import io.delta.kernel.statistics.DataFileStatistics;
 import io.delta.kernel.types.StructField;
@@ -259,10 +261,11 @@ public interface Transaction {
    *
    * @param engine {@link Engine} instance to use.
    * @param transactionState The transaction state
-   * @param partitionValues The partition values for the data. If the table is un-partitioned, the
-   *     map should be empty
+   * @param partitionValues The partition values for the data, keyed by logical partition column
+   *     name. If the table is un-partitioned, the map should be empty.
    * @return {@link DataWriteContext} containing metadata about where and how the data for partition
-   *     should be written.
+   *     should be written. For a column-mapped table, the target directory and the returned
+   *     partition-value keys use the physical partition column names.
    */
   static DataWriteContext getWriteContext(
       Engine engine, Row transactionState, Map<String, Literal> partitionValues) {
@@ -273,8 +276,16 @@ public interface Transaction {
     StructType tableSchema = getLogicalSchema(transactionState);
     List<String> partitionColNames = getPartitionColumnsList(transactionState);
 
+    // Validate/sanitize against the logical partition columns.
     partitionValues =
         validateAndSanitizePartitionValues(tableSchema, partitionColNames, partitionValues);
+
+    // For column-mapped tables the on-disk partition directory and AddFile partition-value keys
+    // use physical names, so translate the column-name list and the value-map keys to physical.
+    ColumnMapping.ColumnMappingMode mode = getColumnMappingMode(transactionState);
+    partitionColNames =
+        PartitionUtils.toPhysicalPartitionColNames(tableSchema, partitionColNames, mode);
+    partitionValues = PartitionUtils.toPhysicalPartitionValues(tableSchema, partitionValues, mode);
 
     String targetDirectory =
         getTargetDirectory(getTablePath(transactionState), partitionColNames, partitionValues);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Transaction.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Transaction.java
@@ -264,8 +264,8 @@ public interface Transaction {
    * @param partitionValues The partition values for the data, keyed by logical partition column
    *     name. If the table is un-partitioned, the map should be empty.
    * @return {@link DataWriteContext} containing metadata about where and how the data for partition
-   *     should be written. For a column-mapped table, the target directory and the returned
-   *     partition-value keys use the physical partition column names.
+   *     should be written. The target directory and the returned partition-value keys use the
+   *     physical partition column names.
    */
   static DataWriteContext getWriteContext(
       Engine engine, Row transactionState, Map<String, Literal> partitionValues) {
@@ -276,12 +276,11 @@ public interface Transaction {
     StructType tableSchema = getLogicalSchema(transactionState);
     List<String> partitionColNames = getPartitionColumnsList(transactionState);
 
-    // Validate/sanitize against the logical partition columns.
     partitionValues =
         validateAndSanitizePartitionValues(tableSchema, partitionColNames, partitionValues);
 
-    // For column-mapped tables the on-disk partition directory and AddFile partition-value keys
-    // use physical names, so translate the column-name list and the value-map keys to physical.
+    // The on-disk partition directory and AddFile partition-value keys use physical names, so
+    // translate the column-name list and the value-map keys to physical.
     ColumnMapping.ColumnMappingMode mode = getColumnMappingMode(transactionState);
     partitionColNames =
         PartitionUtils.toPhysicalPartitionColNames(tableSchema, partitionColNames, mode);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/PartitionUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/PartitionUtils.java
@@ -362,6 +362,56 @@ public class PartitionUtils {
   }
 
   /**
+   * Translates the given logical partition column names to their physical (column-mapping) names.
+   *
+   * <p>For a column-mapped table the on-disk Hive-style partition directory and the {@code AddFile}
+   * partition-value keys are stored under the physical {@code col-<uuid>} names. Callers pass
+   * logical partition column names so this rewrites each to {@link
+   * ColumnMapping#getPhysicalName(StructField)}. Returns the input unchanged when column mapping is
+   * disabled.
+   *
+   * @param logicalSchema the table's logical schema.
+   * @param partitionColNames logical partition column names, in partition order.
+   * @param mode the table's column mapping mode.
+   * @return the physical partition column names, in the same order.
+   */
+  public static List<String> toPhysicalPartitionColNames(
+      StructType logicalSchema,
+      List<String> partitionColNames,
+      ColumnMapping.ColumnMappingMode mode) {
+    if (!ColumnMapping.isColumnMappingModeEnabled(mode)) {
+      return partitionColNames;
+    }
+    return partitionColNames.stream()
+        .map(name -> ColumnMapping.getPhysicalName(logicalSchema.get(name)))
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Rewrites the keys of a logical-keyed partition-value map to their physical (column mapping)
+   * names. Returns the input unchanged when column mapping is disabled.
+   *
+   * @param logicalSchema the table's logical schema.
+   * @param partitionValues partition values keyed by logical partition column name.
+   * @param mode the table's column mapping mode.
+   * @return partition values keyed by physical partition column name.
+   */
+  public static Map<String, Literal> toPhysicalPartitionValues(
+      StructType logicalSchema,
+      Map<String, Literal> partitionValues,
+      ColumnMapping.ColumnMappingMode mode) {
+    if (!ColumnMapping.isColumnMappingModeEnabled(mode)) {
+      return partitionValues;
+    }
+    Map<String, Literal> physicalValues = new LinkedHashMap<>();
+    for (Map.Entry<String, Literal> entry : partitionValues.entrySet()) {
+      physicalValues.put(
+          ColumnMapping.getPhysicalName(logicalSchema.get(entry.getKey())), entry.getValue());
+    }
+    return physicalValues;
+  }
+
+  /**
    * Get the target directory for writing data for given partition values. Example: Given partition
    * values (part1=1, part2='abc'), the target directory will be for a table rooted at
    * 's3://bucket/table': 's3://bucket/table/part1=1/part2=abc'.

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/TransactionSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/TransactionSuite.scala
@@ -31,12 +31,13 @@ import io.delta.kernel.internal.actions.{Format, Metadata, Protocol}
 import io.delta.kernel.internal.data.TransactionStateRow
 import io.delta.kernel.internal.tablefeatures.TableFeatures
 import io.delta.kernel.internal.types.DataTypeJsonSerDe
+import io.delta.kernel.internal.util.ColumnMapping
 import io.delta.kernel.internal.util.Utils.toCloseableIterator
 import io.delta.kernel.internal.util.VectorUtils
 import io.delta.kernel.internal.util.VectorUtils.stringStringMapValue
 import io.delta.kernel.statistics.DataFileStatistics
 import io.delta.kernel.test.{MockEngineUtils, VectorTestUtils}
-import io.delta.kernel.types.{DoubleType, FloatType, IntegerType, LongType, StringType, StructField, StructType, TimestampType, VariantType}
+import io.delta.kernel.types.{DoubleType, FieldMetadata, FloatType, IntegerType, LongType, StringType, StructField, StructType, TimestampType, VariantType}
 import io.delta.kernel.utils.{CloseableIterator, DataFileStatus}
 
 import org.scalatest.funsuite.AnyFunSuite
@@ -124,6 +125,36 @@ class TransactionSuite extends AnyFunSuite with VectorTestUtils with MockEngineU
     transformedDateIter.map(_.getData).forEachRemaining { batch =>
       // when MaterializePartitionColumns feature is disabled, partition columns are filtered out
       assert(batch.getSchema === testSchema)
+    }
+  }
+
+  test("getWriteContext: non-column-mapped partitioned table uses logical partition names") {
+    val ctx = getWriteContext(
+      mockEngine(),
+      testTxnState(testSchemaWithPartitions, testPartitionColNames),
+      Map("state" -> Literal.ofString("CA"), "country" -> Literal.ofString("USA")).asJava)
+    // Directory keeps logical names when not using column mapping.
+    assert(ctx.getTargetDirectory.endsWith("/state=CA/country=USA"))
+    val partitionKeys =
+      ctx.asInstanceOf[DataWriteContextImpl].getPartitionValues.keySet().asScala
+    assert(partitionKeys === Set("state", "country"))
+  }
+
+  Seq("name", "id").foreach { cmMode =>
+    test(s"getWriteContext: partitioned column-mapped table uses physical names: cmMode=$cmMode") {
+      // Connector-passed logical partition-value keys must come back keyed by the physical names.
+      val ctx = getWriteContext(
+        mockEngine(),
+        testTxnState(columnMappedPartitionSchema, testPartitionColNames, cmMode = cmMode),
+        Map("state" -> Literal.ofString("CA"), "country" -> Literal.ofString("USA")).asJava)
+
+      // Directory uses physical names.
+      assert(ctx.getTargetDirectory.endsWith("/col-state=CA/col-country=USA"))
+
+      // AddFile partition-value keys use physical names.
+      val partitionKeys =
+        ctx.asInstanceOf[DataWriteContextImpl].getPartitionValues.keySet().asScala
+      assert(partitionKeys === Set("col-state", "col-country"))
     }
   }
 
@@ -326,6 +357,23 @@ object TransactionSuite extends VectorTestUtils with MockEngineUtils {
     .add("country", StringType.STRING) // partition column
 
   val testPartitionColNames = Seq("state", "country")
+
+  /** Column-mapping metadata for a logical field. */
+  private def columnMappingMetadata(physicalName: String, columnId: Long): FieldMetadata =
+    FieldMetadata.builder()
+      .putString(ColumnMapping.COLUMN_MAPPING_PHYSICAL_NAME_KEY, physicalName)
+      .putLong(ColumnMapping.COLUMN_MAPPING_ID_KEY, columnId)
+      .build()
+
+  /**
+   * A partitioned schema where every column carries column-mapping metadata.
+   */
+  val columnMappedPartitionSchema: StructType = new StructType()
+    .add("name", StringType.STRING, true, columnMappingMetadata("col-name", 1))
+    .add("id", LongType.LONG, true, columnMappingMetadata("col-id", 2))
+    .add("city", StringType.STRING, true, columnMappingMetadata("col-city", 3))
+    .add("state", StringType.STRING, true, columnMappingMetadata("col-state", 4))
+    .add("country", StringType.STRING, true, columnMappingMetadata("col-country", 5))
 
   def columnarBatch(schema: StructType, vectors: Seq[ColumnVector]): ColumnarBatch = {
     new ColumnarBatch {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

For a column-mapped table, partition data is stored under physical (`col-<uuid>`) names on disk and in `AddFile.partitionValues`, so the logical-named output does not round-trip on read. These changes translate the partition column names (and partition-value map keys) to their physical names. The caller still passes logical keys but Kernel now returns physical names in both the target directory and the partition metadata. Non-column-mapped tables are unaffected.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

New `TransactionSuite` cases for `getWriteContext` on partitioned tables: non-column-mapped (logical names preserved) and column-mapped in both name and id modes.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No