### PR TITLE
[Kernel] Add opt-in log replay telemetry

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/engine/Engine.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/engine/Engine.java
@@ -61,4 +61,14 @@ public interface Engine {
   default List<MetricsReporter> getMetricsReporters() {
     return Collections.emptyList();
   };
+
+  /**
+   * Whether to emit internal transaction-log replay metrics.
+   *
+   * <p>This capability defaults to disabled so existing engine implementations retain their
+   * existing behavior.
+   */
+  default boolean isLogReplayMetricsEnabled() {
+    return false;
+  }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
@@ -154,6 +154,7 @@ public class ScanImpl implements Scan {
     boolean shouldReadStats = hasDataSkippingFilter || includeStats;
     logger.info("Generated data skipping filter = {}", dataSkippingFilter);
 
+    boolean logReplayMetricsEnabled = engine.isLogReplayMetricsEnabled();
     Timer.Timed planningDuration = scanMetrics.totalPlanningTimer.start();
     // ScanReportReporter stores the current context and can be invoked (in the future) with
     // `reportError` or `reportSuccess` to stop the planning duration timer and push a report to
@@ -191,7 +192,9 @@ public class ScanImpl implements Scan {
                           rewritePartitionPredicateOnCheckpointFileSchema(
                               predicate, partitionColToStructFieldMap.get())),
               scanMetrics,
-              paginationContextOpt);
+              paginationContextOpt,
+              logReplayMetricsEnabled,
+              snapshotReport.getReportUUID());
 
       // Apply partition pruning
       scanFileIter = applyPartitionPruning(engine, scanFileIter);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/metrics/LogReplayReport.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/metrics/LogReplayReport.java
