### PR TITLE
Add SingleCommit handle and getChangesIterator for streaming commit access

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -366,6 +366,43 @@ class DeltaLog private(
     }
   }
 
+  /**
+   * Lazily get all commits starting from "startVersion" (inclusive) as [[SingleCommit]]
+   * handles, without exposing the underlying log files. If startVersion doesn't exist, return an
+   * empty Iterator. This is the streaming counterpart of [[getChanges]]
+   *
+   * Callers are encouraged to use the other override which takes the endVersion if available to
+   * avoid I/O and improve performance of this method.
+   */
+  private[sql] def getChangesIterator(
+      startVersion: Long,
+      catalogTableOpt: Option[CatalogTable] = None,
+      failOnDataLoss: Boolean = false): Iterator[SingleCommit] =
+    getChangeLogFiles(startVersion, catalogTableOpt, failOnDataLoss).map {
+      case (version, status) => SingleCommit(this, version, status)
+    }
+
+  private[sql] def getChangesIterator(
+      startVersion: Long,
+      endVersion: Long,
+      catalogTableOpt: Option[CatalogTable],
+      failOnDataLoss: Boolean): Iterator[SingleCommit] =
+    getChangeLogFiles(startVersion, endVersion, catalogTableOpt, failOnDataLoss).map {
+      case (version, status) => SingleCommit(this, version, status)
+    }
+
+  /**
+   * Get access to all commit log files over [startVersion, endVersion] (both inclusive) via
+   * [[FileStatus]].
+   *
+   * NOTE: This method exposes the log's raw [[FileStatus]]es and will be removed in the future. New
+   * callers should use [[getChangesIterator]] instead, which returns [[SingleCommit]] handles and
+   * keeps the log's physical layout internal (a prerequisite for the Adaptive Metadata Tree).
+   */
+  @deprecated(
+    "This method exposes the log's raw file statuses and will be removed in the " +
+    "future. Use getChanges and variants instead"
+  )
   private[sql] def getChangeLogFiles(
       startVersion: Long,
       endVersion: Long,
@@ -400,7 +437,15 @@ class DeltaLog private(
    * If `startVersion` doesn't exist, return an empty Iterator.
    * Callers are encouraged to use the other override which takes the endVersion if available to
    * avoid I/O and improve performance of this method.
+   *
+   * NOTE: This method exposes the log's raw [[FileStatus]]es and will be removed in the future. New
+   * callers should use [[getChangesIterator]] instead, which returns [[SingleCommit]] handles and
+   * keeps the log's physical layout internal (a prerequisite for the Adaptive Metadata Tree).
    */
+  @deprecated(
+    "This method exposes the log's raw file statuses and will be removed in the " +
+    "future. Use getChanges and variants instead"
+  )
   def getChangeLogFiles(
       startVersion: Long,
       catalogTableOpt: Option[CatalogTable] = None,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/SingleCommit.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/SingleCommit.scala
@@ -1,0 +1,97 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.delta.actions.Action
+import org.apache.spark.sql.delta.storage.{ClosableIterator, SupportsRewinding}
+import org.apache.spark.sql.delta.storage.ClosableIterator._
+import org.apache.hadoop.fs.FileStatus
+
+/**
+ * A handle to a single commit in the Delta log, standing in for the raw commit log file that
+ * [[DeltaLog.getChangeLogFiles]] used to expose as a [[FileStatus]] -- now hidden so the log's
+ * physical layout stays internal, a prerequisite for the Adaptive Metadata Tree (AMT).
+ */
+class SingleCommit private (
+    private val deltaLog: DeltaLog,
+    val version: Long,
+    val fileModificationTimestamp: Long,
+    private val fileStatus: FileStatus
+) {
+  /**
+   * Open a fresh iterator over all of this commit's actions.
+   *
+   * @param maxInMemoryFileSizeBytes commits whose log file is smaller than this are read into
+   *        memory once and replayed on every `rewind()`; larger commits are re-read on each pass.
+   *        Defaults to 0, i.e. always stream via `readAsIterator` -- callers that want the
+   *        in-memory/rewind fast path opt in by passing a threshold.
+   */
+  def getActionsIterator(
+      maxInMemoryFileSizeBytes: Long = 0): ClosableIterator[Action] with SupportsRewinding[Action] =
+    SingleCommit.createRewindableActionIterator(deltaLog, fileStatus, maxInMemoryFileSizeBytes)
+}
+
+object SingleCommit {
+  /** Wrap a commit's log file into a [[SingleCommit]] handle. The commit
+   * `fileModificationTimestamp` is derived from the file's modification time; the raw
+   * [[FileStatus]] stays hidden inside the handle so the log's physical layout is not exposed to
+   * callers.
+   */
+  private[delta] def apply(
+      deltaLog: DeltaLog,
+      version: Long,
+      fileStatus: FileStatus): SingleCommit =
+    new SingleCommit(deltaLog, version, fileStatus.getModificationTime, fileStatus)
+
+  /**
+   * Read a single commit's actions into a rewindable, closable iterator, respecting memory
+   * constraints. If the commit's log file is smaller than `maxInMemoryFileSizeBytes`, its actions
+   * are read into memory once and replayed on every `rewind()`; otherwise the file is re-read on
+   * each pass.
+   *
+   * TODO(AMT): This needs AMT support for manifest commits, whose file actions live in the content
+   * tree rather than the commit JSON.
+   */
+  private def createRewindableActionIterator(
+      deltaLog: DeltaLog,
+      fileStatus: FileStatus,
+      maxInMemoryFileSizeBytes: Long): ClosableIterator[Action] with SupportsRewinding[Action] = {
+    lazy val actions =
+      deltaLog.store.read(fileStatus, deltaLog.newDeltaHadoopConf()).map(Action.fromJson)
+    // If the commit is smaller than the threshold, read it into memory once and iterate over that
+    // buffer on every pass; otherwise re-read the file each time.
+    val shouldLoadIntoMemory = fileStatus.getLen < maxInMemoryFileSizeBytes
+    def createClosableIterator(): ClosableIterator[Action] = if (shouldLoadIntoMemory) {
+      actions.toIterator.toClosable
+    } else {
+      deltaLog.store.readAsIterator(fileStatus, deltaLog.newDeltaHadoopConf()).withClose {
+        _.map(Action.fromJson)
+      }
+    }
+    new ClosableIterator[Action] with SupportsRewinding[Action] {
+      private var delegatedIterator: ClosableIterator[Action] = createClosableIterator()
+      override def hasNext: Boolean = delegatedIterator.hasNext
+      override def next(): Action = delegatedIterator.next()
+      override def close(): Unit = delegatedIterator.close()
+      override def rewind(): Unit = {
+        // Close the outgoing delegate before replacing it.
+        delegatedIterator.close()
+        delegatedIterator = createClosableIterator()
+      }
+    }
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
@@ -996,6 +996,106 @@ class DeltaLogSuite extends QueryTest
       }
     }
   }
+
+  private def createDeltaTableWithCommits(tableDir: File, numVersions: Int): DeltaLog = {
+    val log = DeltaLog.forTable(spark, tableDir.getCanonicalPath)
+    spark.sql(s"CREATE TABLE delta.`${tableDir.getCanonicalPath}` (id INT) USING delta")
+    (1 to numVersions).foreach { i =>
+      spark.sql(s"INSERT INTO delta.`${tableDir.getCanonicalPath}` VALUES ($i)")
+    }
+    log
+  }
+
+  test("getChangesIterator yields one SingleCommit per commit with the right version") {
+    withTempDir { tableDir =>
+      val log = createDeltaTableWithCommits(tableDir, numVersions = 3)
+      // CREATE is version 0, the three INSERTs are versions 1..3.
+      val commits = log.getChangesIterator(startVersion = 0).toList
+      assert(commits.map(_.version) === (0L to 3L).toList)
+
+      // The handle exposes the commit file's modification time (not the in-commit timestamp), so it
+      // matches what getChangeLogFiles reports for the same commit.
+      val fileModTimes =
+        log.getChangeLogFiles(startVersion = 0).map(_._2.getModificationTime).toList
+      assert(commits.map(_.fileModificationTimestamp) === fileModTimes)
+    }
+  }
+
+  test("getChangesIterator endVersion override bounds the range (both inclusive)") {
+    withTempDir { tableDir =>
+      val log = createDeltaTableWithCommits(tableDir, numVersions = 5)
+      val commits = log.getChangesIterator(
+        startVersion = 1, endVersion = 3, catalogTableOpt = None, failOnDataLoss = true).toList
+      assert(commits.map(_.version) === List(1L, 2L, 3L))
+    }
+  }
+
+  test("SingleCommit.getActionsIterator returns the commit's actions and matches getChanges") {
+    withTempDir { tableDir =>
+      val log = createDeltaTableWithCommits(tableDir, numVersions = 3)
+      val viaHandle = log.getChangesIterator(startVersion = 0).map { commit =>
+        (commit.version, commit.getActionsIterator().processAndClose(_.toList))
+      }.toList
+      val viaGetChanges = log.getChanges(startVersion = 0).map {
+        case (version, actions) => (version, actions.toList)
+      }.toList
+      assert(viaHandle === viaGetChanges)
+    }
+  }
+
+  test("SingleCommit.getActionsIterator is rewindable and replays the same actions") {
+    withTempDir { tableDir =>
+      val log = createDeltaTableWithCommits(tableDir, numVersions = 1)
+      // Version 1 is the single INSERT; open its actions and read twice via rewind().
+      val commit = log.getChangesIterator(startVersion = 1).next()
+      val iter = commit.getActionsIterator()
+      try {
+        val firstPass = iter.toList
+        assert(firstPass.nonEmpty)
+        iter.rewind()
+        val secondPass = iter.toList
+        assert(secondPass === firstPass)
+      } finally {
+        iter.close()
+      }
+    }
+  }
+
+  test("SingleCommit.getActionsIterator returns all actions of a multi-action commit") {
+    withTempDir { dir =>
+      val log = DeltaLog.forTable(spark, new Path(dir.getCanonicalPath))
+      // Commit 0 creates the table and adds "old". Commit 1 packs several data actions -- three new
+      // AddFiles and a RemoveFile of "old" -- into one commit so the commit has more than one
+      // action.
+      log.startTransaction().commitManually(
+        Metadata(configuration = Map(DeltaConfigs.CHECKPOINT_INTERVAL.key -> "10")),
+        createTestAddFile(encodedPath = "old"))
+      val dataActions: Seq[Action] = Seq(
+        createTestAddFile(encodedPath = "a"),
+        createTestAddFile(encodedPath = "b"),
+        createTestAddFile(encodedPath = "c"),
+        RemoveFile("old", Some(System.currentTimeMillis()), dataChange = true))
+      log.startTransaction().commitManually(dataActions: _*)
+
+      // Read commit 1 (the multi-action one) back through the new API.
+      val commit = log.getChangesIterator(startVersion = 1).next()
+      assert(commit.version === 1L)
+      val actions = commit.getActionsIterator().processAndClose(_.toList)
+
+      // It contains more than one action, and every data action we committed is present (order and
+      // exact identity of synthesized CommitInfo/Protocol are not asserted -- commit() adds those).
+      assert(actions.size > 1, s"expected a multi-action commit, got: $actions")
+      val addedPaths = actions.collect { case a: AddFile => a.path }.toSet
+      assert(addedPaths === Set("a", "b", "c"), s"missing AddFiles, got: $addedPaths")
+      val removedPaths = actions.collect { case r: RemoveFile => r.path }.toSet
+      assert(removedPaths === Set("old"), s"missing RemoveFile, got: $removedPaths")
+
+      // The authoritative invariant: getActionsIterator returns exactly what getChanges returns for
+      // this same multi-action commit.
+      val viaGetChanges = log.getChanges(startVersion = 1).next()._2.toList
+      assert(actions === viaGetChanges)
+    }
+  }
 }
 
 class DeltaLogWithCatalogOwnedBatch1Suite extends DeltaLogSuite {


### PR DESCRIPTION
## Description

This PR adds a streaming, handle-based way to walk a Delta table's commits without exposing the log's raw file layout to callers.

- `DeltaLog.getChangesIterator(startVersion, ...)` (and an `endVersion` overload) returns one `SingleCommit` per commit, as the streaming counterpart of `getChanges`.
- New `SingleCommit` class wraps a single commit and offers `getActionsIterator(...)`, which returns a rewindable, closable iterator over that commit's actions. An optional `maxInMemoryFileSizeBytes` threshold lets small commit files be read into memory once and replayed on each `rewind()`; larger files are re-read per pass.
- `getChangeLogFiles` is now `@deprecated` in favor of `getChangesIterator`, since it exposes the log's raw `FileStatus` objects. Keeping the physical layout internal lets the log evolve its on-disk representation without breaking consumers.

## How was this patch tested?

Added unit tests in `DeltaLogSuite`:
- `getChangesIterator` yields one `SingleCommit` per commit with the correct version and file modification timestamp.
- The `endVersion` overload bounds the range inclusively.
- `SingleCommit.getActionsIterator` returns a commit's actions and matches `getChanges`, including for a multi-action commit (multiple `AddFile`s plus a `RemoveFile`).
- `getActionsIterator` is rewindable and replays the same actions.

## Does this PR introduce _any_ user-facing changes?

No.