### PR TITLE
[Flink] Migrate UC table creation to the Delta-Tables API

### DIFF
--- a/flink/src/main/java/io/delta/flink/table/AbstractKernelTable.java
+++ b/flink/src/main/java/io/delta/flink/table/AbstractKernelTable.java
@@ -139,7 +139,14 @@ public abstract class AbstractKernelTable implements DeltaTable {
 
   protected final DeltaCatalog catalog;
   protected String tableId;
-  protected String tableUUID;
+
+  /**
+   * @deprecated The UC Delta API no longer requires a table UUID for credential lookup. This field
+   *     is retained for remaining Kernel and metrics call sites and should be removed after they
+   *     are migrated.
+   */
+  @Deprecated protected String tableUUID;
+
   protected URI tablePath;
   protected final TableConf conf;
   /*
@@ -469,8 +476,10 @@ public abstract class AbstractKernelTable implements DeltaTable {
           partitionColumns,
           conf.catalogConf(),
           tableDesc -> {
+            this.conf.update(tableDesc.requiredProperties);
             this.tablePath = normalize(tableDesc.tablePath);
             this.tableUUID = tableDesc.uuid;
+            credentialManager.initializeCredentials(tableDesc.getStorageProperties());
             createDeltaTable();
           });
     }

--- a/flink/src/main/java/io/delta/flink/table/CatalogManagedTable.java
+++ b/flink/src/main/java/io/delta/flink/table/CatalogManagedTable.java
@@ -16,9 +16,6 @@
 
 package io.delta.flink.table;
 
-import static io.delta.kernel.internal.tablefeatures.TableFeatures.*;
-import static io.delta.kernel.unitycatalog.UCCatalogManagedClient.UC_TABLE_ID_KEY;
-
 import io.delta.kernel.Snapshot;
 import io.delta.kernel.data.Row;
 import io.delta.kernel.transaction.CreateTableTransactionBuilder;
@@ -32,8 +29,6 @@ import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.apache.flink.util.Preconditions;
 import org.apache.hadoop.conf.Configuration;
 import org.slf4j.Logger;
@@ -56,17 +51,6 @@ import org.slf4j.LoggerFactory;
 public class CatalogManagedTable extends AbstractKernelTable {
 
   private static final Logger LOG = LoggerFactory.getLogger(CatalogManagedTable.class);
-  public static final Map<String, String> CATALOG_MANAGED_REQUIRED_FEATURES_CONF =
-      Stream.of(
-              CATALOG_MANAGED_RW_FEATURE,
-              DELETION_VECTORS_RW_FEATURE,
-              DOMAIN_METADATA_W_FEATURE,
-              IN_COMMIT_TIMESTAMP_W_FEATURE,
-              ROW_TRACKING_W_FEATURE,
-              CHECKPOINT_V2_RW_FEATURE,
-              VACUUM_PROTOCOL_CHECK_RW_FEATURE)
-          .map(feature -> String.format("delta.feature.%s", feature.featureName()))
-          .collect(Collectors.toMap(key -> key, key -> "supported"));
 
   private final URI endpoint;
   private final UnityCatalog.AuthMode authMode;
@@ -168,21 +152,11 @@ public class CatalogManagedTable extends AbstractKernelTable {
   }
 
   @Override
-  protected void createDeltaTable() {
-    conf.update(Map.of(UC_TABLE_ID_KEY, tableUUID));
-    super.createDeltaTable();
-  }
-
-  @Override
   protected CreateTableTransactionBuilder buildCreateTableTransaction() {
+    // Pass the table identifier so the UC committer finalizes (promotes) the staging table when
+    // the version 0 commit is written, rather than relying on a separate catalog registration.
     return catalogManagedClient.buildCreateTableTransaction(
-        tableUUID, tablePath.toString(), schema, ENGINE_INFO);
-  }
-
-  @Override
-  protected Map<String, String> extraConf() {
-    // Make sure the table supports table features needed by CatalogManaged.
-    return CATALOG_MANAGED_REQUIRED_FEATURES_CONF;
+        tableUUID, tablePath.toString(), schema, ENGINE_INFO, getUcTableIdentifier());
   }
 
   @Override

--- a/flink/src/main/java/io/delta/flink/table/DeltaCatalog.java
+++ b/flink/src/main/java/io/delta/flink/table/DeltaCatalog.java
@@ -122,6 +122,9 @@ public interface DeltaCatalog extends Serializable {
     /** Storage properties returned while resolving the table, when available. */
     Map<String, String> storageProperties = Map.of();
 
+    /** Properties the catalog requires when initializing a newly allocated table. */
+    Map<String, String> requiredProperties = Map.of();
+
     public TableDescriptor() {}
 
     public TableDescriptor(String tableId, String uuid, URI tablePath) {
@@ -134,6 +137,16 @@ public interface DeltaCatalog extends Serializable {
       this.uuid = uuid;
       this.tablePath = tablePath;
       this.storageProperties = Collections.unmodifiableMap(new HashMap<>(storageProperties));
+    }
+
+    public TableDescriptor(
+        String tableId,
+        String uuid,
+        URI tablePath,
+        Map<String, String> storageProperties,
+        Map<String, String> requiredProperties) {
+      this(tableId, uuid, tablePath, storageProperties);
+      this.requiredProperties = Collections.unmodifiableMap(new HashMap<>(requiredProperties));
     }
 
     public String getTableId() {
@@ -150,6 +163,10 @@ public interface DeltaCatalog extends Serializable {
 
     public Map<String, String> getStorageProperties() {
       return storageProperties;
+    }
+
+    public Map<String, String> getRequiredProperties() {
+      return requiredProperties;
     }
   }
 }

--- a/flink/src/main/java/io/delta/flink/table/UnityCatalog.java
+++ b/flink/src/main/java/io/delta/flink/table/UnityCatalog.java
@@ -19,10 +19,10 @@ package io.delta.flink.table;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.failsafe.function.CheckedSupplier;
-import io.delta.kernel.internal.types.DataTypeJsonSerDe;
 import io.delta.kernel.types.*;
 import io.delta.kernel.unitycatalog.UCTableIdentifier;
 import io.delta.storage.commit.TableIdentifier;
+import io.delta.storage.commit.actions.AbstractProtocol;
 import io.delta.storage.commit.uccommitcoordinator.UCConfigUtils;
 import io.delta.storage.commit.uccommitcoordinator.UCDeltaClient;
 import io.delta.storage.commit.uccommitcoordinator.UCDeltaModels;
@@ -40,7 +40,6 @@ import java.net.URI;
 import java.util.*;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import org.apache.flink.util.Preconditions;
 import org.apache.hadoop.conf.Configuration;
 import org.slf4j.Logger;
@@ -68,69 +67,6 @@ import org.slf4j.LoggerFactory;
 public class UnityCatalog implements DeltaCatalog {
 
   private static final Logger LOG = LoggerFactory.getLogger(UnityCatalog.class);
-
-  private static ColumnTypeName columnTypeName(DataType dataType) {
-    if (dataType instanceof IntegerType) {
-      return ColumnTypeName.INT;
-    } else if (dataType instanceof LongType) {
-      return ColumnTypeName.LONG;
-    } else if (dataType instanceof ShortType) {
-      return ColumnTypeName.SHORT;
-    } else if (dataType instanceof ByteType) {
-      return ColumnTypeName.BYTE;
-    } else if (dataType instanceof BooleanType) {
-      return ColumnTypeName.BOOLEAN;
-    } else if (dataType instanceof FloatType) {
-      return ColumnTypeName.FLOAT;
-    } else if (dataType instanceof DoubleType) {
-      return ColumnTypeName.DOUBLE;
-    } else if (dataType instanceof StringType) {
-      return ColumnTypeName.STRING;
-    } else if (dataType instanceof BinaryType) {
-      return ColumnTypeName.BINARY;
-    } else if (dataType instanceof DecimalType) {
-      return ColumnTypeName.DECIMAL;
-    } else if (dataType instanceof DateType) {
-      return ColumnTypeName.DATE;
-    } else if (dataType instanceof TimestampType) {
-      return ColumnTypeName.TIMESTAMP;
-    } else if (dataType instanceof TimestampNTZType) {
-      return ColumnTypeName.TIMESTAMP_NTZ;
-    } else if (dataType instanceof ArrayType) {
-      return ColumnTypeName.ARRAY;
-    } else if (dataType instanceof MapType) {
-      return ColumnTypeName.MAP;
-    } else if (dataType instanceof StructType) {
-      return ColumnTypeName.STRUCT;
-    } else {
-      throw new UnsupportedOperationException("Unsupported data type: " + dataType);
-    }
-  }
-
-  private static String typeText(DataType dataType) {
-    if (dataType instanceof DecimalType) {
-      DecimalType decimalType = (DecimalType) dataType;
-      return String.format("DECIMAL(%d,%d)", decimalType.getPrecision(), decimalType.getScale());
-    } else if (dataType instanceof BasePrimitiveType) {
-      return dataType.toString().toUpperCase(Locale.ROOT);
-    } else if (dataType instanceof ArrayType) {
-      ArrayType arrayType = (ArrayType) dataType;
-      return String.format("ARRAY<%s>", typeText(arrayType.getElementType()));
-    } else if (dataType instanceof MapType) {
-      MapType mapType = (MapType) dataType;
-      return String.format(
-          "MAP<%s,%s>", typeText(mapType.getKeyType()), typeText(mapType.getValueType()));
-    } else if (dataType instanceof StructType) {
-      StructType structType = (StructType) dataType;
-      return String.format(
-          "STRUCT<%s>",
-          structType.fields().stream()
-              .map(field -> String.format("%s:%s", field.getName(), typeText(field.getDataType())))
-              .collect(Collectors.joining(",")));
-    } else {
-      throw new UnsupportedOperationException("Unsupported data type: " + dataType);
-    }
-  }
 
   enum AuthMode {
     token,
@@ -179,6 +115,56 @@ public class UnityCatalog implements DeltaCatalog {
         .forEach(
             (name, version) -> ucConfig.put(UCConfigUtils.APP_VERSIONS_PREFIX + name, version));
     return ucConfig;
+  }
+
+  private static Map<String, String> requiredCreateProperties(
+      String tableId,
+      Map<String, String> requestedProperties,
+      UCDeltaModels.StagingTableInfo stagingTableInfo) {
+    Map<String, String> requiredProperties = new HashMap<>();
+    AbstractProtocol requiredProtocol = stagingTableInfo.getRequiredProtocol();
+    if (requiredProtocol != null) {
+      Set<String> requiredFeatures = new HashSet<>();
+      if (requiredProtocol.getReaderFeatures() != null) {
+        requiredFeatures.addAll(requiredProtocol.getReaderFeatures());
+      }
+      if (requiredProtocol.getWriterFeatures() != null) {
+        requiredFeatures.addAll(requiredProtocol.getWriterFeatures());
+      }
+      requiredFeatures.forEach(
+          feature ->
+              putRequiredProperty(
+                  tableId,
+                  requestedProperties,
+                  requiredProperties,
+                  "delta.feature." + feature,
+                  "supported"));
+    }
+    stagingTableInfo
+        .getRequiredProperties()
+        .forEach(
+            (key, value) -> {
+              if (value != null) {
+                putRequiredProperty(tableId, requestedProperties, requiredProperties, key, value);
+              }
+            });
+    return requiredProperties;
+  }
+
+  private static void putRequiredProperty(
+      String tableId,
+      Map<String, String> requestedProperties,
+      Map<String, String> requiredProperties,
+      String key,
+      String requiredValue) {
+    String requestedValue = requestedProperties.get(key);
+    if (requestedValue != null && !requestedValue.equals(requiredValue)) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Cannot create table %s: catalog requires %s=%s, but the requested value is %s",
+              tableId, key, requiredValue, requestedValue));
+    }
+    requiredProperties.put(key, requiredValue);
   }
 
   private final String name;
@@ -397,14 +383,14 @@ public class UnityCatalog implements DeltaCatalog {
   }
 
   /**
-   * Creates a new table in the backed UnityCatalog
+   * Reserves a staging table in Unity Catalog and hands its allocated storage location to {@code
+   * callback} so the caller can initialize the Delta table there.
    *
-   * <p>The {@code tableId} identifies the table within UC. This operation registers the table
-   * metadata with the remote catalog, including schema, partition specification, and table
-   * properties.
+   * <p>The staging table is promoted to a real managed table by the Kernel UC committer when the
+   * initial (version 0) commit is written, so this method does not register the table itself.
    *
-   * <p>This call will create a staging table, init the snapshot, then upgrade the staging table to
-   * real table.
+   * @param tableId the {@code catalog.schema.table} identifier of the table to create
+   * @param callback invoked with the reserved table id and storage location
    */
   @Override
   public void createTable(
@@ -419,61 +405,18 @@ public class UnityCatalog implements DeltaCatalog {
     Objects.requireNonNull(properties);
     withErrorHandling(
         () -> {
-          TablesApi tablesApi = new TablesApi(apiClient);
-          // Obtain names
-          UCTableIdentifier tableIdentifier = toUcTableIdentifier(tableId);
-          String schemaName = tableIdentifier.getSchemaName();
-          String tableName = tableIdentifier.getTableName();
-          // Column Info
-          List<ColumnInfo> columnInfos =
-              IntStream.range(0, schema.fields().size())
-                  .mapToObj(
-                      index -> {
-                        StructField field = schema.fields().get(index);
-                        ColumnInfo colInfo =
-                            new ColumnInfo()
-                                .name(field.getName())
-                                .typeName(columnTypeName(field.getDataType()))
-                                .typeText(typeText(field.getDataType()))
-                                .typeJson(DataTypeJsonSerDe.serializeDataType(field.getDataType()))
-                                .position(index)
-                                .nullable(field.isNullable());
-                        if (field.getDataType() instanceof DecimalType) {
-                          DecimalType decimalType = (DecimalType) field.getDataType();
-                          colInfo
-                              .typePrecision(decimalType.getPrecision())
-                              .typeScale(decimalType.getScale());
-                        }
-                        return colInfo;
-                      })
-                  .collect(Collectors.toList());
-
-          // Create a staging table and init the storage
-          StagingTableInfo stagingTableInfo =
-              tablesApi.createStagingTable(
-                  new CreateStagingTable()
-                      .catalogName(getName())
-                      .schemaName(schemaName)
-                      .name(tableName));
-
-          // Init Delta snapshot
-          String storageLocation = stagingTableInfo.getStagingLocation();
-          Objects.requireNonNull(storageLocation);
-
-          TableDescriptor desc =
-              new TableDescriptor(tableId, stagingTableInfo.getId(), URI.create(storageLocation));
-          callback.accept(desc);
-
-          tablesApi.createTable(
-              new CreateTable()
-                  .catalogName(getName())
-                  .schemaName(schemaName)
-                  .name(tableName)
-                  .storageLocation(stagingTableInfo.getStagingLocation())
-                  .tableType(TableType.MANAGED)
-                  .dataSourceFormat(DataSourceFormat.DELTA)
-                  .columns(columnInfos)
-                  .properties(properties));
+          UCDeltaModels.StagingTableInfo stagingTableInfo =
+              deltaClient.createStagingTable(toStorageTableIdentifier(tableId));
+          String storageLocation = Objects.requireNonNull(stagingTableInfo.getLocation());
+          Map<String, String> requiredProperties =
+              requiredCreateProperties(tableId, properties, stagingTableInfo);
+          callback.accept(
+              new TableDescriptor(
+                  tableId,
+                  stagingTableInfo.getTableId().toString(),
+                  URI.create(storageLocation),
+                  stagingTableInfo.getStorageProperties(),
+                  requiredProperties));
           return null;
         });
   }

--- a/flink/src/test/java/io/delta/flink/MockHttp.java
+++ b/flink/src/test/java/io/delta/flink/MockHttp.java
@@ -32,6 +32,12 @@ public class MockHttp {
       "/api/2.1/unity-catalog/delta/v1/catalogs/[^/]+/schemas/[^/]+/tables/[^/]+$";
   private static final String DELTA_CREDENTIALS_PATH =
       "/api/2.1/unity-catalog/delta/v1/catalogs/[^/]+/schemas/[^/]+/tables/[^/]+/credentials$";
+  private static final String DELTA_CREATE_TABLE_PATH =
+      "/api/2.1/unity-catalog/delta/v1/catalogs/[^/]+/schemas/[^/]+/tables$";
+  private static final String DELTA_STAGING_TABLE_PATH =
+      "/api/2.1/unity-catalog/delta/v1/catalogs/[^/]+/schemas/[^/]+/staging-tables$";
+  private static final String DELTA_STAGING_CREDENTIALS_PATH =
+      "/api/2.1/unity-catalog/delta/v1/staging-tables/[^/]+/credentials$";
 
   private static String loadTableJson(String tableId, String tablePath) {
     return String.format(
@@ -53,12 +59,8 @@ public class MockHttp {
 
   public static MockHttp forNewUCTable(String tableId, String tablePath) {
     Map<String, String> stubs = new HashMap<>();
-    stubs.put(
-        "/api/2.1/unity-catalog/staging-tables",
-        String.format("{\"id\": \"%s\", \"staging_location\":\"%s\"}", tableId, tablePath));
-    stubs.put("/api/2.1/unity-catalog/tables", "{}"); // For write
-    stubs.put("/api/2.1/unity-catalog/temporary-table-credentials", "{}");
     stubs.put(DELTA_CREDENTIALS_PATH, "{}");
+    stubs.put(DELTA_STAGING_CREDENTIALS_PATH, "{}");
     stubs.put("/api/2.1/unity-catalog/delta/preview/metrics", "");
     MockHttp mock = new MockHttp(stubs, Map.of());
 
@@ -69,12 +71,22 @@ public class MockHttp {
             .whenScenarioStateIs(Scenario.STARTED)
             .willReturn(notFound()));
     mock.wireMockServer.stubFor(
-        post(urlPathMatching("/api/2.1/unity-catalog/staging-tables"))
+        post(urlPathMatching(DELTA_STAGING_TABLE_PATH))
             .inScenario(scenario)
             .willReturn(
                 okJson(
                     String.format(
-                        "{\"id\": \"%s\", \"staging_location\":\"%s\"}", tableId, tablePath)))
+                        "{\"table-id\": \"%s\", \"table-type\": \"MANAGED\", \"location\": \"%s\", "
+                            + "\"required-protocol\": {\"min-reader-version\": 3, "
+                            + "\"min-writer-version\": 7, \"reader-features\": [\"deletionVectors\"], "
+                            + "\"writer-features\": [\"deletionVectors\"]}, "
+                            + "\"required-properties\": {\"delta.enableDeletionVectors\": \"true\", "
+                            + "\"io.unitycatalog.tableId\": \"%s\"}}",
+                        tableId, tablePath, tableId))));
+    mock.wireMockServer.stubFor(
+        post(urlPathMatching(DELTA_CREATE_TABLE_PATH))
+            .inScenario(scenario)
+            .willReturn(okJson(loadTableJson(tableId, tablePath)))
             .willSetStateTo("created"));
     mock.wireMockServer.stubFor(
         get(urlPathMatching(DELTA_TABLES_PATH))
@@ -160,5 +172,13 @@ public class MockHttp {
 
   public void verifyCredentialRequests(int count) {
     wireMockServer.verify(count, getRequestedFor(urlPathMatching(DELTA_CREDENTIALS_PATH)));
+  }
+
+  public void verifyStagingCredentialRequests(int count) {
+    wireMockServer.verify(count, getRequestedFor(urlPathMatching(DELTA_STAGING_CREDENTIALS_PATH)));
+  }
+
+  public void verifyPostRequest(String path) {
+    this.wireMockServer.verify(1, postRequestedFor(urlPathEqualTo(path)));
   }
 }

--- a/flink/src/test/java/io/delta/flink/table/CatalogManagedTableTest.java
+++ b/flink/src/test/java/io/delta/flink/table/CatalogManagedTableTest.java
@@ -16,6 +16,7 @@
 
 package io.delta.flink.table;
 
+import static io.delta.kernel.unitycatalog.UCCatalogManagedClient.UC_TABLE_ID_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -25,8 +26,10 @@ import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.internal.tablefeatures.TableFeatures;
 import io.delta.kernel.types.IntegerType;
 import io.delta.kernel.types.StructType;
+import io.delta.kernel.utils.CloseableIterable;
 import java.net.URI;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 
 /** JUnit test suite for CCv2Table. */
@@ -56,21 +59,78 @@ class CatalogManagedTableTest extends TestHelper {
                       AbstractKernelTable.normalize(URI.create(dir.getAbsolutePath())),
                       table.getTablePath());
 
-                  CatalogManagedTable.CATALOG_MANAGED_REQUIRED_FEATURES_CONF.forEach(
-                      (key, value) -> assertEquals(value, table.conf.catalogConf().get(key)));
-                  assertEquals(uuid, table.conf.catalogConf().get("io.unitycatalog.tableId"));
+                  assertEquals(uuid, table.conf.catalogConf().get(UC_TABLE_ID_KEY));
+                  assertEquals("true", table.conf.catalogConf().get("delta.enableDeletionVectors"));
 
                   SnapshotImpl snapshot = (SnapshotImpl) table.snapshot().get();
-                  assertEquals(uuid, snapshot.getTableProperties().get("io.unitycatalog.tableId"));
+                  assertEquals(uuid, snapshot.getTableProperties().get(UC_TABLE_ID_KEY));
+                  assertEquals(
+                      "true", snapshot.getTableProperties().get("delta.enableDeletionVectors"));
 
                   assertTrue(
-                      CatalogManagedTable.CATALOG_MANAGED_REQUIRED_FEATURES_CONF.keySet().stream()
-                          .map(s -> s.replace("delta.feature.", ""))
-                          .allMatch(
-                              s ->
-                                  snapshot
-                                      .getProtocol()
-                                      .supportsFeature(TableFeatures.getTableFeature(s))));
+                      snapshot
+                          .getProtocol()
+                          .supportsFeature(TableFeatures.DELETION_VECTORS_RW_FEATURE));
+                }
+              });
+        });
+  }
+
+  @Test
+  void testCreateCatalogManagedTableWithAmbientCredentials() {
+    withTempDir(
+        dir -> {
+          String uuid = UUID.randomUUID().toString();
+          StructType schema = new StructType().add("id", IntegerType.INTEGER);
+          MockHttp.withMock(
+              MockHttp.forNewUCTable(uuid, dir.getAbsolutePath()),
+              mockHttp -> {
+                try (CatalogManagedTable table =
+                    new CatalogManagedTable(
+                        new UnityCatalog(
+                            "main", mockHttp.uri(), "", /* credentialVendingEnabled = */ false),
+                        "main.abc.def",
+                        Map.of(TableConf.CREDENTIALS_SOURCE.key(), "ambient"),
+                        schema,
+                        List.of(),
+                        mockHttp.uri(),
+                        "")) {
+                  table.open();
+                  mockHttp.verifyStagingCredentialRequests(0);
+                }
+              });
+        });
+  }
+
+  @Test
+  void testCommitCatalogManagedTable() {
+    withTempDir(
+        dir -> {
+          String uuid = UUID.randomUUID().toString();
+          StructType schema = new StructType().add("id", IntegerType.INTEGER);
+          MockHttp.withMock(
+              MockHttp.forNewUCTable(uuid, dir.getAbsolutePath()),
+              mockHttp -> {
+                try (CatalogManagedTable table =
+                    new CatalogManagedTable(
+                        new UnityCatalog("main", mockHttp.uri(), ""),
+                        "main.abc.def",
+                        Collections.emptyMap(),
+                        schema,
+                        List.of(),
+                        mockHttp.uri(),
+                        "")) {
+                  table.open();
+
+                  table.commit(
+                      CloseableIterable.emptyIterable(), "test-app", 1L, Collections.emptyMap());
+
+                  mockHttp.verifyPostRequest(
+                      "/api/2.1/unity-catalog/delta/v1/catalogs/main/schemas/abc/tables/def");
+
+                  // Let asynchronous post-commit work finish before the mock and temp table close.
+                  table.generalThreadPool.shutdown();
+                  assertTrue(table.generalThreadPool.awaitTermination(10, TimeUnit.SECONDS));
                 }
               });
         });

--- a/flink/src/test/java/io/delta/flink/table/UnityCatalogTest.java
+++ b/flink/src/test/java/io/delta/flink/table/UnityCatalogTest.java
@@ -24,6 +24,7 @@ import io.delta.flink.TestHelper;
 import io.delta.kernel.types.*;
 import io.delta.kernel.unitycatalog.UCTableIdentifier;
 import java.net.URI;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
@@ -101,6 +102,34 @@ class UnityCatalogTest extends TestHelper {
 
           assertEquals("ak", credentials.get("fs.s3a.init.access.key"));
           mockHttp.verifyCredentialRequests(1);
+        });
+  }
+
+  @Test
+  void testCreateTableDescriptorIncludesStagingProperties() {
+    withTempDir(
+        dir -> {
+          String tableName = "main.default.tbl";
+          String uuid = UUID.randomUUID().toString();
+          MockHttp.withMock(
+              MockHttp.forNewUCTable(uuid, dir.getAbsolutePath()),
+              mockHttp -> {
+                UnityCatalog uc = new UnityCatalog("main", mockHttp.uri(), "");
+                uc.open();
+
+                uc.createTable(
+                    tableName,
+                    new StructType().add("id", IntegerType.INTEGER),
+                    List.of(),
+                    Map.of(),
+                    descriptor -> {
+                      assertEquals(uuid, descriptor.getUuid());
+                      assertEquals(Map.of(), descriptor.getStorageProperties());
+                      assertEquals(
+                          "true",
+                          descriptor.getRequiredProperties().get("delta.enableDeletionVectors"));
+                    });
+              });
         });
   }
 }

