### PR TITLE
fix(codec): reject out-of-range Z85 blocks

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/deletionvectors/Base85Codec.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/deletionvectors/Base85Codec.java
@@ -147,6 +147,7 @@ public final class Base85Codec {
       sum += inputCharDecoder.decodeInputChar(inputIndex + 2) * BASE_2ND_POWER;
       sum += inputCharDecoder.decodeInputChar(inputIndex + 3) * BASE;
       sum += inputCharDecoder.decodeInputChar(inputIndex + 4);
+      checkArgument(sum <= 0xFFFFFFFFL, () -> "Input is not valid Z85: " + encoded);
       buffer.putInt((int) sum);
       inputIndex += 5;
     }

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/deletionvectors/Base85CodecSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/deletionvectors/Base85CodecSuite.scala
@@ -105,6 +105,13 @@ class Base85CodecSuite extends AnyFunSuite {
   }
   // scalastyle:on nonascii
 
+  test("Reject illegal Z85 input - out-of-range block") {
+    val ex = intercept[IllegalArgumentException] {
+      Base85Codec.decodeAlignedBytes("#####")
+    }
+    assert(ex.getMessage.contains("Input is not valid Z85"))
+  }
+
   test("base85 codec uuid roundtrips") {
     for ((id, _) <- testUuids) {
       val encodedString = Base85Codec.encodeUUID(id)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/Codec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/Codec.scala
@@ -197,6 +197,7 @@ object Codec {
         sum += decodeInputChar(inputIndex + 2) * BASE_2ND_POWER
         sum += decodeInputChar(inputIndex + 3) * BASE
         sum += decodeInputChar(inputIndex + 4)
+        require(sum <= 0xFFFFFFFFL, s"Input is not valid Z85: $encoded")
         buffer.putInt(sum.toInt)
         inputIndex += 5
       }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/util/CodecSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/util/CodecSuite.scala
@@ -104,6 +104,13 @@ class CodecSuite extends SparkFunSuite {
   }
   // scalastyle:on nonascii
 
+  test("Reject illegal Z85 input - out-of-range block") {
+    val ex = intercept[IllegalArgumentException] {
+      Codec.Base85Codec.decodeAlignedBytes("#####")
+    }
+    assert(ex.getMessage.contains("Input is not valid Z85"))
+  }
+
   test("base85 codec uuid roundtrips") {
     for ((id, _) <- testUuids) {
       val encodedString = Codec.Base85Codec.encodeUUID(id)


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

* [x] Spark
* [x] Kernel
* [ ] Standalone
* [ ] Flink
* [ ] Other (fill in here)

## Description

This PR adds overflow validation to the Z85/Base85 decoders used by both Spark and the Delta Kernel.

Previously, each 5-character Z85 block was accumulated into a `long` and then converted to a 32-bit integer without validating that the accumulated value fit within the unsigned 32-bit range. As a result, malformed inputs whose decoded value exceeded `0xFFFFFFFF` were silently wrapped during conversion instead of being rejected.

This change adds an explicit upper-bound check before the conversion. Inputs that decode to values outside the valid unsigned 32-bit range now throw `IllegalArgumentException`, matching the existing behavior for other malformed Z85 inputs such as invalid characters or incorrect input length.

The change is intentionally minimal and keeps the behavior for valid Z85 inputs unchanged.

## How was this patch tested?

Added regression tests for both implementations:

* `io.delta.kernel.deletionvectors.Base85CodecSuite`
* `org.apache.spark.sql.delta.util.CodecSuite`

Verified that the new tests fail on the unmodified implementation and pass after the fix.

Ran the affected test suites:

```bash
./build/sbt "kernelApi/testOnly io.delta.kernel.deletionvectors.Base85CodecSuite"

./build/sbt -DuseDefaultUnityCatalogReleaseVersion=true \
  "spark/testOnly org.apache.spark.sql.delta.util.CodecSuite"
```

Also verified:

```bash
git diff --check
```

## Does this PR introduce *any* user-facing changes?

Yes.

Previously, malformed Z85 blocks whose decoded value exceeded the unsigned 32-bit range were silently accepted and decoded into incorrect bytes due to integer overflow.

After this change, such malformed inputs are rejected with `IllegalArgumentException`. Valid Z85-encoded data is unaffected.
