### PR TITLE
[Kernel] Add deletion-vector metrics to CRCInfo

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checksum/CRCInfo.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checksum/CRCInfo.java
@@ -71,9 +71,7 @@ public class CRCInfo {
           .add(FILE_SIZE_HISTOGRAM, FileSizeHistogram.FULL_SCHEMA, /*nullable*/ true)
           .add(IN_COMMIT_TIMESTAMP, LongType.LONG, /*nullable*/ true)
           .add(
-              SET_TRANSACTIONS,
-              new ArrayType(SetTransaction.FULL_SCHEMA, false),
-              /*nullable*/ true)
+              SET_TRANSACTIONS, new ArrayType(SetTransaction.FULL_SCHEMA, false), /*nullable*/ true)
           .add(NUM_DELETED_RECORDS_OPT, LongType.LONG, /*nullable*/ true)
           .add(NUM_DELETION_VECTORS_OPT, LongType.LONG, /*nullable*/ true);
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checksum/CRCInfo.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checksum/CRCInfo.java
@@ -54,6 +54,8 @@ public class CRCInfo {
   private static final String FILE_SIZE_HISTOGRAM = "fileSizeHistogram";
   private static final String IN_COMMIT_TIMESTAMP = "inCommitTimestampOpt";
   private static final String SET_TRANSACTIONS = "setTransactions";
+  private static final String NUM_DELETED_RECORDS_OPT = "numDeletedRecordsOpt";
+  private static final String NUM_DELETION_VECTORS_OPT = "numDeletionVectorsOpt";
   private static final String HISTOGRAM_OPT = "histogramOpt";
 
   public static final StructType CRC_FILE_SCHEMA =
@@ -71,7 +73,9 @@ public class CRCInfo {
           .add(
               SET_TRANSACTIONS,
               new ArrayType(SetTransaction.FULL_SCHEMA, false),
-              /*nullable*/ true);
+              /*nullable*/ true)
+          .add(NUM_DELETED_RECORDS_OPT, LongType.LONG, /*nullable*/ true)
+          .add(NUM_DELETION_VECTORS_OPT, LongType.LONG, /*nullable*/ true);
 
   // Used by ChecksumReader to support reading CRC files with the legacy "histogramOpt" field.
   public static final StructType CRC_FILE_READ_SCHEMA =
@@ -117,12 +121,7 @@ public class CRCInfo {
                 VectorUtils.toJavaList(domainMetadataVector.getArray(rowId)).stream()
                     .map(row -> DomainMetadata.fromRow((StructRow) row))
                     .collect(Collectors.toSet()));
-    ColumnVector inCommitTimestampVector =
-        batch.getColumnVector(getSchemaIndex(IN_COMMIT_TIMESTAMP));
-    Optional<Long> inCommitTimestamp =
-        inCommitTimestampVector.isNullAt(rowId)
-            ? Optional.empty()
-            : Optional.of(inCommitTimestampVector.getLong(rowId));
+    Optional<Long> inCommitTimestamp = readOptionalLong(batch, IN_COMMIT_TIMESTAMP, rowId);
     ColumnVector setTransactionsVector = batch.getColumnVector(getSchemaIndex(SET_TRANSACTIONS));
     Optional<List<SetTransaction>> setTransactions =
         setTransactionsVector.isNullAt(rowId)
@@ -131,6 +130,8 @@ public class CRCInfo {
                 VectorUtils.<Row>toJavaList(setTransactionsVector.getArray(rowId)).stream()
                     .map(SetTransaction::fromRow)
                     .collect(Collectors.toList()));
+    Optional<Long> numDeletedRecords = readOptionalLong(batch, NUM_DELETED_RECORDS_OPT, rowId);
+    Optional<Long> numDeletionVectors = readOptionalLong(batch, NUM_DELETION_VECTORS_OPT, rowId);
 
     // protocol and metadata are nullable per fromColumnVector's implementation.
     if (protocol == null || metadata == null) {
@@ -148,7 +149,14 @@ public class CRCInfo {
             domainMetadata,
             fileSizeHistogram,
             inCommitTimestamp,
-            setTransactions));
+            setTransactions,
+            numDeletedRecords,
+            numDeletionVectors));
+  }
+
+  private static Optional<Long> readOptionalLong(ColumnarBatch batch, String fieldName, int rowId) {
+    ColumnVector vector = batch.getColumnVector(getSchemaIndex(fieldName));
+    return vector.isNullAt(rowId) ? Optional.empty() : Optional.of(vector.getLong(rowId));
   }
 
   /**
@@ -206,11 +214,9 @@ public class CRCInfo {
             ? Optional.empty()
             : Optional.of(FileSizeHistogram.fromRow(row.getStruct(histogramIdx)));
 
-    int inCommitTimestampIdx = getSchemaIndex(IN_COMMIT_TIMESTAMP);
-    Optional<Long> inCommitTimestamp =
-        row.isNullAt(inCommitTimestampIdx)
-            ? Optional.empty()
-            : Optional.of(row.getLong(inCommitTimestampIdx));
+    Optional<Long> inCommitTimestamp = readOptionalLongFromRow(row, IN_COMMIT_TIMESTAMP);
+    Optional<Long> numDeletedRecords = readOptionalLongFromRow(row, NUM_DELETED_RECORDS_OPT);
+    Optional<Long> numDeletionVectors = readOptionalLongFromRow(row, NUM_DELETION_VECTORS_OPT);
 
     int setTransactionsIdx = getSchemaIndex(SET_TRANSACTIONS);
     Optional<List<SetTransaction>> setTransactions =
@@ -231,7 +237,14 @@ public class CRCInfo {
         domainMetadata,
         fileSizeHistogram,
         inCommitTimestamp,
-        setTransactions);
+        setTransactions,
+        numDeletedRecords,
+        numDeletionVectors);
+  }
+
+  private static Optional<Long> readOptionalLongFromRow(Row row, String fieldName) {
+    int idx = getSchemaIndex(fieldName);
+    return row.isNullAt(idx) ? Optional.empty() : Optional.of(row.getLong(idx));
   }
 
   private final long version;
@@ -244,6 +257,8 @@ public class CRCInfo {
   private final Optional<FileSizeHistogram> fileSizeHistogram;
   private final Optional<Long> inCommitTimestamp;
   private final Optional<List<SetTransaction>> setTransactions;
+  private final Optional<Long> numDeletedRecords;
+  private final Optional<Long> numDeletionVectors;
 
   public CRCInfo(
       long version,
@@ -264,7 +279,9 @@ public class CRCInfo {
         domainMetadata,
         fileSizeHistogram,
         Optional.empty() /* inCommitTimestamp */,
