### PR TITLE
[Spark] Update changelog shims for Spark 4.2 API

### DIFF
--- a/.github/workflows/changelog_tests_spark42.yaml
+++ b/.github/workflows/changelog_tests_spark42.yaml
@@ -34,11 +34,12 @@ jobs:
       SPARK_VERSION: "4.2"
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
-      - name: install java
-        uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3.14.1
+      - name: Prepare Spark environment
+        uses: ./.github/actions/prepare-spark-env
         with:
-          distribution: "zulu"
-          java-version: "17"
+          spark-version: "4.2"
+          use-spark-source-cache: "true"
+          build-on-miss: "true"
       - name: Restore SBT cache
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:

--- a/project/CrossSparkVersions.scala
+++ b/project/CrossSparkVersions.scala
@@ -310,7 +310,7 @@ object SparkVersionSpec {
     antlr4Version = "4.13.1",
     additionalJavaOptions = java17TestSettings,
     jacksonVersion = "2.18.2",
-    sourceBuildDefaultRef = Some("b6bd005ac7549411ec4e7dc944d7a0e19fd56561")
+    sourceBuildDefaultRef = Some("da6e110231beea1fa1bd0d259c2b49c7ea4d5085")
   )
 
   /** Default Spark version */

--- a/project/tests/test_cross_spark_publish.py
+++ b/project/tests/test_cross_spark_publish.py
@@ -656,12 +656,9 @@ class SparkVersionsScriptTest:
             module.resolve_spark_sha = lambda spark_repo, spark_ref, spark_dir: mock_resolved_sha
             module.load_spark_versions = lambda json_path, repo_root: [source_entry]
 
-            spark_version = (
-                "master" if source_entry["isMaster"] else source_entry["shortVersion"]
-            )
-            artifact_base_version = module.strip_suffix(
-                source_entry["fullVersion"], "-SNAPSHOT"
-            )
+            spark_version = "99.0"
+            expected_artifact_base_version = "99.0.0"
+            expected_spark_artifact_version = "99.0.0-aaaaaaaaaaaa-SNAPSHOT"
 
             previous_argv = sys.argv
             output = io.StringIO()
@@ -687,10 +684,8 @@ class SparkVersionsScriptTest:
                 "spark_version": spark_version,
                 "source_ref": mock_source_ref,
                 "spark_sha": mock_resolved_sha,
-                "artifact_base_version": artifact_base_version,
-                "spark_artifact_version": module.compute_spark_artifact_version(
-                    artifact_base_version, mock_resolved_sha
-                ),
+                "artifact_base_version": expected_artifact_base_version,
+                "spark_artifact_version": expected_spark_artifact_version,
             }
             for key, expected_value in expected.items():
                 if values.get(key) != expected_value:
@@ -702,7 +697,7 @@ class SparkVersionsScriptTest:
                 return False
             expected_cache_prefix = (
                 "spark-m2-ubuntu-24.04-scala-2.13-"
-                f"{spark_version}-{artifact_base_version}-"
+                f"{spark_version}-{expected_artifact_base_version}-"
             )
             if not values["cache_key"].startswith(expected_cache_prefix):
                 print(f"  ✗ unexpected cache_key: {values['cache_key']}")

--- a/project/tests/test_cross_spark_publish.py
+++ b/project/tests/test_cross_spark_publish.py
@@ -21,6 +21,7 @@ import json
 import contextlib
 import importlib.util
 import io
+import re
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -566,11 +567,14 @@ class SparkVersionsScriptTest:
                 print(f"  ✗ Expected {expected}, got {source_build_versions}")
                 return False
 
-            if "4.2" in source_build_versions:
-                by_short = {entry["shortVersion"]: entry for entry in data}
-                spark42 = by_short["4.2"]
-                if spark42["sourceBuildDefaultRef"] != "da6e110231beea1fa1bd0d259c2b49c7ea4d5085":
-                    print("  ✗ Spark 4.2 sourceBuildDefaultRef is not the expected pinned SHA")
+            source_build_entries = [entry for entry in data if entry.get("sourceBuildDefaultRef")]
+            for entry in source_build_entries:
+                source_ref = entry["sourceBuildDefaultRef"]
+                if not re.fullmatch(r"[0-9a-f]{7,40}", source_ref):
+                    print(
+                        f"  ✗ {entry['shortVersion']} sourceBuildDefaultRef is not a valid "
+                        f"Git SHA: {source_ref}"
+                    )
                     return False
 
             print(f"  ✓ --source-build-spark-versions (non-blocking lane metadata): {source_build_versions}")
@@ -615,8 +619,17 @@ class SparkVersionsScriptTest:
                 print(f"  ✗ Expected {expected}, got {non_source_build_versions}")
                 return False
 
-            if "4.2" in non_source_build_versions:
-                print("  ✗ Spark 4.2 should be handled by the non-blocking source-build lane")
+            source_build_versions = {
+                "master" if entry["isMaster"] else entry["shortVersion"]
+                for entry in data
+                if entry.get("sourceBuildDefaultRef")
+            }
+            overlap = source_build_versions.intersection(non_source_build_versions)
+            if overlap:
+                print(
+                    "  ✗ Source-build versions also appeared in the published lane: "
+                    f"{sorted(overlap)}"
+                )
                 return False
 
             print(f"  ✓ --non-source-build-spark-versions: {non_source_build_versions}")
