### PR TITLE
Fix misleading tableName parameter in DELTA_TIMESTAMP_GREATER_THAN_COMMIT error

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -3020,8 +3020,7 @@
   },
   "DELTA_TIMESTAMP_GREATER_THAN_COMMIT" : {
     "message" : [
-      "The provided timestamp (<providedTimestamp>) is after the latest version available to this",
-      "table (<tableName>). Please use a timestamp before or at <maximumTimestamp>."
+      "Timestamp <providedTimestamp> is after the table's latest version (<lastCommitTimestamp>). Use a timestamp at or before <maximumTimestamp>."
     ],
     "sqlState" : "42816"
   },

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -1516,7 +1516,7 @@ trait DeltaErrorsSuiteBase
       }
       checkError(e, "DELTA_TIMESTAMP_GREATER_THAN_COMMIT", "42816", Map(
         "providedTimestamp" -> "2022-02-28 10:30:00.0",
-        "tableName" -> "2022-02-28 10:00:00.0",
+        "lastCommitTimestamp" -> "2022-02-28 10:00:00.0",
         "maximumTimestamp" -> "2022-02-28 10:00:00"))
     }
     {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaHistoryManagerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaHistoryManagerSuite.scala
@@ -376,7 +376,7 @@ trait DeltaTimeTravelTests extends QueryTest
         sqlState = "42816",
         parameters = Map(
           "providedTimestamp" -> "2018-10-24 14:24:18.0",
-          "tableName" -> "2018-10-24 14:14:18.0",
+          "lastCommitTimestamp" -> "2018-10-24 14:14:18.0",
           "maximumTimestamp" -> "2018-10-24 14:14:18")
       )
 
@@ -389,7 +389,7 @@ trait DeltaTimeTravelTests extends QueryTest
         sqlState = "42816",
         parameters = Map(
           "providedTimestamp" -> "2018-10-24 14:24:18.0",
-          "tableName" -> "2018-10-24 14:14:18.0",
+          "lastCommitTimestamp" -> "2018-10-24 14:14:18.0",
           "maximumTimestamp" -> "2018-10-24 14:14:18")
       )
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
@@ -1560,18 +1560,35 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
             expected.map(_.toLong).toDF())
         }
       }
-      assert(intercept[StreamingQueryException] {
-        testStartingTimestamp("2020-07-15 00:10:01")
-      }.getMessage.contains("The provided timestamp (2020-07-15 00:10:01.0) " +
-        "is after the latest version"))
-      assert(intercept[StreamingQueryException] {
-        testStartingTimestamp("2020-07-16")
-      }.getMessage.contains("The provided timestamp (2020-07-16 00:00:00.0) " +
-        "is after the latest version"))
-      assert(intercept[StreamingQueryException] {
-        testStartingTimestamp("i am not a timestamp")
-      }.getMessage.contains("The provided timestamp ('i am not a timestamp') " +
-        "cannot be converted to a valid timestamp"))
+      checkError(
+        intercept[StreamingQueryException] {
+          testStartingTimestamp("2020-07-15 00:10:01")
+        }.getCause.asInstanceOf[SparkThrowable],
+        "DELTA_TIMESTAMP_GREATER_THAN_COMMIT",
+        Some("42816"),
+        parameters = Map(
+          "providedTimestamp" -> "2020-07-15 00:10:01\\.0",
+          "lastCommitTimestamp" -> ".*",
+          "maximumTimestamp" -> ".*"),
+        matchPVals = true)
+      checkError(
+        intercept[StreamingQueryException] {
+          testStartingTimestamp("2020-07-16")
+        }.getCause.asInstanceOf[SparkThrowable],
+        "DELTA_TIMESTAMP_GREATER_THAN_COMMIT",
+        Some("42816"),
+        parameters = Map(
+          "providedTimestamp" -> "2020-07-16 00:00:00\\.0",
+          "lastCommitTimestamp" -> ".*",
+          "maximumTimestamp" -> ".*"),
+        matchPVals = true)
+      checkError(
+        intercept[StreamingQueryException] {
+          testStartingTimestamp("i am not a timestamp")
+        }.getCause.asInstanceOf[SparkThrowable],
+        "DELTA_TIMESTAMP_INVALID",
+        "42816",
+        parameters = Map("expr" -> "'i am not a timestamp'"))
 
       // With non-strict parsing this produces null when casted to a timestamp and then parses
       // to 1970-01-01 (unix time 0).

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaStreamUtilsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaStreamUtilsSuite.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.delta
 
 import java.sql.Timestamp
 
-import org.apache.spark.SparkFunSuite
+import org.apache.spark.{SparkFunSuite, SparkThrowable}
 
 import org.apache.spark.sql.delta.sources.DeltaStreamUtils
 