-        Optional.empty() /* setTransactions */);
+        Optional.empty() /* setTransactions */,
+        Optional.empty() /* numDeletedRecords */,
+        Optional.empty() /* numDeletionVectors */);
   }
 
   public CRCInfo(
@@ -277,7 +294,9 @@ public class CRCInfo {
       Optional<Set<DomainMetadata>> domainMetadata,
       Optional<FileSizeHistogram> fileSizeHistogram,
       Optional<Long> inCommitTimestamp,
-      Optional<List<SetTransaction>> setTransactions) {
+      Optional<List<SetTransaction>> setTransactions,
+      Optional<Long> numDeletedRecords,
+      Optional<Long> numDeletionVectors) {
     checkArgument(tableSizeBytes >= 0);
     checkArgument(numFiles >= 0);
     // Live Domain Metadata actions at this version, excluding tombstones.
@@ -311,6 +330,13 @@ public class CRCInfo {
                       "SetTransactions in CRC must be unique per appId, found duplicate: %s",
                       txn.getAppId()));
         });
+    this.numDeletedRecords = requireNonNull(numDeletedRecords);
+    this.numDeletionVectors = requireNonNull(numDeletionVectors);
+    checkArgument(
+        numDeletedRecords.isPresent() == numDeletionVectors.isPresent(),
+        "numDeletedRecords and numDeletionVectors must both be present or both absent");
+    numDeletedRecords.ifPresent(n -> checkArgument(n >= 0, "numDeletedRecords must be >= 0"));
+    numDeletionVectors.ifPresent(n -> checkArgument(n >= 0, "numDeletionVectors must be >= 0"));
   }
 
   /** Used by callers to supply an ICT that cannot be derived from the file actions alone. */
@@ -325,7 +351,9 @@ public class CRCInfo {
         domainMetadata,
         fileSizeHistogram,
         inCommitTimestamp,
-        setTransactions);
+        setTransactions,
+        numDeletedRecords,
+        numDeletionVectors);
   }
 
   /** The version of the Delta table that this CRCInfo represents. */
@@ -366,6 +394,15 @@ public class CRCInfo {
 
   public Optional<List<SetTransaction>> getSetTransactions() {
     return setTransactions;
+  }
+
+  /** DV stats */
+  public Optional<Long> getNumDeletedRecords() {
+    return numDeletedRecords;
+  }
+
+  public Optional<Long> getNumDeletionVectors() {
+    return numDeletionVectors;
   }
 
   /**
@@ -414,6 +451,8 @@ public class CRCInfo {
                 VectorUtils.buildArrayValue(
                     txns.stream().map(SetTransaction::toRow).collect(Collectors.toList()),
                     SetTransaction.FULL_SCHEMA)));
+    numDeletedRecords.ifPresent(n -> values.put(getSchemaIndex(NUM_DELETED_RECORDS_OPT), n));
+    numDeletionVectors.ifPresent(n -> values.put(getSchemaIndex(NUM_DELETION_VECTORS_OPT), n));
     return new GenericRow(CRC_FILE_SCHEMA, values);
   }
 
@@ -429,7 +468,9 @@ public class CRCInfo {
         domainMetadata,
         fileSizeHistogram,
         inCommitTimestamp,
-        setTransactions);
+        setTransactions,
+        numDeletedRecords,
+        numDeletionVectors);
   }
 
   @Override
@@ -447,7 +488,9 @@ public class CRCInfo {
         && domainMetadata.equals(other.domainMetadata)
         && fileSizeHistogram.equals(other.fileSizeHistogram)
         && inCommitTimestamp.equals(other.inCommitTimestamp)
-        && setTransactions.equals(other.setTransactions);
+        && setTransactions.equals(other.setTransactions)
+        && numDeletedRecords.equals(other.numDeletedRecords)
+        && numDeletionVectors.equals(other.numDeletionVectors);
   }
 
   private static int getSchemaIndex(String fieldName) {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checksum/ChecksumUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checksum/ChecksumUtils.java
@@ -295,7 +295,7 @@ public class ChecksumUtils {
     Set<DomainMetadata> finalDomainMetadata = getNonRemovedDomainMetadata(state);
 
     // Deletion-vector metrics, present only for DV-capable tables.
-    Optional<Long>[] dvMetrics = dvMetricsFor(finalProtocol, state);
+    DvMetrics dvMetrics = dvMetricsFor(finalProtocol, state, /* seedReliable = */ true);
 
     return new CRCInfo(
         logSegmentAtVersion.getVersion(),
@@ -308,12 +308,9 @@ public class ChecksumUtils {
         Optional.of(state.addedFileSizeHistogram),
         Optional.empty() /* inCommitTimestamp */,
         filterAndBoundSetTransactions(
-            state.collectedSetTransactions(),
-            finalMetadata,
-            clock,
-            state.setTransactionsThreshold),
-        dvMetrics[0] /* numDeletedRecords */,
-        dvMetrics[1] /* numDeletionVectors */);
+            state.collectedSetTransactions(), finalMetadata, clock, state.setTransactionsThreshold),
+        dvMetrics.numDeletedRecords,
+        dvMetrics.numDeletionVectors);
   }
 
   /**
@@ -344,6 +341,22 @@ public class ChecksumUtils {
       logger.info(
           "Falling back to full replay after {}ms: "
               + "detected current crc missing file size histogram.",
+          System.currentTimeMillis() - startTime);
+      return Optional.empty();
+    }
+    // Deletion-vector metrics can only be folded forward from a trustworthy base. If the base
+    // table is DV-capable but its CRC omitted the DV metrics, seeding from 0 would undercount the
+    // records/vectors already present at the base version. Fall back to full replay in that case.
+    boolean baseSupportsDv =
+        lastSeenCrcInfo.getProtocol().supportsFeature(TableFeatures.DELETION_VECTORS_RW_FEATURE);
+    boolean baseHasDvMetrics =
+        lastSeenCrcInfo.getNumDeletionVectors().isPresent()
+            && lastSeenCrcInfo.getNumDeletedRecords().isPresent();
+    boolean dvSeedReliable = !baseSupportsDv || baseHasDvMetrics;
+    if (!canBuildWithOnlyRequiredFields && !dvSeedReliable) {
+      logger.info(
+          "Falling back to full replay after {}ms: "
+              + "base crc missing deletion-vector metrics on a DV-enabled table.",
           System.currentTimeMillis() - startTime);
       return Optional.empty();
     }
@@ -442,7 +455,7 @@ public class ChecksumUtils {
             state.removedFileSizeHistogram.insert(fileSize);
             state.fileCount.decrement();
             // Subtract the removed file's deletion-vector metrics.
-            applyDeletionVectorMetrics(removeVector, REMOVE_DV_INDEX, state, i, /* sign = */ -1);
+            applyDeletionVectorMetrics(removeVector, REMOVE_DV_INDEX, state, i, DvDelta.REMOVE);
           }
 
           // Process domain metadata, protocol, metadata, and transactions
