### PR TITLE
Add start-version parameter to findLastCompleteCheckpoint for efficient forward listing

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
@@ -551,10 +551,21 @@ trait Checkpoints extends DeltaLogging {
   }
 
   /** Returns the last complete checkpoint in the delta log directory (if any) */
-  private def findLastCompleteCheckpoint(): Option[CheckpointInstance] = {
+  private def findLastCompleteCheckpoint(): Option[CheckpointInstance] =
+    findLastCompleteCheckpoint(startVersion = 0L)
+
+  /**
+   * Returns the last complete checkpoint at or after `startVersion` by listing the delta log
+   * directory forward from that version. Unlike [[findLastCompleteCheckpointBefore]], which lists
+   * backward from an upper bound, this lists forward from a floor and returns the newest complete
+   * checkpoint found. `startVersion` is only a listing optimization (e.g. a `_last_checkpoint`
+   * hint used as a floor): if no complete checkpoint exists at or after it, the result is None and
+   * the caller is expected to fall back to a full listing from version 0.
+   */
+  private[delta] def findLastCompleteCheckpoint(startVersion: Long): Option[CheckpointInstance] = {
     val hadoopConf = newDeltaHadoopConf()
     val listingResult = store
-      .listFrom(listingPrefix(logPath, 0L), hadoopConf)
+      .listFrom(listingPrefix(logPath, math.max(0L, startVersion)), hadoopConf)
       // Checkpoint files of 0 size are invalid but Spark will ignore them silently when
       // reading such files, hence we drop them so that we never pick up such checkpoints.
       .collect { case CheckpointFile(file, _) if file.getLen != 0 => file }


### PR DESCRIPTION
## Description

Add a `startVersion` parameter to `findLastCompleteCheckpoint` so callers can provide a listing floor instead of always listing from version 0. The no-argument overload retains its existing behavior (lists from 0).

This enables checkpoint validation to mirror the read path: use a known hint version as a listing floor, list forward from it to find the true latest complete checkpoint, and fall back to a full listing only when the hint is absent or points past the newest checkpoint on disk.

### Why this matters

A checkpoint write can fail after the checkpoint files are written but before `_last_checkpoint` is advanced to that version, leaving a corrupt checkpoint at a version **newer** than `_last_checkpoint`. Snapshot/LogSegment construction lists the log forward and picks up the newer corrupt checkpoint, so reads fail. This change enables callers to use a stale hint as a listing *floor* (not a ceiling) so the forward listing always finds the true latest checkpoint on disk.

## How was this tested?

- Updated `FsckRepairTableCorruptCheckpointSuite` with a regression test: sets `_last_checkpoint` to an older version while a newer corrupt checkpoint exists on disk, asserts the table is unreadable, then verifies that the validation scan detects and quarantines the corruption and restores readability.
- All existing corrupt-checkpoint suite cases pass.
- `FindLastCompleteCheckpointSuite` passes.
