### PR TITLE
[Kernel] Promote Snapshot/Scan/CommitRange accessors used by Delta Spark

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/CommitRange.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/CommitRange.java
@@ -22,6 +22,8 @@ import io.delta.kernel.engine.Engine;
 import io.delta.kernel.exceptions.KernelException;
 import io.delta.kernel.internal.DeltaLogActionUtils;
 import io.delta.kernel.utils.CloseableIterator;
+import io.delta.kernel.utils.FileStatus;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -52,6 +54,15 @@ public interface CommitRange {
    * @return the ending version number of the commit range
    */
   long getEndVersion();
+
+  /**
+   * Returns the delta commit files that make up this commit range, one per version in {@code
+   * [getStartVersion(), getEndVersion()]}, in increasing version order.
+   *
+   * @return the list of {@link FileStatus}es for the delta commit files in this range
+   * @since 4.4.0
+   */
+  List<FileStatus> getDeltaFiles();
 
   /**
    * Returns the original query boundary used to define the start boundary of this commit range.

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Scan.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Scan.java
@@ -107,6 +107,28 @@ public interface Scan {
   CloseableIterator<FilteredColumnarBatch> getScanFiles(Engine engine);
 
   /**
+   * Get an iterator of data files to scan, optionally including the file statistics.
+   *
+   * <p>Behaves like {@link #getScanFiles(Engine)}, but when {@code includeStats} is {@code true}
+   * the returned scan-file rows are guaranteed to include the JSON file statistics read from the
+   * log (schema {@code add.stats}). When {@code includeStats} is {@code false} the statistics may
+   * or may not be present, depending on whether they were needed internally (e.g. for data
+   * skipping); callers must not rely on their presence.
+   *
+   * @param engine {@link Engine} instance to use in Delta Kernel.
+   * @param includeStats whether to guarantee the JSON file statistics are included in the
+   *     scan-file rows.
+   * @return iterator of {@link FilteredColumnarBatch}s, one selected row per scan file, with the
+   *     schema described in {@link #getScanFiles(Engine)} (plus {@code stats} when {@code
+   *     includeStats} is {@code true}).
+   * @since 4.4.0
+   */
+  default CloseableIterator<FilteredColumnarBatch> getScanFiles(
+      Engine engine, boolean includeStats) {
+    return getScanFiles(engine);
+  }
+
+  /**
    * Get the remaining filter that is not guaranteed to be satisfied for the data Delta Kernel
    * returns. This filter is used by Delta Kernel to do data skipping when possible.
    *

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Scan.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Scan.java
@@ -116,8 +116,8 @@ public interface Scan {
    * skipping); callers must not rely on their presence.
    *
    * @param engine {@link Engine} instance to use in Delta Kernel.
-   * @param includeStats whether to guarantee the JSON file statistics are included in the
-   *     scan-file rows.
+   * @param includeStats whether to guarantee the JSON file statistics are included in the scan-file
+   *     rows.
    * @return iterator of {@link FilteredColumnarBatch}s, one selected row per scan file, with the
    *     schema described in {@link #getScanFiles(Engine)} (plus {@code stats} when {@code
    *     includeStats} is {@code true}).
@@ -125,6 +125,10 @@ public interface Scan {
    */
   default CloseableIterator<FilteredColumnarBatch> getScanFiles(
       Engine engine, boolean includeStats) {
+    if (includeStats) {
+      throw new UnsupportedOperationException(
+          "getScanFiles(Engine, boolean) with includeStats=true is not implemented for this Scan");
+    }
     return getScanFiles(engine);
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Scan.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Scan.java
@@ -123,14 +123,7 @@ public interface Scan {
    *     includeStats} is {@code true}).
    * @since 4.4.0
    */
-  default CloseableIterator<FilteredColumnarBatch> getScanFiles(
-      Engine engine, boolean includeStats) {
-    if (includeStats) {
-      throw new UnsupportedOperationException(
-          "getScanFiles(Engine, boolean) with includeStats=true is not implemented for this Scan");
-    }
-    return getScanFiles(engine);
-  }
+  CloseableIterator<FilteredColumnarBatch> getScanFiles(Engine engine, boolean includeStats);
 
   /**
    * Get the remaining filter that is not guaranteed to be satisfied for the data Delta Kernel

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Snapshot.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Snapshot.java
@@ -18,11 +18,15 @@ package io.delta.kernel;
 
 import io.delta.kernel.annotation.Evolving;
 import io.delta.kernel.clustering.ClusteringColumnInfo;
+import io.delta.kernel.commit.Committer;
 import io.delta.kernel.commit.PublishFailedException;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.exceptions.CheckpointAlreadyExistsException;
 import io.delta.kernel.exceptions.KernelException;
+import io.delta.kernel.internal.actions.Metadata;
+import io.delta.kernel.internal.actions.Protocol;
 import io.delta.kernel.internal.checksum.CRCInfo;
+import io.delta.kernel.internal.fs.Path;
 import io.delta.kernel.statistics.SnapshotStatistics;
 import io.delta.kernel.transaction.UpdateTableTransactionBuilder;
 import io.delta.kernel.types.StructType;
@@ -133,6 +137,95 @@ public interface Snapshot {
    */
   // TODO: expose a public checksum-info type; CRCInfo is currently an internal type.
   default Optional<CRCInfo> getCurrentCrcInfo() {
+    return Optional.empty();
+  }
+
+  /**
+   * Returns the table protocol at this snapshot.
+   *
+   * <p>The default implementation throws {@link UnsupportedOperationException}; {@link
+   * io.delta.kernel.internal.SnapshotImpl} overrides it.
+   *
+   * @return the {@link Protocol} for this snapshot
+   * @since 4.4.0
+   */
+  // TODO: expose a public protocol type; Protocol is currently an internal type.
+  default Protocol getProtocol() {
+    throw new UnsupportedOperationException("getProtocol() is not implemented for this Snapshot");
+  }
+
+  /**
+   * Returns the table metadata at this snapshot.
+   *
+   * <p>The default implementation throws {@link UnsupportedOperationException}; {@link
+   * io.delta.kernel.internal.SnapshotImpl} overrides it.
+   *
+   * @return the {@link Metadata} for this snapshot
+   * @since 4.4.0
+   */
+  // TODO: expose a public metadata type; Metadata is currently an internal type.
+  default Metadata getMetadata() {
+    throw new UnsupportedOperationException("getMetadata() is not implemented for this Snapshot");
+  }
+
+  /**
+   * Returns the {@link Committer} used to commit transactions against this snapshot's table.
+   *
+   * <p>The default implementation throws {@link UnsupportedOperationException}; {@link
+   * io.delta.kernel.internal.SnapshotImpl} overrides it.
+   *
+   * @return the committer for this snapshot
+   * @since 4.4.0
+   */
+  default Committer getCommitter() {
+    throw new UnsupportedOperationException("getCommitter() is not implemented for this Snapshot");
+  }
+
+  /**
+   * Returns the table data path as a {@link Path}.
+   *
+   * <p>The default implementation wraps {@link #getPath()} in a {@link Path}. {@link
+   * io.delta.kernel.internal.SnapshotImpl} overrides it to return the path used to load the
+   * snapshot (the same value {@link #getPath()} stringifies).
+   *
+   * @return the table data path
+   * @since 4.4.0
+   */
+  // TODO: expose a public path type; Path is currently an internal type.
+  default Path getDataPath() {
+    return new Path(getPath());
+  }
+
+  /**
+   * Returns the path to this table's {@code _delta_log} directory.
+   *
+   * <p>The default implementation returns {@code new Path(getDataPath(), "_delta_log")}; {@link
+   * io.delta.kernel.internal.SnapshotImpl} overrides it to return the path used to load the
+   * snapshot.
+   *
+   * @return the {@code _delta_log} path
+   * @since 4.4.0
+   */
+  // TODO: expose a public path type; Path is currently an internal type.
+  default Path getLogPath() {
+    return new Path(getDataPath(), "_delta_log");
+  }
+
+  /**
+   * Returns the latest transaction version recorded in the Delta log for the given application id,
+   * or empty if none exists.
+   *
+   * <p>The default implementation returns {@link Optional#empty()}; {@link
+   * io.delta.kernel.internal.SnapshotImpl} overrides it to read transaction identifiers from the
+   * log.
+   *
+   * @param engine the engine to use for IO operations
+   * @param applicationId identifier of the application that wrote transaction identifiers into the
+   *     Delta log
+   * @return the last transaction version for {@code applicationId}, or empty if none
+   * @since 4.4.0
+   */
+  default Optional<Long> getLatestTransactionVersion(Engine engine, String applicationId) {
     return Optional.empty();
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Snapshot.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Snapshot.java
@@ -25,7 +25,6 @@ import io.delta.kernel.exceptions.CheckpointAlreadyExistsException;
 import io.delta.kernel.exceptions.KernelException;
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.actions.Protocol;
-import io.delta.kernel.internal.checksum.CRCInfo;
 import io.delta.kernel.internal.fs.Path;
 import io.delta.kernel.statistics.SnapshotStatistics;
 import io.delta.kernel.transaction.UpdateTableTransactionBuilder;
@@ -124,21 +123,6 @@ public interface Snapshot {
 
   /** @return statistics about this snapshot */
   SnapshotStatistics getStatistics();
-
-  /**
-   * Returns the checksum ({@code CRC}) information for this snapshot if it was loaded from a
-   * checksum file, otherwise empty.
-   *
-   * <p>The default implementation returns {@link Optional#empty()}; implementations backed by a
-   * checksum file override it to return the loaded {@link CRCInfo}.
-   *
-   * @return the {@link CRCInfo} for this snapshot, or empty if no checksum was loaded
-   * @since 4.4.0
-   */
-  // TODO: expose a public checksum-info type; CRCInfo is currently an internal type.
-  default Optional<CRCInfo> getCurrentCrcInfo() {
-    return Optional.empty();
-  }
 
   /**
    * Returns the table protocol at this snapshot.

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Snapshot.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Snapshot.java
@@ -22,6 +22,7 @@ import io.delta.kernel.commit.PublishFailedException;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.exceptions.CheckpointAlreadyExistsException;
 import io.delta.kernel.exceptions.KernelException;
+import io.delta.kernel.internal.checksum.CRCInfo;
 import io.delta.kernel.statistics.SnapshotStatistics;
 import io.delta.kernel.transaction.UpdateTableTransactionBuilder;
 import io.delta.kernel.types.StructType;
@@ -119,6 +120,21 @@ public interface Snapshot {
 
   /** @return statistics about this snapshot */
   SnapshotStatistics getStatistics();
+
+  /**
+   * Returns the checksum ({@code CRC}) information for this snapshot if it was loaded from a
+   * checksum file, otherwise empty.
+   *
+   * <p>The default implementation returns {@link Optional#empty()}; implementations backed by a
+   * checksum file override it to return the loaded {@link CRCInfo}.
+   *
+   * @return the {@link CRCInfo} for this snapshot, or empty if no checksum was loaded
+   * @since 4.4.0
+   */
+  // TODO: expose a public checksum-info type; CRCInfo is currently an internal type.
+  default Optional<CRCInfo> getCurrentCrcInfo() {
+    return Optional.empty();
+  }
 
   /**
    * Get per-clustering-column descriptors with the physical column reference (as stored in the

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Snapshot.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Snapshot.java
@@ -25,7 +25,9 @@ import io.delta.kernel.exceptions.CheckpointAlreadyExistsException;
 import io.delta.kernel.exceptions.KernelException;
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.actions.Protocol;
+import io.delta.kernel.internal.checksum.CRCInfo;
 import io.delta.kernel.internal.fs.Path;
+import io.delta.kernel.internal.snapshot.LogSegment;
 import io.delta.kernel.statistics.SnapshotStatistics;
 import io.delta.kernel.transaction.UpdateTableTransactionBuilder;
 import io.delta.kernel.types.StructType;
@@ -133,7 +135,6 @@ public interface Snapshot {
    * @return the {@link Protocol} for this snapshot
    * @since 4.4.0
    */
-  // TODO: expose a public protocol type; Protocol is currently an internal type.
   default Protocol getProtocol() {
     throw new UnsupportedOperationException("getProtocol() is not implemented for this Snapshot");
   }
@@ -147,7 +148,6 @@ public interface Snapshot {
    * @return the {@link Metadata} for this snapshot
    * @since 4.4.0
    */
-  // TODO: expose a public metadata type; Metadata is currently an internal type.
   default Metadata getMetadata() {
     throw new UnsupportedOperationException("getMetadata() is not implemented for this Snapshot");
   }
@@ -175,7 +175,6 @@ public interface Snapshot {
    * @return the table data path
    * @since 4.4.0
    */
-  // TODO: expose a public path type; Path is currently an internal type.
   default Path getDataPath() {
     return new Path(getPath());
   }
@@ -190,7 +189,6 @@ public interface Snapshot {
    * @return the {@code _delta_log} path
    * @since 4.4.0
    */
-  // TODO: expose a public path type; Path is currently an internal type.
   default Path getLogPath() {
     return new Path(getDataPath(), "_delta_log");
   }
@@ -211,6 +209,33 @@ public interface Snapshot {
    */
   default Optional<Long> getLatestTransactionVersion(Engine engine, String applicationId) {
     return Optional.empty();
+  }
+
+  /**
+   * Returns the checksum ({@code CRC}) information for this snapshot if it was loaded from a
+   * checksum file, otherwise empty.
+   *
+   * <p>The default implementation returns {@link Optional#empty()}; {@link
+   * io.delta.kernel.internal.SnapshotImpl} overrides it to return the loaded {@link CRCInfo}.
+   *
+   * @return the {@link CRCInfo} for this snapshot, or empty if no checksum was loaded
+   * @since 4.4.0
+   */
+  default Optional<CRCInfo> getCurrentCrcInfo() {
+    return Optional.empty();
+  }
+
+  /**
+   * Returns the log segment that backs this snapshot.
+   *
+   * <p>The default implementation throws {@link UnsupportedOperationException}; {@link
+   * io.delta.kernel.internal.SnapshotImpl} overrides it.
+   *
+   * @return the {@link LogSegment} for this snapshot
+   * @since 4.4.0
+   */
+  default LogSegment getLogSegment() {
+    throw new UnsupportedOperationException("getLogSegment() is not implemented for this Snapshot");
   }
 
   /**

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Snapshot.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Snapshot.java
@@ -27,6 +27,7 @@ import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.actions.Protocol;
 import io.delta.kernel.internal.checksum.CRCInfo;
 import io.delta.kernel.internal.fs.Path;
+import io.delta.kernel.internal.replay.CreateCheckpointIterator;
 import io.delta.kernel.internal.snapshot.LogSegment;
 import io.delta.kernel.statistics.SnapshotStatistics;
 import io.delta.kernel.transaction.UpdateTableTransactionBuilder;
@@ -129,48 +130,33 @@ public interface Snapshot {
   /**
    * Returns the table protocol at this snapshot.
    *
-   * <p>The default implementation throws {@link UnsupportedOperationException}; {@link
-   * io.delta.kernel.internal.SnapshotImpl} overrides it.
-   *
    * @return the {@link Protocol} for this snapshot
    * @since 4.4.0
    */
-  default Protocol getProtocol() {
-    throw new UnsupportedOperationException("getProtocol() is not implemented for this Snapshot");
-  }
+  Protocol getProtocol();
 
   /**
    * Returns the table metadata at this snapshot.
    *
-   * <p>The default implementation throws {@link UnsupportedOperationException}; {@link
-   * io.delta.kernel.internal.SnapshotImpl} overrides it.
-   *
    * @return the {@link Metadata} for this snapshot
    * @since 4.4.0
    */
-  default Metadata getMetadata() {
-    throw new UnsupportedOperationException("getMetadata() is not implemented for this Snapshot");
-  }
+  Metadata getMetadata();
 
   /**
    * Returns the {@link Committer} used to commit transactions against this snapshot's table.
    *
-   * <p>The default implementation throws {@link UnsupportedOperationException}; {@link
-   * io.delta.kernel.internal.SnapshotImpl} overrides it.
-   *
    * @return the committer for this snapshot
    * @since 4.4.0
    */
-  default Committer getCommitter() {
-    throw new UnsupportedOperationException("getCommitter() is not implemented for this Snapshot");
-  }
+  Committer getCommitter();
 
   /**
-   * Returns the table data path as a {@link Path}.
+   * Returns the table data path, i.e. the same location as {@link #getPath()} in {@link Path} form.
    *
-   * <p>The default implementation wraps {@link #getPath()} in a {@link Path}. {@link
-   * io.delta.kernel.internal.SnapshotImpl} overrides it to return the path used to load the
-   * snapshot (the same value {@link #getPath()} stringifies).
+   * <p>When turning the result back into a string for file paths, use {@link Path#toString()}
+   * rather than {@code toUri().toString()}: the latter percent-encodes special characters, which
+   * breaks resolution for table roots containing e.g. spaces.
    *
    * @return the table data path
    * @since 4.4.0
@@ -182,10 +168,6 @@ public interface Snapshot {
   /**
    * Returns the path to this table's {@code _delta_log} directory.
    *
-   * <p>The default implementation returns {@code new Path(getDataPath(), "_delta_log")}; {@link
-   * io.delta.kernel.internal.SnapshotImpl} overrides it to return the path used to load the
-   * snapshot.
-   *
    * @return the {@code _delta_log} path
    * @since 4.4.0
    */
@@ -196,10 +178,6 @@ public interface Snapshot {
   /**
    * Returns the latest transaction version recorded in the Delta log for the given application id,
    * or empty if none exists.
-   *
-   * <p>The default implementation returns {@link Optional#empty()}; {@link
-   * io.delta.kernel.internal.SnapshotImpl} overrides it to read transaction identifiers from the
-   * log.
    *
    * @param engine the engine to use for IO operations
    * @param applicationId identifier of the application that wrote transaction identifiers into the
@@ -215,8 +193,7 @@ public interface Snapshot {
    * Returns the checksum ({@code CRC}) information for this snapshot if it was loaded from a
    * checksum file, otherwise empty.
    *
-   * <p>The default implementation returns {@link Optional#empty()}; {@link
-   * io.delta.kernel.internal.SnapshotImpl} overrides it to return the loaded {@link CRCInfo}.
+   * <p>An empty result means no checksum was read, not that the table has no checksum file.
    *
    * @return the {@link CRCInfo} for this snapshot, or empty if no checksum was loaded
    * @since 4.4.0
@@ -228,15 +205,20 @@ public interface Snapshot {
   /**
    * Returns the log segment that backs this snapshot.
    *
-   * <p>The default implementation throws {@link UnsupportedOperationException}; {@link
-   * io.delta.kernel.internal.SnapshotImpl} overrides it.
-   *
    * @return the {@link LogSegment} for this snapshot
    * @since 4.4.0
    */
-  default LogSegment getLogSegment() {
-    throw new UnsupportedOperationException("getLogSegment() is not implemented for this Snapshot");
-  }
+  LogSegment getLogSegment();
+
+  /**
+   * Returns an iterator over the actions that should be written into a checkpoint for this
+   * snapshot.
+   *
+   * @param engine the engine to use for IO operations
+   * @return iterator of filtered columnar batches for checkpoint writing
+   * @since 4.4.0
+   */
+  CreateCheckpointIterator getCreateCheckpointIterator(Engine engine);
 
   /**
    * Get per-clustering-column descriptors with the physical column reference (as stored in the

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaHistoryManager.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaHistoryManager.java
@@ -20,6 +20,7 @@ import static io.delta.kernel.internal.TableConfig.*;
 import static io.delta.kernel.internal.fs.Path.getName;
 import static io.delta.kernel.internal.util.Preconditions.checkArgument;
 
+import io.delta.kernel.Snapshot;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.exceptions.KernelException;
 import io.delta.kernel.exceptions.TableNotFoundException;
@@ -72,7 +73,7 @@ public final class DeltaHistoryManager {
       Engine engine,
       Path logPath,
       long millisSinceEpochUTC,
-      SnapshotImpl latestSnapshot,
+      Snapshot latestSnapshot,
       List<ParsedCatalogCommitData> catalogCommits) {
     DeltaHistoryManager.Commit commit =
         DeltaHistoryManager.getActiveCommitAtTimestamp(
@@ -122,7 +123,7 @@ public final class DeltaHistoryManager {
       Engine engine,
       Path logPath,
       long millisSinceEpochUTC,
-      SnapshotImpl latestSnapshot,
+      Snapshot latestSnapshot,
       List<ParsedCatalogCommitData> catalogCommits) {
     return DeltaHistoryManager.getActiveCommitAtTimestamp(
             engine,
@@ -163,7 +164,7 @@ public final class DeltaHistoryManager {
    */
   public static Commit getActiveCommitAtTimestamp(
       Engine engine,
-      SnapshotImpl latestSnapshot,
+      Snapshot latestSnapshot,
       Path logPath,
       long timestamp,
       boolean mustBeRecreatable,
@@ -334,7 +335,7 @@ public final class DeltaHistoryManager {
    *     timestamps enabled, this will be the commit after the latest version. If in-commit
    *     timestamps were enabled for the entire history, this will be `earliestCommit`.
    */
-  private static Commit getICTEnablementCommit(SnapshotImpl snapshot, Commit earliestCommit) {
+  private static Commit getICTEnablementCommit(Snapshot snapshot, Commit earliestCommit) {
     Metadata metadata = snapshot.getMetadata();
     if (!IN_COMMIT_TIMESTAMPS_ENABLED.fromMetadata(metadata)) {
       // Pretend ICT will be enabled after the latest version and requested timestamp.

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/PaginatedScanImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/PaginatedScanImpl.java
@@ -84,6 +84,7 @@ public class PaginatedScanImpl implements PaginatedScan {
     return this.getScanFiles(engine, false /* include stats */);
   }
 
+  @Override
   public PaginatedScanFilesIterator getScanFiles(Engine engine, boolean includeStates) {
     CloseableIterator<FilteredColumnarBatch> filteredScanFilesIter =
         baseScan.getScanFiles(engine, includeStates, Optional.of(paginationContext));

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
@@ -119,6 +119,7 @@ public class ScanImpl implements Scan {
    *
    * @return data in {@link ColumnarBatch} batch format. Each row correspond to one survived file.
    */
+  @Override
   public CloseableIterator<FilteredColumnarBatch> getScanFiles(
       Engine engine, boolean includeStats) {
     return getScanFiles(engine, includeStats, Optional.empty() /* paginationContextOpt */);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
@@ -419,6 +419,7 @@ public class SnapshotImpl implements Snapshot {
   }
 
   /** Returns the crc info for the current snapshot if the checksum file is read */
+  @Override
   public Optional<CRCInfo> getCurrentCrcInfo() {
     return logReplay.getCrcInfoAtSnapshotVersion();
   }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
@@ -423,7 +423,6 @@ public class SnapshotImpl implements Snapshot {
   }
 
   /** Returns the crc info for the current snapshot if the checksum file is read */
-  @Override
   public Optional<CRCInfo> getCurrentCrcInfo() {
     return logReplay.getCrcInfoAtSnapshotVersion();
   }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
@@ -351,14 +351,17 @@ public class SnapshotImpl implements Snapshot {
     return new ReplaceTableTransactionBuilderV2Impl(this, schema, engineInfo);
   }
 
+  @Override
   public Committer getCommitter() {
     return committer;
   }
 
+  @Override
   public Path getLogPath() {
     return logPath;
   }
 
+  @Override
   public Path getDataPath() {
     return dataPath;
   }
@@ -372,6 +375,7 @@ public class SnapshotImpl implements Snapshot {
     return wasBuiltAsLatest;
   }
 
+  @Override
   public Protocol getProtocol() {
     return protocol;
   }
@@ -424,6 +428,7 @@ public class SnapshotImpl implements Snapshot {
     return logReplay.getCrcInfoAtSnapshotVersion();
   }
 
+  @Override
   public Metadata getMetadata() {
     return metadata;
   }
@@ -445,14 +450,14 @@ public class SnapshotImpl implements Snapshot {
 
   /**
    * Get the latest transaction version for given <i>applicationId</i>. This information comes from
-   * the transactions identifiers stored in Delta transaction log. This API is not a public API. For
-   * now keep this internal to enable Flink upgrade to use Kernel.
+   * the transactions identifiers stored in Delta transaction log.
    *
    * @param applicationId Identifier of the application that put transaction identifiers in Delta
    *     transaction log
    * @return Last transaction version or {@link Optional#empty()} if no transaction identifier
    *     exists for this application.
    */
+  @Override
   public Optional<Long> getLatestTransactionVersion(Engine engine, String applicationId) {
     return logReplay.getLatestTransactionIdentifier(engine, applicationId);
   }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
@@ -443,6 +443,7 @@ public class SnapshotImpl implements Snapshot {
     return lazyLogSegment;
   }
 
+  @Override
   public CreateCheckpointIterator getCreateCheckpointIterator(Engine engine) {
     long minFileRetentionTimestampMillis =
         System.currentTimeMillis() - TOMBSTONE_RETENTION.fromMetadata(metadata);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
@@ -423,6 +423,7 @@ public class SnapshotImpl implements Snapshot {
   }
 
   /** Returns the crc info for the current snapshot if the checksum file is read */
+  @Override
   public Optional<CRCInfo> getCurrentCrcInfo() {
     return logReplay.getCrcInfoAtSnapshotVersion();
   }
@@ -432,6 +433,7 @@ public class SnapshotImpl implements Snapshot {
     return metadata;
   }
 
+  @Override
   public LogSegment getLogSegment() {
     return lazyLogSegment.get();
   }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/commitrange/CommitRangeImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/commitrange/CommitRangeImpl.java
@@ -27,7 +27,6 @@ import io.delta.kernel.data.ColumnarBatch;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.internal.DeltaLogActionUtils;
 import io.delta.kernel.internal.TableChangesUtils;
-import io.delta.kernel.internal.annotation.VisibleForTesting;
 import io.delta.kernel.internal.files.ParsedDeltaData;
 import io.delta.kernel.internal.fs.Path;
 import io.delta.kernel.utils.CloseableIterator;
@@ -90,7 +89,7 @@ public class CommitRangeImpl implements CommitRange {
     return endBoundaryOpt;
   }
 
-  @VisibleForTesting
+  @Override
   public List<FileStatus> getDeltaFiles() {
     return deltas.stream().map(ParsedDeltaData::getFileStatus).collect(Collectors.toList());
   }


### PR DESCRIPTION
Surface Kernel accessors that already exist on the `*Impl` classes onto their public interfaces so connectors (Delta Spark) can use them without casting to internal types.

## Summary

Abstract (implementers must provide; a throwing default would be a contract callers can't rely on):
- `Scan.getScanFiles(Engine, boolean includeStats)`
- `Snapshot.getProtocol()`, `getMetadata()`, `getCommitter()`, `getLogSegment()`, `getCreateCheckpointIterator(Engine)`

Default, because the default is a real fallback rather than a throw:
- `Snapshot.getDataPath()` (wraps `getPath()`), `getLogPath()`, `getCurrentCrcInfo()` (empty), `getLatestTransactionVersion(...)` (empty)

Also `CommitRange.getDeltaFiles()`, and `DeltaHistoryManager`'s timestamp-resolution helpers widened from `SnapshotImpl` to `Snapshot`.

**Breaking:** making the six methods abstract is source-breaking for `Scan`/`Snapshot` implementers outside this repo. Both interfaces are `@Evolving` and `kernelApi` is not under Mima. In-tree the only implementers are `ScanImpl`, `PaginatedScanImpl`, and `SnapshotImpl`, which already provide all of them.

Return types that are still internal (`Protocol`, `Metadata`, `Path`, `CRCInfo`, `LogSegment`) match the existing pattern and are tracked by #4820 / #4821. `getClusteringColumnInfos()` keeps its throwing default from 4.3.0 — out of scope here.

Follow-up Spark de-casts: #7273.

## Test plan
- [x] `kernelApi` compile (main + test) + javafmt + checkstyle
- [x] `CommitRangeBuilderSuite` (1161), `PostCommitSnapshotSuite` + `CreateCheckpointSuite` (36), `ScanSuite` (63)
- [ ] CI

## Does this PR introduce any user-facing changes?
Yes — new public Kernel API methods on `Snapshot`, `Scan`, and `CommitRange` (@since 4.4.0). Six are abstract, so third-party implementers of `Scan`/`Snapshot` must add them.
