### PR TITLE
[Spark][Test] Isolate DSv2 type-widening test tables

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningTestMixin.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningTestMixin.scala
@@ -16,6 +16,9 @@
 
 package org.apache.spark.sql.delta.typewidening
 
+import java.io.File
+import java.util.UUID
+
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.actions.{RemoveFile, TableFeatureProtocolUtils}
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
@@ -32,6 +35,7 @@ import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.internal.{LegacyBehaviorPolicy, SQLConf}
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
+import org.apache.spark.util.Utils
 
 /**
  * Test mixin that enables type widening by default for all tests in the suite.
@@ -152,6 +156,30 @@ trait TypeWideningDSv2TestMixin
   extends TypeWideningTestMixin
     with DeltaDSv2TestMixin
     with DeltaDMLTestUtilsNameBased { self: QueryTest =>
+
+  private var testTableName = "test_delta_table"
+  private var testTablePaths = List.empty[File]
+
+  override protected def beforeEach(): Unit = {
+    // A failed V2 write may leave a canceled task running briefly after the write returns. Give
+    // every test its own managed-table path so a late orphan file cannot affect the next test.
+    testTableName = s"test_delta_table_${UUID.randomUUID().toString.replace('-', '_')}"
+    val path = spark.sessionState.catalog.defaultTablePath(tableIdentifier).getPath
+    testTablePaths ::= new File(path)
+    super.beforeEach()
+  }
+
+  override protected def tableSQLIdentifier: String = testTableName
+
+  override protected def afterAll(): Unit = {
+    try {
+      super.afterAll()
+    } finally {
+      // `super.afterAll()` stops the shared Spark context, so canceled tasks can no longer
+      // recreate files while this final cleanup runs.
+      testTablePaths.foreach(Utils.deleteRecursively)
+    }
+  }
 
   protected override def sparkConf: SparkConf = {
     super.sparkConf.set(DeltaSQLConf.V2_ENABLE_MODE.key, "AUTO")

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningTestMixin.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningTestMixin.scala
@@ -89,13 +89,22 @@ trait TypeWideningTestMixin
    * doesn't get automatically widened. Depending on the data, the write may succeed or overflow.
    */
   protected def mayOverflow(write: => Unit): Unit = {
+    val allowedConditions = Set(
+      "CAST_OVERFLOW_IN_TABLE_INSERT",
+      "CAST_OVERFLOW",
+      "DELTA_CAST_OVERFLOW_IN_TABLE_WRITE")
+
+    def isAllowedOverflow(error: Throwable): Boolean = error match {
+      case e: SparkThrowable if allowedConditions.contains(e.getCondition) => true
+      case e if e.getCause != null && (e.getCause ne e) => isAllowedOverflow(e.getCause)
+      case _ => false
+    }
+
     try {
       write
     } catch {
-      case e: ArithmeticException with SparkThrowable if Set(
-          "CAST_OVERFLOW_IN_TABLE_INSERT",
-          "CAST_OVERFLOW",
-          "DELTA_CAST_OVERFLOW_IN_TABLE_WRITE").contains(e.getCondition) =>
+      // Spark may report the arithmetic error directly or wrap it in TASK_WRITE_FAILED.
+      case e: Exception if isAllowedOverflow(e) =>
     }
   }
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

The Spark 4.2 shard failure exposed on [PR #7241](https://github.com/delta-io/delta/pull/7241) was a test-isolation race in the DSv2 type-widening suites, not a failure caused by #7241's UC caller changes. The failing test tried to recreate `test_delta_table` after the preceding overflow test and found a nonempty, non-Delta managed-table location.

The suites tolerate cast overflow from a V2 write. When one task fails, Spark can return through the V2 abort path while canceled task attempts are still unwinding. Delta's executor writer deletes its own partial output on abort, but the batch abort intentionally leaves orphan files for VACUUM. PR [#7074](https://github.com/delta-io/delta/pull/7074) already added recursive deletion after each named-table test; a late task can still recreate that static directory after deletion and contaminate the next test.

This change scopes isolation to the two DSv2 type-widening suites:

- Give every test a unique lowercase managed-table name and location, preventing a late write from affecting the next test.
- Track the owned locations and delete them again after the shared Spark context stops, so late orphans do not accumulate across suite runs.

Evidence:

- [Failing Spark 4.2 shard](https://github.com/delta-io/delta/actions/runs/29542876355/job/87768849822)
- [Successful unchanged baseline](https://github.com/delta-io/delta/actions/runs/29532480006/job/87745001425)
- [Investigation comment on #7241](https://github.com/delta-io/delta/pull/7241#issuecomment-4998247084)

## How was this patch tested?

Local validation used source-built Spark 4.2 snapshot `37a442c0ae57`; GitHub CI will validate the current pinned Spark 4.2 SHA.

- [x] `spark / Test / compile` (including Scalastyle: 0 errors)
- [x] Full `TypeWideningInsertSchemaEvolutionBasicDSv2Suite`: 61 passed, 4 ignored
- [x] `TypeWideningInsertSchemaEvolutionExtendedDSv2Suite` top-level evolution matrix: 58 passed
- [x] Pre-fix exact overflow sequence stress: 10 fresh forked test JVMs, 20/20 selected tests passed; the low-rate CI flake did not reproduce locally
- [x] Post-fix two-CPU-pinned exact sequence stress: 10 fresh forked test JVMs, 20/20 selected tests passed
- [x] Verified both suite warehouse directories were empty after suite teardown
- [x] `git diff --check`
- [ ] Current pinned Spark 4.2 GitHub CI

Verification commands:

```bash
build/sbt -DsparkVersion=4.2 "spark / Test / compile"
build/sbt -DsparkVersion=4.2 \
  "spark/testOnly org.apache.spark.sql.delta.typewidening.TypeWideningInsertSchemaEvolutionBasicDSv2Suite"
build/sbt -DsparkVersion=4.2 \
  'spark/testOnly org.apache.spark.sql.delta.typewidening.TypeWideningInsertSchemaEvolutionExtendedDSv2Suite -- -z "top-level type evolution"'
```

## Does this PR introduce _any_ user-facing changes?

No. This only changes test table isolation and cleanup.
