### PR TITLE
[Kernel] Store the AddFile list (allFiles) in CRCInfo

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checksum/CRCInfo.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checksum/CRCInfo.java
@@ -21,6 +21,7 @@ import static java.util.Objects.requireNonNull;
 import io.delta.kernel.data.ColumnVector;
 import io.delta.kernel.data.ColumnarBatch;
 import io.delta.kernel.data.Row;
+import io.delta.kernel.internal.actions.AddFile;
 import io.delta.kernel.internal.actions.DomainMetadata;
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.actions.Protocol;
@@ -56,6 +57,7 @@ public class CRCInfo {
   private static final String SET_TRANSACTIONS = "setTransactions";
   private static final String NUM_DELETED_RECORDS_OPT = "numDeletedRecordsOpt";
   private static final String NUM_DELETION_VECTORS_OPT = "numDeletionVectorsOpt";
+  private static final String ALL_FILES = "allFiles";
   private static final String HISTOGRAM_OPT = "histogramOpt";
 
   public static final StructType CRC_FILE_SCHEMA =
@@ -73,11 +75,15 @@ public class CRCInfo {
           .add(
               SET_TRANSACTIONS, new ArrayType(SetTransaction.FULL_SCHEMA, false), /*nullable*/ true)
           .add(NUM_DELETED_RECORDS_OPT, LongType.LONG, /*nullable*/ true)
-          .add(NUM_DELETION_VECTORS_OPT, LongType.LONG, /*nullable*/ true);
+          .add(NUM_DELETION_VECTORS_OPT, LongType.LONG, /*nullable*/ true)
+          .add(ALL_FILES, new ArrayType(AddFile.FULL_SCHEMA, false), /*nullable*/ true);
 
   // Used by ChecksumReader to support reading CRC files with the legacy "histogramOpt" field.
   public static final StructType CRC_FILE_READ_SCHEMA =
       CRC_FILE_SCHEMA.add(HISTOGRAM_OPT, FileSizeHistogram.FULL_SCHEMA, /*nullable*/ true);
+
+  /** AllFiles is only stored when the table has at most this many files. */
+  public static final long DEFAULT_ALL_FILES_IN_CRC_THRESHOLD = 20L;
 
   public static Optional<CRCInfo> fromColumnarBatch(
       long version, ColumnarBatch batch, int rowId, String crcFilePath) {
@@ -130,6 +136,14 @@ public class CRCInfo {
                     .collect(Collectors.toList()));
     Optional<Long> numDeletedRecords = readOptionalLong(batch, NUM_DELETED_RECORDS_OPT, rowId);
     Optional<Long> numDeletionVectors = readOptionalLong(batch, NUM_DELETION_VECTORS_OPT, rowId);
+    ColumnVector allFilesVector = batch.getColumnVector(getSchemaIndex(ALL_FILES));
+    Optional<List<AddFile>> allFiles =
+        allFilesVector.isNullAt(rowId)
+            ? Optional.empty()
+            : Optional.of(
+                VectorUtils.<Row>toJavaList(allFilesVector.getArray(rowId)).stream()
+                    .map(AddFile::new)
+                    .collect(Collectors.toList()));
 
     // protocol and metadata are nullable per fromColumnVector's implementation.
     if (protocol == null || metadata == null) {
@@ -149,7 +163,8 @@ public class CRCInfo {
             inCommitTimestamp,
             setTransactions,
             numDeletedRecords,
-            numDeletionVectors));
+            numDeletionVectors,
+            allFiles));
   }
 
   private static Optional<Long> readOptionalLong(ColumnarBatch batch, String fieldName, int rowId) {
@@ -225,6 +240,15 @@ public class CRCInfo {
                     .map(SetTransaction::fromRow)
                     .collect(Collectors.toList()));
 
+    int allFilesIdx = getSchemaIndex(ALL_FILES);
+    Optional<List<AddFile>> allFiles =
+        row.isNullAt(allFilesIdx)
+            ? Optional.empty()
+            : Optional.of(
+                VectorUtils.<Row>toJavaList(row.getArray(allFilesIdx)).stream()
+                    .map(AddFile::new)
+                    .collect(Collectors.toList()));
+
     return new CRCInfo(
         version,
         metadata,
@@ -237,7 +261,8 @@ public class CRCInfo {
         inCommitTimestamp,
         setTransactions,
         numDeletedRecords,
-        numDeletionVectors);
+        numDeletionVectors,
+        allFiles);
   }
 
   private static Optional<Long> readOptionalLongFromRow(Row row, String fieldName) {
@@ -257,6 +282,7 @@ public class CRCInfo {
   private final Optional<List<SetTransaction>> setTransactions;
   private final Optional<Long> numDeletedRecords;
   private final Optional<Long> numDeletionVectors;
+  private final Optional<List<AddFile>> allFiles;
 
   public CRCInfo(
       long version,
@@ -279,7 +305,8 @@ public class CRCInfo {
         Optional.empty() /* inCommitTimestamp */,
         Optional.empty() /* setTransactions */,
         Optional.empty() /* numDeletedRecords */,
-        Optional.empty() /* numDeletionVectors */);
+        Optional.empty() /* numDeletionVectors */,
+        Optional.empty() /* allFiles */);
   }
 
   public CRCInfo(
@@ -294,7 +321,8 @@ public class CRCInfo {
       Optional<Long> inCommitTimestamp,
       Optional<List<SetTransaction>> setTransactions,
       Optional<Long> numDeletedRecords,
-      Optional<Long> numDeletionVectors) {
+      Optional<Long> numDeletionVectors,
+      Optional<List<AddFile>> allFiles) {
     checkArgument(tableSizeBytes >= 0);
     checkArgument(numFiles >= 0);
     // Live Domain Metadata actions at this version, excluding tombstones.
@@ -335,6 +363,16 @@ public class CRCInfo {
         "numDeletedRecords and numDeletionVectors must both be present or both absent");
     numDeletedRecords.ifPresent(n -> checkArgument(n >= 0, "numDeletedRecords must be >= 0"));
     numDeletionVectors.ifPresent(n -> checkArgument(n >= 0, "numDeletionVectors must be >= 0"));
+    // The complete list of live AddFile actions at this version, when small enough to store.
+    // When present it must be consistent with numFiles.
+    this.allFiles = requireNonNull(allFiles);
+    allFiles.ifPresent(
+        files ->
+            checkArgument(
+                files.size() == numFiles,
+                "allFiles size (%s) must match numFiles (%s)",
+                files.size(),
+                numFiles));
   }
 
   /** Used by callers to supply an ICT that cannot be derived from the file actions alone. */
@@ -351,7 +389,8 @@ public class CRCInfo {
         inCommitTimestamp,
         setTransactions,
         numDeletedRecords,
-        numDeletionVectors);
+        numDeletionVectors,
+        allFiles);
   }
 
   /** The version of the Delta table that this CRCInfo represents. */
@@ -412,6 +451,11 @@ public class CRCInfo {
     return inCommitTimestamp;
   }
 
