### PR TITLE
Add adaptiveMetadata-preview feature dependencies and enable them

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -11,6 +11,24 @@
     ],
     "sqlState" : "0B000"
   },
+  "DELTA_ADAPTIVE_METADATA_REQUIRES_COLUMN_MAPPING_ID_MODE" : {
+    "message" : [
+      "The table feature '<feature>' requires column mapping mode 'id', but the table property '<prop>' is set to '<mode>'. Recreate the table with '<prop>' = 'id', or omit the property to have it set automatically."
+    ],
+    "sqlState" : "42000"
+  },
+  "DELTA_ADAPTIVE_METADATA_REQUIRES_DEPENDENT_FEATURE_ENABLED" : {
+    "message" : [
+      "The table feature '<feature>' requires the table property '<prop>' to be enabled, but it is explicitly set to '<value>'. Set '<prop>' = 'true', or omit the property to have it enabled automatically."
+    ],
+    "sqlState" : "42000"
+  },
+  "DELTA_ADAPTIVE_METADATA_UPGRADE_NOT_SUPPORTED" : {
+    "message" : [
+      "Enabling the table feature '<feature>' on an existing table is not supported. Please create a new table with the feature enabled instead."
+    ],
+    "sqlState" : "0A000"
+  },
   "DELTA_ADDING_COLUMN_WITH_INTERNAL_NAME_FAILED" : {
     "message" : [
       "Failed to add column <colName> because the name is reserved."

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -2484,6 +2484,32 @@ trait DeltaErrorsBase
     )
   }
 
+  def adaptiveMetadataRequiresColumnMappingIdMode(
+      featureName: String, actualMode: String): Throwable = {
+    val key = DeltaConfigs.COLUMN_MAPPING_MODE.key
+    new DeltaAnalysisException(
+      errorClass = "DELTA_ADAPTIVE_METADATA_REQUIRES_COLUMN_MAPPING_ID_MODE",
+      // Template order: <feature>, <prop>, <mode>, <prop>.
+      messageParameters = Array(featureName, key, actualMode, key)
+    )
+  }
+
+  def adaptiveMetadataRequiresDependentFeatureEnabled(
+      featureName: String, propertyKey: String, actualValue: String): Throwable = {
+    new DeltaAnalysisException(
+      errorClass = "DELTA_ADAPTIVE_METADATA_REQUIRES_DEPENDENT_FEATURE_ENABLED",
+      // Template order: <feature>, <prop>, <value>, <prop>.
+      messageParameters = Array(featureName, propertyKey, actualValue, propertyKey)
+    )
+  }
+
+  def adaptiveMetadataUpgradeNotSupported(featureName: String): Throwable = {
+    new DeltaAnalysisException(
+      errorClass = "DELTA_ADAPTIVE_METADATA_UPGRADE_NOT_SUPPORTED",
+      messageParameters = Array(featureName)
+    )
+  }
+
   def maxColumnIdNotSetCorrectly(tableMax: Long, fieldMax: Long): Throwable = {
     new DeltaAnalysisException(
       errorClass = "DELTA_COLUMN_MAPPING_MAX_COLUMN_ID_NOT_SET_CORRECTLY",

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -650,6 +650,8 @@ trait OptimisticTransactionImpl extends TransactionHelper
     }
 
     val protocolBeforeUpdate = protocol
+    newMetadataTmp = enableAdaptiveMetadataDependentFeatures(newMetadataTmp)
+
     // `readVersion == -1` indicates the current transaction is reading from a snapshot
     // where the table has not existed yet.
     // `isCreatingNewTable` will be true for commands like REPLACE and CREATE,
@@ -1050,6 +1052,60 @@ trait OptimisticTransactionImpl extends TransactionHelper
     } else {
       metadata
     }
