### PR TITLE
[Spark] Distribute AMT checkpoint state reconstruction across leaves

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTCheckpointProvider.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTCheckpointProvider.scala
@@ -18,11 +18,10 @@ package org.apache.spark.sql.delta.amt
 
 import org.apache.spark.sql.delta.{CheckpointPolicy, CheckpointProvider, DeltaLog, DeltaLogFileIndex, Snapshot}
 import org.apache.spark.sql.delta.DeltaLogFileIndex.COMMIT_VERSION_COLUMN
-import org.apache.spark.sql.delta.actions.{AddFile, Checkpoint, ContentRoot, SingleAction}
-import org.apache.spark.sql.delta.stats.DeltaStatistics
+import org.apache.spark.sql.delta.actions.{Checkpoint, ContentRoot, SingleAction}
 import org.apache.hadoop.fs.{FileStatus, Path}
 
-import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.{DataFrame, Dataset, SparkSession}
 import org.apache.spark.sql.functions.{col, lit}
 import org.apache.spark.sql.types.StructType
 
@@ -83,43 +82,51 @@ final class AMTCheckpointProvider(
 
   override def loadActionsForStateReconstruction(
       spark: SparkSession, deltaLog: DeltaLog): Option[DataFrame] = {
-    val tableRoot = deltaLog.dataPath
-    val dataEntries = if (leaves.isEmpty) {
-      Seq.empty
-    } else {
-      AMTCheckpointProvider
-        .readAMTEntries(spark, deltaLog, leaves.map(l => new Path(l.path)))
-        .filter(_.content_type == AMTSingleAction.ContentType.Type.Data)
-    }
-    val addActions = dataEntries.map { entry =>
-      val dv = entry.deletion_vector.map(DeletionVector.toDescriptor(_, tableRoot)).orNull
-      // `record_count` (Iceberg field 103) and the Delta `numRecords` statistic are both the
-      // physical row count (total records in the file, including DV-deleted rows), so store it
-      // directly.
-      val stats = s"""{"${DeltaStatistics.NUM_RECORDS}":${entry.record_count}}"""
-      val add = AddFile(
-        path = entry.location,
-        partitionValues = entry.partition.values.getOrElse(Map.empty),
-        size = entry.file_size_in_bytes,
-        modificationTime = 0L,
-        dataChange = false,
-        stats = stats,
-        deletionVector = dv,
-        baseRowId = entry.tracking.first_row_id,
-        defaultRowCommitVersion = entry.tracking.sequence_number)
-      SingleAction(add = add)
-    }
-    val nonFileActions =
-      Seq(
-        SingleAction(protocol = checkpointAction.protocol),
-        SingleAction(metaData = checkpointAction.metaData)) ++
-      checkpointAction.domainMetadata.map(dm => SingleAction(domainMetadata = dm)) ++
-      checkpointAction.txns.map(txn => SingleAction(txn = txn))
-    import org.apache.spark.sql.delta.implicits._
-    val df = spark.createDataset(addActions ++ nonFileActions).toDF()
+    val df = allActions(spark, deltaLog).toDF()
       .withColumn(COMMIT_VERSION_COLUMN, lit(version))
       .withColumn(Snapshot.ADD_STATS_TO_USE_COL_NAME, col("add.stats"))
     Some(df)
+  }
+  /**
+   * The full action set of this checkpoint as a distributed [[Dataset]] of [[SingleAction]]: the
+   * live file `AddFile`s reconstructed from the AMT(root + leaves), unioned with the inline
+   * non-content actions (protocol, metadata, domain metadata, txns) built on the driver.
+   *
+   * Note: Iceberg metadata inheritance (manifest entries inheriting fields such as partition
+   * values, sequence numbers, or snapshot id from the parent manifest) is not supported yet;
+   * entries are read as fully materialized rows.
+   */
+  private def allActions(spark: SparkSession, deltaLog: DeltaLog): Dataset[SingleAction] = {
+    import org.apache.spark.sql.delta.implicits._
+    val nonFileActions = spark.createDataset(nonContentSingleActions)
+    liveAddSingleActions(spark, deltaLog).union(nonFileActions)
+  }
+
+  /** The inline, non-content actions carried directly on the [[Checkpoint]] action. */
+  private def nonContentSingleActions: Seq[SingleAction] =
+    Seq(
+      SingleAction(protocol = checkpointAction.protocol),
+      SingleAction(metaData = checkpointAction.metaData)) ++
+    checkpointAction.domainMetadata.map(dm => SingleAction(domainMetadata = dm)) ++
+    checkpointAction.txns.map(txn => SingleAction(txn = txn))
+
+  /**
+   * Reconstructs the live-file AddFile actions from the AMT as a [[Dataset]].
+   */
+  private def liveAddSingleActions(
+      spark: SparkSession, deltaLog: DeltaLog): Dataset[SingleAction] = {
+    import org.apache.spark.sql.delta.implicits._
+    val tableRoot = deltaLog.dataPath
+    val paths = new Path(contentRoot.path) +: leaves.map(l => new Path(l.path))
+    AMTCheckpointProvider.loadEntries(spark, deltaLog, paths)
+      .where(col("content_type") === lit(AMTSingleAction.ContentType.Type.Data))
+      .map { entry =>
+        entry.unwrap match {
+          case data: DataEntry => SingleAction(add = data.toAddFile(tableRoot))
+          case other => throw new IllegalStateException(
+            s"Expected a DATA entry after filtering, got ${other.getClass.getSimpleName}.")
+        }
+      }
   }
 }
 
