### PR TITLE
[Spark] Test Delta and Unity Catalog against Spark 4.2.0

### DIFF
--- a/.github/actions/prepare-spark-env/action.yml
+++ b/.github/actions/prepare-spark-env/action.yml
@@ -39,8 +39,13 @@ runs:
       run: |
         # The script automatically generates spark-versions.json if needed.
         JVM_VERSION=$(python3 project/scripts/get_spark_version_info.py --get-field "${{ inputs.spark-version }}" targetJvm | jq -r)
+        SPARK_FULL_VERSION=$(python3 project/scripts/get_spark_version_info.py --get-field "${{ inputs.spark-version }}" fullVersion | jq -r)
         echo "jvm_version=$JVM_VERSION" >> "$GITHUB_OUTPUT"
-        echo "Using JVM version: $JVM_VERSION for Spark ${{ inputs.spark-version }}"
+        echo "spark_full_version=$SPARK_FULL_VERSION" >> "$GITHUB_OUTPUT"
+        # Published rows use this exact release. Source-build rows overwrite it below with the
+        # commit-qualified Maven version after restoring the source cache.
+        echo "SPARK_ARTIFACT_VERSION=$SPARK_FULL_VERSION" >> "$GITHUB_ENV"
+        echo "Using JVM version: $JVM_VERSION for Spark ${{ inputs.spark-version }} ($SPARK_FULL_VERSION)"
 
     - name: install java
       uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3.14.1

--- a/.github/actions/run-delta-spark-tests/action.yml
+++ b/.github/actions/run-delta-spark-tests/action.yml
@@ -52,8 +52,8 @@ runs:
         SCALA_VERSION: ${{ inputs.scala }}
         SPARK_VERSION: ${{ inputs.spark-version }}
         NUM_SHARDS: ${{ inputs.num-shards }}
-        # SPARK_COMMIT / SPARK_ARTIFACT_VERSION are inherited from GITHUB_ENV (set by
-        # prepare-spark-env for source-build rows; unset for published rows).
+        # SPARK_ARTIFACT_VERSION is inherited from GITHUB_ENV for every row; SPARK_COMMIT is
+        # additionally set by prepare-spark-env for source-build rows.
       run: |
         TEST_PARALLELISM_COUNT=4 python3 run-tests.py --group spark --shard ${{ inputs.shard }} --spark-version ${{ inputs.spark-version }}
 

--- a/.github/actions/run-delta-spark-tests/action.yml
+++ b/.github/actions/run-delta-spark-tests/action.yml
@@ -36,6 +36,8 @@ runs:
     # unreleased UC. Publish the pinned UC build locally before sbt tries to resolve it.
     - name: Set up pinned Unity Catalog
       uses: ./.github/actions/setup-unitycatalog
+      env:
+        SPARK_VERSION: ${{ inputs.spark-version }}
 
     - name: Scala structured logging style check
       shell: bash

--- a/.github/actions/setup-unitycatalog/action.yml
+++ b/.github/actions/setup-unitycatalog/action.yml
@@ -2,11 +2,11 @@ name: "Set up pinned Unity Catalog build"
 description: >-
   Publishes Unity Catalog jars from the commit pinned in project/scripts/setup_unitycatalog_main.sh
   (the UC_PIN_SHA= line) to the runner's local Ivy / Maven caches, using GitHub Actions cache so the
-  slow UC build only runs the first time a pin is seen. Reads SPARK_VERSION (Spark major.minor
-  short form) from the calling job's env to pick the Spark variant UC builds against; matrix
-  workflows set this from `matrix.spark_version`, other workflows leave it unset and inherit the
-  script's default. The cache key reflects SPARK_VERSION literally - workflows that share the
-  default share one cache entry under an empty `spark-` segment.
+  slow UC build only runs the first time a pin and Spark artifact are seen. Reads SPARK_VERSION
+  (Spark major.minor short form) and optional SPARK_ARTIFACT_VERSION (the exact published or
+  commit-qualified Maven version) from the calling job's env. Matrix workflows set both; other
+  workflows leave them unset and inherit the script's default. The cache key includes both values
+  so UC bytecode compiled against one Spark artifact cannot be restored for another.
 
 runs:
   using: "composite"
@@ -20,11 +20,18 @@ runs:
           ~/.ivy2/local
           ~/.m2/repository/io/unitycatalog
         # Cache key hashes the setup script (so any script change invalidates) and includes the
-        # Spark short version (so 4.0 and 4.1 don't fight over a single shared cache entry).
-        key: uc-jars-${{ runner.os }}-spark${{ env.SPARK_VERSION }}-${{ hashFiles('project/scripts/setup_unitycatalog_main.sh') }}
+        # Spark variant plus exact artifact version. The latter changes with a source-build SHA.
+        key: uc-jars-${{ runner.os }}-spark${{ env.SPARK_VERSION }}-${{ env.SPARK_ARTIFACT_VERSION }}-${{ hashFiles('project/scripts/setup_unitycatalog_main.sh') }}
     - name: Build Unity Catalog from pinned SHA
       shell: bash
-      run: bash project/scripts/setup_unitycatalog_main.sh
+      run: |
+        # The broader SBT cache is restored before this action and may contain UC jars built by
+        # an older setup. On an exact UC-cache miss, force a rebuild instead of accepting those
+        # stale canaries. A cache hit is still verified by the script's Spark-build marker.
+        if [[ "${{ steps.uc-cache.outputs.cache-hit }}" != "true" ]]; then
+          export UC_FORCE=1
+        fi
+        bash project/scripts/setup_unitycatalog_main.sh
     - name: Save pinned UC cache
       # Only attempt a save when the restore missed. When multiple parallel matrix jobs all see
       # a cache miss (first CI run after a pin bump), only the first to reach this step wins the
@@ -37,4 +44,4 @@ runs:
         path: |
           ~/.ivy2/local
           ~/.m2/repository/io/unitycatalog
-        key: uc-jars-${{ runner.os }}-spark${{ env.SPARK_VERSION }}-${{ hashFiles('project/scripts/setup_unitycatalog_main.sh') }}
+        key: uc-jars-${{ runner.os }}-spark${{ env.SPARK_VERSION }}-${{ env.SPARK_ARTIFACT_VERSION }}-${{ hashFiles('project/scripts/setup_unitycatalog_main.sh') }}