+  /** The complete list of live {@link AddFile} actions comprising the table at this version. */
+  public Optional<List<AddFile>> getAllFiles() {
+    return allFiles;
+  }
+
   /**
    * Encode as a {@link Row} object with the schema {@link CRCInfo#CRC_FILE_SCHEMA}.
    *
@@ -451,6 +495,13 @@ public class CRCInfo {
                     SetTransaction.FULL_SCHEMA)));
     numDeletedRecords.ifPresent(n -> values.put(getSchemaIndex(NUM_DELETED_RECORDS_OPT), n));
     numDeletionVectors.ifPresent(n -> values.put(getSchemaIndex(NUM_DELETION_VECTORS_OPT), n));
+    allFiles.ifPresent(
+        files ->
+            values.put(
+                getSchemaIndex(ALL_FILES),
+                VectorUtils.buildArrayValue(
+                    files.stream().map(AddFile::toRow).collect(Collectors.toList()),
+                    AddFile.FULL_SCHEMA)));
     return new GenericRow(CRC_FILE_SCHEMA, values);
   }
 
@@ -468,7 +519,8 @@ public class CRCInfo {
         inCommitTimestamp,
         setTransactions,
         numDeletedRecords,
-        numDeletionVectors);
+        numDeletionVectors,
+        allFiles);
   }
 
   @Override
@@ -488,7 +540,8 @@ public class CRCInfo {
         && inCommitTimestamp.equals(other.inCommitTimestamp)
         && setTransactions.equals(other.setTransactions)
         && numDeletedRecords.equals(other.numDeletedRecords)
-        && numDeletionVectors.equals(other.numDeletionVectors);
+        && numDeletionVectors.equals(other.numDeletionVectors)
+        && allFiles.equals(other.allFiles);
   }
 
   private static int getSchemaIndex(String fieldName) {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checksum/ChecksumUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checksum/ChecksumUtils.java
@@ -25,6 +25,7 @@ import io.delta.kernel.data.FilteredColumnarBatch;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.internal.TableConfig;
 import io.delta.kernel.internal.actions.*;
+import io.delta.kernel.internal.data.StructRow;
 import io.delta.kernel.internal.fs.Path;
 import io.delta.kernel.internal.replay.ActionWrapper;
 import io.delta.kernel.internal.replay.ActionsIterator;
@@ -102,6 +103,7 @@ public class ChecksumUtils {
    *   <li>File size histogram
    *   <li>Domain metadata information
    *   <li>Deletion-vector metrics
+   *   <li>Add file list (optional)
    * </ul>
    *
    * <p>If a checksum file already exists for exactly this version, the existing {@link CRCInfo} is
@@ -152,6 +154,7 @@ public class ChecksumUtils {
    *   <li>File size histogram
    *   <li>Domain metadata information
    *   <li>Deletion-vector metrics
+   *   <li>Add file list (optional)
    * </ul>
    *
    * <p>Note: For very large tables, this operation may be expensive as it requires scanning the
@@ -160,6 +163,10 @@ public class ChecksumUtils {
    * <p>The returned {@link CRCInfo} does not carry an in-commit timestamp, which is not derivable
    * from the file actions this replay reads. A caller that holds the commit's {@code CommitInfo}
    * can inject it via {@link CRCInfo#withInCommitTimestamp(Optional)}.
+   *
+   * <p>The full list of {@link CRCInfo#getAllFiles() allFiles} is collected when the table is
+   * within {@link CRCInfo#DEFAULT_ALL_FILES_IN_CRC_THRESHOLD}; use {@link #computeChecksum(Engine,
+   * LogSegment, boolean)} to disable that collection.
    *
    * @param engine The Engine instance used to access the underlying storage
    * @param logSegmentAtVersion The LogSegment instance of the table at a specific version
@@ -177,6 +184,26 @@ public class ChecksumUtils {
    * by the full-replay path; it is only consulted when that property is set.
    */
   public static CRCInfo computeChecksum(Engine engine, LogSegment logSegmentAtVersion, Clock clock)
+      throws IOException {
+    return computeChecksum(engine, logSegmentAtVersion, clock, /* collectAllFiles */ true);
+  }
+
+  /**
+   * Computes the state of a Delta table at the provided snapshot's version, optionally collecting
+   * the full {@link AddFile} list.
+   */
+  public static CRCInfo computeChecksum(
+      Engine engine, LogSegment logSegmentAtVersion, boolean collectAllFiles) throws IOException {
+    return computeChecksum(engine, logSegmentAtVersion, System::currentTimeMillis, collectAllFiles);
+  }
+
+  /**
+   * Computes the state of a Delta table at the provided snapshot's version, taking both an explicit
+   * {@link Clock} (for the {@code delta.setTransactionRetentionDuration} cutoff) and a flag
+   * controlling whether the full {@link AddFile} list is collected.
+   */
+  public static CRCInfo computeChecksum(
+      Engine engine, LogSegment logSegmentAtVersion, Clock clock, boolean collectAllFiles)
       throws IOException {
     requireNonNull(engine);
     requireNonNull(logSegmentAtVersion);
@@ -196,13 +223,14 @@ public class ChecksumUtils {
                 lastSeenCrcInfo.get(),
                 engine,
                 logSegmentAtVersion,
-                /* canBuildWithOnlyRequiredFields */ false)
+                /* canBuildWithOnlyRequiredFields */ false,
+                collectAllFiles)
             : Optional.empty();
 
     // Use incrementally built CRC if available, otherwise do full log replay
     return incrementallyBuiltCrc.isPresent()
         ? incrementallyBuiltCrc.get()
-        : buildCrcInfoWithFullLogReplay(engine, logSegmentAtVersion, clock);
+        : buildCrcInfoWithFullLogReplay(engine, logSegmentAtVersion, clock, collectAllFiles);
   }
 
   /**
@@ -220,7 +248,11 @@ public class ChecksumUtils {
       Engine engine, LogSegment logSegment, Optional<CRCInfo> lastSeenCrcInfo) throws IOException {
     return lastSeenCrcInfo.isPresent()
         ? buildCrcInfoIncrementally(
-            lastSeenCrcInfo.get(), engine, logSegment, /* canBuildWithOnlyRequiredFields */ true)
+            lastSeenCrcInfo.get(),
+            engine,
+            logSegment,
+            /* canBuildWithOnlyRequiredFields */ true,
+            /* collectAllFiles */ true)
         : Optional.empty();
   }
 