@@ -69,11 +69,18 @@ class DeltaStreamUtilsSuite extends SparkFunSuite {
     val commitVersion = 5L
     val latestVersion = 5L
     val timestamp = new Timestamp(2000)
-    val e = intercept[Exception] {
+    val e = intercept[SparkThrowable] {
       DeltaStreamUtils.getStartingVersionFromCommitAtTimestamp(
         timeZone, commitTs, commitVersion, latestVersion, timestamp, canExceedLatest = false)
     }
-    assert(e.getMessage.contains("DELTA_TIMESTAMP_GREATER_THAN_COMMIT"))
+    checkError(
+      e,
+      "DELTA_TIMESTAMP_GREATER_THAN_COMMIT",
+      "42816",
+      Map(
+        "providedTimestamp" -> "1969-12-31 16:00:02.0",
+        "lastCommitTimestamp" -> "1969-12-31 16:00:01.0",
+        "maximumTimestamp" -> "1970-01-01 00:00:01"))
   }
 
   test("getStartingVersionFromCommitAtTimestamp - " +

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTimeTravelSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTimeTravelSuite.scala
@@ -252,7 +252,7 @@ class DeltaTimeTravelSuite extends QueryTest
         sqlState = "42816",
         parameters = Map(
           "providedTimestamp" -> "2018-10-24 17:34:18.0",
-          "tableName" -> "2018-10-24 17:14:18.0",
+          "lastCommitTimestamp" -> "2018-10-24 17:14:18.0",
           "maximumTimestamp" -> "2018-10-24 17:14:18")
       )
       assert(history.getActiveCommitAtTime(start + 180.minutes, true).version === 9)
@@ -573,7 +573,7 @@ class DeltaTimeTravelSuite extends QueryTest
         sqlState = "42816",
         parameters = Map(
           "providedTimestamp" -> "2018-10-24 14:24:18.0",
-          "tableName" -> "2018-10-24 14:14:18.0",
+          "lastCommitTimestamp" -> "2018-10-24 14:14:18.0",
           "maximumTimestamp" -> "2018-10-24 14:14:18")
       )
 
@@ -587,7 +587,7 @@ class DeltaTimeTravelSuite extends QueryTest
         sqlState = "42816",
         parameters = Map(
           "providedTimestamp" -> "2018-10-24 14:24:18.0",
-          "tableName" -> "2018-10-24 14:14:18.0",
+          "lastCommitTimestamp" -> "2018-10-24 14:14:18.0",
           "maximumTimestamp" -> "2018-10-24 14:14:18")
       )
 
@@ -855,7 +855,7 @@ class DeltaTimeTravelSuite extends QueryTest
           sqlState = "42816",
           parameters = Map(
             "providedTimestamp" -> s"$timeAfterVersion2",
-            "tableName" -> s"$timeAtVersion1",
+            "lastCommitTimestamp" -> s"$timeAtVersion1",
             "maximumTimestamp" -> s"${timeAtVersion1.replaceFirst("\\.\\d+$", "")}") // exclude ms
         )
       }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/InCommitTimestampSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/InCommitTimestampSuite.scala
@@ -1187,7 +1187,15 @@ class InCommitTimestampSuite
           catalogTableOpt = None,
           canReturnLastCommit = false)
       }
-      assert(e.getMessage.contains("The provided timestamp") && e.getMessage.contains("is after"))
+      checkError(
+        e,
+        "DELTA_TIMESTAMP_GREATER_THAN_COMMIT",
+        Some("42816"),
+        parameters = Map(
+          "providedTimestamp" -> ".*",
+          "lastCommitTimestamp" -> ".*",
+          "maximumTimestamp" -> ".*"),
+        matchPVals = true)
     }
   }
 


### PR DESCRIPTION
## Description

The `DELTA_TIMESTAMP_GREATER_THAN_COMMIT` error message has three parameter slots: `<providedTimestamp>`, `<tableName>`, and `<maximumTimestamp>`. The `<tableName>` slot was actually filled with the last commit timestamp, not a table name -- both semantically misleading and inconsistent with the sibling `DELTA_TIMESTAMP_EARLIER_THAN_COMMIT_RETENTION` error, which uses `<commitTs>` for the analogous slot.

This renames the template parameter `<tableName>` to `<lastCommitTimestamp>` to reflect the value it actually holds, and rewords the message for clarity:

> Timestamp `<providedTimestamp>` is after the table's latest version (`<lastCommitTimestamp>`). Use a timestamp at or before `<maximumTimestamp>`.

## How was this patch tested?

Updated the existing error-parameter assertions in the affected suites (`DeltaErrorsSuite`, `DeltaHistoryManagerSuite`, `DeltaTimeTravelSuite`, `InCommitTimestampSuite`, `DeltaStreamUtilsSuite`, `DeltaSourceSuite`), converting loose message-substring checks to `checkError` assertions.