### PR TITLE
[Flink] Migrate catalog-managed tables to the UC Delta-Tables API

### DIFF
--- a/flink/src/main/java/io/delta/flink/table/CatalogManagedTable.java
+++ b/flink/src/main/java/io/delta/flink/table/CatalogManagedTable.java
@@ -27,8 +27,7 @@ import io.delta.kernel.unitycatalog.UCCatalogManagedClient;
 import io.delta.kernel.unitycatalog.UCTableIdentifier;
 import io.delta.kernel.utils.CloseableIterable;
 import io.delta.storage.commit.uccommitcoordinator.UCClient;
-import io.delta.storage.commit.uccommitcoordinator.UCTokenBasedRestClient;
-import io.unitycatalog.client.auth.TokenProvider;
+import io.delta.storage.commit.uccommitcoordinator.UCDeltaTokenBasedRestClient;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
@@ -36,6 +35,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.flink.util.Preconditions;
+import org.apache.hadoop.conf.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,9 +44,14 @@ import org.slf4j.LoggerFactory;
  * catalog. It supports:
  *
  * <ul>
- *   <li>loading existing tables from a catalog via the UC Open API, and
+ *   <li>loading existing tables from a catalog via the UC Delta-Tables API, and
  *   <li>committing table changes back to the CCv2 catalog.
  * </ul>