@@ -491,7 +504,8 @@ public class ChecksumUtils {
         isSetTransactionRetentionConfigured(finalMetadata)
             ? Optional.empty()
             : state.collectedSetTransactions();
-    Optional<Long>[] finalDvMetrics = dvMetricsFor(finalProtocol, state);
+    // Omit DV stats if the seed is unreliable (base CRC lacked DV metrics on a DV-enabled table).
+    DvMetrics finalDvMetrics = dvMetricsFor(finalProtocol, state, dvSeedReliable);
 
     // Build and return the new CRC info
     return Optional.of(
@@ -506,8 +520,8 @@ public class ChecksumUtils {
             finalHistogram,
             Optional.empty() /* inCommitTimestamp */,
             incrementalSetTransactions,
-            finalDvMetrics[0] /* numDeletedRecords */,
-            finalDvMetrics[1] /* numDeletionVectors */));
+            finalDvMetrics.numDeletedRecords,
+            finalDvMetrics.numDeletionVectors));
   }
 
   /** Processes an add file record and updates the state tracker. */
@@ -522,7 +536,7 @@ public class ChecksumUtils {
       state.tableSizeByte.add(fileSize);
       state.addedFileSizeHistogram.insert(fileSize);
       state.fileCount.increment();
-      applyDeletionVectorMetrics(addVector, ADD_DV_INDEX, state, rowId, /* sign = */ 1);
+      applyDeletionVectorMetrics(addVector, ADD_DV_INDEX, state, rowId, DvDelta.ADD);
     }
   }
 
@@ -652,34 +666,57 @@ public class ChecksumUtils {
     }
   }
 
-  /** Adds (sign = +1) or removes (sign = -1) an action's deletion-vector metrics from the state. */
+  /**
+   * Whether a file action contributes its deletion-vector metrics to the running state (an AddFile)
+   * or retracts them (a RemoveFile).
+   */
+  private enum DvDelta {
+    ADD(1),
+    REMOVE(-1);
+
+    final int sign;
+
+    DvDelta(int sign) {
+      this.sign = sign;
+    }
+  }
+
+  /** Adds (ADD) or removes (REMOVE) an action's deletion-vector metrics from the state. */
   private static void applyDeletionVectorMetrics(
-      ColumnVector fileVector, int dvChildIndex, StateTracker state, int rowId, int sign) {
+      ColumnVector fileVector, int dvChildIndex, StateTracker state, int rowId, DvDelta delta) {
     ColumnVector dvVector = fileVector.getChild(dvChildIndex);
     if (dvVector.isNullAt(rowId)) {
       return;
     }
     long cardinality = dvVector.getChild(DV_CARDINALITY_INDEX).getLong(rowId);
-    state.numDeletionVectors.add(sign);
-    state.numDeletedRecords.add(sign * cardinality);
+    state.numDeletionVectors.add(delta.sign);
+    state.numDeletedRecords.add(delta.sign * cardinality);
   }
 
   /**
-   * The deletion-vector metrics to store, present ONLY when the resolved protocol supports the
-   * deletion-vectors table feature.
+   * The deletion-vector metrics to store. Present ONLY when the resolved protocol supports the
+   * deletion-vectors table feature AND the accumulated state is trustworthy.
    */