@@ -627,16 +640,28 @@ class SparkVersionsScriptTest:
             return False
 
     def test_resolve_source_build(self) -> bool:
-        """Test source-build resolution without fetching Spark from Git."""
-        if not self.ensure_json_exists():
-            return False
-
-        fake_sha = "b6bd005ac7549411ec4e7dc944d7a0e19fd56561"
+        """Test source-build resolution with synthetic metadata and no Git fetch."""
+        mock_source_ref = "test-source-ref"
+        mock_resolved_sha = "a" * 40
+        source_entry = {
+            "fullVersion": "99.0.0-SNAPSHOT",
+            "shortVersion": "99.0",
+            "isMaster": False,
+            "sourceBuildDefaultRef": mock_source_ref,
+        }
         try:
             spec = importlib.util.spec_from_file_location("get_spark_version_info", self.script_path)
             module = importlib.util.module_from_spec(spec)
             spec.loader.exec_module(module)
-            module.resolve_spark_sha = lambda spark_repo, spark_ref, spark_dir: fake_sha
+            module.resolve_spark_sha = lambda spark_repo, spark_ref, spark_dir: mock_resolved_sha
+            module.load_spark_versions = lambda json_path, repo_root: [source_entry]
+
+            spark_version = (
+                "master" if source_entry["isMaster"] else source_entry["shortVersion"]
+            )
+            artifact_base_version = module.strip_suffix(
+                source_entry["fullVersion"], "-SNAPSHOT"
+            )
 
             previous_argv = sys.argv
             output = io.StringIO()
@@ -645,7 +670,7 @@ class SparkVersionsScriptTest:
                     str(self.script_path),
                     "--resolve-source-build",
                     "--spark-version",
-                    "4.2",
+                    spark_version,
                 ]
                 with contextlib.redirect_stdout(output):
                     module.main()
@@ -659,10 +684,13 @@ class SparkVersionsScriptTest:
                     values[key] = value
 
             expected = {
-                "spark_version": "4.2",
-                "spark_sha": fake_sha,
-                "artifact_base_version": "4.2.0",
-                "spark_artifact_version": "4.2.0-b6bd005ac754-SNAPSHOT",
+                "spark_version": spark_version,
+                "source_ref": mock_source_ref,
+                "spark_sha": mock_resolved_sha,
+                "artifact_base_version": artifact_base_version,
+                "spark_artifact_version": module.compute_spark_artifact_version(
+                    artifact_base_version, mock_resolved_sha
+                ),
             }
             for key, expected_value in expected.items():
                 if values.get(key) != expected_value:
@@ -672,11 +700,15 @@ class SparkVersionsScriptTest:
             if "cache_key" not in values:
                 print("  ✗ --resolve-source-build did not emit cache_key")
                 return False
-            if not values["cache_key"].startswith("spark-m2-ubuntu-24.04-scala-2.13-4.2-4.2.0-"):
+            expected_cache_prefix = (
+                "spark-m2-ubuntu-24.04-scala-2.13-"
+                f"{spark_version}-{artifact_base_version}-"
+            )
+            if not values["cache_key"].startswith(expected_cache_prefix):
                 print(f"  ✗ unexpected cache_key: {values['cache_key']}")
                 return False
 
-            print("  ✓ --resolve-source-build: emitted expected non-blocking source-build metadata")
+            print("  ✓ --resolve-source-build: emitted expected synthetic source-build metadata")
             return True
 
         except Exception as e:

--- a/project/tests/test_cross_spark_publish.py
+++ b/project/tests/test_cross_spark_publish.py
@@ -569,7 +569,7 @@ class SparkVersionsScriptTest:
             if "4.2" in source_build_versions:
                 by_short = {entry["shortVersion"]: entry for entry in data}
                 spark42 = by_short["4.2"]
-                if spark42["sourceBuildDefaultRef"] != "b6bd005ac7549411ec4e7dc944d7a0e19fd56561":
+                if spark42["sourceBuildDefaultRef"] != "da6e110231beea1fa1bd0d259c2b49c7ea4d5085":
                     print("  ✗ Spark 4.2 sourceBuildDefaultRef is not the expected pinned SHA")
                     return False
 

