### PR TITLE
Introduce AMTWriterManager to structure the adaptive metadata write path

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
@@ -68,7 +68,8 @@ private[delta] case class CurrentTransactionInfo(
     val readRowIdHighWatermark: Long,
     val catalogTable: Option[CatalogTable],
     val domainMetadata: Seq[DomainMetadata],
-    val op: DeltaOperations.Operation
+    val op: DeltaOperations.Operation,
+    val preCommitLatestAMTCheckpointOpt: Option[Checkpoint] = None
     , val convertedIcebergMetadata: Option[UniformMetadata] = None
  ) {
 
@@ -165,6 +166,8 @@ private[delta] class WinningCommitSummary(
     commitInfo.exists(_.operation == ROW_TRACKING_UNBACKFILL_OPERATION_NAME)
   val removedFiles: Seq[RemoveFile] = actions.collect { case a: RemoveFile => a }
   val addedFiles: Seq[AddFile] = actions.collect { case a: AddFile => a }
+  // The inline AMT (Adaptive Metadata Tree) checkpoint this winning commit emitted, if any.
+  val amtCheckpoint: Option[Checkpoint] = actions.collectFirst { case a: Checkpoint => a }
   // This is used in resolveRowTrackingBackfillConflicts.
   lazy val addedFilePathToActionMap: Map[String, AddFile] =
     addedFiles.map(af => (af.path, af)).toMap
@@ -305,6 +308,13 @@ private[delta] class ConflictChecker(
     checkForDeletedFilesAgainstCurrentTxnReadFiles()
     checkForDeletedFilesAgainstCurrentTxnDeletedFiles()
     resolveTimestampOrderingConflicts()
+
+    // If the winning commit emitted an inline AMT checkpoint, it is now the latest checkpoint
+    // before the next commit attempt.
+    winningCommitSummary.amtCheckpoint.foreach { checkpoint =>
+      currentTransactionInfo =
+        currentTransactionInfo.copy(preCommitLatestAMTCheckpointOpt = Some(checkpoint))
+    }
 
     logMetrics()
     currentTransactionInfo

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
@@ -880,6 +880,18 @@ object DeltaOperations {
     override def canChangePartitionColumns: Boolean = false
   }
 
+  /** Recorded for manifest commits made just for AMT maintenance. */
+  case class OptimizeCheckpoint() extends Operation("OPTIMIZE CHECKPOINT") {
+    override val parameters: Map[String, Any] = Map.empty
+
+    // This operation only rewrites the manifest tree; it commits no new AddFile actions.
+    override def checkAddFileWithDeletionVectorStatsAreNotTightBounds: Boolean = false
+
+    override val isInPlaceFileMetadataUpdate: Option[Boolean] = Some(false)
+
+    override def canChangePartitionColumns: Boolean = false
+  }
+
   /** Recorded when cloning a Delta table into a new location. */
   val OP_CLONE = "CLONE"
   case class Clone(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -37,7 +37,7 @@ import org.apache.spark.sql.delta.DeltaGeoSpatial
 import org.apache.spark.sql.delta.DeltaOperations.{ChangeColumn, ChangeColumns, CreateTable, Operation, ReplaceColumns, ReplaceTable, UpdateSchema}
 import org.apache.spark.sql.delta.RowId.RowTrackingMetadataDomain
 import org.apache.spark.sql.delta.actions._
-import org.apache.spark.sql.delta.amt.AMTWriteHelper
+import org.apache.spark.sql.delta.amt.{AMTCheckpointProvider, AMTWriteMetrics, AMTWriterManager}
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.commands.DeletionVectorUtils
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
@@ -135,7 +135,9 @@ case class CommitStats(
   addFilesHistogram: Option[FileSizeHistogram] = None,
   removeFilesHistogram: Option[FileSizeHistogram] = None,
   numOfDomainMetadatas: Long = 0,
-  txnId: Option[String] = None
+  txnId: Option[String] = None,
+  /** Metrics for the inline AMT (Adaptive Metadata Tree) write, if this commit emitted one. */
+  amtWriteMetrics: Option[AMTWriteMetrics] = None
 )
 
 /**
@@ -1833,6 +1835,10 @@ trait OptimisticTransactionImpl extends TransactionHelper
           case other => other
         }
       }
+      val preCommitLatestAMTCheckpointOpt = snapshot.checkpointProvider match {
+        case amt: AMTCheckpointProvider => Some(amt.checkpointAction)
+        case _ => None
+      }
       val currentTransactionInfo = CurrentTransactionInfo(
         txnId = txnId,
         readPredicates = readPredicates.asScala.toVector,
@@ -1847,7 +1853,8 @@ trait OptimisticTransactionImpl extends TransactionHelper
         readRowIdHighWatermark = readRowIdHighWatermark,
         catalogTable = catalogTable,
         domainMetadata = domainMetadata,
-        op = op)
+        op = op,
+        preCommitLatestAMTCheckpointOpt = preCommitLatestAMTCheckpointOpt)
 
       // Register post-commit hooks if any
       lazy val hasFileActions = preparedActions.exists {
@@ -2644,6 +2651,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
     lockCommitIfEnabled {
       var commitVersion = attemptVersion
       var updatedCurrentTransactionInfo = currentTransactionInfo
+      val amtWriterManager = new AMTWriterManager(snapshot, currentTransactionInfo.op)
       val isFsToCcCommit =
         snapshot.metadata.coordinatedCommitsCoordinatorName.isEmpty &&
           metadata.coordinatedCommitsCoordinatorName.nonEmpty
@@ -2656,7 +2664,9 @@ trait OptimisticTransactionImpl extends TransactionHelper
       for (attemptNumber <- 0 to maxRetryAttempts) {
         try {
           val (postCommitSnapshot, committedTransactionInfo) = if (!shouldCheckForConflicts) {
-            doCommit(commitVersion, updatedCurrentTransactionInfo, attemptNumber, isolationLevel)
+            doCommit(
+              commitVersion, updatedCurrentTransactionInfo, attemptNumber, isolationLevel,
+              amtWriterManager)
           } else recordDeltaOperation(deltaLog, "delta.commit.retry") {
             // The [[CurrentTransactionInfo]] might keep on getting updated while resolving
             // conflicts against the already committed concurrent transactions. This can happen
@@ -2667,7 +2677,9 @@ trait OptimisticTransactionImpl extends TransactionHelper
               commitVersion, updatedCurrentTransactionInfo, attemptNumber, isolationLevel)
             commitVersion = newCommitVersion
             updatedCurrentTransactionInfo = newCurrentTransactionInfo
-            doCommit(commitVersion, updatedCurrentTransactionInfo, attemptNumber, isolationLevel)
+            doCommit(
+              commitVersion, updatedCurrentTransactionInfo, attemptNumber, isolationLevel,
+              amtWriterManager)
           }
           return (commitVersion, postCommitSnapshot, updatedCurrentTransactionInfo)
         } catch {
@@ -2715,13 +2727,15 @@ trait OptimisticTransactionImpl extends TransactionHelper
    * Commit `actions` using `attemptVersion` version number. Throws a FileAlreadyExistsException
    * if any conflicts are detected.
    *
+   * @param amtWriterManager the AMT writer for this commit, shared across all attempts.
    * @return the post-commit snapshot and transaction info used by the successful commit.
    */
   protected def doCommit(
       attemptVersion: Long,
       currentTransactionInfo: CurrentTransactionInfo,
       attemptNumber: Int,
-      isolationLevel: IsolationLevel): (Snapshot, CurrentTransactionInfo) = {
+      isolationLevel: IsolationLevel,
+      amtWriterManager: AMTWriterManager): (Snapshot, CurrentTransactionInfo) = {
     val targetCatalogTable = catalogTable
     // If the table requires atomic Iceberg metadata generation
     // , generate iceberg metadata and update the transaction info.
@@ -2746,15 +2760,17 @@ trait OptimisticTransactionImpl extends TransactionHelper
         updatedInfo
       }.getOrElse(currentTransactionInfo)
     val baseActions = updatedCurrentTransactionInfo.finalActionsToCommit
-    val amtCheckpointOpt = AMTWriteHelper.maybeCreateInlineAMTCheckpoint(
-      spark = spark,
-      deltaLog = deltaLog,
-      readSnapshot = snapshot,
-      attemptVersion = attemptVersion,
-      protocol = updatedCurrentTransactionInfo.protocol,
-      metadata = updatedCurrentTransactionInfo.metadata,
-      commitActions = updatedCurrentTransactionInfo.actions)
-    val actions = baseActions ++ amtCheckpointOpt.toSeq
+    val amtWriteResultOpt = amtWriterManager.writeAMT(
+      commitVersion = attemptVersion,
+      currentTransactionInfo = updatedCurrentTransactionInfo,
+      preCommitLogSegment = preCommitLogSegment)
+    val actions = amtWriteResultOpt match {
+      case Some(result) if !result.includeActionsInCommitJson =>
+        throw new UnsupportedOperationException(
+          "Omitting file actions from the commit JSON is not yet supported.")
+      case Some(result) => baseActions :+ result.checkpoint
+      case None => baseActions
+    }
     logInfo(
       log"Attempting to commit version ${MDC(DeltaLogKeys.VERSION, attemptVersion)} with " +
       log"${MDC(DeltaLogKeys.NUM_ACTIONS, actions.size.toLong)} actions with " +
@@ -2793,7 +2809,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
       newChecksumOpt,
       preCommitLogSegment,
       catalogTableForPostCommitSnapshot,
-      amtCheckpointOpt = amtCheckpointOpt)
+      amtCheckpointOpt = amtWriteResultOpt.map(_.checkpoint))
     val postCommitReconstructionTime = System.nanoTime()
     needsCheckpoint = isCheckpointNeeded(attemptVersion, postCommitSnapshot)
     val commitStatsComputer = new CommitStatsComputer()
@@ -2818,7 +2834,9 @@ trait OptimisticTransactionImpl extends TransactionHelper
       // because it can trigger full state reconstruction.
       fileSizeHistogramOpt = postCommitSnapshot.checksumOpt.flatMap(_.fileSizeHistogram),
       commitInfoOpt = currentTransactionInfo.commitInfo,
-      commitSizeBytes = commitSizeBytes
+      commitSizeBytes = commitSizeBytes,
+      amtWriteMetricsOpt = Option.when(amtWriterManager.metrics.attempts.nonEmpty)(
+        amtWriterManager.metrics)
     )
 
     (postCommitSnapshot, committedTransactionInfo)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriteHelper.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriteHelper.scala
@@ -16,7 +16,9 @@
 
 package org.apache.spark.sql.delta.amt
 
-import org.apache.spark.sql.delta.{AdaptiveMetadataTableFeature, Checkpoints, DeltaLog, Snapshot}
+import java.util.concurrent.TimeUnit.NANOSECONDS
+
+import org.apache.spark.sql.delta.{Checkpoints, Snapshot}
 import org.apache.spark.sql.delta.actions.{Action, AddFile, Checkpoint, ContentRoot, InMemoryLogReplay, Metadata, Protocol}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.FileNames
@@ -29,66 +31,46 @@ import org.apache.spark.sql.SparkSession
 object AMTWriteHelper {
 
   /**
-   * Builds the inline AMT [[Checkpoint]] action for the commit at `attemptVersion`, or `None` when
-   * [[shouldCreateInlineAMTCheckpoint]] is false. When emitting, materializes a manifest tree under
-   * `<table>/metadata/` from the post-commit live file set and returns a Checkpoint pointing at the
-   * tree's root, plus the post-commit non-file state (protocol, metadata, domain metadata, set
-   * transactions) carried inline.
-   *
-   * @param readSnapshot the transaction's read snapshot, used to derive the post-commit state.
-   * @param commitActions the commit's non-CommitInfo actions (AddFile, RemoveFile, DomainMetadata,
-   *                      SetTransaction, ...).
+   * Materializes the full live file set into a fresh manifest tree and builds the inline Checkpoint
+   * action, returning the write result plus its metrics.
    */
-  def maybeCreateInlineAMTCheckpoint(
+  def writeFullMaterialization(
       spark: SparkSession,
-      deltaLog: DeltaLog,
       readSnapshot: Snapshot,
-      attemptVersion: Long,
-      protocol: Protocol,
-      metadata: Metadata,
-      commitActions: Seq[Action]): Option[Checkpoint] = {
-    if (!shouldCreateInlineAMTCheckpoint(
-        spark, deltaLog, attemptVersion, protocol, metadata)) {
-      return None
-    }
-    val postCommitState = computePostCommitState(readSnapshot, commitActions)
+      commitVersion: Long,
+      actionsToCommit: Seq[Action],
+      postCommitProtocol: Protocol,
+      postCommitMetadata: Metadata,
+      trigger: AmtTrigger): (AMTWriteResult, SingleAMTWriteMetrics) = {
+    val deltaLog = readSnapshot.deltaLog
+    val startNanos = System.nanoTime()
+    val postCommitState = computePostCommitState(readSnapshot, actionsToCommit)
     val hadoopConf = deltaLog.newDeltaHadoopConf()
-    val entriesPerLeaf =
-      spark.sessionState.conf.getConf(DeltaSQLConf.AMT_ENTRIES_PER_LEAF)
-    val contentRoot = writeManifestTree(
+    val entriesPerLeaf = spark.sessionState.conf.getConf(DeltaSQLConf.AMT_ENTRIES_PER_LEAF)
+    val (contentRoot, leaves) = writeManifestTree(
       spark = spark,
       hadoopConf = hadoopConf,
       tableRoot = deltaLog.dataPath,
       useRename = deltaLog.store.isPartialWriteVisible(deltaLog.logPath, hadoopConf),
       liveAddFiles = postCommitState.allFiles,
       entriesPerLeaf = entriesPerLeaf)
-    Some(Checkpoint(
-      version = attemptVersion,
+    val checkpoint = Checkpoint(
+      version = commitVersion,
       contentRoot = contentRoot,
-      protocol = protocol,
-      metaData = metadata,
+      protocol = postCommitProtocol,
+      metaData = postCommitMetadata,
       domainMetadata = postCommitState.getDomainMetadatas.toSeq,
       txns = postCommitState.getTransactions.toSeq,
-      sidecars = Seq.empty))
-  }
-
-  /**
-   * Returns true iff the in-flight commit at `commitVersion` should embed an inline
-   * `adaptiveMetadata-preview` (AMT) checkpoint action.
-   */
-  private def shouldCreateInlineAMTCheckpoint(
-      spark: SparkSession,
-      deltaLog: DeltaLog,
-      commitVersion: Long,
-      protocol: Protocol,
-      metadata: Metadata): Boolean = {
-    if (commitVersion <= 0) return false
-    if (!spark.sessionState.conf
-        .getConf(DeltaSQLConf.V4_ADAPTIVE_METADATA_TABLE_PREVIEW_ENABLED)) {
-      return false
-    }
-    if (!protocol.isFeatureSupported(AdaptiveMetadataTableFeature)) return false
-    commitVersion % deltaLog.checkpointInterval(metadata) == 0
+      sidecars = Seq.empty)
+    val result = AMTWriteResult(
+      contentRootVersion = commitVersion,
+      checkpoint = checkpoint,
+      leaves = leaves,
+      includeActionsInCommitJson = true)
+    val singleMetric = SingleAMTWriteMetrics(
+      trigger = trigger.toString,
+      materializeDurationMs = NANOSECONDS.toMillis(System.nanoTime() - startNanos))
+    (result, singleMetric)
   }
 
   // Post-commit table state = the read snapshot's state with this commit's actions applied,
@@ -118,7 +100,7 @@ object AMTWriteHelper {
       tableRoot: Path,
       useRename: Boolean,
       liveAddFiles: Seq[AddFile],
-      entriesPerLeaf: Int): ContentRoot = {
+      entriesPerLeaf: Int): (ContentRoot, Seq[AMTCheckpointProvider.LeafInfo]) = {
     require(entriesPerLeaf > 0, "entriesPerLeaf must be positive.")
 
     val fs = tableRoot.getFileSystem(hadoopConf)
@@ -140,7 +122,14 @@ object AMTWriteHelper {
       writeLeaf(spark, fs, hadoopConf, tableRoot, metadataDir, useRename, batch)
     }
 
-    writeRoot(spark, fs, hadoopConf, metadataDir, useRename, leafPointers)
+    val contentRoot = writeRoot(spark, fs, hadoopConf, metadataDir, useRename, leafPointers)
+    val leafInfos = leafPointers.map { leaf =>
+      AMTCheckpointProvider.LeafInfo(
+        path = leaf.path,
+        sizeInBytes = leaf.sizeInBytes,
+        numEntries = leaf.manifestInfo.added_files_count.toLong)
+    }
+    (contentRoot, leafInfos)
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriterManager.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriterManager.scala
@@ -1,0 +1,152 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.amt
+
+import org.apache.spark.sql.delta.{AdaptiveMetadataTableFeature, CurrentTransactionInfo, DeltaErrors, DeltaLog, DeltaOperations, LogSegment, Snapshot}
+import org.apache.spark.sql.delta.actions.{Action, Checkpoint, Metadata, Protocol}
+
+import org.apache.spark.sql.SparkSession
+
+/** What made an AMT write happen. */
+sealed abstract class AmtTrigger(val name: String) {
+  override def toString: String = name
+}
+
+object AmtTrigger {
+  /** An OPTIMIZE checkpoint forced a full manifest-tree rewrite. */
+  case object OptimizeCheckpoint extends AmtTrigger("OPTIMIZE_CHECKPOINT")
+  /** Commits since the last AMT reached the table's checkpoint interval. */
+  case object CheckpointInterval extends AmtTrigger("CHECKPOINT_INTERVAL")
+}
+
+/** Metrics describing an AMT (Adaptive Metadata Tree) write, one entry per attempt. */
+case class AMTWriteMetrics(
+    private[delta] var attempts: Seq[SingleAMTWriteMetrics] = Seq.empty)
+
+/** Metrics for a single AMT write attempt (one per commit attempt that materializes a tree). */
+case class SingleAMTWriteMetrics(
+    trigger: String,
+    materializeDurationMs: Long)
+
+/**
+ * The outcome of an AMT write for a single commit attempt.
+ *
+ * @param contentRootVersion          the table version the manifest tree describes
+ * @param checkpoint                  the inline [[Checkpoint]] action to embed in the commit JSON
+ * @param leaves                      pointer metadata for each leaf written
+ * @param includeActionsInCommitJson  whether the transaction should still write the commit's file
+ *                                    actions inline in the commit JSON.
+ */
+case class AMTWriteResult(
+    contentRootVersion: Long,
+    checkpoint: Checkpoint,
+    leaves: Seq[AMTCheckpointProvider.LeafInfo],
+    includeActionsInCommitJson: Boolean)
+
+/**
+ * Orchestrates write of an AMT for a given transaction (including reattempts on a conflict).
+ */
+class AMTWriterManager(
+    readSnapshot: Snapshot,
+    initialOperation: DeltaOperations.Operation) {
+
+  private def spark: SparkSession = SparkSession.active
+  private def deltaLog: DeltaLog = readSnapshot.deltaLog
+
+  val metrics = AMTWriteMetrics()
+
+  private var lastAMTWriteResultOpt: Option[AMTWriteResult] = None
+
+  /**
+   * Builds the AMT write for a commit attempt, or `None` when no AMT should be written. Serves both
+   * the first attempt and any conflict-resolution retry.
+   *
+   * @param commitVersion       the version this attempt targets
+   * @param currentTransactionInfo the in-flight transaction (its actions, protocol, metadata)
+   * @param preCommitLogSegment the log segment prior to this commit
+   */
+  def writeAMT(
+      commitVersion: Long,
+      currentTransactionInfo: CurrentTransactionInfo,
+      preCommitLogSegment: LogSegment): Option[AMTWriteResult] = {
+    if (!amtEnabled(commitVersion)) return None
+    if (preCommitLogSegment.version > readSnapshot.version) {
+      throw DeltaErrors.concurrentWriteException(conflictingCommit = None)
+    }
+    val actionsToCommit = currentTransactionInfo.actions
+    val resultOpt = getAMTTriggerMode(
+      commitVersion, actionsToCommit, preCommitLogSegment, currentTransactionInfo.metadata)
+      .map {
+        case AmtTrigger.OptimizeCheckpoint =>
+          // An OPTIMIZE checkpoint only rewrites the manifest tree; it commits no user actions.
+          assert(actionsToCommit.isEmpty,
+            s"OPTIMIZE checkpoint commit must carry no actions, got ${actionsToCommit.size}.")
+          throw new UnsupportedOperationException(
+            "Full AMT rewrite for OPTIMIZE checkpoints is not yet supported.")
+        case trigger =>
+          val (result, singleMetric) = AMTWriteHelper.writeFullMaterialization(
+            spark = spark,
+            readSnapshot = readSnapshot,
+            commitVersion = commitVersion,
+            actionsToCommit = actionsToCommit,
+            postCommitProtocol = currentTransactionInfo.protocol,
+            postCommitMetadata = currentTransactionInfo.metadata,
+            trigger = trigger)
+          metrics.attempts :+= singleMetric
+          result
+      }
+    lastAMTWriteResultOpt = resultOpt
+    resultOpt
+  }
+
+  /**
+   * Whether AMT write is possible at all for this commit.
+   * Note: We don't create AMT at commit 0 as of now but this could be relaxed in future.
+   */
+  private def amtEnabled(commitVersion: Long): Boolean = {
+    if (commitVersion <= 0) return false
+    readSnapshot.protocol.isFeatureSupported(AdaptiveMetadataTableFeature)
+  }
+
+  /**
+   * The trigger reason for why an AMT write is needed for this commit, or `None` if AMT write is
+   * not needed.
+   */
+  private def getAMTTriggerMode(
+      commitVersion: Long,
+      actionsToCommit: Seq[Action],
+      preCommitLogSegment: LogSegment,
+      postCommitMetadata: Metadata): Option[AmtTrigger] = {
+    if (!amtEnabled(commitVersion)) return None
+    // -- case-1 --
+    if (initialOperation.isInstanceOf[DeltaOperations.OptimizeCheckpoint]) {
+      return Some(AmtTrigger.OptimizeCheckpoint)
+    }
+
+    // -- case-2 --
+    // Assume 0 as version -- this is to make sure future AMTs are at even boundaries e.g.
+    // 10/20/30 instead of 9/19/29. (similar logic in checkpoints as well)
+    val lastAMTVersion = math.max(0L, preCommitLogSegment.checkpointProvider.version)
+    val commitsSinceLastAMT = commitVersion - lastAMTVersion
+    if (commitsSinceLastAMT >= deltaLog.checkpointInterval(postCommitMetadata)) {
+      return Some(AmtTrigger.CheckpointInterval)
+    }
+
+
+    None
+  }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/TransactionHelper.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/TransactionHelper.scala
@@ -25,6 +25,7 @@ import org.apache.spark.sql.delta.{CatalogOwnedTableFeature, CommitStats, Commit
 import org.apache.spark.sql.delta.DeltaOperations.Operation
 import org.apache.spark.sql.delta.RowId.RowTrackingMetadataDomain
 import org.apache.spark.sql.delta.actions.{Action, AddCDCFile, AddFile, CommitInfo, DomainMetadata, FileAction, Metadata, Protocol, RemoveFile, SetTransaction}
+import org.apache.spark.sql.delta.amt.AMTWriteMetrics
 import org.apache.spark.sql.delta.coordinatedcommits.{CatalogOwnedTableUtils, TableCommitCoordinatorClient}
 import org.apache.spark.sql.delta.hooks.PostCommitHook
 import org.apache.spark.sql.delta.logging.DeltaLogKeys
@@ -380,7 +381,8 @@ trait TransactionHelper extends DeltaLogging {
         isolationLevel: IsolationLevel,
         fileSizeHistogramOpt: Option[FileSizeHistogram],
         commitInfoOpt: Option[CommitInfo],
-        commitSizeBytes: Long): Unit = {
+        commitSizeBytes: Long,
+        amtWriteMetricsOpt: Option[AMTWriteMetrics] = None): Unit = {
       assertStateBeforeFinalization()
 
       val doCollectCommitStats =
@@ -425,7 +427,8 @@ trait TransactionHelper extends DeltaLogging {
         addFilesHistogram = addFilesHistogram.map(FileSizeHistogramUtils.compress),
         removeFilesHistogram = removeFilesHistogram.map(FileSizeHistogramUtils.compress),
         numOfDomainMetadatas = numOfDomainMetadatas,
-        txnId = Some(txnId))
+        txnId = Some(txnId),
+        amtWriteMetrics = amtWriteMetricsOpt)
       recordDeltaEvent(deltaLog, DeltaLogging.DELTA_COMMIT_STATS_OPTYPE, data = stats)
     }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/CommitInfoSerializerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CommitInfoSerializerSuite.scala
@@ -172,6 +172,7 @@ class CommitInfoSerializerSuite extends QueryTest with SharedSparkSession {
       auto = true,
       clusterBy = Some(Seq("col3")),
       isFull = false)),
+    "OptimizeCheckpoint" -> (() => DeltaOperations.OptimizeCheckpoint()),
     "Clone" -> (() => DeltaOperations.Clone(
       source = "s3://bucket/path/to/table",
       sourceVersion = 10L)),

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointWriteSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointWriteSuite.scala
@@ -18,9 +18,11 @@ package org.apache.spark.sql.delta.amt
 
 import java.io.File
 
-import org.apache.spark.sql.delta.DeltaLog
+import com.databricks.spark.util.{Log4jUsageLogger, MetricDefinitions}
+import org.apache.spark.sql.delta.{CommitStats, DeltaLog}
 import org.apache.spark.sql.delta.actions.{AddFile, Checkpoint}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.util.JsonUtils
 
 class AMTCheckpointWriteSuite extends AMTCheckpointTestBase {
 
@@ -94,6 +96,45 @@ class AMTCheckpointWriteSuite extends AMTCheckpointTestBase {
       // Two live AddFiles, one per leaf -> two leaves, one root.
       assert(leafFiles(path).size == 2, s"Expected 2 leaves, got ${leafFiles(path).size}.")
       assert(rootFiles(path).size == 1)
+    }
+  }
+
+  /** Parses the `delta.commit.stats` [[CommitStats]] logged for `version`, or fails. */
+  private def commitStatsAt(f: => Unit, version: Long): CommitStats = {
+    Log4jUsageLogger.track(f)
+      .filter(e => e.metric == MetricDefinitions.EVENT_TAHOE.name &&
+        e.tags.get("opType").contains("delta.commit.stats"))
+      .map(e => JsonUtils.fromJson[CommitStats](e.blob))
+      .find(_.commitVersion == version)
+      .getOrElse(fail(s"No commit stats logged for version $version."))
+  }
+
+  test("commit stats carry AMT write metrics when an AMT is emitted") {
+    withTempDir { dir =>
+      val path = dir.getCanonicalPath
+      createAMTTable(path, checkpointInterval = 2)
+      sql(s"INSERT INTO delta.`$path` VALUES (1)") // v1: below the interval, no AMT.
+
+      // v2 hits the interval boundary and emits an AMT; capture that commit's stats.
+      val commitStats = commitStatsAt(sql(s"INSERT INTO delta.`$path` VALUES (2)"), version = 2)
+
+      val metrics = commitStats.amtWriteMetrics
+        .getOrElse(fail("Commit stats should carry AMT write metrics when an AMT is emitted."))
+      assert(metrics.attempts.size == 1, s"Expected one AMT write attempt, got ${metrics.attempts}")
+      assert(metrics.attempts.head.trigger == AmtTrigger.CheckpointInterval.toString)
+      assert(metrics.attempts.head.materializeDurationMs >= 0L)
+    }
+  }
+
+  test("commit stats carry no AMT write metrics when no AMT is emitted") {
+    withTempDir { dir =>
+      val path = dir.getCanonicalPath
+      createAMTTable(path, checkpointInterval = 100) // interval far away, so v1 emits no AMT.
+
+      val commitStats = commitStatsAt(sql(s"INSERT INTO delta.`$path` VALUES (1)"), version = 1)
+
+      assert(commitStats.amtWriteMetrics.isEmpty,
+        "Commit stats must not carry AMT write metrics when no AMT is emitted.")
     }
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTWriterManagerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTWriterManagerSuite.scala
@@ -1,0 +1,141 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.amt
+
+import org.apache.spark.sql.delta.{CurrentTransactionInfo, DeltaLog, DeltaOperations, Snapshot}
+import io.delta.exceptions.ConcurrentWriteException
+
+/**
+ * Tests for [[AMTWriterManager]]: the emission policy (checkpoint-interval and accumulated-size
+ * triggers), the unsupported OPTIMIZE-checkpoint branch, and the conflict-rebase hard-fail.
+ */
+class AMTWriterManagerSuite extends AMTCheckpointTestBase {
+
+  // Reads the current snapshot and returns (manager, snapshot) for direct method-level tests.
+  private def managerFor(
+      path: String,
+      operation: DeltaOperations.Operation = DeltaOperations.ManualUpdate):
+      (AMTWriterManager, Snapshot) = {
+    val snapshot = DeltaLog.forTable(spark, path).update()
+    (new AMTWriterManager(snapshot, operation), snapshot)
+  }
+
+  // A minimal transaction info over `snapshot` carrying `actions`, for direct writeAMT calls.
+  private def txnInfoFor(
+      snapshot: Snapshot, actions: Seq[org.apache.spark.sql.delta.actions.Action]) =
+    CurrentTransactionInfo(
+      txnId = "txn",
+      readPredicates = Vector.empty,
+      readFiles = Set.empty,
+      readWholeTable = false,
+      readAppIds = Set.empty,
+      metadata = snapshot.metadata,
+      protocol = snapshot.protocol,
+      actions = actions,
+      readSnapshot = snapshot,
+      commitInfo = None,
+      readRowIdHighWatermark = 0L,
+      catalogTable = None,
+      domainMetadata = Seq.empty,
+      op = DeltaOperations.ManualUpdate)
+
+  test("writeAMT throws UnsupportedOperationException for an OPTIMIZE checkpoint operation") {
+    withTempDir { dir =>
+      val path = dir.getCanonicalPath
+      createAMTTable(path, checkpointInterval = 2)
+      sql(s"INSERT INTO delta.`$path` VALUES (1)")
+
+      val (manager, snapshot) = managerFor(path, DeltaOperations.OptimizeCheckpoint())
+      val ex = intercept[UnsupportedOperationException] {
+        manager.writeAMT(
+          commitVersion = snapshot.version + 1,
+          currentTransactionInfo = txnInfoFor(snapshot, actions = Seq.empty),
+          preCommitLogSegment = snapshot.logSegment)
+      }
+      assert(ex.getMessage.contains("OPTIMIZE checkpoints"))
+    }
+  }
+
+  test("emits AMT when commit count since last checkpoint reaches the checkpoint interval") {
+    withTempDir { dir =>
+      val path = dir.getCanonicalPath
+      createAMTTable(path, checkpointInterval = 3)
+      sql(s"INSERT INTO delta.`$path` VALUES (1)") // v1: 1 commit since genesis, < 3.
+      sql(s"INSERT INTO delta.`$path` VALUES (2)") // v2: 2 commits since genesis, < 3.
+      sql(s"INSERT INTO delta.`$path` VALUES (3)") // v3: 3 commits since genesis, >= 3 -> emit.
+
+      val deltaLog = DeltaLog.forTable(spark, path)
+      assert(checkpointsAt(deltaLog, 1).isEmpty, "v1 is below the interval; no emission.")
+      assert(checkpointsAt(deltaLog, 2).isEmpty, "v2 is below the interval; no emission.")
+      assert(checkpointsAt(deltaLog, 3).size == 1, "v3 reaches the interval; AMT must be emitted.")
+      assert(rootFiles(path).size == 1 && leafFiles(path).nonEmpty,
+        "A manifest tree must be written at the interval boundary.")
+      assert(amtProvider(deltaLog.update()).isDefined)
+    }
+  }
+
+
+  test("does not emit AMT when no trigger fires") {
+    withTempDir { dir =>
+      val path = dir.getCanonicalPath
+      // Interval far away, and a tiny commit stays well below the default size threshold, so
+      // neither the count nor the (edge-only) size trigger fires.
+      createAMTTable(path, checkpointInterval = 1000)
+      sql(s"INSERT INTO delta.`$path` VALUES (1)")
+
+      val deltaLog = DeltaLog.forTable(spark, path)
+      assert(checkpointsAt(deltaLog, 1).isEmpty, "No trigger fires; no emission.")
+      assert(rootFiles(path).isEmpty && leafFiles(path).isEmpty, "No manifest tree written.")
+      assert(amtProvider(deltaLog.update()).isEmpty)
+    }
+  }
+
+  test("writeAMT hard-fails an AMT table on a conflict-resolution retry") {
+    withTempDir { dir =>
+      val path = dir.getCanonicalPath
+      createAMTTable(path, checkpointInterval = 2)
+      sql(s"INSERT INTO delta.`$path` VALUES (1)")
+
+      val (manager, snapshot) = managerFor(path)
+      // A retry: conflict resolution advanced the segment past the read snapshot's version.
+      val retrySegment = snapshot.logSegment.copy(version = snapshot.version + 1)
+      intercept[ConcurrentWriteException] {
+        manager.writeAMT(
+          commitVersion = snapshot.version + 2,
+          currentTransactionInfo = txnInfoFor(snapshot, actions = Seq.empty),
+          preCommitLogSegment = retrySegment)
+      }
+    }
+  }
+
+  test("writeAMT does not hard-fail a non-AMT table on a conflict-resolution retry") {
+    withTempDir { dir =>
+      val path = dir.getCanonicalPath
+      // A vanilla Delta table without the AMT feature must not be hard-failed on a conflict.
+      sql(s"CREATE TABLE delta.`$path` (id INT) USING DELTA")
+      sql(s"INSERT INTO delta.`$path` VALUES (1)")
+
+      val (manager, snapshot) = managerFor(path)
+      val retrySegment = snapshot.logSegment.copy(version = snapshot.version + 1)
+      val result = manager.writeAMT(
+        commitVersion = snapshot.version + 2,
+        currentTransactionInfo = txnInfoFor(snapshot, actions = Seq.empty),
+        preCommitLogSegment = retrySegment)
+      assert(result.isEmpty, "Non-AMT tables emit no AMT and are not hard-failed on a retry.")
+    }
+  }
+}


### PR DESCRIPTION
## Description

Refactors the inline adaptive-metadata (AMT) checkpoint write path into a dedicated `AMTWriterManager`. Previously the emission decision and the manifest-tree materialization were spread between `OptimisticTransaction` and the free-standing `AMTWriteHelper`, and the conflict-retry case was handled inline. This change gives the write path a single owner.

- `AMTWriterManager` is constructed once per commit and threaded into `doCommit`; the per-attempt values (commit version, transaction info, log segment) are passed as method arguments. It maintains the write metrics and the previous attempt's result across conflict retries.
- `writeAMT` serves both the first attempt and any conflict-resolution retry, dispatching on `getAMTTriggerMode`, which returns the trigger (`OPTIMIZE_CHECKPOINT` / `CHECKPOINT_INTERVAL`) or `None` when no AMT write is needed.
- Adds the `OptimizeCheckpoint` operation to `DeltaOperations`.
- Adds `preCommitLatestAMTCheckpointOpt` to `CurrentTransactionInfo`, initialized from the read snapshot's checkpoint provider and updated during conflict resolution when a winning commit emitted an inline checkpoint.
- Delegates manifest-tree materialization to `AMTWriteHelper` and wires per-attempt AMT write metrics into `CommitStats`.

## How was this patch tested?

Adds `AMTWriterManagerSuite` (emission-trigger policy, the OPTIMIZE-checkpoint branch, and the conflict-retry behavior) and extends `AMTCheckpointWriteSuite` with commit-stats coverage. `CommitInfoSerializerSuite` is updated to cover the new operation.

## Does this PR introduce _any_ user-facing changes?

No.