@@ -229,16 +261,20 @@ public class ChecksumUtils {
    *
    * @param engine The engine instance
    * @param logSegmentAtVersion The log segment at the target version
+   * @param collectAllFiles whether to collect the full {@link AddFile} list (up to the threshold)
    * @return The complete CRC info
    */
   private static CRCInfo buildCrcInfoWithFullLogReplay(
-      Engine engine, LogSegment logSegmentAtVersion, Clock clock) throws IOException {
+      Engine engine, LogSegment logSegmentAtVersion, Clock clock, boolean collectAllFiles)
+      throws IOException {
 
     StateTracker state = new StateTracker();
     state.collectSetTransactions = true;
     // Make the full-replay path collect every appId so retention filtering runs first. This
     // prevents expired appIds from being counted towards the threshold.
     state.abandonAboveThreshold = false;
+    // Collect the full AddFile list up to the threshold; abandoned automatically if exceeded.
+    state.collectAllFiles = collectAllFiles;
 
     // Process logs and update state
     try (CreateCheckpointIterator checkpointIterator =
@@ -310,7 +346,8 @@ public class ChecksumUtils {
         filterAndBoundSetTransactions(
             state.collectedSetTransactions(), finalMetadata, clock, state.setTransactionsThreshold),
         dvMetrics.numDeletedRecords,
-        dvMetrics.numDeletionVectors);
+        dvMetrics.numDeletionVectors,
+        state.collectedAllFiles());
   }
 
   /**
@@ -322,13 +359,16 @@ public class ChecksumUtils {
    * @param logSegment The log segment to process
    * @param canBuildWithOnlyRequiredFields If true, allows building CRC with only required fields.
    *     Tolerates missing optional fields.
+   * @param collectAllFiles If true, maintain the full {@link AddFile} list ({@link
+   *     CRCInfo#getAllFiles()}) when the base CRC carries it; if false, leave it absent.
    * @return Optional containing the new CRC info, or empty if fallback is needed
    */
   private static Optional<CRCInfo> buildCrcInfoIncrementally(
       CRCInfo lastSeenCrcInfo,
       Engine engine,
       LogSegment logSegment,
-      boolean canBuildWithOnlyRequiredFields)
+      boolean canBuildWithOnlyRequiredFields,
+      boolean collectAllFiles)
       throws IOException {
     long startTime = System.currentTimeMillis();
     if (!canBuildWithOnlyRequiredFields && !lastSeenCrcInfo.getDomainMetadata().isPresent()) {
@@ -368,6 +408,16 @@ public class ChecksumUtils {
     // Obtain deletion-vector metrics from the base CRC to allow incremental folding.
     lastSeenCrcInfo.getNumDeletionVectors().ifPresent(n -> state.numDeletionVectors.add(n));
     lastSeenCrcInfo.getNumDeletedRecords().ifPresent(n -> state.numDeletedRecords.add(n));
+    // Incrementally update allFiles only when the base CRC already has it.
+    if (collectAllFiles) {
+      lastSeenCrcInfo
+          .getAllFiles()
+          .ifPresent(
+              baseFiles -> {
+                state.collectAllFiles = true;
+                baseFiles.forEach(f -> state.addFilesByIdentity.put(FileIdentity.of(f), f));
+              });
+    }
 
     // TODO: use compacted logs.
     List<FileStatus> deltaFiles =
@@ -456,6 +506,12 @@ public class ChecksumUtils {
             state.fileCount.decrement();
             // Subtract the removed file's deletion-vector metrics.
             applyDeletionVectorMetrics(removeVector, REMOVE_DV_INDEX, state, i, DvDelta.REMOVE);
+
+            if (state.collectAllFiles) {
+              RemoveFile removeFile = new RemoveFile(StructRow.fromStructVector(removeVector, i));
+              state.removeAddFile(
+                  FileIdentity.of(removeFile.getPath(), removeFile.getDeletionVector()));
+            }
           }
 
           // Process domain metadata, protocol, metadata, and transactions
@@ -507,6 +563,12 @@ public class ChecksumUtils {
     // Omit DV stats if the seed is unreliable (base CRC lacked DV metrics on a DV-enabled table).
     DvMetrics finalDvMetrics = dvMetricsFor(finalProtocol, state, dvSeedReliable);
 
+    long finalNumFiles = state.fileCount.longValue() + lastSeenCrcInfo.getNumFiles();
+    // Only keep the incrementally-maintained allFiles if it stayed consistent with the computed
+    // file count. Else drop it.
+    Optional<List<AddFile>> finalAllFiles =
+        state.collectedAllFiles().filter(files -> files.size() == finalNumFiles);
+
     // Build and return the new CRC info
     return Optional.of(
         new CRCInfo(
@@ -514,14 +576,15 @@ public class ChecksumUtils {
             finalMetadata,
             finalProtocol,
             state.tableSizeByte.longValue() + lastSeenCrcInfo.getTableSizeBytes(),
-            state.fileCount.longValue() + lastSeenCrcInfo.getNumFiles(),
+            finalNumFiles,
             Optional.empty(),
             finalDomainMetadata,
             finalHistogram,
             Optional.empty() /* inCommitTimestamp */,
             incrementalSetTransactions,
             finalDvMetrics.numDeletedRecords,
-            finalDvMetrics.numDeletionVectors));
+            finalDvMetrics.numDeletionVectors,
+            finalAllFiles));
   }
 
   /** Processes an add file record and updates the state tracker. */
@@ -537,6 +600,10 @@ public class ChecksumUtils {
       state.addedFileSizeHistogram.insert(fileSize);
       state.fileCount.increment();
       applyDeletionVectorMetrics(addVector, ADD_DV_INDEX, state, rowId, DvDelta.ADD);
+
+      if (state.collectAllFiles) {
+        state.recordAddFile(new AddFile(StructRow.fromStructVector(addVector, rowId)));
+      }
     }
   }
 
@@ -635,14 +702,23 @@ public class ChecksumUtils {
     Map<String, DomainMetadata> domainMetadataMap = new HashMap<>();
     final Map<String, SetTransaction> setTransactionsByAppId = new LinkedHashMap<>();
     boolean collectSetTransactions = false;
+
+    // Set transactions logic.
     long setTransactionsThreshold = DEFAULT_SET_TRANSACTIONS_IN_CRC_THRESHOLD;
     // When true, abandon collection once the distinct-appId count exceeds the threshold. The
     // full-replay path disables this so retention filtering runs before the threshold check.
     boolean abandonAboveThreshold = true;
 
-    // Deletion-vector metrics 2 fields.
+    // Deletion-vector metrics (2 fields).
     LongAdder numDeletionVectors = new LongAdder();
     LongAdder numDeletedRecords = new LongAdder();
+
+    // AddFiles logic.
+    final Map<FileIdentity, AddFile> addFilesByIdentity = new LinkedHashMap<>();
+    // We are iterating in reverse, so we track already seen so most recent actions take precedence.
+    final Set<FileIdentity> seenIdentities = new HashSet<>();
+    boolean collectAllFiles = false;
+    long allFilesThreshold = CRCInfo.DEFAULT_ALL_FILES_IN_CRC_THRESHOLD;
 
     /** Records a SetTransaction if collecting and its appId is not already seen. */
     void recordSetTransaction(SetTransaction txn) {
@@ -663,6 +739,84 @@ public class ChecksumUtils {
       return collectSetTransactions
           ? Optional.of(new ArrayList<>(setTransactionsByAppId.values()))
           : Optional.empty();
+    }
+
+    /** Records a live AddFile if collecting, unless a newer action for its identity was seen. */
+    void recordAddFile(AddFile addFile) {
+      if (!collectAllFiles) {
+        return;
+      }
+      FileIdentity identity = FileIdentity.of(addFile);
+      // Don't record if a later action for this identity has already been seen.
+      if (!seenIdentities.add(identity)) {
+        return;
+      }
+      addFilesByIdentity.put(identity, addFile);
+      if (addFilesByIdentity.size() > allFilesThreshold) {
+        collectAllFiles = false;
+        addFilesByIdentity.clear();
+        seenIdentities.clear();
+      }
+    }
+
+    /** Removes a live AddFile by (path, dv) identity if collecting. */
+    void removeAddFile(FileIdentity identity) {
+      if (!collectAllFiles) {
+        return;
+      }
+      // A remove that was superseded by a later add must not delete that add's entry.
+      if (!seenIdentities.add(identity)) {
+        return;
+      }
+      addFilesByIdentity.remove(identity);
+    }
+
+    /** The collected allFiles list, or empty if collection was disabled or exceeded threshold. */
+    Optional<List<AddFile>> collectedAllFiles() {
+      return collectAllFiles
+          ? Optional.of(new ArrayList<>(addFilesByIdentity.values()))
+          : Optional.empty();
+    }
+  }
+
+  /**
+   * Identity of a file action for allFiles bookkeeping: its path together with its deletion-vector
+   * unique id (empty when the file has no DV). Two actions match iff both agree, so an
+   * add-with-new-DV and a remove-of-the-old-file for the same path are distinct entries.
+   *
+   * <p>TODO: Refactor to Record type if Java 16
+   */
+  private static final class FileIdentity {
+    private final String path;
+    private final Optional<String> dvId;
+
+    private FileIdentity(String path, Optional<String> dvId) {
+      this.path = path;
+      this.dvId = dvId;
+    }
+
+    static FileIdentity of(AddFile addFile) {
+      return new FileIdentity(
+          addFile.getPath(),
+          addFile.getDeletionVector().map(DeletionVectorDescriptor::getUniqueId));
+    }
+
+    static FileIdentity of(String path, Optional<DeletionVectorDescriptor> dv) {
+      return new FileIdentity(path, dv.map(DeletionVectorDescriptor::getUniqueId));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (!(o instanceof FileIdentity)) {
+        return false;
+      }
+      FileIdentity other = (FileIdentity) o;
+      return path.equals(other.path) && dvId.equals(other.dvId);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(path, dvId);
     }
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checksum/ChecksumUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checksum/ChecksumUtils.java
@@ -25,6 +25,7 @@ import io.delta.kernel.data.FilteredColumnarBatch;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.internal.TableConfig;
 import io.delta.kernel.internal.actions.*;
+import io.delta.kernel.internal.annotation.VisibleForTesting;
 import io.delta.kernel.internal.data.StructRow;
 import io.delta.kernel.internal.fs.Path;
 import io.delta.kernel.internal.replay.ActionWrapper;
@@ -82,7 +83,7 @@ public class ChecksumUtils {
    * its "already seen" set. Unlike the live-file count, this grows with the number of add/remove
    * actions across the folded range (e.g. many rewrites).
    */
-  private static final int MAX_SEEN_IDENTITIES = 1000;
+  @VisibleForTesting static final int MAX_SEEN_IDENTITIES = 1000;
 
   private static final Set<String> INCREMENTAL_SUPPORTED_OPS =
       Collections.unmodifiableSet(
@@ -701,7 +702,8 @@ public class ChecksumUtils {
   }
 
   /** Class for tracking state during log processing. */
-  private static class StateTracker {
+  @VisibleForTesting
+  static class StateTracker {
     Optional<Metadata> metadataFromLog = Optional.empty();
     Optional<Protocol> protocolFromLog = Optional.empty();
     LongAdder tableSizeByte = new LongAdder();

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checksum/ChecksumUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checksum/ChecksumUtils.java
@@ -77,6 +77,13 @@ public class ChecksumUtils {
    */
   public static final long DEFAULT_SET_TRANSACTIONS_IN_CRC_THRESHOLD = 100L;
 
+  /**
+   * Upper bound on the number of distinct file identities the incremental allFiles fold tracks in
+   * its "already seen" set. Unlike the live-file count, this grows with the number of add/remove
+   * actions across the folded range (e.g. many rewrites).
+   */
+  private static final int MAX_SEEN_IDENTITIES = 1000;
+
   private static final Set<String> INCREMENTAL_SUPPORTED_OPS =
       Collections.unmodifiableSet(
           new HashSet<>(
@@ -752,14 +759,12 @@ public class ChecksumUtils {
       }
       UniqueFileActionTuple identity = LogReplayUtils.getUniqueFileAction(addFile);
       // Don't record if a later action for this identity has already been seen.
-      if (!seenIdentities.add(identity)) {
+      if (!markSeen(identity)) {
         return;
       }
       addFilesByIdentity.put(identity, addFile);
       if (addFilesByIdentity.size() > allFilesThreshold) {
-        collectAllFiles = false;
-        addFilesByIdentity.clear();
-        seenIdentities.clear();
+        abandonAllFiles();
       }
     }
 
@@ -769,10 +774,38 @@ public class ChecksumUtils {
         return;
       }
       // A remove that was superseded by a later add must not delete that add's entry.
-      if (!seenIdentities.add(identity)) {
+      if (!markSeen(identity)) {
         return;
       }
       addFilesByIdentity.remove(identity);
+    }
+
+    /**
+     * Records {@code identity} as seen and returns true if it had not been seen before (so the
+     * caller should apply the action). Abandons allFiles collection and returns false if adding it
+     * would push the seen-set past {@link #MAX_SEEN_IDENTITIES}, bounding memory on churn-heavy
+     * ranges.
+     *
+     * <p>Delta files are replayed in reverse version order, so an identity is marked before its
+     * action is applied; the most recent action for a file wins and older duplicates are skipped.
+     */
+    private boolean markSeen(UniqueFileActionTuple identity) {
+      if (seenIdentities.contains(identity)) {
+        return false;
+      }
+      if (seenIdentities.size() >= MAX_SEEN_IDENTITIES) {
+        abandonAllFiles();
+        return false;
+      }
+      seenIdentities.add(identity);
+      return true;
+    }
+
+    /** Stops allFiles collection and releases the memory held for it. */
+    private void abandonAllFiles() {
+      collectAllFiles = false;
+      addFilesByIdentity.clear();
+      seenIdentities.clear();
     }
 
     /** The collected allFiles list, or empty if collection was disabled or exceeded threshold. */

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checksum/ChecksumUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checksum/ChecksumUtils.java
@@ -30,6 +30,8 @@ import io.delta.kernel.internal.fs.Path;
 import io.delta.kernel.internal.replay.ActionWrapper;
 import io.delta.kernel.internal.replay.ActionsIterator;
 import io.delta.kernel.internal.replay.CreateCheckpointIterator;
+import io.delta.kernel.internal.replay.LogReplayUtils;
+import io.delta.kernel.internal.replay.LogReplayUtils.UniqueFileActionTuple;
 import io.delta.kernel.internal.snapshot.LogSegment;
 import io.delta.kernel.internal.stats.FileSizeHistogram;
 import io.delta.kernel.internal.tablefeatures.TableFeatures;
@@ -415,7 +417,8 @@ public class ChecksumUtils {
           .ifPresent(
               baseFiles -> {
                 state.collectAllFiles = true;
-                baseFiles.forEach(f -> state.addFilesByIdentity.put(FileIdentity.of(f), f));
+                baseFiles.forEach(
+                    f -> state.addFilesByIdentity.put(LogReplayUtils.getUniqueFileAction(f), f));
               });
     }
 
@@ -509,8 +512,7 @@ public class ChecksumUtils {
 
             if (state.collectAllFiles) {
               RemoveFile removeFile = new RemoveFile(StructRow.fromStructVector(removeVector, i));
-              state.removeAddFile(
-                  FileIdentity.of(removeFile.getPath(), removeFile.getDeletionVector()));
+              state.removeAddFile(LogReplayUtils.getUniqueFileAction(removeFile));
             }
           }
 
@@ -713,10 +715,12 @@ public class ChecksumUtils {
     LongAdder numDeletionVectors = new LongAdder();
     LongAdder numDeletedRecords = new LongAdder();
 
-    // AddFiles logic.
-    final Map<FileIdentity, AddFile> addFilesByIdentity = new LinkedHashMap<>();
+    // AddFiles logic. Keyed on UniqueFileActionTuple (path URI, deletionVectorId) -- the same
+    // file identity used by log replay -- so an add-with-new-DV and a remove-of-the-old-file for
+    // the same path are distinct entries.
+    final Map<UniqueFileActionTuple, AddFile> addFilesByIdentity = new LinkedHashMap<>();
     // We are iterating in reverse, so we track already seen so most recent actions take precedence.
-    final Set<FileIdentity> seenIdentities = new HashSet<>();
+    final Set<UniqueFileActionTuple> seenIdentities = new HashSet<>();
     boolean collectAllFiles = false;
     long allFilesThreshold = CRCInfo.DEFAULT_ALL_FILES_IN_CRC_THRESHOLD;
 
@@ -746,7 +750,7 @@ public class ChecksumUtils {
       if (!collectAllFiles) {
         return;
       }
-      FileIdentity identity = FileIdentity.of(addFile);
+      UniqueFileActionTuple identity = LogReplayUtils.getUniqueFileAction(addFile);
       // Don't record if a later action for this identity has already been seen.
       if (!seenIdentities.add(identity)) {
         return;
@@ -760,7 +764,7 @@ public class ChecksumUtils {
     }
 
     /** Removes a live AddFile by (path, dv) identity if collecting. */
-    void removeAddFile(FileIdentity identity) {
+    void removeAddFile(UniqueFileActionTuple identity) {
       if (!collectAllFiles) {
         return;
       }
@@ -776,47 +780,6 @@ public class ChecksumUtils {
       return collectAllFiles
           ? Optional.of(new ArrayList<>(addFilesByIdentity.values()))
           : Optional.empty();
-    }
-  }
-
-  /**
-   * Identity of a file action for allFiles bookkeeping: its path together with its deletion-vector
-   * unique id (empty when the file has no DV). Two actions match iff both agree, so an
-   * add-with-new-DV and a remove-of-the-old-file for the same path are distinct entries.
-   *
-   * <p>TODO: Refactor to Record type if Java 16
-   */
-  private static final class FileIdentity {
-    private final String path;
-    private final Optional<String> dvId;
-
-    private FileIdentity(String path, Optional<String> dvId) {
-      this.path = path;
-      this.dvId = dvId;
-    }
-
-    static FileIdentity of(AddFile addFile) {
-      return new FileIdentity(
-          addFile.getPath(),
-          addFile.getDeletionVector().map(DeletionVectorDescriptor::getUniqueId));
-    }
-
-    static FileIdentity of(String path, Optional<DeletionVectorDescriptor> dv) {
-      return new FileIdentity(path, dv.map(DeletionVectorDescriptor::getUniqueId));
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (!(o instanceof FileIdentity)) {
-        return false;
-      }
-      FileIdentity other = (FileIdentity) o;
-      return path.equals(other.path) && dvId.equals(other.dvId);
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(path, dvId);
     }
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/LogReplayUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/LogReplayUtils.java
@@ -19,7 +19,9 @@ import static io.delta.kernel.internal.util.Preconditions.checkArgument;
 
 import io.delta.kernel.data.ColumnVector;
 import io.delta.kernel.data.ColumnarBatch;
+import io.delta.kernel.internal.actions.AddFile;
 import io.delta.kernel.internal.actions.DeletionVectorDescriptor;
+import io.delta.kernel.internal.actions.RemoveFile;
 import io.delta.kernel.internal.util.Tuple2;
 import io.delta.kernel.types.DataType;
 import io.delta.kernel.types.StructType;
@@ -46,6 +48,20 @@ public class LogReplayUtils {
             .map(DeletionVectorDescriptor::getUniqueId);
 
     return new UniqueFileActionTuple(pathAsUri, dvId);
+  }
+
+  /** Builds the unique file-action key for a materialized {@link AddFile}. */
+  public static UniqueFileActionTuple getUniqueFileAction(AddFile addFile) {
+    return new UniqueFileActionTuple(
+        pathToUri(addFile.getPath()),
+        addFile.getDeletionVector().map(DeletionVectorDescriptor::getUniqueId));
+  }
+
+  /** Builds the unique file-action key for a materialized {@link RemoveFile}. */
+  public static UniqueFileActionTuple getUniqueFileAction(RemoveFile removeFile) {
+    return new UniqueFileActionTuple(
+        pathToUri(removeFile.getPath()),
+        removeFile.getDeletionVector().map(DeletionVectorDescriptor::getUniqueId));
   }
 
   static boolean[] prepareSelectionVectorBuffer(boolean[] currentSelectionVector, int newSize) {

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/checksum/CRCInfoFromRowSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/checksum/CRCInfoFromRowSuite.scala
@@ -15,11 +15,12 @@
  */
 package io.delta.kernel.internal.checksum
 
+import java.lang.{Boolean => JBoolean, Long => JLong}
 import java.util
 import java.util.{Collections, Optional}
 
 import io.delta.kernel.data.Row
-import io.delta.kernel.internal.actions.{DomainMetadata, Format, Metadata, Protocol, SetTransaction}
+import io.delta.kernel.internal.actions.{AddFile, DomainMetadata, Format, Metadata, Protocol, SetTransaction}
 import io.delta.kernel.internal.data.GenericRow
 import io.delta.kernel.internal.stats.FileSizeHistogram
 import io.delta.kernel.internal.types.DataTypeJsonSerDe
@@ -56,6 +57,22 @@ class CRCInfoFromRowSuite extends AnyFunSuite {
     val bytes = Array(fileCount * 100, 0L)
     new FileSizeHistogram(boundaries, counts, bytes)
   }
+
+  /** Builds a minimal AddFile row for allFiles round-trip tests. */
+  private def testAddFileRow(path: String, size: Long): Row =
+    AddFile.createAddFileRow(
+      null, // statistics
+      path,
+      stringStringMapValue(Collections.emptyMap[String, String]()),
+      size.asInstanceOf[JLong],
+      20L.asInstanceOf[JLong], // modificationTime
+      true.asInstanceOf[JBoolean], // dataChange
+      Optional.empty(), // deletionVector
+      Optional.empty(), // tags
+      Optional.empty(), // baseRowId
+      Optional.empty(), // defaultRowCommitVersion
+      Optional.empty() // stats
+    )
 
   private def domainMetadataSet(entries: (String, String)*): util.Set[DomainMetadata] = {
     val set = new util.HashSet[DomainMetadata]()
@@ -131,9 +148,10 @@ class CRCInfoFromRowSuite extends AnyFunSuite {
       Optional.empty(),
       Optional.empty(),
       Optional.of(java.lang.Long.valueOf(1749830855993L)),
-      Optional.empty(),
-      Optional.empty(),
-      Optional.empty()))
+      /* setTransactions */ Optional.empty(),
+      /* numDeletedRecords */ Optional.empty(),
+      /* numDeletionVectors */ Optional.empty(),
+      /* allFiles */ Optional.empty()))
   }
 
   test("round-trips with setTransactions present") {
@@ -147,11 +165,48 @@ class CRCInfoFromRowSuite extends AnyFunSuite {
       Optional.empty(),
       Optional.empty(),
       Optional.empty(),
-      Optional.of(util.Arrays.asList(
+      /* setTransactions */ Optional.of(util.Arrays.asList(
         new SetTransaction("app1", 5L, Optional.of(java.lang.Long.valueOf(100L))),
         new SetTransaction("app2", 9L, Optional.empty()))),
+      /* numDeletedRecords */ Optional.empty(),
+      /* numDeletionVectors */ Optional.empty(),
+      /* allFiles */ Optional.empty()))
+  }
+
+  test("round-trips with numDeletedRecords and numDeletionVectors present") {
+    assertRoundTrips(new CRCInfo(
+      15L,
+      testMetadata,
+      testProtocol,
+      4900L,
+      49L,
       Optional.empty(),
-      Optional.empty()))
+      Optional.empty(),
+      Optional.empty(),
+      Optional.empty(),
+      /* setTransactions */ Optional.empty(),
+      /* numDeletedRecords */ Optional.of(java.lang.Long.valueOf(7L)),
+      /* numDeletionVectors */ Optional.of(java.lang.Long.valueOf(2L)),
+      /* allFiles */ Optional.empty()))
+  }
+
+  test("round-trips with allFiles present") {
+    assertRoundTrips(new CRCInfo(
+      16L,
+      testMetadata,
+      testProtocol,
+      /* tableSizeBytes */ 300L,
+      /* numFiles */ 2L,
+      Optional.empty(),
+      Optional.empty(),
+      Optional.empty(),
+      Optional.empty(),
+      /* setTransactions */ Optional.empty(),
+      /* numDeletedRecords */ Optional.empty(),
+      /* numDeletionVectors */ Optional.empty(),
+      /* allFiles */ Optional.of(util.Arrays.asList(
+        new AddFile(testAddFileRow("f1", 100L)),
+        new AddFile(testAddFileRow("f2", 200L))))))
   }
 
   test("round-trips with all optional fields present") {
@@ -159,16 +214,18 @@ class CRCInfoFromRowSuite extends AnyFunSuite {
       13L,
       testMetadata,
       testProtocol,
-      5000L,
-      50L,
+      /* tableSizeBytes */ 5000L,
+      /* numFiles */ 1L,
       Optional.of("txn-xyz"),
       Optional.of(domainMetadataSet("delta.clustering" -> "{\"cols\":[\"c1\"]}")),
       Optional.of(createTestHistogram(fileCount = 50)),
       Optional.of(java.lang.Long.valueOf(1749830871085L)),
-      Optional.of(util.Arrays.asList(
+      /* setTransactions */ Optional.of(util.Arrays.asList(
         new SetTransaction("app1", 5L, Optional.of(java.lang.Long.valueOf(100L))))),
-      Optional.of(java.lang.Long.valueOf(7L)),
-      Optional.of(java.lang.Long.valueOf(2L))))
+      /* numDeletedRecords */ Optional.of(java.lang.Long.valueOf(7L)),
+      /* numDeletionVectors */ Optional.of(java.lang.Long.valueOf(2L)),
+      /* allFiles */ Optional.of(util.Arrays.asList(
+        new AddFile(testAddFileRow("f1", 100L))))))
   }
 
   test("preserves the supplied version, independent of the row (toRow omits version)") {

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/checksum/CRCInfoReadCompatSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/checksum/CRCInfoReadCompatSuite.scala
@@ -15,13 +15,14 @@
  */
 package io.delta.kernel.internal.checksum
 
+import java.lang.{Boolean => JBoolean, Long => JLong}
 import java.util
 import java.util.{Collections, Optional}
 
 import scala.collection.JavaConverters._
 
 import io.delta.kernel.data.{ColumnarBatch, ColumnVector, Row}
-import io.delta.kernel.internal.actions.{DomainMetadata, Format, Metadata, Protocol, SetTransaction}
+import io.delta.kernel.internal.actions.{AddFile, DomainMetadata, Format, Metadata, Protocol, SetTransaction}
 import io.delta.kernel.internal.checksum.CRCInfo.{CRC_FILE_READ_SCHEMA, CRC_FILE_SCHEMA}
 import io.delta.kernel.internal.data.GenericColumnVector
 import io.delta.kernel.internal.stats.FileSizeHistogram
@@ -54,6 +55,22 @@ class CRCInfoReadCompatSuite extends AnyFunSuite with VectorTestUtils {
     stringStringMapValue(new util.HashMap[String, String]() {
       put("delta.appendOnly", "true")
     }))
+
+  /** Builds a minimal AddFile row for allFiles tests. */
+  private def testAddFileRow(path: String, size: Long): Row =
+    AddFile.createAddFileRow(
+      null, // statistics
+      path,
+      stringStringMapValue(Collections.emptyMap[String, String]()),
+      size.asInstanceOf[JLong],
+      20L.asInstanceOf[JLong], // modificationTime
+      true.asInstanceOf[JBoolean], // dataChange
+      Optional.empty(), // deletionVector
+      Optional.empty(), // tags
+      Optional.empty(), // baseRowId
+      Optional.empty(), // defaultRowCommitVersion
+      Optional.empty() // stats
+    )
 
   /** Creates a simple histogram with distinct values for identification in tests. */
   private def createTestHistogram(fileCount: Long): FileSizeHistogram = {
@@ -116,6 +133,7 @@ class CRCInfoReadCompatSuite extends AnyFunSuite with VectorTestUtils {
               CRC_FILE_SCHEMA.get("numDeletedRecordsOpt").getDataType)
           case "numDeletionVectorsOpt" => nullColumnVector(
               CRC_FILE_SCHEMA.get("numDeletionVectorsOpt").getDataType)
+          case "allFiles" => nullColumnVector(CRC_FILE_SCHEMA.get("allFiles").getDataType)
           case "fileSizeHistogram" => histogramColumnVector(fileSizeHistogram)
           case "histogramOpt" => histogramColumnVector(histogramOpt)
           case _ =>
@@ -221,6 +239,7 @@ class CRCInfoReadCompatSuite extends AnyFunSuite with VectorTestUtils {
               CRC_FILE_SCHEMA.get("numDeletedRecordsOpt").getDataType)
           case "numDeletionVectorsOpt" => nullColumnVector(
               CRC_FILE_SCHEMA.get("numDeletionVectorsOpt").getDataType)
+          case "allFiles" => nullColumnVector(CRC_FILE_SCHEMA.get("allFiles").getDataType)
           case "fileSizeHistogram" => histogramColumnVector(None)
           case _ =>
             throw new IllegalArgumentException(s"Unknown field: $fieldName")
@@ -258,6 +277,7 @@ class CRCInfoReadCompatSuite extends AnyFunSuite with VectorTestUtils {
             nullColumnVector(CRC_FILE_SCHEMA.get("numDeletedRecordsOpt").getDataType)
           case "numDeletionVectorsOpt" =>
             nullColumnVector(CRC_FILE_SCHEMA.get("numDeletionVectorsOpt").getDataType)
+          case "allFiles" => nullColumnVector(CRC_FILE_SCHEMA.get("allFiles").getDataType)
           case "fileSizeHistogram" => histogramColumnVector(None)
           case _ => throw new IllegalArgumentException(s"Unknown field: $fieldName")
         }
@@ -290,7 +310,8 @@ class CRCInfoReadCompatSuite extends AnyFunSuite with VectorTestUtils {
       /* inCommitTimestamp */ Optional.of(java.lang.Long.valueOf(1749830871085L)),
       /* setTransactions */ Optional.empty(),
       /* numDeletedRecords */ Optional.empty(),
-      /* numDeletionVectors */ Optional.empty())
+      /* numDeletionVectors */ Optional.empty(),
+      /* allFiles */ Optional.empty())
     val row = original.toRow()
     val ictIdx = CRC_FILE_SCHEMA.indexOf("inCommitTimestampOpt")
     assert(!row.isNullAt(ictIdx))
@@ -352,7 +373,8 @@ class CRCInfoReadCompatSuite extends AnyFunSuite with VectorTestUtils {
       /* inCommitTimestamp */ Optional.empty(),
       /* setTransactions */ Optional.of(txns),
       /* numDeletedRecords */ Optional.empty(),
-      /* numDeletionVectors */ Optional.empty())
+      /* numDeletionVectors */ Optional.empty(),
+      /* allFiles */ Optional.empty())
     val row = original.toRow()
     val idx = CRC_FILE_SCHEMA.indexOf("setTransactions")
     assert(!row.isNullAt(idx))
@@ -389,7 +411,8 @@ class CRCInfoReadCompatSuite extends AnyFunSuite with VectorTestUtils {
         /* inCommitTimestamp */ Optional.empty(),
         /* setTransactions */ Optional.of(dupes),
         /* numDeletedRecords */ Optional.empty(),
-        /* numDeletionVectors */ Optional.empty())
+        /* numDeletionVectors */ Optional.empty(),
+        /* allFiles */ Optional.empty())
     }
     assert(ex.getMessage.contains("unique per appId"))
   }
@@ -415,7 +438,8 @@ class CRCInfoReadCompatSuite extends AnyFunSuite with VectorTestUtils {
       /* inCommitTimestamp */ Optional.empty(),
       /* setTransactions */ Optional.empty(),
       /* numDeletedRecords */ Optional.of(java.lang.Long.valueOf(42L)),
-      /* numDeletionVectors */ Optional.of(java.lang.Long.valueOf(3L)))
+      /* numDeletionVectors */ Optional.of(java.lang.Long.valueOf(3L)),
+      /* allFiles */ Optional.empty())
     val row = withDv.toRow()
     assert(row.getLong(CRC_FILE_SCHEMA.indexOf("numDeletedRecordsOpt")) === 42L)
     assert(row.getLong(CRC_FILE_SCHEMA.indexOf("numDeletionVectorsOpt")) === 3L)
@@ -448,8 +472,74 @@ class CRCInfoReadCompatSuite extends AnyFunSuite with VectorTestUtils {
         /* inCommitTimestamp */ Optional.empty(),
         /* setTransactions */ Optional.empty(),
         /* numDeletedRecords */ Optional.of(java.lang.Long.valueOf(1L)),
-        /* numDeletionVectors */ Optional.empty())
+        /* numDeletionVectors */ Optional.empty(),
+        /* allFiles */ Optional.empty())
     }
     assert(ex.getMessage.contains("both be present or both absent"))
+  }
+
+  test("allFiles is empty when the column is null (older .crc / large table)") {
+    val batch = buildBatch(CRC_FILE_READ_SCHEMA, fileSizeHistogram = None, histogramOpt = None)
+    val crcInfo = CRCInfo.fromColumnarBatch(1L, batch, 0, "test.crc")
+    assert(crcInfo.isPresent)
+    assert(!crcInfo.get().getAllFiles.isPresent)
+  }
+
+  test("toRow serializes allFiles into the allFiles array column") {
+    val addFiles = java.util.Arrays.asList(
+      new AddFile(testAddFileRow("f1", 100L)),
+      new AddFile(testAddFileRow("f2", 200L)))
+    val original = new CRCInfo(
+      3L,
+      testMetadata,
+      testProtocol,
+      /* tableSizeBytes */ 300L,
+      /* numFiles */ 2L,
+      Optional.empty(),
+      Optional.empty(),
+      Optional.empty(),
+      /* inCommitTimestamp */ Optional.empty(),
+      /* setTransactions */ Optional.empty(),
+      /* numDeletedRecords */ Optional.empty(),
+      /* numDeletionVectors */ Optional.empty(),
+      /* allFiles */ Optional.of(addFiles))
+    val row = original.toRow()
+    val allFilesIdx = CRC_FILE_SCHEMA.indexOf("allFiles")
+    assert(!row.isNullAt(allFilesIdx))
+    assert(row.getArray(allFilesIdx).getSize === 2)
+  }
+
+  test("toRow leaves allFiles column null when absent") {
+    val original = new CRCInfo(
+      4L,
+      testMetadata,
+      testProtocol,
+      1000L,
+      10L,
+      Optional.empty(),
+      Optional.empty(),
+      Optional.empty())
+    assert(original.toRow().isNullAt(CRC_FILE_SCHEMA.indexOf("allFiles")))
+  }
+
+  test("constructor rejects allFiles whose size disagrees with numFiles") {
+    val oneFile = java.util.Collections.singletonList(new AddFile(testAddFileRow("f1", 100L)))
+    val ex = intercept[IllegalArgumentException] {
+      new CRCInfo(
+        5L,
+        testMetadata,
+        testProtocol,
+        100L,
+        /* numFiles */ 2L, // disagrees with allFiles.size == 1
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        /* inCommitTimestamp */ Optional.empty(),
+        /* setTransactions */ Optional.empty(),
+        /* numDeletedRecords */ Optional.empty(),
+        /* numDeletionVectors */ Optional.empty(),
+        Optional.of(oneFile))
+    }
+    assert(ex.getMessage.contains("allFiles size"))
   }
 }

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/checksum/ChecksumStateTrackerSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/checksum/ChecksumStateTrackerSuite.scala
@@ -1,0 +1,103 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.internal.checksum
+
+import java.lang.{Boolean => JBoolean, Long => JLong}
+import java.util.{Collections, Optional}
+
+import io.delta.kernel.data.Row
+import io.delta.kernel.internal.actions.AddFile
+import io.delta.kernel.internal.replay.LogReplayUtils
+import io.delta.kernel.internal.replay.LogReplayUtils.UniqueFileActionTuple
+import io.delta.kernel.internal.util.VectorUtils.stringStringMapValue
+
+import org.scalatest.funsuite.AnyFunSuite
+
+/**
+ * Unit tests for [[ChecksumUtils.StateTracker]]'s allFiles bookkeeping, exercised directly rather
+ * than through a full table computation. The seen-identity cap in particular is only reachable with
+ * ~1000 distinct file actions, which is impractical to drive via real commits.
+ */
+class ChecksumStateTrackerSuite extends AnyFunSuite {
+
+  /** A minimal AddFile at the given path (unique path => unique file identity). */
+  private def addFile(path: String): AddFile = {
+    val row: Row = AddFile.createAddFileRow(
+      null, // statistics
+      path,
+      stringStringMapValue(Collections.emptyMap[String, String]()),
+      100L.asInstanceOf[JLong], // size
+      20L.asInstanceOf[JLong], // modificationTime
+      true.asInstanceOf[JBoolean], // dataChange
+      Optional.empty(), // deletionVector
+      Optional.empty(), // tags
+      Optional.empty(), // baseRowId
+      Optional.empty(), // defaultRowCommitVersion
+      Optional.empty() // stats
+    )
+    new AddFile(row)
+  }
+
+  /** The (path URI, dvId) identity for a file at the given path. */
+  private def identity(path: String): UniqueFileActionTuple =
+    LogReplayUtils.getUniqueFileAction(addFile(path))
+
+  /** A StateTracker collecting allFiles, live-file cap raised so only the seen cap can fire. */
+  private def collectingTracker(): ChecksumUtils.StateTracker = {
+    val state = new ChecksumUtils.StateTracker()
+    state.collectAllFiles = true
+    // Raise the live-file map cap so it does not fire first (we want to isolate the seen cap).
+    state.allFilesThreshold = Long.MaxValue
+    state
+  }
+
+  test("recordAddFile abandons allFiles once the seen set exceeds MAX_SEEN_IDENTITIES") {
+    val state = collectingTracker()
+    val cap = ChecksumUtils.MAX_SEEN_IDENTITIES
+
+    // Record exactly `cap` distinct adds and assert that all are collected.
+    (0 until cap).foreach(i => state.recordAddFile(addFile(s"f$i")))
+    assert(state.collectAllFiles)
+    assert(state.collectedAllFiles().isPresent)
+    assert(state.collectedAllFiles().get().size() === cap)
+
+    // Re-recording an already-seen identity is a no-op.
+    state.recordAddFile(addFile("f0"))
+    assert(state.collectAllFiles)
+    assert(state.seenIdentities.size() === cap)
+
+    // Passing threshold triggers abandoning allFiles.
+    state.recordAddFile(addFile(s"f$cap"))
+    assert(!state.collectAllFiles)
+    assert(!state.collectedAllFiles().isPresent)
+    assert(state.addFilesByIdentity.isEmpty)
+    assert(state.seenIdentities.isEmpty)
+  }
+
+  test("removeAddFile also counts toward the seen cap and can trigger abandonment") {
+    val state = collectingTracker()
+    val cap = ChecksumUtils.MAX_SEEN_IDENTITIES
+
+    // Record exactly `cap` distinct removes and assert that all are collected.
+    (0 until cap).foreach(i => state.removeAddFile(identity(s"r$i")))
+    assert(state.collectAllFiles)
+
+    // Passing threshold triggers abandoning allFiles.
+    state.removeAddFile(identity(s"r$cap"))
+    assert(!state.collectAllFiles)
+    assert(state.seenIdentities.isEmpty)
+  }
+}

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/CRCInfoSerializationSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/CRCInfoSerializationSuite.scala
@@ -92,7 +92,8 @@ class CRCInfoSerializationSuite extends AnyFunSuite {
       Optional.empty(), /* inCommitTimestamp */
       Optional.of(Collections.emptyList[SetTransaction]()), /* setTransactions */
       Optional.empty(), /* numDeletedRecords */
-      Optional.empty() /* numDeletionVectors */
+      Optional.empty(), /* numDeletionVectors */
+      Optional.empty() /* allFiles */
     )
 
     val expected =
@@ -122,7 +123,8 @@ class CRCInfoSerializationSuite extends AnyFunSuite {
       Optional.empty(), /* inCommitTimestamp */
       Optional.of(txns), /* setTransactions */
       Optional.empty(), /* numDeletedRecords */
-      Optional.empty() /* numDeletionVectors */ )
+      Optional.empty(), /* numDeletionVectors */
+      Optional.empty() /* allFiles */ )
 
     val expected =
       """{"tableSizeBytes":100,"numFiles":1,"numMetadata":1,"numProtocol":1,""" +

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ChecksumUtilsSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ChecksumUtilsSuite.scala
@@ -25,7 +25,7 @@ import io.delta.kernel.defaults.utils.WriteUtils
 import io.delta.kernel.engine.Engine
 import io.delta.kernel.expressions.{Column, Literal}
 import io.delta.kernel.internal.{SnapshotImpl, TableImpl}
-import io.delta.kernel.internal.checksum.ChecksumUtils
+import io.delta.kernel.internal.checksum.{ChecksumUtils, CRCInfo}
 import io.delta.kernel.internal.util.ManualClock
 import io.delta.kernel.types.{StringType, StructType}
 import io.delta.kernel.utils.CloseableIterable.emptyIterable
@@ -378,6 +378,140 @@ class ChecksumUtilsSuite extends AnyFunSuite with WriteUtils with LogReplayBaseS
       assert(crcInfo.getNumDeletionVectors.isPresent)
       assert(crcInfo.getNumDeletedRecords.get() === 5L)
       assert(crcInfo.getNumDeletionVectors.get() >= 1L)
+    }
+  }
+
+  test("computeChecksum populates allFiles for a small table (full replay path)") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      initialTestTable(tablePath, engine)
+
+      val snapshot1 = Table.forPath(
+        engine,
+        tablePath).getSnapshotAsOfVersion(engine, 1).asInstanceOf[SnapshotImpl]
+      val crcInfo = ChecksumUtils.computeChecksum(engine, snapshot1.getLogSegment)
+
+      assert(crcInfo.getAllFiles.isPresent)
+      assert(crcInfo.getAllFiles.get().size() === crcInfo.getNumFiles)
+      assert(crcInfo.getNumFiles > 0)
+    }
+  }
+
+  test("computeChecksum omits allFiles once the file count exceeds the threshold") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      initialTestTable(tablePath, engine)
+
+      // Append until the table has more than DEFAULT_ALL_FILES_IN_CRC_THRESHOLD (20) files.
+      var version = 1L
+      var crossedThreshold = false
+      var iterations = 0L
+      while (!crossedThreshold && iterations < CRCInfo.DEFAULT_ALL_FILES_IN_CRC_THRESHOLD + 1) {
+        val snapshot = Table.forPath(
+          engine,
+          tablePath).getSnapshotAsOfVersion(engine, version).asInstanceOf[SnapshotImpl]
+        val crc = ChecksumUtils.computeChecksum(engine, snapshot.getLogSegment)
+        if (crc.getNumFiles > CRCInfo.DEFAULT_ALL_FILES_IN_CRC_THRESHOLD) {
+          assert(
+            !crc.getAllFiles.isPresent,
+            s"expected allFiles absent at ${crc.getNumFiles} files (> threshold)")
+          crossedThreshold = true
+        } else {
+          assert(
+            crc.getAllFiles.isPresent,
+            s"expected allFiles present at ${crc.getNumFiles} files (<= threshold)")
+          assert(crc.getAllFiles.get().size() === crc.getNumFiles)
+          appendData(
+            engine,
+            tablePath,
+            isNewTable = false,
+            data = Seq(Map.empty[String, Literal] -> dataBatches1))
+          version += 1
+        }
+        iterations += 1
+      }
+      assert(crossedThreshold, "test did not grow the table beyond the allFiles threshold")
+    }
+  }
+
+  test("computeChecksum omits allFiles when collectAllFiles=false") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      initialTestTable(tablePath, engine)
+
+      val snapshot1 = Table.forPath(
+        engine,
+        tablePath).getSnapshotAsOfVersion(engine, 1).asInstanceOf[SnapshotImpl]
+
+      // Default (true) collects allFiles.
+      val withFiles = ChecksumUtils.computeChecksum(engine, snapshot1.getLogSegment)
+      val collectAllFiles = false
+      val withoutFiles =
+        ChecksumUtils.computeChecksum(engine, snapshot1.getLogSegment, collectAllFiles)
+
+      assert(withFiles.getAllFiles.isPresent)
+      assert(!withoutFiles.getAllFiles.isPresent)
+
+      assert(withoutFiles.getNumFiles === withFiles.getNumFiles)
+      assert(withoutFiles.getTableSizeBytes === withFiles.getTableSizeBytes)
+      assert(withoutFiles.getMetadata === withFiles.getMetadata)
+      assert(withoutFiles.getProtocol === withFiles.getProtocol)
+    }
+  }
+
+  test("computeChecksum maintains allFiles across an incremental commit") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      initialTestTable(tablePath, engine)
+
+      // Persist v1's checksum (with allFiles) so the next computation can build incrementally.
+      val snapshot1 = Table.forPath(
+        engine,
+        tablePath).getSnapshotAsOfVersion(engine, 1).asInstanceOf[SnapshotImpl]
+      ChecksumUtils.computeStateAndWriteChecksum(engine, snapshot1.getLogSegment)
+      val numFilesV1 = ChecksumUtils.computeChecksum(engine, snapshot1.getLogSegment).getNumFiles
+
+      appendData(
+        engine,
+        tablePath,
+        isNewTable = false,
+        data = Seq(Map.empty[String, Literal] -> dataBatches1))
+      val snapshot2 = Table.forPath(
+        engine,
+        tablePath).getSnapshotAsOfVersion(engine, 2).asInstanceOf[SnapshotImpl]
+      val crcV2 = ChecksumUtils.computeChecksum(engine, snapshot2.getLogSegment)
+
+      // allFiles is carried forward and stays consistent with the file count.
+      assert(crcV2.getVersion === 2)
+      assert(crcV2.getAllFiles.isPresent)
+      assert(crcV2.getAllFiles.get().size() === crcV2.getNumFiles)
+      assert(crcV2.getNumFiles > numFilesV1)
+    }
+  }
+
+  test("computeChecksum (incremental) resolves a file added and removed within the folded range") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      spark.sql(
+        s"CREATE TABLE delta.`$tablePath` (id LONG) USING DELTA " +
+          "TBLPROPERTIES ('delta.enableDeletionVectors' = 'false')")
+      spark.range(0, 5).write.format("delta").mode("append").save(tablePath) // v1 -> file A
+
+      deleteChecksumFileForTableUsingHadoopFs(tablePath.stripPrefix("file:"), 0 to 3)
+      val snapshot1 = Table.forPath(engine, tablePath)
+        .getSnapshotAsOfVersion(engine, 1).asInstanceOf[SnapshotImpl]
+      ChecksumUtils.computeStateAndWriteChecksum(engine, snapshot1.getLogSegment)
+      val baseCrc = ChecksumUtils.computeChecksum(engine, snapshot1.getLogSegment)
+      assert(baseCrc.getAllFiles.isPresent)
+      val numFilesV1 = baseCrc.getNumFiles
+
+      spark.range(100, 105).write.format("delta").mode("append").save(tablePath) // v2 -> file B
+      spark.sql(s"DELETE FROM delta.`$tablePath` WHERE id >= 100") // v3 -> removes file B
+      deleteChecksumFileForTableUsingHadoopFs(tablePath.stripPrefix("file:"), 2 to 3)
+
+      val snapshot3 = Table.forPath(engine, tablePath)
+        .getSnapshotAsOfVersion(engine, 3).asInstanceOf[SnapshotImpl]
+      val crcV3 = ChecksumUtils.computeChecksum(engine, snapshot3.getLogSegment)
+
+      assert(crcV3.getVersion === 3)
+      assert(crcV3.getNumFiles === numFilesV1)
+      assert(crcV3.getAllFiles.isPresent)
+      assert(crcV3.getAllFiles.get().size() === crcV3.getNumFiles)
     }
   }
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)
## Description