+  }
+
+  /**
+   * Enable the dependencies of the [[AdaptiveMetadataTableFeature]] in the metadata.
+   * [[AdaptiveMetadataTableFeature.requiredFeatures]] only guarantees these features are present
+   * in the protocol (supported); several of them additionally need a metadata flag to be truly
+   * enabled(rowTracking, deletionVectors) or a specific configuration (column mapping `id` mode).
+   */
+  private def enableAdaptiveMetadataDependentFeatures(metadata: Metadata): Metadata = {
+    val adaptiveMetadataEnabled =
+      protocol.isFeatureSupported(AdaptiveMetadataTableFeature) ||
+        TableFeatureProtocolUtils.isFeatureSupportedInTableConfigs(
+          metadata.configuration, AdaptiveMetadataTableFeature)
+    if (!adaptiveMetadataEnabled) {
+      return metadata
+    }
+
+    val existingTableHasAdaptiveMetadata =
+      snapshot.protocol.isFeatureSupported(AdaptiveMetadataTableFeature)
+    if (!isCreatingNewTable && !existingTableHasAdaptiveMetadata) {
+      throw DeltaErrors.adaptiveMetadataUpgradeNotSupported(AdaptiveMetadataTableFeature.name)
+    }
+
+    // rowTracking / deletionVectors: these dependencies must be enabled via their metadata flag.
+    // If the flag is not set, auto-enable it. If it is explicitly set to `false`, the user is
+    // asking for behavior that conflicts with the feature's requirement, so fail rather than
+    // silently overriding.
+    val flagEnablements = Seq(
+      DeltaConfigs.ROW_TRACKING_ENABLED.key,
+      DeltaConfigs.ENABLE_DELETION_VECTORS_CREATION.key)
+      .flatMap { key =>
+        metadata.configuration.get(key) match {
+          case None => Some(key -> "true")
+          case Some(v) if v.toBoolean => None
+          case Some(v) =>
+            throw DeltaErrors.adaptiveMetadataRequiresDependentFeatureEnabled(
+              AdaptiveMetadataTableFeature.name, key, v)
+        }
+      }
+    var updatedConfig = metadata.configuration ++ flagEnablements
+
+    // columnMapping: the feature requires `id` mode.
+    //  - New table, mode unspecified: auto-set `id`.
+    //  - Otherwise (e.g. an explicit mode was requested at CREATE) the resulting mode must be `id`,
+    //    else fail.
+    val modeExplicitlySet = metadata.configuration.contains(DeltaConfigs.COLUMN_MAPPING_MODE.key)
+    if (!modeExplicitlySet && isCreatingNewTable) {
+      updatedConfig += (DeltaConfigs.COLUMN_MAPPING_MODE.key -> IdMapping.name)
+    } else if (metadata.columnMappingMode != IdMapping) {
+      throw DeltaErrors.adaptiveMetadataRequiresColumnMappingIdMode(
+        AdaptiveMetadataTableFeature.name, metadata.columnMappingMode.name)
+    }
+
+    metadata.copy(configuration = updatedConfig)
   }
 
   private def setNewProtocolWithFeaturesEnabledByMetadata(metadata: Metadata): Unit = {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
@@ -922,9 +922,20 @@ object DeletionVectorsTableFeature
 object AdaptiveMetadataTableFeature
   extends ReaderWriterFeature(name = "adaptiveMetadata-preview") {
 
-  // Iceberg v4 manifests reference columns by field ID, so column mapping must be supported on
-  // any table that enables this feature.
-  override def requiredFeatures: Set[TableFeature] = Set(ColumnMappingTableFeature)
+  // The [[AdaptiveMetadataTableFeature]] relies on the following features:
+  //  - catalogManaged: adaptive metadata tables are catalog managed (CCv2) only.
+  //  - rowTracking: stable row identity is required by the adaptive metadata layout.
+  //  - domainMetadata: listed explicitly even though rowTracking already requires it.
+  //  - deletionVectors: deletes are expressed as DVs rather than file rewrites.
+  //  - columnMapping: Iceberg v4 manifests reference columns by field ID, so column mapping
+  //    must be present. Note that presence alone is not enough; `id` mode is enforced separately
+  //    in [[OptimisticTransaction.scala]].
+  override def requiredFeatures: Set[TableFeature] = Set(
+    CatalogOwnedTableFeature,
+    RowTrackingFeature,
+    DomainMetadataTableFeature,
+    DeletionVectorsTableFeature,
+    ColumnMappingTableFeature)
 }
 
 object RowTrackingFeature extends WriterFeature(name = "rowTracking")

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTCheckpointProvider.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTCheckpointProvider.scala
@@ -104,7 +104,9 @@ final class AMTCheckpointProvider(
         modificationTime = 0L,
         dataChange = false,
         stats = stats,
-        deletionVector = dv)
+        deletionVector = dv,
+        baseRowId = entry.tracking.first_row_id,
+        defaultRowCommitVersion = entry.tracking.sequence_number)
       SingleAction(add = add)
     }
     val nonFileActions =

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/actions.scala
@@ -258,7 +258,11 @@ object DataEntry {
     DataEntry(
       location = add.path,
       file_format = AMTSingleAction.FileFormatParquet,
-      tracking = tracking,
+      // Round-trip the AddFile's row-tracking fields through the Iceberg tracking envelope so a
+      // rowTracking-enabled table can reconstruct them on read.
+      tracking = tracking.copy(
+        first_row_id = add.baseRowId,
+        sequence_number = add.defaultRowCommitVersion),
       // Iceberg field 103 is the physical record count of the file, not the live/logical
       // count after deletes; throw rather than guess when the AddFile carries no stats.
       record_count = add.numPhysicalRecords.getOrElse(

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
@@ -251,7 +251,8 @@ class DeltaLogSuite extends QueryTest
         log.store.write(
           FileNames.unsafeDeltaFile(log.logPath, 0L),
           Iterator(Action.supportedProtocolVersion(
-            featuresToExclude = Seq(CatalogOwnedTableFeature)), Metadata(), add)
+            featuresToExclude = Seq(CatalogOwnedTableFeature, AdaptiveMetadataTableFeature)),
+            Metadata(), add)
             .map(a => JsonUtils.toJson(a.wrap)),
           overwrite = false,
           log.newDeltaHadoopConf())
@@ -281,7 +282,8 @@ class DeltaLogSuite extends QueryTest
         log.store.write(
           FileNames.unsafeDeltaFile(log.logPath, 0L),
           Iterator(Action.supportedProtocolVersion(
-            featuresToExclude = Seq(CatalogOwnedTableFeature)), Metadata(), add)
+            featuresToExclude = Seq(CatalogOwnedTableFeature, AdaptiveMetadataTableFeature)),
+            Metadata(), add)
             .map(a => JsonUtils.toJson(a.wrap)),
           overwrite = false,
           log.newDeltaHadoopConf())

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -159,9 +159,9 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
       val log = createTableWithProtocol(Protocol(1, 1), path)
       assert(log.snapshot.protocol === Protocol(1, 1))
       log.upgradeProtocol(Action.supportedProtocolVersion(
-        featuresToExclude = Seq(CatalogOwnedTableFeature)))
+        featuresToExclude = Seq(CatalogOwnedTableFeature, AdaptiveMetadataTableFeature)))
       assert(log.snapshot.protocol === Action.supportedProtocolVersion(
-        featuresToExclude = Seq(CatalogOwnedTableFeature)))
+        featuresToExclude = Seq(CatalogOwnedTableFeature, AdaptiveMetadataTableFeature)))
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
@@ -2108,7 +2108,8 @@ class DeltaSuite extends QueryTest
     // Now make a commit that comes from an "external" writer that deletes existing data and
     // changes the schema
     val actions = Seq(Action.supportedProtocolVersion(
-      featuresToExclude = Seq(CatalogOwnedTableFeature)), newMetadata) ++ files.map(_.remove)
+      featuresToExclude = Seq(CatalogOwnedTableFeature, AdaptiveMetadataTableFeature)),
+      newMetadata) ++ files.map(_.remove)
     deltaLog.store.write(
       FileNames.unsafeDeltaFile(deltaLog.logPath, snapshot.version + 1),
       actions.map(_.json).iterator,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
@@ -247,9 +247,11 @@ class OptimisticTransactionSuite
       t => t.metadata
     ),
     concurrentWrites = Seq(
-      Action.supportedProtocolVersion(featuresToExclude = Seq(CatalogOwnedTableFeature))),
+      Action.supportedProtocolVersion(
+        featuresToExclude = Seq(CatalogOwnedTableFeature, AdaptiveMetadataTableFeature))),
     actions = Seq(
-      Action.supportedProtocolVersion(featuresToExclude = Seq(CatalogOwnedTableFeature))))
+      Action.supportedProtocolVersion(
+        featuresToExclude = Seq(CatalogOwnedTableFeature, AdaptiveMetadataTableFeature))))
 
   check(
     "taint whole table",
@@ -976,7 +978,7 @@ class OptimisticTransactionSuite
         .add("part", "string")
       deltaLog.withNewTransaction { txn =>
         val protocol = Action.supportedProtocolVersion(
-          featuresToExclude = Seq(CatalogOwnedTableFeature))
+          featuresToExclude = Seq(CatalogOwnedTableFeature, AdaptiveMetadataTableFeature))
         val metadata = Metadata(
           schemaString = schema.json,
           partitionColumns = partitionColumns)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuiteBase.scala
@@ -63,7 +63,7 @@ trait OptimisticTransactionSuiteBase
       name: String,
       conflicts: Boolean,
       setup: Seq[Action] = Seq(Metadata(), Action.supportedProtocolVersion(
-        featuresToExclude = Seq(CatalogOwnedTableFeature))),
+        featuresToExclude = Seq(CatalogOwnedTableFeature, AdaptiveMetadataTableFeature))),
       reads: Seq[OptimisticTransaction => Unit],
       concurrentWrites: Seq[Action],
       actions: Seq[Action],

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointTestBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointTestBase.scala
@@ -22,23 +22,34 @@ import java.io.File
 import org.apache.spark.sql.delta.{AdaptiveMetadataTableFeature, DeltaLog, Snapshot}
 import org.apache.spark.sql.delta.actions.{Action, Checkpoint}
 import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils._