-  private static Optional<Long>[] dvMetricsFor(Protocol protocol, StateTracker state) {
-    @SuppressWarnings("unchecked")
-    Optional<Long>[] result = new Optional[2];
+  private static DvMetrics dvMetricsFor(
+      Protocol protocol, StateTracker state, boolean seedReliable) {
     boolean dvSupported = protocol.supportsFeature(TableFeatures.DELETION_VECTORS_RW_FEATURE);
-    if (dvSupported) {
-      result[0] = Optional.of(state.numDeletedRecords.longValue());
-      result[1] = Optional.of(state.numDeletionVectors.longValue());
-    } else {
-      result[0] = Optional.empty();
-      result[1] = Optional.empty();
+    if (dvSupported && seedReliable) {
+      return new DvMetrics(
+          Optional.of(state.numDeletedRecords.longValue()),
+          Optional.of(state.numDeletionVectors.longValue()));
     }
-    return result;
+    return new DvMetrics(Optional.empty(), Optional.empty());
+  }
+
+  /** The pair of deletion-vector metrics stored in a {@link CRCInfo}. */
+  private static class DvMetrics {
+    final Optional<Long> numDeletedRecords;
+    final Optional<Long> numDeletionVectors;
+
+    DvMetrics(Optional<Long> numDeletedRecords, Optional<Long> numDeletionVectors) {
+      this.numDeletedRecords = numDeletedRecords;
+      this.numDeletionVectors = numDeletionVectors;
+    }
   }
 
   private static void validateDeltaContinuity(List<FileStatus> deltas, long checksumVersion) {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checksum/ChecksumUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checksum/ChecksumUtils.java
@@ -31,6 +31,7 @@ import io.delta.kernel.internal.replay.ActionsIterator;
 import io.delta.kernel.internal.replay.CreateCheckpointIterator;
 import io.delta.kernel.internal.snapshot.LogSegment;
 import io.delta.kernel.internal.stats.FileSizeHistogram;
+import io.delta.kernel.internal.tablefeatures.TableFeatures;
 import io.delta.kernel.internal.util.Clock;
 import io.delta.kernel.internal.util.FileNames;
 import io.delta.kernel.types.StructType;
@@ -59,7 +60,11 @@ public class ChecksumUtils {
   private static final int DOMAIN_METADATA_INDEX = CHECKPOINT_SCHEMA.indexOf("domainMetadata");
   private static final int TXN_INDEX = CHECKPOINT_SCHEMA.indexOf("txn");
   private static final int ADD_SIZE_INDEX = AddFile.FULL_SCHEMA.indexOf("size");
+  private static final int ADD_DV_INDEX = AddFile.FULL_SCHEMA.indexOf("deletionVector");
   private static final int REMOVE_SIZE_INDEX = RemoveFile.FULL_SCHEMA.indexOf("size");
+  private static final int REMOVE_DV_INDEX = RemoveFile.FULL_SCHEMA.indexOf("deletionVector");
+  private static final int DV_CARDINALITY_INDEX =
+      DeletionVectorDescriptor.READ_SCHEMA.indexOf("cardinality");
   // commitInfo is appended after CHECKPOINT_SCHEMA in incremental read
   private static final int COMMIT_INFO_INDEX = CHECKPOINT_SCHEMA.length();
 
@@ -96,6 +101,7 @@ public class ChecksumUtils {
    *   <li>Total number of files
    *   <li>File size histogram
    *   <li>Domain metadata information
+   *   <li>Deletion-vector metrics
    * </ul>
    *
    * <p>If a checksum file already exists for exactly this version, the existing {@link CRCInfo} is
@@ -145,6 +151,7 @@ public class ChecksumUtils {
    *   <li>Total number of files
    *   <li>File size histogram
    *   <li>Domain metadata information
+   *   <li>Deletion-vector metrics
    * </ul>
    *
    * <p>Note: For very large tables, this operation may be expensive as it requires scanning the
@@ -287,6 +294,9 @@ public class ChecksumUtils {
     // Filter to only non-removed domain metadata
     Set<DomainMetadata> finalDomainMetadata = getNonRemovedDomainMetadata(state);
 
+    // Deletion-vector metrics, present only for DV-capable tables.
+    Optional<Long>[] dvMetrics = dvMetricsFor(finalProtocol, state);
+
     return new CRCInfo(
         logSegmentAtVersion.getVersion(),
         finalMetadata,
@@ -301,7 +311,9 @@ public class ChecksumUtils {
             state.collectedSetTransactions(),
             finalMetadata,
             clock,
-            state.setTransactionsThreshold));
+            state.setTransactionsThreshold),
+        dvMetrics[0] /* numDeletedRecords */,
+        dvMetrics[1] /* numDeletionVectors */);
   }
 
   /**
@@ -340,6 +352,9 @@ public class ChecksumUtils {
     StateTracker state = new StateTracker();
     // Maintain setTransactions incrementally only when the base CRC carries the list.
     state.collectSetTransactions = lastSeenCrcInfo.getSetTransactions().isPresent();
+    // Obtain deletion-vector metrics from the base CRC to allow incremental folding.
+    lastSeenCrcInfo.getNumDeletionVectors().ifPresent(n -> state.numDeletionVectors.add(n));
+    lastSeenCrcInfo.getNumDeletedRecords().ifPresent(n -> state.numDeletedRecords.add(n));
 
     // TODO: use compacted logs.
     List<FileStatus> deltaFiles =
@@ -426,6 +441,8 @@ public class ChecksumUtils {
             state.tableSizeByte.add(-fileSize);
             state.removedFileSizeHistogram.insert(fileSize);
             state.fileCount.decrement();
+            // Subtract the removed file's deletion-vector metrics.
+            applyDeletionVectorMetrics(removeVector, REMOVE_DV_INDEX, state, i, /* sign = */ -1);
           }
 
           // Process domain metadata, protocol, metadata, and transactions
@@ -466,6 +483,7 @@ public class ChecksumUtils {
             .map(h -> state.addedFileSizeHistogram.plus(h).minus(state.removedFileSizeHistogram));
 
     Metadata finalMetadata = state.metadataFromLog.orElseGet(lastSeenCrcInfo::getMetadata);
+    Protocol finalProtocol = state.protocolFromLog.orElseGet(lastSeenCrcInfo::getProtocol);
 
     // Omit setTransactions on incremental path since it cannot maintain the wall-clock retention
     // filter deterministically
@@ -473,19 +491,23 @@ public class ChecksumUtils {
         isSetTransactionRetentionConfigured(finalMetadata)
             ? Optional.empty()
             : state.collectedSetTransactions();
+    Optional<Long>[] finalDvMetrics = dvMetricsFor(finalProtocol, state);
+
     // Build and return the new CRC info
     return Optional.of(
         new CRCInfo(
             logSegment.getVersion(),
             finalMetadata,
-            state.protocolFromLog.orElseGet(lastSeenCrcInfo::getProtocol),
+            finalProtocol,
             state.tableSizeByte.longValue() + lastSeenCrcInfo.getTableSizeBytes(),
             state.fileCount.longValue() + lastSeenCrcInfo.getNumFiles(),
             Optional.empty(),
             finalDomainMetadata,
             finalHistogram,
             Optional.empty() /* inCommitTimestamp */,
-            incrementalSetTransactions));
+            incrementalSetTransactions,
+            finalDvMetrics[0] /* numDeletedRecords */,
+            finalDvMetrics[1] /* numDeletionVectors */));
   }
 
   /** Processes an add file record and updates the state tracker. */
@@ -500,6 +522,7 @@ public class ChecksumUtils {
       state.tableSizeByte.add(fileSize);
       state.addedFileSizeHistogram.insert(fileSize);
       state.fileCount.increment();
+      applyDeletionVectorMetrics(addVector, ADD_DV_INDEX, state, rowId, /* sign = */ 1);
     }
   }
 
