### PR TITLE
[Build] Compile Unity Catalog per Spark release

### DIFF
--- a/.github/actions/setup-unitycatalog/action.yml
+++ b/.github/actions/setup-unitycatalog/action.yml
@@ -3,14 +3,20 @@ description: >-
   Publishes Unity Catalog jars from the commit pinned in project/scripts/setup_unitycatalog_main.sh
   (the UC_PIN_SHA= line) to the runner's local Ivy / Maven caches, using GitHub Actions cache so the
   slow UC build only runs the first time a pin is seen. Reads SPARK_VERSION (Spark major.minor
-  short form) from the calling job's env to pick the Spark variant UC builds against; matrix
-  workflows set this from `matrix.spark_version`, other workflows leave it unset and inherit the
-  script's default. The cache key reflects SPARK_VERSION literally - workflows that share the
-  default share one cache entry under an empty `spark-` segment.
+  short form) from the calling job's env to pick the Spark variant UC builds against, then derives
+  the exact artifact version from Delta's CrossSparkVersions configuration.
 
 runs:
   using: "composite"
   steps:
+    - name: Resolve exact Spark artifact version
+      id: spark-version
+      shell: bash
+      run: |
+        requested="${SPARK_VERSION:-default}"
+        full_version=$(python3 project/scripts/get_spark_version_info.py \
+          --get-field "$requested" fullVersion | jq -r)
+        echo "full-version=$full_version" >> "$GITHUB_OUTPUT"
     - name: Restore pinned UC cache
       id: uc-cache
       uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
@@ -20,10 +26,13 @@ runs:
           ~/.ivy2/local
           ~/.m2/repository/io/unitycatalog
         # Cache key hashes the setup script (so any script change invalidates) and includes the
-        # Spark short version (so 4.0 and 4.1 don't fight over a single shared cache entry).
-        key: uc-jars-${{ runner.os }}-spark${{ env.SPARK_VERSION }}-${{ hashFiles('project/scripts/setup_unitycatalog_main.sh') }}
+        # exact Spark release (so patch bumps cannot restore a connector compiled against an older
+        # binary API).
+        key: uc-jars-${{ runner.os }}-spark${{ steps.spark-version.outputs.full-version }}-${{ hashFiles('project/scripts/setup_unitycatalog_main.sh') }}
     - name: Build Unity Catalog from pinned SHA
       shell: bash
+      env:
+        SPARK_ARTIFACT_VERSION: ${{ steps.spark-version.outputs.full-version }}
       run: bash project/scripts/setup_unitycatalog_main.sh
     - name: Save pinned UC cache
       # Only attempt a save when the restore missed. When multiple parallel matrix jobs all see
@@ -37,4 +46,4 @@ runs:
         path: |
           ~/.ivy2/local
           ~/.m2/repository/io/unitycatalog
