### PR TITLE
[Spark] Preserve collation identifiers in V2 schemas

### DIFF
--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/SchemaUtils.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/SchemaUtils.java
@@ -21,6 +21,7 @@ import io.delta.kernel.types.ArrayType;
 import io.delta.kernel.types.BinaryType;
 import io.delta.kernel.types.BooleanType;
 import io.delta.kernel.types.ByteType;
+import io.delta.kernel.types.CollationIdentifier;
 import io.delta.kernel.types.DataType;
 import io.delta.kernel.types.DateType;
 import io.delta.kernel.types.DecimalType;
@@ -40,9 +41,14 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
+import org.apache.spark.QueryContext;
+import org.apache.spark.SparkException;
+import org.apache.spark.SparkRuntimeException;
+import org.apache.spark.sql.catalyst.util.CollationFactory;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
 import org.apache.spark.sql.types.MetadataBuilder;
+import scala.collection.immutable.Map;
 import scala.jdk.CollectionConverters;
 
 /** A utility class for converting between Delta Kernel and Spark schemas and data types. */
@@ -76,7 +82,25 @@ public class SchemaUtils {
       DataType kernelDataType) {
     requireNonNull(kernelDataType);
     if (kernelDataType instanceof StringType) {
-      return DataTypes.StringType;
+      CollationIdentifier collation = ((StringType) kernelDataType).getCollationIdentifier();
+      if (collation.isSparkUTF8BinaryCollation()) {
+        return DataTypes.StringType;
+      }
+      assertValidCollationProvider(collation.getProvider());
+      org.apache.spark.sql.types.StringType sparkStringType =
+          org.apache.spark.sql.types.StringType$.MODULE$.apply(collation.getName());
+      CollationFactory.CollationIdentifier sparkCollation =
+          CollationFactory.fetchCollation(sparkStringType.collationId()).identifier();
+      // Compare providers only so Spark can canonicalize valid collation aliases.
+      if (!sparkCollation.getProvider().equalsIgnoreCase(collation.getProvider())) {
+        throw new SparkRuntimeException(
+            "COLLATION_INVALID_NAME",
+            new Map.Map2<>("collationName", collation.toStringWithoutVersion(), "proposals", ""),
+            null,
+            new QueryContext[] {},
+            "");
+      }
+      return sparkStringType;
     } else if (kernelDataType instanceof BooleanType) {
       return DataTypes.BooleanType;
     } else if (kernelDataType instanceof IntegerType) {
@@ -119,6 +143,24 @@ public class SchemaUtils {
       return DataTypes.VariantType;
     } else {
       throw new IllegalArgumentException("unsupported data type " + kernelDataType);
+    }
+  }
+
+  private static void assertValidCollationProvider(String provider) {
+    try {
+      CollationFactory.assertValidProvider(provider);
+    } catch (SparkException exception) {
+      java.util.Map<String, String> parameters = exception.getMessageParameters();
+      throw new SparkRuntimeException(
+          "COLLATION_INVALID_PROVIDER",
+          new Map.Map2<>(
+              "provider",
+              parameters.get("provider"),
+              "supportedProviders",
+              parameters.get("supportedProviders")),
+          exception,
+          new QueryContext[] {},
+          "");
     }
   }
 

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/SchemaUtilsTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/SchemaUtilsTest.java
@@ -41,6 +41,7 @@ import io.delta.kernel.types.TimestampNTZType;
 import io.delta.kernel.types.TimestampType;
 import io.delta.kernel.types.VariantType;
 import java.util.stream.Stream;
+import org.apache.spark.SparkRuntimeException;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
 import org.apache.spark.sql.types.MetadataBuilder;
@@ -171,6 +172,37 @@ public class SchemaUtilsTest {
     assertEquals(expectedSparkSchema, actualSparkSchema);
   }
 
+  @Test
+  public void testConvertKernelCollationsToSpark() {
+    assertEquals(
+        org.apache.spark.sql.types.StringType$.MODULE$.apply("UTF8_LCASE"),
+        SchemaUtils.convertKernelDataTypeToSparkDataType(new StringType("SPARK.UTF8_LCASE")));
+    assertEquals(
+        org.apache.spark.sql.types.StringType$.MODULE$.apply("UNICODE"),
+        SchemaUtils.convertKernelDataTypeToSparkDataType(new StringType("ICU.UNICODE")));
+    assertEquals(
+        org.apache.spark.sql.types.StringType$.MODULE$.apply("en_CI"),
+        SchemaUtils.convertKernelDataTypeToSparkDataType(new StringType("ICU.en_AS_CI")));
+  }
+
+  @Test
+  public void testConvertKernelCollationRejectsUnknownProvider() {
+    SparkRuntimeException exception =
+        assertThrows(
+            SparkRuntimeException.class,
+            () ->
+                SchemaUtils.convertKernelDataTypeToSparkDataType(
+                    new StringType("OTHER.UTF8_LCASE")));
+    assertEquals("COLLATION_INVALID_PROVIDER", exception.getCondition());
+    assertEquals("OTHER", exception.getMessageParameters().get("provider"));
+    assertEquals("spark, icu", exception.getMessageParameters().get("supportedProviders"));
+  }
+
+  @Test
+  public void testConvertKernelCollationRejectsProviderNameMismatch() {
+    assertInvalidKernelCollation("ICU.UTF8_LCASE");
+  }
+
   static Stream<Arguments> nullInPrimitiveArraysProvider() {
     return Stream.of(
         Arguments.of(
@@ -242,6 +274,16 @@ public class SchemaUtilsTest {
     org.apache.spark.sql.types.DataType toSpark =
         SchemaUtils.convertKernelDataTypeToSparkDataType(kernelDataType);
     assertEquals(sparkDataType, toSpark);
+  }
+
+  private void assertInvalidKernelCollation(String collationIdentifier) {
+    SparkRuntimeException exception =
+        assertThrows(
+            SparkRuntimeException.class,
+            () ->
+                SchemaUtils.convertKernelDataTypeToSparkDataType(
+                    new StringType(collationIdentifier)));
+    assertEquals("COLLATION_INVALID_NAME", exception.getCondition());
   }
 
   ////////////////////////////////

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/SchemaUtilsTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/SchemaUtilsTest.java
@@ -41,6 +41,7 @@ import io.delta.kernel.types.TimestampNTZType;
 import io.delta.kernel.types.TimestampType;
 import io.delta.kernel.types.VariantType;
 import java.util.stream.Stream;
+import org.apache.spark.SparkException;
 import org.apache.spark.SparkRuntimeException;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
@@ -203,6 +204,19 @@ public class SchemaUtilsTest {
     assertInvalidKernelCollation("ICU.UTF8_LCASE");
   }
 
+  @Test
+  public void testConvertKernelCollationRejectsUnknownName() {
+    SparkException exception =
+        assertThrows(
+            SparkException.class,
+            () ->
+                SchemaUtils.convertKernelDataTypeToSparkDataType(
+                    new StringType("SPARK.UNKNOWN_COLLATION")));
+    assertEquals("COLLATION_INVALID_NAME", exception.getCondition());
+    assertEquals("UNKNOWN_COLLATION", exception.getMessageParameters().get("collationName"));
+    assertEquals("sr_Latn", exception.getMessageParameters().get("proposals"));
+  }
+
   static Stream<Arguments> nullInPrimitiveArraysProvider() {
     return Stream.of(
         Arguments.of(
@@ -284,6 +298,8 @@ public class SchemaUtilsTest {
                 SchemaUtils.convertKernelDataTypeToSparkDataType(
                     new StringType(collationIdentifier)));
     assertEquals("COLLATION_INVALID_NAME", exception.getCondition());
+    assertEquals(collationIdentifier, exception.getMessageParameters().get("collationName"));
+    assertEquals("", exception.getMessageParameters().get("proposals"));
   }
 
   ////////////////////////////////


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Preserve collation provider information when converting kernel string types to Spark string types.

The conversion now validates supported providers, rejects provider/name mismatches, and retains valid provider aliases. Tests cover valid aliases as well as invalid provider and provider/name combinations.

## How was this patch tested?

- `sparkV2/javafmtCheckAll`
- `sparkV2/Test/javafmtCheckAll`
- `SchemaUtilsTest`: 32/32 tests passed.
- The normal SBT invocation is currently blocked before this suite by the pre-existing,
  unrelated `UCDeltaClientCommitE2ESuite` constructor compile error. The suite passed
  with only that unrelated source excluded.

## Does this PR introduce _any_ user-facing changes?

No.