@@ -603,6 +626,10 @@ public class ChecksumUtils {
     // full-replay path disables this so retention filtering runs before the threshold check.
     boolean abandonAboveThreshold = true;
 
+    // Deletion-vector metrics 2 fields.
+    LongAdder numDeletionVectors = new LongAdder();
+    LongAdder numDeletedRecords = new LongAdder();
+
     /** Records a SetTransaction if collecting and its appId is not already seen. */
     void recordSetTransaction(SetTransaction txn) {
       if (!collectSetTransactions) {
@@ -623,6 +650,36 @@ public class ChecksumUtils {
           ? Optional.of(new ArrayList<>(setTransactionsByAppId.values()))
           : Optional.empty();
     }
+  }
+
+  /** Adds (sign = +1) or removes (sign = -1) an action's deletion-vector metrics from the state. */
+  private static void applyDeletionVectorMetrics(
+      ColumnVector fileVector, int dvChildIndex, StateTracker state, int rowId, int sign) {
+    ColumnVector dvVector = fileVector.getChild(dvChildIndex);
+    if (dvVector.isNullAt(rowId)) {
+      return;
+    }
+    long cardinality = dvVector.getChild(DV_CARDINALITY_INDEX).getLong(rowId);
+    state.numDeletionVectors.add(sign);
+    state.numDeletedRecords.add(sign * cardinality);
+  }
+
+  /**
+   * The deletion-vector metrics to store, present ONLY when the resolved protocol supports the
+   * deletion-vectors table feature.
+   */
+  private static Optional<Long>[] dvMetricsFor(Protocol protocol, StateTracker state) {
+    @SuppressWarnings("unchecked")
+    Optional<Long>[] result = new Optional[2];
+    boolean dvSupported = protocol.supportsFeature(TableFeatures.DELETION_VECTORS_RW_FEATURE);
+    if (dvSupported) {
+      result[0] = Optional.of(state.numDeletedRecords.longValue());
+      result[1] = Optional.of(state.numDeletionVectors.longValue());
+    } else {
+      result[0] = Optional.empty();
+      result[1] = Optional.empty();
+    }
+    return result;
   }
 
   private static void validateDeltaContinuity(List<FileStatus> deltas, long checksumVersion) {

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/checksum/CRCInfoFromRowSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/checksum/CRCInfoFromRowSuite.scala
@@ -131,6 +131,8 @@ class CRCInfoFromRowSuite extends AnyFunSuite {
       Optional.empty(),
       Optional.empty(),
       Optional.of(java.lang.Long.valueOf(1749830855993L)),
+      Optional.empty(),
+      Optional.empty(),
       Optional.empty()))
   }
 
@@ -147,7 +149,9 @@ class CRCInfoFromRowSuite extends AnyFunSuite {
       Optional.empty(),
       Optional.of(util.Arrays.asList(
         new SetTransaction("app1", 5L, Optional.of(java.lang.Long.valueOf(100L))),
-        new SetTransaction("app2", 9L, Optional.empty())))))
+        new SetTransaction("app2", 9L, Optional.empty()))),
+      Optional.empty(),
+      Optional.empty()))
   }
 
   test("round-trips with all optional fields present") {
@@ -162,7 +166,9 @@ class CRCInfoFromRowSuite extends AnyFunSuite {
       Optional.of(createTestHistogram(fileCount = 50)),
       Optional.of(java.lang.Long.valueOf(1749830871085L)),
       Optional.of(util.Arrays.asList(
-        new SetTransaction("app1", 5L, Optional.of(java.lang.Long.valueOf(100L)))))))
+        new SetTransaction("app1", 5L, Optional.of(java.lang.Long.valueOf(100L))))),
+      Optional.of(java.lang.Long.valueOf(7L)),
+      Optional.of(java.lang.Long.valueOf(2L))))
   }
 
   test("preserves the supplied version, independent of the row (toRow omits version)") {

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/checksum/CRCInfoReadCompatSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/checksum/CRCInfoReadCompatSuite.scala
@@ -112,6 +112,10 @@ class CRCInfoReadCompatSuite extends AnyFunSuite with VectorTestUtils {
               CRC_FILE_SCHEMA.get("inCommitTimestampOpt").getDataType)
           case "setTransactions" => nullColumnVector(
               CRC_FILE_SCHEMA.get("setTransactions").getDataType)
+          case "numDeletedRecordsOpt" => nullColumnVector(
+              CRC_FILE_SCHEMA.get("numDeletedRecordsOpt").getDataType)
+          case "numDeletionVectorsOpt" => nullColumnVector(
+              CRC_FILE_SCHEMA.get("numDeletionVectorsOpt").getDataType)
           case "fileSizeHistogram" => histogramColumnVector(fileSizeHistogram)
           case "histogramOpt" => histogramColumnVector(histogramOpt)
           case _ =>
@@ -213,6 +217,10 @@ class CRCInfoReadCompatSuite extends AnyFunSuite with VectorTestUtils {
               CRC_FILE_SCHEMA.get("inCommitTimestampOpt").getDataType)
           case "setTransactions" => nullColumnVector(
               CRC_FILE_SCHEMA.get("setTransactions").getDataType)
+          case "numDeletedRecordsOpt" => nullColumnVector(
+              CRC_FILE_SCHEMA.get("numDeletedRecordsOpt").getDataType)
+          case "numDeletionVectorsOpt" => nullColumnVector(
+              CRC_FILE_SCHEMA.get("numDeletionVectorsOpt").getDataType)
           case "fileSizeHistogram" => histogramColumnVector(None)
           case _ =>
             throw new IllegalArgumentException(s"Unknown field: $fieldName")
@@ -246,6 +254,10 @@ class CRCInfoReadCompatSuite extends AnyFunSuite with VectorTestUtils {
           case "inCommitTimestampOpt" => longVector(Seq(1749830855993L))
           case "setTransactions" =>
             nullColumnVector(CRC_FILE_SCHEMA.get("setTransactions").getDataType)
+          case "numDeletedRecordsOpt" =>
+            nullColumnVector(CRC_FILE_SCHEMA.get("numDeletedRecordsOpt").getDataType)
+          case "numDeletionVectorsOpt" =>
+            nullColumnVector(CRC_FILE_SCHEMA.get("numDeletionVectorsOpt").getDataType)
           case "fileSizeHistogram" => histogramColumnVector(None)
           case _ => throw new IllegalArgumentException(s"Unknown field: $fieldName")
         }
@@ -276,7 +288,9 @@ class CRCInfoReadCompatSuite extends AnyFunSuite with VectorTestUtils {
       Optional.empty(),
       Optional.empty(),
       /* inCommitTimestamp */ Optional.of(java.lang.Long.valueOf(1749830871085L)),
-      /* setTransactions */ Optional.empty())
+      /* setTransactions */ Optional.empty(),
+      /* numDeletedRecords */ Optional.empty(),
+      /* numDeletionVectors */ Optional.empty())
     val row = original.toRow()
     val ictIdx = CRC_FILE_SCHEMA.indexOf("inCommitTimestampOpt")
     assert(!row.isNullAt(ictIdx))
