### PR TITLE
[Kernel] Add inCommitTimestamp to CRCInfo, injected via withInCommitTimestamp

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checksum/CRCInfo.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checksum/CRCInfo.java
@@ -51,6 +51,7 @@ public class CRCInfo {
   private static final String TXN_ID = "txnId";
   private static final String DOMAIN_METADATA = "domainMetadata";
   private static final String FILE_SIZE_HISTOGRAM = "fileSizeHistogram";
+  private static final String IN_COMMIT_TIMESTAMP = "inCommitTimestampOpt";
   private static final String HISTOGRAM_OPT = "histogramOpt";
 
   public static final StructType CRC_FILE_SCHEMA =
@@ -63,7 +64,8 @@ public class CRCInfo {
           .add(PROTOCOL, Protocol.FULL_SCHEMA)
           .add(TXN_ID, StringType.STRING, /*nullable*/ true)
           .add(DOMAIN_METADATA, new ArrayType(DomainMetadata.FULL_SCHEMA, false), /*nullable*/ true)
-          .add(FILE_SIZE_HISTOGRAM, FileSizeHistogram.FULL_SCHEMA, /*nullable*/ true);
+          .add(FILE_SIZE_HISTOGRAM, FileSizeHistogram.FULL_SCHEMA, /*nullable*/ true)
+          .add(IN_COMMIT_TIMESTAMP, LongType.LONG, /*nullable*/ true);
 
   // Used by ChecksumReader to support reading CRC files with the legacy "histogramOpt" field.
   public static final StructType CRC_FILE_READ_SCHEMA =
@@ -109,6 +111,12 @@ public class CRCInfo {
                 VectorUtils.toJavaList(domainMetadataVector.getArray(rowId)).stream()
                     .map(row -> DomainMetadata.fromRow((StructRow) row))
                     .collect(Collectors.toSet()));
+    ColumnVector inCommitTimestampVector =
+        batch.getColumnVector(getSchemaIndex(IN_COMMIT_TIMESTAMP));
+    Optional<Long> inCommitTimestamp =
+        inCommitTimestampVector.isNullAt(rowId)
+            ? Optional.empty()
+            : Optional.of(inCommitTimestampVector.getLong(rowId));
 
     // protocol and metadata are nullable per fromColumnVector's implementation.
     if (protocol == null || metadata == null) {
@@ -124,7 +132,8 @@ public class CRCInfo {
             numFiles,
             txnId,
             domainMetadata,
-            fileSizeHistogram));
+            fileSizeHistogram,
+            inCommitTimestamp));
   }
 
   /**
@@ -182,6 +191,12 @@ public class CRCInfo {
             ? Optional.empty()
             : Optional.of(FileSizeHistogram.fromRow(row.getStruct(histogramIdx)));
 
+    int inCommitTimestampIdx = getSchemaIndex(IN_COMMIT_TIMESTAMP);
+    Optional<Long> inCommitTimestamp =
+        row.isNullAt(inCommitTimestampIdx)
+            ? Optional.empty()
+            : Optional.of(row.getLong(inCommitTimestampIdx));
+
     return new CRCInfo(
         version,
         metadata,
@@ -190,7 +205,8 @@ public class CRCInfo {
         numFiles,
         txnId,
         domainMetadata,
-        fileSizeHistogram);
+        fileSizeHistogram,
+        inCommitTimestamp);
   }
 
   private final long version;
@@ -201,6 +217,7 @@ public class CRCInfo {
   private final Optional<String> txnId;
   private final Optional<Set<DomainMetadata>> domainMetadata;
   private final Optional<FileSizeHistogram> fileSizeHistogram;
+  private final Optional<Long> inCommitTimestamp;
 
   public CRCInfo(
       long version,
@@ -211,6 +228,28 @@ public class CRCInfo {
       Optional<String> txnId,
       Optional<Set<DomainMetadata>> domainMetadata,
       Optional<FileSizeHistogram> fileSizeHistogram) {
+    this(
+        version,
+        metadata,
+        protocol,
+        tableSizeBytes,
+        numFiles,
+        txnId,
+        domainMetadata,
+        fileSizeHistogram,
+        Optional.empty() /* inCommitTimestamp */);
+  }
+
+  public CRCInfo(
+      long version,
+      Metadata metadata,
+      Protocol protocol,
+      long tableSizeBytes,
+      long numFiles,
+      Optional<String> txnId,
+      Optional<Set<DomainMetadata>> domainMetadata,
+      Optional<FileSizeHistogram> fileSizeHistogram,
+      Optional<Long> inCommitTimestamp) {
     checkArgument(tableSizeBytes >= 0);
     checkArgument(numFiles >= 0);
     // Live Domain Metadata actions at this version, excluding tombstones.
@@ -232,6 +271,21 @@ public class CRCInfo {
     this.numFiles = numFiles;
     this.txnId = requireNonNull(txnId);
     this.fileSizeHistogram = requireNonNull(fileSizeHistogram);
+    this.inCommitTimestamp = requireNonNull(inCommitTimestamp);
+  }
+
+  /** Used by callers to supply an ICT that cannot be derived from the file actions alone. */
+  public CRCInfo withInCommitTimestamp(Optional<Long> inCommitTimestamp) {
+    return new CRCInfo(
+        version,
+        metadata,
+        protocol,
+        tableSizeBytes,
+        numFiles,
+        txnId,
+        domainMetadata,
+        fileSizeHistogram,
+        inCommitTimestamp);
   }
 
   /** The version of the Delta table that this CRCInfo represents. */
@@ -271,6 +325,15 @@ public class CRCInfo {
   }
 
   /**
+   * The in-commit timestamp of the commit at this version, if the table has the inCommitTimestamp
+   * feature enabled. Empty otherwise, or when read from a checksum file written before this field
+   * existed.
+   */
+  public Optional<Long> getInCommitTimestamp() {
+    return inCommitTimestamp;
+  }
+
+  /**
    * Encode as a {@link Row} object with the schema {@link CRCInfo#CRC_FILE_SCHEMA}.
    *
    * @return {@link Row} object with the schema {@link CRCInfo#CRC_FILE_SCHEMA}
@@ -299,6 +362,7 @@ public class CRCInfo {
     fileSizeHistogram.ifPresent(
         fileSizeHistogram ->
             values.put(getSchemaIndex(FILE_SIZE_HISTOGRAM), fileSizeHistogram.toRow()));
+    inCommitTimestamp.ifPresent(ict -> values.put(getSchemaIndex(IN_COMMIT_TIMESTAMP), ict));
     return new GenericRow(CRC_FILE_SCHEMA, values);
   }
 
@@ -312,7 +376,8 @@ public class CRCInfo {
         numFiles,
         txnId,
         domainMetadata,
-        fileSizeHistogram);
+        fileSizeHistogram,
+        inCommitTimestamp);
   }
 
   @Override
@@ -328,7 +393,8 @@ public class CRCInfo {
         && protocol.equals(other.protocol)
         && txnId.equals(other.txnId)
         && domainMetadata.equals(other.domainMetadata)
-        && fileSizeHistogram.equals(other.fileSizeHistogram);
+        && fileSizeHistogram.equals(other.fileSizeHistogram)
+        && inCommitTimestamp.equals(other.inCommitTimestamp);
   }
 
   private static int getSchemaIndex(String fieldName) {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checksum/ChecksumUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checksum/ChecksumUtils.java
@@ -136,6 +136,10 @@ public class ChecksumUtils {
    * <p>Note: For very large tables, this operation may be expensive as it requires scanning the
    * table state to compute statistics.
    *
+   * <p>The returned {@link CRCInfo} does not carry an in-commit timestamp, which is not derivable
+   * from the file actions this replay reads. A caller that holds the commit's {@code CommitInfo}
+   * can inject it via {@link CRCInfo#withInCommitTimestamp(Optional)}.
+   *
    * @param engine The Engine instance used to access the underlying storage
    * @param logSegmentAtVersion The LogSegment instance of the table at a specific version
    * @return The computed CRC info for the table at the given version

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/checksum/CRCInfoFromRowSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/checksum/CRCInfoFromRowSuite.scala
@@ -120,6 +120,19 @@ class CRCInfoFromRowSuite extends AnyFunSuite {
       Optional.of(createTestHistogram(fileCount = 40))))
   }
 
+  test("round-trips with inCommitTimestamp present") {
+    assertRoundTrips(new CRCInfo(
+      12L,
+      testMetadata,
+      testProtocol,
+      4500L,
+      45L,
+      Optional.empty(),
+      Optional.empty(),
+      Optional.empty(),
+      Optional.of(java.lang.Long.valueOf(1749830855993L))))
+  }
+
   test("round-trips with all optional fields present") {
     assertRoundTrips(new CRCInfo(
       13L,
@@ -129,7 +142,8 @@ class CRCInfoFromRowSuite extends AnyFunSuite {
       50L,
       Optional.of("txn-xyz"),
       Optional.of(domainMetadataSet("delta.clustering" -> "{\"cols\":[\"c1\"]}")),
-      Optional.of(createTestHistogram(fileCount = 50))))
+      Optional.of(createTestHistogram(fileCount = 50)),
+      Optional.of(java.lang.Long.valueOf(1749830871085L))))
   }
 
   test("preserves the supplied version, independent of the row (toRow omits version)") {

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/checksum/CRCInfoReadCompatSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/checksum/CRCInfoReadCompatSuite.scala
@@ -108,6 +108,8 @@ class CRCInfoReadCompatSuite extends AnyFunSuite with VectorTestUtils {
           case "txnId" => stringVector(Seq(null))
           case "domainMetadata" => nullColumnVector(
               CRC_FILE_SCHEMA.get("domainMetadata").getDataType)
+          case "inCommitTimestampOpt" => nullColumnVector(
+              CRC_FILE_SCHEMA.get("inCommitTimestampOpt").getDataType)
           case "fileSizeHistogram" => histogramColumnVector(fileSizeHistogram)
           case "histogramOpt" => histogramColumnVector(histogramOpt)
           case _ =>
@@ -205,6 +207,8 @@ class CRCInfoReadCompatSuite extends AnyFunSuite with VectorTestUtils {
           case "txnId" => stringVector(Seq(null))
           case "domainMetadata" => nullColumnVector(
               CRC_FILE_SCHEMA.get("domainMetadata").getDataType)
+          case "inCommitTimestampOpt" => nullColumnVector(
+              CRC_FILE_SCHEMA.get("inCommitTimestampOpt").getDataType)
           case "fileSizeHistogram" => histogramColumnVector(None)
           case _ =>
             throw new IllegalArgumentException(s"Unknown field: $fieldName")
@@ -215,5 +219,92 @@ class CRCInfoReadCompatSuite extends AnyFunSuite with VectorTestUtils {
     val crcInfo = CRCInfo.fromColumnarBatch(1L, batch, 0, "test.crc")
     assert(crcInfo.isPresent)
     assert(!crcInfo.get().getFileSizeHistogram.isPresent)
+  }
+
+  test("reads inCommitTimestamp when present") {
+    val batch = new ColumnarBatch {
+      override def getSchema: StructType = CRC_FILE_SCHEMA
+      override def getSize: Int = 1
+      override def getColumnVector(ordinal: Int): ColumnVector = {
+        val fieldName = CRC_FILE_SCHEMA.at(ordinal).getName
+        fieldName match {
+          case "tableSizeBytes" => longVector(Seq(1000L))
+          case "numFiles" => longVector(Seq(10L))
+          case "numMetadata" => longVector(Seq(1L))
+          case "numProtocol" => longVector(Seq(1L))
+          case "metadata" =>
+            new GenericColumnVector(util.Arrays.asList(testMetadata.toRow()), Metadata.FULL_SCHEMA)
+          case "protocol" =>
+            new GenericColumnVector(util.Arrays.asList(testProtocol.toRow()), Protocol.FULL_SCHEMA)
+          case "txnId" => stringVector(Seq(null))
+          case "domainMetadata" =>
+            nullColumnVector(CRC_FILE_SCHEMA.get("domainMetadata").getDataType)
+          case "inCommitTimestampOpt" => longVector(Seq(1749830855993L))
+          case "fileSizeHistogram" => histogramColumnVector(None)
+          case _ => throw new IllegalArgumentException(s"Unknown field: $fieldName")
+        }
+      }
+    }
+
+    val crcInfo = CRCInfo.fromColumnarBatch(1L, batch, 0, "test.crc")
+    assert(crcInfo.isPresent)
+    assert(
+      crcInfo.get().getInCommitTimestamp === Optional.of(java.lang.Long.valueOf(1749830855993L)))
+  }
+
+  test("inCommitTimestamp is empty when the column is null (older .crc files)") {
+    val batch = buildBatch(CRC_FILE_READ_SCHEMA, fileSizeHistogram = None, histogramOpt = None)
+    val crcInfo = CRCInfo.fromColumnarBatch(1L, batch, 0, "test.crc")
+    assert(crcInfo.isPresent)
+    assert(!crcInfo.get().getInCommitTimestamp.isPresent)
+  }
+
+  test("toRow serializes inCommitTimestamp into the CRC_FILE_SCHEMA column") {
+    val original = new CRCInfo(
+      7L,
+      testMetadata,
+      testProtocol,
+      2000L,
+      20L,
+      Optional.empty(),
+      Optional.empty(),
+      Optional.empty(),
+      /* inCommitTimestamp */ Optional.of(java.lang.Long.valueOf(1749830871085L)))
+    val row = original.toRow()
+    val ictIdx = CRC_FILE_SCHEMA.indexOf("inCommitTimestampOpt")
+    assert(!row.isNullAt(ictIdx))
+    assert(row.getLong(ictIdx) === 1749830871085L)
+  }
+
+  test("toRow leaves inCommitTimestamp column null when absent") {
+    val original = new CRCInfo(
+      8L,
+      testMetadata,
+      testProtocol,
+      2100L,
+      21L,
+      Optional.empty(),
+      Optional.empty(),
+      Optional.empty())
+    val row = original.toRow()
+    assert(row.isNullAt(CRC_FILE_SCHEMA.indexOf("inCommitTimestampOpt")))
+  }
+
+  test("withInCommitTimestamp stamps the ICT onto an existing CRCInfo") {
+    val base = new CRCInfo(
+      9L,
+      testMetadata,
+      testProtocol,
+      3000L,
+      30L,
+      Optional.empty(),
+      Optional.empty(),
+      Optional.empty())
+    assert(!base.getInCommitTimestamp.isPresent)
+    val stamped = base.withInCommitTimestamp(Optional.of(java.lang.Long.valueOf(1700000000000L)))
+    assert(stamped.getInCommitTimestamp === Optional.of(java.lang.Long.valueOf(1700000000000L)))
+    assert(stamped.getVersion === base.getVersion)
+    assert(stamped.getTableSizeBytes === base.getTableSizeBytes)
+    assert(stamped.getNumFiles === base.getNumFiles)
   }
 }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ChecksumUtilsSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ChecksumUtilsSuite.scala
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 package io.delta.kernel.defaults
+import java.util.Optional
+
 import scala.collection.immutable.Seq
 import scala.jdk.CollectionConverters._
 