--- a/.github/ci-requirements/spark-python/pyspark4.2.lock
+++ b/.github/ci-requirements/spark-python/pyspark4.2.lock
@@ -1,4 +1,0 @@
-# PySpark 4.2.0 was uploaded after the workflow's global UV_EXCLUDE_NEWER cutoff.
-# Keep this post-cutoff exception constrained to the exact published sdist and SHA-256.
-pyspark @ https://files.pythonhosted.org/packages/c3/33/c987434f5d50aa802779a004ca0fd45ee4350caab50554ad7283d5a22b50/pyspark-4.2.0.tar.gz \
-    --hash=sha256:5ad689d53570ee1674193fd4f9bda065f0db3be9363a27d2a3406cc457b70b61

--- a/.github/ci-requirements/spark-python/pyspark4.2.lock
+++ b/.github/ci-requirements/spark-python/pyspark4.2.lock
@@ -1,0 +1,4 @@
+# PySpark 4.2.0 was uploaded after the workflow's global UV_EXCLUDE_NEWER cutoff.
+# Keep this post-cutoff exception constrained to the exact published sdist and SHA-256.
+pyspark @ https://files.pythonhosted.org/packages/c3/33/c987434f5d50aa802779a004ca0fd45ee4350caab50554ad7283d5a22b50/pyspark-4.2.0.tar.gz \
+    --hash=sha256:5ad689d53570ee1674193fd4f9bda065f0db3be9363a27d2a3406cc457b70b61

--- a/.github/ci-requirements/spark-python/spark4.2-overrides.lock
+++ b/.github/ci-requirements/spark-python/spark4.2-overrides.lock
@@ -6,3 +6,7 @@ pyspark @ https://files.pythonhosted.org/packages/c3/33/c987434f5d50aa802779a004
 # Spark Connect in PySpark 4.2 requires PyArrow 18 or newer. Pin the Python 3.10 Linux wheel.
 pyarrow @ https://files.pythonhosted.org/packages/8a/77/4b3fab91a30e19e233e738d0c5eca5a8f6dd05758bc349a2ca262c65de79/pyarrow-18.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl \
     --hash=sha256:c0a03da7f2758645d17b7b4f83c8bffeae5bbb7f974523fe901f36288d2eab71
+
+# PySpark 4.2's generated Spark Connect code requires the Protobuf 6.33.5 runtime.
+protobuf @ https://files.pythonhosted.org/packages/9b/53/a9443aa3ca9ba8724fdfa02dd1887c1bcd8e89556b715cfbacca6b63dbec/protobuf-6.33.5-cp39-abi3-manylinux2014_x86_64.whl \
+    --hash=sha256:cbf16ba3350fb7b889fca858fb215967792dc125b35c7976ca4818bee3521cf0

--- a/.github/ci-requirements/spark-python/spark4.2-overrides.lock
+++ b/.github/ci-requirements/spark-python/spark4.2-overrides.lock
@@ -1,0 +1,8 @@
+# Spark 4.2 Python overrides for packages not covered by the shared Spark 4.1 lock.
+# PySpark 4.2.0 was uploaded after UV_EXCLUDE_NEWER, so pin its exact published sdist.
+pyspark @ https://files.pythonhosted.org/packages/c3/33/c987434f5d50aa802779a004ca0fd45ee4350caab50554ad7283d5a22b50/pyspark-4.2.0.tar.gz \
+    --hash=sha256:5ad689d53570ee1674193fd4f9bda065f0db3be9363a27d2a3406cc457b70b61
+
+# Spark Connect in PySpark 4.2 requires PyArrow 18 or newer. Pin the Python 3.10 Linux wheel.
+pyarrow @ https://files.pythonhosted.org/packages/8a/77/4b3fab91a30e19e233e738d0c5eca5a8f6dd05758bc349a2ca262c65de79/pyarrow-18.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl \
+    --hash=sha256:c0a03da7f2758645d17b7b4f83c8bffeae5bbb7f974523fe901f36288d2eab71

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,8 +49,10 @@ jobs:
       - name: Set up pinned Unity Catalog for each released Spark version
         run: |
           for sv in $(python3 project/scripts/get_spark_version_info.py --released-spark-versions | jq -r '.[]'); do
-            echo "::group::Set up pinned UC for Spark $sv"
-            SPARK_VERSION="$sv" bash project/scripts/setup_unitycatalog_main.sh
+            full_version=$(python3 project/scripts/get_spark_version_info.py --get-field "$sv" fullVersion | jq -r)
+            echo "::group::Set up pinned UC for Spark $full_version"
+            SPARK_VERSION="$sv" SPARK_ARTIFACT_VERSION="$full_version" \
+              bash project/scripts/setup_unitycatalog_main.sh
             echo "::endgroup::"
           done
 

--- a/.github/workflows/changelog_tests_spark42.yaml
+++ b/.github/workflows/changelog_tests_spark42.yaml
@@ -4,10 +4,8 @@ name: "V2 Changelog Tests (Spark 4.2)"
 # narrowly the tests under io.delta.spark.internal.v2.read.changelog.*
 # in spark-unified/test, which is what PR #6830 (test classpath fix) and
 # PR #6832 (DV support) actually exercise. The full Delta test suite
-# against Spark 4.2 is run by spark_test.yaml as a matrix lane with
-# continue-on-error: true, and includes pre-existing UC connector
-# incompatibilities (UCProxy bytecode against Spark 4.0's
-# CatalogStorageFormat.copy) that are not in scope for these PRs.
+# against released Spark 4.2 is run by spark_test.yaml as a blocking
+# published-artifact matrix lane.
 #
 # This workflow exists on the fork-CI branches only and is meant as
 # proof that the changelog tests pass against a real Spark 4.2 release.
@@ -32,6 +30,7 @@ jobs:
     env:
       SCALA_VERSION: "2.13.16"
       SPARK_VERSION: "4.2"
+      SPARK_ARTIFACT_VERSION: "4.2.0"
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: install java

--- a/.github/workflows/changelog_tests_spark42.yaml
+++ b/.github/workflows/changelog_tests_spark42.yaml
@@ -1,6 +1,6 @@
 name: "V2 Changelog Tests (Spark 4.2)"
 
-# Runs only the V2 changelog tests against Spark 4.2-preview4. Scope is
+# Runs only the V2 changelog tests against the released Spark 4.2.0. Scope is
 # narrowly the tests under io.delta.spark.internal.v2.read.changelog.*
 # in spark-unified/test, which is what PR #6830 (test classpath fix) and
 # PR #6832 (DV support) actually exercise. The full Delta test suite