--- a/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/UCCatalogManagedCommitterSuite.scala
+++ b/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/UCCatalogManagedCommitterSuite.scala
@@ -750,6 +750,7 @@ class UCCatalogManagedCommitterSuite
       // ===== THEN =====
       assert(ex.isRetryable && !ex.isConflict)
       assert(ex.getMessage.contains("Failed to write delta file due to: Network hiccup"))
+      assert(ucClient.getLastFinalizeCreateRecord.isEmpty)
     }
   }
 


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/7245/files) to review incremental changes.
- [stack/tw/flink-uc-delta-tables-api](https://github.com/delta-io/delta/pull/7229) [[Files changed](https://github.com/delta-io/delta/pull/7229/files)] [MERGED]
  - [stack/flink-uc-2-lookup-creds](https://github.com/delta-io/delta/pull/7244) [[Files changed](https://github.com/delta-io/delta/pull/7244/files)] [MERGED]
    - [**stack/flink-uc-3-create**](https://github.com/delta-io/delta/pull/7245) [[Files changed](https://github.com/delta-io/delta/pull/7245/files)] ← _this PR_
      - [stack/flink-uc-4-metrics](https://github.com/delta-io/delta/pull/7246) [[Files changed](https://github.com/delta-io/delta/pull/7246/files/e5c353e7eb4232dbc74341a1810c0cad9f82c68f..a1dd46e9ab4f97c2dbaa07bf4683ccb34feb55d4)]
        - [stack/flink-uc-5-browsing](https://github.com/delta-io/delta/pull/7247) [[Files changed](https://github.com/delta-io/delta/pull/7247/files/a1dd46e9ab4f97c2dbaa07bf4683ccb34feb55d4..1d2737997ca49cadcaa7876798aea47ba8e4d976)]
          - [stack/flink-uc-6-catalog-correctness](https://github.com/delta-io/delta/pull/7349) [[Files changed](https://github.com/delta-io/delta/pull/7349/files/1d2737997ca49cadcaa7876798aea47ba8e4d976..0ea5512aad374f242169158e5d8e0dc4f6535006)]

---------
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [x] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## What this PR enables

Enables **catalog-managed table creation** over the Delta-Tables API, including both UC-vended and ambient credential modes.

```text
ENDPOINT                                                                 OPERATION                    STATUS
----------------------------------------------------------------------   --------------------------   ------
GET /v1/catalogs/{catalog}/schemas/{schema}/tables/{table}               Load table / table exists    ✅ done
POST /v1/catalogs/{catalog}/schemas/{schema}/tables/{table}              Commit (updateTable)         ✅ done
GET /v1/catalogs/{catalog}/schemas/{schema}/tables/{table}/credentials   Vend table storage creds     ✅ done
POST /v1/catalogs/{catalog}/schemas/{schema}/staging-tables              Reserve staging table        ⏳ THIS PR
POST /v1/catalogs/{catalog}/schemas/{schema}/tables                      Finalize (create) table       ⏳ THIS PR
GET /v1/staging-tables/{table_id}/credentials                            Vend staging storage creds   ⏳ THIS PR
POST /v1/catalogs/{catalog}/schemas/{schema}/tables/{table}/metrics      Report commit metrics        ⏭️ next PR
GET /v1/catalogs/{catalog}/schemas/{schema}                              List tables in schema        ⛔ blocked
```

_Status legend: ✅ done (earlier PR in this stack) · ⏳ THIS PR · ⏭️ next PR (later in this stack) · ⛔ blocked (no UC Delta client binding; stays on the OpenAPI client)._

## Description

This is the third PR in the stack. It moves catalog-managed table creation onto the new Delta-Tables API.

The connector reserves a staging table with `createStagingTable`, writes the version 0 Delta commit, and lets the Kernel UC committer finalize the staging table. Passing the three-part `UCTableIdentifier` to the committer removes the old Flink-owned `TablesApi.createTable` promotion call and the hand-built UC column list.

Creation uses the same Delta-Tables client that PR2 configured from `credentials.source`:

- With `credentials.source=uc`, `createStagingTable` vends temporary storage credentials, and Flink carries the returned storage properties into the Kernel engine for the initial commit.
- With `credentials.source=ambient`, credential vending is disabled on that client. UC still allocates and returns the staging table UUID and location, while the TaskManager accesses that location with its ambient cloud identity.

The staging response's catalog-required table properties are also carried into Kernel initialization so the version 0 commit can finalize the table correctly.

## How was this patch tested?

`build/sbt "flink / test"` passes: 246 total, 242 passed, 4 skipped. `CatalogManagedTableTest` covers both UC-vended and ambient creation against a stateful WireMock lifecycle and verifies the commit request.

## Does this PR introduce _any_ user-facing changes?

No.