### PR TITLE
[Spark] Preserve action JSON with newer Jackson

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/Checksum.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Checksum.scala
@@ -850,11 +850,17 @@ trait ValidateChecksum extends DeltaLogging { self: Snapshot =>
    */
   def validateFileListAgainstCRC(checksum: VersionChecksum, contextOpt: Option[String]): Boolean = {
     val fileSortKey = (f: AddFile) => (f.path, f.modificationTime, f.size)
-    val filesFromCrc = checksum.allFiles.map(_.sortBy(fileSortKey)).getOrElse { return true }
+    // Normalize null tags so state-reconstructed files (which can still surface null tags from
+    // Parquet) compare equal to CRC-deserialized files (which default to empty maps after the
+    // Jackson upgrade).
+    val filesFromCrc = checksum.allFiles
+      .map(_.sortBy(fileSortKey))
+      .getOrElse { return true }
+      .map(_.withNormalizedTags)
     val filesFromStateReconstruction = recordFrameProfile(
         "Delta", "snapshot.allFiles") {
       allFilesViaStateReconstruction.collect().toSeq.sortBy(fileSortKey)
-    }
+    }.map(_.withNormalizedTags)
     if (filesFromCrc == filesFromStateReconstruction) return true
 
     val filesFromCrcWithoutStats = filesFromCrc.map(_.copy(stats = ""))

--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -909,7 +909,8 @@ case class AddFile(
     modificationTime: Long,
     override val dataChange: Boolean,
     override val stats: String = null,
-    override val tags: Map[String, String] = null,
+    @JsonInclude(Include.NON_EMPTY)
+    override val tags: Map[String, String] = Map.empty,
     override val deletionVector: DeletionVectorDescriptor = null,
     @JsonDeserialize(contentAs = classOf[java.lang.Long])
     baseRowId: Option[Long] = None,
@@ -920,6 +921,14 @@ case class AddFile(
   require(path.nonEmpty)
 
   override def wrap: SingleAction = SingleAction(add = this)
+
+  /**
+   * Returns a copy of this file with `tags` normalized to `Map.empty` when null.
+   * State reconstruction from Parquet checkpoint files can still produce null tags even though
+   * Jackson 2.19+ defaults missing collection fields to empty maps.
+   */
+  @JsonIgnore
+  def withNormalizedTags: AddFile = if (tags == null) copy(tags = Map.empty) else this
 
   def remove: RemoveFile = removeWithTimestamp()
 
@@ -1149,7 +1158,8 @@ case class RemoveFile(
     partitionValues: Map[String, String] = null,
     @JsonDeserialize(contentAs = classOf[java.lang.Long])
     size: Option[Long] = None,
-    override val tags: Map[String, String] = null,
+    @JsonInclude(Include.NON_EMPTY)
+    override val tags: Map[String, String] = Map.empty,
     override val deletionVector: DeletionVectorDescriptor = null,
     @JsonDeserialize(contentAs = classOf[java.lang.Long])
     baseRowId: Option[Long] = None,
@@ -1206,7 +1216,8 @@ case class AddCDCFile(
     @JsonInclude(JsonInclude.Include.ALWAYS)
     partitionValues: Map[String, String],
     size: Long,
-    override val tags: Map[String, String] = null,
+    @JsonInclude(Include.NON_EMPTY)
+    override val tags: Map[String, String] = Map.empty,
     override val stats: String = null) extends FileAction with HasNumRecords {
   override val dataChange = false
   @JsonIgnore
@@ -1650,15 +1661,15 @@ case class Checkpoint(
  * @param path - sidecar path relative to `_delta_log/_sidecar` directory
  * @param sizeInBytes - size in bytes for the sidecar file
  * @param modificationTime - modification time of the sidecar file
- * @param tags - attributes of the sidecar file, defaults to null (which is semantically same as an
- *               empty Map). This is kept null to ensure that the field is not present in the
- *               generated json.
+ * @param tags - attributes of the sidecar file, defaults to an empty map. Both null and empty maps
+ *               are omitted from the generated json.
  */
 case class SidecarFile(
     path: String,
     sizeInBytes: Long,
     modificationTime: Long,
-    tags: Map[String, String] = null,
+    @JsonInclude(Include.NON_EMPTY)
+    tags: Map[String, String] = Map.empty,
     // Applicable only for AMT checkpoint sidecars.
     // Sidecars corresponding to V2Checkpoints do not have concept of sidecarType.
     @JsonProperty("type")
@@ -1691,13 +1702,13 @@ object SidecarFile {
  * Holds information about the Delta Checkpoint. This action will only be part of checkpoints.
  *
  * @param version version of the checkpoint
- * @param tags    attributes of the checkpoint, defaults to null (which is semantically same as an
- *                empty Map). This is kept null to ensure that the field is not present in the
- *                generated json.
+ * @param tags    attributes of the checkpoint, defaults to an empty map. Both null and empty maps
+ *                are omitted from the generated json.
  */
 case class CheckpointMetadata(
     version: Long,
-    tags: Map[String, String] = null)
+    @JsonInclude(Include.NON_EMPTY)
+    tags: Map[String, String] = Map.empty)
   extends CheckpointOnlyAction {
 
   override def wrap: SingleAction = SingleAction(checkpointMetadata = this)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeStats.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeStats.scala
@@ -20,6 +20,8 @@ import scala.collection.mutable.ArrayBuffer
 
 import org.apache.spark.sql.delta.NumRecordsStats
 import org.apache.spark.sql.util.ScalaExtensions._
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonInclude.Include
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import org.apache.commons.lang3.StringUtils
 
@@ -85,14 +87,19 @@ case class MergeStats(
 
     // Expressions used in old MERGE stats, now always Null
     updateConditionExpr: String,
+    @JsonInclude(Include.NON_EMPTY)
     updateExprs: Seq[String],
     insertConditionExpr: String,
+    @JsonInclude(Include.NON_EMPTY)
     insertExprs: Seq[String],
     deleteConditionExpr: String,
 
     // Newer expressions used in MERGE with any number of MATCHED/NOT MATCHED/NOT MATCHED BY SOURCE
+    @JsonInclude(Include.NON_EMPTY)
     matchedStats: Seq[MergeClauseStats],
+    @JsonInclude(Include.NON_EMPTY)
     notMatchedStats: Seq[MergeClauseStats],
+    @JsonInclude(Include.NON_EMPTY)
     notMatchedBySourceStats: Seq[MergeClauseStats],
 
     // Timings

--- a/spark/src/test/scala/org/apache/spark/sql/delta/ActionSerializerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/ActionSerializerSuite.scala
@@ -100,7 +100,11 @@ class ActionSerializerSuite extends QueryTest with SharedSparkSession with Delta
         stats = null,
         tags = Map.empty)
     assert(action2 === Action.fromJson(json2))
-    assert(action2.json === json2.replaceAll("\\s", ""))
+    val expectedJson =
+      """{"add":{""" +
+        """"path":"a",""" +
+        """"partitionValues":{},"size":1,"modificationTime":2,"dataChange":false}}"""
+    assert(action2.json === expectedJson)
   }
 
   // This is the same test as "removefile" in OSS, but due to a Jackson library upgrade the behavior
@@ -111,12 +115,30 @@ class ActionSerializerSuite extends QueryTest with SharedSparkSession with Delta
     val removeJson = RemoveFile("a", Some(2L)).json
     assert(removeJson.contains(""""deletionTimestamp":2"""))
     assert(!removeJson.contains("""delTimestamp"""))
+    assert(!removeJson.contains("""partitionValues"""))
     val json1 = """{"remove":{"path":"a","deletionTimestamp":2,"dataChange":true}}"""
     val json2 = """{"remove":{"path":"a","dataChange":false}}"""
     val json4 = """{"remove":{"path":"a","deletionTimestamp":5}}"""
-    assert(Action.fromJson(json1) === RemoveFile("a", Some(2L), dataChange = true))
-    assert(Action.fromJson(json2) === RemoveFile("a", None, dataChange = false))
-    assert(Action.fromJson(json4) === RemoveFile("a", Some(5L), dataChange = true))
+    assert(normalizeActionCollections(Action.fromJson(json1)) ===
+      normalizeActionCollections(RemoveFile("a", Some(2L), dataChange = true)))
+    assert(normalizeActionCollections(Action.fromJson(json2)) ===
+      normalizeActionCollections(RemoveFile("a", None, dataChange = false)))
+    assert(normalizeActionCollections(Action.fromJson(json4)) ===
+      normalizeActionCollections(RemoveFile("a", Some(5L), dataChange = true)))
+  }
+
+  test("RemoveFile preserves empty partition values with extended metadata") {
+    val remove = AddFile(
+      path = "a",
+      partitionValues = Map.empty,
+      size = 1,
+      modificationTime = 2,
+      dataChange = true).removeWithTimestamp(timestamp = 3)
+
+    assert(remove.json ===
+      """{"remove":{"path":"a","deletionTimestamp":3,"dataChange":true,""" +
+        """"extendedFileMetadata":true,"partitionValues":{},"size":1}}""")
+    assert(Action.fromJson(remove.json) === remove)
   }
 
   roundTripCompare("SetTransaction",
@@ -544,7 +566,6 @@ class ActionSerializerSuite extends QueryTest with SharedSparkSession with Delta
         |"modificationTime":1,
         |"dataChange":true,
         |"stats":"{\"numRecords\":3}",
-        |"tags":{},
         |"deletionVector":{
         |"storageType":"p",
         |"pathOrInlineDv":"/test.dv",
@@ -601,14 +622,15 @@ class ActionSerializerSuite extends QueryTest with SharedSparkSession with Delta
     )
 
     assert(m1.json === """{"checkpointMetadata":{"version":1}}""")
-    assert(m2.json === """{"checkpointMetadata":{"version":1,"tags":{}}}""")
+    assert(m2.json === """{"checkpointMetadata":{"version":1}}""")
     assert(m3.json ===
       """{"checkpointMetadata":{"version":1,""" +
         """"tags":{"k1":"v1","schema":"{\"type\":\"struct\",\"fields\":[]}"}}}""")
 
-    Seq(m1, m2, m3).foreach { metadata =>
-      assert(metadata === JsonUtils.fromJson[SingleAction](metadata.json).unwrap)
-    }
+    // Jackson 2.19+ deserializes null collection values as empty collections.
+    assert(m2 === JsonUtils.fromJson[SingleAction](m1.json).unwrap)
+    assert(m2 === JsonUtils.fromJson[SingleAction](m2.json).unwrap)
+    assert(m3 === JsonUtils.fromJson[SingleAction](m3.json).unwrap)
   }
 
   test("SidecarFile - serialize/deserialize") {
@@ -622,15 +644,15 @@ class ActionSerializerSuite extends QueryTest with SharedSparkSession with Delta
     assert(f1.json ===
       """{"sidecar":{"path":"/t1/p1","sizeInBytes":1,"modificationTime":3}}""")
     assert(f2.json ===
-      """{"sidecar":{"path":"/t1/p1","sizeInBytes":1,""" +
-        """"modificationTime":3,"tags":{}}}""")
+      """{"sidecar":{"path":"/t1/p1","sizeInBytes":1,"modificationTime":3}}""")
     assert(f3.json ===
       """{"sidecar":{"path":"/t1/p1","sizeInBytes":1,"modificationTime":3,""" +
         """"tags":{"k1":"v1","schema":"{\"type\":\"struct\",\"fields\":[]}"}}}""".stripMargin)
 
-    Seq(f1, f2, f3).foreach { file =>
-      assert(file === JsonUtils.fromJson[SingleAction](file.json).unwrap)
-    }
+    // Jackson 2.19+ deserializes null collection values as empty collections.
+    assert(f2 === JsonUtils.fromJson[SingleAction](f1.json).unwrap)
+    assert(f2 === JsonUtils.fromJson[SingleAction](f2.json).unwrap)
+    assert(f3 === JsonUtils.fromJson[SingleAction](f3.json).unwrap)
   }
 
   testActionSerDe(
@@ -855,8 +877,15 @@ class ActionSerializerSuite extends QueryTest with SharedSparkSession with Delta
       val asJson = actions.map(_.json)
       val asObjects = asJson.map(Action.fromJson)
 
-      assert(actions === asObjects)
+      assert(actions.map(normalizeActionCollections) === asObjects.map(normalizeActionCollections))
     }
+  }
+
+  private def normalizeActionCollections(action: Action): Action = action match {
+    case remove: RemoveFile
+        if remove.partitionValues == null && !remove.extendedFileMetadata.contains(true) =>
+      remove.copy(partitionValues = Map.empty)
+    case other => other
   }
 
   /** Test serialization/deserialization of [[Action]] by doing an actual commit */

--- a/spark/src/test/scala/org/apache/spark/sql/delta/CheckpointProviderSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CheckpointProviderSuite.scala
@@ -70,9 +70,14 @@ class CheckpointProviderSuite
           .underlyingCheckpointProvider
           .asInstanceOf[V2CheckpointProvider]
 
-        // Check whether these checkpoints are equivalent after being loaded
-        assert(compatCheckpoint.sidecarFiles.toSet === origCheckpoint.sidecarFiles.toSet)
-        assert(compatCheckpoint.checkpointMetadata === origCheckpoint.checkpointMetadata)
+        // Normalize null tags so reconstructed sidecars and metadata compare equal to freshly
+        // constructed instances that default to empty maps after the Jackson upgrade.
+        assert(compatCheckpoint.sidecarFiles
+          .map(f => f.copy(tags = Option(f.tags).getOrElse(Map.empty))).toSet ===
+          origCheckpoint.sidecarFiles.toSet)
+        assert(compatCheckpoint.checkpointMetadata.copy(tags =
+          Option(compatCheckpoint.checkpointMetadata.tags).getOrElse(Map.empty)) ===
+          origCheckpoint.checkpointMetadata)
 
         val compatDf =
             deltaLog.loadIndex(compatCheckpoint.topLevelFileIndex.get, Action.logSchema)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
@@ -335,7 +335,7 @@ class DeltaLogSuite extends QueryTest
         createTestAddFile(encodedPath = "bar", modificationTime = System.currentTimeMillis())
       log.startTransaction().commit(otherAdd :: Nil, DeltaOperations.ManualUpdate)
 
-      assert(log.update().allFiles.collect().find(_.path == "foo")
+      assert(log.update().allFiles.collect().find(_.path == "foo").map(_.withNormalizedTags)
         // `dataChange` is set to `false` after replaying logs.
         === Some(add2.copy(
           dataChange = false, baseRowId = Some(1), defaultRowCommitVersion = Some(2))))

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsSuite.scala
@@ -1067,7 +1067,7 @@ abstract class CommitCoordinatorSuiteBase
         assert(log.unsafeVolatileSnapshot.metadata === newMetadata2)
         // State reconstruction should give correct results
         var expectedFileNames = Set("1", "2", "post-upgrade-file")
-        assert(log.unsafeVolatileSnapshot.allFiles.collect().toSet ===
+        assert(log.unsafeVolatileSnapshot.allFiles.map(_.withNormalizedTags).collect().toSet ===
           expectedFileNames.map(name => createTestAddFile(name, dataChange = false)))
         // commit-coordinator should not be invoked for commit API.
         // Register table API should not be called until the end
@@ -1099,7 +1099,7 @@ abstract class CommitCoordinatorSuiteBase
         assert(log.unsafeVolatileSnapshot.metadata.coordinatedCommitsCoordinatorConf === Map.empty)
         assert(log.unsafeVolatileSnapshot.metadata.coordinatedCommitsTableConf === Map.empty)
         expectedFileNames = Set("1", "2", "post-upgrade-file", "upgrade-2-file")
-        assert(log.unsafeVolatileSnapshot.allFiles.collect().toSet ===
+        assert(log.unsafeVolatileSnapshot.allFiles.map(_.withNormalizedTags).collect().toSet ===
           expectedFileNames.map(name => createTestAddFile(name, dataChange = false)))
         assert(Seq(cs1, cs2).map(_.numCommitsCalled.get) == Seq(3, 0))
         assert(Seq(cs1, cs2).map(_.numRegisterTableCalled.get) == Seq(1, 1))
@@ -1112,7 +1112,7 @@ abstract class CommitCoordinatorSuiteBase
         // Make 1 more commit, this should go to new owner
         log.startTransaction().commitManually(newMetadata3, createTestAddFile("4"))
         expectedFileNames = Set("1", "2", "post-upgrade-file", "upgrade-2-file", "4")
-        assert(log.unsafeVolatileSnapshot.allFiles.collect().toSet ===
+        assert(log.unsafeVolatileSnapshot.allFiles.map(_.withNormalizedTags).collect().toSet ===
           expectedFileNames.map(name => createTestAddFile(name, dataChange = false)))
         assert(Seq(cs1, cs2).map(_.numCommitsCalled.get) == Seq(3, 1))
         assert(Seq(cs1, cs2).map(_.numRegisterTableCalled.get) == Seq(1, 1))


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/7215/files) to review incremental changes.
- [**stack/spark42-jackson-compat**](https://github.com/delta-io/delta/pull/7215) [[Files changed](https://github.com/delta-io/delta/pull/7215/files)] ← _this PR_
  - [stack/spark42-uc-build-prep](https://github.com/delta-io/delta/pull/7216) [[Files changed](https://github.com/delta-io/delta/pull/7216/files/1ea3213da270ad5cf56d98179f43bee48c238e8e..20f1b1d1353debd11ddca7a99911e652388fd7b3)]
    - [stack/spark42-python-prep](https://github.com/delta-io/delta/pull/7217) [[Files changed](https://github.com/delta-io/delta/pull/7217/files/20f1b1d1353debd11ddca7a99911e652388fd7b3..9fec6ddc9ec9ded9fe88e41ad137cdbb2b8389b4)]
      - [stack/support-spark-4.0-4.1-4.2](https://github.com/delta-io/delta/pull/7213) [[Files changed](https://github.com/delta-io/delta/pull/7213/files/9fec6ddc9ec9ded9fe88e41ad137cdbb2b8389b4..a646c3f9f8678e1da5b5e6eddc8829f2728a77aa)]

---------
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

This is the first PR in the Spark 4.2 support stack. It isolates the shared action-serialization compatibility needed before Spark 4.2 brings in newer Jackson dependencies.

Jackson 2.19 and later materialize missing collection fields as empty collections. This change keeps Delta's wire format stable by omitting empty optional tag maps while preserving protocol-required empty partition values for extended `RemoveFile` metadata.

This is a corrected current-master extraction of #5598 and #6635. Murali Ramanujam is retained as a co-author.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

- [x] Spark 4.0.1 `ActionSerializerSuite`: 55/55 passed.
- [x] Spark 4.1.0 `ActionSerializerSuite` and `CheckpointProviderSuite`: 57/57 passed.
- [x] Added a regression test for empty `partitionValues` with extended `RemoveFile` metadata.
- [ ] Full CI for the split revision is running.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No. This preserves existing Delta action JSON behavior across Jackson versions.