### PR TITLE
Revert overridable logPath/dataPath transaction seams (#7184, #7200)

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -297,8 +297,6 @@ trait OptimisticTransactionImpl extends TransactionHelper
 
   def clock: Clock = deltaLog.clock
 
-  override def dataPath: Path = deltaLog.dataPath
-
   // This would be a quick operation if we already validated the checksum
   // Otherwise, we should at least perform the validation here.
   // NOTE: When incremental commits are enabled, skip validation unless it was specifically
@@ -644,7 +642,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
     if (!identityColumnAllowed &&
         ColumnWithDefaultExprUtils.hasIdentityColumn(newMetadataTmp.schema)) {
       throw DeltaErrors.unsupportedWriterTableFeaturesInTableException(
-        dataPath.toString, Seq(IdentityColumnsTableFeature.name))
+        deltaLog.dataPath.toString, Seq(IdentityColumnsTableFeature.name))
     }
 
     val protocolBeforeUpdate = protocol
@@ -1674,9 +1672,9 @@ trait OptimisticTransactionImpl extends TransactionHelper
     // If this transaction commits to the redirect destination location, then there is no
     // need to validate the subsequent no-redirect rules.
     val configuration = deltaLog.newDeltaHadoopConf()
-    val tableDataPath = dataPath.toUri.getPath
+    val dataPath = snapshot.dataPath.toUri.getPath
     val catalog = spark.sessionState.catalog
-    val isRedirectDest = redirectConfig.spec.isRedirectDest(catalog, configuration, tableDataPath)
+    val isRedirectDest = redirectConfig.spec.isRedirectDest(catalog, configuration, dataPath)
     if (isRedirectDest) return
     // Find all rules that match with the current application name.
     // If appName is not present, its no-redirect-rule are included.
