### PR TITLE
Remove unused sample-based estimation SQL config

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -445,13 +445,6 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .intConf
       .createWithDefault(1000000)
 
-  val DELTA_SAMPLE_ESTIMATOR_ENABLED =
-    buildConf("sampling.enabled")
-      .internal()
-      .doc("Enable sample based estimation.")
-      .booleanConf
-      .createWithDefault(false)
-
   val DELTA_CONVERT_METADATA_CHECK_ENABLED =
     buildConf("convert.metadataCheck.enabled")
       .doc(


### PR DESCRIPTION
## Description

This removes the unused `spark.databricks.delta.sampling.enabled` SQL config. It gated a sample-based statistics estimation read path that is dead code and never took effect (the config defaulted to `false` and had no remaining consumers), so the config definition can be safely removed.

Sample table lifecycle support (`ANALYZE TABLE ... COLLECT SAMPLE`, `DROP SAMPLE`, sample metadata/storage/GC, and the related sample-size and retention settings) is unaffected.

## How was this patch tested?

Existing statistics and sampling test suites continue to pass; this only deletes an unused configuration entry.

## Does this PR introduce _any_ user-facing changes?

No.