### PR TITLE
[Spark] Block generated null type columns in streaming writes

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/GeneratedColumn.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/GeneratedColumn.scala
@@ -122,6 +122,19 @@ object GeneratedColumn extends DeltaLogging with AnalysisHelper {
   }
 
   /**
+   * Returns whether the table has a generated column that has a NullType data type.
+   *
+   * @param protocol the table protocol.
+   * @param schema the table schema.
+   * @return whether the table has a generated column that has a NullType data type.
+   */
+  def hasGeneratedNullTypeColumn(protocol: Protocol, schema: StructType): Boolean = {
+    schema.exists { f =>
+      isGeneratedColumn(protocol, f) && f.dataType.isInstanceOf[NullType]
+    }
+  }
+
+  /**
    * Whether the table has generated columns. A table has generated columns only if its
    * protocol satisfies Generated Column (listed in Table Features or supported implicitly) and
    * some of columns in the table schema contain generation expressions.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSink.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSink.scala
@@ -114,7 +114,11 @@ case class DeltaSink(
     val txn = deltaLog.startTransaction(catalogTable)
     assert(queryId != null)
 
-    if (SchemaUtils.nullTypeExistsRecursively(data.schema)) {
+    // Reject streaming writes if the query output schema contains void (NullType), or if the
+    // target table has a generated void column. Stored (non-generated) void columns are allowed.
+    if (SchemaUtils.nullTypeExistsRecursively(data.schema) ||
+      GeneratedColumn.hasGeneratedNullTypeColumn(
+        txn.protocol, txn.snapshot.schema)) {
       throw DeltaErrors.streamWriteNullTypeException
     }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSinkSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSinkSuite.scala
@@ -726,6 +726,126 @@ class DeltaSinkSuite
     }
   }
 
+  /**
+   * Create a Delta table with the given `columns` at the sink `target`, so a
+   * test can stream into a preexisting table. `target` is a table name when
+   * [[useDsv2]] is set and a filesystem path otherwise, matching how
+   * [[withSinkTarget]] hands it out.
+   */
+  private def createPreexistingTableAtSinkTarget(
+      target: String,
+      columns: Seq[StructField]
+  ): Unit = {
+    val builder = DeltaTable.create(spark)
+    if (useDsv2) builder.tableName(target) else builder.location(target)
+    columns.foreach(builder.addColumn)
+    builder.execute()
+  }
+
+  test("DeltaSink rejects streaming write to table with generated void column") {
+    assume(DeltaTestUtilsBase.nullTypeColumnsSupported)
+    failAfter(streamingTimeout) {
+      withSinkTarget { (target, checkpointDir) =>
+        val columns = Seq(
+          DeltaTable.columnBuilder(spark, "id").dataType("int").build(),
+          DeltaTable.columnBuilder(spark, "v")
+            .dataType("void")
+            .nullable(true)
+            .generatedAlwaysAs("null")
+            .build()
+        )
+        createPreexistingTableAtSinkTarget(target, columns)
+
+        val inputData = MemoryStream[Int]
+        val dsWriter = inputData
+          .toDF()
+          .toDF("id")
+          .writeStream
+          .option("checkpointLocation", checkpointDir.getCanonicalPath)
+          .format("delta")
+
+        val wrapperException = intercept[StreamingQueryException] {
+          val q = startStream(dsWriter, target)
+          inputData.addData(1)
+          q.processAllAvailable()
+        }
+        assert(wrapperException.cause.isInstanceOf[AnalysisException])
+        checkError(
+          wrapperException.cause.asInstanceOf[AnalysisException],
+          "DELTA_NULL_SCHEMA_IN_STREAMING_WRITE"
+        )
+      }
+    }
+  }
+
+  test("DeltaSink allows streaming write to table with non-generated void column") {
+    assume(DeltaTestUtilsBase.nullTypeColumnsSupported)
+    failAfter(streamingTimeout) {
+      withSinkTarget { (target, checkpointDir) =>
+        val columns = Seq(
+          DeltaTable.columnBuilder(spark, "id").dataType("int").build(),
+          DeltaTable.columnBuilder(spark, "v")
+            .dataType("void")
+            .nullable(true)
+            .build()
+        )
+        createPreexistingTableAtSinkTarget(target, columns)
+
+        val inputData = MemoryStream[Int]
+        val dsWriter = inputData
+          .toDF()
+          .toDF("id")
+          .writeStream
+          .option("checkpointLocation", checkpointDir.getCanonicalPath)
+          .format("delta")
+
+        val q = startStream(dsWriter, target)
+        try {
+          inputData.addData(1)
+          q.processAllAvailable()
+          checkAnswer(readTarget(target), Row(1, null))
+        } finally {
+          q.stop()
+        }
+      }
+    }
+  }
+
+  test("DeltaSink rejects streaming write with NullType column in batch schema") {
+    failAfter(streamingTimeout) {
+      withSinkTarget { (target, checkpointDir) =>
+        val columns = Seq(
+          DeltaTable.columnBuilder(spark, "id").dataType("int").build(),
+          DeltaTable.columnBuilder(spark, "value")
+            .dataType("int")
+            .nullable(true)
+            .build()
+        )
+        createPreexistingTableAtSinkTarget(target, columns)
+
+        val inputData = MemoryStream[Int]
+        val dsWriter = inputData
+          .toDF()
+          .toDF("id")
+          .withColumn("value", lit(null).cast(NullType))
+          .writeStream
+          .option("checkpointLocation", checkpointDir.getCanonicalPath)
+          .format("delta")
+
+        val wrapperException = intercept[StreamingQueryException] {
+          val q = startStream(dsWriter, target)
+          inputData.addData(1)
+          q.processAllAvailable()
+        }
+        assert(wrapperException.cause.isInstanceOf[AnalysisException])
+        checkError(
+          wrapperException.cause.asInstanceOf[AnalysisException],
+          "DELTA_NULL_SCHEMA_IN_STREAMING_WRITE"
+        )
+      }
+    }
+  }
+
   test("DeltaSink rejects DataFrame with UDT containing NullType") {
     failAfter(streamingTimeout) {
       withSinkTarget { (target, checkpointDir) =>

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSinkSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSinkSuite.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.delta.test.{DeltaColumnMappingSelectedTestMixin, Del
 import org.apache.spark.sql.delta.test.DeltaSQLTestUtils
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 import org.apache.spark.sql.delta.test.shims.StreamingTestShims.{MemoryStream, MicroBatchExecution, StreamingQueryWrapper}
-import io.delta.tables.DeltaTable
+import io.delta.tables.{DeltaTable => IODeltaTable}
 import org.apache.commons.io.FileUtils
 import org.scalatest.time.SpanSugar._
 
@@ -127,9 +127,9 @@ class DeltaSinkSuite
     else DeltaLog.forTable(spark, target)
 
   /** Resolve the [[DeltaTable]] for `target`, by name (DSv2) or path. */
-  protected def deltaTableForTarget(target: String): DeltaTable =
-    if (useDsv2) DeltaTable.forName(spark, target)
-    else DeltaTable.forPath(spark, target)
+  protected def deltaTableForTarget(target: String): IODeltaTable =
+    if (useDsv2) IODeltaTable.forName(spark, target)
+    else IODeltaTable.forPath(spark, target)
 
   test("append mode") {
     failAfter(streamingTimeout) {
@@ -736,7 +736,7 @@ class DeltaSinkSuite
       target: String,
       columns: Seq[StructField]
   ): Unit = {
-    val builder = DeltaTable.create(spark)
+    val builder = IODeltaTable.create(spark)
     if (useDsv2) builder.tableName(target) else builder.location(target)
     columns.foreach(builder.addColumn)
     builder.execute()
@@ -747,8 +747,8 @@ class DeltaSinkSuite
     failAfter(streamingTimeout) {
       withSinkTarget { (target, checkpointDir) =>
         val columns = Seq(
-          DeltaTable.columnBuilder(spark, "id").dataType("int").build(),
-          DeltaTable.columnBuilder(spark, "v")
+          IODeltaTable.columnBuilder(spark, "id").dataType("int").build(),
+          IODeltaTable.columnBuilder(spark, "v")
             .dataType("void")
             .nullable(true)
             .generatedAlwaysAs("null")
@@ -783,8 +783,8 @@ class DeltaSinkSuite
     failAfter(streamingTimeout) {
       withSinkTarget { (target, checkpointDir) =>
         val columns = Seq(
-          DeltaTable.columnBuilder(spark, "id").dataType("int").build(),
-          DeltaTable.columnBuilder(spark, "v")
+          IODeltaTable.columnBuilder(spark, "id").dataType("int").build(),
+          IODeltaTable.columnBuilder(spark, "v")
             .dataType("void")
             .nullable(true)
             .build()
@@ -815,8 +815,8 @@ class DeltaSinkSuite
     failAfter(streamingTimeout) {
       withSinkTarget { (target, checkpointDir) =>
         val columns = Seq(
-          DeltaTable.columnBuilder(spark, "id").dataType("int").build(),
-          DeltaTable.columnBuilder(spark, "value")
+          IODeltaTable.columnBuilder(spark, "id").dataType("int").build(),
+          IODeltaTable.columnBuilder(spark, "value")
             .dataType("int")
             .nullable(true)
             .build()


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Delta already rejects streaming writes when the **batch schema** contains `NullType` (`void`). This PR extends that guard to also reject streaming writes into tables that have a **generated** `void` column in their schema.
Generated `void` columns are always `NULL` and cannot be supplied by the streaming query output. Allowing a streaming write into such a table would produce rows that violate the generated-column contract. Non-generated (stored) `void` columns remain allowed, since the writer can omit them and let the table default apply.
Changes:
- Add `GeneratedColumn.hasGeneratedNullTypeColumn` to detect generated `NullType` columns in a table schema.
- Update `DeltaSink` to throw `DELTA_NULL_SCHEMA_IN_STREAMING_WRITE` when the target table has a generated `void` column, in addition to the existing check on the batch schema.
- Add `DeltaSinkSuite` coverage for generated vs non-generated `void` columns and for `NullType` in the batch schema.


## How was this patch tested?

Added unit tests in DeltaSinkSuite:

* DeltaSink rejects streaming write to table with generated void column — expects DELTA_NULL_SCHEMA_IN_STREAMING_WRITE
* DeltaSink allows streaming write to table with non-generated void column — write succeeds
* DeltaSink rejects streaming write with NullType column in batch schema — expects DELTA_NULL_SCHEMA_IN_STREAMING_WRITE

## Does this PR introduce _any_ user-facing changes?

No.