### PR TITLE
Add Delta Sharing test helpers for pinning a snapshot version and per-version parquet responses

### DIFF
--- a/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingDataSourceDeltaTestUtils.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingDataSourceDeltaTestUtils.scala
@@ -359,12 +359,17 @@ trait DeltaSharingDataSourceDeltaTestUtils extends SharedSparkSession {
       inlineDvFormat: Option[RoaringBitmapArrayFormat.Value] = None,
       assertMultipleDvsInOneFile: Boolean = false,
       reverseFileOrder: Boolean = false,
-      limitHint: Option[Long] = None): Unit = {
+      limitHint: Option[Long] = None,
+      snapshotVersion: Option[Long] = None): Unit = {
     val lines = Seq.newBuilder[String]
     var totalSize = 0L
 
-    // To prepare faked delta sharing responses with needed files for DeltaSharingClient.
-    val snapshotToUse = getSnapshotToUse(deltaTable, versionAsOf)
+    // To prepare faked delta sharing responses with needed files for DeltaSharingClient. The block
+    // is keyed by versionAsOf/timestampAsOf, but the snapshot whose data it serves can be pinned
+    // independently via snapshotVersion -- so a timestampAsOf-keyed block can serve an older
+    // version's snapshot (the server returns that version's files/metadata at the timestamp),
+    // which versionAsOf alone cannot express since getSnapshotToUse maps a timestamp to latest.
+    val snapshotToUse = getSnapshotToUse(deltaTable, snapshotVersion.orElse(versionAsOf))
     val fileActionsArrayBuffer = ArrayBuffer[model.DeltaSharingFileAction]()
     val dvPathToCount = scala.collection.mutable.Map[String, Int]()
     var numRecords = 0L

--- a/sharing/src/test/scala/io/delta/sharing/spark/TestClientForDeltaFormatSharing.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/TestClientForDeltaFormatSharing.scala
@@ -114,7 +114,8 @@ private[spark] class TestClientForDeltaFormatSharing(
     while (iterator.hasNext) {
       linesBuilder += iterator.next()
     }
-    if (table.name.contains("shared_parquet_table") &&
+    if ((table.name.contains("shared_parquet_table") ||
+        isParquetPinnedVersion(table, versionAsOf)) &&
       responseFormat.contains(DeltaSharingRestClient.RESPONSE_FORMAT_PARQUET)) {
       val lines = linesBuilder.result()
       val protocol = JsonUtils.fromJson[SingleAction](lines(0)).protocol
@@ -188,7 +189,8 @@ private[spark] class TestClientForDeltaFormatSharing(
     while (iterator.hasNext) {
       linesBuilder += iterator.next()
     }
-    if (table.name.contains("shared_parquet_table") &&
+    if ((table.name.contains("shared_parquet_table") ||
+        isParquetPinnedVersion(table, versionAsOf)) &&
       responseFormat.contains(DeltaSharingRestClient.RESPONSE_FORMAT_PARQUET)) {
       val lines = linesBuilder.result()
       val protocol = JsonUtils.fromJson[SingleAction](lines(0)).protocol
@@ -367,6 +369,20 @@ object TestClientForDeltaFormatSharing {
   val requestedFormat = scala.collection.mutable.Map[String, String]()
   val jsonPredicateHints = scala.collection.mutable.Map[String, String]()
   @volatile var lastCallerOrg: String = ""
+
+  // Tables (by name) whose format is parquet only AT a specific versionAsOf, delta otherwise.
+  // Lets a test model a share that is delta at latest but parquet at a pinned version -- which the
+  // name-based parquet detection cannot express on its own. Empty by default (no effect).
+  val parquetOnlyAtVersion = scala.collection.mutable.Map[String, Long]()
+
+  def clearParquetOnlyAtVersion(): Unit = parquetOnlyAtVersion.clear()
+
+  /** True if `table` responds parquet for this `versionAsOf`, per [[parquetOnlyAtVersion]]. */
+  private def isParquetPinnedVersion(table: Table, versionAsOf: Option[Long]): Boolean =
+    (parquetOnlyAtVersion.get(table.name), versionAsOf) match {
+      case (Some(pinned), Some(requested)) => pinned == requested
+      case _ => false
+    }
 
   // Captures (tableName, queryType, fileIdHash) for each getFiles call.
   val fileIdHashHistory = scala.collection.mutable.ArrayBuffer[(String, String, Option[String])]()


### PR DESCRIPTION
Extends the Delta Sharing test utilities so a test can model a share whose served snapshot and response format vary by the requested version:

- `prepareMockedClientAndFileSystemResult` gains an optional `snapshotVersion` parameter, letting a `versionAsOf`/`timestampAsOf`-keyed mock block serve an older version's snapshot (a timestamp otherwise maps to the latest snapshot).
- `TestClientForDeltaFormatSharing` gains a `parquetOnlyAtVersion` map so a share can respond in parquet only at a specific pinned version while remaining delta otherwise.

Both default to no-op, so existing tests are unaffected.