@@ -87,6 +89,31 @@ class ChecksumUtilsSuite extends AnyFunSuite with WriteUtils with LogReplayBaseS
       // The writing counterpart still persists an equivalent, valid checksum.
       ChecksumUtils.computeStateAndWriteChecksum(engine, snapshot1.getLogSegment)
       verifyChecksumForSnapshot(snapshot1)
+    }
+  }
+
+  test("withInCommitTimestamp stamps a caller-supplied ICT onto a computed CRCInfo") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      initialTestTable(tablePath, engine)
+
+      val snapshot1 = Table.forPath(
+        engine,
+        tablePath).getSnapshotAsOfVersion(engine, 1).asInstanceOf[SnapshotImpl]
+
+      // computeChecksum derives from file actions, so ICT is absent (not derivable from replay).
+      val crcInfo = ChecksumUtils.computeChecksum(engine, snapshot1.getLogSegment)
+      assert(!crcInfo.getInCommitTimestamp.isPresent)
+
+      // A caller holding the commit's CommitInfo stamps the ICT on; all other fields are preserved.
+      val ict = java.lang.Long.valueOf(1749830855993L)
+      val withIct = crcInfo.withInCommitTimestamp(Optional.of(ict))
+      assert(withIct.getInCommitTimestamp === Optional.of(ict))
+      assert(withIct.getVersion === crcInfo.getVersion)
+      assert(withIct.getNumFiles === crcInfo.getNumFiles)
+      assert(withIct.getTableSizeBytes === crcInfo.getTableSizeBytes)
+      assert(withIct.getMetadata === crcInfo.getMetadata)
+      assert(withIct.getProtocol === crcInfo.getProtocol)
+      assert(withIct.getDomainMetadata === crcInfo.getDomainMetadata)
     }
   }
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)
## Description

`CRCInfo`, aka checksum, carries table statistics derivable from a log replay. It does **not** carry the in-commit timestamp (ICT), which is an attribute of the commit's `CommitInfo` action and cannot be recovered from the Add/Remove/Metadata/Protocol actions the checksum replay reads. 

The ICT is freely attainable if a caller is trying to compute the checksum with the most recent CommitInfo. This PR adds an optional `inCommitTimestamp` field to `CRCInfo`.

Backward compatibility:
- The pre-existing 8-arg `CRCInfo` constructor isn't changed
- The caller can directly inject the ICT directly in.

Adding this field will save readers with CommitInfo a FS GET, a worthwhile performance boost with no cost.

## How was this patch tested? 
- `kernelApi / testOnly io.delta.kernel.internal.checksum.CRCInfoReadCompatSuite` (reads ICT when present; empty when the column is null / older files; `toRow` serializes-when-present and omits-when-absent; `withInCommitTimestamp` stamps without altering other fields) 
- `kernelDefaults / testOnly io.delta.kernel.defaults.ChecksumUtilsSuite`: injection logic
## Does this PR introduce any user-facing changes?

No. This is an internal kernel API addition.
