### PR TITLE
[Spark] Add LIMIT pushdown to DSv2 scans

### DIFF
--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2Scan.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2Scan.java
@@ -25,6 +25,7 @@ import io.delta.kernel.engine.Engine;
 import io.delta.kernel.expressions.Predicate;
 import io.delta.kernel.internal.ScanImpl;
 import io.delta.kernel.internal.actions.AddFile;
+import io.delta.kernel.internal.actions.DeletionVectorDescriptor;
 import io.delta.kernel.internal.data.ScanStateRow;
 import io.delta.kernel.utils.CloseableIterator;
 import io.delta.spark.internal.v2.read.cdc.CDCSchemaContext;
@@ -85,6 +86,8 @@ class DeltaV2Scan implements Scan, SupportsReportStatistics, SupportsRuntimeV2Fi
   private final Configuration hadoopConf;
   private final boolean isCDCRead;
   private final CaseInsensitiveStringMap options;
+  // Empty means no limit pushdown from Spark.
+  private final OptionalInt pushedLimit;
   private final scala.collection.immutable.Map<String, String> scalaOptions;
   private final SQLConf sqlConf;
   private final DeltaOptions deltaOptions;
@@ -122,7 +125,8 @@ class DeltaV2Scan implements Scan, SupportsReportStatistics, SupportsRuntimeV2Fi
       Filter[] dataFilters,
       io.delta.kernel.Scan kernelScan,
       Optional<Statistics> catalogStats,
-      CaseInsensitiveStringMap options) {
+      CaseInsensitiveStringMap options,
+      OptionalInt pushedLimit) {
 
     this.snapshotManager = Objects.requireNonNull(snapshotManager, "snapshotManager is null");
     this.initialSnapshot = Objects.requireNonNull(initialSnapshot, "initialSnapshot is null");
@@ -137,6 +141,7 @@ class DeltaV2Scan implements Scan, SupportsReportStatistics, SupportsRuntimeV2Fi
     this.kernelScan = Objects.requireNonNull(kernelScan, "kernelScan is null");
     this.catalogStats = Objects.requireNonNull(catalogStats, "catalogStats is null");
     this.options = Objects.requireNonNull(options, "options is null");
+    this.pushedLimit = Objects.requireNonNull(pushedLimit, "pushedLimit is null");
     this.scalaOptions = ScalaUtils.toScalaMap(options);
     this.hadoopConf = SparkSession.active().sessionState().newHadoopConfWithOptions(scalaOptions);
     this.sqlConf = SQLConf.get();
@@ -267,7 +272,12 @@ class DeltaV2Scan implements Scan, SupportsReportStatistics, SupportsRuntimeV2Fi
             .collect(Collectors.joining(", "));
     final String data =
         Arrays.stream(dataFilters).map(Object::toString).collect(Collectors.joining(", "));
-    return String.format(Locale.ROOT, "PushedFilters: [%s], DataFilters: [%s]", pushed, data);
+    final StringBuilder description =
+        new StringBuilder(
+            String.format(Locale.ROOT, "PushedFilters: [%s], DataFilters: [%s]", pushed, data));
+    pushedLimit.ifPresent(
+        limit -> description.append(String.format(Locale.ROOT, ", PushedLimit: %d", limit)));
+    return description.toString();
   }
 
   @Override
