### PR TITLE
Make logPath and dataPath abstract in TransactionHelper

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/TransactionHelper.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/TransactionHelper.scala
@@ -48,15 +48,13 @@ trait TransactionHelper extends DeltaLogging {
    * The path to the Delta log directory. Not implemented in the base trait; each concrete
    * transaction supplies it.
    */
-  def logPath: Path =
-    throw new UnsupportedOperationException("logPath is not implemented for this transaction")
+  def logPath: Path
 
   /**
    * The path to the Delta table data directory. Not implemented in the base trait; each concrete
    * transaction supplies it.
    */
-  def dataPath: Path =
-    throw new UnsupportedOperationException("dataPath is not implemented for this transaction")
+  def dataPath: Path
 
   def catalogTable: Option[CatalogTable]
   def snapshot: Snapshot


### PR DESCRIPTION
## Description

Turn the `logPath` and `dataPath` methods on the `TransactionHelper` trait from concrete stubs that throw `UnsupportedOperationException` into abstract methods.

The only implementor of the trait, `OptimisticTransactionImpl`, already overrides both (`OptimisticTransaction.scala`). The throwing default implementations were therefore dead code. Making the methods abstract makes the contract explicit and enforces it at compile time.

## How was this patch tested?

- `build/sbt spark/compile` passes.
- `OptimisticTransactionSuite` passes.

## Does this PR introduce _any_ user-facing changes?

No.

This pull request and its description were written by Isaac.