### PR TITLE
Introduce LastManifestCommit in VersionChecksum and CommitInfo

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/Checksum.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Checksum.scala
@@ -65,6 +65,7 @@ import org.apache.spark.util.{SerializableConfiguration, Utils}
  *                          that CRC files written by either Kernel or Delta-Spark are compatible.
  * @param deletedRecordCountsHistogramOpt A histogram of the deleted records count distribution
  *                                        for all the files in the snapshot.
+ * @param lastManifestCommit Info of the last AMT manifest commit up to this version.
  */
 case class VersionChecksum(
     txnId: Option[String],
@@ -87,7 +88,8 @@ case class VersionChecksum(
     @JsonAlias(Array("histogramOpt"))
     fileSizeHistogram: Option[FileSizeHistogram],
     deletedRecordCountsHistogramOpt: Option[DeletedRecordCountsHistogram],
-    allFiles: Option[Seq[AddFile]]) {
+    allFiles: Option[Seq[AddFile]],
+    lastManifestCommit: Option[LastManifestCommit]) {
 
   /**
    * Converts to the legacy representation that serializes the histogram field as
@@ -108,7 +110,8 @@ case class VersionChecksum(
     protocol = protocol,
     histogramOpt = fileSizeHistogram,
     deletedRecordCountsHistogramOpt = deletedRecordCountsHistogramOpt,
-    allFiles = allFiles
+    allFiles = allFiles,
+    lastManifestCommit = lastManifestCommit
   )
 }
 
@@ -135,7 +138,8 @@ case class VersionChecksumLegacy(
     protocol: Protocol,
     histogramOpt: Option[FileSizeHistogram],
     deletedRecordCountsHistogramOpt: Option[DeletedRecordCountsHistogram],
-    allFiles: Option[Seq[AddFile]])
+    allFiles: Option[Seq[AddFile]],
+    lastManifestCommit: Option[LastManifestCommit])
 
 /**
  * Record the state of the table as a checksum file along with a commit.
@@ -544,7 +548,8 @@ trait RecordChecksum extends DeltaLogging {
       domainMetadata = domainMetadata,
       allFiles = allFiles,
       deletedRecordCountsHistogramOpt = deletedRecordCountsHistogramOpt,
-      fileSizeHistogram = fileSizeHistogram
+      fileSizeHistogram = fileSizeHistogram,
+      lastManifestCommit = None
     ))
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
@@ -670,7 +670,8 @@ class Snapshot(
     fileSizeHistogram = Option.when(fileSizeHistogramEnabled) {
       checksumOpt.flatMap(_.fileSizeHistogram)
         .orElse(Option.when(_computedStateTriggered)(fileSizeHistogram).flatten)
-    }.flatten
+    }.flatten,
+    lastManifestCommit = None
   )
 
   /** Returns the data schema of the table, used for reading stats */

--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -1381,6 +1381,7 @@ trait CommitMarker {
  * @param engineInfo The information for the engine that makes the commit.
  *                   If a commit is made by Delta Lake 1.1.0 or above, it will be
  *                   `Apache-Spark/x.y.z Delta-Lake/x.y.z`.
+ * @param lastManifestCommit Info of the last AMT manifest commit up to this version.
  */
 case class CommitInfo(
     // The commit version should be left unfilled during commit(). When reading a delta file, we can
@@ -1407,7 +1408,8 @@ case class CommitInfo(
     userMetadata: Option[String],
     tags: Option[Map[String, String]],
     engineInfo: Option[String],
-    txnId: Option[String])
+    txnId: Option[String],
+    lastManifestCommit: Option[LastManifestCommit])
   extends Action with CommitMarker with SparkAbstractCommitInfo with StorageAbstractCommitInfo {
   override def wrap: SingleAction = SingleAction(commitInfo = this)
 
@@ -1464,7 +1466,7 @@ object NotebookInfo {
 object CommitInfo {
   def empty(version: Option[Long] = None): CommitInfo = {
     CommitInfo(version, None, null, None, None, null, null, None, None,
-      None, None, None, None, None, None, None, None, None)
+      None, None, None, None, None, None, None, None, None, None)
   }
 
   // scalastyle:off argcount
@@ -1524,7 +1526,8 @@ object CommitInfo {
       userMetadata,
       tags,
       getEngineInfo,
-      txnId)
+      txnId,
+      lastManifestCommit = None)
   }
   // scalastyle:on argcount
 
@@ -1643,6 +1646,17 @@ case class Checkpoint(
 
   override def wrap: SingleAction = SingleAction(checkpoint = this)
 }
+
+/**
+ * Info of last AMT manifest commit. Persisted in every [[CommitInfo]] and [[VersionChecksum]]
+ * as the source-of-truth of the last manifest commit up to the current commit version.
+ *
+ * @param version version of the manifest commit
+ * @param contentRootVersion version of the content root recorded in the manifest commit
+ */
+case class LastManifestCommit(
+    version: Long,
+    contentRootVersion: Long)
 
 /**
  * An [[Action]] containing the information about a sidecar file.

--- a/spark/src/test/scala/org/apache/spark/sql/delta/ChecksumSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/ChecksumSuite.scala
@@ -21,6 +21,7 @@ import java.util.TimeZone
 
 import com.databricks.spark.util.Log4jUsageLogger
 import org.apache.spark.sql.delta.DeltaTestUtils._
+import org.apache.spark.sql.delta.actions.{LastManifestCommit, Metadata, Protocol}
 import org.apache.spark.sql.delta.coordinatedcommits.CatalogOwnedTestBaseSuite
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.{DeltaSQLCommandTest, DeltaSQLTestUtils}
@@ -362,6 +363,36 @@ class ChecksumSuite
         }
       }
     }
+  }
+
+  test("VersionChecksum round-trips lastManifestCommit and omits it when None") {
+    val lmc = LastManifestCommit(contentRootVersion = 41, version = 43)
+    val base = VersionChecksum(
+      txnId = None,
+      tableSizeBytes = 100,
+      numFiles = 1,
+      numDeletedRecordsOpt = None,
+      numDeletionVectorsOpt = None,
+      numMetadata = 1,
+      numProtocol = 1,
+      inCommitTimestampOpt = None,
+      setTransactions = None,
+      domainMetadata = None,
+      metadata = Metadata(),
+      protocol = Protocol(),
+      fileSizeHistogram = None,
+      deletedRecordCountsHistogramOpt = None,
+      allFiles = None,
+      lastManifestCommit = Some(lmc))
+
+    val json = JsonUtils.toJson(base)
+    assert(JsonUtils.fromJson[VersionChecksum](json).lastManifestCommit.contains(lmc))
+
+    // None serializes as absent (mapper uses Include.NON_ABSENT), so existing CRCs stay unchanged.
+    val jsonWithoutLmc = JsonUtils.toJson(base.copy(lastManifestCommit = None))
+    assert(!jsonWithoutLmc.contains("lastManifestCommit"))
+    // A CRC written before this field existed deserializes to None.
+    assert(JsonUtils.fromJson[VersionChecksum](jsonWithoutLmc).lastManifestCommit.isEmpty)
   }
 }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImplMetricsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImplMetricsSuite.scala
@@ -192,6 +192,7 @@ class UCDeltaCatalogClientImplMetricsSuite extends QueryTest
       readVersion = None, isolationLevel = None,
       isBlindAppend = Some(false),
       operationMetrics = operationMetrics,
-      userMetadata = None, tags = None, engineInfo = None, txnId = None)
+      userMetadata = None, tags = None, engineInfo = None, txnId = None,
+      lastManifestCommit = None)
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/hooks/metrics/UpdateMetricsHookSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/hooks/metrics/UpdateMetricsHookSuite.scala
@@ -221,7 +221,7 @@ class UpdateMetricsHookSuite extends QueryTest
         isBlindAppend = Some(true),
         operationMetrics = Some(Map("numOutputRows" -> "50")),
         userMetadata = None, tags = None, engineInfo = None,
-        txnId = None)
+        txnId = None, lastManifestCommit = None)
       val txn = makeTxn(deltaLog, ct, Seq(commitInfo, addFile))
       UpdateMetricsHook(Some(ct)).run(spark, txn)
       assert(UpdateMetricsHook.awaitCompletion(10000),


### PR DESCRIPTION
## Description

This change introduces a new `LastManifestCommit` case class that records the
version and content root version of the last manifest commit, and threads an
optional `lastManifestCommit` field through `VersionChecksum` (and its legacy
serialized form) and `CommitInfo`.

This is a mechanical, field-plumbing change. The field is set to `None`
everywhere for now and is not yet populated on the write path; wiring up the
actual population is left to follow-up work.

## How was this patch tested?

Added assertions in `ChecksumSuite` covering the new field.

## Does this PR introduce _any_ user-facing changes?

No.