+import org.apache.spark.sql.delta.coordinatedcommits.CatalogOwnedTestBaseSuite
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.util.FileNames
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.functions.col
-import org.apache.spark.sql.test.SharedSparkSession
 
 /**
  * Shared fixtures for AMT (`adaptiveMetadata-preview`) test suites: table creation, manifest-tree
  * file lookups, and typed access to the snapshot's [[AMTCheckpointProvider]].
+ *
+ * AMT requires the `catalogManaged` feature, so tables must be catalog-managed and accessed by
+ * name (path-based access is blocked). This mixes in [[CatalogOwnedTestBaseSuite]] to register an
+ * in-memory commit coordinator and creates/accesses tables by name.
  */
 trait AMTCheckpointTestBase
   extends QueryTest
-  with SharedSparkSession
+  with CatalogOwnedTestBaseSuite
   with DeltaSQLCommandTest {
+
+  // Register the in-memory commit coordinator so catalog-managed AMT tables can be created locally.
+  // Backfill batch size 1 so every commit is backfilled to a standard NNN.json immediately (rather
+  // than staying as a UUID-named staged commit); the suites read commit actions via
+  // `deltaLog.getChanges`, which only sees backfilled deltas.
+  override def catalogOwnedCoordinatorBackfillBatchSize: Option[Int] = Some(1)
 
   override protected def sparkConf: SparkConf = super.sparkConf
     .set(DeltaSQLConf.DELTA_ALL_FILES_IN_CRC_ENABLED.key, "false")
@@ -50,12 +61,20 @@ trait AMTCheckpointTestBase
       case _ => None
     }
 
