### PR TITLE
[Kernel][Spark] Fix stale UC Delta client test callers

### DIFF
--- a/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/UCDeltaClientCommitE2ESuite.scala
+++ b/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/UCDeltaClientCommitE2ESuite.scala
@@ -18,7 +18,7 @@ package io.delta.kernel.unitycatalog
 
 import java.net.InetSocketAddress
 import java.nio.charset.StandardCharsets
-import java.util.{Collections, Optional}
+import java.util.Optional
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
@@ -32,7 +32,6 @@ import io.delta.storage.commit.uccommitcoordinator.UCDeltaTokenBasedRestClient
 
 import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
 import com.sun.net.httpserver.{HttpExchange, HttpServer}
-import io.unitycatalog.client.auth.TokenProvider
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 import org.scalatest.funsuite.AnyFunSuite
 
@@ -95,8 +94,11 @@ class UCDeltaClientCommitE2ESuite
   override def beforeEach(): Unit = {
     super.beforeEach()
     requests.synchronized { requests.clear() }
-    deltaClient =
-      new UCDeltaTokenBasedRestClient(serverUri, tokenProvider(), Collections.emptyMap())
+    val ucConfig = Map(
+      "uri" -> serverUri,
+      "auth.type" -> "static",
+      "auth.token" -> "mock-token").asJava
+    deltaClient = new UCDeltaTokenBasedRestClient(ucConfig, null)
   }
 
   override def afterEach(): Unit = {
@@ -110,12 +112,6 @@ class UCDeltaClientCommitE2ESuite
       s""""columns":{"type":"struct","fields":[]},"properties":{},""" +
       s""""partition-columns":[],"created-time":1000},""" +
       s""""commits":[],"latest-table-version":0}"""
-
-  private def tokenProvider(): TokenProvider = new TokenProvider {
-    override def accessToken(): String = "mock-token"
-    override def initialize(configs: java.util.Map[String, String]): Unit = {}
-    override def configs(): java.util.Map[String, String] = Collections.emptyMap()
-  }
 
   private val jsonMapper = new ObjectMapper()
 

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCKernelDeltaTablesLiveE2ETest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCKernelDeltaTablesLiveE2ETest.java
@@ -52,7 +52,6 @@ import io.delta.storage.commit.TableIdentifier;
 import io.delta.storage.commit.uccommitcoordinator.UCDeltaModels;
 import io.delta.storage.commit.uccommitcoordinator.UCDeltaTokenBasedRestClient;
 import io.unitycatalog.client.api.TablesApi;
-import io.unitycatalog.client.auth.TokenProvider;
 import io.unitycatalog.client.model.TableInfo;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -110,9 +109,12 @@ public class UCKernelDeltaTablesLiveE2ETest extends UnityCatalogSupport {
       new StructType().add("id", IntegerType.INTEGER).add("name", StringType.STRING);
 
   private UCDeltaTokenBasedRestClient newDeltaClient(UnityCatalogInfo uc) {
-    Map<String, String> authConfig = Map.of("type", "static", "token", uc.serverToken());
-    TokenProvider tokenProvider = TokenProvider.create(authConfig);
-    return new UCDeltaTokenBasedRestClient(uc.serverUri(), tokenProvider, Collections.emptyMap());
+    Map<String, String> ucConfig =
+        Map.of(
+            "uri", uc.serverUri(),
+            "auth.type", "static",
+            "auth.token", uc.serverToken());
+    return new UCDeltaTokenBasedRestClient(ucConfig, null);
   }
 
   private Engine newEngine() {


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

Delta `master` became uncompilable when #7159 and #6825 landed from the same stale base in the opposite order from their CI runs. #7159 introduced two tests using the legacy three-argument `UCDeltaTokenBasedRestClient` constructor. #6825 replaced that constructor with the unified `(Map<String, String>, Supplier<Configuration>)` contract, but its last synthetic merge and CI run predated #7159. Squash-merging #6825 onto the newer base therefore exposed an integration break that neither PR tested.

Migrate both stale callers to the unified config contract:

- pass the UC endpoint through `uri`
- preserve static-token authentication through `auth.type` and `auth.token`
- preserve the previous empty app-version map by omitting `appVersions.*`
- preserve the default Hadoop configuration behavior with a null supplier

This repairs the Kernel UC and Spark UC test-compilation failures on `master`. The Build Test failure has the same root cause because its `publishM2` path compiles the `kernelUnityCatalog` tests classifier.

## How was this patch tested?

- [x] build/sbt "kernelUnityCatalog / Test / scalafmtAll" "sparkUnityCatalog / Test / javafmtAll"`
- [x] `git diff --check`
- [x] build/sbt "++ 2.13.16" "kernelUnityCatalog / Test / compile" "sparkUnityCatalog / Test / compile"`

## Does this PR introduce _any_ user-facing changes?

No.