@@ -336,7 +350,9 @@ class CRCInfoReadCompatSuite extends AnyFunSuite with VectorTestUtils {
       Optional.empty(),
       Optional.empty(),
       /* inCommitTimestamp */ Optional.empty(),
-      /* setTransactions */ Optional.of(txns))
+      /* setTransactions */ Optional.of(txns),
+      /* numDeletedRecords */ Optional.empty(),
+      /* numDeletionVectors */ Optional.empty())
     val row = original.toRow()
     val idx = CRC_FILE_SCHEMA.indexOf("setTransactions")
     assert(!row.isNullAt(idx))
@@ -371,8 +387,69 @@ class CRCInfoReadCompatSuite extends AnyFunSuite with VectorTestUtils {
         Optional.empty(),
         Optional.empty(),
         /* inCommitTimestamp */ Optional.empty(),
-        Optional.of(dupes))
+        /* setTransactions */ Optional.of(dupes),
+        /* numDeletedRecords */ Optional.empty(),
+        /* numDeletionVectors */ Optional.empty())
     }
     assert(ex.getMessage.contains("unique per appId"))
+  }
+
+  test("DV metrics are empty when the columns are null (older .crc / non-DV table)") {
+    val batch = buildBatch(CRC_FILE_READ_SCHEMA, fileSizeHistogram = None, histogramOpt = None)
+    val crcInfo = CRCInfo.fromColumnarBatch(1L, batch, 0, "test.crc")
+    assert(crcInfo.isPresent)
+    assert(!crcInfo.get().getNumDeletedRecords.isPresent)
+    assert(!crcInfo.get().getNumDeletionVectors.isPresent)
+  }
+
+  test("toRow serializes DV metrics when present and leaves them null when absent") {
+    val withDv = new CRCInfo(
+      3L,
+      testMetadata,
+      testProtocol,
+      1000L,
+      10L,
+      Optional.empty(),
+      Optional.empty(),
+      Optional.empty(),
+      /* inCommitTimestamp */ Optional.empty(),
+      /* setTransactions */ Optional.empty(),
+      /* numDeletedRecords */ Optional.of(java.lang.Long.valueOf(42L)),
+      /* numDeletionVectors */ Optional.of(java.lang.Long.valueOf(3L)))
+    val row = withDv.toRow()
+    assert(row.getLong(CRC_FILE_SCHEMA.indexOf("numDeletedRecordsOpt")) === 42L)
+    assert(row.getLong(CRC_FILE_SCHEMA.indexOf("numDeletionVectorsOpt")) === 3L)
+
+    val withoutDv = new CRCInfo(
+      4L,
+      testMetadata,
+      testProtocol,
+      1000L,
+      10L,
+      Optional.empty(),
+      Optional.empty(),
+      Optional.empty())
+    val row2 = withoutDv.toRow()
+    assert(row2.isNullAt(CRC_FILE_SCHEMA.indexOf("numDeletedRecordsOpt")))
+    assert(row2.isNullAt(CRC_FILE_SCHEMA.indexOf("numDeletionVectorsOpt")))
+  }
+
+  test("constructor rejects DV metrics that are not both-present-or-both-absent") {
+    val ex = intercept[IllegalArgumentException] {
+      new CRCInfo(
+        5L,
+        testMetadata,
+        testProtocol,
+        1000L,
+        10L,
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        /* inCommitTimestamp */ Optional.empty(),
+        /* setTransactions */ Optional.empty(),
+        /* numDeletedRecords */ Optional.of(java.lang.Long.valueOf(1L)),
+        /* numDeletionVectors */ Optional.empty())
+    }
+    assert(ex.getMessage.contains("both be present or both absent"))
   }
 }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/CRCInfoSerializationSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/CRCInfoSerializationSuite.scala