+ *
+ * <p>Snapshot loading and commit coordination go through the UC Delta-Tables API (via {@link
+ * UCDeltaTokenBasedRestClient}). Table creation, lookup, and credential vending are still served by
+ * the {@link UnityCatalog} catalog over the classic UC table APIs, so the backing UC server must
+ * expose both surfaces.
  */
 public class CatalogManagedTable extends AbstractKernelTable {
 
@@ -125,14 +130,11 @@ public class CatalogManagedTable extends AbstractKernelTable {
   @Override
   public void open() {
     if (ucClient == null) {
-      Map<String, String> tokenProviderConf =
-          UnityCatalog.buildTokenProviderConf(
-              authMode, token, oauthUri, oauthClientId, oauthClientSecret);
+      Map<String, String> ucConfig =
+          UnityCatalog.buildUcConfig(
+              endpoint, authMode, token, oauthUri, oauthClientId, oauthClientSecret);
       ucClient =
-          new UCTokenBasedRestClient(
-              endpoint.toString(),
-              TokenProvider.create(tokenProviderConf),
-              VersionHelper.appVersions());
+          new UCDeltaTokenBasedRestClient(ucConfig, /* hadoopConfSupplier = */ Configuration::new);
     }
     if (catalogManagedClient == null) {
       catalogManagedClient = new UCCatalogManagedClient(ucClient);

--- a/flink/src/main/java/io/delta/flink/table/UnityCatalog.java
+++ b/flink/src/main/java/io/delta/flink/table/UnityCatalog.java
@@ -22,6 +22,8 @@ import dev.failsafe.function.CheckedSupplier;
 import io.delta.kernel.internal.types.DataTypeJsonSerDe;
 import io.delta.kernel.types.*;
 import io.delta.kernel.unitycatalog.UCTableIdentifier;
+import io.delta.storage.commit.uccommitcoordinator.UCConfigUtils;
+import io.delta.storage.commit.uccommitcoordinator.UCDeltaTokenBasedRestClient;
 import io.unitycatalog.client.ApiClient;
 import io.unitycatalog.client.ApiClientBuilder;
 import io.unitycatalog.client.ApiException;
@@ -151,6 +153,28 @@ public class UnityCatalog implements DeltaCatalog {
       default:
         return Map.of("type", "static", "token", token);
     }
+  }
+
+  /**
+   * Builds the {@code ucConfig} map consumed by {@link UCDeltaTokenBasedRestClient}: the endpoint
+   * under {@code uri}, the auth settings under the {@code auth.} prefix, and the app versions under
+   * the {@code appVersions.} prefix.
+   */
+  static Map<String, String> buildUcConfig(
+      URI endpoint,
+      AuthMode authMode,
+      String token,
+      URI oauthUri,
+      String oauthClientId,
+      String oauthClientSecret) {
+    Map<String, String> ucConfig = new HashMap<>();
+    ucConfig.put(UCConfigUtils.URI_KEY, endpoint.toString());
+    buildTokenProviderConf(authMode, token, oauthUri, oauthClientId, oauthClientSecret)
+        .forEach((key, value) -> ucConfig.put(UCConfigUtils.AUTH_PREFIX + key, value));
+    VersionHelper.appVersions()
+        .forEach(
+            (name, version) -> ucConfig.put(UCConfigUtils.APP_VERSIONS_PREFIX + name, version));
+    return ucConfig;
   }
 
   private final String name;

--- a/flink/src/test/java/io/delta/flink/MockHttp.java
+++ b/flink/src/test/java/io/delta/flink/MockHttp.java
@@ -43,9 +43,14 @@ public class MockHttp {
         String.format("{\"id\": \"%s\", \"staging_location\":\"%s\"}", tableId, tablePath));
     stubs.put("/api/2.1/unity-catalog/tables", "{}"); // For write
     stubs.put("/api/2.1/unity-catalog/temporary-table-credentials", "{}");
+    // UC Delta-Tables API: getCommits loads the table (GET) and commit updates it (POST) on the
+    // same path. getCommits validates that metadata.table-uuid matches the requested table id.
     stubs.put(
-        "/api/2.1/unity-catalog/delta/preview/commits",
-        "{\"commits\": [], \"latest_table_version\": 1230}");
+        "/api/2.1/unity-catalog/delta/v1/catalogs/.*/schemas/.*/tables/[^/]+$",
+        String.format(
+            "{\"metadata\": {\"table-uuid\": \"%s\"}, \"commits\": [], "
+                + "\"latest-table-version\": 1230}",
+            tableId));
     stubs.put("/api/2.1/unity-catalog/delta/preview/metrics", "");
 
     Map<String, String> errors =


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/7229/files) to review incremental changes.
- [**stack/tw/flink-uc-delta-tables-api**](https://github.com/delta-io/delta/pull/7229) [[Files changed](https://github.com/delta-io/delta/pull/7229/files)] ← _this PR_
  - [stack/flink-uc-2-lookup-creds](https://github.com/delta-io/delta/pull/7244) [[Files changed](https://github.com/delta-io/delta/pull/7244/files/3b22ca5071b6bef7329a0ed8395a88d4f9d91629..774b5d213d51fd5e76d0929b25e4883a6efee20a)]
    - [stack/flink-uc-3-create](https://github.com/delta-io/delta/pull/7245) [[Files changed](https://github.com/delta-io/delta/pull/7245/files/774b5d213d51fd5e76d0929b25e4883a6efee20a..943b6826b71cf38c21fd888d5490248942104ae2)]
      - [stack/flink-uc-4-metrics](https://github.com/delta-io/delta/pull/7246) [[Files changed](https://github.com/delta-io/delta/pull/7246/files/943b6826b71cf38c21fd888d5490248942104ae2..374cd30f8c3149028d962924546f566aabddc190)]
        - [stack/flink-uc-5-browsing](https://github.com/delta-io/delta/pull/7247) [[Files changed](https://github.com/delta-io/delta/pull/7247/files/374cd30f8c3149028d962924546f566aabddc190..7c544b0925691cc088b67d14033b53332977a5b2)]

---------
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [x] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## What this PR enables

Enables **catalog-managed reads (snapshot load) and writes (commit)** over the Delta-Tables API, by swapping the commit-coordination `UCClient` implementation.

```text
ENDPOINT                                                                 OPERATION                    STATUS
----------------------------------------------------------------------   --------------------------   ------
GET /v1/catalogs/{catalog}/schemas/{schema}/tables/{table}               Load table metadata          ⏳ THIS PR
POST /v1/catalogs/{catalog}/schemas/{schema}/tables/{table}              Commit (updateTable)         ⏳ THIS PR
HEAD /v1/catalogs/{catalog}/schemas/{schema}/tables/{table}              Table exists                 ⏭️ next PR
GET /v1/catalogs/{catalog}/schemas/{schema}/tables/{table}/credentials   Vend table storage creds     ⏭️ next PR
POST /v1/catalogs/{catalog}/schemas/{schema}/staging-tables              Reserve staging table        ⏭️ next PR
POST /v1/catalogs/{catalog}/schemas/{schema}/tables                      Finalize (create) table      ⏭️ next PR
GET /v1/staging-tables/{table_id}/credentials                            Vend staging storage creds   ⏭️ next PR
POST /v1/catalogs/{catalog}/schemas/{schema}/tables/{table}/metrics      Report commit metrics        ⏭️ next PR
GET /v1/catalogs/{catalog}/schemas/{schema}                              List tables in schema        ⛔ blocked
DELETE /v1/catalogs/{catalog}/schemas/{schema}/tables/{table}            Drop table                   n/a (not a sink op)
POST /v1/catalogs/{catalog}/schemas/{schema}/tables/{table}/rename       Rename table                 n/a (not a sink op)
GET /v1/temporary-path-credentials                                       Vend path creds              n/a (not a sink op)
```

_Status legend: ✅ done (earlier PR in this stack) · ⏳ THIS PR · ⏭️ next PR (later in this stack) · ⛔ blocked (no UC Delta client binding; stays on the OpenAPI client) · n/a (the Flink sink does not perform this operation)._

## Description

Unity Catalog has a new Delta-Tables API, and the Flink connector needs to move onto it. This is the first PR in a stack that does that migration piece by piece; here we move the core read and write path for catalog-managed (CCv2) tables.

Here's how it works today. For a catalog-managed table, `CatalogManagedTable` creates a `UCClient` and hands it to the Delta Kernel (`UCCatalogManagedClient`), which uses it to load the table's snapshot and to commit. Until now that client was `UCTokenBasedRestClient`, which speaks UC's older Delta-Commits API (the `/delta/preview/commits` endpoint).

All this PR does is build `UCDeltaTokenBasedRestClient` instead, which speaks the new Delta-Tables API. Because both clients implement the same `UCClient` interface, the Kernel needs no other change — that one swap moves both the snapshot read (`getCommits` → `loadTable`) and the commit (`updateTable`) onto the new API. delta-spark already defaults to this client, so this just brings Flink in line. The only other change is updating the WireMock test stubs to answer on the new `/v1/.../tables/{table}` endpoint.

Worth calling out: this relies on Kernel PR #7159, which makes `loadSnapshot` pass the three-part table identifier (catalog.schema.table) down to the committer. The new client needs that identifier when it commits, so the write path won't work without #7159 underneath it.

The credentials, table-creation, and metrics paths still use the old client after this PR — the follow-up PRs in the stack move those.

## How was this patch tested?

Updated the `MockHttp` WireMock stubs to serve the Delta-Tables endpoint. `build/sbt flink/test` passes (238 tests). Verified end-to-end against a remote Databricks UC workspace via the Flink SQL client: load, commit (CATALOG_WRITE), and metrics all succeed.

## Does this PR introduce _any_ user-facing changes?

No. Only the UC REST surface used for commit coordination changes.
