### PR TITLE
[Spark] Use SingleCommit iterator in Delta streaming source

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
@@ -34,7 +34,7 @@ import org.apache.spark.sql.delta.storage.{ClosableIterator, SupportsRewinding}
 import org.apache.spark.sql.delta.storage.ClosableIterator._
 import org.apache.spark.sql.delta.util.{DateTimeUtils, TimestampFormatter}
 import org.apache.spark.sql.util.ScalaExtensions._
-import org.apache.hadoop.fs.{FileStatus, Path}
+import org.apache.hadoop.fs.Path
 
 import org.apache.spark.internal.MDC
 import org.apache.spark.sql.{DataFrame, SparkSession}
@@ -809,11 +809,12 @@ case class DeltaSource(
       //    in that case, we need to recompute the start snapshot and evolve the schema if needed
       require(options.failOnDataLoss || !trackingMetadataChange,
         "Using schema from schema tracking log cannot tolerate missing commit files.")
-      deltaLog.getChangeLogFiles(
+      deltaLog.getChangesIterator(
         startVersion, catalogTableOpt, options.failOnDataLoss).flatMapWithClose {
-        case (version, filestatus) =>
+        commit =>
+          val version = commit.version
           // First pass reads the whole commit and closes the iterator.
-          val iter = DeltaSource.createRewindableActionIterator(spark, deltaLog, filestatus)
+          val iter = DeltaSource.createRewindableActionIterator(spark, commit)
           val (shouldSkipCommit, metadataOpt, protocolOpt) = iter
             .processAndClose { actionsIter =>
               validateCommitAndDecideSkipping(
@@ -1520,35 +1521,13 @@ object DeltaSource extends DeltaLogging {
   }
 
   /**
-   * Read an [[ClosableIterator]] of Delta actions from file status, considering memory constraints
+   * Read an [[ClosableIterator]] of Delta actions from a commit, considering memory constraints.
    */
   def createRewindableActionIterator(
       spark: SparkSession,
-      deltaLog: DeltaLog,
-      fileStatus: FileStatus): ClosableIterator[Action] with SupportsRewinding[Action] = {
+      commit: SingleCommit): ClosableIterator[Action] with SupportsRewinding[Action] = {
     val threshold = spark.sessionState.conf.getConf(DeltaSQLConf.LOG_SIZE_IN_MEMORY_THRESHOLD)
-    lazy val actions =
-      deltaLog.store.read(fileStatus, deltaLog.newDeltaHadoopConf()).map(Action.fromJson)
-    // Return a new [[CloseableIterator]] over the commit. If the commit is smaller than the
-    // threshold, we will read it into memory once and iterate over that every time.
-    // Otherwise, we read it again every time.
-    val shouldLoadIntoMemory = fileStatus.getLen < threshold
-    def createClosableIterator(): ClosableIterator[Action] = if (shouldLoadIntoMemory) {
-      // Reuse in the memory actions
-      actions.toIterator.toClosable
-    } else {
-      deltaLog.store.readAsIterator(fileStatus, deltaLog.newDeltaHadoopConf())
-        .withClose {
-          _.map(Action.fromJson)
-        }
-    }
-    new ClosableIterator[Action] with SupportsRewinding[Action] {
-      var delegatedIterator: ClosableIterator[Action] = createClosableIterator()
-      override def hasNext: Boolean = delegatedIterator.hasNext
-      override def next(): Action = delegatedIterator.next()
-      override def close(): Unit = delegatedIterator.close()
-      override def rewind(): Unit = delegatedIterator = createClosableIterator()
-    }
+    commit.getActionsIterator(threshold)
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSourceMetadataEvolutionSupport.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSourceMetadataEvolutionSupport.scala
@@ -154,12 +154,11 @@ trait DeltaSourceMetadataEvolutionSupport extends DeltaSourceBase { base: DeltaS
       startVersion: Long,
       endVersion: Long
   ): ClosableIterator[(Long, Action)] = {
-    deltaLog.getChangeLogFiles(startVersion, catalogTableOpt, options.failOnDataLoss).takeWhile {
-      case (version, _) => version <= endVersion
-    }.flatMapWithClose { case (version, fileStatus) =>
-      DeltaSource.createRewindableActionIterator(spark, deltaLog, fileStatus)
-        .map((version, _))
-        .toClosable
+    deltaLog.getChangesIterator(startVersion, catalogTableOpt, options.failOnDataLoss).takeWhile {
+      commit => commit.version <= endVersion
+    }.flatMapWithClose { commit =>
+      DeltaSource.createRewindableActionIterator(spark, commit)
+        .withClose(_.map((commit.version, _)))
     }
   }
 
@@ -748,12 +747,12 @@ object DeltaSourceMetadataEvolutionSupport extends Logging {
     // We start from the currentSchemaVersion so that we can stop early in case the current
     // version still has file actions that potentially needs to be processed.
     val untilMetadataChange =
-      deltaLog.getChangeLogFiles(
-        currentMetadataVersion, catalogTableOpt).map { case (version, fileStatus) =>
+      deltaLog.getChangesIterator(
+        currentMetadataVersion, catalogTableOpt).map { commit =>
         var metadataAction: Option[Metadata] = None
         var protocolAction: Option[Protocol] = None
         var hasFileAction = false
-        DeltaSource.createRewindableActionIterator(spark, deltaLog, fileStatus)
+        DeltaSource.createRewindableActionIterator(spark, commit)
           .processAndClose { actionsIter =>
             actionsIter.foreach {
               case m: Metadata => metadataAction = Some(m)
@@ -763,7 +762,7 @@ object DeltaSourceMetadataEvolutionSupport extends Logging {
             }
           }
         (!hasFileAction && (metadataAction.isDefined || protocolAction.isDefined),
-          version, metadataAction, protocolAction)
+          commit.version, metadataAction, protocolAction)
       }.takeWhile(_._1)
     // Fold the chain so the merged entry tracks the latest Metadata and Protocol seen
     // anywhere in the run, not just the last commit's actions -- otherwise a (Metadata,


### PR DESCRIPTION
## Description

Updates the Delta streaming source to consume commits through the
`getChangesIterator` API, which returns `SingleCommit` handles, instead of
`getChangeLogFiles`, which exposes raw `FileStatus` objects.

`DeltaSource.createRewindableActionIterator` now takes a `SingleCommit` and
delegates the in-memory-vs-streaming read decision to
`SingleCommit.getActionsIterator`, removing the duplicated threshold logic that
previously lived in `DeltaSource`. `DeltaSourceMetadataEvolutionSupport` is
updated to the same API. This keeps the log's physical layout internal to the
`SingleCommit` abstraction and no longer requires the `FileStatus` import in
`DeltaSource`.

No behavior change: the memory threshold and rewind semantics are preserved by
`SingleCommit.getActionsIterator`.

## How was this patch tested?

Existing streaming source and metadata-evolution suites exercise these paths.

## Does this PR introduce _any_ user-facing change?

No.