@@ -148,7 +155,10 @@ object AMTCheckpointProvider {
       spark: SparkSession,
       deltaLog: DeltaLog,
       checkpoint: Checkpoint): AMTCheckpointProvider = {
-    val leaves = readAMTEntries(spark, deltaLog, Seq(new Path(checkpoint.contentRoot.path)))
+    // The root manifest is small (one row per leaf), so collect it to the driver to enumerate the
+    // leaf pointers.
+    val rootPath = new Path(checkpoint.contentRoot.path)
+    val leaves = loadEntries(spark, deltaLog, Seq(rootPath)).collect().toSeq
       .filter(_.content_type == AMTSingleAction.ContentType.Type.DataManifest)
       .map(row => LeafInfo(
         path = row.location,
@@ -158,18 +168,15 @@ object AMTCheckpointProvider {
   }
 
   /**
-   * Reads AMT manifest parquet files (root or leaves) into [[AMTSingleAction]] rows. Uses
-   * `deltaLog.loadIndex` rather than `spark.read.parquet`: these files live under the table root,
-   * so a path-based parquet read would trip Delta's table-root format check.
+   * Reads AMT manifest parquet files (root or leaves) into a [[Dataset]] of
+   * [[AMTSingleAction]].
    */
-  private def readAMTEntries(
-      spark: SparkSession, deltaLog: DeltaLog, paths: Seq[Path]): Seq[AMTSingleAction] = {
+  private def loadEntries(
+      spark: SparkSession, deltaLog: DeltaLog, paths: Seq[Path]): Dataset[AMTSingleAction] = {
     import org.apache.spark.sql.delta.implicits._
     val fs = paths.head.getFileSystem(deltaLog.newDeltaHadoopConf())
     val index = DeltaLogFileIndex(DeltaLogFileIndex.CHECKPOINT_FILE_FORMAT_PARQUET, fs, paths)
     deltaLog.loadIndex(index, spark.emptyDataset[AMTSingleAction].schema)
       .as[AMTSingleAction]
-      .collect()
-      .toSeq
   }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/actions.scala
@@ -21,6 +21,7 @@ import java.util.UUID
 import scala.util.Try
 
 import org.apache.spark.sql.delta.actions.{AddFile, DeletionVectorDescriptor}
+import org.apache.spark.sql.delta.stats.DeltaStatistics
 import org.apache.spark.sql.delta.storage.dv.DeletionVectorStore
 import org.apache.hadoop.fs.Path
 
@@ -250,6 +251,23 @@ case class DataEntry(
     key_metadata = key_metadata,
     split_offsets = split_offsets,
     column_files = column_files)
+
+  def toAddFile(tableRoot: Path): AddFile = {
+    val dv = deletion_vector.map(DeletionVector.toDescriptor(_, tableRoot)).orNull
+    // `record_count` (Iceberg field 103) and the Delta `numRecords` statistic are both the physical
+    // row count (total records in the file, including DV-deleted rows), so store it directly.
+    val stats = s"""{"${DeltaStatistics.NUM_RECORDS}":$record_count}"""
+    AddFile(
+      path = location,
+      partitionValues = partition.values.getOrElse(Map.empty),
+      size = file_size_in_bytes,
+      modificationTime = 0L,
+      dataChange = false,
+      stats = stats,
+      deletionVector = dv,
+      baseRowId = tracking.first_row_id,
+      defaultRowCommitVersion = tracking.sequence_number)
+  }
 }
 
 object DataEntry {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotSuite.scala
@@ -16,12 +16,15 @@
 
 package org.apache.spark.sql.delta.amt
 
-import org.apache.spark.sql.delta.{DeletionVectorsTestUtils, DeltaOperations}
-import org.apache.spark.sql.delta.actions.{AddFile, DeletionVectorDescriptor}
+import org.apache.spark.sql.delta.{Checkpoints, DeletionVectorsTestUtils, DeltaLog, DeltaOperations}
+import org.apache.spark.sql.delta.actions.{AddFile, Checkpoint, ContentRoot, DeletionVectorDescriptor}
 import org.apache.spark.sql.delta.deletionvectors.RoaringBitmapArray
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.util.FileNames
+import org.apache.hadoop.fs.Path
 
 import org.apache.spark.sql.Row
+import org.apache.spark.sql.execution.datasources.LogicalRelation
 
 /**
  * Verifies that [[Snapshot]] APIs correct results on AMT tables.
@@ -171,5 +174,111 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
       assert(reconstructed.head.numLogicalRecords.contains(1L),
         "Reconstructed logical record count must match the committed file.")
     }
+  }
+
+  test("distributed reconstruction reads across multiple leaves via a file scan") {
+    withTable("amt_dist_multileaf") {
+      val name = "amt_dist_multileaf"
+      // Pack at most 2 entries per leaf so 5 files span multiple leaves; the distributed read must
+      // fan out across all leaf parquet files and union their entries.
+      withSQLConf(DeltaSQLConf.AMT_ENTRIES_PER_LEAF.key -> "2") {
+        createAMTTable(name, checkpointInterval = 5)
+        (1 to 5).foreach(i => sql(s"INSERT INTO $name VALUES ($i)")) // v5: emit.
+      }
+      val snapshot = deltaLogForName(name).unsafeVolatileSnapshot
+      val provider = amtProvider(snapshot).getOrElse(fail("expected AMTCheckpointProvider"))
+      assert(provider.leaves.size >= 2,
+        "entriesPerLeaf=2 with 5 files must produce multiple leaves.")
+      checkAnswer(spark.read.table(name), (1 to 5).map(Row(_)))
+      val committedPaths = snapshot.allFiles.select("path").as[String].collect().toSet
+      assert(committedPaths.size == 5)
+      val df = provider.loadActionsForStateReconstruction(spark, snapshot.deltaLog)
+        .getOrElse(fail("AMT provider must contribute leaf-derived actions."))
+
+      // The leaves must be read through a distributed parquet scan, not a driver-side collected
+      // LocalRelation.
+      val hasFileScan = df.queryExecution.optimizedPlan.collectFirst {
+        case l: LogicalRelation => l
+      }.isDefined
+      assert(hasFileScan,
+        "Reconstruction must read the leaves through a distributed file scan, " +
+          "not collect them to the driver.")
+
+      val addPaths = df.where("add is not null").select("add.path").as[String].collect().toSet
+      assert(addPaths == committedPaths,
+        "Reconstruction must surface every leaf entry exactly once across leaves.")
+      assert(df.where("protocol.minReaderVersion is not null").count() == 1,
+        "Reconstruction must carry the inline protocol action.")
+      assert(df.where("metaData.id is not null").count() == 1,
+        "Reconstruction must carry the inline metadata action.")
+    }
+  }
+
+  test("reconstruction surfaces DATA entries that live directly in the root") {
+    withTable("amt_root_data") {
+      val name = "amt_root_data"
+      createAMTTable(name, checkpointInterval = 2)
+      sql(s"INSERT INTO $name VALUES (1)") // v1.
+      sql(s"INSERT INTO $name VALUES (2)") // v2: emit -> a real root + leaf.
+
+      val deltaLog = deltaLogForName(name)
+      val provider = amtProvider(deltaLog.unsafeVolatileSnapshot)
+        .getOrElse(fail("expected AMTCheckpointProvider"))
+      val tableRoot = deltaLog.dataPath
+
+      // TODO(v4amt): once the write path can emit DATA entries directly into the root, drop this
+      // synthetic-root scaffolding (checkpointWithSyntheticRoot / addedTracking) and drive the test
+      // from a real writer-produced root instead.
+      val rootAdds = Seq("root-data-1.parquet", "root-data-2.parquet").map { path =>
+        AddFile(path = path, partitionValues = Map.empty, size = 128L, modificationTime = 0L,
+          dataChange = false, stats = s"""{"numRecords":3}""")
+      }
+      val rootDataRows = rootAdds.map(add =>
+        AMTSingleAction.fromAddFile(add, addedTracking, tableRoot))
+      val checkpoint =
+        checkpointWithSyntheticRoot(deltaLog, provider.checkpointAction, rootDataRows)
+
+      val rootProvider = AMTCheckpointProvider.fromCheckpoint(spark, deltaLog, checkpoint)
+      assert(rootProvider.leaves.isEmpty, "A DATA-only root must yield no leaf pointers.")
+
+      val expected = rootAdds.map(_.path).toSet
+      val df = rootProvider.loadActionsForStateReconstruction(spark, deltaLog)
+        .getOrElse(fail("AMT provider must contribute root-derived actions."))
+      val addPaths = df.where("add is not null").select("add.path").as[String].collect().toSet
+      assert(addPaths == expected,
+        "Reconstruction must surface the DATA entries stored directly in the root.")
+      assert(df.where("protocol.minReaderVersion is not null").count() == 1,
+        "Reconstruction must still carry the inline protocol action.")
+      assert(df.where("metaData.id is not null").count() == 1,
+        "Reconstruction must still carry the inline metadata action.")
+    }
+  }
+
+  /** An ADDED tracking envelope with no lineage/sequence numbers, matching the AMT writer. */
+  private def addedTracking: Tracking = Tracking(
+    status = Tracking.Status.Added,
+    snapshot_id = None,
+    dv_snapshot_id = None,
+    sequence_number = None,
+    file_sequence_number = None,
+    first_row_id = None,
+    deleted_positions = None,
+    replaced_positions = None)
+
+  /**
+   * Writes `rows` to a fresh AMT root manifest parquet under the table's metadata dir and returns
+   * a [[Checkpoint]] (copied from `base`) pointing at it.
+   */
+  private def checkpointWithSyntheticRoot(
+      deltaLog: DeltaLog, base: Checkpoint, rows: Seq[AMTSingleAction]): Checkpoint = {
+    val hadoopConf = deltaLog.newDeltaHadoopConf()
+    val metadataDir = FileNames.amtMetadataDirPath(deltaLog.dataPath)
+    val rootFile = FileNames.newAMTRootManifestFile(metadataDir)
+    val useRename = deltaLog.store.isPartialWriteVisible(deltaLog.logPath, hadoopConf)
+    val enc = org.apache.spark.sql.delta.implicits.amtSingleActionEncoder
+    val df = spark.createDataset(rows)(enc).toDF()
+    Checkpoints.writeAtomicCheckpointParquetFile(spark, df, rootFile, hadoopConf, useRename)
+    val size = rootFile.getFileSystem(hadoopConf).getFileStatus(rootFile).getLen
+    base.copy(contentRoot = ContentRoot(path = rootFile.toString, sizeInBytes = size))
   }
 }


### PR DESCRIPTION
## Description

This PR makes AMT state reconstruction **distributed**.
- The manifest content is now read as a distributed scan and converted to file actions in parallel on executors, instead of being collected to the driver. Only the small, fixed set of non-file actions carried inline on the checkpoint (protocol, metadata, domain metadata, transaction identifiers) is still assembled on the driver and merged into the same result.
- Reconstruction now also reads file entries that live **directly in the root** of the tree, not just those under the leaf manifests.


## How was this patch tested?

UTs

## Does this PR introduce _any_ user-facing changes?

No.