--- a/.github/workflows/spark_examples_test.yaml
+++ b/.github/workflows/spark_examples_test.yaml
@@ -86,6 +86,8 @@ jobs:
       # sparkUnityCatalog; publish the pinned UC build locally before sbt runs.
       - name: Set up pinned Unity Catalog
         uses: ./.github/actions/setup-unitycatalog
+        env:
+          SPARK_ARTIFACT_VERSION: ${{ steps.spark-details.outputs.spark_full_version }}
       - name: Run Delta Spark Local Publishing and Examples Compilation
         # examples/scala/build.sbt will compile against the local Delta release version (e.g. 3.2.0-SNAPSHOT).
         # Thus, we need to publishM2 first so those jars are locally accessible.

--- a/.github/workflows/spark_python_test.yaml
+++ b/.github/workflows/spark_python_test.yaml
@@ -93,11 +93,11 @@ jobs:
             uv pip install --python .venv/bin/python --require-hashes -r .github/ci-requirements/spark-python/spark4.1.lock
           fi
           # pyspark installed with --no-deps: its only transitive dep (py4j) is in the lock file.
-          # Spark 4.2.0 was published after UV_EXCLUDE_NEWER, so install its exact hash-pinned
-          # sdist while keeping the global package-date lockdown for every other dependency.
+          # Spark 4.2 needs PyArrow 18 for Spark Connect, and PySpark 4.2.0 was published after
+          # UV_EXCLUDE_NEWER. Install exact hash-pinned overrides while keeping the global cutoff.
           if [[ "${{ matrix.spark_version }}" == "4.2" ]]; then
             uv pip install --python .venv/bin/python --no-deps --require-hashes \
-              -r .github/ci-requirements/spark-python/pyspark4.2.lock
+              -r .github/ci-requirements/spark-python/spark4.2-overrides.lock
           else
             uv pip install --python .venv/bin/python --no-deps pyspark==${{ steps.spark-details.outputs.spark_full_version }}
           fi

--- a/.github/workflows/spark_python_test.yaml
+++ b/.github/workflows/spark_python_test.yaml
@@ -93,8 +93,9 @@ jobs:
             uv pip install --python .venv/bin/python --require-hashes -r .github/ci-requirements/spark-python/spark4.1.lock
           fi
           # pyspark installed with --no-deps: its only transitive dep (py4j) is in the lock file.
-          # Spark 4.2 needs PyArrow 18 for Spark Connect, and PySpark 4.2.0 was published after
-          # UV_EXCLUDE_NEWER. Install exact hash-pinned overrides while keeping the global cutoff.
+          # Spark 4.2 needs newer PyArrow and Protobuf for Spark Connect, and PySpark 4.2.0 was
+          # published after UV_EXCLUDE_NEWER. Install exact hash-pinned overrides while keeping
+          # the global cutoff.
           if [[ "${{ matrix.spark_version }}" == "4.2" ]]; then
             uv pip install --python .venv/bin/python --no-deps --require-hashes \
               -r .github/ci-requirements/spark-python/spark4.2-overrides.lock

--- a/.github/workflows/spark_python_test.yaml
+++ b/.github/workflows/spark_python_test.yaml
@@ -92,8 +92,15 @@ jobs:
           else
             uv pip install --python .venv/bin/python --require-hashes -r .github/ci-requirements/spark-python/spark4.1.lock
           fi
-          # pyspark installed with --no-deps: its only transitive dep (py4j) is in the lock file
-          uv pip install --python .venv/bin/python --no-deps pyspark==${{ steps.spark-details.outputs.spark_full_version }}
+          # pyspark installed with --no-deps: its only transitive dep (py4j) is in the lock file.
+          # Spark 4.2.0 was published after UV_EXCLUDE_NEWER, so install its exact hash-pinned
+          # sdist while keeping the global package-date lockdown for every other dependency.
+          if [[ "${{ matrix.spark_version }}" == "4.2" ]]; then
+            uv pip install --python .venv/bin/python --no-deps --require-hashes \
+              -r .github/ci-requirements/spark-python/pyspark4.2.lock
+          else
+            uv pip install --python .venv/bin/python --no-deps pyspark==${{ steps.spark-details.outputs.spark_full_version }}
+          fi
       - name: Run Python tests
         # when changing TEST_PARALLELISM_COUNT make sure to also change it in spark_test.yaml
         run: |

--- a/.github/workflows/spark_test.yaml
+++ b/.github/workflows/spark_test.yaml
@@ -19,11 +19,11 @@ on:
 # Every PR runs:
 # 1. generate-matrix: split Spark versions (from CrossSparkVersions.scala) into published
 #    vs source-build lists.
-# 2. prepare_spark_source_cache: for each source-build Spark version, build Spark once and
+# 2. prepare_spark_source_cache: for each configured source-build Spark version, build Spark once and
 #    save the Maven cache (via the prepare-spark-env action with build-on-miss). This job is
 #    non-blocking; any source Spark build/cache failure is reported through source_spark_test.
-# 3. test: published Spark shards (4.0/4.1) without waiting on step 2.
-# 4. source_spark_test: source-built Spark shards (4.2 today) after step 2. It still runs if
+# 3. test: published Spark shards without waiting on step 2.
+# 4. source_spark_test: configured source-built Spark shards after step 2. It still runs if
 #    prepare_spark_source_cache fails, so the source-built Spark signal stays non-blocking.
 #
 # test and source_spark_test share two composite actions:
@@ -70,6 +70,7 @@ jobs:
     name: "Prepare Spark ${{ matrix.spark_version }} source cache"
     runs-on: ubuntu-24.04
     needs: generate-matrix
+    if: ${{ needs.generate-matrix.outputs.source_build_spark_versions != '[]' }}
     # Source-built Spark tracks unreleased APIs. Keep the producer non-blocking too,
     # otherwise a checkout/build/cache-save failure blocks the whole workflow before
     # source_spark_test can surface the same signal.
@@ -118,14 +119,14 @@ jobs:
           # Important: This must be the same as the length of shards in matrix
           num-shards: '8'
 
