### PR TITLE
feat: populate row count statistics for V2 writes

### DIFF
--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2DataWriter.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2DataWriter.java
@@ -21,6 +21,7 @@ import io.delta.kernel.data.Row;
 import io.delta.kernel.defaults.engine.DefaultEngine;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.internal.util.Utils;
+import io.delta.kernel.statistics.DataFileStatistics;
 import io.delta.kernel.utils.CloseableIterator;
 import io.delta.kernel.utils.DataFileStatus;
 import io.delta.spark.internal.v2.utils.SerializableKernelRowWrapper;
@@ -139,12 +140,21 @@ class DeltaV2DataWriter implements DataWriter<InternalRow> {
 
     FileSystem fs = outputPath.getFileSystem(conf);
     FileStatus fileStatus = fs.getFileStatus(outputPath);
+    // Populate numRecords so AddFile.stats is non-null: metadata-only count(*) and
+    // IcebergCompat V2/V3 validation require it. Column min/max/null stats are not collected here.
+    DataFileStatistics stats =
+        new DataFileStatistics(
+            rowCount,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Optional.empty());
     DataFileStatus dataFileStatus =
         new DataFileStatus(
             outputPath.toString(),
             fileStatus.getLen(),
             fileStatus.getModificationTime(),
-            Optional.empty());
+            Optional.of(stats));
 
     CloseableIterator<DataFileStatus> dataFilesIter =
         Utils.toCloseableIterator(Collections.singletonList(dataFileStatus).iterator());


### PR DESCRIPTION
DeltaV2DataWriter already tracks rowCount while streaming InternalRows to Parquet but was passing Optional.empty() for the file's statistics, so Transaction.generateAppendActions produced an AddFile with a null stats column. Readers that satisfy count(*) from log metadata (e.g. Reyden) saw 0; queries with a predicate worked because the reader fell back to opening the data file. The same gap blocked delta.icebergCompatV2/V3 writes since their validators require numRecords to be present.

This PR populates DataFileStatistics with numRecords = rowCount on every committed V2 writer file. Column-level minValues / maxValues / nullCount are not collected here yet (separate work, equivalent to wiring V1's DeltaJobStatisticsTracker), so only the known row count is populated.

For the FFI add-files path, this PR also avoids inventing a row count when statistics are absent. DataFileStatus.getStatistics() == Optional.empty() now leaves the nullable Arrow stats struct unset instead of serializing numRecords = 0; an explicit numRecords = 0 remains a real known row count. The Java Arrow schemas now declare stats.numRecords nullable to match the Rust kernel schema.

The DataFileStatistics import comes from the renamed kerneljvm.io.delta.kernel.statistics namespace because the dropin shading rules don't relocate it; DataFileStatus.getStatistics() already exposes the kerneljvm type.

How was this patch tested?
New JUnit test DeltaV2DataWriterTest.commitPopulatesNumRecordsInAddFileStats writes 5 rows, decodes the committed AddFile, and asserts stats is non-null with numRecords == 5.
New JUnit test ActionRowConverterTest.missingStatsLeavesStatsStructNull asserts missing statistics leave the Arrow stats struct null while explicit numRecords = 0 remains present.
New JUnit test TransactionAddFilesTest.absentStatisticsDoNotWriteZeroNumRecords commits a file without statistics and asserts the commit log does not serialize numRecords = 0.

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