Add an optional `allFiles` field to `CRCInfo` holding the complete list of live `AddFile` actions comprising the table at a version. When present, a reader can obtain the table's file list directly from the checksum instead of reconstructing state from the log when absent. DBR VersionChecksum currently has this field to accelerate reads for small tables.

To bound the size of the `.crc` file, `allFiles` is stored only when the table has at most `DEFAULT_ALL_FILES_IN_CRC_THRESHOLD` (20) files (not mirroring Delta-Spark's `allFilesInCrc.thresholdNumFiles`, but instead, mirroring what the cache approves). Above the threshold the field is left absent. We are also capping the Set threshold (total number of add and remove actions) to 1000 to limit set size.

Both computation paths populate it:
- **Full log replay** collects the live `AddFile`s it already visits (memory only, no extra IO), abandoning collection if the threshold is crossed.
- **Incremental** computation maintains the list from the base CRC by applying the new commits' adds/removes by path. It maintains `allFiles` ONLY when the base CRC carried it, and drops the list otherwise (for accuracy).

Backward compatibility: the field is nullable in `CRC_FILE_SCHEMA` and defaulted to empty by the pre-existing 8-arg `CRCInfo` constructor, so older `.crc` files read back with an empty `allFiles` and existing callers are unaffected (only a small KB size increase when enabled for addFiles and set size, but added gate just in case caller wanted to disable). The constructor also asserts that a present `allFiles` has size equal to `numFiles` (safety check).

## How was this patch tested?
- `CRCInfoReadCompatSuite`: `allFiles` empty when the column is null (older files / large tables); `toRow` serializes it into the array column and leaves it null when absent; the constructor rejects an `allFiles` list whose size disagrees with `numFiles`.
- `ChecksumUtilsSuite`: `computeChecksum` populates `allFiles` for a small table (full-replay path) and maintains it consistently across an incremental commit.
- `ChecksumStateTrackerSuite.scala`: unit tests that StateTracker abandons allFiles once the seen-identity set would exceed MAX_SEEN_IDENTITIES (1000), via both recordAddFile and removeAddFile. Kept as a separate kernel-api suite because the cap can only be reached with ~1000 distinct file actions (slow through real commits), so we exercise the tracker directly in-memory.

## Does this PR introduce any user-facing changes?

No. This is an internal kernel API addition.