-  # Validates source-built Spark for every PR using the SHA in this branch's metadata.
+  # Validates each configured source-built Spark line using the SHA in branch metadata.
   source_spark_test:
     name: "DS Source Spark ${{ matrix.spark_version }}, Scala ${{ matrix.scala }}, Shard ${{ matrix.shard }}"
     runs-on: ubuntu-24.04
     needs: [generate-matrix, prepare_spark_source_cache]
     # Run even if the non-blocking prepare job failed. If no cache was produced, each
     # shard fails during restore/verification under this already non-blocking job.
-    if: ${{ always() && needs.generate-matrix.result == 'success' }}
+    if: ${{ always() && needs.generate-matrix.result == 'success' && needs.generate-matrix.outputs.source_build_spark_versions != '[]' }}
     # Source-built Spark lanes track unreleased Spark APIs and remain non-blocking
     # while still producing a full pass/fail signal for every PR.
     continue-on-error: true

--- a/build.sbt
+++ b/build.sbt
@@ -869,12 +869,13 @@ def publishPinnedUnityCatalog(log: sbt.util.Logger, canary: java.io.File): Unit 
   val procLogger = ProcessLogger(
     line => log.info(s"[UC setup] $line"),
     line => log.warn(s"[UC setup] $line"))
-  // SPARK_VERSION tells the script which Spark variant to build (forwarded to UC's sbt as
-  // -DsparkVersion).
+  // SPARK_VERSION selects UC's shim/artifact suffix. SPARK_ARTIFACT_VERSION selects the exact
+  // Spark dependency, including a commit-qualified Maven version for source-build rows.
   val exit = Process(
     Seq("bash", unityCatalogSetupScript),
     None,
-    "SPARK_VERSION" -> CrossSparkVersions.getSparkVersionSpec().shortVersion).!(procLogger)
+    "SPARK_VERSION" -> CrossSparkVersions.getSparkVersionSpec().shortVersion,
+    "SPARK_ARTIFACT_VERSION" -> CrossSparkVersions.getSparkArtifactVersion()).!(procLogger)
   if (exit != 0) {
     sys.error(
       s"[UC] $unityCatalogSetupScript exited with code $exit. Run it manually to see full output.")
@@ -907,7 +908,13 @@ Global / ensurePinnedUnityCatalog := {
     val m2Canary = home / ".m2" / "repository" / "io" / "unitycatalog" /
       sparkArtifact / unityCatalogVersion /
       s"$sparkArtifact-$unityCatalogVersion.pom"
-    if (!ivy2Canary.exists || !m2Canary.exists) {
+    val expectedSparkBuildVersion = CrossSparkVersions.getSparkArtifactVersion()
+    val ivy2SparkBuildMarker = ivy2Canary.getParentFile.getParentFile / ".spark-build-version"
+    val m2SparkBuildMarker = m2Canary.getParentFile / ".spark-build-version"
+    def markerMatches(marker: java.io.File): Boolean =
+      marker.exists && IO.read(marker).trim == expectedSparkBuildVersion
+    if (!ivy2Canary.exists || !m2Canary.exists ||
+        !markerMatches(ivy2SparkBuildMarker) || !markerMatches(m2SparkBuildMarker)) {
       publishPinnedUnityCatalog(log, ivy2Canary)
     }
   }

--- a/project/CrossSparkVersions.scala
+++ b/project/CrossSparkVersions.scala
@@ -298,19 +298,15 @@ object SparkVersionSpec {
     jacksonVersion = "2.18.2"
   )
 
-  // Spark 4.2 source-build jobs use this compatibility line (shims, JVM flags,
-  // dependency overrides) while resolving Spark artifacts from the configured
-  // source ref for CI.
-  private val spark42Snapshot = SparkVersionSpec(
-    fullVersion = "4.2.0-SNAPSHOT",
+  private val spark42 = SparkVersionSpec(
+    fullVersion = "4.2.0",
     targetJvm = "17",
     additionalSourceDir = Some("scala-shims/spark-4.2"),
     supportIceberg = false,
     supportHudi = false,
     antlr4Version = "4.13.1",
     additionalJavaOptions = java17TestSettings,
-    jacksonVersion = "2.18.2",
-    sourceBuildDefaultRef = Some("b6bd005ac7549411ec4e7dc944d7a0e19fd56561")
+    jacksonVersion = "2.18.2"
   )
 
   /** Default Spark version */
@@ -320,7 +316,7 @@ object SparkVersionSpec {
   val MASTER: Option[SparkVersionSpec] = None
 
   /** All supported Spark versions - internal use only */
-  val ALL_SPECS = Seq(spark40, spark41, spark42Snapshot)
+  val ALL_SPECS = Seq(spark40, spark41, spark42)
 }
 
 /** See docs on top of this file */

--- a/project/SparkMimaExcludes.scala
+++ b/project/SparkMimaExcludes.scala
@@ -98,7 +98,7 @@ object SparkMimaExcludes {
       ProblemFilters.exclude[MissingTypesProblem]("io.delta.exceptions.*"),
 
       // Changes in 4.2.0
-      // MDC and logBasedOnLevel were removed from Spark's Logging trait in Spark 4.2.0-SNAPSHOT
+      // MDC and logBasedOnLevel were removed from Spark's Logging trait in Spark 4.2.0
       ProblemFilters.exclude[DirectMissingMethodProblem]("io.delta.tables.DeltaMergeBuilder.MDC"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("io.delta.tables.DeltaMergeBuilder.logBasedOnLevel")
 

--- a/project/scripts/setup_unitycatalog_main.sh
+++ b/project/scripts/setup_unitycatalog_main.sh
@@ -63,6 +63,11 @@
 #                 CrossSparkVersions when invoking the script; matrix CI workflows set it from
 #                 `matrix.spark_version`. Workflows that don't care which Spark variant UC builds
 #                 (kernel/flink/etc.) inherit the in-script fallback below.
+#   SPARK_ARTIFACT_VERSION
+#                 exact Spark Maven version UC should compile against. Published rows use a release
+#                 such as 4.2.0; source-build rows use a commit-qualified version such as
+#                 4.3.0-<sha>-SNAPSHOT. When set, the pinned UC checkout's matching Spark metadata
+#                 entry is rewritten before sbt loads it. When unset, UC's pinned metadata is used.
 #
 # Modes of operation:
 #   1. Pinned SHA (default, PR CI): UC_REF defaults to UC_PIN_SHA, version is computed as
@@ -92,7 +97,21 @@ UC_REPO="${UC_REPO:-https://github.com/unitycatalog/unitycatalog.git}"
 UC_REF="${UC_REF:-$UC_PIN_SHA}"
 UC_FORCE="${UC_FORCE:-0}"
 SPARK_VERSION="${SPARK_VERSION:-4.1}"
+SPARK_ARTIFACT_VERSION="${SPARK_ARTIFACT_VERSION:-}"
 DELTA_RELEASE_MODE="${DELTA_RELEASE_MODE:-0}"
+
+# The short version selects UC's shim directory and artifact suffix; the exact version selects
+# the Spark dependency. Derive the short form from the exact artifact for a future `master` row.
+SPARK_MAJOR_MINOR="$SPARK_VERSION"
+if [[ -n "$SPARK_ARTIFACT_VERSION" ]]; then
+  if [[ "$SPARK_ARTIFACT_VERSION" =~ ^([0-9]+\.[0-9]+)\. ]]; then
+    SPARK_MAJOR_MINOR="${BASH_REMATCH[1]}"
+  else
+    echo "ERROR: SPARK_ARTIFACT_VERSION='$SPARK_ARTIFACT_VERSION' has no major.minor prefix." >&2
+    exit 1
+  fi
+fi
+SPARK_BUILD_VERSION="${SPARK_ARTIFACT_VERSION:-$SPARK_VERSION}"
 
 # Compose version coordinate. When UC_VERSION is set from env, use it verbatim (no SHA suffix).
 # Otherwise compute from UC_BASE_VERSION + abbreviated ref.
@@ -116,31 +135,36 @@ fi
 # ~/.ivy2/local, mvn (kernel-examples integration tests) resolves from ~/.m2/repository. If any
 # is missing in either layout we must re-publish.
 # UC publishes its Spark connector under a per-Spark-version coordinate
-# (unitycatalog-spark_${SPARK_VERSION}_2.13). The suffix tracks SPARK_VERSION so the
+# (unitycatalog-spark_${SPARK_MAJOR_MINOR}_2.13). The suffix tracks the selected Spark line so the
 # canary check matches whatever variant we tell UC to build below.
 IVY_LOCAL="$HOME/.ivy2/local/io.unitycatalog"
 IVY_CANARY_CLIENT="$IVY_LOCAL/unitycatalog-client/$UC_VERSION/ivys/ivy.xml"
 IVY_CANARY_SERVER="$IVY_LOCAL/unitycatalog-server/$UC_VERSION/ivys/ivy.xml"
-UC_SPARK_ARTIFACT="unitycatalog-spark_${SPARK_VERSION}_2.13"
+UC_SPARK_ARTIFACT="unitycatalog-spark_${SPARK_MAJOR_MINOR}_2.13"
 IVY_CANARY_SPARK="$IVY_LOCAL/$UC_SPARK_ARTIFACT/$UC_VERSION/ivys/ivy.xml"
 IVY_CANARY_HADOOP="$IVY_LOCAL/unitycatalog-hadoop/$UC_VERSION/ivys/ivy.xml"
+IVY_SPARK_BUILD_MARKER="$IVY_LOCAL/$UC_SPARK_ARTIFACT/$UC_VERSION/.spark-build-version"
 M2_LOCAL="$HOME/.m2/repository/io/unitycatalog"
 M2_CANARY_CLIENT="$M2_LOCAL/unitycatalog-client/$UC_VERSION/unitycatalog-client-$UC_VERSION.pom"
 M2_CANARY_SERVER="$M2_LOCAL/unitycatalog-server/$UC_VERSION/unitycatalog-server-$UC_VERSION.pom"
 M2_CANARY_SPARK="$M2_LOCAL/$UC_SPARK_ARTIFACT/$UC_VERSION/$UC_SPARK_ARTIFACT-$UC_VERSION.pom"
 M2_CANARY_HADOOP="$M2_LOCAL/unitycatalog-hadoop/$UC_VERSION/unitycatalog-hadoop-$UC_VERSION.pom"
+M2_SPARK_BUILD_MARKER="$M2_LOCAL/$UC_SPARK_ARTIFACT/$UC_VERSION/.spark-build-version"
 ALL_CANARIES=("$IVY_CANARY_CLIENT" "$IVY_CANARY_SERVER" "$IVY_CANARY_SPARK" "$IVY_CANARY_HADOOP"
-              "$M2_CANARY_CLIENT" "$M2_CANARY_SERVER" "$M2_CANARY_SPARK" "$M2_CANARY_HADOOP")
+              "$M2_CANARY_CLIENT" "$M2_CANARY_SERVER" "$M2_CANARY_SPARK" "$M2_CANARY_HADOOP"
+              "$IVY_SPARK_BUILD_MARKER" "$M2_SPARK_BUILD_MARKER")
 
 all_canaries_present() {
   for c in "${ALL_CANARIES[@]}"; do
     [[ -f "$c" ]] || return 1
   done
+  [[ "$(< "$IVY_SPARK_BUILD_MARKER")" == "$SPARK_BUILD_VERSION" ]] || return 1
+  [[ "$(< "$M2_SPARK_BUILD_MARKER")" == "$SPARK_BUILD_VERSION" ]] || return 1
   return 0
 }
 
 if [[ "$UC_FORCE" != "1" ]] && all_canaries_present; then
-  echo ">>> UC $UC_VERSION already published to ~/.ivy2/local; skipping."
+  echo ">>> UC $UC_VERSION already published for Spark $SPARK_BUILD_VERSION; skipping."
   echo ">>> (Set UC_FORCE=1 to rebuild anyway.)"
   exit 0
 fi
@@ -179,6 +203,40 @@ else
   # refs/tags/ entry in a fresh init'd repo, so `git checkout <tag>` fails.
   # FETCH_HEAD works uniformly for branches, tags, and SHAs.
   git checkout --quiet FETCH_HEAD
+fi
+
+# UC's pinned metadata still names the Spark preview that was current at this commit. CI supplies
+# the exact active artifact so the connector bytecode is compiled against the same Spark that runs
+# Delta. This also supports future source rows, whose Maven versions include the resolved commit.
+if [[ -n "$SPARK_ARTIFACT_VERSION" ]]; then
+  echo ">>> Configuring UC Spark $SPARK_MAJOR_MINOR variant for $SPARK_ARTIFACT_VERSION"
+  python3 - "$SPARK_MAJOR_MINOR" "$SPARK_ARTIFACT_VERSION" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+short_version, artifact_version = sys.argv[1:]
+metadata_path = Path("project/spark-versions.json")
+metadata = json.loads(metadata_path.read_text())
+
+def major_minor(version):
+    return ".".join(version.split(".")[:2])
+
+matches = [
+    entry for entry in metadata["versions"]
+    if major_minor(entry["version"]) == short_version
+]
+if len(matches) != 1:
+    raise SystemExit(
+        f"Expected one UC Spark {short_version} metadata entry, found {len(matches)}"
+    )
+
+old_version = matches[0]["version"]
+matches[0]["version"] = artifact_version
+if metadata["default"] == old_version:
+    metadata["default"] = artifact_version
+metadata_path.write_text(json.dumps(metadata, indent=2) + "\n")
+PY
 fi
 
 # Sanity-check UC_BASE_VERSION against what UC actually declares at this commit. If they drift
@@ -234,12 +292,12 @@ fi
   hadoop/publishLocal \
   hadoop/publishM2
 
-# Publish the Spark connector for the caller's Spark version. Each CI matrix cell passes its own
-# SPARK_VERSION; when auto-triggered by ensurePinnedUnityCatalog (no env), defaults above.
-echo ">>> Publishing UC spark connector for Spark $SPARK_VERSION"
+# Publish the Spark connector for the caller's Spark version. CI and Delta's automatic bootstrap
+# pass both the compatibility line and exact artifact; standalone callers can use the defaults.
+echo ">>> Publishing UC spark connector for Spark $SPARK_BUILD_VERSION"
 for attempt in 1 2 3; do
   if ./build/sbt \
-    -DsparkVersion="$SPARK_VERSION" \
+    -DsparkVersion="$SPARK_BUILD_VERSION" \
     -DskipDeltaSpark=true \
     "$SET_VERSION_CMD" \
     "${SET_OVERWRITE_CMDS[@]}" \
@@ -249,12 +307,17 @@ for attempt in 1 2 3; do
     break
   fi
   if [[ "$attempt" -eq 3 ]]; then
-    echo ">>> spark/publishM2 (Spark $SPARK_VERSION) failed after 3 attempts"
+    echo ">>> spark/publishM2 (Spark $SPARK_BUILD_VERSION) failed after 3 attempts"
     exit 1
   fi
-  echo ">>> spark/publishM2 (Spark $SPARK_VERSION) failed on attempt $attempt; retrying..."
+  echo ">>> spark/publishM2 (Spark $SPARK_BUILD_VERSION) failed on attempt $attempt; retrying..."
   sleep 5
 done
+
+# The UC coordinate and Spark suffix do not encode the exact Spark artifact. Persist a marker in
+# both cached layouts so a stale connector cannot satisfy the idempotence check after a ref change.
+printf '%s\n' "$SPARK_BUILD_VERSION" > "$IVY_SPARK_BUILD_MARKER"
+printf '%s\n' "$SPARK_BUILD_VERSION" > "$M2_SPARK_BUILD_MARKER"
 
 echo ">>> Verifying published artifacts"
 for c in "${ALL_CANARIES[@]}"; do

--- a/project/tests/test_cross_spark_publish.py
+++ b/project/tests/test_cross_spark_publish.py
@@ -21,6 +21,7 @@ import json
 import contextlib
 import importlib.util
 import io
+import re
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -111,7 +112,7 @@ class SparkVersionSpec:
 SPARK_VERSIONS: Dict[str, SparkVersionSpec] = {
     "4.0.1": SparkVersionSpec(suffix="_4.0", support_iceberg=True, support_hudi=True),
     "4.1.0": SparkVersionSpec(suffix="_4.1", support_iceberg=True, support_hudi=False),
-    "4.2.0-SNAPSHOT": SparkVersionSpec(suffix="_4.2", support_iceberg=False, support_hudi=False)
+    "4.2.0": SparkVersionSpec(suffix="_4.2", support_iceberg=False, support_hudi=False)
 }
 
 # The default Spark version
@@ -566,11 +567,14 @@ class SparkVersionsScriptTest:
                 print(f"  ✗ Expected {expected}, got {source_build_versions}")
                 return False
 
-            if "4.2" in source_build_versions:
-                by_short = {entry["shortVersion"]: entry for entry in data}
-                spark42 = by_short["4.2"]
-                if spark42["sourceBuildDefaultRef"] != "b6bd005ac7549411ec4e7dc944d7a0e19fd56561":
-                    print("  ✗ Spark 4.2 sourceBuildDefaultRef is not the expected pinned SHA")
+            source_build_entries = [entry for entry in data if entry.get("sourceBuildDefaultRef")]
+            for entry in source_build_entries:
+                source_ref = entry["sourceBuildDefaultRef"]
+                if not re.fullmatch(r"[0-9a-f]{7,40}", source_ref):
+                    print(
+                        f"  ✗ {entry['shortVersion']} sourceBuildDefaultRef is not a valid "
+                        f"Git SHA: {source_ref}"
+                    )
                     return False
 
             print(f"  ✓ --source-build-spark-versions (non-blocking lane metadata): {source_build_versions}")
@@ -615,8 +619,17 @@ class SparkVersionsScriptTest:
                 print(f"  ✗ Expected {expected}, got {non_source_build_versions}")
                 return False
 
-            if "4.2" in non_source_build_versions:
-                print("  ✗ Spark 4.2 should be handled by the non-blocking source-build lane")
+            source_build_versions = {
+                "master" if entry["isMaster"] else entry["shortVersion"]
+                for entry in data
+                if entry.get("sourceBuildDefaultRef")
+            }
+            overlap = source_build_versions.intersection(non_source_build_versions)
+            if overlap:
+                print(
+                    "  ✗ Source-build versions also appeared in the published lane: "
+                    f"{sorted(overlap)}"
+                )
                 return False
 
             print(f"  ✓ --non-source-build-spark-versions: {non_source_build_versions}")
@@ -627,17 +640,28 @@ class SparkVersionsScriptTest:
             return False
 
     def test_resolve_source_build(self) -> bool:
-        """Test source-build resolution without fetching Spark from Git."""
-        if not self.ensure_json_exists():
-            return False
-
-        fake_sha = "b6bd005ac7549411ec4e7dc944d7a0e19fd56561"
+        """Test source-build resolution with synthetic metadata and no Git fetch."""
+        mock_source_ref = "test-source-ref"
+        mock_resolved_sha = "a" * 40
+        source_entry = {
+            "fullVersion": "99.0.0-SNAPSHOT",
+            "shortVersion": "99.0",
+            "isMaster": False,
+            "sourceBuildDefaultRef": mock_source_ref,
+        }
         try:
             spec = importlib.util.spec_from_file_location("get_spark_version_info", self.script_path)
             module = importlib.util.module_from_spec(spec)
             spec.loader.exec_module(module)
-            module.resolve_spark_sha = lambda spark_repo, spark_ref, spark_dir: fake_sha
+            module.resolve_spark_sha = lambda spark_repo, spark_ref, spark_dir: mock_resolved_sha
+            module.load_spark_versions = lambda json_path, repo_root: [source_entry]
 
+            spark_version = (
+                "master" if source_entry["isMaster"] else source_entry["shortVersion"]
+            )
+            artifact_base_version = module.strip_suffix(
+                source_entry["fullVersion"], "-SNAPSHOT"
+            )
             previous_argv = sys.argv
             output = io.StringIO()
             try:
@@ -645,7 +669,7 @@ class SparkVersionsScriptTest:
                     str(self.script_path),
                     "--resolve-source-build",
                     "--spark-version",
-                    "4.2",
+                    spark_version,
                 ]
                 with contextlib.redirect_stdout(output):
                     module.main()
@@ -659,10 +683,13 @@ class SparkVersionsScriptTest:
                     values[key] = value
 
             expected = {
-                "spark_version": "4.2",
-                "spark_sha": fake_sha,
-                "artifact_base_version": "4.2.0",
-                "spark_artifact_version": "4.2.0-b6bd005ac754-SNAPSHOT",
+                "spark_version": spark_version,
+                "source_ref": mock_source_ref,
+                "spark_sha": mock_resolved_sha,
+                "artifact_base_version": artifact_base_version,
+                "spark_artifact_version": module.compute_spark_artifact_version(
+                    artifact_base_version, mock_resolved_sha
+                ),
             }
             for key, expected_value in expected.items():
                 if values.get(key) != expected_value:
@@ -672,11 +699,15 @@ class SparkVersionsScriptTest:
             if "cache_key" not in values:
                 print("  ✗ --resolve-source-build did not emit cache_key")
                 return False
-            if not values["cache_key"].startswith("spark-m2-ubuntu-24.04-scala-2.13-4.2-4.2.0-"):
+            expected_cache_prefix = (
+                "spark-m2-ubuntu-24.04-scala-2.13-"
+                f"{spark_version}-{artifact_base_version}-"
+            )
+            if not values["cache_key"].startswith(expected_cache_prefix):
                 print(f"  ✗ unexpected cache_key: {values['cache_key']}")
                 return False
 
-            print("  ✓ --resolve-source-build: emitted expected non-blocking source-build metadata")
+            print("  ✓ --resolve-source-build: emitted expected synthetic source-build metadata")
             return True
 
         except Exception as e:

--- a/setup.py
+++ b/setup.py
@@ -32,9 +32,10 @@ class VerifyVersionCommand(install):
 with open("python/README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
-# Upper bounds: last known good versions before 2026-03-10 (the canonical date for uv_exclude_newer)
-# pyspark 4.1.1 (2026-01-09), importlib_metadata 8.7.1 (2025-12-21)
-install_requires_arg = ['pyspark>=4.0.1,<=4.1.1', 'importlib_metadata>=1.0.0,<=8.7.1']
+# Upper bounds: last known good versions validated by the Python CI matrix.
+# PySpark 4.2.0 is hash-pinned in CI because it was published after UV_EXCLUDE_NEWER;
+# importlib_metadata remains capped at the last version before that cutoff.
+install_requires_arg = ['pyspark>=4.0.1,<=4.2.0', 'importlib_metadata>=1.0.0,<=8.7.1']
 python_requires_arg = '>=3.10'
 
 setup(

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableCreationTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaTableCreationTest.java
@@ -927,7 +927,15 @@ public class UCDeltaTableCreationTest extends UCDeltaTableIntegrationBaseTest {
     }
 
     // Verify basic table properties
-    assertThat(describeResult.get("Name")).isEqualTo(fullTableName);
+    // Spark 4.2 replaced the legacy Name row with structured identifier rows.
+    if (describeResult.containsKey("Name")) {
+      assertThat(describeResult.get("Name")).isEqualTo(fullTableName);
+    } else {
+      assertThat(describeResult.get("Catalog")).isEqualTo(catalogName);
+      assertThat(describeResult.get("Namespace")).isEqualTo(schemaName);
+      assertThat(describeResult.get("Database")).isEqualTo(schemaName);
+      assertThat(describeResult.get("Table")).isEqualTo(parseTableName(fullTableName));
+    }
     assertThat(describeResult.get("Type")).isEqualTo(tableType.name());
     assertThat(describeResult.get("Provider")).isEqualToIgnoringCase("delta");
     assertThat(describeResult.get("Is_managed_location"))

--- a/spark/v2/src/main/java-shims/spark-4.0/io/delta/spark/internal/v2/catalog/DeltaV2TableShims.java
+++ b/spark/v2/src/main/java-shims/spark-4.0/io/delta/spark/internal/v2/catalog/DeltaV2TableShims.java
@@ -17,13 +17,21 @@
 package io.delta.spark.internal.v2.catalog;
 
 import java.util.Optional;
+import org.apache.spark.sql.connector.catalog.CatalogV2Util;
+import org.apache.spark.sql.connector.catalog.Column;
 import org.apache.spark.sql.connector.catalog.TableCapability;
+import org.apache.spark.sql.types.StructType;
 
 /**
  * Shim to build the DSv2 Delta table connector against different Spark versions.
  * This is the shim for Spark 4.0.
  */
 public abstract class DeltaV2TableShims {
+
+  /** Convert a Spark schema to DSv2 columns using the Spark 4.0 API. */
+  public static Column[] structTypeToV2Columns(StructType schema) {
+    return CatalogV2Util.structTypeToV2Columns(schema);
+  }
 
   /** No schema evolution capability in DSv2 before Spark 4.2. */
   public static Optional<TableCapability> schemaEvolutionCapability() {

--- a/spark/v2/src/main/java-shims/spark-4.1/io/delta/spark/internal/v2/catalog/DeltaV2TableShims.java
+++ b/spark/v2/src/main/java-shims/spark-4.1/io/delta/spark/internal/v2/catalog/DeltaV2TableShims.java
@@ -17,13 +17,21 @@
 package io.delta.spark.internal.v2.catalog;
 
 import java.util.Optional;
+import org.apache.spark.sql.connector.catalog.CatalogV2Util;
+import org.apache.spark.sql.connector.catalog.Column;
 import org.apache.spark.sql.connector.catalog.TableCapability;
+import org.apache.spark.sql.types.StructType;
 
 /**
  * Shim to build the DSv2 Delta table connector against different Spark versions.
  * This is the shim for Spark 4.1.
  */
 public abstract class DeltaV2TableShims {
+
+  /** Convert a Spark schema to DSv2 columns using the Spark 4.1 API. */
+  public static Column[] structTypeToV2Columns(StructType schema) {
+    return CatalogV2Util.structTypeToV2Columns(schema);
+  }
 
   /** No schema evolution capability in DSv2 before Spark 4.2. */
   public static Optional<TableCapability> schemaEvolutionCapability() {

--- a/spark/v2/src/main/java-shims/spark-4.2/io/delta/spark/internal/v2/catalog/DeltaV2TableShims.java
+++ b/spark/v2/src/main/java-shims/spark-4.2/io/delta/spark/internal/v2/catalog/DeltaV2TableShims.java
@@ -22,9 +22,12 @@ import org.apache.spark.sql.delta.v2.interop.AbstractProtocol;
 import io.delta.spark.internal.v2.utils.ScalaUtils;
 import java.util.Optional;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.connector.catalog.CatalogV2Util;
+import org.apache.spark.sql.connector.catalog.Column;
 import org.apache.spark.sql.connector.catalog.SupportsSchemaEvolution;
 import org.apache.spark.sql.connector.catalog.TableCapability;
 import org.apache.spark.sql.connector.catalog.TableChange;
+import org.apache.spark.sql.types.StructType;
 
 /**
  * Shim to build the DSv2 Delta table connector against different Spark versions.
@@ -32,6 +35,11 @@ import org.apache.spark.sql.connector.catalog.TableChange;
  * - Schema evolution support in DSV2 (add columns, change type) was added in Spark 4.2.
  */
 public abstract class DeltaV2TableShims implements SupportsSchemaEvolution {
+
+  /** Convert a Spark schema to DSv2 columns while preserving field IDs. */
+  public static Column[] structTypeToV2Columns(StructType schema) {
+    return CatalogV2Util.structTypeToV2Columns(schema, true);
+  }
 
   /** Implemented in DeltaV2Table to provide access to the table protocol/metadata. */
   protected abstract AbstractProtocol protocol();

--- a/spark/v2/src/main/java-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelog.java
+++ b/spark/v2/src/main/java-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelog.java
@@ -2,8 +2,8 @@ package io.delta.spark.internal.v2.read.changelog;
 
 import io.delta.kernel.Snapshot;
 import io.delta.spark.internal.v2.catalog.DeltaV2Table;
+import io.delta.spark.internal.v2.catalog.DeltaV2TableShims;
 import io.delta.spark.internal.v2.utils.SchemaUtils;
-import org.apache.spark.sql.connector.catalog.CatalogV2Util;
 import org.apache.spark.sql.connector.catalog.Changelog;
 import org.apache.spark.sql.connector.catalog.Column;
 import org.apache.spark.sql.connector.expressions.FieldReference;
@@ -67,7 +67,7 @@ public class DeltaChangelog implements Changelog {
             .add("_commit_version", DataTypes.LongType, false)
             .add("_commit_timestamp", DataTypes.TimestampType, false);
 
-    return CatalogV2Util.structTypeToV2Columns(cdcSchema);
+    return DeltaV2TableShims.structTypeToV2Columns(cdcSchema);
   }
 
   // TODO: optimise to false when deletion vectors are guaranteed enabled across the entire

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
@@ -53,7 +53,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.catalog.CatalogTable;
-import org.apache.spark.sql.connector.catalog.CatalogV2Util;
 import org.apache.spark.sql.connector.catalog.Column;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.MetadataColumn;
@@ -404,7 +403,7 @@ public class DeltaV2Table extends DeltaV2TableShims
 
   @Override
   public Column[] columns() {
-    return CatalogV2Util.structTypeToV2Columns(schema());
+    return DeltaV2TableShims.structTypeToV2Columns(schema());
   }
 
   @Override


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Spark 4.2.0 is released, so Delta's active 4.2 lane should test the published release instead of rebuilding a pinned Spark commit. This moves 4.2 into the blocking published-artifact matrix while retaining the generic source-build/cache path for the next unreleased Spark line.

This is the follow-up to #7222 and should merge after it. #7222 owns the changelog API shim; this PR deliberately does not duplicate that change.

- Use `4.2.0` throughout Delta's Spark metadata and released Python matrix, skipping source-cache jobs when no source line is configured.
- Shim the Spark 4.2 DSv2 schema conversion API while preserving field IDs.
- Admit PySpark 4.2.0 in package metadata and hash-pin its post-cutoff PySpark, PyArrow, and Protobuf requirements.
- Compile pinned Unity Catalog against the exact Spark artifact used by each row (`4.2.0` for this release, commit-qualified versions for future source rows), and key/verify caches by that artifact to prevent stale preview bytecode.
- Accept Spark 4.2's structured `Catalog`/`Namespace`/`Database`/`Table` rows in `DESCRIBE EXTENDED` while retaining older-Spark coverage.

## How was this patch tested?

- [x] `bash -n project/scripts/setup_unitycatalog_main.sh`
- [x] Parsed all changed workflow/action YAML files with PyYAML.
- [x] Ran the focused `SparkVersionsScriptTest` matrix/helper checks; released versions are `[4.0, 4.1, 4.2]` and the active source-build list is empty.
- [x] `build/sbt "sparkUnityCatalog / Test / javafmtCheck"`
- [x] `build/sbt -DsparkVersion=4.2 "show sparkArtifactVersion"` resolves `4.2.0`.
- [x] Exercised the pinned UC setup through metadata rewrite and dependency resolution; it selected `org.apache.spark:spark-sql_2.13:4.2.0`.
- [ ] Full local UC/Delta 4.2 test execution is blocked in this environment: the internal Maven mirror has not mirrored Spark 4.2.0, and public Maven DNS is unavailable. GitHub CI can resolve the published release and is the end-to-end validation.

## Does this PR introduce _any_ user-facing changes?

Yes. Delta's Python package metadata now permits PySpark 4.2.0. There is no Delta API or runtime semantic change beyond Spark 4.2 compatibility.