@@ -433,68 +443,123 @@ class DeltaV2Scan implements Scan, SupportsReportStatistics, SupportsRuntimeV2Fi
   /**
    * Plan the files to scan by materializing {@link PartitionedFile}s and aggregating size stats.
    * Ensures all iterators are closed to avoid resource leaks.
+   *
+   * <p>When a limit is pushed (via {@link SupportsPushDownLimit}), per-file {@code numRecords}
+   * (minus deletion-vector cardinality) are used to stop adding files once enough logical rows have
+   * been accumulated to satisfy the limit. Files that lack statistics are added but do not count
+   * toward the limit.
    */
   private void planScanFiles() {
+    // Short-circuit LIMIT 0. When plan stats are enabled, mark the row count as known because it is
+    // derived directly from the limit, rather than falling back to catalog stats.
+    if (isLimitPushed() && pushedLimit.getAsInt() == 0) {
+      estimatedSizeInBytes = 0;
+      rowCountKnown = arePlanStatsEnabled();
+      totalRows = 0;
+      return;
+    }
+
     final Engine tableEngine = DefaultEngine.create(hadoopConf);
     final String tablePath = getTablePath();
+
     // TODO: Promote getScanFiles(Engine, boolean includeStats) to the public Scan interface to
     // avoid coupling to the kernel-internal ScanImpl class. Until that API is available, this
     // instanceof check is the only way to request per-file statistics from the kernel.
     //
-    // Parse stats JSON when both of:
+    // Read per-file stats JSON when either:
     //  - the optimizer will use numRows (CBO or planStats enabled), matching V1's behavior
-    //    (LogicalRelation.computeStats())
-    //  - the kernel scan is ScanImpl (the only path that supports includeStats)
-    final boolean includeStats = kernelScan instanceof ScanImpl && arePlanStatsEnabled();
-    final Iterator<FilteredColumnarBatch> scanFileBatches;
+    //    (LogicalRelation.computeStats()), or
+    //  - a limit is pushed, in which case we need numRecords to decide when to stop planning.
+    // Both require the kernel scan to be a ScanImpl (the only path that supports includeStats).
+    final boolean scanIsStatsCapable = kernelScan instanceof ScanImpl;
+    final boolean includeStats = scanIsStatsCapable && (arePlanStatsEnabled() || isLimitPushed());
+    final CloseableIterator<FilteredColumnarBatch> scanFileBatches;
     if (includeStats) {
       scanFileBatches = ((ScanImpl) kernelScan).getScanFiles(tableEngine, true /* includeStats */);
-      rowCountKnown = true; // assume all files have stats; set to false on first miss
+      // Only participate in CBO numRows reporting when the optimizer actually consumes it, matching
+      // V1's LogicalRelation.computeStats() gate. A limit alone forces stats to be read (for
+      // termination via logicalRowCount) but must not start surfacing numRows when CBO is off.
+      rowCountKnown = arePlanStatsEnabled(); // assume all files have stats; cleared on first miss
     } else {
       rowCountKnown = false;
       scanFileBatches = kernelScan.getScanFiles(tableEngine);
     }
 
-    final String[] locations = new String[0];
-    final scala.collection.immutable.Map<String, Object> otherConstantMetadataColumnValues =
-        scala.collection.immutable.Map$.MODULE$.empty();
+    // Tracks logical (surviving) rows accumulated so far for limit pushdown. This differs from
+    // totalRows, which is the physical numRecords sum used for CBO and stops being tracked once any
+    // file lacks stats. accumulatedLimitRows always drives limit termination when a limit is
+    // pushed.
+    long accumulatedLimitRows = 0L;
+    try (scanFileBatches) {
+      // Check the limit before hasNext() to avoid any unnecessary kernel iterator I/O.
+      while (!isLimitReached(accumulatedLimitRows) && scanFileBatches.hasNext()) {
+        final FilteredColumnarBatch batch = scanFileBatches.next();
 
-    while (scanFileBatches.hasNext()) {
-      final FilteredColumnarBatch batch = scanFileBatches.next();
+        try (CloseableIterator<Row> addFileRowIter = batch.getRows()) {
+          while (!isLimitReached(accumulatedLimitRows) && addFileRowIter.hasNext()) {
+            final Row row = addFileRowIter.next();
+            final AddFile addFile = new AddFile(row.getStruct(0));
 
-      try (CloseableIterator<Row> addFileRowIter = batch.getRows()) {
-        while (addFileRowIter.hasNext()) {
-          final Row row = addFileRowIter.next();
-          final AddFile addFile = new AddFile(row.getStruct(0));
+            final PartitionedFile partitionedFile =
+                PartitionUtils.buildPartitionedFile(addFile, partitionSchema, tablePath, zoneId);
 
-          final PartitionedFile partitionedFile =
-              PartitionUtils.buildPartitionedFile(addFile, partitionSchema, tablePath, zoneId);
+            totalBytes += addFile.getSize();
+            partitionedFiles.add(partitionedFile);
+            selectedFiles.add(new DeltaScanFile(addFile));
 
-          totalBytes += addFile.getSize();
-          partitionedFiles.add(partitionedFile);
-          selectedFiles.add(new DeltaScanFile(addFile));
+            Optional<Long> numRecords =
+                rowCountKnown || isLimitPushed() ? addFile.getNumRecords() : Optional.empty();
+            if (rowCountKnown) {
+              if (numRecords.isPresent()) {
+                totalRows += numRecords.get();
+                perFileRowCounts.add(numRecords.get());
+              } else {
+                // This file has no numRecords — row count is unknowable for the whole scan.
+                // Clear partial state and stop accumulating for all subsequent files.
+                rowCountKnown = false;
+                totalRows = 0;
+                perFileRowCounts.clear();
+              }
+            }
 
-          if (rowCountKnown) {
-            Optional<Long> numRecords = addFile.getNumRecords();
-            if (numRecords.isPresent()) {
-              totalRows += numRecords.get();
-              perFileRowCounts.add(numRecords.get());
-            } else {
-              // This file has no numRecords — row count is unknowable for the whole scan.
-              // Clear partial state and stop accumulating for all subsequent files.
-              rowCountKnown = false;
-              totalRows = 0;
-              perFileRowCounts.clear();
+            if (isLimitPushed()) {
+              accumulatedLimitRows += logicalRowCount(addFile, numRecords);
             }
           }
         }
-      } catch (IOException e) {
-        throw new RuntimeException(e);
       }
+    } catch (IOException e) {
+      throw new RuntimeException(e);
     }
 
     // Pre-compute estimated size accounting for column projection
     estimatedSizeInBytes = computeEstimatedSizeWithColumnProjection(totalBytes);
+  }
+
+  /** Returns true iff a limit was pushed down from Spark. */
+  private boolean isLimitPushed() {
+    return pushedLimit.isPresent();
+  }
+
+  /**
+   * Returns true iff a limit is pushed and the accumulated logical row count already satisfies it.
+   */
+  private boolean isLimitReached(long accumulatedLimitRows) {
+    return isLimitPushed() && accumulatedLimitRows >= pushedLimit.getAsInt();
+  }
+
+  /**
+   * Returns the surviving row count contributed by a file toward a pushed limit: the physical
+   * {@code numRecords} minus deletion-vector cardinality. Returns 0 when statistics are missing, so
+   * a file without stats is planned but never counted toward the limit.
+   */
+  private static long logicalRowCount(AddFile addFile, Optional<Long> numRecords) {
+    if (!numRecords.isPresent()) {
+      return 0L;
+    }
+    long dvCardinality =
+        addFile.getDeletionVector().map(DeletionVectorDescriptor::getCardinality).orElse(0L);
+    return Math.max(0L, numRecords.get() - dvCardinality);
   }
 
   /**
@@ -594,6 +659,11 @@ class DeltaV2Scan implements Scan, SupportsReportStatistics, SupportsRuntimeV2Fi
     return hadoopConf;
   }
 
+  /** Returns the limit pushed down from Spark, if any. Package-private for testing. */
+  OptionalInt getPushedLimit() {
+    return pushedLimit;
+  }
+
   @Override
   public NamedReference[] filterAttributes() {
     return Arrays.stream(partitionSchema.fields())
@@ -603,6 +673,18 @@ class DeltaV2Scan implements Scan, SupportsReportStatistics, SupportsRuntimeV2Fi
 
   @Override
   public void filter(org.apache.spark.sql.connector.expressions.filter.Predicate[] predicates) {
+    // Spark currently invokes this method for DynamicPruningExpression predicates. These normally
+    // come from join dynamic partition pruning, but group-based row-level operations can also use
+    // them to select the file groups that must be rewritten. Delta advertises only partition
+    // columns through filterAttributes(), so accepted predicates prune the already-planned file
+    // list by partition value.
+    //
+    // Runtime pruning happens after planScanFiles(), so combining it with a pushed limit would be
+    // unsafe: limit planning could stop before files that survive the runtime predicate, and this
+    // method can only remove planned files. Current Spark plan shapes prevent that combination.
+    // Join DPP places a Join between the Limit and the scan. Group-based row-level operations do
+    // not place a direct Limit over the scan, so neither shape matches Spark's
+    // PhysicalOperation(_, Nil, scanBuilderHolder) limit pushdown gate.
 
     // Try to convert runtime predicates to catalyst expressions, then create predicate evaluators
     // Only track predicates that successfully convert to evaluators
@@ -665,6 +747,7 @@ class DeltaV2Scan implements Scan, SupportsReportStatistics, SupportsRuntimeV2Fi
         // ignoring kernelScan because it is derived from Snapshot which is created from tablePath,
         // with pushed down filters that are also recorded in `pushedToKernelFilters`
         && Objects.equals(options, that.options)
+        && Objects.equals(pushedLimit, that.pushedLimit)
         && Objects.equals(appliedRuntimePredicates, that.appliedRuntimePredicates)
         && Objects.equals(catalogStats, that.catalogStats);
   }
@@ -679,6 +762,7 @@ class DeltaV2Scan implements Scan, SupportsReportStatistics, SupportsRuntimeV2Fi
         partitionSchema,
         readDataSchema,
         options,
+        pushedLimit,
         appliedRuntimePredicates,
         pushedToKernelFiltersSet,
         dataFiltersSet);

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2ScanBuilder.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2ScanBuilder.java
@@ -28,6 +28,7 @@ import java.util.stream.Collectors;
 import org.apache.spark.sql.connector.read.ScanBuilder;
 import org.apache.spark.sql.connector.read.Statistics;
 import org.apache.spark.sql.connector.read.SupportsPushDownFilters;
+import org.apache.spark.sql.connector.read.SupportsPushDownLimit;
 import org.apache.spark.sql.connector.read.SupportsPushDownRequiredColumns;
 import org.apache.spark.sql.sources.Filter;
 import org.apache.spark.sql.types.StructField;
@@ -41,7 +42,10 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
  * Spark's public connector interfaces instead of coupling to Delta's internal V2 implementation.
  */
 class DeltaV2ScanBuilder
-    implements ScanBuilder, SupportsPushDownRequiredColumns, SupportsPushDownFilters {
+    implements ScanBuilder,
+        SupportsPushDownRequiredColumns,
+        SupportsPushDownFilters,
+        SupportsPushDownLimit {
 
   private io.delta.kernel.ScanBuilder kernelScanBuilder;
   private final Snapshot initialSnapshot;
@@ -60,6 +64,9 @@ class DeltaV2ScanBuilder
   private Predicate[] pushedKernelPredicates;
   private Filter[] pushedSparkFilters;
   private Filter[] dataFilters;
+  // Tracks whether any filter still needs to be applied after the scan.
+  private boolean hasPOstScanResidualFilters = false;
+  private OptionalInt pushedLimit = OptionalInt.empty();
 
   /**
    * Creates a DeltaV2ScanBuilder with the given snapshot and configuration.
@@ -166,7 +173,11 @@ class DeltaV2ScanBuilder
       this.kernelScanBuilder = this.kernelScanBuilder.withFilter(kernelAnd.get());
     }
     this.dataFilters = dataFilterList.toArray(new Filter[0]);
-    return postScanFilters.toArray(new Filter[0]);
+    Filter[] postScan = postScanFilters.toArray(new Filter[0]);
+    // ScanBuilder mutations can be cumulative, so a later pushFilters call should not make an
+    // earlier residual safe to ignore.
+    this.hasPOstScanResidualFilters |= postScan.length > 0;
+    return postScan;
   }
 
   @Override
@@ -174,8 +185,38 @@ class DeltaV2ScanBuilder
     return this.pushedSparkFilters;
   }
 
+  /**
+   * Accepts a LIMIT hint from Spark's optimizer.
+   *
+   * <p>Always returns {@code true}: the connector treats the limit as a best-effort hint, using
+   * per-file {@code numRecords} statistics to stop adding files to the scan plan once enough rows
+   * have been accumulated (see {@link DeltaV2Scan}). Because pruning happens at file granularity,
+   * the planned scan may still return more rows than requested (for example, a single file with
+   * 1,000 rows for LIMIT 5), so {@link #isPartiallyPushed()} is left at its default of {@code true}
+   * and Spark keeps its limit operators as a backstop.
+   *
+   * @param limit the row limit requested by Spark which must be non-negative.
+   */
+  @Override
+  public boolean pushLimit(int limit) {
+    if (limit < 0) {
+      throw new IllegalArgumentException("Pushed limit must be non-negative, but got: " + limit);
+    }
+    this.pushedLimit = OptionalInt.of(limit);
+    return true;
+  }
+
+  // isPartiallyPushed() intentionally uses the interface default (true). Because pruning happens at
+  // file granularity, the scan may produce more rows than requested, so Spark must reapply LIMIT.
+
   @Override
   public org.apache.spark.sql.connector.read.Scan build() {
+    // Spark's V2ScanRelationPushDown only pushes a limit when no post-scan residual remains. It
+    // matches PhysicalOperation(_, Nil, sHolder). Retain this defensive check for direct callers
+    // that may invoke the ScanBuilder methods in a different order.
+    OptionalInt effectiveLimit =
+        hasPOstScanResidualFilters ? OptionalInt.empty() : this.pushedLimit;
+
     return new DeltaV2Scan(
         snapshotManager,
         initialSnapshot,
@@ -187,7 +228,8 @@ class DeltaV2ScanBuilder
         dataFilters,
         kernelScanBuilder.build(),
         catalogStats,
-        options);
+        options,
+        effectiveLimit);
   }
 
   CaseInsensitiveStringMap getOptions() {
@@ -200,5 +242,9 @@ class DeltaV2ScanBuilder
 
   StructType getPartitionSchema() {
     return partitionSchema;
+  }
+
+  OptionalInt getPushedLimit() {
+    return pushedLimit;
   }
 }

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2ScanBuilder.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2ScanBuilder.java
@@ -65,7 +65,7 @@ class DeltaV2ScanBuilder
   private Filter[] pushedSparkFilters;
   private Filter[] dataFilters;
   // Tracks whether any filter still needs to be applied after the scan.
-  private boolean hasPOstScanResidualFilters = false;
+  private boolean hasPostScanResidualFilters = false;
   private OptionalInt pushedLimit = OptionalInt.empty();
 
   /**
@@ -176,7 +176,7 @@ class DeltaV2ScanBuilder
     Filter[] postScan = postScanFilters.toArray(new Filter[0]);
     // ScanBuilder mutations can be cumulative, so a later pushFilters call should not make an
     // earlier residual safe to ignore.
-    this.hasPOstScanResidualFilters |= postScan.length > 0;
+    this.hasPostScanResidualFilters |= postScan.length > 0;
     return postScan;
   }
 
@@ -215,7 +215,7 @@ class DeltaV2ScanBuilder
     // matches PhysicalOperation(_, Nil, sHolder). Retain this defensive check for direct callers
     // that may invoke the ScanBuilder methods in a different order.
     OptionalInt effectiveLimit =
-        hasPOstScanResidualFilters ? OptionalInt.empty() : this.pushedLimit;
+        hasPostScanResidualFilters ? OptionalInt.empty() : this.pushedLimit;
 
     return new DeltaV2Scan(
         snapshotManager,

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/V2LimitPushdownTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/V2LimitPushdownTest.java
@@ -1,0 +1,445 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.spark.internal.v2;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.File;
+import java.util.List;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.delta.DeltaLog;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import scala.Option;
+
+/**
+ * End-to-end tests for LIMIT pushdown ({@code SupportsPushDownLimit}) in the Delta V2 connector.
+ *
+ * <p>The pushdown tests verify that {@code SELECT ... LIMIT N} returns the correct number of rows
+ * and that the limit is reflected in (or correctly absent from) the physical plan. File-level
+ * pruning behavior is covered separately by {@code DeltaV2ScanTest}.
+ *
+ * <p>Some of the tests also compare ordered DSv1 and DSv2 results as connector sanity checks. Those
+ * queries intentionally use {@code ORDER BY} for deterministic row comparison and therefore do not
+ * exercise plain LIMIT pushdown (Delta does not implement {@code SupportsPushDownTopN}).
+ */
+public class V2LimitPushdownTest extends V2TestBase {
+
+  /**
+   * Asserts that the physical plan for a DSv2 {@code LIMIT} query records a pushed limit of the
+   * expected value. This confirms the limit reached the scan, not just that the row count was
+   * correct (which Spark's own LocalLimit would also guarantee).
+   */
+  private void assertLimitPushed(String tablePath, int expectedLimit) {
+    String query = str("SELECT * FROM dsv2.delta.`%s` LIMIT %d", tablePath, expectedLimit);
+    assertLimitPushedForQuery(query, expectedLimit);
+  }
+
+  private void assertLimitPushedForQuery(String query, int expectedLimit) {
+    String plan = spark.sql(query).queryExecution().executedPlan().toString();
+    assertTrue(
+        plan.contains("PushedLimit: " + expectedLimit),
+        str("Expected 'PushedLimit: %d' in physical plan, but got:\n%s", expectedLimit, plan));
+  }
+
+  /**
+   * Asserts that the physical plan for a filtered DSv2 {@code LIMIT} query does NOT record a pushed
+   * limit. Used where a data filter produces a post-scan residual, which makes limit pushdown
+   * unsafe (the connector must not prune files that could hold the only matching rows).
+   */
+  private void assertLimitNotPushed(String tablePath, String filter, int limit) {
+    String query = str("SELECT * FROM dsv2.delta.`%s` WHERE %s LIMIT %d", tablePath, filter, limit);
+    assertLimitNotPushedForQuery(query);
+  }
+
+  private void assertLimitNotPushedForQuery(String query) {
+    String plan = spark.sql(query).queryExecution().executedPlan().toString();
+    assertFalse(
+        plan.contains("PushedLimit:"),
+        "Expected no PushedLimit in the physical plan for query:\n" + query + "\nPlan:\n" + plan);
+  }
+
+  // Asserts ordered DSv1 and DSv2 results match as a connector-level sanity check.
+  private void assertOrderedV1V2Sanity(String tablePath, String orderByCol, int limit) {
+    assertOrderedV1V2SanityWithFilter(tablePath, null, orderByCol, limit);
+  }
+
+  /**
+   * Asserts ordered DSv1 and DSv2 results match for an optionally filtered connector sanity query.
+   * This does not exercise plain LIMIT pushdown because the query includes ORDER BY clause.
+   */
+  private void assertOrderedV1V2SanityWithFilter(
+      String tablePath, String filter, String orderByCol, int limit) {
+    String where = (filter != null) ? " WHERE " + filter : "";
+    String v1Query =
+        str("SELECT * FROM delta.`%s`%s ORDER BY %s LIMIT %d", tablePath, where, orderByCol, limit);
+    String v2Query =
+        str(
+            "SELECT * FROM dsv2.delta.`%s`%s ORDER BY %s LIMIT %d",
+            tablePath, where, orderByCol, limit);
+
+    List<Row> v1Rows = spark.sql(v1Query).collectAsList();
+    List<Row> v2Rows = spark.sql(v2Query).collectAsList();
+
+    assertEquals(
+        v1Rows.size(),
+        v2Rows.size(),
+        str("Row count mismatch: V1=%d, V2=%d", v1Rows.size(), v2Rows.size()));
+    for (int i = 0; i < v1Rows.size(); i++) {
+      assertEquals(
+          v1Rows.get(i).toString(),
+          v2Rows.get(i).toString(),
+          str("Row %d differs between V1 and V2", i));
+    }
+  }
+
+  // Correctness Tests
+  @Test
+  public void testLimitBasic(@TempDir File tempDir) {
+    String tablePath = tempDir.getAbsolutePath();
+    spark.sql(str("CREATE TABLE delta.`%s` (id INT, name STRING) USING delta", tablePath));
+    spark.sql(
+        str(
+            "INSERT INTO delta.`%s` VALUES (1, 'a'), (2, 'b'), (3, 'c'), (4, 'd'), (5, 'e')",
+            tablePath));
+
+    long count = spark.sql(str("SELECT * FROM dsv2.delta.`%s` LIMIT 3", tablePath)).count();
+    assertEquals(3, count, "LIMIT 3 should return exactly 3 rows");
+    assertLimitPushed(tablePath, 3);
+  }
+
+  @Test
+  public void testLimitLargerThanTable(@TempDir File tempDir) {
+    String tablePath = tempDir.getAbsolutePath();
+    spark.sql(str("CREATE TABLE delta.`%s` (id INT) USING delta", tablePath));
+    spark.sql(str("INSERT INTO delta.`%s` VALUES (1), (2), (3)", tablePath));
+
+    long count = spark.sql(str("SELECT * FROM dsv2.delta.`%s` LIMIT 100", tablePath)).count();
+    assertEquals(3, count, "LIMIT larger than the table should return all rows");
+    assertLimitPushed(tablePath, 100);
+  }
+
+  @Test
+  public void testLimit0(@TempDir File tempDir) {
+    String tablePath = tempDir.getAbsolutePath();
+    spark.sql(str("CREATE TABLE delta.`%s` (id INT) USING delta", tablePath));
+    spark.sql(str("INSERT INTO delta.`%s` VALUES (1), (2), (3)", tablePath));
+
+    long count = spark.sql(str("SELECT * FROM dsv2.delta.`%s` LIMIT 0", tablePath)).count();
+    assertEquals(0, count, "LIMIT 0 should return 0 rows");
+  }
+
+  @Test
+  public void testLimit1(@TempDir File tempDir) {
+    String tablePath = tempDir.getAbsolutePath();
+    spark.sql(str("CREATE TABLE delta.`%s` (id INT) USING delta", tablePath));
+    spark.sql(str("INSERT INTO delta.`%s` VALUES (1), (2), (3)", tablePath));
+
+    long count = spark.sql(str("SELECT * FROM dsv2.delta.`%s` LIMIT 1", tablePath)).count();
+    assertEquals(1, count, "LIMIT 1 should return exactly 1 row");
+    assertLimitPushed(tablePath, 1);
+  }
+
+  @Test
+  public void testLimitEmptyTable(@TempDir File tempDir) {
+    String tablePath = tempDir.getAbsolutePath();
+    spark.sql(str("CREATE TABLE delta.`%s` (id INT) USING delta", tablePath));
+
+    long count = spark.sql(str("SELECT * FROM dsv2.delta.`%s` LIMIT 10", tablePath)).count();
+    assertEquals(0, count, "LIMIT on an empty table should return 0 rows");
+    assertLimitPushed(tablePath, 10);
+  }
+
+  @Test
+  public void testLimitWithDeletionVectors(@TempDir File tempDir) {
+    String tablePath = tempDir.getAbsolutePath();
+
+    spark.sql(
+        str(
+            "CREATE TABLE delta.`%s` (id LONG, value STRING) USING delta "
+                + "TBLPROPERTIES ('delta.enableDeletionVectors' = 'true')",
+            tablePath));
+    spark
+        .range(1000)
+        .selectExpr("id", "cast(id as string) as value")
+        .write()
+        .format("delta")
+        .mode("append")
+        .save(tablePath);
+
+    // Delete half the rows, producing deletion vectors.
+    spark.sql(str("DELETE FROM delta.`%s` WHERE id %% 2 = 0", tablePath));
+
+    DeltaLog deltaLog = DeltaLog.forTable(spark, tablePath);
+    long numDVs =
+        (long)
+            deltaLog
+                .update(false, Option.empty(), Option.empty())
+                .numDeletionVectorsOpt()
+                .getOrElse(() -> 0L);
+    assertTrue(numDVs > 0, "Expected deletion vectors to be created");
+
+    long count = spark.sql(str("SELECT * FROM dsv2.delta.`%s` LIMIT 50", tablePath)).count();
+    assertEquals(50, count, "LIMIT 50 with DVs should return exactly 50 rows");
+    assertLimitPushed(tablePath, 50);
+  }
+
+  @Test
+  public void testLimitWithHeavyDVs(@TempDir File tempDir) {
+    String tablePath = tempDir.getAbsolutePath();
+    spark.sql(
+        str(
+            "CREATE TABLE delta.`%s` (id LONG, value STRING) USING delta "
+                + "TBLPROPERTIES ('delta.enableDeletionVectors' = 'true')",
+            tablePath));
+
+    // Two single-file batches so file-level DV accounting matters for the limit.
+    spark
+        .range(0, 100)
+        .selectExpr("id", "cast(id as string) as value")
+        .coalesce(1)
+        .write()
+        .format("delta")
+        .mode("append")
+        .save(tablePath);
+    spark
+        .range(100, 200)
+        .selectExpr("id", "cast(id as string) as value")
+        .coalesce(1)
+        .write()
+        .format("delta")
+        .mode("append")
+        .save(tablePath);
+
+    // Delete 60 rows from each file via DVs, leaving 40 logical rows in each. LIMIT 50 must
+    // therefore span both files regardless of their enumeration order.
+    String deletePredicate = "(id >= 40 AND id < 100) OR (id >= 140 AND id < 200)";
+    spark.sql(str("DELETE FROM delta.`%s` WHERE %s", tablePath, deletePredicate));
+
+    long count = spark.sql(str("SELECT * FROM dsv2.delta.`%s` LIMIT 50", tablePath)).count();
+    assertEquals(50, count, "LIMIT 50 with heavy DVs should return exactly 50 rows");
+    assertLimitPushed(tablePath, 50);
+  }
+
+  @Test
+  public void testLimitWithPartitionFilter(@TempDir File tempDir) {
+    String tablePath = tempDir.getAbsolutePath();
+    spark.sql(
+        str(
+            "CREATE TABLE delta.`%s` (id INT, part STRING) USING delta PARTITIONED BY (part)",
+            tablePath));
+    spark.sql(
+        str(
+            "INSERT INTO delta.`%s` VALUES (1, 'a'), (2, 'a'), (3, 'a'), (4, 'b'), (5, 'b')",
+            tablePath));
+
+    // A partition filter is fully pushed (no post-scan residual), so limit pushdown stays active.
+    long count =
+        spark.sql(str("SELECT * FROM dsv2.delta.`%s` WHERE part = 'a' LIMIT 2", tablePath)).count();
+    assertEquals(2, count, "Partition filter + LIMIT should return 2 rows");
+    assertLimitPushedForQuery(
+        str("SELECT * FROM dsv2.delta.`%s` WHERE part = 'a' LIMIT 2", tablePath), 2);
+    assertOrderedV1V2SanityWithFilter(tablePath, "part = 'a'", "id", 2);
+  }
+
+  @Test
+  public void testLimitWithDataFilter(@TempDir File tempDir) {
+    String tablePath = tempDir.getAbsolutePath();
+    spark.sql(str("CREATE TABLE delta.`%s` (id INT, name STRING) USING delta", tablePath));
+    spark.sql(
+        str(
+            "INSERT INTO delta.`%s` VALUES (1, 'a'), (2, 'b'), (3, 'c'), (4, 'd'), (5, 'e')",
+            tablePath));
+
+    // A data filter becomes a post-scan residual, so the limit must NOT be pushed — but the query
+    // must still return correct results.
+    long count =
+        spark.sql(str("SELECT * FROM dsv2.delta.`%s` WHERE id > 2 LIMIT 2", tablePath)).count();
+    assertEquals(2, count, "Data filter + LIMIT should return 2 rows");
+    assertLimitNotPushed(tablePath, "id > 2", 2);
+  }
+
+  @Test
+  public void testLimitWithDynamicPartitionPruningIsNotPushed(@TempDir File tempDir)
+      throws Exception {
+    String factPath = new File(tempDir, "fact").getAbsolutePath();
+    String dimensionPath = new File(tempDir, "dimension").getAbsolutePath();
+
+    spark.sql(
+        str(
+            "CREATE TABLE delta.`%s` (id INT, part INT) USING delta PARTITIONED BY (part)",
+            factPath));
+    spark.sql(str("INSERT INTO delta.`%s` VALUES (1, 1), (2, 2), (3, 3)", factPath));
+    spark.sql(str("CREATE TABLE delta.`%s` (part INT, tag STRING) USING delta", dimensionPath));
+    spark.sql(
+        str("INSERT INTO delta.`%s` VALUES (1, 'drop'), (2, 'keep'), (3, 'drop')", dimensionPath));
+
+    String query =
+        str(
+            "SELECT fact.id FROM dsv2.delta.`%s` fact "
+                + "JOIN dsv2.delta.`%s` dimension ON fact.part = dimension.part "
+                + "WHERE dimension.tag = 'keep' LIMIT 1",
+            factPath, dimensionPath);
+
+    withSQLConf(
+        "spark.sql.adaptive.enabled",
+        "false",
+        () ->
+            withSQLConf(
+                "spark.sql.optimizer.dynamicPartitionPruning.enabled",
+                "true",
+                () -> {
+                  Dataset<Row> result = spark.sql(query);
+                  String plan = result.queryExecution().executedPlan().toString();
+
+                  assertTrue(
+                      plan.contains("RuntimeFilters: [dynamicpruningexpression("),
+                      "Expected a DSv2 dynamic partition pruning runtime filter, but got:\n"
+                          + plan);
+                  assertFalse(
+                      plan.contains("PushedLimit:"),
+                      "LIMIT must not be pushed into a scan receiving a runtime filter:\n" + plan);
+                  assertEquals(
+                      1,
+                      result.collectAsList().size(),
+                      "Runtime pruning with LIMIT should return one row");
+                }));
+  }
+
+  @Test
+  public void testLimitWithColumnProjection(@TempDir File tempDir) {
+    String tablePath = tempDir.getAbsolutePath();
+    spark.sql(
+        str("CREATE TABLE delta.`%s` (id INT, name STRING, value DOUBLE) USING delta", tablePath));
+    spark.sql(
+        str(
+            "INSERT INTO delta.`%s` VALUES (1, 'a', 1.0), (2, 'b', 2.0), (3, 'c', 3.0)",
+            tablePath));
+
+    Dataset<Row> result = spark.sql(str("SELECT name FROM dsv2.delta.`%s` LIMIT 2", tablePath));
+    assertEquals(2, result.count(), "Column projection + LIMIT should return 2 rows");
+    assertEquals(1, result.columns().length, "Projected result should have exactly 1 column");
+    assertEquals("name", result.columns()[0]);
+    assertLimitPushedForQuery(str("SELECT name FROM dsv2.delta.`%s` LIMIT 2", tablePath), 2);
+  }
+
+  @Test
+  public void testLimitWithColumnMapping(@TempDir File tempDir) {
+    String tablePath = tempDir.getAbsolutePath();
+    spark.sql(
+        str(
+            "CREATE TABLE delta.`%s` (id INT, name STRING) USING delta "
+                + "TBLPROPERTIES ('delta.columnMapping.mode' = 'name')",
+            tablePath));
+    spark.sql(str("INSERT INTO delta.`%s` VALUES (1, 'a'), (2, 'b'), (3, 'c')", tablePath));
+
+    long count = spark.sql(str("SELECT * FROM dsv2.delta.`%s` LIMIT 2", tablePath)).count();
+    assertEquals(2, count, "LIMIT with column mapping should return 2 rows");
+    assertLimitPushed(tablePath, 2);
+  }
+
+  // Robustness Tests
+  @Test
+  public void testLimitWithMultipleFiles(@TempDir File tempDir) {
+    String tablePath = tempDir.getAbsolutePath();
+    spark.sql(str("CREATE TABLE delta.`%s` (id INT) USING delta", tablePath));
+
+    // One row per file (20 files) so the limit must terminate part-way through the file list.
+    for (int i = 0; i < 20; i++) {
+      spark.sql(str("INSERT INTO delta.`%s` VALUES (%d)", tablePath, i));
+    }
+
+    long count = spark.sql(str("SELECT * FROM dsv2.delta.`%s` LIMIT 3", tablePath)).count();
+    assertEquals(3, count, "LIMIT 3 over 20 single-row files should return 3 rows");
+    assertLimitPushed(tablePath, 3);
+  }
+
+  @Test
+  public void testLimitWithNonDeterministicFilterIsNotPushed(@TempDir File tempDir) {
+    String tablePath = tempDir.getAbsolutePath();
+    spark.sql(str("CREATE TABLE delta.`%s` (id INT) USING delta", tablePath));
+    spark
+        .range(100)
+        .selectExpr("cast(id as int) as id")
+        .write()
+        .format("delta")
+        .mode("append")
+        .save(tablePath);
+
+    // A seeded rand gives reproducible results but is still a non-deterministic Catalyst expression
+    // that must remain a post-scan filter. Pruning files before evaluating it would be unsafe.
+    String query = str("SELECT * FROM dsv2.delta.`%s` WHERE rand(0) > 0.5 LIMIT 5", tablePath);
+    assertEquals(5, spark.sql(query).count());
+    assertLimitNotPushedForQuery(query);
+  }
+
+  @Test
+  public void testLimitWithOffsetPushesCombinedRowRequirement(@TempDir File tempDir) {
+    String tablePath = tempDir.getAbsolutePath();
+    spark.sql(str("CREATE TABLE delta.`%s` (id INT) USING delta", tablePath));
+    spark.sql(str("INSERT INTO delta.`%s` VALUES (1), (2), (3), (4), (5)", tablePath));
+
+    String query = str("SELECT * FROM dsv2.delta.`%s` LIMIT 2 OFFSET 1", tablePath);
+    assertEquals(2, spark.sql(query).count());
+    // Spark pushes LIMIT + OFFSET so the retained OFFSET still has three input rows available.
+    assertLimitPushedForQuery(query, 3);
+  }
+
+  @Test
+  public void testLimitStreamingUnaffected(@TempDir File tempDir) throws Exception {
+    String tablePath = tempDir.getAbsolutePath();
+
+    // Write via V1 (V2 does not support writes yet).
+    spark.sql(str("CREATE TABLE delta.`%s` (id INT) USING delta", tablePath));
+    spark.sql(str("INSERT INTO delta.`%s` VALUES (1), (2), (3)", tablePath));
+    spark.sql(str("INSERT INTO delta.`%s` VALUES (4), (5)", tablePath));
+
+    // A streaming read must read all data regardless of any batch limit-pushdown state.
+    String dsv2TableRef = str("dsv2.delta.`%s`", tablePath);
+    Dataset<Row> streamingDF =
+        spark.readStream().option("startingVersion", "1").table(dsv2TableRef);
+
+    String queryName = "limit_streaming_test_" + System.nanoTime();
+    List<Row> rows = processStreamingQuery(streamingDF, queryName);
+    assertEquals(5, rows.size(), "Streaming should read all 5 rows regardless of limit pushdown");
+  }
+
+  @Test
+  public void testLimitOrderBy(@TempDir File tempDir) {
+    String tablePath = tempDir.getAbsolutePath();
+    spark.sql(str("CREATE TABLE delta.`%s` (id INT, name STRING) USING delta", tablePath));
+    spark.sql(
+        str(
+            "INSERT INTO delta.`%s` VALUES (3, 'c'), (1, 'a'), (5, 'e'), (2, 'b'), (4, 'd')",
+            tablePath));
+
+    // ORDER BY + LIMIT is not a pushed TopN (no SupportsPushDownTopN); Spark handles it via
+    // Sort + LocalLimit. Results must still be correct and match V1.
+    List<Row> rows =
+        spark
+            .sql(str("SELECT * FROM dsv2.delta.`%s` ORDER BY id LIMIT 3", tablePath))
+            .collectAsList();
+    assertEquals(3, rows.size(), "ORDER BY + LIMIT should return 3 rows");
+    assertEquals(1, rows.get(0).getInt(0), "First row should have id=1");
+    assertEquals(2, rows.get(1).getInt(0), "Second row should have id=2");
+    assertEquals(3, rows.get(2).getInt(0), "Third row should have id=3");
+    assertLimitNotPushedForQuery(
+        str("SELECT * FROM dsv2.delta.`%s` ORDER BY id LIMIT 3", tablePath));
+    assertOrderedV1V2Sanity(tablePath, "id", 3);
+  }
+}

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2ScanBuilderTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2ScanBuilderTest.java
@@ -17,6 +17,7 @@ package io.delta.spark.internal.v2.read;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.delta.kernel.Snapshot;
@@ -31,6 +32,7 @@ import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Set;
 import org.apache.spark.sql.connector.read.Scan;
 import org.apache.spark.sql.connector.read.streaming.MicroBatchStream;
@@ -962,5 +964,127 @@ public class DeltaV2ScanBuilderTest extends DeltaV2TestBase {
     }
     Optional<?> opt = (Optional<?>) raw;
     return opt.map(Predicate.class::cast);
+  }
+
+  // Limit Pushdown Tests
+
+  @Test
+  public void testPushLimit_nonNegativeAccepted(@TempDir File tempDir) {
+    DeltaV2ScanBuilder builder = createTestScanBuilder(tempDir);
+    assertTrue(builder.pushLimit(10), "A non-negative limit should be accepted as a hint");
+  }
+
+  @Test
+  public void testPushLimit_isPartiallyPushedIsTrue(@TempDir File tempDir) {
+    DeltaV2ScanBuilder builder = createTestScanBuilder(tempDir);
+    builder.pushLimit(10);
+    // The pushdown is partial because pruning stops only at file boundaries, so the selected files
+    // may produce more than the requested number of rows. Keep the default true so Spark retains
+    // the LIMIT and trims the final result to exactly N rows.
+    assertTrue(builder.isPartiallyPushed(), "isPartiallyPushed should return true");
+  }
+
+  @Test
+  public void testPushLimit_propagatedToScan(@TempDir File tempDir) {
+    DeltaV2ScanBuilder builder = createTestScanBuilder(tempDir);
+    builder.pushLimit(42);
+    DeltaV2Scan scan = (DeltaV2Scan) builder.build();
+    assertEquals(OptionalInt.of(42), scan.getPushedLimit());
+  }
+
+  @Test
+  public void testPushLimit_absentByDefault(@TempDir File tempDir) {
+    DeltaV2ScanBuilder builder = createTestScanBuilder(tempDir);
+    DeltaV2Scan scan = (DeltaV2Scan) builder.build();
+    assertEquals(OptionalInt.empty(), scan.getPushedLimit());
+  }
+
+  @Test
+  public void testPushLimit_lastValueWins(@TempDir File tempDir) {
+    DeltaV2ScanBuilder builder = createTestScanBuilder(tempDir);
+    builder.pushLimit(10);
+    builder.pushLimit(20);
+    assertEquals(OptionalInt.of(20), builder.getPushedLimit());
+    DeltaV2Scan scan = (DeltaV2Scan) builder.build();
+    assertEquals(OptionalInt.of(20), scan.getPushedLimit());
+  }
+
+  @Test
+  public void testPushLimit_negativeRejected(@TempDir File tempDir) {
+    DeltaV2ScanBuilder builder = createTestScanBuilder(tempDir);
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> builder.pushLimit(-1),
+        "A negative pushed limit should be rejected");
+  }
+
+  @Test
+  public void testPushLimit_clearedWhenDataFiltersPresent(@TempDir File tempDir) throws Exception {
+    DeltaV2ScanBuilder builder = createTestScanBuilder(tempDir);
+    // A data filter (on a non-partition column) becomes a post-scan residual.
+    builder.pushFilters(new Filter[] {new org.apache.spark.sql.sources.EqualTo("name", "x")});
+    builder.pushLimit(10);
+    DeltaV2Scan scan = (DeltaV2Scan) builder.build();
+    assertEquals(
+        OptionalInt.empty(),
+        scan.getPushedLimit(),
+        "Pushed limit must be cleared when data filters would leave a post-scan residual");
+  }
+
+  @Test
+  public void testPushLimit_clearedWhenUnsupportedPartitionFilterLeavesResidual(
+      @TempDir File tempDir) throws Exception {
+    // StringEndsWith is not convertible to a kernel predicate, so even on a partition column
+    // (dep_id) it stays as a post-scan residual - but it is NOT a data filter (dep_id is a
+    // partition column). This is the case a data filters only check would miss: the residual
+    // exists, so the limit must still be cleared to mirror Spark's PhysicalOperation(_, Nil, _)
+    // gate.
+    DeltaV2ScanBuilder builder = createTestScanBuilder(tempDir);
+    Filter[] residual =
+        builder.pushFilters(
+            new Filter[] {new org.apache.spark.sql.sources.StringEndsWith("dep_id", "1")});
+    assertEquals(1, residual.length, "unsupported partition filter should be a post-scan residual");
+    assertEquals(0, getDataFilters(builder).length, "the residual must not be a data filter");
+
+    builder.pushLimit(10);
+    DeltaV2Scan scan = (DeltaV2Scan) builder.build();
+    assertEquals(
+        OptionalInt.empty(),
+        scan.getPushedLimit(),
+        "Pushed limit must be cleared for any post-scan residual, not only data filters");
+  }
+
+  @Test
+  public void testPushLimit_remainsClearedAfterLaterEmptyPushFilters(@TempDir File tempDir) {
+    DeltaV2ScanBuilder builder = createTestScanBuilder(tempDir);
+    Filter[] residual =
+        builder.pushFilters(
+            new Filter[] {new org.apache.spark.sql.sources.StringEndsWith("dep_id", "1")});
+    assertEquals(1, residual.length);
+
+    // ScanBuilder state is cumulative. A later empty call cannot retract the residual Spark must
+    // still evaluate from the earlier call, so it must not make limit pruning safe again.
+    assertEquals(0, builder.pushFilters(new Filter[0]).length);
+    assertTrue(builder.pushLimit(10));
+    assertEquals(OptionalInt.empty(), ((DeltaV2Scan) builder.build()).getPushedLimit());
+  }
+
+  @Test
+  public void testPushLimit_keptWhenFullyPushedPartitionFilterLeavesNoResidual(
+      @TempDir File tempDir) throws Exception {
+    // A fully-converted partition filter (EqualTo on dep_id) is used for partition pruning and
+    // leaves NO post-scan residual, so the pushed limit is safe to keep - matching Spark, which
+    // still offers pushLimit in this shape.
+    DeltaV2ScanBuilder builder = createTestScanBuilder(tempDir);
+    Filter[] residual =
+        builder.pushFilters(new Filter[] {new org.apache.spark.sql.sources.EqualTo("dep_id", 1)});
+    assertEquals(0, residual.length, "fully-pushed partition filter should leave no residual");
+
+    builder.pushLimit(10);
+    DeltaV2Scan scan = (DeltaV2Scan) builder.build();
+    assertEquals(
+        OptionalInt.of(10),
+        scan.getPushedLimit(),
+        "Pushed limit must be kept when a partition filter leaves no post-scan residual");
   }
 }

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2ScanTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2ScanTest.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.OptionalInt;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.spark.sql.catalyst.TableIdentifier;
 import org.apache.spark.sql.catalyst.catalog.CatalogColumnStat;
@@ -1851,5 +1852,173 @@ public class DeltaV2ScanTest extends DeltaV2TestBase {
       b.$plus$eq(new scala.Tuple2<>(keys[i], values[i]));
     }
     return (scala.collection.immutable.Map<String, CatalogColumnStat>) b.result();
+  }
+
+  // Limit Pushdown Tests
+
+  @Test
+  public void testLimitPushdown_descriptionIncludesLimit() {
+    DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    builder.pushLimit(10);
+    DeltaV2Scan scan = (DeltaV2Scan) builder.build();
+    assertTrue(
+        scan.description().contains("PushedLimit: 10"),
+        "description should include the pushed limit");
+  }
+
+  @Test
+  public void testLimitPushdown_descriptionOmitsLimitWhenAbsent() {
+    DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan = (DeltaV2Scan) builder.build();
+    assertFalse(
+        scan.description().contains("PushedLimit"),
+        "description should not mention PushedLimit when no limit is pushed");
+  }
+
+  @Test
+  public void testLimitPushdown_equalHashCodeWithSameLimit() {
+    DeltaV2Scan scan1 = buildScanWithLimit(10);
+    DeltaV2Scan scan2 = buildScanWithLimit(10);
+    assertEquals(scan1, scan2);
+    assertEquals(scan1.hashCode(), scan2.hashCode());
+  }
+
+  @Test
+  public void testLimitPushdown_notEqualWithDifferentLimit() {
+    DeltaV2Scan scan1 = buildScanWithLimit(5);
+    DeltaV2Scan scan2 = buildScanWithLimit(100);
+    assertNotEquals(scan1, scan2);
+    assertNotEquals(scan1.hashCode(), scan2.hashCode());
+  }
+
+  @Test
+  public void testLimitPushdown_notEqualWithAndWithoutLimit() {
+    DeltaV2Scan withoutLimit =
+        (DeltaV2Scan) ((DeltaV2ScanBuilder) table.newScanBuilder(options)).build();
+    DeltaV2Scan withLimit = buildScanWithLimit(10);
+    assertNotEquals(withoutLimit, withLimit);
+    assertNotEquals(withoutLimit.hashCode(), withLimit.hashCode());
+  }
+
+  @Test
+  public void testLimitPushdown_noLimitPlansAllFiles() throws Exception {
+    DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan = (DeltaV2Scan) builder.build();
+    // The shared partitioned test table has 5 single-row files.
+    assertEquals(
+        5, getPartitionedFiles(scan).size(), "all files should be planned without a limit");
+  }
+
+  @Test
+  public void testLimitPushdown_limit0PlansNoFiles() throws Exception {
+    DeltaV2Scan scan = buildScanWithLimit(0);
+    assertEquals(0, getPartitionedFiles(scan).size(), "LIMIT 0 should plan zero files");
+    assertEquals(0, getTotalBytes(scan), "LIMIT 0 should read zero bytes");
+    assertEquals(0, getEstimatedSizeInBytes(scan), "LIMIT 0 should estimate zero size");
+  }
+
+  @Test
+  public void testLimitPushdown_prunesFilesForSmallLimit() throws Exception {
+    // The partitioned test table has 5 one-row files. LIMIT 1 needs exactly one.
+    DeltaV2Scan scan = buildScanWithLimit(1);
+    List<PartitionedFile> files = getPartitionedFiles(scan);
+    assertEquals(1, files.size(), "LIMIT 1 over single-row files should plan exactly one file");
+
+    DeltaV2Scan unlimited =
+        (DeltaV2Scan) ((DeltaV2ScanBuilder) table.newScanBuilder(options)).build();
+    assertTrue(
+        getTotalBytes(scan) <= getTotalBytes(unlimited),
+        "planned bytes with a limit should not exceed the full-scan bytes");
+  }
+
+  @Test
+  public void testLimitPushdown_getterReflectsBuilder() {
+    assertEquals(OptionalInt.of(7), buildScanWithLimit(7).getPushedLimit());
+    DeltaV2Scan noLimit =
+        (DeltaV2Scan) ((DeltaV2ScanBuilder) table.newScanBuilder(options)).build();
+    assertEquals(OptionalInt.empty(), noLimit.getPushedLimit());
+  }
+
+  @Test
+  public void testLimitPushdown_limit0ReportsZeroNumRowsNotStaleCatalog(@TempDir File tempDir)
+      throws Exception {
+    // The LIMIT 0 short-circuit reads no files. Under CBO with catalog stats present, numRows()
+    // must report 0 (the scan logically returns zero rows), NOT the stale table-level catalog
+    // count. This adds regression guard for the short-circuit setting rowCountKnown/totalRows.
+    String path = tempDir.getAbsolutePath();
+    String tblName = "stats_limit0_numrows";
+    spark.sql(
+        String.format(
+            "CREATE TABLE %s (id INT, name STRING) USING delta LOCATION '%s'", tblName, path));
+    spark.sql(String.format("INSERT INTO %s VALUES (1, 'a'), (2, 'b'), (3, 'c')", tblName));
+
+    // Catalog stats claim 999 rows - distinguishable from the correct LIMIT 0 answer of 0.
+    CatalogStatistics catalogStats =
+        new CatalogStatistics(
+            scala.math.BigInt.apply(1024L),
+            scala.Option.apply(scala.math.BigInt.apply(999L)),
+            buildColStatsMap(new String[] {}, new CatalogColumnStat[] {}));
+    CatalogTable catalogTable = injectCatalogStats(tblName, catalogStats);
+
+    withSQLConf(
+        "spark.sql.cbo.enabled",
+        "true",
+        () -> {
+          Identifier id = Identifier.of(new String[] {"default"}, tblName);
+          DeltaV2Table sparkTable = new DeltaV2Table(id, catalogTable, Collections.emptyMap());
+          DeltaV2ScanBuilder builder =
+              (DeltaV2ScanBuilder)
+                  sparkTable.newScanBuilder(new CaseInsensitiveStringMap(new HashMap<>()));
+          builder.pushLimit(0);
+          DeltaV2Scan scan = (DeltaV2Scan) builder.build();
+
+          assertTrue(isRowCountKnown(scan), "LIMIT 0 under CBO should mark the row count known");
+          Statistics stats = scan.estimateStatistics();
+          assertTrue(stats.numRows().isPresent(), "numRows should be present under CBO");
+          assertEquals(
+              0L,
+              stats.numRows().getAsLong(),
+              "LIMIT 0 must report 0 rows, not the stale catalog count (999)");
+          assertEquals(
+              0L, getTotalBytes(scan), "LIMIT 0 should read zero bytes even with catalog stats");
+        });
+  }
+
+  @Test
+  public void testLimitPushdown_missingNumRecordsPlansAllFiles(@TempDir File tempDir)
+      throws Exception {
+    String path = tempDir.getAbsolutePath();
+    String tblName = "limit_missing_numrecords";
+    try {
+      spark.sql(String.format("CREATE TABLE %s (id INT) USING delta LOCATION '%s'", tblName, path));
+      withSQLConf(
+          "spark.databricks.delta.stats.collect",
+          "false",
+          () -> {
+            // Separate appends create two files, neither with numRecords in its AddFile action.
+            spark.sql(String.format("INSERT INTO %s VALUES (1)", tblName));
+            spark.sql(String.format("INSERT INTO %s VALUES (2)", tblName));
+          });
+
+      DeltaV2Table tableWithoutStats =
+          new DeltaV2Table(
+              Identifier.of(new String[] {"spark_catalog", "default"}, tblName), path, options);
+      DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) tableWithoutStats.newScanBuilder(options);
+      assertTrue(builder.pushLimit(1));
+      DeltaV2Scan scan = (DeltaV2Scan) builder.build();
+
+      assertEquals(
+          2,
+          getPartitionedFiles(scan).size(),
+          "Files without numRecords must not count toward the limit; all must be planned");
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + tblName);
+    }
+  }
+
+  private DeltaV2Scan buildScanWithLimit(int limit) {
+    DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    builder.pushLimit(limit);
+    return (DeltaV2Scan) builder.build();
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

- Stop file planning once stats guarantee enough rows
- Disable pruning around residual filters and handle missing stats and DVs conservatively

Resolves #6326

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

Formatting checks
 ```bash
  build/sbt \
    'sparkV2 / Compile / javafmtAll' \
    'sparkV2 / Test / javafmtAll'
  ```

Newly added unit and e2e tests (also checks plan shapes)

```bash
  build/sbt \
    "sparkV2/testOnly io.delta.spark.internal.v2.V2LimitPushdownTest" \
    "sparkV2/testOnly io.delta.spark.internal.v2.read.DeltaV2ScanBuilderTest -- *PushLimit*" \
    "sparkV2/testOnly io.delta.spark.internal.v2.read.DeltaV2ScanTest -- *LimitPushdown*"
  ```

  Ran the complete Spark V2 test suite:

  ```bash
  build/sbt sparkV2/test
  ```

Sanity test with spark 4.0

```bash
  build/sbt -DsparkVersion=4.0 \
    "sparkV2/testOnly io.delta.spark.internal.v2.V2LimitPushdownTest"
  ```


## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No. We only optimize limit pushdowns.