@@ -90,8 +90,10 @@ class CRCInfoSerializationSuite extends AnyFunSuite {
       Optional.empty(),
       Optional.empty(),
       Optional.empty(), /* inCommitTimestamp */
-      Optional.of(Collections.emptyList[SetTransaction]())
-    ) /* setTransactions */
+      Optional.of(Collections.emptyList[SetTransaction]()), /* setTransactions */
+      Optional.empty(), /* numDeletedRecords */
+      Optional.empty() /* numDeletionVectors */
+    )
 
     val expected =
       """{"tableSizeBytes":100,"numFiles":1,"numMetadata":1,"numProtocol":1,""" +
@@ -117,8 +119,10 @@ class CRCInfoSerializationSuite extends AnyFunSuite {
       Optional.empty(),
       Optional.empty(),
       Optional.empty(),
-      Optional.empty(),
-      Optional.of(txns))
+      Optional.empty(), /* inCommitTimestamp */
+      Optional.of(txns), /* setTransactions */
+      Optional.empty(), /* numDeletedRecords */
+      Optional.empty() /* numDeletionVectors */ )
 
     val expected =
       """{"tableSizeBytes":100,"numFiles":1,"numMetadata":1,"numProtocol":1,""" +

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ChecksumUtilsSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ChecksumUtilsSuite.scala
@@ -349,6 +349,38 @@ class ChecksumUtilsSuite extends AnyFunSuite with WriteUtils with LogReplayBaseS
     }
   }
 
+  test("computeChecksum falls back to full replay when the base CRC omits DV metrics on a " +
+    "DV-enabled table") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      // DV-enabled table with two deletes at two versions (5 total deleted records).
+      spark.sql(
+        s"CREATE TABLE delta.`$tablePath` (id LONG) USING DELTA " +
+          "TBLPROPERTIES ('delta.enableDeletionVectors' = 'true')")
+      spark.range(0, 10).write.format("delta").mode("append").save(tablePath)
+      spark.sql(s"DELETE FROM delta.`$tablePath` WHERE id < 3")
+      spark.sql(s"DELETE FROM delta.`$tablePath` WHERE id >= 8")
+
+      deleteChecksumFileForTableUsingHadoopFs(tablePath, 0 to 3)
+      val snapshot2 = Table.forPath(engine, tablePath)
+        .getSnapshotAsOfVersion(engine, 2).asInstanceOf[SnapshotImpl]
+      ChecksumUtils.computeStateAndWriteChecksum(engine, snapshot2.getLogSegment)
+
+      // Simulate a base CRC that never captured DV metrics.
+      rewriteChecksumFileToExcludeDvMetrics(engine, tablePath, 2)
+
+      // computeChecksum at v3 finds the stripped v2 CRC as its base. Fall back to full replay.
+      val snapshot3 = Table.forPath(engine, tablePath)
+        .getSnapshotAsOfVersion(engine, 3).asInstanceOf[SnapshotImpl]
+      val crcInfo = ChecksumUtils.computeChecksum(engine, snapshot3.getLogSegment)
+
+      assert(crcInfo.getVersion === 3)
+      assert(crcInfo.getNumDeletedRecords.isPresent)
+      assert(crcInfo.getNumDeletionVectors.isPresent)
+      assert(crcInfo.getNumDeletedRecords.get() === 5L)
+      assert(crcInfo.getNumDeletionVectors.get() >= 1L)
+    }
+  }
+
   test("computeChecksum returns the existing CRCInfo as-is for an already-checksummed " +
     "version, without recomputation") {
     withTempDirAndEngine { (tablePath, engine) =>

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ChecksumUtilsSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ChecksumUtilsSuite.scala
@@ -317,6 +317,38 @@ class ChecksumUtilsSuite extends AnyFunSuite with WriteUtils with LogReplayBaseS
     }
   }
 