@@ -2760,7 +2758,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
 
     if (readVersion > -1 && metadata.id != snapshot.metadata.id) {
       val msg = s"Change in the table id detected in txn. Table id for txn on table at " +
-        s"${dataPath} was ${snapshot.metadata.id} when the txn was created and " +
+        s"${deltaLog.dataPath} was ${snapshot.metadata.id} when the txn was created and " +
         s"is now changed to ${metadata.id}."
       logWarning(msg)
       recordDeltaEvent(deltaLog, "delta.metadataCheck.commit", data = Map(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -297,8 +297,6 @@ trait OptimisticTransactionImpl extends TransactionHelper
 
   def clock: Clock = deltaLog.clock
 
-  override def logPath: Path = deltaLog.logPath
-
   override def dataPath: Path = deltaLog.dataPath
 
   // This would be a quick operation if we already validated the checksum
@@ -1873,7 +1871,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
         postCommitSnapshot,
         Some(updatedCurrentTransactionInfo))
       logInfo(log"Committed delta #${MDC(DeltaLogKeys.VERSION, commitVersion)} to " +
-        log"${MDC(DeltaLogKeys.PATH, logPath)}")
+        log"${MDC(DeltaLogKeys.PATH, deltaLog.logPath)}")
       commitVersion
     } catch {
       case e: DeltaConcurrentModificationException =>
@@ -2300,14 +2298,14 @@ trait OptimisticTransactionImpl extends TransactionHelper
           // FS -> CC conversion
           val (commitCoordinatorName, commitCoordinatorConf) =
             CoordinatedCommitsUtils.getCoordinatedCommitsConfs(finalMetadata)
-          logInfo(log"Table ${MDC(DeltaLogKeys.PATH, logPath)} transitioning from " +
+          logInfo(log"Table ${MDC(DeltaLogKeys.PATH, deltaLog.logPath)} transitioning from " +
             log"file-system based table to coordinated-commits table: " +
             log"[commit-coordinator: ${MDC(DeltaLogKeys.COORDINATOR_NAME, commitCoordinatorName)}" +
             log", conf: ${MDC(DeltaLogKeys.COORDINATOR_CONF, commitCoordinatorConf)}]")
           val tableIdentifierOpt =
             CoordinatedCommitsUtils.toCCTableIdentifier(catalogTable.map(_.identifier))
           newCoordinatedCommitsTableConf = Some(newCommitCoordinatorClient.registerTable(
-            logPath,
+            deltaLog.logPath,
             tableIdentifierOpt,
             readVersion,
             finalMetadata,
@@ -2316,7 +2314,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
           // CC -> FS conversion
           val (newOwnerName, newOwnerConf) =
             CoordinatedCommitsUtils.getCoordinatedCommitsConfs(snapshot.metadata)
-          logInfo(log"Table ${MDC(DeltaLogKeys.PATH, logPath)} transitioning from " +
+          logInfo(log"Table ${MDC(DeltaLogKeys.PATH, deltaLog.logPath)} transitioning from " +
             log"coordinated-commits table to file-system table: " +
             log"[commit-coordinator: ${MDC(DeltaLogKeys.COORDINATOR_NAME, newOwnerName)}, " +
             log"conf: ${MDC(DeltaLogKeys.COORDINATOR_CONF, newOwnerConf)}]")
@@ -2328,7 +2326,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
           // commit-coordinator.
           val (newOwnerName, newOwnerConf) =
             CoordinatedCommitsUtils.getCoordinatedCommitsConfs(finalMetadata)
-          val message = s"Transition of table ${logPath} from one commit-coordinator to" +
+          val message = s"Transition of table ${deltaLog.logPath} from one commit-coordinator to" +
             s" another commit-coordinator is not allowed: [old commit-coordinator: $oldOwnerName," +
             s" new commit-coordinator: $newOwnerName, old commit-coordinator conf: $oldOwnerConf," +
             s" new commit-coordinator conf: $newOwnerConf]."
@@ -2361,7 +2359,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
     }
 
     logInfo(log"Committed delta #${MDC(DeltaLogKeys.VERSION, attemptVersion)} to " +
-      log"${MDC(DeltaLogKeys.PATH, logPath)}. Wrote " +
+      log"${MDC(DeltaLogKeys.PATH, deltaLog.logPath)}. Wrote " +
       log"${MDC(DeltaLogKeys.NUM_ACTIONS, commitSize.toLong)} actions.")
 
     deltaLog.checkpoint(currentSnapshot, catalogTable)
@@ -2613,7 +2611,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
 
   private[delta] def isCommitLockEnabled: Boolean = {
     spark.sessionState.conf.getConf(DeltaSQLConf.DELTA_COMMIT_LOCK_ENABLED).getOrElse(
-      deltaLog.store.isPartialWriteVisible(logPath, deltaLog.newDeltaHadoopConf()))
+      deltaLog.store.isPartialWriteVisible(deltaLog.logPath, deltaLog.newDeltaHadoopConf()))
   }
 
   private def lockCommitIfEnabled[T](body: => T): T = {
@@ -2953,7 +2951,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
       )
     }
     if (attemptVersion == 0L) {
-      val expectedPathForCommitZero = unsafeDeltaFile(logPath, version = 0L).toUri
+      val expectedPathForCommitZero = unsafeDeltaFile(deltaLog.logPath, version = 0L).toUri
       val actualCommitPath = commitResponse.getCommit.getFileStatus.getPath.toUri
       if (actualCommitPath != expectedPathForCommitZero) {
         throw new IllegalStateException("Expected 0th commit to be written to " +

--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/TransactionHelper.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/TransactionHelper.scala
@@ -45,13 +45,6 @@ trait TransactionHelper extends DeltaLogging {
   def deltaLog: DeltaLog
 
   /**
-   * The path to the Delta log directory. Not implemented in the base trait; each concrete
-   * transaction supplies it.
-   */
-  def logPath: Path =
-    throw new UnsupportedOperationException("logPath is not implemented for this transaction")
-
-  /**
    * The path to the Delta table data directory. Not implemented in the base trait; each concrete
    * transaction supplies it.
    */
@@ -199,7 +192,7 @@ trait TransactionHelper extends DeltaLogging {
         case _ =>
           throw new IllegalStateException(
             "Unexpected state found when trying " +
-            s"to generate CoordinatedCommitsStats for table ${logPath}. " +
+            s"to generate CoordinatedCommitsStats for table ${deltaLog.logPath}. " +
             s"$readSnapshotTableCommitCoordinatorClientOpt, " +
             s"$metadata, $snapshot, $catalogTable")
       }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/TransactionHelper.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/TransactionHelper.scala
@@ -32,7 +32,6 @@ import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.stats.{FileSizeHistogram, FileSizeHistogramUtils}
 import org.apache.spark.sql.util.ScalaExtensions._
-import org.apache.hadoop.fs.Path
 
 import org.apache.spark.internal.MDC
 import org.apache.spark.sql.SparkSession
@@ -43,14 +42,6 @@ import org.apache.spark.sql.catalyst.catalog.CatalogTable
  */
 trait TransactionHelper extends DeltaLogging {
   def deltaLog: DeltaLog
-
-  /**
-   * The path to the Delta table data directory. Not implemented in the base trait; each concrete
-   * transaction supplies it.
-   */
-  def dataPath: Path =
-    throw new UnsupportedOperationException("dataPath is not implemented for this transaction")
-
   def catalogTable: Option[CatalogTable]
   def snapshot: Snapshot
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
@@ -316,14 +316,6 @@ class OptimisticTransactionSuite
     }
   }
 
-  test("logPath resolves to deltaLog.logPath") {
-    withTempDir { tempDir =>
-      val log = DeltaLog.forTable(spark, new Path(tempDir.getCanonicalPath))
-      val txn = log.startTransaction()
-      assert(txn.logPath === log.logPath)
-    }
-  }
-
   test("dataPath resolves to deltaLog.dataPath") {
     withTempDir { tempDir =>
       val log = DeltaLog.forTable(spark, new Path(tempDir.getCanonicalPath))

--- a/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
@@ -316,14 +316,6 @@ class OptimisticTransactionSuite
     }
   }
 
-  test("dataPath resolves to deltaLog.dataPath") {
-    withTempDir { tempDir =>
-      val log = DeltaLog.forTable(spark, new Path(tempDir.getCanonicalPath))
-      val txn = log.startTransaction()
-      assert(txn.dataPath === log.dataPath)
-    }
-  }
-
   test("enabling Coordinated Commits on an existing table should create commit dir") {
     withTempDir { tempDir =>
       val log = DeltaLog.forTable(spark, new Path(tempDir.getAbsolutePath))


### PR DESCRIPTION
## Description

Reverts two recently-merged PRs that added overridable transaction path seams on `TransactionHelper`:

- #7184 — "Add overridable logPath to the transaction"
- #7200 — "Add overridable dataPath for transactions"

Both introduced `logPath` / `dataPath` members on the `TransactionHelper` base trait (defaulting to throw) with concrete overrides in `OptimisticTransactionImpl`, and rewired internal path references to go through them. This restores the prior behavior of dereferencing `deltaLog.dataPath` / `deltaLog.logPath` directly.

The reverts are applied in reverse-merge order (#7184 first, then #7200) and apply cleanly.

## How was this patch tested?

Existing transaction suites. The unit tests added by each PR are removed along with the reverted changes.

## Does this PR introduce _any_ user-facing changes?

No.
