### PR TITLE
[Spark] Upgrade Jackson to 2.21 for Spark 4.2

### DIFF
--- a/project/CrossSparkVersions.scala
+++ b/project/CrossSparkVersions.scala
@@ -220,6 +220,7 @@ case class SparkVersionSpec(
   antlr4Version: String,
   additionalJavaOptions: Seq[String] = Seq.empty,
   jacksonVersion: String = "2.15.2",
+  jacksonAnnotationsVersion: Option[String] = None,
   additionalResolvers: Seq[Resolver] = Seq.empty
 ) {
   /** Returns the Spark short version (e.g., "3.5", "4.0") */
@@ -294,7 +295,8 @@ object SparkVersionSpec {
     supportHudi = false,
     antlr4Version = "4.13.1",
     additionalJavaOptions = java17TestSettings,
-    jacksonVersion = "2.18.2"
+    jacksonVersion = "2.21.2",
+    jacksonAnnotationsVersion = Some("2.21")
   )
 
   /** Default Spark version */
@@ -412,13 +414,14 @@ object CrossSparkVersions extends AutoPlugin {
     val jacksonOverrides = Seq(
       dependencyOverrides ++= {
         val sparkVer = sparkVersionKey.value
-        val jacksonVer = SparkVersionSpec.ALL_SPECS.find(_.fullVersion == sparkVer)
+        val selectedSpec = SparkVersionSpec.ALL_SPECS.find(_.fullVersion == sparkVer)
           .getOrElse(throw new IllegalArgumentException(s"Unknown Spark version: $sparkVer"))
-          .jacksonVersion
+        val jacksonVer = selectedSpec.jacksonVersion
         Seq(
           "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVer,
           "com.fasterxml.jackson.core" % "jackson-core" % jacksonVer,
-          "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVer,
+          "com.fasterxml.jackson.core" % "jackson-annotations" %
+            selectedSpec.jacksonAnnotationsVersion.getOrElse(jacksonVer),
           "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % jacksonVer,
           "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVer
         )

--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -39,6 +39,7 @@ import org.apache.spark.sql.delta.util.PartitionUtils
 import com.fasterxml.jackson.annotation._
 import com.fasterxml.jackson.annotation.JsonInclude.Include
 import com.fasterxml.jackson.core.{JsonGenerator, JsonParser}
+import com.fasterxml.jackson.core.`type`.TypeReference
 import com.fasterxml.jackson.databind._
 import com.fasterxml.jackson.databind.annotation.{JsonDeserialize, JsonSerialize}
 import com.fasterxml.jackson.databind.node.ObjectNode
@@ -909,6 +910,7 @@ case class AddFile(
     modificationTime: Long,
     override val dataChange: Boolean,
     override val stats: String = null,
+    @JsonDeserialize(using = classOf[NullPreservingStringMapDeserializer])
     override val tags: Map[String, String] = null,
     override val deletionVector: DeletionVectorDescriptor = null,
     @JsonDeserialize(contentAs = classOf[java.lang.Long])
@@ -1146,9 +1148,11 @@ case class RemoveFile(
     deletionTimestamp: Option[Long],
     override val dataChange: Boolean = true,
     extendedFileMetadata: Option[Boolean] = None,
+    @JsonDeserialize(using = classOf[NullPreservingStringMapDeserializer])
     partitionValues: Map[String, String] = null,
     @JsonDeserialize(contentAs = classOf[java.lang.Long])
     size: Option[Long] = None,
+    @JsonDeserialize(using = classOf[NullPreservingStringMapDeserializer])
     override val tags: Map[String, String] = null,
     override val deletionVector: DeletionVectorDescriptor = null,
     @JsonDeserialize(contentAs = classOf[java.lang.Long])
@@ -1206,6 +1210,7 @@ case class AddCDCFile(
     @JsonInclude(JsonInclude.Include.ALWAYS)
     partitionValues: Map[String, String],
     size: Long,
+    @JsonDeserialize(using = classOf[NullPreservingStringMapDeserializer])
     override val tags: Map[String, String] = null,
     override val stats: String = null) extends FileAction with HasNumRecords {
   override val dataChange = false
@@ -1658,6 +1663,7 @@ case class SidecarFile(
     path: String,
     sizeInBytes: Long,
     modificationTime: Long,
+    @JsonDeserialize(using = classOf[NullPreservingStringMapDeserializer])
     tags: Map[String, String] = null,
     // Applicable only for AMT checkpoint sidecars.
     // Sidecars corresponding to V2Checkpoints do not have concept of sidecarType.
@@ -1697,6 +1703,7 @@ object SidecarFile {
  */
 case class CheckpointMetadata(
     version: Long,
+    @JsonDeserialize(using = classOf[NullPreservingStringMapDeserializer])
     tags: Map[String, String] = null)
   extends CheckpointOnlyAction {
 
@@ -1892,6 +1899,13 @@ class JsonMapDeserializer extends JsonDeserializer[Map[String, String]] {
     val map = ctxt.readValue(jp, classOf[Map[String, Any]])
     map.mapValues(JsonUtils.toJson(_)).toMap
   }
+}
+
+class NullPreservingStringMapDeserializer extends JsonDeserializer[Map[String, String]] {
+  override def deserialize(
+      jp: JsonParser,
+      ctxt: DeserializationContext): Map[String, String] =
+    jp.readValueAs(new TypeReference[Map[String, String]] {})
 }
 
 /**


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

For Spark 4.2, this PR updates Jackson from 2.18.2 to 2.21.2. `jackson-annotations` uses 2.21 because version 2.21.2 is not published. Spark 4.0.1 and Spark 4.1.0 still use Jackson 2.18.2.

Jackson 2.21 changes how map fields are read. Without the fix, a missing field, `null`, and `{}` all become `Map.empty`. This table uses `tags` as an example:

| JSON input | Without the fix | With the fix |
| --- | --- | --- |
| `tags` is missing | `Map.empty` | `null` |
| `"tags": null` | `Map.empty` | `null` |
| `"tags": {}` | `Map.empty` | `Map.empty` |
| `"tags": {"k": "v"}` | `Map("k" -> "v")` | `Map("k" -> "v")` |

Delta needs `null` and `{}` to stay different. `null` means do not write the field to JSON. An empty map means write `"tags": {}`. Without the fix, 12 tests in `ActionSerializerSuite` fail.

The fix keeps a missing field or `null` as `null`. It applies only to `AddFile.tags`, `RemoveFile.partitionValues`, `RemoveFile.tags`, `AddCDCFile.tags`, `SidecarFile.tags`, and `CheckpointMetadata.tags`. It is not used for other fields.

The first commit updates the Jackson versions. The second commit keeps `null` for these six fields.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

- [x] Spark 4.2 with Jackson 2.21.2: all 54 `ActionSerializerSuite` tests passed.
- [x] Spark 4.1.0 with Jackson 2.18.2: all 54 `ActionSerializerSuite` tests passed.
- [x] Spark 4.0.1 with Jackson 2.18.2: all 54 `ActionSerializerSuite` tests passed.
- [x] `git diff --check` passed.
- [ ] GitHub Actions is still running.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No. Spark 4.2 is not released yet. This change keeps the existing JSON output for these six fields.
