### PR TITLE
[Spark] Support SQL path-based time travel queries in DSv2

### DIFF
--- a/spark-unified/src/main/java/org/apache/spark/sql/delta/catalog/DeltaCatalog.java
+++ b/spark-unified/src/main/java/org/apache/spark/sql/delta/catalog/DeltaCatalog.java
@@ -17,9 +17,14 @@
 package org.apache.spark.sql.delta.catalog;
 
 import io.delta.spark.internal.v2.catalog.DeltaV2Table;
+import io.delta.spark.internal.v2.exception.TableNotFoundException;
 import io.delta.spark.internal.v2.exception.TimestampOutOfRangeException;
 import io.delta.spark.internal.v2.exception.VersionNotFoundException;
+import io.delta.spark.internal.v2.utils.ScalaUtils;
+import org.apache.spark.sql.delta.DeltaTableUtils$;
+import org.apache.spark.sql.delta.DeltaTimeTravelSpec;
 import org.apache.spark.sql.delta.DeltaV2Mode;
+import org.apache.spark.sql.delta.util.DateTimeUtils$;
 import org.apache.spark.sql.delta.v2.interop.DeltaV2ErrorInterop$;
 import java.util.HashMap;
 import java.util.function.Supplier;
@@ -103,9 +108,50 @@ public class DeltaCatalog extends AbstractDeltaCatalog implements ChangelogSuppo
   @Override
   public Table loadPathTable(Identifier ident) {
     return loadTableInternal(
-        // delta.`/path/to/table`, where ident.name() is `/path/to/table`
-        () -> new DeltaV2Table(ident, ident.name()),
+        // delta.`/path/to/table`, where ident.name() is `/path/to/table`.
+        () -> pinPathTable(ident),
         () -> super.loadPathTable(ident));
+  }
+
+  /**
+   * Builds a Kernel-backed V2 table for a path-based identifier, honoring an `@`-suffix time travel
+   * spec if present.
+   *
+   * <p>Reuses the V1
+   * {@link org.apache.spark.sql.delta.DeltaTableUtils#extractIfPathContainsTimeTravel} helper.
+   *
+   * @param ident The path identifier.
+   * @return A {@link DeltaV2Table} pinned to the requested version/timestamp, or the latest
+   *     snapshot.
+   */
+  private DeltaV2Table pinPathTable(Identifier ident) {
+    scala.Tuple2<String, scala.Option<DeltaTimeTravelSpec>> resolved =
+        DeltaTableUtils$.MODULE$.extractIfPathContainsTimeTravel(
+            spark(), ident.name(), ScalaUtils.toScalaMap(new HashMap<>()));
+    String realPath = resolved._1();
+    scala.Option<DeltaTimeTravelSpec> timeTravelByPath = resolved._2();
+    try {
+      DeltaV2Table table = new DeltaV2Table(ident, realPath);
+      if (timeTravelByPath.isEmpty()) {
+        return table;
+      }
+      DeltaTimeTravelSpec spec = timeTravelByPath.get();
+      if (spec.version().isDefined()) {
+        return table.withVersion((Long) spec.version().get());
+      }
+      long timestampMicros = DateTimeUtils$.MODULE$.fromJavaTimestamp(
+          spec.getTimestamp(spark().sessionState().conf()));
+      return table.withTimestamp(timestampMicros);
+    } catch (TableNotFoundException e) {
+      DeltaV2ErrorInterop$.MODULE$.throwAsDeltaError(e);
+      throw new IllegalStateException("unreachable");
+    } catch (VersionNotFoundException e) {
+      DeltaV2ErrorInterop$.MODULE$.throwAsDeltaError(e);
+      throw new IllegalStateException("unreachable");
+    } catch (TimestampOutOfRangeException e) {
+      DeltaV2ErrorInterop$.MODULE$.throwAsDeltaError(e);
+      throw new IllegalStateException("unreachable");
+    }
   }
 
   /**

--- a/spark-unified/src/main/scala/org/apache/spark/sql/delta/v2/interop/DeltaV2ErrorInterop.scala
+++ b/spark-unified/src/main/scala/org/apache/spark/sql/delta/v2/interop/DeltaV2ErrorInterop.scala
@@ -20,7 +20,7 @@ import java.sql.Timestamp
 
 import org.apache.spark.sql.delta.{DeltaErrors, VersionNotFoundException => V1VersionNotFoundException}
 import org.apache.spark.sql.delta.util.{DateTimeUtils, TimestampFormatter}
-import io.delta.spark.internal.v2.exception.{TimestampOutOfRangeException, VersionNotFoundException}
+import io.delta.spark.internal.v2.exception.{TableNotFoundException, TimestampOutOfRangeException, VersionNotFoundException}
 
 import org.apache.spark.sql.internal.SQLConf
 
@@ -48,4 +48,7 @@ object DeltaV2ErrorInterop {
 
   def throwAsDeltaError(e: VersionNotFoundException): Nothing =
     throw V1VersionNotFoundException(e.getUserVersion, e.getEarliest, e.getLatest)
+
+  def throwAsDeltaError(e: TableNotFoundException): Nothing =
+    throw DeltaErrors.pathNotExistsException(e.getTablePath)
 }

--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaHistoryManagerV2Suite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaHistoryManagerV2Suite.scala
@@ -32,6 +32,8 @@ import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.parser.ParseException
+import org.apache.spark.sql.execution.FileSourceScanExec
+import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 
 /**
  * DSv2 parity tests for time travel queries exercising the STRICT-mode Kernel-backed connector
@@ -496,6 +498,406 @@ class DeltaHistoryManagerV2Suite extends DeltaTimeTravelTestHelpers {
         } finally {
           q.stop()
         }
+      }
+    }
+  }
+
+  test("SQL path-based VERSION AS OF returns the historical snapshot") {
+    withTempDir { dir =>
+      val tbl = "delta_tt_v2_path"
+      val path = dir.getCanonicalPath
+      withTable(tbl) {
+        val start = System.currentTimeMillis() - 5.days.toMillis
+        inV1 { generateCommitsAtPath(tbl, path, start, start + 20.minutes) }
+
+        checkAnswer(
+          sql(s"SELECT * FROM delta.`$path` FOR VERSION AS OF 0"), spark.range(0, 10).toDF())
+        checkAnswer(
+          sql(s"SELECT * FROM delta.`$path` VERSION AS OF 1"), spark.range(0, 20).toDF())
+      }
+    }
+  }
+
+  test("SQL path-based VERSION AS OF past the latest version fails with DELTA_VERSION_NOT_FOUND") {
+    withTempDir { dir =>
+      val tbl = "delta_tt_v2_path_notfound"
+      val path = dir.getCanonicalPath
+      withTable(tbl) {
+        val start = System.currentTimeMillis() - 5.days.toMillis
+        inV1 { generateCommitsAtPath(tbl, path, start, start + 20.minutes) }
+
+        val ex = intercept[VersionNotFoundException] {
+          sql(s"SELECT * FROM delta.`$path` FOR VERSION AS OF 2").collect()
+        }
+        checkError(
+          ex,
+          "DELTA_VERSION_NOT_FOUND",
+          sqlState = "22003",
+          parameters = Map("userVersion" -> "2", "earliest" -> "0", "latest" -> "1"))
+      }
+    }
+  }
+
+  test("SQL path-based VERSION AS OF across multiple versions in one query (relation caching)") {
+    withTempDir { dir =>
+      val tbl = "delta_tt_v2_path_cache"
+      val path = dir.getCanonicalPath
+      withTable(tbl) {
+        inV1 {
+          sql(s"CREATE TABLE $tbl USING delta LOCATION '$path' AS SELECT 1 AS c")
+          sql(s"INSERT INTO $tbl SELECT 2 AS c")
+        }
+        checkAnswer(
+          sql(s"SELECT * FROM delta.`$path` VERSION AS OF '0' " +
+            s"UNION ALL SELECT * FROM delta.`$path` VERSION AS OF '1'"),
+          Row(1) :: Row(1) :: Row(2) :: Nil)
+      }
+    }
+  }
+
+  test("SQL path-based VERSION AS OF reflects historical column defaults") {
+    withTempDir { dir =>
+      val tbl = "delta_tt_v2_path_defaults"
+      val path = dir.getCanonicalPath
+      withTable(tbl) {
+        inV1 {
+          sql(s"CREATE TABLE $tbl(id long) USING delta LOCATION '$path' " +
+            "TBLPROPERTIES('delta.feature.allowColumnDefaults' = 'enabled')")
+          sql(s"INSERT INTO $tbl SELECT default")
+          sql(s"ALTER TABLE $tbl ALTER COLUMN id SET DEFAULT 42")
+          sql(s"INSERT INTO $tbl SELECT default")
+        }
+        checkAnswer(sql(s"SELECT * FROM delta.`$path` FOR VERSION AS OF 0"), Seq.empty[Row])
+        checkAnswer(sql(s"SELECT * FROM delta.`$path` FOR VERSION AS OF 1"), Seq(Row(null)))
+        checkAnswer(sql(s"SELECT * FROM delta.`$path`"), Seq(Row(null), Row(42L)))
+      }
+    }
+  }
+
+  test("SQL path-based VERSION AS OF below the earliest recreatable commit fails") {
+    withTempDir { dir =>
+      val tbl = "delta_tt_v2_path_recreatable"
+      val path = dir.getCanonicalPath
+      withTable(tbl) {
+        val start = System.currentTimeMillis() - 5.days.toMillis
+        inV1 {
+          // v0, v1, v2. Checkpoint at v2, then delete v0's commit file
+          generateCommitsAtPath(tbl, path, start, start + 20.minutes, start + 40.minutes)
+          val deltaLog = DeltaLog.forTable(spark, path)
+          deltaLog.checkpoint(deltaLog.update())
+          new File(FileNames.unsafeDeltaFile(deltaLog.logPath, 0).toUri).delete()
+        }
+
+        val ex = intercept[VersionNotFoundException] {
+          sql(s"SELECT * FROM delta.`$path` VERSION AS OF 1").collect()
+        }
+        checkError(
+          ex,
+          "DELTA_VERSION_NOT_FOUND",
+          sqlState = "22003",
+          parameters = Map("userVersion" -> "1", "earliest" -> "2", "latest" -> "2"))
+      }
+    }
+  }
+
+  test("SQL path-based VERSION AS OF a negative version is rejected by the parser") {
+    withTempDir { dir =>
+      val tbl = "delta_tt_v2_path_negative"
+      val path = dir.getCanonicalPath
+      withTable(tbl) {
+        inV1 { generateCommitsAtPath(tbl, path, System.currentTimeMillis() - 5.days.toMillis) }
+        intercept[ParseException] {
+          sql(s"SELECT * FROM delta.`$path` VERSION AS OF -1").collect()
+        }
+      }
+    }
+  }
+
+  test("SQL path-based VERSION AS OF on a non-existent path fails with DELTA_PATH_DOES_NOT_EXIST") {
+    withTempDir { dir =>
+      val path = new File(dir, "does_not_exist").getCanonicalPath
+      val ex = intercept[AnalysisException] {
+        sql(s"SELECT * FROM delta.`$path` VERSION AS OF 0").collect()
+      }
+      assert(ex.getCondition === "DELTA_PATH_DOES_NOT_EXIST")
+      assert(ex.getMessage.contains(path))
+    }
+  }
+
+  test("SQL path-based VERSION AS OF reflects the historical schema before a column was added") {
+    withTempDir { dir =>
+      val tbl = "delta_tt_v2_path_schema"
+      val path = dir.getCanonicalPath
+      withTable(tbl) {
+        inV1 {
+          sql(s"CREATE TABLE $tbl (id INT) USING delta LOCATION '$path'") // v0
+          sql(s"INSERT INTO $tbl VALUES (1)")                             // v1
+          sql(s"ALTER TABLE $tbl ADD COLUMNS (name STRING)")              // v2
+          sql(s"INSERT INTO $tbl VALUES (2, 'b')")                        // v3
+        }
+        val atV1 = sql(s"SELECT * FROM delta.`$path` VERSION AS OF 1")
+        assert(atV1.schema.fieldNames.toSeq === Seq("id"))
+        checkAnswer(atV1, Row(1))
+        assert(sql(s"SELECT * FROM delta.`$path`").schema.fieldNames.toSeq === Seq("id", "name"))
+        checkAnswer(sql(s"SELECT * FROM delta.`$path`"), Row(1, null) :: Row(2, "b") :: Nil)
+      }
+    }
+  }
+
+  test("SQL path-based VERSION AS OF after VACUUM removed the data files fails") {
+    withTempDir { dir =>
+      val tbl = "delta_tt_v2_path_vacuum"
+      val path = dir.getCanonicalPath
+      withTable(tbl) {
+        val start = System.currentTimeMillis() - 5.days.toMillis
+        inV1 {
+          generateCommitsAtPath(tbl, path, start, start + 20.minutes)  // v0, v1
+          sql(s"OPTIMIZE delta.`$path`")  // the v0/v1 data files become unreferenced
+          withSQLConf("spark.databricks.delta.retentionDurationCheck.enabled" -> "false") {
+            sql(s"VACUUM delta.`$path` RETAIN 0 HOURS")
+          }
+        }
+        val ex = intercept[Exception] {
+          sql(s"SELECT * FROM delta.`$path` VERSION AS OF 0").collect()
+        }
+        val causes = Iterator.iterate(ex: Throwable)(_.getCause).takeWhile(_ != null).toList
+        assert(
+          causes.exists { c =>
+            c.isInstanceOf[FileNotFoundException] || c.isInstanceOf[IOException]
+          },
+          "expected a missing-data-file read failure, got:\n" +
+            causes.map(c => s"  [${c.getClass.getName}] ${c.getMessage}").mkString("\n"))
+      }
+    }
+  }
+
+  test("SQL path-based TIMESTAMP AS OF resolves to the commit active at that time") {
+    withTempDir { dir =>
+      val tbl = "delta_tt_v2_path_ts"
+      val path = dir.getCanonicalPath
+      withTable(tbl) {
+        val start = System.currentTimeMillis() - 5.days.toMillis
+        inV1 { generateCommitsAtPath(tbl, path, start, start + 20.minutes, start + 40.minutes) }
+
+        val q = s"delta.`$path`"
+        // A string-literal timestamp is required.
+        def countAsOf(millis: Long): DataFrame =
+          sql(s"SELECT count(*) FROM ${timestampAsOf(q, s"'${timestampString(millis)}'")}")
+        // A timestamp between commits resolves to the commit active at that time.
+        checkAnswer(countAsOf(start + 10.minutes), Row(10L))
+        checkAnswer(countAsOf(start + 30.minutes), Row(20L))
+        // Exact commit timestamps resolve to that commit.
+        checkAnswer(countAsOf(start), Row(10L))
+        checkAnswer(countAsOf(start + 20.minutes), Row(20L))
+      }
+    }
+  }
+
+  test("SQL path-based TIMESTAMP AS OF after the latest commit fails " +
+      "with DELTA_TIMESTAMP_GREATER_THAN_COMMIT") {
+    withTempDir { dir =>
+      val tbl = "delta_tt_v2_path_ts_err"
+      val path = dir.getCanonicalPath
+      withTable(tbl) {
+        val start = 1540415658000L
+        inV1 { generateCommitsAtPath(tbl, path, start) }
+
+        val ts = Seq(new Timestamp(start + 10.minutes)).toDF("ts")
+          .select($"ts".cast("string")).as[String].collect().map(i => s"'$i'")
+
+        val ex = intercept[DeltaErrors.TemporallyUnstableInputException] {
+          sql(s"SELECT count(*) FROM ${timestampAsOf(s"delta.`$path`", ts(0))}").collect()
+        }
+        checkError(
+          ex,
+          "DELTA_TIMESTAMP_GREATER_THAN_COMMIT",
+          sqlState = "42816",
+          parameters = Map(
+            "providedTimestamp" -> "2018-10-24 14:24:18.0",
+            "lastCommitTimestamp" -> "2018-10-24 14:14:18.0",
+            "maximumTimestamp" -> "2018-10-24 14:14:18"))
+      }
+    }
+  }
+
+  test("SQL path-based TIMESTAMP AS OF before the earliest recreatable commit fails") {
+    withTempDir { dir =>
+      val tbl = "delta_tt_v2_path_ts_recreatable"
+      val path = dir.getCanonicalPath
+      withTable(tbl) {
+        val start = System.currentTimeMillis() - 5.days.toMillis
+        inV1 {
+          // v0, v1, v2. Checkpoint at v2, then delete v0's commit file.
+          generateCommitsAtPath(tbl, path, start, start + 20.minutes, start + 40.minutes)
+          val deltaLog = DeltaLog.forTable(spark, path)
+          deltaLog.checkpoint(deltaLog.update())
+          new File(FileNames.unsafeDeltaFile(deltaLog.logPath, 0).toUri).delete()
+        }
+
+        val ts = Seq(new Timestamp(start)).toDF("ts")
+          .select($"ts".cast("string")).as[String].head()
+        val ex = intercept[DeltaErrors.TimestampEarlierThanCommitRetentionException] {
+          sql(s"SELECT * FROM ${timestampAsOf(s"delta.`$path`", s"'$ts'")}").collect()
+        }
+        assert(ex.getCondition === "DELTA_TIMESTAMP_EARLIER_THAN_COMMIT_RETENTION")
+        assert(ex.getSqlState === "42816")
+      }
+    }
+  }
+
+  test("SQL path-based TIMESTAMP AS OF reflects the historical schema before a column was added") {
+    withTempDir { dir =>
+      val tbl = "delta_tt_v2_path_ts_schema"
+      val path = dir.getCanonicalPath
+      val start = System.currentTimeMillis() - 5.days.toMillis
+      withTable(tbl) {
+        inV1 {
+          sql(s"CREATE TABLE $tbl (id INT) USING delta LOCATION '$path'") // v0
+          sql(s"INSERT INTO $tbl VALUES (1)")                             // v1
+          sql(s"ALTER TABLE $tbl ADD COLUMNS (name STRING)")              // v2
+          sql(s"INSERT INTO $tbl VALUES (2, 'b')")                        // v3
+          // Pin deterministic commit timestamps.
+          val deltaLog = DeltaLog.forTable(spark, path)
+          Seq(0L, 1L, 2L, 3L).foreach { v =>
+            modifyCommitTimestamp(deltaLog, v, start + v * 20.minutes)
+          }
+        }
+
+        val ts = Seq(new Timestamp(start + 30.minutes)).toDF("ts")
+          .select($"ts".cast("string")).as[String].head()
+        val atV1 = sql(s"SELECT * FROM ${timestampAsOf(s"delta.`$path`", s"'$ts'")}")
+        assert(atV1.schema.fieldNames.toSeq === Seq("id"))
+        checkAnswer(atV1, Row(1))
+        assert(sql(s"SELECT * FROM delta.`$path`").schema.fieldNames.toSeq === Seq("id", "name"))
+      }
+    }
+  }
+
+  test("SQL path-based TIMESTAMP AS OF rejects a non-literal timestamp expression") {
+    withTempDir { dir =>
+      val tbl = "delta_tt_v2_path_ts_expr"
+      val path = dir.getCanonicalPath
+      withTable(tbl) {
+        val ts = inV1 {
+          spark.range(10).write.format("delta").option("path", path).saveAsTable(tbl)
+          sql(s"DESCRIBE HISTORY delta.`$path`").select("timestamp").head().getTimestamp(0)
+        }
+        val ex = intercept[AnalysisException] {
+          sql(s"SELECT count(*) FROM delta.`$path` TIMESTAMP AS OF " +
+            s"coalesce(CAST ('$ts' AS TIMESTAMP), current_date())").collect()
+        }
+        assert(ex.getCondition === "UNSUPPORTED_DATASOURCE_FOR_DIRECT_QUERY")
+      }
+    }
+  }
+
+  test("SQL path-based time travel resolves through the native V2 connector (BatchScan)") {
+    withTempDir { dir =>
+      val tbl = "delta_tt_v2_path_planshape"
+      val path = dir.getCanonicalPath
+      withTable(tbl) {
+        val start = System.currentTimeMillis() - 5.days.toMillis
+        inV1 { generateCommitsAtPath(tbl, path, start, start + 20.minutes) }
+
+        val plan = sql(s"SELECT * FROM delta.`$path` VERSION AS OF 0").queryExecution.executedPlan
+        assert(
+          plan.collectFirst { case b: BatchScanExec => b }.isDefined,
+          "expected a native DSv2 BatchScan (not a V1 FileSourceScanExec), got:\n" + plan)
+        assert(
+          plan.collectFirst { case f: FileSourceScanExec => f }.isEmpty,
+          "unexpected V1 FileSourceScanExec in the plan:\n" + plan)
+      }
+    }
+  }
+
+  test("SQL path @-syntax VERSION returns the historical snapshot") {
+    withTempDir { dir =>
+      val tbl = "delta_tt_v2_at_ver"
+      val path = dir.getCanonicalPath
+      withTable(tbl) {
+        val start = System.currentTimeMillis() - 5.days.toMillis
+        inV1 { generateCommitsAtPath(tbl, path, start, start + 20.minutes) }
+
+        checkAnswer(
+          sql(s"SELECT * FROM delta.`${identifierWithVersion(path, 0)}`"),
+          spark.range(0, 10).toDF())
+        checkAnswer(
+          sql(s"SELECT * FROM delta.`${identifierWithVersion(path, 1)}`"),
+          spark.range(0, 20).toDF())
+      }
+    }
+  }
+
+  test("SQL path @-syntax VERSION past the latest version fails with DELTA_VERSION_NOT_FOUND") {
+    withTempDir { dir =>
+      val tbl = "delta_tt_v2_at_ver_notfound"
+      val path = dir.getCanonicalPath
+      withTable(tbl) {
+        val start = System.currentTimeMillis() - 5.days.toMillis
+        inV1 { generateCommitsAtPath(tbl, path, start, start + 20.minutes) }
+
+        val ex = intercept[VersionNotFoundException] {
+          sql(s"SELECT * FROM delta.`${identifierWithVersion(path, 2)}`").collect()
+        }
+        checkError(
+          ex,
+          "DELTA_VERSION_NOT_FOUND",
+          sqlState = "22003",
+          parameters = Map("userVersion" -> "2", "earliest" -> "0", "latest" -> "1"))
+      }
+    }
+  }
+
+  test("SQL path @-syntax TIMESTAMP resolves to the commit active at that time") {
+    withTempDir { dir =>
+      val tbl = "delta_tt_v2_at_ts"
+      val path = dir.getCanonicalPath
+      withTable(tbl) {
+        val start = System.currentTimeMillis() - 5.days.toMillis
+        inV1 { generateCommitsAtPath(tbl, path, start, start + 20.minutes, start + 40.minutes) }
+
+        // A timestamp between commits resolves to the commit active at that time.
+        checkAnswer(
+          sql(s"SELECT count(*) FROM delta.`${identifierWithTimestamp(path, start + 10.minutes)}`"),
+          Row(10L))
+        checkAnswer(
+          sql(s"SELECT count(*) FROM delta.`${identifierWithTimestamp(path, start + 30.minutes)}`"),
+          Row(20L))
+      }
+    }
+  }
+
+  test("SQL path @-syntax does not time travel a valid path whose name contains @vN") {
+    withTempDir { dir =>
+      // A real directory literally named `base@v0` which contains the table.
+      val path = new File(dir, "base@v0").getCanonicalPath
+      val tbl = "delta_tt_v2_at_literal"
+      withTable(tbl) {
+        inV1 { generateCommitsAtPath(tbl, path, System.currentTimeMillis() - 5.days.toMillis) }
+        inV1 { spark.range(10, 20).write.format("delta").mode("append").save(path) }
+
+        checkAnswer(
+          sql(s"SELECT * FROM delta.`$path`"), spark.range(0, 20).toDF())
+      }
+    }
+  }
+
+  test("SQL path @-syntax resolves through the native V2 connector (BatchScan)") {
+    withTempDir { dir =>
+      val tbl = "delta_tt_v2_at_planshape"
+      val path = dir.getCanonicalPath
+      withTable(tbl) {
+        val start = System.currentTimeMillis() - 5.days.toMillis
+        inV1 { generateCommitsAtPath(tbl, path, start, start + 20.minutes) }
+
+        val plan = sql(s"SELECT * FROM delta.`${identifierWithVersion(path, 0)}`")
+          .queryExecution.executedPlan
+        assert(
+          plan.collectFirst { case b: BatchScanExec => b }.isDefined,
+          "expected a native DSv2 BatchScan (not a V1 FileSourceScanExec), got:\n" + plan)
+        assert(
+          plan.collectFirst { case f: FileSourceScanExec => f }.isEmpty,
+          "unexpected V1 FileSourceScanExec in the plan:\n" + plan)
       }
     }
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
@@ -516,6 +516,7 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
     DeltaTableV2(spark, new Path(ident.name()))
   }
 
+
   private def getProvider(properties: util.Map[String, String]): String = {
     Option(properties.get("provider"))
       .getOrElse(spark.sessionState.conf.getConf(SQLConf.DEFAULT_DATA_SOURCE_NAME))

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaHistoryManagerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaHistoryManagerSuite.scala
@@ -79,6 +79,12 @@ trait DeltaTimeTravelTestHelpers extends QueryTest
     // TODO: would be great to verify our logging metrics
   }
 
+  protected def identifierWithTimestamp(identifier: String, ts: Long): String = {
+    s"$identifier@${timeFormatter.format(new Date(ts))}"
+  }
+  protected def identifierWithVersion(identifier: String, v: Long): String = {
+    s"$identifier@v$v"
+  }
   protected def getTableLocation(table: String): String = {
     spark.sessionState.catalog.getTableMetadata(TableIdentifier(table)).location.toString
   }

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
@@ -28,6 +28,7 @@ import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.internal.rowtracking.RowTracking;
 import io.delta.spark.internal.v2.adapters.KernelMetadataAdapter;
 import io.delta.spark.internal.v2.adapters.KernelProtocolAdapter;
+import io.delta.spark.internal.v2.exception.TableNotFoundException;
 import io.delta.spark.internal.v2.exception.TimestampOutOfRangeException;
 import io.delta.spark.internal.v2.read.DeltaV2ScanUtils;
 import io.delta.spark.internal.v2.read.MetadataEvolutionHandler;
@@ -238,10 +239,15 @@ public class DeltaV2Table extends DeltaV2TableShims
         SparkSession.active().sessionState().newHadoopConfWithOptions(toScalaMap(options));
     this.kernelEngine = DefaultEngine.create(this.hadoopConf);
     this.snapshotManager = SnapshotManagerFactory.create(tablePath, kernelEngine, catalogTable);
-    this.initialSnapshot =
-        timeTravelVersion.isPresent()
-            ? loadSnapshotAtCheckedVersion(snapshotManager, timeTravelVersion.getAsLong())
-            : snapshotManager.loadLatestSnapshot();
+    try {
+      this.initialSnapshot =
+          timeTravelVersion.isPresent()
+              ? loadSnapshotAtCheckedVersion(snapshotManager, timeTravelVersion.getAsLong())
+              : snapshotManager.loadLatestSnapshot();
+    } catch (io.delta.kernel.exceptions.TableNotFoundException e) {
+      // Rethrow as the Delta-module wrapper so catalog/interop layer never names a Kernel type.
+      throw new TableNotFoundException(tablePath);
+    }
 
     this.isCDCRead = CDCReader.isCDCRead(new CaseInsensitiveStringMap(this.options));
 

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/exception/TableNotFoundException.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/exception/TableNotFoundException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.exception;
+
+/** Exception thrown when no Delta table exists at the requested path. */
+public class TableNotFoundException extends RuntimeException {
+
+  private final String tablePath;
+
+  public TableNotFoundException(String tablePath) {
+    super(String.format("Delta table does not exist at path: %s.", tablePath));
+    this.tablePath = tablePath;
+  }
+
+  public String getTablePath() {
+    return tablePath;
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Adds support for SQL path-based time travel in the DSv2 (Kernel-backed) connector:

- `SELECT ... FROM path VERSION AS OF <N>` / `TIMESTAMP AS OF <TS>` (and the `@vN` / `@<ts>` path suffix) now resolve to the pinned snapshot.
- `loadPathTable` strips the `@` suffix (reusing `DeltaTableUtils.extractIfPathContainsTimeTravel`) and pins the `DeltaV2Table` via `withVersion` / `withTimestamp`.
- A non-existent path surfaces as `DELTA_PATH_DOES_NOT_EXIST`.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

Added path-based time travel cases to `DeltaHistoryManagerV2Suite`, additionally tested through the DSv2 connector's existing read paths.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No