-  protected def createAMTTable(path: String, checkpointInterval: Int = 2): Unit = {
+  /** The [[DeltaLog]] for a catalog-managed table accessed by name. */
+  protected def deltaLogForName(tableName: String): DeltaLog =
+    DeltaLog.forTable(spark, new TableIdentifier(tableName))
+
+  /** The physical data path of a catalog-managed table accessed by name. */
+  protected def tablePath(tableName: String): String =
+    new File(deltaLogForName(tableName).dataPath.toUri).getCanonicalPath
+
+  protected def createAMTTable(tableName: String, checkpointInterval: Int = 2): Unit = {
     sql(
-      s"""CREATE TABLE delta.`$path` (id INT) USING DELTA
+      s"""CREATE TABLE $tableName (id INT) USING DELTA
          |TBLPROPERTIES (
          |  '${propertyKey(AdaptiveMetadataTableFeature)}' = '$FEATURE_PROP_SUPPORTED',
-         |  'delta.columnMapping.mode' = 'name',
+         |  'delta.columnMapping.mode' = 'id',
          |  'delta.enableDeletionVectors' = 'true',
          |  'delta.checkpointInterval' = '$checkpointInterval')""".stripMargin)
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointWriteSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointWriteSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.delta.amt
 import java.io.File
 
 import com.databricks.spark.util.{Log4jUsageLogger, MetricDefinitions}
-import org.apache.spark.sql.delta.{CommitStats, DeltaLog}
+import org.apache.spark.sql.delta.CommitStats
 import org.apache.spark.sql.delta.actions.{AddFile, Checkpoint}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.JsonUtils
@@ -27,13 +27,14 @@ import org.apache.spark.sql.delta.util.JsonUtils
 class AMTCheckpointWriteSuite extends AMTCheckpointTestBase {
 
   test("inline emission embeds a Checkpoint action in the same commit at the interval boundary") {
-    withTempDir { dir =>
-      val path = dir.getCanonicalPath
-      createAMTTable(path, checkpointInterval = 2)
-      sql(s"INSERT INTO delta.`$path` VALUES (1)") // v1: not an interval boundary.
-      sql(s"INSERT INTO delta.`$path` VALUES (2)") // v2: interval boundary -> emit.
+    withTable("amt_inline_emit") {
+      val name = "amt_inline_emit"
+      createAMTTable(name, checkpointInterval = 2)
+      sql(s"INSERT INTO $name VALUES (1)") // v1: not an interval boundary.
+      sql(s"INSERT INTO $name VALUES (2)") // v2: interval boundary -> emit.
 
-      val deltaLog = DeltaLog.forTable(spark, path)
+      val deltaLog = deltaLogForName(name)
+      val path = tablePath(name)
       val snapshot = deltaLog.update()
       assert(snapshot.version == 2, "No follow-up commit: emission rides in the v2 commit itself.")
 
@@ -56,15 +57,16 @@ class AMTCheckpointWriteSuite extends AMTCheckpointTestBase {
   }
 
   test("no emission on a vanilla (non-AMT) table") {
-    withTempDir { dir =>
-      val path = dir.getCanonicalPath
+    withTable("amt_vanilla") {
+      val name = "amt_vanilla"
       sql(
-        s"""CREATE TABLE delta.`$path` (id INT) USING DELTA
+        s"""CREATE TABLE $name (id INT) USING DELTA
            |TBLPROPERTIES ('delta.checkpointInterval' = '2')""".stripMargin)
-      sql(s"INSERT INTO delta.`$path` VALUES (1)")
-      sql(s"INSERT INTO delta.`$path` VALUES (2)") // interval boundary, but no AMT feature.
+      sql(s"INSERT INTO $name VALUES (1)")
+      sql(s"INSERT INTO $name VALUES (2)") // interval boundary, but no AMT feature.
 
-      val deltaLog = DeltaLog.forTable(spark, path)
+      val deltaLog = deltaLogForName(name)
+      val path = tablePath(name)
       assert(rootFiles(path).isEmpty && leafFiles(path).isEmpty,
         "No AMT artifacts on a vanilla table.")
       assert(checkpointsAt(deltaLog, 2).isEmpty, "No Checkpoint action on a vanilla table.")
@@ -73,26 +75,28 @@ class AMTCheckpointWriteSuite extends AMTCheckpointTestBase {
   }
 
   test("no emission on a non-interval commit") {
-    withTempDir { dir =>
-      val path = dir.getCanonicalPath
-      createAMTTable(path, checkpointInterval = 10) // interval far from the versions we write.
-      sql(s"INSERT INTO delta.`$path` VALUES (1)") // v1: 1 % 10 != 0.
+    withTable("amt_non_interval") {
+      val name = "amt_non_interval"
+      createAMTTable(name, checkpointInterval = 10) // interval far from the versions we write.
+      sql(s"INSERT INTO $name VALUES (1)") // v1: 1 % 10 != 0.
 
-      val deltaLog = DeltaLog.forTable(spark, path)
+      val deltaLog = deltaLogForName(name)
       assert(checkpointsAt(deltaLog, 1).isEmpty, "v1 is not an interval boundary; no emission.")
-      assert(rootFiles(path).isEmpty, "No manifest tree written off an interval boundary.")
+      assert(rootFiles(tablePath(name)).isEmpty,
+        "No manifest tree written off an interval boundary.")
       assert(amtProvider(deltaLog.update()).isEmpty)
     }
   }
 
   test("leaf cardinality respects AMT_ENTRIES_PER_LEAF") {
-    withTempDir { dir =>
-      val path = dir.getCanonicalPath
-      createAMTTable(path, checkpointInterval = 2)
+    withTable("amt_entries_per_leaf") {
+      val name = "amt_entries_per_leaf"
+      createAMTTable(name, checkpointInterval = 2)
       withSQLConf(DeltaSQLConf.AMT_ENTRIES_PER_LEAF.key -> "1") {
-        sql(s"INSERT INTO delta.`$path` VALUES (1)") // v1: one data file.
-        sql(s"INSERT INTO delta.`$path` VALUES (2)") // v2: one more data file -> 2 live files.
+        sql(s"INSERT INTO $name VALUES (1)") // v1: one data file.
+        sql(s"INSERT INTO $name VALUES (2)") // v2: one more data file -> 2 live files.
       }
+      val path = tablePath(name)
       // Two live AddFiles, one per leaf -> two leaves, one root.
       assert(leafFiles(path).size == 2, s"Expected 2 leaves, got ${leafFiles(path).size}.")
       assert(rootFiles(path).size == 1)
@@ -110,13 +114,13 @@ class AMTCheckpointWriteSuite extends AMTCheckpointTestBase {
   }
 
   test("commit stats carry AMT write metrics when an AMT is emitted") {
-    withTempDir { dir =>
-      val path = dir.getCanonicalPath
-      createAMTTable(path, checkpointInterval = 2)
-      sql(s"INSERT INTO delta.`$path` VALUES (1)") // v1: below the interval, no AMT.
+    withTable("amt_commit_stats") {
+      val name = "amt_commit_stats"
+      createAMTTable(name, checkpointInterval = 2)
+      sql(s"INSERT INTO $name VALUES (1)") // v1: below the interval, no AMT.
 
       // v2 hits the interval boundary and emits an AMT; capture that commit's stats.
-      val commitStats = commitStatsAt(sql(s"INSERT INTO delta.`$path` VALUES (2)"), version = 2)
+      val commitStats = commitStatsAt(sql(s"INSERT INTO $name VALUES (2)"), version = 2)
 
       val metrics = commitStats.amtWriteMetrics
         .getOrElse(fail("Commit stats should carry AMT write metrics when an AMT is emitted."))
@@ -127,11 +131,11 @@ class AMTCheckpointWriteSuite extends AMTCheckpointTestBase {
   }
 
   test("commit stats carry no AMT write metrics when no AMT is emitted") {
-    withTempDir { dir =>
-      val path = dir.getCanonicalPath
-      createAMTTable(path, checkpointInterval = 100) // interval far away, so v1 emits no AMT.
+    withTable("amt_no_commit_stats") {
+      val name = "amt_no_commit_stats"
+      createAMTTable(name, checkpointInterval = 100) // interval far away, so v1 emits no AMT.
 
-      val commitStats = commitStatsAt(sql(s"INSERT INTO delta.`$path` VALUES (1)"), version = 1)
+      val commitStats = commitStatsAt(sql(s"INSERT INTO $name VALUES (1)"), version = 1)
 
       assert(commitStats.amtWriteMetrics.isEmpty,
         "Commit stats must not carry AMT write metrics when no AMT is emitted.")

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotDiscoverySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotDiscoverySuite.scala
@@ -16,7 +16,7 @@
 
 package org.apache.spark.sql.delta.amt
 
-import org.apache.spark.sql.delta.{DeltaLog, Snapshot}
+import org.apache.spark.sql.delta.Snapshot
 import org.apache.spark.sql.delta.util.FileNames
 
 class AMTSnapshotDiscoverySuite extends AMTCheckpointTestBase {
@@ -34,13 +34,13 @@ class AMTSnapshotDiscoverySuite extends AMTCheckpointTestBase {
   ///////////////////////////
 
   test("inline emission installs an AMTCheckpointProvider on the post-commit snapshot") {
-    withTempDir { dir =>
-      val path = dir.getCanonicalPath
-      createAMTTable(path, checkpointInterval = 2)
-      sql(s"INSERT INTO delta.`$path` VALUES (1)")
-      sql(s"INSERT INTO delta.`$path` VALUES (2)") // v2: emit.
+    withTable("amt_provider_install") {
+      val name = "amt_provider_install"
+      createAMTTable(name, checkpointInterval = 2)
+      sql(s"INSERT INTO $name VALUES (1)")
+      sql(s"INSERT INTO $name VALUES (2)") // v2: emit.
 
-      val deltaLog = DeltaLog.forTable(spark, path)
+      val deltaLog = deltaLogForName(name)
       val snapshot = deltaLog.unsafeVolatileSnapshot
       assert(snapshot.version == 2)
       val provider = amtProvider(snapshot)
@@ -53,16 +53,16 @@ class AMTSnapshotDiscoverySuite extends AMTCheckpointTestBase {
   }
 
   test("post-commit LogSegment carries the AMT provider and only post-checkpoint deltas") {
-    withTempDir { dir =>
-      val path = dir.getCanonicalPath
-      createAMTTable(path, checkpointInterval = 3)
+    withTable("amt_log_segment") {
+      val name = "amt_log_segment"
+      createAMTTable(name, checkpointInterval = 3)
       // After each commit, the post-commit snapshot's log segment holds the deltas after the latest
       // checkpoint. A checkpoint emits at every interval boundary (v3, v6); the provider persists
       // across the intervening commits (deltaLog.update() is a no-op for AMT, so the cached
       // post-commit snapshot is returned as-is). Expected (version -> delta count):
       //   v0=1, v1=2, v2=3, v3=0 (checkpoint), v4=1, v5=2, v6=0 (checkpoint).
       val expected = Seq(0L -> 1, 1L -> 2, 2L -> 3, 3L -> 0, 4L -> 1, 5L -> 2, 6L -> 0)
-      val deltaLog = DeltaLog.forTable(spark, path)
+      val deltaLog = deltaLogForName(name)
 
       def assertSegment(snapshot: Snapshot, expectedVersion: Long, expectedDeltas: Int): Unit = {
         assert(snapshot.version == expectedVersion)
@@ -79,8 +79,8 @@ class AMTSnapshotDiscoverySuite extends AMTCheckpointTestBase {
 
       assertSegment(deltaLog.unsafeVolatileSnapshot, expected.head._1, expected.head._2)
       expected.tail.foreach { case (version, deltas) =>
-        sql(s"INSERT INTO delta.`$path` VALUES ($version)")
-        assertSegment(DeltaLog.forTable(spark, path).unsafeVolatileSnapshot, version, deltas)
+        sql(s"INSERT INTO $name VALUES ($version)")
+        assertSegment(deltaLogForName(name).unsafeVolatileSnapshot, version, deltas)
       }
     }
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotSuite.scala
@@ -16,7 +16,7 @@
 
 package org.apache.spark.sql.delta.amt
 
-import org.apache.spark.sql.delta.{DeletionVectorsTestUtils, DeltaLog, DeltaOperations}
+import org.apache.spark.sql.delta.{DeletionVectorsTestUtils, DeltaOperations}
 import org.apache.spark.sql.delta.actions.{AddFile, DeletionVectorDescriptor}
 import org.apache.spark.sql.delta.deletionvectors.RoaringBitmapArray
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
@@ -35,22 +35,22 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
   ///////////////////////////
 
   test("snapshot.allFiles reflects a DELETE that lands on the checkpoint boundary") {
-    withTempDir { dir =>
-      val path = dir.getCanonicalPath
-      createAMTTable(path, checkpointInterval = 2)
-      sql(s"INSERT INTO delta.`$path` VALUES (1)")   // v1: 1 file.
-      sql(s"INSERT INTO delta.`$path` VALUES (2)")   // v2: emit; 2 live files.
+    withTable("amt_delete_boundary") {
+      val name = "amt_delete_boundary"
+      createAMTTable(name, checkpointInterval = 2)
+      sql(s"INSERT INTO $name VALUES (1)")   // v1: 1 file.
+      sql(s"INSERT INTO $name VALUES (2)")   // v2: emit; 2 live files.
       // Sanity: snapshot state and leaves agree at the first checkpoint.
-      assert(DeltaLog.forTable(spark, path).unsafeVolatileSnapshot.allFiles.count() == 2)
+      assert(deltaLogForName(name).unsafeVolatileSnapshot.allFiles.count() == 2)
 
-      sql(s"INSERT INTO delta.`$path` VALUES (3)")   // v3: 3 live files (not a boundary).
-      sql(s"DELETE FROM delta.`$path` WHERE id = 1") // v4: emit; live set drops id=1.
+      sql(s"INSERT INTO $name VALUES (3)")   // v3: 3 live files (not a boundary).
+      sql(s"DELETE FROM $name WHERE id = 1") // v4: emit; live set drops id=1.
 
-      val snapshot = DeltaLog.forTable(spark, path).unsafeVolatileSnapshot
+      val snapshot = deltaLogForName(name).unsafeVolatileSnapshot
       assert(snapshot.version == 4)
       assert(amtProvider(snapshot).isDefined)
       // allFiles must reflect the DELETE: the removed file is gone from the post-commit live set.
-      checkAnswer(spark.read.format("delta").load(path), Seq(Row(2), Row(3)))
+      checkAnswer(spark.read.table(name), Seq(Row(2), Row(3)))
       // The manifest tree written at the checkpoint captures exactly the post-DELETE live files
       // (computePostCommitState applied the RemoveFile), i.e. it matches snapshot.allFiles.
       assert(currentLeafDataEntries(snapshot) == snapshot.allFiles.count(),
@@ -59,18 +59,18 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
   }
 
   test("snapshot.allFiles matches leaves across insert/overwrite/delete before a checkpoint") {
-    withTempDir { dir =>
-      val path = dir.getCanonicalPath
-      createAMTTable(path, checkpointInterval = 4)
-      sql(s"INSERT INTO delta.`$path` VALUES (1)")            // v1.
-      sql(s"INSERT INTO delta.`$path` VALUES (2)")            // v2.
-      sql(s"INSERT OVERWRITE delta.`$path` VALUES (10), (20)") // v3: replaces all prior files.
-      sql(s"DELETE FROM delta.`$path` WHERE id = 10")         // v4: emit; removes one.
+    withTable("amt_overwrite") {
+      val name = "amt_overwrite"
+      createAMTTable(name, checkpointInterval = 4)
+      sql(s"INSERT INTO $name VALUES (1)")            // v1.
+      sql(s"INSERT INTO $name VALUES (2)")            // v2.
+      sql(s"INSERT OVERWRITE $name VALUES (10), (20)") // v3: replaces all prior files.
+      sql(s"DELETE FROM $name WHERE id = 10")         // v4: emit; removes one.
 
-      val snapshot = DeltaLog.forTable(spark, path).unsafeVolatileSnapshot
+      val snapshot = deltaLogForName(name).unsafeVolatileSnapshot
       assert(snapshot.version == 4)
       assert(amtProvider(snapshot).isDefined)
-      checkAnswer(spark.read.format("delta").load(path), Seq(Row(20)))
+      checkAnswer(spark.read.table(name), Seq(Row(20)))
       assert(snapshot.allFiles.count() == 1, "Only the surviving overwrite file should be live.")
       assert(currentLeafDataEntries(snapshot) == 1,
         "Leaves must capture exactly the surviving live file after overwrite + delete.")
@@ -78,36 +78,36 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
   }
 
   test("filtered scan is correct after emission (reconstruction from trimmed deltas + leaves)") {
-    withTempDir { dir =>
-      val path = dir.getCanonicalPath
-      createAMTTable(path, checkpointInterval = 2)
-      sql(s"INSERT INTO delta.`$path` VALUES (1)")
-      sql(s"INSERT INTO delta.`$path` VALUES (2)")   // v2: emit; provider is AMT.
-      sql(s"INSERT INTO delta.`$path` VALUES (3)")   // v3.
-      sql(s"DELETE FROM delta.`$path` WHERE id = 1") // v4: emit again.
+    withTable("amt_filtered_scan") {
+      val name = "amt_filtered_scan"
+      createAMTTable(name, checkpointInterval = 2)
+      sql(s"INSERT INTO $name VALUES (1)")
+      sql(s"INSERT INTO $name VALUES (2)")   // v2: emit; provider is AMT.
+      sql(s"INSERT INTO $name VALUES (3)")   // v3.
+      sql(s"DELETE FROM $name WHERE id = 1") // v4: emit again.
 
       // SQL data-skipping reconstruction is disabled for AMT tables, so reads go through the
       // allFiles-based reconstruction: the leaves supply state up to the checkpoint and the
       // trimmed deltas supply the rest. Each row must appear exactly once -- a double-count would
       // surface as duplicate rows or wrong counts.
-      checkAnswer(spark.read.format("delta").load(path).filter("id >= 2"), Seq(Row(2), Row(3)))
+      checkAnswer(spark.read.table(name).filter("id >= 2"), Seq(Row(2), Row(3)))
       checkAnswer(
-        spark.read.format("delta").load(path).groupBy().count(), Seq(Row(2L)))
-      checkAnswer(spark.read.format("delta").load(path), Seq(Row(2), Row(3)))
+        spark.read.table(name).groupBy().count(), Seq(Row(2L)))
+      checkAnswer(spark.read.table(name), Seq(Row(2), Row(3)))
     }
   }
 
   test("deletion vector round-trips through the leaves with a matching uniqueId") {
-    withTempDir { dir =>
-      val path = dir.getCanonicalPath
-      createAMTTable(path, checkpointInterval = 2)
+    withTable("amt_dv") {
+      val name = "amt_dv"
+      createAMTTable(name, checkpointInterval = 2)
       Seq(1, 2).toDF("id").coalesce(1)
-        .write.format("delta").mode("append").save(path) // v1: one file, two rows.
+        .write.mode("append").insertInto(name) // v1: one file, two rows.
 
       // Attach a persistent DV directly rather than relying on DELETE's DV-vs-rewrite heuristic:
       // write a DV marking row 0 deleted and commit the resulting AddFile (with DV) + RemoveFile.
       // v2 is a checkpoint boundary -> emit.
-      val log = DeltaLog.forTable(spark, path)
+      val log = deltaLogForName(name)
       val fileToDv = log.unsafeVolatileSnapshot.allFiles.collect()
       assert(fileToDv.length == 1, "The two rows must land in a single file.")
       val dvActions = writeFileWithDVOnDisk(log, fileToDv.head, RoaringBitmapArray(0L))
@@ -117,10 +117,10 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
         log.startTransaction().commit(dvActions, DeltaOperations.Delete(predicate = Seq.empty))
       }
 
-      val snapshot = DeltaLog.forTable(spark, path).unsafeVolatileSnapshot
+      val snapshot = deltaLogForName(name).unsafeVolatileSnapshot
       assert(snapshot.version == 2)
       val provider = amtProvider(snapshot).getOrElse(fail("expected AMTCheckpointProvider"))
-      checkAnswer(spark.read.format("delta").load(path), Seq(Row(2)))
+      checkAnswer(spark.read.table(name), Seq(Row(2)))
 
       // The one surviving live file must carry a deletion vector in committed state.
       val committed = snapshot.allFiles.collect()

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTWriterManagerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTWriterManagerSuite.scala
@@ -16,7 +16,7 @@
 
 package org.apache.spark.sql.delta.amt
 
-import org.apache.spark.sql.delta.{CurrentTransactionInfo, DeltaLog, DeltaOperations, Snapshot}
+import org.apache.spark.sql.delta.{CurrentTransactionInfo, DeltaOperations, Snapshot}
 import io.delta.exceptions.ConcurrentWriteException
 
 /**
@@ -27,10 +27,10 @@ class AMTWriterManagerSuite extends AMTCheckpointTestBase {
 
   // Reads the current snapshot and returns (manager, snapshot) for direct method-level tests.
   private def managerFor(
-      path: String,
+      tableName: String,
       operation: DeltaOperations.Operation = DeltaOperations.ManualUpdate):
       (AMTWriterManager, Snapshot) = {
-    val snapshot = DeltaLog.forTable(spark, path).update()
+    val snapshot = deltaLogForName(tableName).update()
     (new AMTWriterManager(snapshot, operation), snapshot)
   }
 
@@ -54,12 +54,12 @@ class AMTWriterManagerSuite extends AMTCheckpointTestBase {
       op = DeltaOperations.ManualUpdate)
 
   test("writeAMT throws UnsupportedOperationException for an OPTIMIZE checkpoint operation") {
-    withTempDir { dir =>
-      val path = dir.getCanonicalPath
-      createAMTTable(path, checkpointInterval = 2)
-      sql(s"INSERT INTO delta.`$path` VALUES (1)")
+    withTable("amt_optimize_ckpt") {
+      val name = "amt_optimize_ckpt"
+      createAMTTable(name, checkpointInterval = 2)
+      sql(s"INSERT INTO $name VALUES (1)")
 
-      val (manager, snapshot) = managerFor(path, DeltaOperations.OptimizeCheckpoint())
+      val (manager, snapshot) = managerFor(name, DeltaOperations.OptimizeCheckpoint())
       val ex = intercept[UnsupportedOperationException] {
         manager.writeAMT(
           commitVersion = snapshot.version + 1,
@@ -71,14 +71,15 @@ class AMTWriterManagerSuite extends AMTCheckpointTestBase {
   }
 
   test("emits AMT when commit count since last checkpoint reaches the checkpoint interval") {
-    withTempDir { dir =>
-      val path = dir.getCanonicalPath
-      createAMTTable(path, checkpointInterval = 3)
-      sql(s"INSERT INTO delta.`$path` VALUES (1)") // v1: 1 commit since genesis, < 3.
-      sql(s"INSERT INTO delta.`$path` VALUES (2)") // v2: 2 commits since genesis, < 3.
-      sql(s"INSERT INTO delta.`$path` VALUES (3)") // v3: 3 commits since genesis, >= 3 -> emit.
+    withTable("amt_count_trigger") {
+      val name = "amt_count_trigger"
+      createAMTTable(name, checkpointInterval = 3)
+      sql(s"INSERT INTO $name VALUES (1)") // v1: 1 commit since genesis, < 3.
+      sql(s"INSERT INTO $name VALUES (2)") // v2: 2 commits since genesis, < 3.
+      sql(s"INSERT INTO $name VALUES (3)") // v3: 3 commits since genesis, >= 3 -> emit.
 
-      val deltaLog = DeltaLog.forTable(spark, path)
+      val deltaLog = deltaLogForName(name)
+      val path = tablePath(name)
       assert(checkpointsAt(deltaLog, 1).isEmpty, "v1 is below the interval; no emission.")
       assert(checkpointsAt(deltaLog, 2).isEmpty, "v2 is below the interval; no emission.")
       assert(checkpointsAt(deltaLog, 3).size == 1, "v3 reaches the interval; AMT must be emitted.")
@@ -90,14 +91,15 @@ class AMTWriterManagerSuite extends AMTCheckpointTestBase {
 
 
   test("does not emit AMT when no trigger fires") {
-    withTempDir { dir =>
-      val path = dir.getCanonicalPath
+    withTable("amt_no_trigger") {
+      val name = "amt_no_trigger"
       // Interval far away, and a tiny commit stays well below the default size threshold, so
       // neither the count nor the (edge-only) size trigger fires.
-      createAMTTable(path, checkpointInterval = 1000)
-      sql(s"INSERT INTO delta.`$path` VALUES (1)")
+      createAMTTable(name, checkpointInterval = 1000)
+      sql(s"INSERT INTO $name VALUES (1)")
 
-      val deltaLog = DeltaLog.forTable(spark, path)
+      val deltaLog = deltaLogForName(name)
+      val path = tablePath(name)
       assert(checkpointsAt(deltaLog, 1).isEmpty, "No trigger fires; no emission.")
       assert(rootFiles(path).isEmpty && leafFiles(path).isEmpty, "No manifest tree written.")
       assert(amtProvider(deltaLog.update()).isEmpty)
@@ -105,12 +107,12 @@ class AMTWriterManagerSuite extends AMTCheckpointTestBase {
   }
 
   test("writeAMT hard-fails an AMT table on a conflict-resolution retry") {
-    withTempDir { dir =>
-      val path = dir.getCanonicalPath
-      createAMTTable(path, checkpointInterval = 2)
-      sql(s"INSERT INTO delta.`$path` VALUES (1)")
+    withTable("amt_conflict_fail") {
+      val name = "amt_conflict_fail"
+      createAMTTable(name, checkpointInterval = 2)
+      sql(s"INSERT INTO $name VALUES (1)")
 
-      val (manager, snapshot) = managerFor(path)
+      val (manager, snapshot) = managerFor(name)
       // A retry: conflict resolution advanced the segment past the read snapshot's version.
       val retrySegment = snapshot.logSegment.copy(version = snapshot.version + 1)
       intercept[ConcurrentWriteException] {
@@ -123,13 +125,13 @@ class AMTWriterManagerSuite extends AMTCheckpointTestBase {
   }
 
   test("writeAMT does not hard-fail a non-AMT table on a conflict-resolution retry") {
-    withTempDir { dir =>
-      val path = dir.getCanonicalPath
+    withTable("amt_non_amt_conflict") {
+      val name = "amt_non_amt_conflict"
       // A vanilla Delta table without the AMT feature must not be hard-failed on a conflict.
-      sql(s"CREATE TABLE delta.`$path` (id INT) USING DELTA")
-      sql(s"INSERT INTO delta.`$path` VALUES (1)")
+      sql(s"CREATE TABLE $name (id INT) USING DELTA")
+      sql(s"INSERT INTO $name VALUES (1)")
 
-      val (manager, snapshot) = managerFor(path)
+      val (manager, snapshot) = managerFor(name)
       val retrySegment = snapshot.logSegment.copy(version = snapshot.version + 1)
       val result = manager.writeAMT(
         commitVersion = snapshot.version + 2,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AdaptiveMetadataTableFeatureSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AdaptiveMetadataTableFeatureSuite.scala
@@ -20,25 +20,49 @@ import java.util.Locale
 
 import org.apache.spark.sql.delta.{
   AdaptiveMetadataTableFeature,
+  CatalogOwnedTableFeature,
   ColumnMappingTableFeature,
+  DeletionVectorsTableFeature,
+  DeltaAnalysisException,
+  DeltaConfigs,
   DeltaLog,
   DeltaTableFeatureException,
+  DomainMetadataTableFeature,
   FeatureAutomaticallyEnabledByMetadata,
   RemovableFeature,
+  RowTrackingFeature,
   TableFeature
 }
-import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils._
+import org.apache.spark.sql.delta.coordinatedcommits.CatalogOwnedTestBaseSuite
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
-import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.delta.test.{DeltaSQLCommandTest, DeltaSQLTestUtils}
 
 import org.apache.spark.sql.QueryTest
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.catalyst.TableIdentifier
 
 class AdaptiveMetadataTableFeatureSuite
   extends QueryTest
-  with SharedSparkSession
-  with DeltaSQLCommandTest {
+  with DeltaSQLTestUtils
+  with DeltaSQLCommandTest
+  with CatalogOwnedTestBaseSuite {
+
+  // Register the in-memory commit coordinator so catalog-managed tables can be created locally.
+  override def catalogOwnedCoordinatorBackfillBatchSize: Option[Int] = Some(2)
+
+  /** Creates a table by name with the AMT feature plus any extra table properties. */
+  private def createAdaptiveMetadataTable(
+      tableName: String, extraProps: Map[String, String] = Map.empty): Unit = {
+    val props = (Map(propertyKey(AdaptiveMetadataTableFeature) -> FEATURE_PROP_SUPPORTED) ++
+      extraProps).map { case (k, v) => s"'$k' = '$v'" }.mkString(", ")
+    sql(s"CREATE TABLE $tableName (id INT) USING DELTA TBLPROPERTIES ($props)")
+  }
+
+  private def metadataOf(tableName: String) =
+    DeltaLog.forTableWithSnapshot(spark, new TableIdentifier(tableName))._2.metadata
+
+  private def protocolOf(tableName: String) =
+    DeltaLog.forTableWithSnapshot(spark, new TableIdentifier(tableName))._2.protocol
 
   test("feature is a ReaderWriterFeature and is NOT a RemovableFeature") {
     assert(AdaptiveMetadataTableFeature.isReaderWriterFeature)
@@ -49,22 +73,108 @@ class AdaptiveMetadataTableFeatureSuite
     assert(!AdaptiveMetadataTableFeature.isInstanceOf[FeatureAutomaticallyEnabledByMetadata])
   }
 
-  test("feature requires column mapping") {
-    assert(AdaptiveMetadataTableFeature.requiredFeatures === Set(ColumnMappingTableFeature))
+  test("feature requires catalogManaged, rowTracking, domainMetadata, DVs and column mapping") {
+    assert(AdaptiveMetadataTableFeature.requiredFeatures === Set(
+      CatalogOwnedTableFeature,
+      RowTrackingFeature,
+      DomainMetadataTableFeature,
+      DeletionVectorsTableFeature,
+      ColumnMappingTableFeature))
   }
 
-  test("creating a Delta table with delta.feature.adaptiveMetadata-preview=supported succeeds") {
-    withTempDir { dir =>
-      val path = dir.getCanonicalPath
-      sql(
-        s"""CREATE TABLE delta.`$path` (id INT) USING DELTA
-           |TBLPROPERTIES ('${propertyKey(AdaptiveMetadataTableFeature)}' =
-           |  '$FEATURE_PROP_SUPPORTED')""".stripMargin)
+  /** All features feature depends on, transitively. */
+  private def dependentFeatures(feature: TableFeature): Seq[TableFeature] = {
+    feature.requiredFeatures.toSeq ++ feature.requiredFeatures.toSeq.flatMap(dependentFeatures)
+  }
 
-      val deltaLog = DeltaLog.forTable(spark, path)
-      val protocol = deltaLog.update().protocol
+  test("creating the table records it and all required features as supported in the protocol") {
+    withTable("amt_supported") {
+      createAdaptiveMetadataTable("amt_supported")
+      val protocol = protocolOf("amt_supported")
       assert(protocol.isFeatureSupported(AdaptiveMetadataTableFeature),
         s"Protocol must record adaptiveMetadata-preview as supported. Got: $protocol")
+      // Every required feature (and their transitive dependencies) must be present.
+      dependentFeatures(AdaptiveMetadataTableFeature).foreach { f =>
+        assert(protocol.readerAndWriterFeatureNames.contains(f.name),
+          s"Protocol must contain required feature ${f.name}. Got: $protocol")
+      }
+    }
+  }
+
+  test("the feature property is not persisted in the table metadata configuration") {
+    withTable("amt_no_feature_prop") {
+      createAdaptiveMetadataTable("amt_no_feature_prop")
+      // AdaptiveMetadataTableFeature does not have [[metadataRequiresFeatureToBeEnabled]], so no
+      // metadata property drives its enablement.
+      val metadata = metadataOf("amt_no_feature_prop")
+      val featurePropKey = propertyKey(AdaptiveMetadataTableFeature)
+      assert(!metadata.configuration.contains(featurePropKey),
+        s"'$featurePropKey' should not be present in metadata configuration. " +
+          s"Got: ${metadata.configuration}")
+      // Sanity check: the feature is still recorded in the protocol.
+      assert(protocolOf("amt_no_feature_prop").isFeatureSupported(AdaptiveMetadataTableFeature))
+    }
+  }
+
+  test("creating the table auto-enables rowTracking, deletionVectors and id column mapping") {
+    withTable("amt_enable") {
+      createAdaptiveMetadataTable("amt_enable")
+      val metadata = metadataOf("amt_enable")
+      assert(metadata.columnMappingMode.name === "id",
+        s"Column mapping mode should be auto-set to id. Got: ${metadata.columnMappingMode}")
+      assert(DeltaConfigs.ROW_TRACKING_ENABLED.fromMetaData(metadata),
+        "rowTracking should be enabled in metadata.")
+      assert(DeltaConfigs.ENABLE_DELETION_VECTORS_CREATION.fromMetaData(metadata),
+        "deletionVectors should be enabled in metadata.")
+      // ICT is required by catalogManaged and must be enabled as well.
+      assert(DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.fromMetaData(metadata),
+        "In-commit timestamps should be enabled in metadata.")
+    }
+  }
+
+  test("creating the table with explicit id column mapping mode succeeds") {
+    withTable("amt_explicit_id") {
+      createAdaptiveMetadataTable(
+        "amt_explicit_id", Map(DeltaConfigs.COLUMN_MAPPING_MODE.key -> "id"))
+      assert(metadataOf("amt_explicit_id").columnMappingMode.name === "id")
+    }
+  }
+
+  test("creating the table with non-id column mapping mode is rejected") {
+    withTable("amt_bad_mode") {
+      val ex = intercept[DeltaAnalysisException] {
+        createAdaptiveMetadataTable(
+          "amt_bad_mode", Map(DeltaConfigs.COLUMN_MAPPING_MODE.key -> "name"))
+      }
+      assert(ex.getErrorClass === "DELTA_ADAPTIVE_METADATA_REQUIRES_COLUMN_MAPPING_ID_MODE",
+        s"Unexpected error: ${ex.getMessage}")
+    }
+  }
+
+  for (prop <- Seq(
+      DeltaConfigs.ROW_TRACKING_ENABLED.key,
+      DeltaConfigs.ENABLE_DELETION_VECTORS_CREATION.key)) {
+    test(s"creating the table with $prop explicitly disabled is rejected") {
+      withTable("amt_dep_disabled") {
+        val ex = intercept[DeltaAnalysisException] {
+          createAdaptiveMetadataTable("amt_dep_disabled", Map(prop -> "false"))
+        }
+        assert(
+          ex.getErrorClass === "DELTA_ADAPTIVE_METADATA_REQUIRES_DEPENDENT_FEATURE_ENABLED",
+          s"Unexpected error: ${ex.getMessage}")
+      }
+    }
+  }
+
+  test("enabling the feature on an existing table is rejected") {
+    withTable("amt_upgrade") {
+      sql("CREATE TABLE amt_upgrade (id INT) USING DELTA")
+      val ex = intercept[DeltaAnalysisException] {
+        sql(s"ALTER TABLE amt_upgrade SET TBLPROPERTIES " +
+          s"('${propertyKey(AdaptiveMetadataTableFeature)}' = '$FEATURE_PROP_SUPPORTED')")
+      }
+      assert(ex.getErrorClass === "DELTA_ADAPTIVE_METADATA_UPGRADE_NOT_SUPPORTED",
+        s"Unexpected error: ${ex.getMessage}")
     }
   }
 
@@ -73,13 +183,9 @@ class AdaptiveMetadataTableFeatureSuite
       // The feature is unregistered, so featureNameToFeature returns None.
       assert(TableFeature.featureNameToFeature(AdaptiveMetadataTableFeature.name).isEmpty)
 
-      withTempDir { dir =>
-        val path = dir.getCanonicalPath
+      withTable("amt_killswitch") {
         val ex = intercept[DeltaTableFeatureException] {
-          sql(
-            s"""CREATE TABLE delta.`$path` (id INT) USING DELTA
-               |TBLPROPERTIES ('${propertyKey(AdaptiveMetadataTableFeature)}' =
-               |  '$FEATURE_PROP_SUPPORTED')""".stripMargin)
+          createAdaptiveMetadataTable("amt_killswitch")
         }
         assert(ex.getMessage.toLowerCase(Locale.ROOT).contains("unsupported"),
           s"Expected an unsupported-feature error, got: ${ex.getMessage}")


### PR DESCRIPTION
## Description

The `adaptiveMetadata-preview` table feature (`AdaptiveMetadataTableFeature`) previously only declared `columnMapping` as a required feature. This change expands its dependencies to the full set the feature actually relies on and ensures they are enabled when a table is created with the feature.

`AdaptiveMetadataTableFeature.requiredFeatures` now includes:
- `catalogManaged` — adaptive metadata tables are catalog-managed only.
- `rowTracking` — stable row identity is required by the adaptive metadata layout.
- `domainMetadata` — listed explicitly (also transitively required by row tracking).
- `deletionVectors` — deletes are expressed as deletion vectors rather than file rewrites.
- `columnMapping` — manifests reference columns by field ID; `id` mode is enforced.

On table creation, dependent features that need a metadata flag (`rowTracking`, `deletionVectors`) are auto-enabled, and column mapping is set to `id` mode. If a user explicitly disables a required dependency or requests a non-`id` column mapping mode, the transaction fails with a clear error rather than silently overriding the request. Enabling the feature on an existing table is rejected.

## How was this patch tested?

Added unit tests in `AdaptiveMetadataTableFeatureSuite` covering: the expanded required-feature set, auto-enablement of dependencies on create, explicit `id` mode, rejection of non-`id` mode, rejection of explicitly-disabled dependencies, and rejection of enabling the feature on an existing table. Updated existing protocol/transaction suites to exclude the new feature where they assert on the full supported-feature set.

## Does this PR introduce _any_ user-facing changes?

No. The feature is a preview feature and is not enabled by default.