-        key: uc-jars-${{ runner.os }}-spark${{ env.SPARK_VERSION }}-${{ hashFiles('project/scripts/setup_unitycatalog_main.sh') }}
+        key: uc-jars-${{ runner.os }}-spark${{ steps.spark-version.outputs.full-version }}-${{ hashFiles('project/scripts/setup_unitycatalog_main.sh') }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,7 +50,10 @@ jobs:
         run: |
           for sv in $(python3 project/scripts/get_spark_version_info.py --released-spark-versions | jq -r '.[]'); do
             echo "::group::Set up pinned UC for Spark $sv"
-            SPARK_VERSION="$sv" bash project/scripts/setup_unitycatalog_main.sh
+            full_version=$(python3 project/scripts/get_spark_version_info.py \
+              --get-field "$sv" fullVersion | jq -r)
+            SPARK_VERSION="$sv" SPARK_ARTIFACT_VERSION="$full_version" \
+              bash project/scripts/setup_unitycatalog_main.sh
             echo "::endgroup::"
           done
 

--- a/build.sbt
+++ b/build.sbt
@@ -839,7 +839,9 @@ def isAtLeastVersion(current: String, target: String): Boolean = {
     .forall { case (a, b) => a >= b }
 }
 
-val sparkUnityCatalogJacksonVersion = "2.15.4" // We are using Spark 4.0's Jackson version 2.15.x, to override Unity Catalog 0.3.0's version 2.18.x
+val sparkUnityCatalogJacksonVersion = CrossSparkVersions.getSparkVersionSpec().jacksonVersion
+val sparkUnityCatalogJacksonAnnotationsVersion =
+  CrossSparkVersions.getSparkVersionSpec().effectiveJacksonAnnotationsVersion
 
 // Publishes the pinned UC jars to ~/.ivy2/local if they're not already cached there. Hooked
 // into `update` on the UC-dependent projects below, so plain `sbt testOnly ...` on a clean
@@ -867,12 +869,12 @@ def publishPinnedUnityCatalog(log: sbt.util.Logger, canary: java.io.File): Unit 
   val procLogger = ProcessLogger(
     line => log.info(s"[UC setup] $line"),
     line => log.warn(s"[UC setup] $line"))
-  // SPARK_VERSION tells the script which Spark variant to build (forwarded to UC's sbt as
-  // -DsparkVersion).
+  val sparkSpec = CrossSparkVersions.getSparkVersionSpec()
   val exit = Process(
     Seq("bash", unityCatalogSetupScript),
     None,
-    "SPARK_VERSION" -> CrossSparkVersions.getSparkVersionSpec().shortVersion).!(procLogger)
+    "SPARK_VERSION" -> sparkSpec.shortVersion,
+    "SPARK_ARTIFACT_VERSION" -> sparkSpec.fullVersion).!(procLogger)
   if (exit != 0) {
     sys.error(
       s"[UC] $unityCatalogSetupScript exited with code $exit. Run it manually to see full output.")
@@ -939,7 +941,8 @@ lazy val sparkUnityCatalog = (project in file("spark/unitycatalog"))
     // This overrides Jackson from Unity Catalog's transitive dependencies (e.g., Armeria)
     dependencyOverrides ++= Seq(
       "com.fasterxml.jackson.core" % "jackson-core" % sparkUnityCatalogJacksonVersion,
-      "com.fasterxml.jackson.core" % "jackson-annotations" % sparkUnityCatalogJacksonVersion,
+      "com.fasterxml.jackson.core" % "jackson-annotations" %
+        sparkUnityCatalogJacksonAnnotationsVersion,
       "com.fasterxml.jackson.core" % "jackson-databind" % sparkUnityCatalogJacksonVersion,
       "com.fasterxml.jackson.module" %% "jackson-module-scala" % sparkUnityCatalogJacksonVersion,
       "com.fasterxml.jackson.dataformat" % "jackson-dataformat-yaml" % sparkUnityCatalogJacksonVersion,
@@ -958,7 +961,7 @@ lazy val sparkUnityCatalog = (project in file("spark/unitycatalog"))
       "org.projectlombok" % "lombok" % "1.18.34" % "test",
 
       // Unity Catalog dependencies - per-Spark-version artifact (unitycatalog-spark_4.X_2.13).
-      // Exclude Jackson to use Spark's Jackson 2.15.x
+      // Exclude Jackson to use the selected Spark release's Jackson version.
       "io.unitycatalog" %% s"unitycatalog-spark_${CrossSparkVersions.getSparkVersionSpec().shortVersion}" % unityCatalogVersion % "test" excludeAll(
         ExclusionRule(organization = "com.fasterxml.jackson.core"),
         ExclusionRule(organization = "com.fasterxml.jackson.module"),

--- a/project/CrossSparkVersions.scala
+++ b/project/CrossSparkVersions.scala
@@ -220,6 +220,7 @@ case class SparkVersionSpec(
   antlr4Version: String,
   additionalJavaOptions: Seq[String] = Seq.empty,
   jacksonVersion: String = "2.15.2",
+  jacksonAnnotationsVersion: Option[String] = None,
   additionalResolvers: Seq[Resolver] = Seq.empty
 ) {
   /** Returns the Spark short version (e.g., "3.5", "4.0") */
@@ -237,6 +238,10 @@ case class SparkVersionSpec(
 
   /** Returns log4j config file */
   def log4jConfig: String = "log4j2.properties"
+
+  /** Jackson annotations stopped publishing patch-versioned artifacts in the 2.20 line. */
+  def effectiveJacksonAnnotationsVersion: String =
+    jacksonAnnotationsVersion.getOrElse(jacksonVersion)
 
   /** Whether this is an unreleased snapshot or master version */
   def isSnapshot: Boolean = isMaster || fullVersion.contains("SNAPSHOT")
@@ -412,13 +417,14 @@ object CrossSparkVersions extends AutoPlugin {
     val jacksonOverrides = Seq(
       dependencyOverrides ++= {
         val sparkVer = sparkVersionKey.value
-        val jacksonVer = SparkVersionSpec.ALL_SPECS.find(_.fullVersion == sparkVer)
+        val selectedSpec = SparkVersionSpec.ALL_SPECS.find(_.fullVersion == sparkVer)
           .getOrElse(throw new IllegalArgumentException(s"Unknown Spark version: $sparkVer"))
-          .jacksonVersion
+        val jacksonVer = selectedSpec.jacksonVersion
         Seq(
           "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVer,
           "com.fasterxml.jackson.core" % "jackson-core" % jacksonVer,
-          "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVer,
+          "com.fasterxml.jackson.core" % "jackson-annotations" %
+            selectedSpec.effectiveJacksonAnnotationsVersion,
           "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % jacksonVer,
           "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVer
         )

--- a/project/scripts/setup_unitycatalog_main.sh
+++ b/project/scripts/setup_unitycatalog_main.sh
@@ -63,6 +63,8 @@
 #                 CrossSparkVersions when invoking the script; matrix CI workflows set it from
 #                 `matrix.spark_version`. Workflows that don't care which Spark variant UC builds
 #                 (kernel/flink/etc.) inherit the in-script fallback below.
+#   SPARK_ARTIFACT_VERSION
+#                 Exact Spark artifact UC should compile against (for example, 4.2.0).
 #
 # Modes of operation:
 #   1. Pinned SHA (default, PR CI): UC_REF defaults to UC_PIN_SHA, version is computed as
@@ -83,7 +85,7 @@ set -euo pipefail
 # The pin. Bump both lines together if UC's version.sbt changed at the new SHA. build.sbt's
 # `unityCatalogVersion` is obtained by running this script with `--print-version`, so these two
 # values are the single source of truth.
-UC_PIN_SHA=0f1445227bd251b386420c90136515daefa4e03d
+UC_PIN_SHA=a68cbc5ce92e1bd022977851e6ad4e6b795567a9
 UC_BASE_VERSION=0.5.0-SNAPSHOT
 # ---------------------------------------------------------------------------------------------
 
@@ -92,6 +94,7 @@ UC_REPO="${UC_REPO:-https://github.com/unitycatalog/unitycatalog.git}"
 UC_REF="${UC_REF:-$UC_PIN_SHA}"
 UC_FORCE="${UC_FORCE:-0}"
 SPARK_VERSION="${SPARK_VERSION:-4.1}"
+SPARK_ARTIFACT_VERSION="${SPARK_ARTIFACT_VERSION:-}"
 DELTA_RELEASE_MODE="${DELTA_RELEASE_MODE:-0}"
 
 # Compose version coordinate. When UC_VERSION is set from env, use it verbatim (no SHA suffix).
@@ -198,6 +201,11 @@ fi
 # coordinate. Applied as a persistent setting so it sticks across the two sbt invocations below.
 SET_VERSION_CMD="set ThisBuild / version := \"$UC_VERSION\""
 
+SPARK_ARTIFACT_VERSION_ARGS=()
+if [[ -n "$SPARK_ARTIFACT_VERSION" ]]; then
+  SPARK_ARTIFACT_VERSION_ARGS+=("-DsparkArtifactVersion=$SPARK_ARTIFACT_VERSION")
+fi
+
 # Force publishLocal / publishM2 to overwrite existing artifacts. UC artifacts at the same
 # coordinate can be left behind from a prior run (e.g. cross-Spark publish re-invokes this
 # script for a different sparkVersion while client/server/hadoop are already in ~/.ivy2/local
@@ -240,6 +248,7 @@ echo ">>> Publishing UC spark connector for Spark $SPARK_VERSION"
 for attempt in 1 2 3; do
   if ./build/sbt \
     -DsparkVersion="$SPARK_VERSION" \
+    "${SPARK_ARTIFACT_VERSION_ARGS[@]}" \
     -DskipDeltaSpark=true \
     "$SET_VERSION_CMD" \
     "${SET_OVERWRITE_CMDS[@]}" \

--- a/spark/src/main/scala/org/apache/spark/sql/delta/Checksum.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Checksum.scala
@@ -850,11 +850,17 @@ trait ValidateChecksum extends DeltaLogging { self: Snapshot =>
    */
   def validateFileListAgainstCRC(checksum: VersionChecksum, contextOpt: Option[String]): Boolean = {
     val fileSortKey = (f: AddFile) => (f.path, f.modificationTime, f.size)
-    val filesFromCrc = checksum.allFiles.map(_.sortBy(fileSortKey)).getOrElse { return true }
+    // Normalize null tags so state-reconstructed files (which can still surface null tags from
+    // Parquet) compare equal to CRC-deserialized files (which default to empty maps after the
+    // Jackson upgrade).
+    val filesFromCrc = checksum.allFiles
+      .map(_.sortBy(fileSortKey))
+      .getOrElse { return true }
+      .map(_.withNormalizedTags)
     val filesFromStateReconstruction = recordFrameProfile(
         "Delta", "snapshot.allFiles") {
       allFilesViaStateReconstruction.collect().toSeq.sortBy(fileSortKey)
-    }
+    }.map(_.withNormalizedTags)
     if (filesFromCrc == filesFromStateReconstruction) return true
 
     val filesFromCrcWithoutStats = filesFromCrc.map(_.copy(stats = ""))

--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -909,7 +909,8 @@ case class AddFile(
     modificationTime: Long,
     override val dataChange: Boolean,
     override val stats: String = null,
-    override val tags: Map[String, String] = null,
+    @JsonInclude(Include.NON_EMPTY)
+    override val tags: Map[String, String] = Map.empty,
     override val deletionVector: DeletionVectorDescriptor = null,
     @JsonDeserialize(contentAs = classOf[java.lang.Long])
     baseRowId: Option[Long] = None,
@@ -920,6 +921,14 @@ case class AddFile(
   require(path.nonEmpty)
 
   override def wrap: SingleAction = SingleAction(add = this)
+
+  /**
+   * Returns a copy of this file with `tags` normalized to `Map.empty` when null.
+   * State reconstruction from Parquet checkpoint files can still produce null tags even though
+   * Jackson 2.19+ defaults missing collection fields to empty maps.
+   */
+  @JsonIgnore
+  def withNormalizedTags: AddFile = if (tags == null) copy(tags = Map.empty) else this
 
   def remove: RemoveFile = removeWithTimestamp()
 
@@ -1149,7 +1158,8 @@ case class RemoveFile(
     partitionValues: Map[String, String] = null,
     @JsonDeserialize(contentAs = classOf[java.lang.Long])
     size: Option[Long] = None,
-    override val tags: Map[String, String] = null,
+    @JsonInclude(Include.NON_EMPTY)
+    override val tags: Map[String, String] = Map.empty,
     override val deletionVector: DeletionVectorDescriptor = null,
     @JsonDeserialize(contentAs = classOf[java.lang.Long])
     baseRowId: Option[Long] = None,
@@ -1206,7 +1216,8 @@ case class AddCDCFile(
     @JsonInclude(JsonInclude.Include.ALWAYS)
     partitionValues: Map[String, String],
     size: Long,
-    override val tags: Map[String, String] = null,
+    @JsonInclude(Include.NON_EMPTY)
+    override val tags: Map[String, String] = Map.empty,
     override val stats: String = null) extends FileAction with HasNumRecords {
   override val dataChange = false
   @JsonIgnore
@@ -1650,15 +1661,15 @@ case class Checkpoint(
  * @param path - sidecar path relative to `_delta_log/_sidecar` directory
  * @param sizeInBytes - size in bytes for the sidecar file
  * @param modificationTime - modification time of the sidecar file
- * @param tags - attributes of the sidecar file, defaults to null (which is semantically same as an
- *               empty Map). This is kept null to ensure that the field is not present in the
- *               generated json.
+ * @param tags - attributes of the sidecar file, defaults to an empty map. Both null and empty maps
+ *               are omitted from the generated json.
  */
 case class SidecarFile(
     path: String,
     sizeInBytes: Long,
     modificationTime: Long,
-    tags: Map[String, String] = null,
+    @JsonInclude(Include.NON_EMPTY)
+    tags: Map[String, String] = Map.empty,
     // Applicable only for AMT checkpoint sidecars.
     // Sidecars corresponding to V2Checkpoints do not have concept of sidecarType.
     @JsonProperty("type")
@@ -1691,13 +1702,13 @@ object SidecarFile {
  * Holds information about the Delta Checkpoint. This action will only be part of checkpoints.
  *
  * @param version version of the checkpoint
- * @param tags    attributes of the checkpoint, defaults to null (which is semantically same as an
- *                empty Map). This is kept null to ensure that the field is not present in the
- *                generated json.
+ * @param tags    attributes of the checkpoint, defaults to an empty map. Both null and empty maps
+ *                are omitted from the generated json.
  */
 case class CheckpointMetadata(
     version: Long,
-    tags: Map[String, String] = null)
+    @JsonInclude(Include.NON_EMPTY)
+    tags: Map[String, String] = Map.empty)
   extends CheckpointOnlyAction {
 
   override def wrap: SingleAction = SingleAction(checkpointMetadata = this)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeStats.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeStats.scala
@@ -20,6 +20,8 @@ import scala.collection.mutable.ArrayBuffer
 
 import org.apache.spark.sql.delta.NumRecordsStats
 import org.apache.spark.sql.util.ScalaExtensions._
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonInclude.Include
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import org.apache.commons.lang3.StringUtils
 
@@ -85,14 +87,19 @@ case class MergeStats(
 
     // Expressions used in old MERGE stats, now always Null
     updateConditionExpr: String,
+    @JsonInclude(Include.NON_EMPTY)
     updateExprs: Seq[String],
     insertConditionExpr: String,
+    @JsonInclude(Include.NON_EMPTY)
     insertExprs: Seq[String],
     deleteConditionExpr: String,
 
     // Newer expressions used in MERGE with any number of MATCHED/NOT MATCHED/NOT MATCHED BY SOURCE
+    @JsonInclude(Include.NON_EMPTY)
     matchedStats: Seq[MergeClauseStats],
+    @JsonInclude(Include.NON_EMPTY)
     notMatchedStats: Seq[MergeClauseStats],
+    @JsonInclude(Include.NON_EMPTY)
     notMatchedBySourceStats: Seq[MergeClauseStats],
 
     // Timings

--- a/spark/src/test/scala/org/apache/spark/sql/delta/ActionSerializerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/ActionSerializerSuite.scala
@@ -100,7 +100,11 @@ class ActionSerializerSuite extends QueryTest with SharedSparkSession with Delta
         stats = null,
         tags = Map.empty)
     assert(action2 === Action.fromJson(json2))
-    assert(action2.json === json2.replaceAll("\\s", ""))
+    val expectedJson =
+      """{"add":{""" +
+        """"path":"a",""" +
+        """"partitionValues":{},"size":1,"modificationTime":2,"dataChange":false}}"""
+    assert(action2.json === expectedJson)
   }
 
   // This is the same test as "removefile" in OSS, but due to a Jackson library upgrade the behavior
@@ -111,12 +115,30 @@ class ActionSerializerSuite extends QueryTest with SharedSparkSession with Delta
     val removeJson = RemoveFile("a", Some(2L)).json
     assert(removeJson.contains(""""deletionTimestamp":2"""))
     assert(!removeJson.contains("""delTimestamp"""))
+    assert(!removeJson.contains("""partitionValues"""))
     val json1 = """{"remove":{"path":"a","deletionTimestamp":2,"dataChange":true}}"""
     val json2 = """{"remove":{"path":"a","dataChange":false}}"""
     val json4 = """{"remove":{"path":"a","deletionTimestamp":5}}"""
-    assert(Action.fromJson(json1) === RemoveFile("a", Some(2L), dataChange = true))
-    assert(Action.fromJson(json2) === RemoveFile("a", None, dataChange = false))
-    assert(Action.fromJson(json4) === RemoveFile("a", Some(5L), dataChange = true))
+    assert(normalizeActionCollections(Action.fromJson(json1)) ===
+      normalizeActionCollections(RemoveFile("a", Some(2L), dataChange = true)))
+    assert(normalizeActionCollections(Action.fromJson(json2)) ===
+      normalizeActionCollections(RemoveFile("a", None, dataChange = false)))
+    assert(normalizeActionCollections(Action.fromJson(json4)) ===
+      normalizeActionCollections(RemoveFile("a", Some(5L), dataChange = true)))
+  }
+
+  test("RemoveFile preserves empty partition values with extended metadata") {
+    val remove = AddFile(
+      path = "a",
+      partitionValues = Map.empty,
+      size = 1,
+      modificationTime = 2,
+      dataChange = true).removeWithTimestamp(timestamp = 3)
+
+    assert(remove.json ===
+      """{"remove":{"path":"a","deletionTimestamp":3,"dataChange":true,""" +
+        """"extendedFileMetadata":true,"partitionValues":{},"size":1}}""")
+    assert(Action.fromJson(remove.json) === remove)
   }
 
   roundTripCompare("SetTransaction",
@@ -544,7 +566,6 @@ class ActionSerializerSuite extends QueryTest with SharedSparkSession with Delta
         |"modificationTime":1,
         |"dataChange":true,
         |"stats":"{\"numRecords\":3}",
-        |"tags":{},
         |"deletionVector":{
         |"storageType":"p",
         |"pathOrInlineDv":"/test.dv",
@@ -601,14 +622,15 @@ class ActionSerializerSuite extends QueryTest with SharedSparkSession with Delta
     )
 
     assert(m1.json === """{"checkpointMetadata":{"version":1}}""")
-    assert(m2.json === """{"checkpointMetadata":{"version":1,"tags":{}}}""")
+    assert(m2.json === """{"checkpointMetadata":{"version":1}}""")
     assert(m3.json ===
       """{"checkpointMetadata":{"version":1,""" +
         """"tags":{"k1":"v1","schema":"{\"type\":\"struct\",\"fields\":[]}"}}}""")
 
-    Seq(m1, m2, m3).foreach { metadata =>
-      assert(metadata === JsonUtils.fromJson[SingleAction](metadata.json).unwrap)
-    }
+    // Jackson 2.19+ deserializes null collection values as empty collections.
+    assert(m2 === JsonUtils.fromJson[SingleAction](m1.json).unwrap)
+    assert(m2 === JsonUtils.fromJson[SingleAction](m2.json).unwrap)
+    assert(m3 === JsonUtils.fromJson[SingleAction](m3.json).unwrap)
   }
 
   test("SidecarFile - serialize/deserialize") {
@@ -622,15 +644,15 @@ class ActionSerializerSuite extends QueryTest with SharedSparkSession with Delta
     assert(f1.json ===
       """{"sidecar":{"path":"/t1/p1","sizeInBytes":1,"modificationTime":3}}""")
     assert(f2.json ===
-      """{"sidecar":{"path":"/t1/p1","sizeInBytes":1,""" +
-        """"modificationTime":3,"tags":{}}}""")
+      """{"sidecar":{"path":"/t1/p1","sizeInBytes":1,"modificationTime":3}}""")
     assert(f3.json ===
       """{"sidecar":{"path":"/t1/p1","sizeInBytes":1,"modificationTime":3,""" +
         """"tags":{"k1":"v1","schema":"{\"type\":\"struct\",\"fields\":[]}"}}}""".stripMargin)
 
-    Seq(f1, f2, f3).foreach { file =>
-      assert(file === JsonUtils.fromJson[SingleAction](file.json).unwrap)
-    }
+    // Jackson 2.19+ deserializes null collection values as empty collections.
+    assert(f2 === JsonUtils.fromJson[SingleAction](f1.json).unwrap)
+    assert(f2 === JsonUtils.fromJson[SingleAction](f2.json).unwrap)
+    assert(f3 === JsonUtils.fromJson[SingleAction](f3.json).unwrap)
   }
 
   testActionSerDe(
@@ -855,8 +877,15 @@ class ActionSerializerSuite extends QueryTest with SharedSparkSession with Delta
       val asJson = actions.map(_.json)
       val asObjects = asJson.map(Action.fromJson)
 
-      assert(actions === asObjects)
+      assert(actions.map(normalizeActionCollections) === asObjects.map(normalizeActionCollections))
     }
+  }
+
+  private def normalizeActionCollections(action: Action): Action = action match {
+    case remove: RemoveFile
+        if remove.partitionValues == null && !remove.extendedFileMetadata.contains(true) =>
+      remove.copy(partitionValues = Map.empty)
+    case other => other
   }
 
   /** Test serialization/deserialization of [[Action]] by doing an actual commit */

--- a/spark/src/test/scala/org/apache/spark/sql/delta/CheckpointProviderSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CheckpointProviderSuite.scala
@@ -70,9 +70,14 @@ class CheckpointProviderSuite
           .underlyingCheckpointProvider
           .asInstanceOf[V2CheckpointProvider]
 
-        // Check whether these checkpoints are equivalent after being loaded
-        assert(compatCheckpoint.sidecarFiles.toSet === origCheckpoint.sidecarFiles.toSet)
-        assert(compatCheckpoint.checkpointMetadata === origCheckpoint.checkpointMetadata)
+        // Normalize null tags so reconstructed sidecars and metadata compare equal to freshly
+        // constructed instances that default to empty maps after the Jackson upgrade.
+        assert(compatCheckpoint.sidecarFiles
+          .map(f => f.copy(tags = Option(f.tags).getOrElse(Map.empty))).toSet ===
+          origCheckpoint.sidecarFiles.toSet)
+        assert(compatCheckpoint.checkpointMetadata.copy(tags =
+          Option(compatCheckpoint.checkpointMetadata.tags).getOrElse(Map.empty)) ===
+          origCheckpoint.checkpointMetadata)
 
         val compatDf =
             deltaLog.loadIndex(compatCheckpoint.topLevelFileIndex.get, Action.logSchema)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
@@ -335,7 +335,7 @@ class DeltaLogSuite extends QueryTest
         createTestAddFile(encodedPath = "bar", modificationTime = System.currentTimeMillis())
       log.startTransaction().commit(otherAdd :: Nil, DeltaOperations.ManualUpdate)
 
-      assert(log.update().allFiles.collect().find(_.path == "foo")
+      assert(log.update().allFiles.collect().find(_.path == "foo").map(_.withNormalizedTags)
         // `dataChange` is set to `false` after replaying logs.
         === Some(add2.copy(
           dataChange = false, baseRowId = Some(1), defaultRowCommitVersion = Some(2))))

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsSuite.scala
@@ -1067,7 +1067,7 @@ abstract class CommitCoordinatorSuiteBase
         assert(log.unsafeVolatileSnapshot.metadata === newMetadata2)
         // State reconstruction should give correct results
         var expectedFileNames = Set("1", "2", "post-upgrade-file")
-        assert(log.unsafeVolatileSnapshot.allFiles.collect().toSet ===
+        assert(log.unsafeVolatileSnapshot.allFiles.map(_.withNormalizedTags).collect().toSet ===
           expectedFileNames.map(name => createTestAddFile(name, dataChange = false)))
         // commit-coordinator should not be invoked for commit API.
         // Register table API should not be called until the end
@@ -1099,7 +1099,7 @@ abstract class CommitCoordinatorSuiteBase
         assert(log.unsafeVolatileSnapshot.metadata.coordinatedCommitsCoordinatorConf === Map.empty)
         assert(log.unsafeVolatileSnapshot.metadata.coordinatedCommitsTableConf === Map.empty)
         expectedFileNames = Set("1", "2", "post-upgrade-file", "upgrade-2-file")
-        assert(log.unsafeVolatileSnapshot.allFiles.collect().toSet ===
+        assert(log.unsafeVolatileSnapshot.allFiles.map(_.withNormalizedTags).collect().toSet ===
           expectedFileNames.map(name => createTestAddFile(name, dataChange = false)))
         assert(Seq(cs1, cs2).map(_.numCommitsCalled.get) == Seq(3, 0))
         assert(Seq(cs1, cs2).map(_.numRegisterTableCalled.get) == Seq(1, 1))
@@ -1112,7 +1112,7 @@ abstract class CommitCoordinatorSuiteBase
         // Make 1 more commit, this should go to new owner
         log.startTransaction().commitManually(newMetadata3, createTestAddFile("4"))
         expectedFileNames = Set("1", "2", "post-upgrade-file", "upgrade-2-file", "4")
-        assert(log.unsafeVolatileSnapshot.allFiles.collect().toSet ===
+        assert(log.unsafeVolatileSnapshot.allFiles.map(_.withNormalizedTags).collect().toSet ===
           expectedFileNames.map(name => createTestAddFile(name, dataChange = false)))
         assert(Seq(cs1, cs2).map(_.numCommitsCalled.get) == Seq(3, 1))
         assert(Seq(cs1, cs2).map(_.numRegisterTableCalled.get) == Seq(1, 1))


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/7216/files/1ea3213da270ad5cf56d98179f43bee48c238e8e..20f1b1d1353debd11ddca7a99911e652388fd7b3) to review incremental changes.
- [stack/spark42-jackson-compat](https://github.com/delta-io/delta/pull/7215) [[Files changed](https://github.com/delta-io/delta/pull/7215/files)]
  - [**stack/spark42-uc-build-prep**](https://github.com/delta-io/delta/pull/7216) [[Files changed](https://github.com/delta-io/delta/pull/7216/files/1ea3213da270ad5cf56d98179f43bee48c238e8e..20f1b1d1353debd11ddca7a99911e652388fd7b3)] ← _this PR_
    - [stack/spark42-python-prep](https://github.com/delta-io/delta/pull/7217) [[Files changed](https://github.com/delta-io/delta/pull/7217/files/20f1b1d1353debd11ddca7a99911e652388fd7b3..9fec6ddc9ec9ded9fe88e41ad137cdbb2b8389b4)]
      - [stack/support-spark-4.0-4.1-4.2](https://github.com/delta-io/delta/pull/7213) [[Files changed](https://github.com/delta-io/delta/pull/7213/files/9fec6ddc9ec9ded9fe88e41ad137cdbb2b8389b4..a646c3f9f8678e1da5b5e6eddc8829f2728a77aa)]

---------
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

This is the second PR in the Spark 4.2 support stack. It makes Unity Catalog compilation and caching use the exact Spark artifact version selected by Delta instead of only the major/minor line.

The setup action now resolves `fullVersion`, passes it to the pinned Unity Catalog build, and keys the cache by that exact release. Jackson annotations can also use their independently published version when it differs from the rest of Jackson.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

- [x] Shell syntax checks passed.
- [x] Cross-version metadata helper checks passed.
- [x] The same code was exercised in an earlier all-green combined CI revision.
- [ ] Full CI for the split revision is running.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No. This changes build and test plumbing only.