--- a/spark-unified/src/main/scala-shims/spark-4.2/io/delta/internal/ResolveTableChangesV2.scala
+++ b/spark-unified/src/main/scala-shims/spark-4.2/io/delta/internal/ResolveTableChangesV2.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.catalyst.analysis.ChangelogContextUtils
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.connector.catalog.{ChangelogContext, Identifier}
-import org.apache.spark.sql.delta.TableChanges
+import org.apache.spark.sql.delta.{DeltaErrors, TableChanges}
 import org.apache.spark.sql.delta.catalog.{ChangelogSupport, DeltaV2TableMarker}
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
@@ -73,6 +73,7 @@ class ResolveTableChangesV2(session: SparkSession) extends Rule[LogicalPlan] {
       catalog: ChangelogSupport,
       ident: Identifier,
       options: CaseInsensitiveStringMap): LogicalPlan = {
+    rejectUnsupportedOptions(options)
     // We can use [[ChangelogContextUtils.fromOptions]] directly here because Spark's CDC options
     // match Delta's CDF options, e.g. startingVersion, endingVersion.
     val baseContext = ChangelogContextUtils.fromOptions(
@@ -85,5 +86,20 @@ class ResolveTableChangesV2(session: SparkSession) extends Rule[LogicalPlan] {
     val changelog = catalog.loadChangelog(ident, context, options)
     DataSourceV2Relation.create(
       ChangelogTable(changelog, context), Some(catalog), Some(ident), options)
+  }
+
+  /**
+   * Rejects Spark processing options that conflict with the fixed semantics of Delta's existing
+   * CDF APIs. Spark's native CHANGES APIs bypass this bridge and retain support for these options.
+   */
+  private def rejectUnsupportedOptions(options: CaseInsensitiveStringMap): Unit = {
+    val unsupportedOptions = Seq(
+      "computeUpdates",
+      "deduplicationMode",
+      "startingBoundInclusive",
+      "endingBoundInclusive")
+    unsupportedOptions.foreach { key =>
+      if (options.containsKey(key)) throw DeltaErrors.changelogUnsupportedOption(key)
+    }
   }
 }

--- a/spark-unified/src/main/scala-shims/spark-4.2/io/delta/internal/ResolveTableChangesV2.scala
+++ b/spark-unified/src/main/scala-shims/spark-4.2/io/delta/internal/ResolveTableChangesV2.scala
@@ -19,11 +19,11 @@ package io.delta.internal
 import io.delta.spark.internal.v2.catalog.DeltaV2Table
 
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.catalyst.analysis.ChangelogInfoUtils
+import org.apache.spark.sql.catalyst.analysis.ChangelogContextUtils
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.rules.Rule
-import org.apache.spark.sql.connector.catalog.{ChangelogInfo, Identifier}
-import org.apache.spark.sql.delta.{DeltaErrors, TableChanges}
+import org.apache.spark.sql.connector.catalog.{ChangelogContext, Identifier}
+import org.apache.spark.sql.delta.TableChanges
 import org.apache.spark.sql.delta.catalog.{ChangelogSupport, DeltaV2TableMarker}
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
@@ -73,33 +73,17 @@ class ResolveTableChangesV2(session: SparkSession) extends Rule[LogicalPlan] {
       catalog: ChangelogSupport,
       ident: Identifier,
       options: CaseInsensitiveStringMap): LogicalPlan = {
-    rejectUnsupportedOptions(options)
-    // We can use [[ChangelogInfoUtils.fromOptions]] directly here because Spark's CDC options
-    // match Delta's CDF options, e.p. startingVersion, endingVersion.
-    val baseInfo = ChangelogInfoUtils.fromOptions(
+    // We can use [[ChangelogContextUtils.fromOptions]] directly here because Spark's CDC options
+    // match Delta's CDF options, e.g. startingVersion, endingVersion.
+    val baseContext = ChangelogContextUtils.fromOptions(
       options,
       session.sessionState.conf.sessionLocalTimeZone)
-    val info = new ChangelogInfo(
-      baseInfo.range(),
-      ChangelogInfo.DeduplicationMode.DROP_CARRYOVERS,
+    val context = new ChangelogContext(
+      baseContext.range(),
+      ChangelogContext.DeduplicationMode.DROP_CARRYOVERS,
       /* computeUpdates = */ true)
-    val changelog = catalog.loadChangelog(ident, info)
+    val changelog = catalog.loadChangelog(ident, context, options)
     DataSourceV2Relation.create(
-      ChangelogTable(changelog, info), Some(catalog), Some(ident), options)
-  }
-
-  /**
-   * Rejects options that aren't supposed to be supported with Delta CDF, even though Spark's CDC
-   * implementation can support these modes.
-   */
-  private def rejectUnsupportedOptions(options: CaseInsensitiveStringMap): Unit = {
-    val unsupportedOptions = Seq(
-      "computeUpdates",
-      "deduplicationMode",
-      "startingBoundInclusive",
-      "endingBoundInclusive")
-    unsupportedOptions.foreach { key =>
-      if (options.containsKey(key)) throw DeltaErrors.changelogUnsupportedOption(key)
-    }
+      ChangelogTable(changelog, context), Some(catalog), Some(ident), options)
   }
 }

--- a/spark-unified/src/main/scala-shims/spark-4.2/org/apache/spark/sql/delta/catalog/ChangelogSupport.scala
+++ b/spark-unified/src/main/scala-shims/spark-4.2/org/apache/spark/sql/delta/catalog/ChangelogSupport.scala
@@ -20,10 +20,11 @@ import io.delta.spark.internal.v2.catalog.DeltaV2Table
 import io.delta.spark.internal.v2.read.changelog.DeltaChangelog
 
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.connector.catalog.{Changelog, ChangelogInfo, Identifier, TableCatalog}
+import org.apache.spark.sql.connector.catalog.{Changelog, ChangelogContext, Identifier, TableCatalog}
 import org.apache.spark.sql.connector.catalog.ChangelogRange.{TimestampRange, UnboundedRange, VersionRange}
 import org.apache.spark.sql.delta.{DeltaErrors, DeltaV2Mode}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 /**
  * Mixed into a [[TableCatalog]] implementation to add read-time CDF support. Provides the
@@ -33,11 +34,12 @@ import org.apache.spark.sql.delta.sources.DeltaSQLConf
  * mixes this trait in must already be a `TableCatalog`. The trait itself does not provide a
  * `TableCatalog` implementation.
  *
- * <p>The trait is intentionally thin. `loadChangelog` resolves the table via the catalog's own
- * `loadTable`. Read-time CDF only flows through the V2 connector, so in `AUTO`/`STRICT` mode (see
- * [[DeltaV2Mode.shouldRouteChangelogToV2]]) the table is re-resolved to a [[DeltaV2Table]] for the
- * CHANGES read; in `NONE` mode it is rejected. It then resolves the requested [[ChangelogRange]]
- * against the table's snapshot manager, and wraps everything into a [[DeltaChangelog]].
+ * <p>The trait is intentionally thin. `loadChangelog` validates connector-specific options and
+ * resolves the table via the catalog's own `loadTable`. Read-time CDF only flows through the V2
+ * connector, so in `AUTO`/`STRICT` mode (see [[DeltaV2Mode.shouldRouteChangelogToV2]]) the table is
+ * re-resolved to a [[DeltaV2Table]] for the CHANGES read; in `NONE` mode it is rejected. It then
+ * resolves the requested [[ChangelogRange]] against the table's snapshot manager, and wraps
+ * everything into a [[DeltaChangelog]].
  * All connector-level work (loading snapshots, validating row tracking, inspecting metadata
  * actions) is deferred to the read path inside [[DeltaChangelog]].
  *
@@ -47,13 +49,17 @@ import org.apache.spark.sql.delta.sources.DeltaSQLConf
  */
 trait ChangelogSupport extends TableCatalog {
 
-  override def loadChangelog(ident: Identifier, changelogInfo: ChangelogInfo): Changelog = {
+  override def loadChangelog(
+      ident: Identifier,
+      context: ChangelogContext,
+      options: CaseInsensitiveStringMap): Changelog = {
     val spark = SparkSession.active
     if (!spark.sessionState.conf.getConf(DeltaSQLConf.DELTA_CHANGELOG_V2_ENABLED)) {
       // Feature gated off: fall back to the parent's default, which surfaces
       // UNSUPPORTED_FEATURE.CHANGE_DATA_CAPTURE to the user.
-      return super.loadChangelog(ident, changelogInfo)
+      return super.loadChangelog(ident, context, options)
     }
+    rejectUnsupportedOptions(options)
     val routeChangelogToV2 = new DeltaV2Mode(spark.sessionState.conf).shouldRouteChangelogToV2()
     val sparkTable = loadTable(ident) match {
       case st: DeltaV2Table => st
@@ -63,8 +69,24 @@ trait ChangelogSupport extends TableCatalog {
       case other =>
         DeltaErrors.throwChangelogRequiresV2Table(ident.toString, other.getClass.getName)
     }
-    val (startVersion, endVersion) = resolveRange(sparkTable, changelogInfo.range())
+    val (startVersion, endVersion) = resolveRange(sparkTable, context.range())
     new DeltaChangelog(ident.name(), sparkTable, startVersion, endVersion)
+  }
+
+  /**
+   * Rejects options that aren't supported with Delta CDF, even though Spark's CDC implementation
+   * can support these modes. Validating at the catalog boundary covers both Delta's CDF APIs and
+   * Spark's native CHANGES APIs, which pass the original options to `loadChangelog`.
+   */
+  private def rejectUnsupportedOptions(options: CaseInsensitiveStringMap): Unit = {
+    val unsupportedOptions = Seq(
+      "computeUpdates",
+      "deduplicationMode",
+      "startingBoundInclusive",
+      "endingBoundInclusive")
+    unsupportedOptions.foreach { key =>
+      if (options.containsKey(key)) throw DeltaErrors.changelogUnsupportedOption(key)
+    }
   }
 
   /**

--- a/spark-unified/src/main/scala-shims/spark-4.2/org/apache/spark/sql/delta/catalog/ChangelogSupport.scala
+++ b/spark-unified/src/main/scala-shims/spark-4.2/org/apache/spark/sql/delta/catalog/ChangelogSupport.scala
@@ -34,18 +34,18 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap
  * mixes this trait in must already be a `TableCatalog`. The trait itself does not provide a
  * `TableCatalog` implementation.
  *
- * <p>The trait is intentionally thin. `loadChangelog` validates connector-specific options and
- * resolves the table via the catalog's own `loadTable`. Read-time CDF only flows through the V2
- * connector, so in `AUTO`/`STRICT` mode (see [[DeltaV2Mode.shouldRouteChangelogToV2]]) the table is
- * re-resolved to a [[DeltaV2Table]] for the CHANGES read; in `NONE` mode it is rejected. It then
- * resolves the requested [[ChangelogRange]] against the table's snapshot manager, and wraps
- * everything into a [[DeltaChangelog]].
+ * <p>The trait is intentionally thin. `loadChangelog` resolves the table via the catalog's own
+ * `loadTable`. Read-time CDF only flows through the V2 connector, so in `AUTO`/`STRICT` mode (see
+ * [[DeltaV2Mode.shouldRouteChangelogToV2]]) the table is re-resolved to a [[DeltaV2Table]] for the
+ * CHANGES read; in `NONE` mode it is rejected. It then resolves the requested [[ChangelogRange]]
+ * against the table's snapshot manager, and wraps everything into a [[DeltaChangelog]].
  * All connector-level work (loading snapshots, validating row tracking, inspecting metadata
  * actions) is deferred to the read path inside [[DeltaChangelog]].
  *
  * <p>The whole entry point is gated by [[DeltaSQLConf.DELTA_CHANGELOG_V2_ENABLED]] (default
- * `false`). When the flag is off the trait delegates to the parent `loadChangelog` default,
- * which surfaces `UNSUPPORTED_FEATURE.CHANGE_DATA_CAPTURE`.
+ * `false`). When the flag is off the trait follows the parent `loadChangelog` contract and throws
+ * `UnsupportedOperationException`, which the Spark analyzer surfaces as
+ * `UNSUPPORTED_FEATURE.CHANGE_DATA_CAPTURE`.
  */
 trait ChangelogSupport extends TableCatalog {
 
@@ -55,11 +55,12 @@ trait ChangelogSupport extends TableCatalog {
       options: CaseInsensitiveStringMap): Changelog = {
     val spark = SparkSession.active
     if (!spark.sessionState.conf.getConf(DeltaSQLConf.DELTA_CHANGELOG_V2_ENABLED)) {
-      // Feature gated off: fall back to the parent's default, which surfaces
-      // UNSUPPORTED_FEATURE.CHANGE_DATA_CAPTURE to the user.
-      return super.loadChangelog(ident, context, options)
+      // Calling the Java interface default through a Scala trait-super bridge produces an
+      // AbstractMethodError. Throw the same exception as TableCatalog's default implementation;
+      // Spark's analyzer translates it to UNSUPPORTED_FEATURE.CHANGE_DATA_CAPTURE.
+      throw new UnsupportedOperationException(
+        s"${name()} does not support Change Data Capture (CDC)")
     }
-    rejectUnsupportedOptions(options)
     val routeChangelogToV2 = new DeltaV2Mode(spark.sessionState.conf).shouldRouteChangelogToV2()
     val sparkTable = loadTable(ident) match {
       case st: DeltaV2Table => st
@@ -71,22 +72,6 @@ trait ChangelogSupport extends TableCatalog {
     }
     val (startVersion, endVersion) = resolveRange(sparkTable, context.range())
     new DeltaChangelog(ident.name(), sparkTable, startVersion, endVersion)
-  }
-
-  /**
-   * Rejects options that aren't supported with Delta CDF, even though Spark's CDC implementation
-   * can support these modes. Validating at the catalog boundary covers both Delta's CDF APIs and
-   * Spark's native CHANGES APIs, which pass the original options to `loadChangelog`.
-   */
-  private def rejectUnsupportedOptions(options: CaseInsensitiveStringMap): Unit = {
-    val unsupportedOptions = Seq(
-      "computeUpdates",
-      "deduplicationMode",
-      "startingBoundInclusive",
-      "endingBoundInclusive")
-    unsupportedOptions.foreach { key =>
-      if (options.containsKey(key)) throw DeltaErrors.changelogUnsupportedOption(key)
-    }
   }
 
   /**

--- a/spark-unified/src/test/scala-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogCatalogIntegrationTest.java
+++ b/spark-unified/src/test/scala-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogCatalogIntegrationTest.java
@@ -181,6 +181,116 @@ public class DeltaChangelogCatalogIntegrationTest extends DeltaChangelogTestBase
         });
   }
 
+  /**
+   * Delta's table_changes API always asks Spark to remove carryovers and derive update pre/post
+   * images. This verifies that the context constructed by ResolveTableChangesV2 preserves that
+   * behavior after the Spark API migration from ChangelogInfo to ChangelogContext.
+   */
+  @Test
+  public void testTableChangesComputesUpdates() throws Exception {
+    String tableName = "dsv2_cdc_catalog_update_" + System.nanoTime();
+
+    withTable(
+        new String[] {tableName},
+        () -> {
+          spark.sql(
+              String.format(
+                  "CREATE TABLE %s (id BIGINT, name STRING) USING delta TBLPROPERTIES "
+                      + "('delta.enableDeletionVectors'='false', "
+                      + "'delta.enableRowTracking'='true')",
+                  tableName));
+          spark.sql(String.format("INSERT INTO %s VALUES (1, 'Alice')", tableName));
+          spark.sql(String.format("UPDATE %s SET name = 'AliceX' WHERE id = 1", tableName));
+
+          withSQLConf(
+              "spark.databricks.delta.v2.enableMode",
+              "STRICT",
+              () -> {
+                List<Row> rows =
+                    spark
+                        .sql(
+                            String.format(
+                                "SELECT id, name, _change_type, _commit_version "
+                                    + "FROM table_changes('%s', 2, 2)",
+                                tableName))
+                        .collectAsList();
+
+                assertEquals(2, rows.size(), "Expected one preimage and one postimage");
+                assertTrue(
+                    rows.stream()
+                        .anyMatch(
+                            row ->
+                                "update_preimage".equals(row.getAs("_change_type"))
+                                    && "Alice".equals(row.getAs("name"))),
+                    "Expected the original row as update_preimage");
+                assertTrue(
+                    rows.stream()
+                        .anyMatch(
+                            row ->
+                                "update_postimage".equals(row.getAs("_change_type"))
+                                    && "AliceX".equals(row.getAs("name"))),
+                    "Expected the updated row as update_postimage");
+                for (Row row : rows) {
+                  assertEquals(1L, ((Number) row.getAs("id")).longValue());
+                  assertEquals(2L, ((Number) row.getAs("_commit_version")).longValue());
+                }
+              });
+        });
+  }
+
+  /**
+   * Spark now passes the original CHANGES options into TableCatalog.loadChangelog. Validate them
+   * at that catalog boundary so native DataFrameReader.changes calls enforce the same Delta CDF
+   * option policy as table_changes and readChangeFeed.
+   */
+  @Test
+  public void testDataFrameChangesRejectsUnsupportedDeltaOptions() throws Exception {
+    String tableName = "dsv2_cdc_catalog_options_" + System.nanoTime();
+    String[][] unsupportedOptions = {
+      {"computeUpdates", "true"},
+      {"deduplicationMode", "none"},
+      {"startingBoundInclusive", "false"},
+      {"endingBoundInclusive", "false"}
+    };
+
+    withTable(
+        new String[] {tableName},
+        () -> {
+          spark.sql(
+              String.format(
+                  "CREATE TABLE %s (id BIGINT) USING delta TBLPROPERTIES "
+                      + "('delta.enableDeletionVectors'='false', "
+                      + "'delta.enableRowTracking'='true')",
+                  tableName));
+          spark.sql(String.format("INSERT INTO %s VALUES (1)", tableName));
+
+          withSQLConf(
+              "spark.databricks.delta.v2.enableMode",
+              "STRICT",
+              () -> {
+                for (String[] option : unsupportedOptions) {
+                  Exception ex =
+                      assertThrows(
+                          Exception.class,
+                          () ->
+                              spark
+                                  .read()
+                                  .option("startingVersion", "1")
+                                  .option("endingVersion", "1")
+                                  .option(option[0], option[1])
+                                  .changes(tableName)
+                                  .collectAsList());
+                  assertTrue(
+                      ex.getMessage().contains("DELTA_CHANGELOG_UNSUPPORTED_OPTION"),
+                      "Expected unsupported-option error for " + option[0] + ", got: " + ex);
+                  assertTrue(
+                      ex.getMessage().contains(option[0]),
+                      "Expected error to identify option " + option[0] + ", got: " + ex);
+                }
+              });
+        });
+  }
+
   // ===========================================================================================
   // Connector-mode routing for CHANGES reads
   // ===========================================================================================

--- a/spark-unified/src/test/scala-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogCatalogIntegrationTest.java
+++ b/spark-unified/src/test/scala-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogCatalogIntegrationTest.java
@@ -181,11 +181,7 @@ public class DeltaChangelogCatalogIntegrationTest extends DeltaChangelogTestBase
         });
   }
 
-  /**
-   * Delta's table_changes API always asks Spark to remove carryovers and derive update pre/post
-   * images. This verifies that the context constructed by ResolveTableChangesV2 preserves that
-   * behavior after the Spark API migration from ChangelogInfo to ChangelogContext.
-   */
+  /** Delta's table_changes API always asks Spark to derive update pre/post images. */
   @Test
   public void testTableChangesComputesUpdates() throws Exception {
     String tableName = "dsv2_cdc_catalog_update_" + System.nanoTime();
@@ -230,6 +226,69 @@ public class DeltaChangelogCatalogIntegrationTest extends DeltaChangelogTestBase
                                 "update_postimage".equals(row.getAs("_change_type"))
                                     && "AliceX".equals(row.getAs("name"))),
                     "Expected the updated row as update_postimage");
+                for (Row row : rows) {
+                  assertEquals(1L, ((Number) row.getAs("id")).longValue());
+                  assertEquals(2L, ((Number) row.getAs("_commit_version")).longValue());
+                }
+              });
+        });
+  }
+
+  /**
+   * Delta's table_changes API always asks Spark to remove carryovers. Updating one row rewrites a
+   * base file that also contains an unchanged row; only the changed row should be returned.
+   */
+  @Test
+  public void testTableChangesDropsCarryovers() throws Exception {
+    String tableName = "dsv2_cdc_catalog_carryovers_" + System.nanoTime();
+
+    withTable(
+        new String[] {tableName},
+        () -> {
+          spark.sql(
+              String.format(
+                  "CREATE TABLE %s (id BIGINT, name STRING) USING delta TBLPROPERTIES "
+                      + "('delta.enableDeletionVectors'='false', "
+                      + "'delta.enableRowTracking'='true')",
+                  tableName));
+          // A single INSERT creates the multi-row base file needed to expose carryovers.
+          spark.sql(
+              String.format(
+                  "INSERT INTO %s VALUES (1, 'Alice'), (2, 'Bob')", tableName));
+          spark.sql(String.format("UPDATE %s SET name = 'AliceX' WHERE id = 1", tableName));
+
+          withSQLConf(
+              "spark.databricks.delta.v2.enableMode",
+              "STRICT",
+              () -> {
+                List<Row> rows =
+                    spark
+                        .sql(
+                            String.format(
+                                "SELECT id, name, _change_type, _commit_version "
+                                    + "FROM table_changes('%s', 2, 2)",
+                                tableName))
+                        .collectAsList();
+
+                assertEquals(2, rows.size(), "Expected only the changed row's update images");
+                assertTrue(
+                    rows.stream()
+                        .anyMatch(
+                            row ->
+                                "update_preimage".equals(row.getAs("_change_type"))
+                                    && "Alice".equals(row.getAs("name"))),
+                    "Expected the original row as update_preimage");
+                assertTrue(
+                    rows.stream()
+                        .anyMatch(
+                            row ->
+                                "update_postimage".equals(row.getAs("_change_type"))
+                                    && "AliceX".equals(row.getAs("name"))),
+                    "Expected the updated row as update_postimage");
+                assertFalse(
+                    rows.stream()
+                        .anyMatch(row -> ((Number) row.getAs("id")).longValue() == 2L),
+                    "Expected the unchanged row to be removed as a carryover");
                 for (Row row : rows) {
                   assertEquals(1L, ((Number) row.getAs("id")).longValue());
                   assertEquals(2L, ((Number) row.getAs("_commit_version")).longValue());

--- a/spark-unified/src/test/scala-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogCatalogIntegrationTest.java
+++ b/spark-unified/src/test/scala-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogCatalogIntegrationTest.java
@@ -238,14 +238,90 @@ public class DeltaChangelogCatalogIntegrationTest extends DeltaChangelogTestBase
         });
   }
 
-  /**
-   * Spark now passes the original CHANGES options into TableCatalog.loadChangelog. Validate them
-   * at that catalog boundary so native DataFrameReader.changes calls enforce the same Delta CDF
-   * option policy as table_changes and readChangeFeed.
-   */
+  /** Spark's native changes API retains its standard processing options at the catalog boundary. */
   @Test
-  public void testDataFrameChangesRejectsUnsupportedDeltaOptions() throws Exception {
-    String tableName = "dsv2_cdc_catalog_options_" + System.nanoTime();
+  public void testDataFrameChangesHonorsSparkProcessingOptions() throws Exception {
+    String tableName = "dsv2_cdc_catalog_native_options_" + System.nanoTime();
+
+    withTable(
+        new String[] {tableName},
+        () -> {
+          spark.sql(
+              String.format(
+                  "CREATE TABLE %s (id BIGINT, name STRING) USING delta TBLPROPERTIES "
+                      + "('delta.enableDeletionVectors'='false', "
+                      + "'delta.enableRowTracking'='true')",
+                  tableName));
+          spark.sql(String.format("INSERT INTO %s VALUES (1, 'Alice')", tableName));
+          spark.sql(String.format("UPDATE %s SET name = 'AliceX' WHERE id = 1", tableName));
+          spark.sql(String.format("DELETE FROM %s WHERE id = 1", tableName));
+
+          withSQLConf(
+              "spark.databricks.delta.v2.enableMode",
+              "STRICT",
+              () -> {
+                List<Row> updateRows =
+                    spark
+                        .read()
+                        .option("startingVersion", "1")
+                        .option("endingVersion", "2")
+                        .option("startingBoundInclusive", "false")
+                        .option("computeUpdates", "true")
+                        .changes(tableName)
+                        .select("id", "name", "_change_type", "_commit_version")
+                        .collectAsList();
+
+                assertEquals(2, updateRows.size(), "Expected only the v2 update after v1");
+                assertTrue(
+                    updateRows.stream()
+                        .anyMatch(
+                            row ->
+                                "update_preimage".equals(row.getAs("_change_type"))
+                                    && "Alice".equals(row.getAs("name"))),
+                    "Expected Spark to derive the update preimage");
+                assertTrue(
+                    updateRows.stream()
+                        .anyMatch(
+                            row ->
+                                "update_postimage".equals(row.getAs("_change_type"))
+                                    && "AliceX".equals(row.getAs("name"))),
+                    "Expected Spark to derive the update postimage");
+                for (Row row : updateRows) {
+                  assertEquals(2L, ((Number) row.getAs("_commit_version")).longValue());
+                }
+
+                List<Row> endingExclusiveRows =
+                    spark
+                        .read()
+                        .option("startingVersion", "1")
+                        .option("endingVersion", "2")
+                        .option("endingBoundInclusive", "false")
+                        .changes(tableName)
+                        .select("id", "name", "_change_type", "_commit_version")
+                        .collectAsList();
+                assertEquals(1, endingExclusiveRows.size(), "Expected only the v1 insert");
+                Row insert = endingExclusiveRows.get(0);
+                assertEquals("Alice", insert.getAs("name"));
+                assertEquals("insert", insert.getAs("_change_type"));
+                assertEquals(1L, ((Number) insert.getAs("_commit_version")).longValue());
+
+                List<Row> netRows =
+                    spark
+                        .read()
+                        .option("startingVersion", "1")
+                        .option("endingVersion", "3")
+                        .option("deduplicationMode", "netChanges")
+                        .changes(tableName)
+                        .collectAsList();
+                assertTrue(netRows.isEmpty(), "Insert then delete should have no net change");
+              });
+        });
+  }
+
+  /** Delta's existing readChangeFeed API keeps rejecting caller-selected processing modes. */
+  @Test
+  public void testReadChangeFeedRejectsSparkProcessingOptions() throws Exception {
+    String tableName = "dsv2_cdc_catalog_delta_options_" + System.nanoTime();
     String[][] unsupportedOptions = {
       {"computeUpdates", "true"},
       {"deduplicationMode", "none"},
@@ -275,10 +351,12 @@ public class DeltaChangelogCatalogIntegrationTest extends DeltaChangelogTestBase
                           () ->
                               spark
                                   .read()
+                                  .format("delta")
+                                  .option("readChangeFeed", "true")
                                   .option("startingVersion", "1")
                                   .option("endingVersion", "1")
                                   .option(option[0], option[1])
-                                  .changes(tableName)
+                                  .table(tableName)
                                   .collectAsList());
                   assertTrue(
                       ex.getMessage().contains("DELTA_CHANGELOG_UNSUPPORTED_OPTION"),
@@ -288,6 +366,48 @@ public class DeltaChangelogCatalogIntegrationTest extends DeltaChangelogTestBase
                       "Expected error to identify option " + option[0] + ", got: " + ex);
                 }
               });
+        });
+  }
+
+  /** The disabled feature gate preserves Spark's error before interpreting native options. */
+  @Test
+  public void testFeatureGateDisabledTakesPrecedenceOverNativeOptions() throws Exception {
+    String tableName = "dsv2_cdc_catalog_gate_" + System.nanoTime();
+
+    withTable(
+        new String[] {tableName},
+        () -> {
+          spark.sql(
+              String.format(
+                  "CREATE TABLE %s (id BIGINT) USING delta TBLPROPERTIES "
+                      + "('delta.enableDeletionVectors'='false', "
+                      + "'delta.enableRowTracking'='true')",
+                  tableName));
+          spark.sql(String.format("INSERT INTO %s VALUES (1)", tableName));
+
+          withSQLConf(
+              "spark.databricks.delta.v2.enableMode",
+              "STRICT",
+              () ->
+                  withSQLConf(
+                      "spark.databricks.delta.changelogV2.enabled",
+                      "false",
+                      () -> {
+                        Exception ex =
+                            assertThrows(
+                                Exception.class,
+                                () ->
+                                    spark
+                                        .read()
+                                        .option("startingVersion", "1")
+                                        .option("endingVersion", "1")
+                                        .option("computeUpdates", "true")
+                                        .changes(tableName)
+                                        .collectAsList());
+                        assertTrue(
+                            ex.getMessage().contains("UNSUPPORTED_FEATURE.CHANGE_DATA_CAPTURE"),
+                            "Expected the disabled-gate error, got: " + ex);
+                      }));
         });
   }
 