@@ -1,0 +1,375 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.internal.metrics;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.delta.kernel.internal.fs.Path;
+import io.delta.kernel.internal.replay.ActionsIterator;
+import io.delta.kernel.internal.replay.DeltaLogFile;
+import io.delta.kernel.internal.util.FileNames;
+import io.delta.kernel.metrics.MetricsReport;
+import io.delta.kernel.utils.FileStatus;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Bounded telemetry for a transaction-log replay.
+ *
+ * <p>A preflight report includes only the already-listed top-level artifacts selected for replay. A
+ * final report uses the same top-level set and additionally includes V2 checkpoint sidecars
+ * observed while parsing manifests. Preflight reporting is best effort before iterator
+ * construction; final reporting is best effort and only occurs after successful completion or an
+ * ordinary exception. Errors, including {@link OutOfMemoryError}, produce no final report.
+ */
+@JsonPropertyOrder({
+  "operationType",
+  "reportUUID",
+  "logReplayId",
+  "tablePath",
+  "tableVersion",
+  "snapshotReportUUID",
+  "phase",
+  "outcome",
+  "selectedCheckpointVersion",
+  "v2CheckpointManifestFormat",
+  "deltaArtifacts",
+  "compactionArtifacts",
+  "checkpointArtifacts",
+  "sidecarArtifacts"
+})
+public final class LogReplayReport implements MetricsReport {
+  public enum Phase {
+    PREFLIGHT,
+    FINAL
+  }
+
+  public enum Outcome {
+    SUCCESS,
+    FAILURE
+  }
+
+  /** Bounded size statistics. Size aggregates exclude entries whose size is unknown. */
+  public static final class ArtifactMetrics {
+    private final long count;
+    private final long knownSizeCount;
+    private final long unknownSizeCount;
+    private final long totalKnownSizeInBytes;
+    private final Long minKnownSizeInBytes;
+    private final Long maxKnownSizeInBytes;
+    private final Double sizeStandardDeviationInBytes;
+
+    private ArtifactMetrics(SizeAccumulator accumulator) {
+      count = accumulator.count;
+      knownSizeCount = accumulator.knownSizeCount;
+      unknownSizeCount = accumulator.count - accumulator.knownSizeCount;
+      totalKnownSizeInBytes = accumulator.totalKnownSizeInBytes;
+      minKnownSizeInBytes =
+          accumulator.knownSizeCount == 0 ? null : accumulator.minKnownSizeInBytes;
+      maxKnownSizeInBytes =
+          accumulator.knownSizeCount == 0 ? null : accumulator.maxKnownSizeInBytes;
+      sizeStandardDeviationInBytes =
+          accumulator.knownSizeCount == 0
+              ? null
+              : Math.sqrt(accumulator.sumSquaredDifferences / accumulator.knownSizeCount);
+    }
+
+    public long getCount() {
+      return count;
+    }
+
+    public long getKnownSizeCount() {
+      return knownSizeCount;
+    }
+
+    public long getUnknownSizeCount() {
+      return unknownSizeCount;
+    }
+
+    public long getTotalKnownSizeInBytes() {
+      return totalKnownSizeInBytes;
+    }
+
+    public Long getMinKnownSizeInBytes() {
+      return minKnownSizeInBytes;
+    }
+
+    public Long getMaxKnownSizeInBytes() {
+      return maxKnownSizeInBytes;
+    }
+
+    public Double getSizeStandardDeviationInBytes() {
+      return sizeStandardDeviationInBytes;
+    }
+  }
+
+  private final UUID logReplayId;
+  private final UUID reportUUID;
+  private final String tablePath;
+  private final long tableVersion;
+  private final UUID snapshotReportUUID;
+  private final Phase phase;
+  private final Outcome outcome;
+  private final Optional<Long> selectedCheckpointVersion;
+  private final Optional<String> v2CheckpointManifestFormat;
+  private final ArtifactMetrics deltaArtifacts;
+  private final ArtifactMetrics compactionArtifacts;
+  private final ArtifactMetrics checkpointArtifacts;
+  private final ArtifactMetrics sidecarArtifacts;
+
+  LogReplayReport(
+      UUID logReplayId,
+      UUID reportUUID,
+      String tablePath,
+      long tableVersion,
+      UUID snapshotReportUUID,
+      Phase phase,
+      Outcome outcome,
+      Optional<Long> selectedCheckpointVersion,
+      Optional<String> v2CheckpointManifestFormat,
+      SizeAccumulator deltas,
+      SizeAccumulator compactions,
+      SizeAccumulator checkpoints,
+      SizeAccumulator sidecars) {
+    this.logReplayId = logReplayId;
+    this.reportUUID = reportUUID;
+    this.tablePath = tablePath;
+    this.tableVersion = tableVersion;
+    this.snapshotReportUUID = snapshotReportUUID;
+    this.phase = phase;
+    this.outcome = outcome;
+    this.selectedCheckpointVersion = selectedCheckpointVersion;
+    this.v2CheckpointManifestFormat = v2CheckpointManifestFormat;
+    this.deltaArtifacts = new ArtifactMetrics(deltas);
+    this.compactionArtifacts = new ArtifactMetrics(compactions);
+    this.checkpointArtifacts = new ArtifactMetrics(checkpoints);
+    this.sidecarArtifacts = new ArtifactMetrics(sidecars);
+  }
+
+  public UUID getLogReplayId() {
+    return logReplayId;
+  }
+
+  public String getOperationType() {
+    return "LogReplay";
+  }
+
+  public UUID getReportUUID() {
+    return reportUUID;
+  }
+
+  public String getTablePath() {
+    return tablePath;
+  }
+
+  public long getTableVersion() {
+    return tableVersion;
+  }
+
+  public UUID getSnapshotReportUUID() {
+    return snapshotReportUUID;
+  }
+
+  public Phase getPhase() {
+    return phase;
+  }
+
+  /** Returns null for preflight because replay has not yet started. */
+  public Outcome getOutcome() {
+    return outcome;
+  }
+
+  public Optional<Long> getSelectedCheckpointVersion() {
+    return selectedCheckpointVersion;
+  }
+
+  /** Returns the V2 checkpoint manifest format when the selected replay includes one. */
+  public Optional<String> getV2CheckpointManifestFormat() {
+    return v2CheckpointManifestFormat;
+  }
+
+  public ArtifactMetrics getDeltaArtifacts() {
+    return deltaArtifacts;
+  }
+
+  public ArtifactMetrics getCompactionArtifacts() {
+    return compactionArtifacts;
+  }
+
+  public ArtifactMetrics getCheckpointArtifacts() {
+    return checkpointArtifacts;
+  }
+
+  /** Sidecars are absent from preflight because they are discovered from replayed manifests. */
+  public ArtifactMetrics getSidecarArtifacts() {
+    return sidecarArtifacts;
+  }
+
+  @Override
+  public String toJson() throws JsonProcessingException {
+    return MetricsReportSerializer.OBJECT_MAPPER.writeValueAsString(this);
+  }
+
+  static final class SizeAccumulator {
+    private long count;
+    private long knownSizeCount;
+    private long totalKnownSizeInBytes;
+    private long minKnownSizeInBytes = Long.MAX_VALUE;
+    private long maxKnownSizeInBytes;
+    private double mean;
+    private double sumSquaredDifferences;
+
+    void add(FileStatus fileStatus) {
+      count++;
+      if (!fileStatus.isSizeKnown()) {
+        return;
+      }
+      addKnownSize(fileStatus.getSize());
+    }
+
+    void addKnownSize(long sizeInBytes) {
+      knownSizeCount++;
+      totalKnownSizeInBytes += sizeInBytes;
+      minKnownSizeInBytes = Math.min(minKnownSizeInBytes, sizeInBytes);
+      maxKnownSizeInBytes = Math.max(maxKnownSizeInBytes, sizeInBytes);
+      double delta = sizeInBytes - mean;
+      mean += delta / knownSizeCount;
+      sumSquaredDifferences += delta * (sizeInBytes - mean);
+    }
+  }
+
+  static final class Builder {
+    private final SizeAccumulator deltas = new SizeAccumulator();
+    private final SizeAccumulator compactions = new SizeAccumulator();
+    private final SizeAccumulator checkpoints = new SizeAccumulator();
+    private final SizeAccumulator sidecars = new SizeAccumulator();
+    private Optional<Long> selectedCheckpointVersion;
+    private Optional<String> v2CheckpointManifestFormat = Optional.empty();
+    private final UUID logReplayId;
+    private final String tablePath;
+    private final long tableVersion;
+    private final UUID snapshotReportUUID;
+
+    Builder(List<FileStatus> selectedTopLevelFiles, Optional<Long> selectedCheckpointVersion) {
+      this(
+          selectedTopLevelFiles,
+          selectedCheckpointVersion,
+          UUID.randomUUID(),
+          "",
+          -1L,
+          UUID.randomUUID());
+    }
+
+    Builder(
+        List<FileStatus> selectedTopLevelFiles,
+        Optional<Long> selectedCheckpointVersion,
+        UUID logReplayId,
+        String tablePath,
+        long tableVersion,
+        UUID snapshotReportUUID) {
+      this.selectedCheckpointVersion = selectedCheckpointVersion;
+      this.logReplayId = logReplayId;
+      this.tablePath = tablePath;
+      this.tableVersion = tableVersion;
+      this.snapshotReportUUID = snapshotReportUUID;
+      for (FileStatus fileStatus : selectedTopLevelFiles) {
+        recordTopLevelArtifact(fileStatus);
+      }
+    }
+
+    Builder(
+        ActionsIterator.SelectedReplayFiles selectedTopLevelFiles,
+        Optional<Long> selectedCheckpointVersion,
+        UUID logReplayId,
+        String tablePath,
+        long tableVersion,
+        UUID snapshotReportUUID) {
+      this.selectedCheckpointVersion = selectedCheckpointVersion;
+      this.logReplayId = logReplayId;
+      this.tablePath = tablePath;
+      this.tableVersion = tableVersion;
+      this.snapshotReportUUID = snapshotReportUUID;
+      for (DeltaLogFile file : selectedTopLevelFiles.getFiles()) {
+        recordTopLevelArtifact(file);
+      }
+    }
+
+    void recordSidecar(String path, long version, long sizeInBytes) {
+      sidecars.addKnownSize(sizeInBytes);
+    }
+
+    void recordSidecar(FileStatus fileStatus, long version) {
+      sidecars.add(fileStatus);
+    }
+
+    LogReplayReport build(Phase phase, Outcome outcome) {
+      return new LogReplayReport(
+          logReplayId,
+          UUID.randomUUID(),
+          tablePath,
+          tableVersion,
+          snapshotReportUUID,
+          phase,
+          outcome,
+          selectedCheckpointVersion,
+          v2CheckpointManifestFormat,
+          deltas,
+          compactions,
+          checkpoints,
+          sidecars);
+    }
+
+    private void recordTopLevelArtifact(FileStatus fileStatus) {
+      Path path = new Path(fileStatus.getPath());
+      String filename = path.getName();
+      if (FileNames.isCommitFile(filename)) {
+        deltas.add(fileStatus);
+      } else if (FileNames.isLogCompactionFile(filename)) {
+        compactions.add(fileStatus);
+      } else {
+        checkpoints.add(fileStatus);
+        if (FileNames.isV2CheckpointFile(filename)) {
+          v2CheckpointManifestFormat =
+              Optional.of(filename.endsWith(".parquet") ? "parquet" : "json");
+        }
+      }
+    }
+
+    private void recordTopLevelArtifact(DeltaLogFile file) {
+      switch (file.getLogType()) {
+        case COMMIT:
+          deltas.add(file.getFile());
+          break;
+        case LOG_COMPACTION:
+          compactions.add(file.getFile());
+          break;
+        case CHECKPOINT_CLASSIC:
+        case MULTIPART_CHECKPOINT:
+          checkpoints.add(file.getFile());
+          break;
+        case V2_CHECKPOINT_MANIFEST:
+          checkpoints.add(file.getFile());
+          String filename = new Path(file.getFile().getPath()).getName();
+          v2CheckpointManifestFormat =
+              Optional.of(filename.endsWith(".parquet") ? "parquet" : "json");
+          break;
+        case SIDECAR:
+          throw new IllegalArgumentException("Sidecars are not top-level replay artifacts");
+      }
+    }
+  }
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/metrics/LogReplayTelemetry.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/metrics/LogReplayTelemetry.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.internal.metrics;
+
+import io.delta.kernel.engine.Engine;
+import io.delta.kernel.engine.MetricsReporter;
+import io.delta.kernel.internal.replay.ActionsIterator;
+import io.delta.kernel.utils.FileStatus;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Emits the bounded preflight and final reports for one log replay. */
+public final class LogReplayTelemetry {
+  private static final Logger logger = LoggerFactory.getLogger(LogReplayTelemetry.class);
+
+  private final Engine engine;
+  private final LogReplayReport.Builder reportBuilder;
+  private boolean finalReportEmitted;
+
+  public LogReplayTelemetry(
+      Engine engine,
+      ActionsIterator.SelectedReplayFiles selectedTopLevelFiles,
+      Optional<Long> checkpointVersion,
+      String tablePath,
+      long tableVersion,
+      UUID snapshotReportUUID) {
+    this.engine = engine;
+    this.reportBuilder =
+        new LogReplayReport.Builder(
+            selectedTopLevelFiles,
+            checkpointVersion,
+            UUID.randomUUID(),
+            tablePath,
+            tableVersion,
+            snapshotReportUUID);
+  }
+
+  /**
+   * Best-effort preflight reporting before an action iterator is constructed.
+   *
+   * <p>This report is emitted before replay begins, but neither it nor a final report is guaranteed
+   * when replay or reporting encounters an {@link Error}, including an {@link OutOfMemoryError}.
+   */
+  public void reportPreflight() {
+    report(LogReplayReport.Phase.PREFLIGHT, null);
+  }
+
+  /**
+   * Records the canonical file status created for a V2 manifest sidecar.
+   *
+   * <p>The status is built from the manifest metadata after pagination filtering, so recording it
+   * does not require an additional filesystem lookup.
+   */
+  public void recordSidecar(FileStatus sidecarFileStatus, long checkpointVersion) {
+    reportBuilder.recordSidecar(sidecarFileStatus, checkpointVersion);
+  }
+
+  /** Emits at most one final report after normal completion or an ordinary exception. */
+  public void reportFinal(LogReplayReport.Outcome outcome) {
+    if (finalReportEmitted) {
+      return;
+    }
+    finalReportEmitted = true;
+    report(LogReplayReport.Phase.FINAL, outcome);
+  }
+
+  private void report(LogReplayReport.Phase phase, LogReplayReport.Outcome outcome) {
+    LogReplayReport report = reportBuilder.build(phase, outcome);
+    final List<MetricsReporter> reporters;
+    try {
+      reporters = engine.getMetricsReporters();
+    } catch (Exception e) {
+      // Reporting is diagnostic only. Do not log the exception: it can contain table paths or
+      // payload data.
+      logger.warn("Log replay telemetry reporters unavailable");
+      return;
+    }
+    reporters.forEach(
+        reporter -> {
+          try {
+            reporter.report(report);
+          } catch (Exception e) {
+            // Reporting is diagnostic only. A faulty reporter must not affect replay or
+            // prevent later reporters from receiving the same event.
+            // Do not log the exception or report: either can contain table paths or payload
+            // data.
+            logger.warn("Log replay telemetry reporter failed");
+          }
+        });
+  }
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ActionsIterator.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ActionsIterator.java
@@ -28,9 +28,9 @@ import io.delta.kernel.data.ColumnarBatch;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.engine.FileReadResult;
 import io.delta.kernel.expressions.*;
-import io.delta.kernel.internal.annotation.VisibleForTesting;
 import io.delta.kernel.internal.checkpoints.SidecarFile;
 import io.delta.kernel.internal.fs.Path;
+import io.delta.kernel.internal.metrics.LogReplayTelemetry;
 import io.delta.kernel.internal.util.*;
 import io.delta.kernel.types.StructType;
 import io.delta.kernel.utils.CloseableIterator;
@@ -39,7 +39,6 @@ import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.io.UncheckedIOException;
 import java.util.*;
-import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,14 +59,11 @@ public class ActionsIterator implements CloseableIterator<ActionWrapper> {
 
   private final Optional<Predicate> checkpointPredicate;
 
-  /**
-   * Linked list of iterator files (commit files and/or checkpoint files) {@link LinkedList} to
-   * allow removing the head of the list and also to peek at the head of the list. The {@link
-   * Iterator} doesn't provide a way to peek.
-   *
-   * <p>Each of these files return an iterator of {@link ColumnarBatch} containing the actions
-   */
-  private final LinkedList<DeltaLogFile> filesList;
+  /** Classified top-level replay files, selected once for this iterator. */
+  private final List<DeltaLogFile> topLevelFiles;
+
+  private int nextTopLevelFileIndex;
+  private final Deque<DeltaLogFile> sidecarFiles;
 
   /** Schema used for reading delta files. */
   private final StructType deltaReadSchema;
@@ -82,15 +78,14 @@ public class ActionsIterator implements CloseableIterator<ActionWrapper> {
 
   /**
    * The current (ColumnarBatch, isFromCheckpoint) tuple. Whenever this iterator is exhausted, we
-   * will try and fetch the next one from the `filesList`.
+   * will try and fetch the next replay file.
    *
    * <p>If it is ever empty, that means there are no more batches to produce.
    */
   private Optional<CloseableIterator<ActionWrapper>> actionsIter;
 
   private final Optional<PaginationContext> paginationContextOpt;
-  private long numCheckpointFilesSkipped = 0;
-  private long numSidecarFilesSkipped = 0;
+  private final Optional<LogReplayTelemetry> logReplayTelemetry;
   private boolean closed;
 
   public ActionsIterator(
@@ -104,7 +99,8 @@ public class ActionsIterator implements CloseableIterator<ActionWrapper> {
         deltaReadSchema,
         deltaReadSchema,
         checkpointPredicate,
-        Optional.empty() /* paginationContextOpt */);
+        Optional.empty() /* paginationContextOpt */,
+        Optional.empty() /* logReplayTelemetry */);
   }
 
   public ActionsIterator(
@@ -114,19 +110,104 @@ public class ActionsIterator implements CloseableIterator<ActionWrapper> {
       StructType checkpointReadSchema,
       Optional<Predicate> checkpointPredicate,
       Optional<PaginationContext> paginationContextOpt) {
+    this(
+        engine,
+        files,
+        deltaReadSchema,
+        checkpointReadSchema,
+        checkpointPredicate,
+        paginationContextOpt,
+        Optional.empty() /* logReplayTelemetry */);
+  }
+
+  public ActionsIterator(
+      Engine engine,
+      List<FileStatus> files,
+      StructType deltaReadSchema,
+      StructType checkpointReadSchema,
+      Optional<Predicate> checkpointPredicate,
+      Optional<PaginationContext> paginationContextOpt,
+      Optional<LogReplayTelemetry> logReplayTelemetry) {
+    this(
+        engine,
+        selectFilesForReplay(files, paginationContextOpt),
+        deltaReadSchema,
+        checkpointReadSchema,
+        checkpointPredicate,
+        paginationContextOpt,
+        logReplayTelemetry);
+  }
+
+  /**
+   * Creates an iterator from replay files that have already been selected for the supplied
+   * pagination context.
+   *
+   * <p>The returned selection is also suitable for log-replay preflight aggregation. Keeping the
+   * classified {@link DeltaLogFile} instances avoids duplicate O(N) status/path classification.
+   */
+  public static ActionsIterator fromSelectedReplayFiles(
+      Engine engine,
+      SelectedReplayFiles selectedReplayFiles,
+      StructType deltaReadSchema,
+      StructType checkpointReadSchema,
+      Optional<Predicate> checkpointPredicate,
+      Optional<PaginationContext> paginationContextOpt,
+      Optional<LogReplayTelemetry> logReplayTelemetry) {
+    return new ActionsIterator(
+        engine,
+        selectedReplayFiles,
+        deltaReadSchema,
+        checkpointReadSchema,
+        checkpointPredicate,
+        paginationContextOpt,
+        logReplayTelemetry);
+  }
+
+  private ActionsIterator(
+      Engine engine,
+      SelectedReplayFiles selectedReplayFiles,
+      StructType deltaReadSchema,
+      StructType checkpointReadSchema,
+      Optional<Predicate> checkpointPredicate,
+      Optional<PaginationContext> paginationContextOpt,
+      Optional<LogReplayTelemetry> logReplayTelemetry) {
     this.engine = engine;
     this.checkpointPredicate = checkpointPredicate;
-    this.filesList = new LinkedList<>();
+    this.topLevelFiles = selectedReplayFiles.getFiles();
+    this.nextTopLevelFileIndex = 0;
+    this.sidecarFiles = new ArrayDeque<>();
     this.paginationContextOpt = paginationContextOpt;
-    this.filesList.addAll(
-        files.stream()
-            .map(DeltaLogFile::forFileStatus)
-            .filter(this::paginatedFilter)
-            .collect(Collectors.toList()));
+    this.logReplayTelemetry = logReplayTelemetry;
     this.deltaReadSchema = deltaReadSchema;
     this.checkpointReadSchema = checkpointReadSchema;
     this.actionsIter = Optional.empty();
     this.schemaContainsAddOrRemoveFiles = LogReplay.containsAddOrRemoveFileActions(deltaReadSchema);
+  }
+
+  /** Selects and classifies top-level replay files without filesystem I/O. */
+  public static SelectedReplayFiles selectFilesForReplay(
+      List<FileStatus> files, Optional<PaginationContext> paginationContextOpt) {
+    List<DeltaLogFile> selectedFiles = new ArrayList<>();
+    for (FileStatus fileStatus : files) {
+      DeltaLogFile logFile = DeltaLogFile.forFileStatus(fileStatus);
+      if (shouldIncludeTopLevelFile(logFile, paginationContextOpt)) {
+        selectedFiles.add(logFile);
+      }
+    }
+    return new SelectedReplayFiles(selectedFiles);
+  }
+
+  /** One classified, pagination-selected top-level replay representation. */
+  public static final class SelectedReplayFiles {
+    private final List<DeltaLogFile> files;
+
+    private SelectedReplayFiles(List<DeltaLogFile> files) {
+      this.files = files;
+    }
+
+    public List<DeltaLogFile> getFiles() {
+      return files;
+    }
   }
 
   /**
@@ -156,10 +237,8 @@ public class ActionsIterator implements CloseableIterator<ActionWrapper> {
    * @param nextLogFile the log file to evaluate
    * @return {@code true} to include the file; {@code false} to skip it
    */
-  @VisibleForTesting
-  // TODO: verify numCheckpointFilesSkipped is correct in E2E test
-  // TODO: add unit test for this method
-  public boolean paginatedFilter(DeltaLogFile nextLogFile) {
+  private static boolean shouldIncludeTopLevelFile(
+      DeltaLogFile nextLogFile, Optional<PaginationContext> paginationContextOpt) {
     Objects.requireNonNull(paginationContextOpt);
     // Pagination isn't enabled.
     if (!paginationContextOpt.isPresent()) return true;
@@ -181,7 +260,6 @@ public class ActionsIterator implements CloseableIterator<ActionWrapper> {
       case MULTIPART_CHECKPOINT:
         if (isFullyConsumedFile(nextFilePath, lastReadLogFilePathOpt.get())) {
           logger.info("Pagination: skip reading multi-part checkpoint file {}", nextFilePath);
-          numCheckpointFilesSkipped++;
           return false;
         } else {
           return true;
@@ -198,7 +276,7 @@ public class ActionsIterator implements CloseableIterator<ActionWrapper> {
    * Returns true if the given file was already fully consumed in a previous page that ends at
    * lastReadLogFilePath.
    */
-  private boolean isFullyConsumedFile(String filePath, String lastReadLogFilePath) {
+  private static boolean isFullyConsumedFile(String filePath, String lastReadLogFilePath) {
     // Files are sorted in reverse lexicographic order.so if `filePath` is *greater* than
     // `lastReadLogFilePath`,
     // it actually comes before lastReadLogFilePath in the log stream, meaning we have already
@@ -256,7 +334,7 @@ public class ActionsIterator implements CloseableIterator<ActionWrapper> {
 
   /**
    * If the current `actionsIter` has no more elements, this function finds the next non-empty file
-   * in `filesList` and uses it to set `actionsIter`.
+   * in the replay sequence and uses it to set `actionsIter`.
    */
   private void tryEnsureNextActionsIterIsReady() {
     if (actionsIter.isPresent()) {
@@ -273,7 +351,7 @@ public class ActionsIterator implements CloseableIterator<ActionWrapper> {
     }
 
     // Search for the next non-empty file and use that iter
-    while (!filesList.isEmpty()) {
+    while (hasNextReplayFile()) {
       actionsIter = Optional.of(getNextActionsIter());
 
       if (actionsIter.get().hasNext()) {
@@ -409,7 +487,6 @@ public class ActionsIterator implements CloseableIterator<ActionWrapper> {
               "Pagination: skip reading sidecar file: index={}, path={}",
               sidecarIndexInV2Manifest,
               sidecarFile.getPath());
-          numSidecarFilesSkipped++;
           continue;
         }
       }
@@ -420,11 +497,9 @@ public class ActionsIterator implements CloseableIterator<ActionWrapper> {
               sidecarFile.getSizeInBytes(),
               sidecarFile.getModificationTime());
 
-      filesList.add(DeltaLogFile.ofSideCar(sideCarFileStatus, checkpointVersion));
-    }
-
-    if (paginationContextOpt.isPresent()) {
-      logger.info("Pagination: number of sidecar files skipped is {}", numSidecarFilesSkipped);
+      logReplayTelemetry.ifPresent(
+          telemetry -> telemetry.recordSidecar(sideCarFileStatus, checkpointVersion));
+      sidecarFiles.add(DeltaLogFile.ofSideCar(sideCarFileStatus, checkpointVersion));
     }
 
     // Delete SidecarFile actions from the schema.
@@ -432,13 +507,13 @@ public class ActionsIterator implements CloseableIterator<ActionWrapper> {
   }
 
   /**
-   * Get the next file from `filesList` (.json or .checkpoint.parquet) read it + inject the
-   * `isFromCheckpoint` information.
+   * Get the next replay file (.json or .checkpoint.parquet) and inject the `isFromCheckpoint`
+   * information.
    *
-   * <p>Requires that `filesList.isEmpty` is false.
+   * <p>Requires that a replay file is available.
    */
   private CloseableIterator<ActionWrapper> getNextActionsIter() {
-    final DeltaLogFile nextLogFile = filesList.pop();
+    final DeltaLogFile nextLogFile = pollNextReplayFile();
     final FileStatus nextFile = nextLogFile.getFile();
     final Path nextFilePath = new Path(nextFile.getPath());
     final String fileName = nextFilePath.getName();
@@ -496,6 +571,24 @@ public class ActionsIterator implements CloseableIterator<ActionWrapper> {
     } catch (IOException ex) {
       throw new UncheckedIOException(ex);
     }
+  }
+
+  private boolean hasNextReplayFile() {
+    return nextTopLevelFileIndex < topLevelFiles.size() || !sidecarFiles.isEmpty();
+  }
+
+  private DeltaLogFile peekNextReplayFile() {
+    if (nextTopLevelFileIndex < topLevelFiles.size()) {
+      return topLevelFiles.get(nextTopLevelFileIndex);
+    }
+    return sidecarFiles.peek();
+  }
+
+  private DeltaLogFile pollNextReplayFile() {
+    if (nextTopLevelFileIndex < topLevelFiles.size()) {
+      return topLevelFiles.get(nextTopLevelFileIndex++);
+    }
+    return sidecarFiles.remove();
   }
 
   private CloseableIterator<ActionWrapper> readCommitOrCompactionFile(
@@ -606,12 +699,12 @@ public class ActionsIterator implements CloseableIterator<ActionWrapper> {
     // Sidecar or multipart checkpoint types are the only files that can have multiple parts.
     if (deltaLogFile.getLogType() == SIDECAR || deltaLogFile.getLogType() == MULTIPART_CHECKPOINT) {
 
-      DeltaLogFile peek = filesList.peek();
+      DeltaLogFile peek = peekNextReplayFile();
       while (peek != null
           && deltaLogFile.getLogType() == peek.getLogType()
           && deltaLogFile.getVersion() == peek.getVersion()) {
-        checkpointFiles.add(filesList.pop().getFile());
-        peek = filesList.peek();
+        checkpointFiles.add(pollNextReplayFile().getFile());
+        peek = peekNextReplayFile();
       }
     }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ActiveAddFilesIterator.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ActiveAddFilesIterator.java
@@ -34,6 +34,8 @@ import io.delta.kernel.expressions.Literal;
 import io.delta.kernel.internal.InternalScanFileUtils;
 import io.delta.kernel.internal.actions.DeletionVectorDescriptor;
 import io.delta.kernel.internal.fs.Path;
+import io.delta.kernel.internal.metrics.LogReplayReport;
+import io.delta.kernel.internal.metrics.LogReplayTelemetry;
 import io.delta.kernel.internal.metrics.ScanMetrics;
 import io.delta.kernel.internal.replay.LogReplayUtils.UniqueFileActionTuple;
 import io.delta.kernel.internal.util.Utils;
@@ -78,8 +80,19 @@ public class ActiveAddFilesIterator implements CloseableIterator<FilteredColumna
    */
   private ScanMetrics metrics;
 
+  private final Optional<LogReplayTelemetry> logReplayTelemetry;
+
   ActiveAddFilesIterator(
       Engine engine, CloseableIterator<ActionWrapper> iter, Path tableRoot, ScanMetrics metrics) {
+    this(engine, iter, tableRoot, metrics, Optional.empty() /* logReplayTelemetry */);
+  }
+
+  ActiveAddFilesIterator(
+      Engine engine,
+      CloseableIterator<ActionWrapper> iter,
+      Path tableRoot,
+      ScanMetrics metrics,
+      Optional<LogReplayTelemetry> logReplayTelemetry) {
     this.engine = engine;
     this.tableRoot = tableRoot;
     this.iter = iter;
@@ -87,6 +100,7 @@ public class ActiveAddFilesIterator implements CloseableIterator<FilteredColumna
     this.addFilesFromJson = new HashSet<>();
     this.next = Optional.empty();
     this.metrics = metrics;
+    this.logReplayTelemetry = logReplayTelemetry;
   }
 
   @Override
@@ -94,10 +108,20 @@ public class ActiveAddFilesIterator implements CloseableIterator<FilteredColumna
     if (closed) {
       throw new IllegalStateException("Can't call `hasNext` on a closed iterator.");
     }
-    if (!next.isPresent()) {
-      prepareNext();
+    try {
+      if (!next.isPresent()) {
+        prepareNext();
+      }
+      if (!next.isPresent()) {
+        logReplayTelemetry.ifPresent(
+            telemetry -> telemetry.reportFinal(LogReplayReport.Outcome.SUCCESS));
+      }
+      return next.isPresent();
+    } catch (Exception e) {
+      logReplayTelemetry.ifPresent(
+          telemetry -> telemetry.reportFinal(LogReplayReport.Outcome.FAILURE));
+      throw e;
     }
-    return next.isPresent();
   }
 
   @Override
@@ -121,6 +145,8 @@ public class ActiveAddFilesIterator implements CloseableIterator<FilteredColumna
     closed = true;
     Utils.closeCloseables(iter);
 
+    // An early close is an incomplete replay. Keep the preflight-only telemetry outcome rather
+    // than emitting a final success or failure event.
     // Log the metrics of the log replay of actions that are consumed so far. If the iterator
     // is closed before consuming all the actions, the metrics will be partial.
     logger.info("Active add file finding log replay metrics: {}", metrics);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/LogReplay.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/LogReplay.java
@@ -26,6 +26,7 @@ import io.delta.kernel.internal.checkpoints.SidecarFile;
 import io.delta.kernel.internal.checksum.CRCInfo;
 import io.delta.kernel.internal.fs.Path;
 import io.delta.kernel.internal.lang.Lazy;
+import io.delta.kernel.internal.metrics.LogReplayTelemetry;
 import io.delta.kernel.internal.metrics.ScanMetrics;
 import io.delta.kernel.internal.snapshot.LogSegment;
 import io.delta.kernel.internal.util.DomainMetadataUtils;
@@ -205,19 +206,51 @@ public class LogReplay {
       boolean shouldReadStats,
       Optional<Predicate> checkpointPredicate,
       ScanMetrics scanMetrics,
-      Optional<PaginationContext> paginationContextOpt) {
+      Optional<PaginationContext> paginationContextOpt,
+      boolean logReplayMetricsEnabled,
+      UUID snapshotReportUUID) {
     // We do not need to look at any `remove` files from the checkpoints. Skip the column to save
     // I/O. Note that we are still going to process the row groups. Adds and removes are randomly
     // scattered through checkpoint part files, so row group push down is unlikely to be useful.
+    LogSegment logSegment = getLogSegment();
+    List<FileStatus> replayFiles = getLogReplayFiles(logSegment);
+    if (!logReplayMetricsEnabled) {
+      final CloseableIterator<ActionWrapper> addRemoveIter =
+          new ActionsIterator(
+              engine,
+              replayFiles,
+              getAddRemoveReadSchema(shouldReadStats),
+              getAddReadSchema(shouldReadStats),
+              checkpointPredicate,
+              paginationContextOpt,
+              Optional.empty() /* logReplayTelemetry */);
+      return new ActiveAddFilesIterator(
+          engine, addRemoveIter, dataPath, scanMetrics, Optional.empty() /* logReplayTelemetry */);
+    }
+
+    ActionsIterator.SelectedReplayFiles selectedReplayFiles =
+        ActionsIterator.selectFilesForReplay(replayFiles, paginationContextOpt);
+    Optional<LogReplayTelemetry> telemetry =
+        Optional.of(
+            new LogReplayTelemetry(
+                engine,
+                selectedReplayFiles,
+                logSegment.getCheckpointVersionOpt(),
+                dataPath.toString(),
+                logSegment.getVersion(),
+                snapshotReportUUID));
+    telemetry.ifPresent(LogReplayTelemetry::reportPreflight);
+
     final CloseableIterator<ActionWrapper> addRemoveIter =
-        new ActionsIterator(
+        ActionsIterator.fromSelectedReplayFiles(
             engine,
-            getLogReplayFiles(getLogSegment()),
+            selectedReplayFiles,
             getAddRemoveReadSchema(shouldReadStats),
             getAddReadSchema(shouldReadStats),
             checkpointPredicate,
-            paginationContextOpt);
-    return new ActiveAddFilesIterator(engine, addRemoveIter, dataPath, scanMetrics);
+            paginationContextOpt,
+            telemetry);
+    return new ActiveAddFilesIterator(engine, addRemoveIter, dataPath, scanMetrics, telemetry);
   }
 
   public LogSegment getLogSegment() {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/utils/FileStatus.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/utils/FileStatus.java
@@ -39,7 +39,7 @@ public class FileStatus {
    * @param modificationTime Modification time of the file in epoch millis
    */
   public static FileStatus of(String path, long size, long modificationTime) {
-    return new FileStatus(path, size, modificationTime);
+    return new FileStatus(path, size, modificationTime, true /* sizeKnown */);
   }
 
   //////////////////////////////////
@@ -49,12 +49,18 @@ public class FileStatus {
   private final String path;
   private final long size;
   private final long modificationTime;
+  private final boolean sizeKnown;
 
   // TODO add further documentation about the expected format for modificationTime?
   protected FileStatus(String path, long size, long modificationTime) {
+    this(path, size, modificationTime, true /* sizeKnown */);
+  }
+
+  protected FileStatus(String path, long size, long modificationTime, boolean sizeKnown) {
     this.path = Objects.requireNonNull(path, "path is null");
     this.size = size; // TODO: validation
     this.modificationTime = modificationTime; // TODO: validation
+    this.sizeKnown = sizeKnown;
   }
 
   /**
@@ -76,6 +82,16 @@ public class FileStatus {
   }
 
   /**
+   * Returns whether this status has a size provided by the file system.
+   *
+   * <p>{@link #of(String)} creates a synthetic status with an unknown size. Its zero value must not
+   * be treated as the size of a real zero-byte file.
+   */
+  public boolean isSizeKnown() {
+    return sizeKnown;
+  }
+
+  /**
    * Get the modification time of the file in epoch millis.
    *
    * @return Modification time in epoch millis
@@ -91,13 +107,17 @@ public class FileStatus {
   }
 
   /**
-   * Create a {@link FileStatus} with the given path with size and modification time set to 0.
+   * Creates a synthetic {@link FileStatus} with an unknown size and modification time.
+   *
+   * <p>The zero-valued size is a placeholder, not a known zero-byte size. Accordingly, {@link
+   * #isSizeKnown()} returns false and this status is intentionally unequal to a {@link FileStatus}
+   * created with {@link #of(String, long, long)} using the same path and a known zero-byte size.
    *
    * @param path Fully qualified file path.
    * @return {@link FileStatus} object
    */
   public static FileStatus of(String path) {
-    return new FileStatus(path, 0 /* size */, 0 /* modTime */);
+    return new FileStatus(path, 0 /* size */, 0 /* modTime */, false /* sizeKnown */);
   }
 
   @Override
@@ -111,11 +131,12 @@ public class FileStatus {
     FileStatus that = (FileStatus) o;
     return Objects.equals(this.path, that.path)
         && Objects.equals(this.size, that.size)
-        && Objects.equals(this.modificationTime, that.modificationTime);
+        && Objects.equals(this.modificationTime, that.modificationTime)
+        && this.sizeKnown == that.sizeKnown;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(path, size, modificationTime);
+    return Objects.hash(path, size, modificationTime, sizeKnown);
   }
 }

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/metrics/MetricsReportSerializerSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/metrics/MetricsReportSerializerSuite.scala
@@ -20,8 +20,11 @@ import java.util.{Collections, Optional, UUID}
 import scala.collection.JavaConverters._
 
 import io.delta.kernel.expressions.{Column, Literal, Predicate}
+import io.delta.kernel.internal.fs.Path
+import io.delta.kernel.internal.util.FileNames
 import io.delta.kernel.metrics.{ScanReport, SnapshotReport, TransactionReport}
 import io.delta.kernel.types.{FieldMetadata, IntegerType, StringType, StructType}
+import io.delta.kernel.utils.FileStatus
 
 import org.scalatest.funsuite.AnyFunSuite
 
@@ -350,4 +353,67 @@ class MetricsReportSerializerSuite extends AnyFunSuite {
       Optional.empty())
     testScanReport(scanReport2)
   }
+
+  test("LogReplayReport is bounded and distinguishes unknown file sizes") {
+    val logPath = new Path("/table/_delta_log")
+    val logReplayId = UUID.randomUUID()
+    val snapshotReportUUID = UUID.randomUUID()
+    val selectedFiles = Seq(
+      FileStatus.of(FileNames.checkpointFileSingular(logPath, 10).toString, 8, 0),
+      FileStatus.of(FileNames.logCompactionPath(logPath, 11, 12).toString, 2, 0),
+      FileStatus.of(FileNames.deltaFile(logPath, 12)))
+    val builder = new LogReplayReport.Builder(
+      selectedFiles.asJava,
+      Optional.of(10L),
+      logReplayId,
+      "/table",
+      12L,
+      snapshotReportUUID)
+
+    val preflight = builder.build(LogReplayReport.Phase.PREFLIGHT, null)
+    assert(preflight.getLogReplayId == logReplayId)
+    assert(preflight.getOperationType == "LogReplay")
+    assert(preflight.getTablePath == "/table")
+    assert(preflight.getTableVersion == 12L)
+    assert(preflight.getSnapshotReportUUID == snapshotReportUUID)
+    assert(preflight.getDeltaArtifacts.getCount == 1)
+    assert(preflight.getDeltaArtifacts.getKnownSizeCount == 0)
+    assert(preflight.getDeltaArtifacts.getUnknownSizeCount == 1)
+    assert(preflight.getDeltaArtifacts.getTotalKnownSizeInBytes == 0)
+    assert(preflight.getDeltaArtifacts.getMinKnownSizeInBytes == null)
+    assert(preflight.getCheckpointArtifacts.getKnownSizeCount == 1)
+    assert(preflight.getV2CheckpointManifestFormat.isEmpty)
+
+    builder.recordSidecar("sidecars/sensitive-sidecar.parquet", 10, 6)
+    val finalReport = builder.build(LogReplayReport.Phase.FINAL, LogReplayReport.Outcome.SUCCESS)
+    assert(finalReport.getSidecarArtifacts.getKnownSizeCount == 1)
+    assert(finalReport.getSidecarArtifacts.getTotalKnownSizeInBytes == 6)
+    assert(finalReport.getReportUUID != preflight.getReportUUID)
+    assert(finalReport.toJson.contains("\"operationType\":\"LogReplay\""))
+    assert(finalReport.toJson.contains(s"\"reportUUID\":\"${finalReport.getReportUUID}\""))
+    assert(finalReport.toJson.contains("\"phase\":\"FINAL\""))
+    assert(finalReport.toJson.contains("\"outcome\":\"SUCCESS\""))
+    assert(!finalReport.toJson.contains("00000000000000000010.checkpoint.parquet"))
+    assert(!finalReport.toJson.contains("sensitive-sidecar.parquet"))
+  }
+
+  test("LogReplayReport uses standard deviation in bytes") {
+    val logPath = new Path("/table/_delta_log")
+    val selectedFiles = Seq(
+      FileStatus.of(FileNames.deltaFile(logPath, 1), 2, 0),
+      FileStatus.of(FileNames.deltaFile(logPath, 2), 6, 0))
+    val report = new LogReplayReport.Builder(selectedFiles.asJava, Optional.empty())
+      .build(LogReplayReport.Phase.PREFLIGHT, null)
+
+    assert(report.getDeltaArtifacts.getSizeStandardDeviationInBytes == 2.0)
+  }
+
+  test("FileStatus equality distinguishes known and synthetic sizes") {
+    val knownZeroSize = FileStatus.of("/table/_delta_log/00000000000000000000.json", 0, 0)
+    val syntheticUnknownSize = FileStatus.of("/table/_delta_log/00000000000000000000.json")
+
+    assert(knownZeroSize != syntheticUnknownSize)
+    assert(knownZeroSize.hashCode != syntheticUnknownSize.hashCode)
+  }
+
 }

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/replay/ActionsIteratorSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/replay/ActionsIteratorSuite.scala
@@ -16,21 +16,26 @@
 package io.delta.kernel.internal.replay
 
 import java.io.{InterruptedIOException, UncheckedIOException}
-import java.util.{Collections, Optional}
+import java.lang.{Long => JLong}
+import java.util.{Arrays, Collections, Optional}
 
 import scala.collection.JavaConverters._
+import scala.collection.mutable.ArrayBuffer
 
+import io.delta.kernel.Meta
 import io.delta.kernel.data.{ColumnarBatch, ColumnVector, Row}
 import io.delta.kernel.engine._
 import io.delta.kernel.expressions.Predicate
-import io.delta.kernel.test.BaseMockJsonHandler
-import io.delta.kernel.test.MockEngineUtils
-import io.delta.kernel.types.StructType
+import io.delta.kernel.internal.checkpoints.SidecarFile
+import io.delta.kernel.internal.metrics.{LogReplayReport, LogReplayTelemetry}
+import io.delta.kernel.metrics.MetricsReport
+import io.delta.kernel.test.{BaseMockJsonHandler, MockEngineUtils, VectorTestUtils}
+import io.delta.kernel.types.{DataType, StructType}
 import io.delta.kernel.utils.{CloseableIterator, FileStatus}
 
 import org.scalatest.funsuite.AnyFunSuite
 
-class ActionsIteratorSuite extends AnyFunSuite with MockEngineUtils {
+class ActionsIteratorSuite extends AnyFunSuite with MockEngineUtils with VectorTestUtils {
 
   /**
    * Test for ActionsIterator resource leak fix validation
@@ -124,5 +129,155 @@ class ActionsIteratorSuite extends AnyFunSuite with MockEngineUtils {
       // Clear the interrupt flag so it doesn't leak into subsequent tests.
       Thread.interrupted()
     }
+  }
+
+  test("preflight telemetry is reported before the first JSON replay read") {
+    val reports = ArrayBuffer.empty[MetricsReport]
+    var preflightReportedBeforeRead = false
+    val engine = new Engine {
+      override def getExpressionHandler: ExpressionHandler = null
+      override def getJsonHandler: JsonHandler = new BaseMockJsonHandler {
+        override def readJsonFiles(
+            fileIter: CloseableIterator[FileStatus],
+            physicalSchema: StructType,
+            predicate: Optional[Predicate]): CloseableIterator[ColumnarBatch] = {
+          preflightReportedBeforeRead = reports.exists {
+            case report: LogReplayReport => report.getPhase == LogReplayReport.Phase.PREFLIGHT
+            case _ => false
+          }
+          new CloseableIterator[ColumnarBatch] {
+            override def hasNext: Boolean = false
+            override def next(): ColumnarBatch = throw new NoSuchElementException()
+            override def close(): Unit = {}
+          }
+        }
+      }
+      override def getFileSystemClient: FileSystemClient = null
+      override def getParquetHandler: ParquetHandler = null
+      override def getMetricsReporters: java.util.List[MetricsReporter] =
+        Collections.singletonList(new MetricsReporter {
+          override def report(report: MetricsReport): Unit = reports += report
+        })
+    }
+    val telemetry = new LogReplayTelemetry(
+      engine,
+      ActionsIterator.selectFilesForReplay(Collections.emptyList(), Optional.empty()),
+      Optional.empty(),
+      "/table",
+      0L,
+      java.util.UUID.randomUUID())
+    telemetry.reportPreflight()
+    val actionsIterator = new ActionsIterator(
+      engine,
+      Collections.singletonList(FileStatus.of("/table/_delta_log/00000000000000000000.json")),
+      new StructType(),
+      Optional.empty[Predicate]())
+
+    actionsIterator.hasNext()
+
+    assert(preflightReportedBeforeRead)
+  }
+
+  test("continuation telemetry excludes consumed multipart checkpoints and V2 sidecars") {
+    val reports = ArrayBuffer.empty[MetricsReport]
+    val engine = new Engine {
+      override def getExpressionHandler: ExpressionHandler = null
+      override def getJsonHandler: JsonHandler = null
+      override def getFileSystemClient: FileSystemClient = null
+      override def getParquetHandler: ParquetHandler = null
+      override def getMetricsReporters: java.util.List[MetricsReporter] =
+        Collections.singletonList(new MetricsReporter {
+          override def report(report: MetricsReport): Unit = reports += report
+        })
+    }
+    val consumedCheckpoint = FileStatus.of(
+      "/table/_delta_log/00000000000000000010.checkpoint.0000000003.0000000003.parquet",
+      30L,
+      1L)
+    val resumedCheckpoint = FileStatus.of(
+      "/table/_delta_log/00000000000000000010.checkpoint.0000000002.0000000003.parquet",
+      20L,
+      1L)
+    val v2Manifest = FileStatus.of(
+      "/table/_delta_log/00000000000000000010.checkpoint.uuid.parquet",
+      40L,
+      1L)
+    val paginationContext = PaginationContext.forPageWithPageToken(
+      "/table",
+      10L,
+      1,
+      1,
+      100L,
+      new PageToken(
+        resumedCheckpoint.getPath,
+        0L,
+        Optional.of(1L),
+        Meta.KERNEL_VERSION,
+        "/table",
+        10L,
+        1,
+        1))
+    val selectedTopLevelFiles = ActionsIterator.selectFilesForReplay(
+      Arrays.asList(consumedCheckpoint, resumedCheckpoint, v2Manifest),
+      Optional.of(paginationContext))
+    assert(selectedTopLevelFiles.getFiles.asScala.map(_.getFile) ==
+      Seq(resumedCheckpoint, v2Manifest))
+    val telemetry = new LogReplayTelemetry(
+      engine,
+      selectedTopLevelFiles,
+      Optional.of(10L),
+      "/table",
+      10L,
+      java.util.UUID.randomUUID())
+    val sidecarPaths = Seq("first.parquet", "second.parquet", "third.parquet")
+    val sidecarVector = new ColumnVector {
+      private val children = Seq(
+        stringVector(sidecarPaths),
+        longVector(Seq(10L, 20L, 30L).map(JLong.valueOf)),
+        longVector(Seq(100L, 200L, 300L).map(JLong.valueOf)))
+
+      override def getDataType: DataType = SidecarFile.READ_SCHEMA
+      override def getSize: Int = sidecarPaths.size
+      override def close(): Unit = {}
+      override def isNullAt(rowId: Int): Boolean = false
+      override def getChild(ordinal: Int): ColumnVector = children(ordinal)
+    }
+    val manifestBatch = new ColumnarBatch {
+      private val schema =
+        new StructType().add(LogReplay.SIDECAR_FIELD_NAME, SidecarFile.READ_SCHEMA)
+
+      override def getSchema: StructType = schema
+      override def getColumnVector(ordinal: Int): ColumnVector = sidecarVector
+      override def getSize: Int = sidecarPaths.size
+      override def withDeletedColumnAt(ordinal: Int): ColumnarBatch = this
+    }
+    val iterator = new ActionsIterator(
+      engine,
+      Collections.emptyList(),
+      new StructType(),
+      new StructType(),
+      Optional.empty(),
+      Optional.of(paginationContext),
+      Optional.of(telemetry))
+
+    telemetry.reportPreflight()
+    iterator.extractSidecarsFromBatch(
+      FileStatus.of("/table/_delta_log/00000000000000000010.checkpoint.parquet", 1L, 1L),
+      10L,
+      manifestBatch)
+    telemetry.reportFinal(LogReplayReport.Outcome.SUCCESS)
+
+    val logReplayReports = reports.collect { case report: LogReplayReport => report }
+    assert(logReplayReports.map(_.getPhase) == Seq(
+      LogReplayReport.Phase.PREFLIGHT,
+      LogReplayReport.Phase.FINAL))
+    logReplayReports.foreach { report =>
+      assert(report.getCheckpointArtifacts.getCount == 2L)
+      assert(report.getCheckpointArtifacts.getKnownSizeCount == 2L)
+      assert(report.getCheckpointArtifacts.getTotalKnownSizeInBytes == 60L)
+    }
+    assert(logReplayReports.head.getSidecarArtifacts.getCount == 0L)
+    assert(logReplayReports.last.getSidecarArtifacts.getCount == 2)
+    assert(logReplayReports.last.getSidecarArtifacts.getTotalKnownSizeInBytes == 50L)
   }
 }

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/DefaultEngine.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/DefaultEngine.java
@@ -24,10 +24,16 @@ import org.apache.hadoop.conf.Configuration;
 
 /** Default implementation of {@link Engine} based on Hadoop APIs. */
 public class DefaultEngine implements Engine {
+  private static final String LOG_REPLAY_METRICS_ENABLED_CONF =
+      "delta.kernel.default.log-replay.metrics.enabled";
+
   private final FileIO fileIO;
+  private final boolean logReplayMetricsEnabled;
 
   protected DefaultEngine(FileIO fileIO) {
     this.fileIO = fileIO;
+    this.logReplayMetricsEnabled =
+        fileIO.getConf(LOG_REPLAY_METRICS_ENABLED_CONF).map(Boolean::parseBoolean).orElse(false);
   }
 
   @Override
@@ -54,6 +60,11 @@ public class DefaultEngine implements Engine {
   public List<MetricsReporter> getMetricsReporters() {
     return Collections.singletonList(new LoggingMetricsReporter());
   };
+
+  @Override
+  public boolean isLogReplayMetricsEnabled() {
+    return logReplayMetricsEnabled;
+  }
 
   /**
    * Create an instance of {@link DefaultEngine}.

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/metrics/LogReplayTelemetrySuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/metrics/LogReplayTelemetrySuite.scala
@@ -1,0 +1,818 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.defaults.metrics
+
+import java.io.File
+import java.util
+import java.util.Optional
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicInteger
+
+import scala.collection.mutable.ArrayBuffer
+
+import io.delta.kernel.Table
+import io.delta.kernel.data.{ColumnarBatch, ColumnVector, Row}
+import io.delta.kernel.defaults.engine.DefaultEngine
+import io.delta.kernel.engine._
+import io.delta.kernel.expressions.Predicate
+import io.delta.kernel.internal.SnapshotImpl
+import io.delta.kernel.internal.fs.Path
+import io.delta.kernel.internal.hook.LogCompactionHook
+import io.delta.kernel.internal.lang.Lazy
+import io.delta.kernel.internal.metrics.{LogReplayReport, LogReplayTelemetry}
+import io.delta.kernel.internal.replay.{ActionsIterator, LogReplay}
+import io.delta.kernel.internal.snapshot.LogSegment
+import io.delta.kernel.metrics.MetricsReport
+import io.delta.kernel.types.StructType
+import io.delta.kernel.utils.{CloseableIterator, FileStatus}
+
+import org.apache.hadoop.conf.Configuration
+import org.scalatest.funsuite.AnyFunSuite
+
+class LogReplayTelemetrySuite extends AnyFunSuite with MetricsReportTestUtils {
+  private val logReplayMetricsEnabledKey = "delta.kernel.default.log-replay.metrics.enabled"
+
+  test("DefaultEngine log replay metrics option defaults to false") {
+    assert(!DefaultEngine.create(new Configuration()).isLogReplayMetricsEnabled)
+
+    val falseConf = new Configuration()
+    falseConf.set(logReplayMetricsEnabledKey, "false")
+    assert(!DefaultEngine.create(falseConf).isLogReplayMetricsEnabled)
+
+    val trueConf = new Configuration()
+    trueConf.set(logReplayMetricsEnabledKey, "true")
+    assert(DefaultEngine.create(trueConf).isLogReplayMetricsEnabled)
+
+    val malformedConf = new Configuration()
+    malformedConf.set(logReplayMetricsEnabledKey, "not-a-boolean")
+    assert(!DefaultEngine.create(malformedConf).isLogReplayMetricsEnabled)
+  }
+
+  test("default and custom Engines do not emit log replay reports when disabled") {
+    withTempDir { tempDir =>
+      spark.range(1).write.format("delta").save(tempDir.getCanonicalPath)
+
+      assert(logReplayReports(
+        DefaultEngine.create(new Configuration()),
+        tempDir.getCanonicalPath).isEmpty)
+      assert(logReplayReports(
+        customEngine(DefaultEngine.create(new Configuration())),
+        tempDir.getCanonicalPath).isEmpty)
+    }
+  }
+
+  test("enabled log replay emits one preflight and one final report") {
+    withTempDir { tempDir =>
+      spark.range(1).write.format("delta").save(tempDir.getCanonicalPath)
+
+      val conf = new Configuration()
+      conf.set(logReplayMetricsEnabledKey, "true")
+      val reports = logReplayReports(DefaultEngine.create(conf), tempDir.getCanonicalPath)
+
+      assert(reports.map(_.getPhase) == Seq(
+        LogReplayReport.Phase.PREFLIGHT,
+        LogReplayReport.Phase.FINAL))
+      assert(reports.head.getOutcome == null)
+      assert(reports.last.getOutcome == LogReplayReport.Outcome.SUCCESS)
+      assert(reports.head.getLogReplayId == reports.last.getLogReplayId)
+      assert(reports.head.getOperationType == "LogReplay")
+      assert(reports.head.getReportUUID != reports.last.getReportUUID)
+      assert(reports.head.getTablePath.endsWith(tempDir.getCanonicalPath))
+      assert(reports.head.getTableVersion == 0L)
+      assert(reports.head.getSnapshotReportUUID == reports.last.getSnapshotReportUUID)
+    }
+  }
+
+  test("enabled early-close replay emits preflight only") {
+    withTempDir { tempDir =>
+      spark.range(1).write.format("delta").save(tempDir.getCanonicalPath)
+
+      val conf = new Configuration()
+      conf.set(logReplayMetricsEnabledKey, "true")
+      val reports = ArrayBuffer.empty[MetricsReport]
+      val engine = reportingEngine(DefaultEngine.create(conf), reports)
+      val snapshot = Table.forPath(engine, tempDir.getCanonicalPath).getLatestSnapshot(engine)
+      val scanFiles = snapshot.getScanBuilder().build().getScanFiles(engine)
+      scanFiles.close()
+
+      val logReplayReports = reports.collect { case report: LogReplayReport => report }.toSeq
+      assert(logReplayReports.map(_.getPhase) == Seq(LogReplayReport.Phase.PREFLIGHT))
+      assert(logReplayReports.head.getOutcome == null)
+      assertArtifactMetrics(
+        logReplayReports.head.getDeltaArtifacts,
+        count = 1,
+        knownSizeCount = 1,
+        unknownSizeCount = 0)
+      assertArtifactMetrics(
+        logReplayReports.head.getCompactionArtifacts,
+        count = 0,
+        knownSizeCount = 0,
+        unknownSizeCount = 0)
+      assertArtifactMetrics(
+        logReplayReports.head.getCheckpointArtifacts,
+        count = 0,
+        knownSizeCount = 0,
+        unknownSizeCount = 0)
+      assertArtifactMetrics(
+        logReplayReports.head.getSidecarArtifacts,
+        count = 0,
+        knownSizeCount = 0,
+        unknownSizeCount = 0)
+    }
+  }
+
+  test("preflight telemetry precedes replay reads and final telemetry waits for exhaustion") {
+    withTempDir { tempDir =>
+      spark.range(4).repartition(2).write.format("delta").save(tempDir.getCanonicalPath)
+
+      val conf = new Configuration()
+      conf.set(logReplayMetricsEnabledKey, "true")
+      val baseEngine = DefaultEngine.create(conf)
+      val reports = ArrayBuffer.empty[MetricsReport]
+      var firstReplayReadStarted = false
+      val engine = new Engine {
+        private val reporter = new MetricsReporter {
+          override def report(report: MetricsReport): Unit = reports += report
+        }
+        private val timingJsonHandler = new JsonHandler {
+          override def parseJson(
+              jsonStringVector: ColumnVector,
+              outputSchema: StructType,
+              selectionVector: Optional[ColumnVector]): ColumnarBatch =
+            baseEngine.getJsonHandler.parseJson(jsonStringVector, outputSchema, selectionVector)
+
+          override def readJsonFiles(
+              fileIter: CloseableIterator[FileStatus],
+              physicalSchema: StructType,
+              predicate: Optional[Predicate]): CloseableIterator[ColumnarBatch] = {
+            firstReplayReadStarted = true
+            assert(reports.collect { case report: LogReplayReport => report.getPhase } ==
+              Seq(LogReplayReport.Phase.PREFLIGHT))
+            baseEngine.getJsonHandler.readJsonFiles(fileIter, physicalSchema, predicate)
+          }
+
+          override def writeJsonFileAtomically(
+              filePath: String,
+              data: CloseableIterator[Row],
+              overwrite: Boolean): Unit =
+            baseEngine.getJsonHandler.writeJsonFileAtomically(filePath, data, overwrite)
+        }
+
+        override def getExpressionHandler: ExpressionHandler = baseEngine.getExpressionHandler
+        override def getJsonHandler: JsonHandler = timingJsonHandler
+        override def getFileSystemClient: FileSystemClient = baseEngine.getFileSystemClient
+        override def getParquetHandler: ParquetHandler = baseEngine.getParquetHandler
+        override def getMetricsReporters: util.List[MetricsReporter] =
+          util.Collections.singletonList(reporter)
+        override def isLogReplayMetricsEnabled: Boolean = true
+      }
+
+      val snapshot =
+        Table.forPath(baseEngine, tempDir.getCanonicalPath).getLatestSnapshot(baseEngine)
+      val scanFiles = snapshot.getScanBuilder().build().getScanFiles(engine)
+      try {
+        assert(!firstReplayReadStarted)
+        assert(reports.collect { case report: LogReplayReport => report.getPhase } ==
+          Seq(LogReplayReport.Phase.PREFLIGHT))
+
+        assert(scanFiles.hasNext)
+        assert(firstReplayReadStarted)
+        assert(reports.collect { case report: LogReplayReport => report.getPhase } ==
+          Seq(LogReplayReport.Phase.PREFLIGHT))
+
+        while (scanFiles.hasNext) {
+          scanFiles.next()
+        }
+        assert(reports.collect { case report: LogReplayReport => report.getPhase } ==
+          Seq(LogReplayReport.Phase.PREFLIGHT, LogReplayReport.Phase.FINAL))
+      } finally {
+        scanFiles.close()
+      }
+    }
+  }
+
+  test("enabled ordinary replay failure reports preflight and final failure") {
+    withTempDir { tempDir =>
+      spark.range(1).write.format("delta").save(tempDir.getCanonicalPath)
+
+      val conf = new Configuration()
+      conf.set(logReplayMetricsEnabledKey, "true")
+      val baseEngine = DefaultEngine.create(conf)
+      val snapshot = Table.forPath(baseEngine, tempDir.getCanonicalPath)
+        .getLatestSnapshot(baseEngine)
+      val reports = ArrayBuffer.empty[MetricsReport]
+      val replayFailure = new RuntimeException("expected replay failure")
+      val engine = reportingEngineWithJsonFailure(baseEngine, reports, replayFailure)
+
+      val thrown = intercept[RuntimeException] {
+        val scanFiles = snapshot.getScanBuilder().build().getScanFiles(engine)
+        try {
+          scanFiles.hasNext
+        } finally {
+          scanFiles.close()
+        }
+      }
+
+      assert(thrown.getCause eq replayFailure)
+      val logReplayReports = reports.collect { case report: LogReplayReport => report }.toSeq
+      assert(logReplayReports.map(_.getPhase) == Seq(
+        LogReplayReport.Phase.PREFLIGHT,
+        LogReplayReport.Phase.FINAL))
+      assert(logReplayReports.map(_.getOutcome) == Seq(
+        null,
+        LogReplayReport.Outcome.FAILURE))
+      assertArtifactMetrics(
+        logReplayReports.head.getDeltaArtifacts,
+        count = 1,
+        knownSizeCount = 1,
+        unknownSizeCount = 0)
+      assertArtifactMetrics(
+        logReplayReports.last.getDeltaArtifacts,
+        count = 1,
+        knownSizeCount = 1,
+        unknownSizeCount = 0)
+      assert(logReplayReports.last.getSidecarArtifacts.getCount == 0)
+    }
+  }
+
+  test("ordinary replay failure survives a throwing reporter and reaches later reporters") {
+    withTempDir { tempDir =>
+      spark.range(1).write.format("delta").save(tempDir.getCanonicalPath)
+
+      val conf = new Configuration()
+      conf.set(logReplayMetricsEnabledKey, "true")
+      val baseEngine = DefaultEngine.create(conf)
+      val snapshot = Table.forPath(baseEngine, tempDir.getCanonicalPath)
+        .getLatestSnapshot(baseEngine)
+      val reports = ArrayBuffer.empty[MetricsReport]
+      val replayFailure = new RuntimeException("expected replay failure")
+      val engine = reportingEngineWithJsonFailure(
+        baseEngine,
+        reports,
+        replayFailure,
+        throwingReporter = true)
+
+      val thrown = intercept[RuntimeException] {
+        val scanFiles = snapshot.getScanBuilder().build().getScanFiles(engine)
+        scanFiles.hasNext
+      }
+
+      assert(thrown.getCause eq replayFailure)
+      val logReplayReports = reports.collect { case report: LogReplayReport => report }.toSeq
+      assert(logReplayReports.map(_.getPhase) == Seq(
+        LogReplayReport.Phase.PREFLIGHT,
+        LogReplayReport.Phase.FINAL))
+      assert(logReplayReports.map(_.getOutcome) == Seq(
+        null,
+        LogReplayReport.Outcome.FAILURE))
+    }
+  }
+
+  test("successful replay survives a throwing reporter and reaches later reporters") {
+    withTempDir { tempDir =>
+      spark.range(1).write.format("delta").save(tempDir.getCanonicalPath)
+
+      val conf = new Configuration()
+      conf.set(logReplayMetricsEnabledKey, "true")
+      val baseEngine = DefaultEngine.create(conf)
+      val snapshot = Table.forPath(baseEngine, tempDir.getCanonicalPath)
+        .getLatestSnapshot(baseEngine)
+      val reports = ArrayBuffer.empty[MetricsReport]
+      val collectingEngine = reportingEngine(baseEngine, reports)
+      val engine = new Engine {
+        private val reporters = util.Arrays.asList(
+          new MetricsReporter {
+            override def report(report: MetricsReport): Unit = {
+              if (report.isInstanceOf[LogReplayReport]) {
+                throw new RuntimeException("reporter failure")
+              }
+            }
+          },
+          collectingEngine.getMetricsReporters.get(0))
+
+        override def getExpressionHandler: ExpressionHandler = collectingEngine.getExpressionHandler
+        override def getJsonHandler: JsonHandler = collectingEngine.getJsonHandler
+        override def getFileSystemClient: FileSystemClient = collectingEngine.getFileSystemClient
+        override def getParquetHandler: ParquetHandler = collectingEngine.getParquetHandler
+        override def getMetricsReporters: util.List[MetricsReporter] = reporters
+        override def isLogReplayMetricsEnabled: Boolean = true
+      }
+
+      val scanFiles = snapshot.getScanBuilder().build().getScanFiles(engine)
+      try {
+        while (scanFiles.hasNext) {
+          scanFiles.next()
+        }
+      } finally {
+        scanFiles.close()
+      }
+
+      val logReplayReports = reports.collect { case report: LogReplayReport => report }.toSeq
+      assert(logReplayReports.map(_.getPhase) == Seq(
+        LogReplayReport.Phase.PREFLIGHT,
+        LogReplayReport.Phase.FINAL))
+      assert(logReplayReports.map(_.getOutcome) == Seq(
+        null,
+        LogReplayReport.Outcome.SUCCESS))
+    }
+  }
+
+  test("successful replay skips telemetry when metrics reporters accessor fails") {
+    withTempDir { tempDir =>
+      spark.range(1).write.format("delta").save(tempDir.getCanonicalPath)
+
+      val conf = new Configuration()
+      conf.set(logReplayMetricsEnabledKey, "true")
+      val baseEngine = DefaultEngine.create(conf)
+      val snapshot = Table.forPath(baseEngine, tempDir.getCanonicalPath)
+        .getLatestSnapshot(baseEngine)
+      val reporterAccesses = new AtomicInteger()
+      val engine = new Engine {
+        override def getExpressionHandler: ExpressionHandler = baseEngine.getExpressionHandler
+        override def getJsonHandler: JsonHandler = baseEngine.getJsonHandler
+        override def getFileSystemClient: FileSystemClient = baseEngine.getFileSystemClient
+        override def getParquetHandler: ParquetHandler = baseEngine.getParquetHandler
+        override def getMetricsReporters: util.List[MetricsReporter] = {
+          if (reporterAccesses.incrementAndGet() <= 2) {
+            throw new RuntimeException("metrics reporter accessor failure")
+          }
+          util.Collections.emptyList()
+        }
+        override def isLogReplayMetricsEnabled: Boolean = true
+      }
+
+      val scanFiles = snapshot.getScanBuilder().build().getScanFiles(engine)
+      try {
+        while (scanFiles.hasNext) {
+          scanFiles.next()
+        }
+      } finally {
+        scanFiles.close()
+      }
+
+      assert(reporterAccesses.get == 3)
+    }
+  }
+
+  test("synthetic OutOfMemoryError reader failure emits preflight only") {
+    withTempDir { tempDir =>
+      spark.range(1).write.format("delta").save(tempDir.getCanonicalPath)
+
+      val conf = new Configuration()
+      conf.set(logReplayMetricsEnabledKey, "true")
+      val baseEngine = DefaultEngine.create(conf)
+      val snapshot = Table.forPath(baseEngine, tempDir.getCanonicalPath)
+        .getLatestSnapshot(baseEngine)
+      val reports = ArrayBuffer.empty[MetricsReport]
+      val replayError = new OutOfMemoryError("synthetic reader failure")
+      val engine = reportingEngineWithJsonFailure(baseEngine, reports, replayError)
+
+      val thrown = intercept[OutOfMemoryError] {
+        val scanFiles = snapshot.getScanBuilder().build().getScanFiles(engine)
+        scanFiles.hasNext
+      }
+
+      assert(thrown eq replayError)
+      assert(reports.collect { case report: LogReplayReport => report.getPhase } ==
+        Seq(LogReplayReport.Phase.PREFLIGHT))
+    }
+  }
+
+  test("v2 checkpoint sidecar resume reports pagination-selected artifacts") {
+    val tablePath = getTestResourceFilePath("kernel-pagination-v2-checkpoint-parquet")
+    val deltaLogPath = new File(tablePath, "_delta_log")
+    val checkpointManifest = deltaLogPath.listFiles()
+      .find(file =>
+        file.getName.startsWith("00000000000000000002.checkpoint") &&
+          file.getName.endsWith(".parquet"))
+      .getOrElse(fail("missing V2 checkpoint manifest"))
+    val sidecarSizes = spark.read.parquet(checkpointManifest.getCanonicalPath)
+      .selectExpr("sidecar.sizeInBytes")
+      .where("sidecar IS NOT NULL")
+      .collect()
+      .map(_.getLong(0))
+      .toSeq
+    assert(sidecarSizes.size == 2)
+
+    val conf = new Configuration()
+    conf.set(logReplayMetricsEnabledKey, "true")
+    val baseEngine = DefaultEngine.create(conf)
+    val snapshot = Table.forPath(baseEngine, tablePath).getSnapshotAsOfVersion(baseEngine, 2)
+
+    val firstPageReports = ArrayBuffer.empty[MetricsReport]
+    val firstPage = snapshot.getScanBuilder().buildPaginated(1, Optional.empty())
+      .getScanFiles(reportingEngine(baseEngine, firstPageReports))
+    val resumeToken =
+      try {
+        while (firstPage.hasNext) {
+          firstPage.next()
+        }
+        firstPage.getCurrentPageToken.get()
+      } finally {
+        firstPage.close()
+      }
+
+    val firstPageLogReplayReports =
+      firstPageReports.collect { case report: LogReplayReport => report }.toSeq
+    assert(firstPageLogReplayReports.map(_.getPhase) == Seq(LogReplayReport.Phase.PREFLIGHT))
+    assertKnownSizes(
+      firstPageLogReplayReports.head.getCheckpointArtifacts,
+      Seq(checkpointManifest.length()))
+    assertArtifactMetrics(
+      firstPageLogReplayReports.head.getSidecarArtifacts,
+      count = 0,
+      knownSizeCount = 0,
+      unknownSizeCount = 0)
+
+    val resumedPageReports = ArrayBuffer.empty[MetricsReport]
+    val resumedPage = snapshot.getScanBuilder().buildPaginated(100, Optional.of(resumeToken))
+      .getScanFiles(reportingEngine(baseEngine, resumedPageReports))
+    try {
+      while (resumedPage.hasNext) {
+        resumedPage.next()
+      }
+    } finally {
+      resumedPage.close()
+    }
+
+    val resumedPageLogReplayReports =
+      resumedPageReports.collect { case report: LogReplayReport => report }.toSeq
+    assert(resumedPageLogReplayReports.map(_.getPhase) == Seq(
+      LogReplayReport.Phase.PREFLIGHT,
+      LogReplayReport.Phase.FINAL))
+    resumedPageLogReplayReports.foreach { report =>
+      assertKnownSizes(report.getCheckpointArtifacts, Seq(checkpointManifest.length()))
+      assertArtifactMetrics(
+        report.getDeltaArtifacts,
+        count = 0,
+        knownSizeCount = 0,
+        unknownSizeCount = 0)
+      assertArtifactMetrics(
+        report.getCompactionArtifacts,
+        count = 0,
+        knownSizeCount = 0,
+        unknownSizeCount = 0)
+    }
+    assertArtifactMetrics(
+      resumedPageLogReplayReports.head.getSidecarArtifacts,
+      count = 0,
+      knownSizeCount = 0,
+      unknownSizeCount = 0)
+    assertKnownSizes(resumedPageLogReplayReports.last.getSidecarArtifacts, sidecarSizes)
+  }
+
+  test("compaction-resolved replay reports only the files it consumes") {
+    withTempDir { tempDir =>
+      val tablePath = tempDir.getCanonicalPath
+      (0 to 3).foreach { value =>
+        spark.range(value * 10, (value + 1) * 10).write
+          .format("delta")
+          .mode(if (value == 0) "error" else "append")
+          .save(tablePath)
+      }
+
+      val conf = new Configuration()
+      conf.set(logReplayMetricsEnabledKey, "true")
+      val baseEngine = DefaultEngine.create(conf)
+      new LogCompactionHook(
+        new Path(s"file:$tablePath"),
+        new Path(s"file:$tablePath", "_delta_log"),
+        0,
+        2,
+        0).threadSafeInvoke(baseEngine)
+
+      val reports = ArrayBuffer.empty[MetricsReport]
+      val engine = reportingEngine(baseEngine, reports)
+      val snapshot = Table.forPath(engine, tablePath).getLatestSnapshot(engine)
+      val rawDeltas = snapshot.asInstanceOf[SnapshotImpl].getLogSegment.getDeltas.size()
+      assert(rawDeltas == 4)
+      val scanFiles = snapshot.getScanBuilder().build().getScanFiles(engine)
+      try {
+        while (scanFiles.hasNext) {
+          scanFiles.next()
+        }
+      } finally {
+        scanFiles.close()
+      }
+
+      val finalReport = reports.collect { case report: LogReplayReport => report }
+        .find(_.getPhase == LogReplayReport.Phase.FINAL)
+        .getOrElse(fail("missing final log replay report"))
+      assertArtifactMetrics(
+        finalReport.getDeltaArtifacts,
+        count = 1,
+        knownSizeCount = 1,
+        unknownSizeCount = 0)
+      assertArtifactMetrics(
+        finalReport.getCompactionArtifacts,
+        count = 1,
+        knownSizeCount = 1,
+        unknownSizeCount = 0)
+      assertArtifactMetrics(
+        finalReport.getCheckpointArtifacts,
+        count = 0,
+        knownSizeCount = 0,
+        unknownSizeCount = 0)
+    }
+  }
+
+  test("disabled replay does not aggregate statuses or report telemetry") {
+    val sizeAccesses = new AtomicInteger()
+    val pathAccesses = new AtomicInteger()
+    val topLevelFile = new FileStatus(
+      "/table/_delta_log/00000000000000000000.json",
+      10,
+      0) {
+      override def getPath: String = {
+        pathAccesses.incrementAndGet()
+        super.getPath
+      }
+
+      override def getSize: Long = {
+        sizeAccesses.incrementAndGet()
+        super.getSize
+      }
+
+      override def isSizeKnown: Boolean = {
+        sizeAccesses.incrementAndGet()
+        super.isSizeKnown
+      }
+    }
+    val logSegment = new LogSegment(
+      new Path("/table/_delta_log"),
+      0,
+      util.Collections.singletonList(topLevelFile),
+      util.Collections.emptyList(),
+      util.Collections.emptyList(),
+      topLevelFile,
+      Optional.empty(),
+      Optional.empty())
+    sizeAccesses.set(0)
+    pathAccesses.set(0)
+    val reports = ArrayBuffer.empty[MetricsReport]
+    val engine = collectingEngine(reports)
+    val replay = new LogReplay(
+      engine,
+      new Path("/table"),
+      new Lazy(() => logSegment),
+      new Lazy(() => Optional.empty()))
+
+    val scanFiles = replay.getAddFilesAsColumnarBatches(
+      engine,
+      false,
+      Optional.empty(),
+      null,
+      Optional.empty(),
+      false,
+      UUID.randomUUID())
+    scanFiles.close()
+
+    assert(reports.isEmpty)
+    assert(sizeAccesses.get == 0)
+    assert(pathAccesses.get == 1)
+  }
+
+  test("enabled replay shares one selected status representation") {
+    val pathAccesses = new AtomicInteger()
+    val topLevelFile = new FileStatus(
+      "/table/_delta_log/00000000000000000000.json",
+      10,
+      0) {
+      override def getPath: String = {
+        pathAccesses.incrementAndGet()
+        super.getPath
+      }
+    }
+    val reports = ArrayBuffer.empty[MetricsReport]
+    val baseEngine = collectingEngine(reports)
+    val engine = new Engine {
+      override def getExpressionHandler: ExpressionHandler = baseEngine.getExpressionHandler
+      override def getJsonHandler: JsonHandler = baseEngine.getJsonHandler
+      override def getFileSystemClient: FileSystemClient = baseEngine.getFileSystemClient
+      override def getParquetHandler: ParquetHandler = baseEngine.getParquetHandler
+      override def getMetricsReporters: util.List[MetricsReporter] = baseEngine.getMetricsReporters
+      override def isLogReplayMetricsEnabled: Boolean = true
+    }
+
+    val selectedReplayFiles = ActionsIterator.selectFilesForReplay(
+      util.Collections.singletonList(topLevelFile),
+      Optional.empty())
+    val telemetry = new LogReplayTelemetry(
+      engine,
+      selectedReplayFiles,
+      Optional.empty(),
+      "/table",
+      0L,
+      UUID.randomUUID())
+    val iterator = ActionsIterator.fromSelectedReplayFiles(
+      engine,
+      selectedReplayFiles,
+      new StructType(),
+      new StructType(),
+      Optional.empty(),
+      Optional.empty(),
+      Optional.of(telemetry))
+
+    telemetry.reportPreflight()
+    iterator.close()
+
+    assert(pathAccesses.get == 1)
+    assert(reports.collect { case report: LogReplayReport => report.getPhase } ==
+      Seq(LogReplayReport.Phase.PREFLIGHT))
+  }
+
+  Seq(LogReplayReport.Outcome.SUCCESS, LogReplayReport.Outcome.FAILURE).foreach { outcome =>
+    test(s"throwing reporter does not prevent later reporter from receiving $outcome telemetry") {
+      val collected = ArrayBuffer.empty[MetricsReport]
+      val baseEngine = DefaultEngine.create(new Configuration())
+      val engine = new Engine {
+        private val reporters = util.Arrays.asList(
+          new MetricsReporter {
+            override def report(report: MetricsReport): Unit = {
+              throw new RuntimeException("reporter failure")
+            }
+          },
+          new MetricsReporter {
+            override def report(report: MetricsReport): Unit = collected += report
+          })
+
+        override def getExpressionHandler: ExpressionHandler = baseEngine.getExpressionHandler
+        override def getJsonHandler: JsonHandler = baseEngine.getJsonHandler
+        override def getFileSystemClient: FileSystemClient = baseEngine.getFileSystemClient
+        override def getParquetHandler: ParquetHandler = baseEngine.getParquetHandler
+        override def getMetricsReporters: util.List[MetricsReporter] = reporters
+      }
+
+      val telemetry = new LogReplayTelemetry(
+        engine,
+        ActionsIterator.selectFilesForReplay(
+          util.Collections.singletonList(
+            FileStatus.of("/table/_delta_log/00000000000000000000.json")),
+          Optional.empty()),
+        Optional.empty(),
+        "/table",
+        0L,
+        UUID.randomUUID())
+      telemetry.reportPreflight()
+      telemetry.reportFinal(outcome)
+
+      assert(collected.collect { case report: LogReplayReport => report.getPhase } ==
+        Seq(LogReplayReport.Phase.PREFLIGHT, LogReplayReport.Phase.FINAL))
+      assert(collected.collect { case report: LogReplayReport => report.getOutcome } ==
+        Seq(null, outcome))
+    }
+  }
+
+  private def logReplayReports(baseEngine: Engine, tablePath: String): Seq[LogReplayReport] = {
+    val reports = ArrayBuffer.empty[MetricsReport]
+    val engine = reportingEngine(baseEngine, reports)
+    val snapshot = Table.forPath(engine, tablePath).getLatestSnapshot(engine)
+    val scanFiles = snapshot.getScanBuilder().build().getScanFiles(engine)
+    try {
+      while (scanFiles.hasNext) {
+        scanFiles.next()
+      }
+    } finally {
+      scanFiles.close()
+    }
+    reports.collect { case report: LogReplayReport => report }.toSeq
+  }
+
+  private def customEngine(baseEngine: Engine): Engine = new Engine {
+    override def getExpressionHandler: ExpressionHandler = baseEngine.getExpressionHandler
+    override def getJsonHandler: JsonHandler = baseEngine.getJsonHandler
+    override def getFileSystemClient: FileSystemClient = baseEngine.getFileSystemClient
+    override def getParquetHandler: ParquetHandler = baseEngine.getParquetHandler
+  }
+
+  private def reportingEngine(
+      baseEngine: Engine,
+      reports: ArrayBuffer[MetricsReport]): Engine = new Engine {
+    private val reporter = new MetricsReporter {
+      override def report(report: MetricsReport): Unit = reports += report
+    }
+
+    override def getExpressionHandler: ExpressionHandler = baseEngine.getExpressionHandler
+    override def getJsonHandler: JsonHandler = baseEngine.getJsonHandler
+    override def getFileSystemClient: FileSystemClient = baseEngine.getFileSystemClient
+    override def getParquetHandler: ParquetHandler = baseEngine.getParquetHandler
+    override def getMetricsReporters: util.List[MetricsReporter] =
+      util.Collections.singletonList(reporter)
+    override def isLogReplayMetricsEnabled: Boolean = baseEngine.isLogReplayMetricsEnabled
+  }
+
+  private def reportingEngineWithJsonFailure(
+      baseEngine: Engine,
+      reports: ArrayBuffer[MetricsReport],
+      replayFailure: Throwable,
+      throwingReporter: Boolean = false): Engine = {
+    val wrappedEngine = reportingEngine(baseEngine, reports)
+    new Engine {
+      private val reporters =
+        if (throwingReporter) {
+          util.Arrays.asList(
+            new MetricsReporter {
+              override def report(report: MetricsReport): Unit = {
+                if (report.isInstanceOf[LogReplayReport]) {
+                  throw new RuntimeException("reporter failure")
+                }
+              }
+            },
+            wrappedEngine.getMetricsReporters.get(0))
+        } else {
+          wrappedEngine.getMetricsReporters
+        }
+
+      private val failingJsonHandler = new JsonHandler {
+        override def parseJson(
+            jsonStringVector: ColumnVector,
+            outputSchema: StructType,
+            selectionVector: Optional[ColumnVector]): ColumnarBatch =
+          wrappedEngine.getJsonHandler.parseJson(jsonStringVector, outputSchema, selectionVector)
+
+        override def readJsonFiles(
+            fileIter: CloseableIterator[FileStatus],
+            physicalSchema: StructType,
+            predicate: Optional[Predicate]): CloseableIterator[ColumnarBatch] =
+          throw replayFailure
+
+        override def writeJsonFileAtomically(
+            filePath: String,
+            data: CloseableIterator[Row],
+            overwrite: Boolean): Unit =
+          wrappedEngine.getJsonHandler.writeJsonFileAtomically(filePath, data, overwrite)
+      }
+
+      override def getExpressionHandler: ExpressionHandler = wrappedEngine.getExpressionHandler
+      override def getJsonHandler: JsonHandler = failingJsonHandler
+      override def getFileSystemClient: FileSystemClient = wrappedEngine.getFileSystemClient
+      override def getParquetHandler: ParquetHandler = wrappedEngine.getParquetHandler
+      override def getMetricsReporters: util.List[MetricsReporter] =
+        reporters
+      override def isLogReplayMetricsEnabled: Boolean =
+        wrappedEngine.isLogReplayMetricsEnabled
+    }
+  }
+
+  private def collectingEngine(reports: ArrayBuffer[MetricsReport]): Engine = new Engine {
+    private val reporter = new MetricsReporter {
+      override def report(report: MetricsReport): Unit = reports += report
+    }
+
+    override def getExpressionHandler: ExpressionHandler = null
+    override def getJsonHandler: JsonHandler = null
+    override def getFileSystemClient: FileSystemClient = null
+    override def getParquetHandler: ParquetHandler = null
+    override def getMetricsReporters: util.List[MetricsReporter] =
+      util.Collections.singletonList(reporter)
+  }
+
+  private def assertArtifactMetrics(
+      metrics: LogReplayReport.ArtifactMetrics,
+      count: Long,
+      knownSizeCount: Long,
+      unknownSizeCount: Long): Unit = {
+    assert(metrics.getCount == count)
+    assert(metrics.getKnownSizeCount == knownSizeCount)
+    assert(metrics.getUnknownSizeCount == unknownSizeCount)
+    if (knownSizeCount == 0) {
+      assert(metrics.getTotalKnownSizeInBytes == 0)
+      assert(metrics.getMinKnownSizeInBytes == null)
+      assert(metrics.getMaxKnownSizeInBytes == null)
+      assert(metrics.getSizeStandardDeviationInBytes == null)
+    } else {
+      assert(metrics.getTotalKnownSizeInBytes > 0)
+      assert(metrics.getMinKnownSizeInBytes > 0)
+      assert(metrics.getMaxKnownSizeInBytes >= metrics.getMinKnownSizeInBytes)
+      assert(metrics.getSizeStandardDeviationInBytes >= 0)
+    }
+  }
+
+  private def assertKnownSizes(
+      metrics: LogReplayReport.ArtifactMetrics,
+      expectedSizes: Seq[Long]): Unit = {
+    assert(metrics.getCount == expectedSizes.size)
+    assert(metrics.getKnownSizeCount == expectedSizes.size)
+    assert(metrics.getUnknownSizeCount == 0)
+    assert(metrics.getTotalKnownSizeInBytes == expectedSizes.sum)
+    assert(metrics.getMinKnownSizeInBytes == expectedSizes.min)
+    assert(metrics.getMaxKnownSizeInBytes == expectedSizes.max)
+    val mean = expectedSizes.sum.toDouble / expectedSizes.size
+    val expectedStandardDeviation =
+      math.sqrt(expectedSizes.map(size => math.pow(size - mean, 2)).sum / expectedSizes.size)
+    assert(math.abs(metrics.getSizeStandardDeviationInBytes - expectedStandardDeviation) < 1e-9)
+  }
+}


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

Adds opt-in Kernel log-replay telemetry for diagnosing large Delta-log replay failures such as ES-2024524.

- Uses a default-off Engine/FileIO configuration capability.
- Emits a bounded preflight report before replay and a final best-effort report after completion or ordinary failure.
- Correlates reports with stable replay, snapshot, table, and event identifiers.
- Reports pagination-aware top-level artifacts and manifest-discovered V2 sidecar aggregates without extra filesystem I/O or file-path disclosure.
- Preserves preflight-only behavior for early close and Error/OOM paths.

Related to ES-2024524.

## How was this patch tested?

- `build/sbt 'kernelApi/testOnly io.delta.kernel.internal.replay.ActionsIteratorSuite'`\n- `build/sbt 'kernelApi/testOnly io.delta.kernel.internal.metrics.MetricsReportSerializerSuite'`\n- `build/sbt 'kernelApi/testOnly io.delta.kernel.internal.replay.PaginationContextSuite'`\n- `build/sbt 'kernelDefaults/testOnly io.delta.kernel.defaults.metrics.LogReplayTelemetrySuite'`\n- `build/sbt 'kernelDefaults/testOnly io.delta.kernel.defaults.PaginatedScanSuite'`\n\nThe focused suites cover disabled/enabled telemetry, reporter failures, Error/OOM preflight-only semantics, pagination resume, V2 sidecars, compaction resolution, correlation, serialization redaction, and preflight timing.\n\n## Does this PR introduce _any_ user-facing changes?\n\nNo. The diagnostic telemetry is disabled by default and is intended for connector/runtime observability.