### PR TITLE
test: retry UC test server bind on port-in-use to fix flaky CI

### DIFF
--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UnityCatalogSupport.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UnityCatalogSupport.java
@@ -299,6 +299,22 @@ public abstract class UnityCatalogSupport {
   }
 
   /**
+   * Whether {@code t} (or anything in its cause chain) is an "address already in use" bind failure.
+   * The server's async bind surfaces it wrapped as a {@link
+   * java.util.concurrent.CompletionException} around a Netty {@code NativeIoException}, so we match
+   * by message across the chain.
+   */
+  private static boolean isAddressInUse(Throwable t) {
+    for (Throwable cause = t; cause != null; cause = cause.getCause()) {
+      final String message = cause.getMessage();
+      if (message != null && message.toLowerCase().contains("address already in use")) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
    * Starts the Unity Catalog server before all tests. IMPORTANT: Starts the server BEFORE calling
    * other setup to ensure the server is running when SharedSparkSession creates the SparkSession.
    */
@@ -361,9 +377,6 @@ public abstract class UnityCatalogSupport {
     ucBaseTableLocation = Files.createTempDirectory("base-table-location-").toFile();
     ucBaseTableLocation.deleteOnExit();
 
-    // Find an available port
-    ucServerPort = findAvailablePort();
-
     // Start the mock OAuth broker before building UnityCatalogInfo (and before serverProperties(),
     // which reads the broker's issuer for the allowed-issuers config).
     if (authMode() == AuthMode.OAUTH) {
@@ -374,17 +387,33 @@ public abstract class UnityCatalogSupport {
       LOG.info("Mock OAuth broker started at " + mockOAuthBroker.issuer());
     }
 
-    // Start UC server with configuration
+    // Start UC server with configuration. findAvailablePort() picks a free port and releases it,
+    // so a concurrently-starting suite on the same runner can grab it before this server binds.
+    // Retry with a fresh port on "address already in use" rather than failing the suite.
     ServerProperties initServerProperties = new ServerProperties(serverProperties());
-
-    UnityCatalogServer server =
-        UnityCatalogServer.builder()
-            .port(ucServerPort)
-            .serverProperties(initServerProperties)
-            .build();
-
-    server.start();
-    ucServer = server;
+    final int maxBindAttempts = 5;
+    for (int attempt = 1; ; attempt++) {
+      ucServerPort = findAvailablePort();
+      UnityCatalogServer server =
+          UnityCatalogServer.builder()
+              .port(ucServerPort)
+              .serverProperties(initServerProperties)
+              .build();
+      try {
+        server.start();
+        ucServer = server;
+        break;
+      } catch (Exception e) {
+        if (attempt < maxBindAttempts && isAddressInUse(e)) {
+          LOG.warn(
+              String.format(
+                  "UC server bind on port %d failed (address in use), retrying (attempt %d/%d)",
+                  ucServerPort, attempt, maxBindAttempts));
+          continue;
+        }
+        throw e;
+      }
+    }
 
     // Now that UC is up, let the OAuth broker reach the token-exchange endpoint.
     if (mockOAuthBroker != null) {


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/7220/files) to review incremental changes.
- [**stack/uc-test-port-bind-fix**](https://github.com/delta-io/delta/pull/7220) [[Files changed](https://github.com/delta-io/delta/pull/7220/files)] ← _this PR_
  - [stack/drc-api-integration](https://github.com/delta-io/delta/pull/7159) [[Files changed](https://github.com/delta-io/delta/pull/7159/files/270f0ffc3d8c6bbe215ba16842121f3afc93b9d9..7459ab2b38b7373acf23ad1c3bb1faad73b0b193)]

---------
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
Kernel, Spark [TEST ONLY]

## Description

The `io.sparkuctest` UC tests each boot a Unity Catalog server on a port chosen by `UnityCatalogSupport.findAvailablePort()`. This opens a server socket, reads its port, and closes it. Between that close and the server's bind, a concurrently-starting suite on the same CI runner can grab the port, so the server fails to bind with `Address already in use`. This change adds a bounded retry for server bind failures.

## How was this patch tested?

Existing `io.sparkuctest` UC suites pass. The retry path is exercised only under port contention on CI runners.

## Does this PR introduce _any_ user-facing changes?

No