--- a/spark-unified/src/test/scala-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogTestBase.java
+++ b/spark-unified/src/test/scala-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogTestBase.java
@@ -26,6 +26,8 @@ import org.junit.jupiter.api.BeforeAll;
  * <p>Swaps the default {@link DeltaV2TestBase} Spark session for one configured with:
  *
  * <ul>
+ *   <li>The unified {@code DeltaSparkSessionExtension}, including the Spark 4.2 rule that routes
+ *       Delta CDF APIs to the DSv2 changelog implementation.
  *   <li>The hybrid {@code DeltaCatalog} (spark-unified) as {@code spark_catalog}, so {@code
  *       TableCatalog.loadChangelog} routes into the {@code ChangelogSupport} trait.
  *   <li>{@code spark.databricks.delta.changelogV2.enabled = true}, the SQLConf gate behind which
@@ -47,7 +49,7 @@ public abstract class DeltaChangelogTestBase extends DeltaV2TestBase {
         SparkSession.builder()
             .master("local[*]")
             .appName("SparkKernelDsv2ChangelogTests")
-            .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtensionV1")
+            .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
             .config(
                 "spark.sql.catalog.spark_catalog",
                 "org.apache.spark.sql.delta.catalog.DeltaCatalog")


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

The Spark 4.2 source API used by Delta revised its changelog connector contract:

- `ChangelogInfoUtils` became `ChangelogContextUtils`.
- `ChangelogInfo` became `ChangelogContext`.
- `loadChangelog(Identifier, ChangelogInfo)` became `loadChangelog(Identifier, ChangelogContext, CaseInsensitiveStringMap)`.

This updates the Spark 4.2 shims to that API and advances the centrally configured Spark source ref to the matching commit. It intentionally retains the existing source-built Spark cache/test workflow. Moving the 4.2 lane to released `4.2.0`, together with any compatibility changes exposed by that move, is being handled separately.

The two changelog callers retain their existing semantics:

- The native Spark DataFrame `changes()` path keeps standard processing options such as update pre/post images, inclusive or exclusive bounds, and `netChanges` deduplication.
- The Delta `table_changes` and `readChangeFeed` bridge keeps its fixed carryover/update behavior and rejects caller-selected processing modes before Spark parses them.
- With the feature gate disabled, the catalog shim follows the Spark default `TableCatalog` contract and preserves the expected unsupported-feature error.

The focused tests use the unified session extension so they exercise the Spark 4.2 DSv2 routing rule. Coverage includes native processing modes, Delta bridge option rejection, the disabled feature gate, and update image computation.

## How was this patch tested?

- Built and locally published the configured Spark 4.2 source target: 39 modules.
- Ran `spark/testOnly io.delta.spark.internal.v2.read.changelog.*`: 36 total, 35 passed, 1 pre-existing test skipped.
- Ran the source-build metadata helper tests, including synthetic resolver metadata: all passed.
- Ran:

  ```bash
  python3.12 -m py_compile project/scripts/get_spark_version_info.py project/tests/test_cross_spark_publish.py
  bash -n build/sbt project/scripts/build_spark.sh
  git diff --check
  ```

## Does this PR introduce _any_ user-facing changes?

No. This is a Spark 4.2 API compatibility update that preserves the existing changelog behavior.