+  test("computeChecksum populates deletion-vector metrics after a DELETE on a DV table") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      // Create a deletion-vectors-enabled table via Spark and delete some rows, producing DVs.
+      spark.sql(
+        s"CREATE TABLE delta.`$tablePath` (id LONG) USING DELTA " +
+          "TBLPROPERTIES ('delta.enableDeletionVectors' = 'true')")
+      spark.range(0, 10).write.format("delta").mode("append").save(tablePath)
+      spark.sql(s"DELETE FROM delta.`$tablePath` WHERE id < 3")
+
+      val snapshot = Table.forPath(engine, tablePath)
+        .getLatestSnapshot(engine).asInstanceOf[SnapshotImpl]
+      val crcInfo = ChecksumUtils.computeChecksum(engine, snapshot.getLogSegment)
+
+      // DV metrics are present (DV-capable table) and reflect the delete.
+      assert(crcInfo.getNumDeletionVectors.isPresent)
+      assert(crcInfo.getNumDeletedRecords.isPresent)
+      assert(crcInfo.getNumDeletionVectors.get() >= 1L)
+      assert(crcInfo.getNumDeletedRecords.get() === 3L)
+    }
+  }
+
+  test("computeChecksum leaves deletion-vector metrics absent for a non-DV table") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      initialTestTable(tablePath, engine)
+      val snapshot = Table.forPath(engine, tablePath)
+        .getLatestSnapshot(engine).asInstanceOf[SnapshotImpl]
+      val crcInfo = ChecksumUtils.computeChecksum(engine, snapshot.getLogSegment)
+      assert(!crcInfo.getNumDeletionVectors.isPresent)
+      assert(!crcInfo.getNumDeletedRecords.isPresent)
+    }
+  }
+
   test("computeChecksum returns the existing CRCInfo as-is for an already-checksummed " +
     "version, without recomputation") {
     withTempDirAndEngine { (tablePath, engine) =>

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestUtils.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestUtils.scala
@@ -900,6 +900,39 @@ trait AbstractTestUtils
         crcInfo.getFileSizeHistogram))
   }
 
+  /**
+   * Rewrites the checksum file at `version` so it omits the deletion-vector metrics.
+   * Used to simulate a base CRC written before DV metrics were captured (or by an
+   * engine that never captured them) on a DV-enabled table.
+   */
+  def rewriteChecksumFileToExcludeDvMetrics(
+      engine: Engine,
+      tablePath: String,
+      version: Long): Unit = {
+    val logPath = new Path(s"$tablePath/_delta_log");
+    val crcInfo = ChecksumReader.tryReadChecksumFile(
+      engine,
+      FileStatus.of(checksumFile(
+        logPath,
+        version).toString)).get()
+    // Delete it in hdfs.
+    engine.getFileSystemClient.delete(FileNames.checksumFile(
+      new Path(s"$tablePath/_delta_log"),
+      version).toString)
+    val crcWriter = new ChecksumWriter(logPath)
+    crcWriter.writeCheckSum(
+      engine,
+      new CRCInfo(
+        crcInfo.getVersion,
+        crcInfo.getMetadata,
+        crcInfo.getProtocol,
+        crcInfo.getTableSizeBytes,
+        crcInfo.getNumFiles,
+        crcInfo.getTxnId,
+        crcInfo.getDomainMetadata,
+        crcInfo.getFileSizeHistogram))
+  }
+
   def executeCrcSimple(result: TransactionCommitResult, engine: Engine): TransactionCommitResult = {
     val crcSimpleHook = result
       .getPostCommitHooks


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)
## Description

Add two optional DV (deletion-vector) metrics to `CRCInfo`: `numDeletedRecordsOpt` (total logically-deleted records across all deletion vectors) and `numDeletionVectorsOpt` (number of files carrying a DV). The field names match Delta-Spark's `VersionChecksum` (including the `Opt` suffix) so a `.crc` written by either engine is cross-readable.

They are computed as a running fold over the actions the checksum replay already reads. The `deletionVector` column is present on both `AddFile` and `RemoveFile`, so this adds **no extra IO**. 
- Each add with a DV contributes `+1` and its `cardinality`
- Each removed DV file subtracts them. 

Both replay paths populate the fields:
- **Full log replay** accumulates over live adds.
- **Incremental** computation obtains the counters from the base CRC and folds the new commits' adds/removes on top.

Mirroring Delta-Spark, the metrics are emitted as present only for tables that support the deletion-vectors table feature (`protocol.supportsFeature`); otherwise both are absent so a reader never compares spurious zeros. The
constructor enforces the both-present-or-both-absent invariant.

Backward compatibility: both fields are nullable in `CRC_FILE_SCHEMA` and defaulted to empty by the pre-existing 8-arg `CRCInfo` constructor, so older `.crc` files read back with empty metrics and existing callers are unaffected.

## How was this patch tested?

- `CRCInfoReadCompatSuite`: metrics empty when the columns are null (older files/ non-DV tables); `toRow` serializes them when present and leaves them null when absent; the constructor rejects a half-present pair.
- `ChecksumUtilsSuite`: `computeChecksum` on a DV-enabled table after a `DELETE` reports the correct deleted-record count (3) and a non-zero DV count, and leaves the metrics absent for a non-DV table.
- Edge case where table with DV that currently don't write DV stats to crc won't get inaccurate results

## Does this PR introduce any user-facing changes?

No. This is an internal kernel API addition.
