### PR TITLE
[Spark] Drop kernel Impl casts for promoted Snapshot/Scan/CommitRange APIs

### DIFF
--- a/flink/src/main/java/io/delta/flink/kernel/CheckpointWriter.java
+++ b/flink/src/main/java/io/delta/flink/kernel/CheckpointWriter.java
@@ -34,7 +34,6 @@ import io.delta.kernel.engine.Engine;
 import io.delta.kernel.engine.FileReadResult;
 import io.delta.kernel.internal.DeltaLogActionUtils;
 import io.delta.kernel.internal.DeltaLogActionUtils.DeltaAction;
-import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.internal.actions.AddFile;
 import io.delta.kernel.internal.actions.DomainMetadata;
 import io.delta.kernel.internal.actions.SetTransaction;
@@ -118,7 +117,7 @@ public class CheckpointWriter {
   }
 
   private final Engine engine;
-  private final SnapshotImpl snapshot;
+  private final Snapshot snapshot;
   private final Path lastCheckpointFilePath;
   private final int sidecarMergeThreshold;
 
@@ -142,7 +141,7 @@ public class CheckpointWriter {
    */
   public CheckpointWriter(Engine engine, Snapshot snapshot, int sidecarMergeThreshold) {
     this.engine = engine;
-    this.snapshot = (SnapshotImpl) snapshot;
+    this.snapshot = snapshot;
 
     Preconditions.checkArgument(
         this.snapshot.getProtocol().supportsFeature(TableFeatures.CHECKPOINT_V2_RW_FEATURE));

--- a/flink/src/main/java/io/delta/flink/table/postcommit/MaintenanceListener.java
+++ b/flink/src/main/java/io/delta/flink/table/postcommit/MaintenanceListener.java
@@ -22,7 +22,6 @@ import io.delta.flink.table.AbstractKernelTable;
 import io.delta.flink.table.TableEventListener;
 import io.delta.kernel.Snapshot;
 import io.delta.kernel.engine.Engine;
-import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.internal.tablefeatures.TableFeatures;
 import io.delta.kernel.metrics.TransactionReport;
 import org.slf4j.Logger;
@@ -58,11 +57,10 @@ public class MaintenanceListener implements TableEventListener {
         table.getCacheManager().put(table.getTablePath().toString(), published);
         // Checkpoint can be done only on published snapshots
         if (table.getConf().shouldCreateCheckpoint()) {
-          if (published instanceof SnapshotImpl
-              && ((SnapshotImpl) published)
-                  .getProtocol()
-                  .getWriterFeatures()
-                  .contains(TableFeatures.CHECKPOINT_V2_RW_FEATURE.featureName())) {
+          if (published
+              .getProtocol()
+              .getWriterFeatures()
+              .contains(TableFeatures.CHECKPOINT_V2_RW_FEATURE.featureName())) {
             // Use v2 incremental checkpoint when possible
             table.withTiming(
                 "postcommit.maintenance.checkpoint",

--- a/flink/src/test/java/io/delta/flink/TestHelper.java
+++ b/flink/src/test/java/io/delta/flink/TestHelper.java
@@ -25,7 +25,6 @@ import io.delta.kernel.defaults.engine.DefaultEngine;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.expressions.Column;
 import io.delta.kernel.expressions.Literal;
-import io.delta.kernel.internal.ScanImpl;
 import io.delta.kernel.internal.actions.AddFile;
 import io.delta.kernel.internal.actions.SingleAction;
 import io.delta.kernel.internal.data.GenericRow;
@@ -325,8 +324,7 @@ public abstract class TestHelper {
   protected void verifyTableContent(String tablePath, TableContentChecker checker) {
     Engine engine = DefaultEngine.create(new Configuration());
     Snapshot snapshot = TableManager.loadSnapshot(tablePath).build(engine);
-    var filesList =
-        ((ScanImpl) snapshot.getScanBuilder().build()).getScanFiles(engine, true).toInMemoryList();
+    var filesList = snapshot.getScanBuilder().build().getScanFiles(engine, true).toInMemoryList();
 
     List<AddFile> actions =
         StreamSupport.stream(filesList.spliterator(), false)

--- a/flink/src/test/java/io/delta/flink/table/AbstractKernelTableTest.java
+++ b/flink/src/test/java/io/delta/flink/table/AbstractKernelTableTest.java
@@ -30,7 +30,6 @@ import io.delta.kernel.defaults.engine.fileio.FileIO;
 import io.delta.kernel.defaults.internal.data.DefaultColumnarBatch;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.expressions.Literal;
-import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.internal.actions.AddFile;
 import io.delta.kernel.internal.actions.SingleAction;
 import io.delta.kernel.internal.util.Utils;
@@ -158,8 +157,7 @@ class AbstractKernelTableTest extends TestHelper {
           assertEquals("true", snapshot.getTableProperties().get("delta.enableDeletionVectors"));
           assertFalse(snapshot.getTableProperties().containsKey("showme"));
           assertFalse(snapshot.getTableProperties().containsKey("something"));
-          assertTrue(
-              ((SnapshotImpl) snapshot).getProtocol().getWriterFeatures().contains("v2Checkpoint"));
+          assertTrue(snapshot.getProtocol().getWriterFeatures().contains("v2Checkpoint"));
         });
   }
 

--- a/flink/src/test/java/io/delta/flink/table/CatalogManagedTableTest.java
+++ b/flink/src/test/java/io/delta/flink/table/CatalogManagedTableTest.java
@@ -21,7 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.delta.flink.MockHttp;
 import io.delta.flink.TestHelper;
-import io.delta.kernel.internal.SnapshotImpl;
+import io.delta.kernel.Snapshot;
 import io.delta.kernel.internal.tablefeatures.TableFeatures;
 import io.delta.kernel.types.IntegerType;
 import io.delta.kernel.types.StructType;
@@ -60,7 +60,7 @@ class CatalogManagedTableTest extends TestHelper {
                       (key, value) -> assertEquals(value, table.conf.catalogConf().get(key)));
                   assertEquals(uuid, table.conf.catalogConf().get("io.unitycatalog.tableId"));
 
-                  SnapshotImpl snapshot = (SnapshotImpl) table.snapshot().get();
+                  Snapshot snapshot = table.snapshot().get();
                   assertEquals(uuid, snapshot.getTableProperties().get("io.unitycatalog.tableId"));
 
                   assertTrue(

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/CommitRange.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/CommitRange.java
@@ -22,6 +22,8 @@ import io.delta.kernel.engine.Engine;
 import io.delta.kernel.exceptions.KernelException;
 import io.delta.kernel.internal.DeltaLogActionUtils;
 import io.delta.kernel.utils.CloseableIterator;
+import io.delta.kernel.utils.FileStatus;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -52,6 +54,15 @@ public interface CommitRange {
    * @return the ending version number of the commit range
    */
   long getEndVersion();
+
+  /**
+   * Returns the delta commit files that make up this commit range, one per version in {@code
+   * [getStartVersion(), getEndVersion()]}, in increasing version order.
+   *
+   * @return the list of {@link FileStatus}es for the delta commit files in this range
+   * @since 4.4.0
+   */
+  List<FileStatus> getDeltaFiles();
 
   /**
    * Returns the original query boundary used to define the start boundary of this commit range.

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/CommitRangeBuilder.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/CommitRangeBuilder.java
@@ -17,10 +17,10 @@
 package io.delta.kernel;
 
 import static io.delta.kernel.internal.util.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
 
 import io.delta.kernel.annotation.Experimental;
 import io.delta.kernel.engine.Engine;
-import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.internal.files.ParsedLogData;
 import java.util.List;
 import java.util.Optional;
@@ -143,9 +143,7 @@ public interface CommitRangeBuilder {
      * @return a new {@code CommitBoundary} representing the specified timestamp
      */
     public static CommitBoundary atTimestamp(long timestamp, Snapshot latestSnapshot) {
-      checkArgument(
-          latestSnapshot instanceof SnapshotImpl,
-          "latestSnapshot must be instance of SnapshotImpl");
+      requireNonNull(latestSnapshot, "latestSnapshot is null");
       return new CommitBoundary(false, timestamp, Optional.of(latestSnapshot));
     }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Scan.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Scan.java
@@ -107,6 +107,28 @@ public interface Scan {
   CloseableIterator<FilteredColumnarBatch> getScanFiles(Engine engine);
 
   /**
+   * Get an iterator of data files to scan, optionally including the file statistics.
+   *
+   * <p>Behaves like {@link #getScanFiles(Engine)}, but when {@code includeStats} is {@code true}
+   * the returned scan-file rows are guaranteed to include the JSON file statistics read from the
+   * log (schema {@code add.stats}). When {@code includeStats} is {@code false} the statistics may
+   * or may not be present, depending on whether they were needed internally (e.g. for data
+   * skipping); callers must not rely on their presence.
+   *
+   * @param engine {@link Engine} instance to use in Delta Kernel.
+   * @param includeStats whether to guarantee the JSON file statistics are included in the
+   *     scan-file rows.
+   * @return iterator of {@link FilteredColumnarBatch}s, one selected row per scan file, with the
+   *     schema described in {@link #getScanFiles(Engine)} (plus {@code stats} when {@code
+   *     includeStats} is {@code true}).
+   * @since 4.4.0
+   */
+  default CloseableIterator<FilteredColumnarBatch> getScanFiles(
+      Engine engine, boolean includeStats) {
+    return getScanFiles(engine);
+  }
+
+  /**
    * Get the remaining filter that is not guaranteed to be satisfied for the data Delta Kernel
    * returns. This filter is used by Delta Kernel to do data skipping when possible.
    *

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Scan.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Scan.java
@@ -116,8 +116,8 @@ public interface Scan {
    * skipping); callers must not rely on their presence.
    *
    * @param engine {@link Engine} instance to use in Delta Kernel.
-   * @param includeStats whether to guarantee the JSON file statistics are included in the
-   *     scan-file rows.
+   * @param includeStats whether to guarantee the JSON file statistics are included in the scan-file
+   *     rows.
    * @return iterator of {@link FilteredColumnarBatch}s, one selected row per scan file, with the
    *     schema described in {@link #getScanFiles(Engine)} (plus {@code stats} when {@code
    *     includeStats} is {@code true}).
@@ -125,6 +125,10 @@ public interface Scan {
    */
   default CloseableIterator<FilteredColumnarBatch> getScanFiles(
       Engine engine, boolean includeStats) {
+    if (includeStats) {
+      throw new UnsupportedOperationException(
+          "getScanFiles(Engine, boolean) with includeStats=true is not implemented for this Scan");
+    }
     return getScanFiles(engine);
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Scan.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Scan.java
@@ -123,14 +123,7 @@ public interface Scan {
    *     includeStats} is {@code true}).
    * @since 4.4.0
    */
-  default CloseableIterator<FilteredColumnarBatch> getScanFiles(
-      Engine engine, boolean includeStats) {
-    if (includeStats) {
-      throw new UnsupportedOperationException(
-          "getScanFiles(Engine, boolean) with includeStats=true is not implemented for this Scan");
-    }
-    return getScanFiles(engine);
-  }
+  CloseableIterator<FilteredColumnarBatch> getScanFiles(Engine engine, boolean includeStats);
 
   /**
    * Get the remaining filter that is not guaranteed to be satisfied for the data Delta Kernel

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Snapshot.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Snapshot.java
@@ -18,11 +18,15 @@ package io.delta.kernel;
 
 import io.delta.kernel.annotation.Evolving;
 import io.delta.kernel.clustering.ClusteringColumnInfo;
+import io.delta.kernel.commit.Committer;
 import io.delta.kernel.commit.PublishFailedException;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.exceptions.CheckpointAlreadyExistsException;
 import io.delta.kernel.exceptions.KernelException;
+import io.delta.kernel.internal.actions.Metadata;
+import io.delta.kernel.internal.actions.Protocol;
 import io.delta.kernel.internal.checksum.CRCInfo;
+import io.delta.kernel.internal.fs.Path;
 import io.delta.kernel.statistics.SnapshotStatistics;
 import io.delta.kernel.transaction.UpdateTableTransactionBuilder;
 import io.delta.kernel.types.StructType;
@@ -133,6 +137,95 @@ public interface Snapshot {
    */
   // TODO: expose a public checksum-info type; CRCInfo is currently an internal type.
   default Optional<CRCInfo> getCurrentCrcInfo() {
+    return Optional.empty();
+  }
+
+  /**
+   * Returns the table protocol at this snapshot.
+   *
+   * <p>The default implementation throws {@link UnsupportedOperationException}; {@link
+   * io.delta.kernel.internal.SnapshotImpl} overrides it.
+   *
+   * @return the {@link Protocol} for this snapshot
+   * @since 4.4.0
+   */
+  // TODO: expose a public protocol type; Protocol is currently an internal type.
+  default Protocol getProtocol() {
+    throw new UnsupportedOperationException("getProtocol() is not implemented for this Snapshot");
+  }
+
+  /**
+   * Returns the table metadata at this snapshot.
+   *
+   * <p>The default implementation throws {@link UnsupportedOperationException}; {@link
+   * io.delta.kernel.internal.SnapshotImpl} overrides it.
+   *
+   * @return the {@link Metadata} for this snapshot
+   * @since 4.4.0
+   */
+  // TODO: expose a public metadata type; Metadata is currently an internal type.
+  default Metadata getMetadata() {
+    throw new UnsupportedOperationException("getMetadata() is not implemented for this Snapshot");
+  }
+
+  /**
+   * Returns the {@link Committer} used to commit transactions against this snapshot's table.
+   *
+   * <p>The default implementation throws {@link UnsupportedOperationException}; {@link
+   * io.delta.kernel.internal.SnapshotImpl} overrides it.
+   *
+   * @return the committer for this snapshot
+   * @since 4.4.0
+   */
+  default Committer getCommitter() {
+    throw new UnsupportedOperationException("getCommitter() is not implemented for this Snapshot");
+  }
+
+  /**
+   * Returns the table data path as a {@link Path}.
+   *
+   * <p>The default implementation wraps {@link #getPath()} in a {@link Path}. {@link
+   * io.delta.kernel.internal.SnapshotImpl} overrides it to return the path used to load the
+   * snapshot (the same value {@link #getPath()} stringifies).
+   *
+   * @return the table data path
+   * @since 4.4.0
+   */
+  // TODO: expose a public path type; Path is currently an internal type.
+  default Path getDataPath() {
+    return new Path(getPath());
+  }
+
+  /**
+   * Returns the path to this table's {@code _delta_log} directory.
+   *
+   * <p>The default implementation returns {@code new Path(getDataPath(), "_delta_log")}; {@link
+   * io.delta.kernel.internal.SnapshotImpl} overrides it to return the path used to load the
+   * snapshot.
+   *
+   * @return the {@code _delta_log} path
+   * @since 4.4.0
+   */
+  // TODO: expose a public path type; Path is currently an internal type.
+  default Path getLogPath() {
+    return new Path(getDataPath(), "_delta_log");
+  }
+
+  /**
+   * Returns the latest transaction version recorded in the Delta log for the given application id,
+   * or empty if none exists.
+   *
+   * <p>The default implementation returns {@link Optional#empty()}; {@link
+   * io.delta.kernel.internal.SnapshotImpl} overrides it to read transaction identifiers from the
+   * log.
+   *
+   * @param engine the engine to use for IO operations
+   * @param applicationId identifier of the application that wrote transaction identifiers into the
+   *     Delta log
+   * @return the last transaction version for {@code applicationId}, or empty if none
+   * @since 4.4.0
+   */
+  default Optional<Long> getLatestTransactionVersion(Engine engine, String applicationId) {
     return Optional.empty();
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Snapshot.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Snapshot.java
@@ -25,7 +25,6 @@ import io.delta.kernel.exceptions.CheckpointAlreadyExistsException;
 import io.delta.kernel.exceptions.KernelException;
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.actions.Protocol;
-import io.delta.kernel.internal.checksum.CRCInfo;
 import io.delta.kernel.internal.fs.Path;
 import io.delta.kernel.statistics.SnapshotStatistics;
 import io.delta.kernel.transaction.UpdateTableTransactionBuilder;
@@ -124,21 +123,6 @@ public interface Snapshot {
 
   /** @return statistics about this snapshot */
   SnapshotStatistics getStatistics();
-
-  /**
-   * Returns the checksum ({@code CRC}) information for this snapshot if it was loaded from a
-   * checksum file, otherwise empty.
-   *
-   * <p>The default implementation returns {@link Optional#empty()}; implementations backed by a
-   * checksum file override it to return the loaded {@link CRCInfo}.
-   *
-   * @return the {@link CRCInfo} for this snapshot, or empty if no checksum was loaded
-   * @since 4.4.0
-   */
-  // TODO: expose a public checksum-info type; CRCInfo is currently an internal type.
-  default Optional<CRCInfo> getCurrentCrcInfo() {
-    return Optional.empty();
-  }
 
   /**
    * Returns the table protocol at this snapshot.

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Snapshot.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Snapshot.java
@@ -22,6 +22,7 @@ import io.delta.kernel.commit.PublishFailedException;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.exceptions.CheckpointAlreadyExistsException;
 import io.delta.kernel.exceptions.KernelException;
+import io.delta.kernel.internal.checksum.CRCInfo;
 import io.delta.kernel.statistics.SnapshotStatistics;
 import io.delta.kernel.transaction.UpdateTableTransactionBuilder;
 import io.delta.kernel.types.StructType;
@@ -119,6 +120,21 @@ public interface Snapshot {
 
   /** @return statistics about this snapshot */
   SnapshotStatistics getStatistics();
+
+  /**
+   * Returns the checksum ({@code CRC}) information for this snapshot if it was loaded from a
+   * checksum file, otherwise empty.
+   *
+   * <p>The default implementation returns {@link Optional#empty()}; implementations backed by a
+   * checksum file override it to return the loaded {@link CRCInfo}.
+   *
+   * @return the {@link CRCInfo} for this snapshot, or empty if no checksum was loaded
+   * @since 4.4.0
+   */
+  // TODO: expose a public checksum-info type; CRCInfo is currently an internal type.
+  default Optional<CRCInfo> getCurrentCrcInfo() {
+    return Optional.empty();
+  }
 
   /**
    * Get per-clustering-column descriptors with the physical column reference (as stored in the

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Snapshot.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Snapshot.java
@@ -25,7 +25,9 @@ import io.delta.kernel.exceptions.CheckpointAlreadyExistsException;
 import io.delta.kernel.exceptions.KernelException;
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.actions.Protocol;
+import io.delta.kernel.internal.checksum.CRCInfo;
 import io.delta.kernel.internal.fs.Path;
+import io.delta.kernel.internal.snapshot.LogSegment;
 import io.delta.kernel.statistics.SnapshotStatistics;
 import io.delta.kernel.transaction.UpdateTableTransactionBuilder;
 import io.delta.kernel.types.StructType;
@@ -133,7 +135,6 @@ public interface Snapshot {
    * @return the {@link Protocol} for this snapshot
    * @since 4.4.0
    */
-  // TODO: expose a public protocol type; Protocol is currently an internal type.
   default Protocol getProtocol() {
     throw new UnsupportedOperationException("getProtocol() is not implemented for this Snapshot");
   }
@@ -147,7 +148,6 @@ public interface Snapshot {
    * @return the {@link Metadata} for this snapshot
    * @since 4.4.0
    */
-  // TODO: expose a public metadata type; Metadata is currently an internal type.
   default Metadata getMetadata() {
     throw new UnsupportedOperationException("getMetadata() is not implemented for this Snapshot");
   }
@@ -175,7 +175,6 @@ public interface Snapshot {
    * @return the table data path
    * @since 4.4.0
    */
-  // TODO: expose a public path type; Path is currently an internal type.
   default Path getDataPath() {
     return new Path(getPath());
   }
@@ -190,7 +189,6 @@ public interface Snapshot {
    * @return the {@code _delta_log} path
    * @since 4.4.0
    */
-  // TODO: expose a public path type; Path is currently an internal type.
   default Path getLogPath() {
     return new Path(getDataPath(), "_delta_log");
   }
@@ -211,6 +209,33 @@ public interface Snapshot {
    */
   default Optional<Long> getLatestTransactionVersion(Engine engine, String applicationId) {
     return Optional.empty();
+  }
+
+  /**
+   * Returns the checksum ({@code CRC}) information for this snapshot if it was loaded from a
+   * checksum file, otherwise empty.
+   *
+   * <p>The default implementation returns {@link Optional#empty()}; {@link
+   * io.delta.kernel.internal.SnapshotImpl} overrides it to return the loaded {@link CRCInfo}.
+   *
+   * @return the {@link CRCInfo} for this snapshot, or empty if no checksum was loaded
+   * @since 4.4.0
+   */
+  default Optional<CRCInfo> getCurrentCrcInfo() {
+    return Optional.empty();
+  }
+
+  /**
+   * Returns the log segment that backs this snapshot.
+   *
+   * <p>The default implementation throws {@link UnsupportedOperationException}; {@link
+   * io.delta.kernel.internal.SnapshotImpl} overrides it.
+   *
+   * @return the {@link LogSegment} for this snapshot
+   * @since 4.4.0
+   */
+  default LogSegment getLogSegment() {
+    throw new UnsupportedOperationException("getLogSegment() is not implemented for this Snapshot");
   }
 
   /**

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Snapshot.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Snapshot.java
@@ -27,6 +27,7 @@ import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.actions.Protocol;
 import io.delta.kernel.internal.checksum.CRCInfo;
 import io.delta.kernel.internal.fs.Path;
+import io.delta.kernel.internal.replay.CreateCheckpointIterator;
 import io.delta.kernel.internal.snapshot.LogSegment;
 import io.delta.kernel.statistics.SnapshotStatistics;
 import io.delta.kernel.transaction.UpdateTableTransactionBuilder;
@@ -129,48 +130,33 @@ public interface Snapshot {
   /**
    * Returns the table protocol at this snapshot.
    *
-   * <p>The default implementation throws {@link UnsupportedOperationException}; {@link
-   * io.delta.kernel.internal.SnapshotImpl} overrides it.
-   *
    * @return the {@link Protocol} for this snapshot
    * @since 4.4.0
    */
-  default Protocol getProtocol() {
-    throw new UnsupportedOperationException("getProtocol() is not implemented for this Snapshot");
-  }
+  Protocol getProtocol();
 
   /**
    * Returns the table metadata at this snapshot.
    *
-   * <p>The default implementation throws {@link UnsupportedOperationException}; {@link
-   * io.delta.kernel.internal.SnapshotImpl} overrides it.
-   *
    * @return the {@link Metadata} for this snapshot
    * @since 4.4.0
    */
-  default Metadata getMetadata() {
-    throw new UnsupportedOperationException("getMetadata() is not implemented for this Snapshot");
-  }
+  Metadata getMetadata();
 
   /**
    * Returns the {@link Committer} used to commit transactions against this snapshot's table.
    *
-   * <p>The default implementation throws {@link UnsupportedOperationException}; {@link
-   * io.delta.kernel.internal.SnapshotImpl} overrides it.
-   *
    * @return the committer for this snapshot
    * @since 4.4.0
    */
-  default Committer getCommitter() {
-    throw new UnsupportedOperationException("getCommitter() is not implemented for this Snapshot");
-  }
+  Committer getCommitter();
 
   /**
-   * Returns the table data path as a {@link Path}.
+   * Returns the table data path, i.e. the same location as {@link #getPath()} in {@link Path} form.
    *
-   * <p>The default implementation wraps {@link #getPath()} in a {@link Path}. {@link
-   * io.delta.kernel.internal.SnapshotImpl} overrides it to return the path used to load the
-   * snapshot (the same value {@link #getPath()} stringifies).
+   * <p>When turning the result back into a string for file paths, use {@link Path#toString()}
+   * rather than {@code toUri().toString()}: the latter percent-encodes special characters, which
+   * breaks resolution for table roots containing e.g. spaces.
    *
    * @return the table data path
    * @since 4.4.0
@@ -182,10 +168,6 @@ public interface Snapshot {
   /**
    * Returns the path to this table's {@code _delta_log} directory.
    *
-   * <p>The default implementation returns {@code new Path(getDataPath(), "_delta_log")}; {@link
-   * io.delta.kernel.internal.SnapshotImpl} overrides it to return the path used to load the
-   * snapshot.
-   *
    * @return the {@code _delta_log} path
    * @since 4.4.0
    */
@@ -196,10 +178,6 @@ public interface Snapshot {
   /**
    * Returns the latest transaction version recorded in the Delta log for the given application id,
    * or empty if none exists.
-   *
-   * <p>The default implementation returns {@link Optional#empty()}; {@link
-   * io.delta.kernel.internal.SnapshotImpl} overrides it to read transaction identifiers from the
-   * log.
    *
    * @param engine the engine to use for IO operations
    * @param applicationId identifier of the application that wrote transaction identifiers into the
@@ -215,8 +193,7 @@ public interface Snapshot {
    * Returns the checksum ({@code CRC}) information for this snapshot if it was loaded from a
    * checksum file, otherwise empty.
    *
-   * <p>The default implementation returns {@link Optional#empty()}; {@link
-   * io.delta.kernel.internal.SnapshotImpl} overrides it to return the loaded {@link CRCInfo}.
+   * <p>An empty result means no checksum was read, not that the table has no checksum file.
    *
    * @return the {@link CRCInfo} for this snapshot, or empty if no checksum was loaded
    * @since 4.4.0
@@ -228,15 +205,20 @@ public interface Snapshot {
   /**
    * Returns the log segment that backs this snapshot.
    *
-   * <p>The default implementation throws {@link UnsupportedOperationException}; {@link
-   * io.delta.kernel.internal.SnapshotImpl} overrides it.
-   *
    * @return the {@link LogSegment} for this snapshot
    * @since 4.4.0
    */
-  default LogSegment getLogSegment() {
-    throw new UnsupportedOperationException("getLogSegment() is not implemented for this Snapshot");
-  }
+  LogSegment getLogSegment();
+
+  /**
+   * Returns an iterator over the actions that should be written into a checkpoint for this
+   * snapshot.
+   *
+   * @param engine the engine to use for IO operations
+   * @return iterator of filtered columnar batches for checkpoint writing
+   * @since 4.4.0
+   */
+  CreateCheckpointIterator getCreateCheckpointIterator(Engine engine);
 
   /**
    * Get per-clustering-column descriptors with the physical column reference (as stored in the

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/TransactionCommitResult.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/TransactionCommitResult.java
@@ -20,7 +20,6 @@ import static java.util.Objects.requireNonNull;
 import io.delta.kernel.annotation.Evolving;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.hook.PostCommitHook;
-import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.metrics.TransactionReport;
 import io.delta.kernel.utils.CloseableIterable;
 import java.util.List;
@@ -37,17 +36,17 @@ public class TransactionCommitResult {
   private final long version;
   private final List<PostCommitHook> postCommitHooks;
   private final TransactionReport transactionReport;
-  private final Optional<SnapshotImpl> postCommitSnapshotOpt;
+  private final Optional<Snapshot> postCommitSnapshotOpt;
 
   public TransactionCommitResult(
       long version,
       List<PostCommitHook> postCommitHooks,
       TransactionReport transactionReport,
-      Optional<SnapshotImpl> postCommitSnapshotOpt) {
+      Optional<? extends Snapshot> postCommitSnapshotOpt) {
     this.version = version;
     this.postCommitHooks = requireNonNull(postCommitHooks);
     this.transactionReport = requireNonNull(transactionReport);
-    this.postCommitSnapshotOpt = requireNonNull(postCommitSnapshotOpt);
+    this.postCommitSnapshotOpt = requireNonNull(postCommitSnapshotOpt).map(s -> s);
   }
 
   /**
@@ -88,6 +87,6 @@ public class TransactionCommitResult {
    * experienced conflicts.
    */
   public Optional<Snapshot> getPostCommitSnapshot() {
-    return postCommitSnapshotOpt.map(s -> s); // Map needed to upcast to Optional<Snapshot>
+    return postCommitSnapshotOpt;
   }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaHistoryManager.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaHistoryManager.java
@@ -20,6 +20,7 @@ import static io.delta.kernel.internal.TableConfig.*;
 import static io.delta.kernel.internal.fs.Path.getName;
 import static io.delta.kernel.internal.util.Preconditions.checkArgument;
 
+import io.delta.kernel.Snapshot;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.exceptions.KernelException;
 import io.delta.kernel.exceptions.TableNotFoundException;
@@ -72,7 +73,7 @@ public final class DeltaHistoryManager {
       Engine engine,
       Path logPath,
       long millisSinceEpochUTC,
-      SnapshotImpl latestSnapshot,
+      Snapshot latestSnapshot,
       List<ParsedCatalogCommitData> catalogCommits) {
     DeltaHistoryManager.Commit commit =
         DeltaHistoryManager.getActiveCommitAtTimestamp(
@@ -122,7 +123,7 @@ public final class DeltaHistoryManager {
       Engine engine,
       Path logPath,
       long millisSinceEpochUTC,
-      SnapshotImpl latestSnapshot,
+      Snapshot latestSnapshot,
       List<ParsedCatalogCommitData> catalogCommits) {
     return DeltaHistoryManager.getActiveCommitAtTimestamp(
             engine,
@@ -163,7 +164,7 @@ public final class DeltaHistoryManager {
    */
   public static Commit getActiveCommitAtTimestamp(
       Engine engine,
-      SnapshotImpl latestSnapshot,
+      Snapshot latestSnapshot,
       Path logPath,
       long timestamp,
       boolean mustBeRecreatable,
@@ -334,7 +335,7 @@ public final class DeltaHistoryManager {
    *     timestamps enabled, this will be the commit after the latest version. If in-commit
    *     timestamps were enabled for the entire history, this will be `earliestCommit`.
    */
-  private static Commit getICTEnablementCommit(SnapshotImpl snapshot, Commit earliestCommit) {
+  private static Commit getICTEnablementCommit(Snapshot snapshot, Commit earliestCommit) {
     Metadata metadata = snapshot.getMetadata();
     if (!IN_COMMIT_TIMESTAMPS_ENABLED.fromMetadata(metadata)) {
       // Pretend ICT will be enabled after the latest version and requested timestamp.

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/PaginatedScanImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/PaginatedScanImpl.java
@@ -84,6 +84,7 @@ public class PaginatedScanImpl implements PaginatedScan {
     return this.getScanFiles(engine, false /* include stats */);
   }
 
+  @Override
   public PaginatedScanFilesIterator getScanFiles(Engine engine, boolean includeStates) {
     CloseableIterator<FilteredColumnarBatch> filteredScanFilesIter =
         baseScan.getScanFiles(engine, includeStates, Optional.of(paginationContext));

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
@@ -119,6 +119,7 @@ public class ScanImpl implements Scan {
    *
    * @return data in {@link ColumnarBatch} batch format. Each row correspond to one survived file.
    */
+  @Override
   public CloseableIterator<FilteredColumnarBatch> getScanFiles(
       Engine engine, boolean includeStats) {
     return getScanFiles(engine, includeStats, Optional.empty() /* paginationContextOpt */);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
@@ -419,6 +419,7 @@ public class SnapshotImpl implements Snapshot {
   }
 
   /** Returns the crc info for the current snapshot if the checksum file is read */
+  @Override
   public Optional<CRCInfo> getCurrentCrcInfo() {
     return logReplay.getCrcInfoAtSnapshotVersion();
   }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
@@ -423,7 +423,6 @@ public class SnapshotImpl implements Snapshot {
   }
 
   /** Returns the crc info for the current snapshot if the checksum file is read */
-  @Override
   public Optional<CRCInfo> getCurrentCrcInfo() {
     return logReplay.getCrcInfoAtSnapshotVersion();
   }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
@@ -351,14 +351,17 @@ public class SnapshotImpl implements Snapshot {
     return new ReplaceTableTransactionBuilderV2Impl(this, schema, engineInfo);
   }
 
+  @Override
   public Committer getCommitter() {
     return committer;
   }
 
+  @Override
   public Path getLogPath() {
     return logPath;
   }
 
+  @Override
   public Path getDataPath() {
     return dataPath;
   }
@@ -372,6 +375,7 @@ public class SnapshotImpl implements Snapshot {
     return wasBuiltAsLatest;
   }
 
+  @Override
   public Protocol getProtocol() {
     return protocol;
   }
@@ -424,6 +428,7 @@ public class SnapshotImpl implements Snapshot {
     return logReplay.getCrcInfoAtSnapshotVersion();
   }
 
+  @Override
   public Metadata getMetadata() {
     return metadata;
   }
@@ -445,14 +450,14 @@ public class SnapshotImpl implements Snapshot {
 
   /**
    * Get the latest transaction version for given <i>applicationId</i>. This information comes from
-   * the transactions identifiers stored in Delta transaction log. This API is not a public API. For
-   * now keep this internal to enable Flink upgrade to use Kernel.
+   * the transactions identifiers stored in Delta transaction log.
    *
    * @param applicationId Identifier of the application that put transaction identifiers in Delta
    *     transaction log
    * @return Last transaction version or {@link Optional#empty()} if no transaction identifier
    *     exists for this application.
    */
+  @Override
   public Optional<Long> getLatestTransactionVersion(Engine engine, String applicationId) {
     return logReplay.getLatestTransactionIdentifier(engine, applicationId);
   }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
@@ -443,6 +443,7 @@ public class SnapshotImpl implements Snapshot {
     return lazyLogSegment;
   }
 
+  @Override
   public CreateCheckpointIterator getCreateCheckpointIterator(Engine engine) {
     long minFileRetentionTimestampMillis =
         System.currentTimeMillis() - TOMBSTONE_RETENTION.fromMetadata(metadata);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
@@ -423,6 +423,7 @@ public class SnapshotImpl implements Snapshot {
   }
 
   /** Returns the crc info for the current snapshot if the checksum file is read */
+  @Override
   public Optional<CRCInfo> getCurrentCrcInfo() {
     return logReplay.getCrcInfoAtSnapshotVersion();
   }
@@ -432,6 +433,7 @@ public class SnapshotImpl implements Snapshot {
     return metadata;
   }
 
+  @Override
   public LogSegment getLogSegment() {
     return lazyLogSegment.get();
   }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableImpl.java
@@ -231,7 +231,7 @@ public class TableImpl implements Table {
    * @throws TableNotFoundException if no delta table is found
    */
   public long getVersionBeforeOrAtTimestamp(Engine engine, long millisSinceEpochUTC) {
-    SnapshotImpl latestSnapshot = (SnapshotImpl) getLatestSnapshot(engine);
+    SnapshotImpl latestSnapshot = getLatestSnapshot(engine);
     return DeltaHistoryManager.getVersionBeforeOrAtTimestamp(
         engine,
         getLogPath(),
@@ -262,7 +262,7 @@ public class TableImpl implements Table {
    * @throws TableNotFoundException if no delta table is found
    */
   public long getVersionAtOrAfterTimestamp(Engine engine, long millisSinceEpochUTC) {
-    SnapshotImpl latestSnapshot = (SnapshotImpl) getLatestSnapshot(engine);
+    SnapshotImpl latestSnapshot = getLatestSnapshot(engine);
     return DeltaHistoryManager.getVersionAtOrAfterTimestamp(
         engine,
         getLogPath(),

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/clustering/ClusteringMetadataDomain.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/clustering/ClusteringMetadataDomain.java
@@ -18,9 +18,9 @@ package io.delta.kernel.internal.clustering;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.delta.kernel.Snapshot;
 import io.delta.kernel.exceptions.KernelException;
 import io.delta.kernel.expressions.Column;
-import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.internal.metadatadomain.JsonMetadataDomain;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -53,13 +53,13 @@ public final class ClusteringMetadataDomain extends JsonMetadataDomain {
   }
 
   /**
-   * Creates an optional instance of {@link ClusteringMetadataDomain} from a {@link SnapshotImpl} if
+   * Creates an optional instance of {@link ClusteringMetadataDomain} from a {@link Snapshot} if
    * present.
    *
    * @param snapshot the snapshot instance
    */
   // TODO: Add the test coverage for this function in the integration test.
-  public static Optional<ClusteringMetadataDomain> fromSnapshot(SnapshotImpl snapshot) {
+  public static Optional<ClusteringMetadataDomain> fromSnapshot(Snapshot snapshot) {
     return JsonMetadataDomain.fromSnapshot(snapshot, ClusteringMetadataDomain.class, DOMAIN_NAME);
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/commitrange/CommitRangeBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/commitrange/CommitRangeBuilderImpl.java
@@ -23,7 +23,6 @@ import io.delta.kernel.CommitRange;
 import io.delta.kernel.CommitRangeBuilder;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.internal.DeltaErrorsInternal;
-import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.internal.files.LogDataUtils;
 import io.delta.kernel.internal.files.ParsedLogData;
 import java.util.Collections;
@@ -124,8 +123,7 @@ public class CommitRangeBuilderImpl implements CommitRangeBuilder {
                 "startVersion (%d) must be <= maxCatalogVersion (%d)",
                 ctx.startBoundary.getVersion(), maxVersion));
       } else if (ctx.startBoundary.isTimestamp()) {
-        long latestSnapshotVersion =
-            ((SnapshotImpl) ctx.startBoundary.getLatestSnapshot()).getVersion();
+        long latestSnapshotVersion = ctx.startBoundary.getLatestSnapshot().getVersion();
         if (latestSnapshotVersion != maxVersion) {
           throw DeltaErrorsInternal.invalidLatestSnapshotForMaxCatalogVersion(
               latestSnapshotVersion, maxVersion);
@@ -142,8 +140,7 @@ public class CommitRangeBuilderImpl implements CommitRangeBuilder {
                   "endVersion (%d) must be <= maxCatalogVersion (%d)",
                   endBoundary.getVersion(), maxVersion));
         } else if (endBoundary.isTimestamp()) {
-          long latestSnapshotVersion =
-              ((SnapshotImpl) endBoundary.getLatestSnapshot()).getVersion();
+          long latestSnapshotVersion = endBoundary.getLatestSnapshot().getVersion();
           if (latestSnapshotVersion != maxVersion) {
             throw DeltaErrorsInternal.invalidLatestSnapshotForMaxCatalogVersion(
                 latestSnapshotVersion, maxVersion);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/commitrange/CommitRangeFactory.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/commitrange/CommitRangeFactory.java
@@ -24,7 +24,6 @@ import io.delta.kernel.CommitRangeBuilder;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.internal.DeltaErrors;
 import io.delta.kernel.internal.DeltaHistoryManager;
-import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.internal.files.LogDataUtils;
 import io.delta.kernel.internal.files.ParsedCatalogCommitData;
 import io.delta.kernel.internal.files.ParsedDeltaData;
@@ -102,7 +101,7 @@ class CommitRangeFactory {
           engine,
           logPath,
           ctx.startBoundary.getTimestamp(),
-          (SnapshotImpl) ctx.startBoundary.getLatestSnapshot(),
+          ctx.startBoundary.getLatestSnapshot(),
           catalogCommits);
     }
   }
@@ -134,7 +133,7 @@ class CommitRangeFactory {
               engine,
               logPath,
               endBoundary.getTimestamp(),
-              (SnapshotImpl) endBoundary.getLatestSnapshot(),
+              endBoundary.getLatestSnapshot(),
               catalogCommits);
       return Optional.of(resolvedVersion);
     }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/commitrange/CommitRangeImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/commitrange/CommitRangeImpl.java
@@ -27,7 +27,6 @@ import io.delta.kernel.data.ColumnarBatch;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.internal.DeltaLogActionUtils;
 import io.delta.kernel.internal.TableChangesUtils;
-import io.delta.kernel.internal.annotation.VisibleForTesting;
 import io.delta.kernel.internal.files.ParsedDeltaData;
 import io.delta.kernel.internal.fs.Path;
 import io.delta.kernel.utils.CloseableIterator;
@@ -90,7 +89,7 @@ public class CommitRangeImpl implements CommitRange {
     return endBoundaryOpt;
   }
 
-  @VisibleForTesting
+  @Override
   public List<FileStatus> getDeltaFiles() {
     return deltas.stream().map(ParsedDeltaData::getFileStatus).collect(Collectors.toList());
   }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/metadatadomain/JsonMetadataDomain.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/metadatadomain/JsonMetadataDomain.java
@@ -22,8 +22,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import io.delta.kernel.Snapshot;
 import io.delta.kernel.exceptions.KernelException;
-import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.internal.actions.DomainMetadata;
 import io.delta.kernel.internal.rowtracking.RowTrackingMetadataDomain;
 import java.util.Optional;
@@ -99,7 +99,7 @@ public abstract class JsonMetadataDomain {
    *     otherwise an empty Optional
    */
   protected static <T> Optional<T> fromSnapshot(
-      SnapshotImpl snapshot, Class<T> clazz, String domainName) {
+      Snapshot snapshot, Class<T> clazz, String domainName) {
     return snapshot
         .getDomainMetadata(domainName)
         .map(config -> fromJsonConfiguration(config, clazz));

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/rowtracking/RowTrackingMetadataDomain.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/rowtracking/RowTrackingMetadataDomain.java
@@ -17,7 +17,7 @@ package io.delta.kernel.internal.rowtracking;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.delta.kernel.internal.SnapshotImpl;
+import io.delta.kernel.Snapshot;
 import io.delta.kernel.internal.metadatadomain.JsonMetadataDomain;
 import java.util.Optional;
 
@@ -39,12 +39,12 @@ public final class RowTrackingMetadataDomain extends JsonMetadataDomain {
   }
 
   /**
-   * Creates an instance of {@link RowTrackingMetadataDomain} from a {@link SnapshotImpl}.
+   * Creates an instance of {@link RowTrackingMetadataDomain} from a {@link Snapshot}.
    *
    * @param snapshot the snapshot instance
    * @return an {@link Optional} containing the {@link RowTrackingMetadataDomain} if present
    */
-  public static Optional<RowTrackingMetadataDomain> fromSnapshot(SnapshotImpl snapshot) {
+  public static Optional<RowTrackingMetadataDomain> fromSnapshot(Snapshot snapshot) {
     return JsonMetadataDomain.fromSnapshot(snapshot, RowTrackingMetadataDomain.class, DOMAIN_NAME);
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/table/SnapshotBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/table/SnapshotBuilderImpl.java
@@ -48,7 +48,7 @@ public class SnapshotBuilderImpl implements SnapshotBuilder {
   public static class Context {
     public final String unresolvedPath;
     public Optional<Long> versionOpt = Optional.empty();
-    public Optional<Tuple2<SnapshotImpl, Long>> timestampQueryContextOpt = Optional.empty();
+    public Optional<Tuple2<Snapshot, Long>> timestampQueryContextOpt = Optional.empty();
     public Optional<Committer> committerOpt = Optional.empty();
     public List<ParsedLogData> logDatas = Collections.emptyList();
     public Optional<Tuple2<Protocol, Metadata>> protocolAndMetadataOpt = Optional.empty();
@@ -79,9 +79,7 @@ public class SnapshotBuilderImpl implements SnapshotBuilder {
   @Override
   public SnapshotBuilderImpl atTimestamp(long millisSinceEpochUTC, Snapshot latestSnapshot) {
     requireNonNull(latestSnapshot, "latestSnapshot is null");
-    checkArgument(latestSnapshot instanceof SnapshotImpl, "latestSnapshot must be a SnapshotImpl");
-    ctx.timestampQueryContextOpt =
-        Optional.of(new Tuple2<>((SnapshotImpl) latestSnapshot, millisSinceEpochUTC));
+    ctx.timestampQueryContextOpt = Optional.of(new Tuple2<>(latestSnapshot, millisSinceEpochUTC));
     return this;
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/table/SnapshotFactory.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/table/SnapshotFactory.java
@@ -73,7 +73,7 @@ public class SnapshotFactory {
   public static long resolveTimestampToSnapshotVersion(
       Engine engine,
       SnapshotQueryContext snapshotQueryCtx,
-      SnapshotImpl latestSnapshot,
+      Snapshot latestSnapshot,
       long millisSinceEpochUTC,
       List<ParsedLogData> logDatas) {
     List<ParsedCatalogCommitData> parsedCatalogCommits =

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/CommitRangeBuilderSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/CommitRangeBuilderSuite.scala
@@ -23,7 +23,6 @@ import io.delta.kernel.{CommitRange, TableManager}
 import io.delta.kernel.CommitRangeBuilder.CommitBoundary
 import io.delta.kernel.engine.Engine
 import io.delta.kernel.exceptions.{InvalidTableException, KernelException}
-import io.delta.kernel.internal.commitrange.{CommitRangeBuilderImpl, CommitRangeImpl}
 import io.delta.kernel.internal.files.{ParsedCatalogCommitData, ParsedDeltaData, ParsedLogData}
 import io.delta.kernel.internal.fs.Path
 import io.delta.kernel.internal.util.FileNames
@@ -129,7 +128,7 @@ class CommitRangeBuilderSuite extends AnyFunSuite with MockFileSystemClientUtils
         version >= expectedStartVersion && version <= expectedEndVersion
       }).filter(fs => FileNames.isCommitFile(fs.getPath))
     assert(expectedFileList.toSet ==
-      commitRange.asInstanceOf[CommitRangeImpl].getDeltaFiles.asScala.toSet)
+      commitRange.getDeltaFiles.asScala.toSet)
   }
 
   /**
@@ -420,7 +419,7 @@ class CommitRangeBuilderSuite extends AnyFunSuite with MockFileSystemClientUtils
       startBound,
       endBound)
     assert(expectedFileList.toSet ==
-      commitRange.asInstanceOf[CommitRangeImpl].getDeltaFiles.asScala.toSet)
+      commitRange.getDeltaFiles.asScala.toSet)
   }
 
   /**

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ChecksumUtilsSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ChecksumUtilsSuite.scala
@@ -24,7 +24,6 @@ import io.delta.kernel.data.Row
 import io.delta.kernel.defaults.utils.WriteUtils
 import io.delta.kernel.engine.Engine
 import io.delta.kernel.expressions.{Column, Literal}
-import io.delta.kernel.internal.{SnapshotImpl, TableImpl}
 import io.delta.kernel.internal.checksum.ChecksumUtils
 import io.delta.kernel.internal.util.ManualClock
 import io.delta.kernel.types.{StringType, StructType}
@@ -56,13 +55,13 @@ class ChecksumUtilsSuite extends AnyFunSuite with WriteUtils with LogReplayBaseS
 
       val snapshot0 = Table.forPath(
         engine,
-        tablePath).getSnapshotAsOfVersion(engine, 0).asInstanceOf[SnapshotImpl]
+        tablePath).getSnapshotAsOfVersion(engine, 0)
       ChecksumUtils.computeStateAndWriteChecksum(engine, snapshot0.getLogSegment)
       verifyChecksumForSnapshot(snapshot0)
 
       val snapshot1 = Table.forPath(
         engine,
-        tablePath).getSnapshotAsOfVersion(engine, 1).asInstanceOf[SnapshotImpl]
+        tablePath).getSnapshotAsOfVersion(engine, 1)
       ChecksumUtils.computeStateAndWriteChecksum(engine, snapshot1.getLogSegment)
       verifyChecksumForSnapshot(snapshot1)
     }
@@ -74,7 +73,7 @@ class ChecksumUtilsSuite extends AnyFunSuite with WriteUtils with LogReplayBaseS
 
       val snapshot1 = Table.forPath(
         engine,
-        tablePath).getSnapshotAsOfVersion(engine, 1).asInstanceOf[SnapshotImpl]
+        tablePath).getSnapshotAsOfVersion(engine, 1)
 
       // Same computation as computeStateAndWriteChecksum
       val crcInfo = ChecksumUtils.computeChecksum(engine, snapshot1.getLogSegment)
@@ -83,7 +82,7 @@ class ChecksumUtilsSuite extends AnyFunSuite with WriteUtils with LogReplayBaseS
       // No checksum file was written: a freshly loaded log segment still sees no checksum.
       val reloaded = Table.forPath(
         engine,
-        tablePath).getSnapshotAsOfVersion(engine, 1).asInstanceOf[SnapshotImpl]
+        tablePath).getSnapshotAsOfVersion(engine, 1)
       assert(!reloaded.getLogSegment.getLastSeenChecksum.isPresent)
 
       // The writing counterpart still persists an equivalent, valid checksum.
@@ -98,7 +97,7 @@ class ChecksumUtilsSuite extends AnyFunSuite with WriteUtils with LogReplayBaseS
 
       val snapshot1 = Table.forPath(
         engine,
-        tablePath).getSnapshotAsOfVersion(engine, 1).asInstanceOf[SnapshotImpl]
+        tablePath).getSnapshotAsOfVersion(engine, 1)
 
       // computeChecksum derives from file actions, so ICT is absent (not derivable from replay).
       val crcInfo = ChecksumUtils.computeChecksum(engine, snapshot1.getLogSegment)
@@ -124,13 +123,13 @@ class ChecksumUtilsSuite extends AnyFunSuite with WriteUtils with LogReplayBaseS
 
       val snapshot1 = Table.forPath(
         engine,
-        tablePath).getSnapshotAsOfVersion(engine, 1).asInstanceOf[SnapshotImpl]
+        tablePath).getSnapshotAsOfVersion(engine, 1)
 
       // Persist a checksum for v1, then reload so the log segment sees it as lastSeenChecksum.
       ChecksumUtils.computeStateAndWriteChecksum(engine, snapshot1.getLogSegment)
       val reloaded = Table.forPath(
         engine,
-        tablePath).getSnapshotAsOfVersion(engine, 1).asInstanceOf[SnapshotImpl]
+        tablePath).getSnapshotAsOfVersion(engine, 1)
       assert(reloaded.getLogSegment.getLastSeenChecksum.isPresent)
 
       // A checksum already exists for exactly this version => returned as-is (no full replay).
@@ -145,7 +144,7 @@ class ChecksumUtilsSuite extends AnyFunSuite with WriteUtils with LogReplayBaseS
 
       val snapshot = Table.forPath(
         engine,
-        tablePath).getSnapshotAsOfVersion(engine, 0).asInstanceOf[SnapshotImpl]
+        tablePath).getSnapshotAsOfVersion(engine, 0)
 
       // First call should create the checksum file
       ChecksumUtils.computeStateAndWriteChecksum(engine, snapshot.getLogSegment)

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/CreateCheckpointSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/CreateCheckpointSuite.scala
@@ -440,7 +440,6 @@ class CreateCheckpointSuite extends CheckpointBase with GeoTestUtils {
       val snapshot = TableManager.loadSnapshot(tablePath)
         .atVersion(2)
         .build(engine)
-        .asInstanceOf[SnapshotImpl]
       snapshot.writeCheckpoint(engine)
 
       // Verify no log cleanup happened

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableSchemaEvolutionSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableSchemaEvolutionSuite.scala
@@ -492,7 +492,7 @@ trait DeltaTableSchemaEvolutionSuiteBase extends AnyFunSuite with AbstractWriteU
 
       updateTableMetadata(engine, tablePath, newSchema)
 
-      val latestSnapshot = table.getLatestSnapshot(engine).asInstanceOf[SnapshotImpl]
+      val latestSnapshot = table.getLatestSnapshot(engine)
       val structType = latestSnapshot.getSchema
       assertColumnMapping(structType.get("a"), 1)
       assertColumnMapping(structType.get("map"), 4, "map")
@@ -644,7 +644,7 @@ trait DeltaTableSchemaEvolutionSuiteBase extends AnyFunSuite with AbstractWriteU
 
       updateTableMetadata(engine, tablePath, expectedSchema)
 
-      val snapshot = table.getLatestSnapshot(engine).asInstanceOf[SnapshotImpl]
+      val snapshot = table.getLatestSnapshot(engine)
       val actualSchema = snapshot.getSchema
 
       assert(expectedSchema == actualSchema)
@@ -676,7 +676,7 @@ trait DeltaTableSchemaEvolutionSuiteBase extends AnyFunSuite with AbstractWriteU
 
       updateTableMetadata(engine, tablePath, expectedSchema)
 
-      val snapshot = table.getLatestSnapshot(engine).asInstanceOf[SnapshotImpl]
+      val snapshot = table.getLatestSnapshot(engine)
       val actualSchema = snapshot.getSchema
 
       assert(expectedSchema == actualSchema)
@@ -1984,7 +1984,7 @@ trait DeltaTableSchemaEvolutionSuiteBase extends AnyFunSuite with AbstractWriteU
             initialSchema,
             tableProperties = Map(TableConfig.COLUMN_MAPPING_MODE.getKey -> "id"))
 
-          val before = table.getLatestSnapshot(engine).asInstanceOf[SnapshotImpl]
+          val before = table.getLatestSnapshot(engine)
           val featuresBefore = before.getProtocol.getImplicitlyAndExplicitlySupportedFeatures
           assert(
             !featuresBefore.contains(GEOSPATIAL_RW_FEATURE),
@@ -1998,7 +1998,7 @@ trait DeltaTableSchemaEvolutionSuiteBase extends AnyFunSuite with AbstractWriteU
 
           updateTableMetadata(engine, tablePath, newSchema)
 
-          val after = table.getLatestSnapshot(engine).asInstanceOf[SnapshotImpl]
+          val after = table.getLatestSnapshot(engine)
           assert(after.getSchema.get("geo").getDataType == geoType)
 
           val featuresAfter = after.getProtocol.getImplicitlyAndExplicitlySupportedFeatures
@@ -2027,7 +2027,7 @@ trait DeltaTableSchemaEvolutionSuiteBase extends AnyFunSuite with AbstractWriteU
         initialSchema,
         tableProperties = Map(TableConfig.COLUMN_MAPPING_MODE.getKey -> "id"))
 
-      val before = table.getLatestSnapshot(engine).asInstanceOf[SnapshotImpl]
+      val before = table.getLatestSnapshot(engine)
       val currentSchema = before.getSchema
       val currentInner = currentSchema.get("info").getDataType.asInstanceOf[StructType]
       val maxIdBefore = getMaxFieldId(engine, tablePath)
@@ -2048,7 +2048,7 @@ trait DeltaTableSchemaEvolutionSuiteBase extends AnyFunSuite with AbstractWriteU
 
       updateTableMetadata(engine, tablePath, newSchema)
 
-      val after = table.getLatestSnapshot(engine).asInstanceOf[SnapshotImpl]
+      val after = table.getLatestSnapshot(engine)
       val features = after.getProtocol.getImplicitlyAndExplicitlySupportedFeatures
       assert(
         features.contains(GEOSPATIAL_RW_FEATURE),

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWritesSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWritesSuite.scala
@@ -35,7 +35,7 @@ import io.delta.kernel.engine.Engine
 import io.delta.kernel.exceptions._
 import io.delta.kernel.expressions.{Column, Literal}
 import io.delta.kernel.expressions.Literal._
-import io.delta.kernel.internal.{ScanImpl, SnapshotImpl, TableConfig}
+import io.delta.kernel.internal.{SnapshotImpl, TableConfig}
 import io.delta.kernel.internal.checkpoints.CheckpointerSuite.selectSingleElement
 import io.delta.kernel.internal.data.GenericRow
 import io.delta.kernel.internal.table.SnapshotBuilderImpl
@@ -815,7 +815,7 @@ abstract class AbstractDeltaTableWritesSuite extends AnyFunSuite with AbstractWr
         // Read stats JSON
         val snapshot = Table.forPath(engine, tblPath).getLatestSnapshot(engine)
         val scan = snapshot.getScanBuilder().build()
-        val scanFiles = scan.asInstanceOf[ScanImpl].getScanFiles(engine, true).toSeq
+        val scanFiles = scan.getScanFiles(engine, true).toSeq
           .flatMap(_.getRows.toSeq)
         val statsJson = scanFiles.headOption.flatMap { row =>
           val add = row.getStruct(row.getSchema.indexOf("add"))
@@ -897,7 +897,7 @@ abstract class AbstractDeltaTableWritesSuite extends AnyFunSuite with AbstractWr
         // Read stats JSON
         val snapshot = Table.forPath(engine, tblPath).getLatestSnapshot(engine)
         val scan = snapshot.getScanBuilder.build()
-        val scanFiles = scan.asInstanceOf[ScanImpl].getScanFiles(engine, true).toSeq
+        val scanFiles = scan.getScanFiles(engine, true).toSeq
           .flatMap(_.getRows.toSeq)
 
         val mapper = JsonUtils.mapper()
@@ -965,7 +965,7 @@ abstract class AbstractDeltaTableWritesSuite extends AnyFunSuite with AbstractWr
       // Read stats JSON
       val snapshot = Table.forPath(engine, tblPath).getLatestSnapshot(engine)
       val scan = snapshot.getScanBuilder().build()
-      val scanFiles = scan.asInstanceOf[ScanImpl].getScanFiles(engine, true).toSeq
+      val scanFiles = scan.getScanFiles(engine, true).toSeq
         .flatMap(_.getRows.toSeq)
       val statsJson = scanFiles.headOption.flatMap { row =>
         val add = row.getStruct(row.getSchema.indexOf("add"))
@@ -1030,7 +1030,7 @@ abstract class AbstractDeltaTableWritesSuite extends AnyFunSuite with AbstractWr
       // Read stats JSON
       val snapshot = Table.forPath(engine, tblPath).getLatestSnapshot(engine)
       val scan = snapshot.getScanBuilder().build()
-      val scanFiles = scan.asInstanceOf[ScanImpl].getScanFiles(engine, true).toSeq
+      val scanFiles = scan.getScanFiles(engine, true).toSeq
         .flatMap(_.getRows.toSeq)
       val statsJson = scanFiles.headOption.flatMap { row =>
         val add = row.getStruct(row.getSchema.indexOf("add"))
@@ -1817,7 +1817,7 @@ abstract class AbstractDeltaTableWritesSuite extends AnyFunSuite with AbstractWr
       // Retrieve the stats JSON from the file.
       val snapshot = Table.forPath(engine, tblPath).getLatestSnapshot(engine)
       val scan = snapshot.getScanBuilder().build()
-      val scanFiles = scan.asInstanceOf[ScanImpl].getScanFiles(engine, true)
+      val scanFiles = scan.getScanFiles(engine, true)
         .toSeq.flatMap(_.getRows.toSeq)
       val statsJson = scanFiles.headOption.flatMap { row =>
         val addFile = row.getStruct(row.getSchema.indexOf("add"))

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/LogCompactionWriterSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/LogCompactionWriterSuite.scala
@@ -26,7 +26,7 @@ import io.delta.kernel.defaults.utils.TestRow
 import io.delta.kernel.engine.Engine
 import io.delta.kernel.expressions.Literal
 import io.delta.kernel.hook.PostCommitHook
-import io.delta.kernel.internal.{DeltaLogActionUtils, SnapshotImpl}
+import io.delta.kernel.internal.DeltaLogActionUtils
 import io.delta.kernel.internal.TableConfig.TOMBSTONE_RETENTION
 import io.delta.kernel.internal.actions._
 import io.delta.kernel.internal.compaction.LogCompactionWriter
@@ -262,7 +262,7 @@ class LogCompactionWriterSuite extends CheckpointBase {
       val logPath = new Path(s"file:${tablePath}", "_delta_log")
       createEmptyTable(engine, tablePath, schema, clock = clock)
       val table = Table.forPath(engine, tablePath)
-      val metadata = table.getLatestSnapshot(engine).asInstanceOf[SnapshotImpl].getMetadata()
+      val metadata = table.getLatestSnapshot(engine).getMetadata()
       val tombstoneRetention = TOMBSTONE_RETENTION.fromMetadata(metadata)
       clock.setTime(tombstoneRetention) // set to the retention time so (time - retention) == 0
       val compactionInterval = 3

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/PostCommitSnapshotSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/PostCommitSnapshotSuite.scala
@@ -47,8 +47,8 @@ class PostCommitSnapshotSuite
 
   private def assertAddFilesMatch(
       engine: Engine,
-      actual: SnapshotImpl,
-      expected: SnapshotImpl): Unit = {
+      actual: Snapshot,
+      expected: Snapshot): Unit = {
     val actualFiles = collectScanFileRows(actual.getScanBuilder.build(), engine)
       .map(x => InternalScanFileUtils.getAddFileStatus(x).getPath)
     val expectedFiles = collectScanFileRows(expected.getScanBuilder.build(), engine)
@@ -173,7 +173,7 @@ class PostCommitSnapshotSuite
         tableProperties = Map(TableConfig.IN_COMMIT_TIMESTAMPS_ENABLED.getKey -> "true"))
 
       val result = appendData(engine, tablePath, data = seqOfUnpartitionedDataBatch1)
-      val postCommitSnapshot = result.getPostCommitSnapshot.get().asInstanceOf[SnapshotImpl]
+      val postCommitSnapshot = result.getPostCommitSnapshot.get()
 
       val failingEngine = mockEngine()
 
@@ -304,7 +304,7 @@ class PostCommitSnapshotSuite
         schema = testSchema,
         data = seqOfUnpartitionedDataBatch1)
 
-      val postCommitSnapshot = result.getPostCommitSnapshot.get().asInstanceOf[SnapshotImpl]
+      val postCommitSnapshot = result.getPostCommitSnapshot.get()
 
       assert(!TableFeatures.isCatalogManagedSupported(postCommitSnapshot.getProtocol))
 
@@ -321,7 +321,7 @@ class PostCommitSnapshotSuite
         schema = testSchema,
         data = seqOfUnpartitionedDataBatch1)
 
-      var postCommitSnapshot = result.getPostCommitSnapshot.get().asInstanceOf[SnapshotImpl]
+      var postCommitSnapshot = result.getPostCommitSnapshot.get()
       var postPublishSnapshot = postCommitSnapshot.publish(engine)
       assert(postPublishSnapshot == postCommitSnapshot)
 
@@ -331,7 +331,7 @@ class PostCommitSnapshotSuite
         isNewTable = false,
         data = seqOfUnpartitionedDataBatch1)
 
-      postCommitSnapshot = result.getPostCommitSnapshot.get().asInstanceOf[SnapshotImpl]
+      postCommitSnapshot = result.getPostCommitSnapshot.get()
       postPublishSnapshot = postCommitSnapshot.publish(engine)
       assert(postPublishSnapshot == postCommitSnapshot)
     }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ScanSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ScanSuite.scala
@@ -36,7 +36,7 @@ import io.delta.kernel.engine.FileReadResult
 import io.delta.kernel.exceptions.KernelEngineException
 import io.delta.kernel.expressions._
 import io.delta.kernel.expressions.Literal._
-import io.delta.kernel.internal.{InternalScanFileUtils, ScanImpl, TableConfig}
+import io.delta.kernel.internal.{InternalScanFileUtils, TableConfig}
 import io.delta.kernel.internal.util.InternalUtils
 import io.delta.kernel.types._
 import io.delta.kernel.types.IntegerType.INTEGER
@@ -1555,15 +1555,15 @@ class ScanSuite extends AnyFunSuite with TestUtils
   }
 
   //////////////////////////////////////////////////////////////////////////////////////////
-  // Check the includeStats parameter on ScanImpl.getScanFiles(engine, includeStats)
+  // Check the includeStats parameter on Scan.getScanFiles(engine, includeStats)
   //////////////////////////////////////////////////////////////////////////////////////////
 
-  test("check ScanImpl.getScanFiles for includeStats=true") {
+  test("check Scan.getScanFiles for includeStats=true") {
     // When includeStats=true the JSON statistic should always be returned in the scan files
     withTempDir { tempDir =>
       spark.range(10).write.format("delta").save(tempDir.getCanonicalPath)
       def checkStatsPresent(scan: Scan): Unit = {
-        val scanFileBatches = scan.asInstanceOf[ScanImpl].getScanFiles(defaultEngine, true)
+        val scanFileBatches = scan.getScanFiles(defaultEngine, true)
         scanFileBatches.forEach { batch =>
           assert(batch.getData().getSchema() == InternalScanFileUtils.SCAN_FILE_SCHEMA_WITH_STATS)
         }
@@ -2739,7 +2739,7 @@ class ScanSuite extends AnyFunSuite with TestUtils
             case Some(pred) => scanBuilder.withFilter(pred).build()
             case None => scanBuilder.build()
           }
-          val scanFiles = scan.asInstanceOf[ScanImpl].getScanFiles(defaultEngine, true)
+          val scanFiles = scan.getScanFiles(defaultEngine, true)
           var numFiles: Int = 0
           scanFiles.forEach { s =>
             numFiles += s.getRows().toSeq.length

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/catalogManaged/CatalogManagedE2EReadSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/catalogManaged/CatalogManagedE2EReadSuite.scala
@@ -24,7 +24,6 @@ import io.delta.kernel.defaults.engine.hadoopio.HadoopFileIO
 import io.delta.kernel.defaults.utils.{TestRow, TestUtilsWithTableManagerAPIs, WriteUtilsWithV2Builders}
 import io.delta.kernel.exceptions.KernelException
 import io.delta.kernel.internal.DeltaHistoryManager
-import io.delta.kernel.internal.commitrange.CommitRangeImpl
 import io.delta.kernel.internal.files.{ParsedCatalogCommitData, ParsedLogData}
 import io.delta.kernel.internal.fs.Path
 import io.delta.kernel.internal.table.SnapshotBuilderImpl
@@ -304,7 +303,7 @@ class CatalogManagedE2EReadSuite extends AnyFunSuite
         // scalastyle:on line.size.limit
       ).map(path => defaultEngine.getFileSystemClient.resolvePath(path))
 
-      assert(commitRange.asInstanceOf[CommitRangeImpl].getDeltaFiles().asScala.map(_.getPath) ==
+      assert(commitRange.getDeltaFiles().asScala.map(_.getPath) ==
         expectedFileList)
     }
   }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestUtils.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestUtils.scala
@@ -926,7 +926,7 @@ trait AbstractTestUtils
   protected def verifyChecksumForSnapshot(
       snapshot: Snapshot,
       expectEmptyTable: Boolean = false): Unit = {
-    val logPath = snapshot.asInstanceOf[SnapshotImpl].getLogPath
+    val logPath = snapshot.getLogPath
     val crcInfoOpt = ChecksumReader.tryReadChecksumFile(
       defaultEngine,
       FileStatus.of(checksumFile(
@@ -937,7 +937,7 @@ trait AbstractTestUtils
       s"CRC information should be present for version ${snapshot.getVersion}")
     crcInfoOpt.toScala.foreach { crcInfo =>
       // TODO: check file size.
-      assert(crcInfo.getProtocol === snapshot.asInstanceOf[SnapshotImpl].getProtocol)
+      assert(crcInfo.getProtocol === snapshot.getProtocol)
       assert(crcInfo.getMetadata.getSchema === snapshot.getSchema)
       assert(
         crcInfo.getNumFiles === collectScanFileRows(snapshot.getScanBuilder.build()).size,

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/WriteUtils.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/WriteUtils.scala
@@ -592,7 +592,7 @@ trait AbstractWriteUtils extends TestUtils with TransactionBuilderSupport {
   def collectStatsFromAddFiles(engine: Engine, path: String): Seq[String] = {
     val snapshot = getTableManagerAdapter.getSnapshotAtLatest(engine, path)
     val scan = snapshot.getScanBuilder.build()
-    val scanFiles = scan.asInstanceOf[ScanImpl].getScanFiles(engine, true)
+    val scanFiles = scan.getScanFiles(engine, true)
 
     scanFiles.asScala.toList.flatMap { scanFile =>
       scanFile.getRows.asScala.toList.flatMap { row =>

--- a/kernel/unitycatalog/src/main/java/io/delta/kernel/unitycatalog/UnityCatalogUtils.java
+++ b/kernel/unitycatalog/src/main/java/io/delta/kernel/unitycatalog/UnityCatalogUtils.java
@@ -23,12 +23,13 @@ import static io.delta.kernel.internal.util.Utils.singletonCloseableIterator;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.delta.kernel.Snapshot;
+import io.delta.kernel.clustering.ClusteringColumnInfo;
 import io.delta.kernel.commit.CommitMetadata;
 import io.delta.kernel.data.ColumnVector;
 import io.delta.kernel.data.ColumnarBatch;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.expressions.Column;
-import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.internal.actions.CommitInfo;
 import io.delta.kernel.internal.actions.DomainMetadata;
 import io.delta.kernel.internal.actions.Metadata;
@@ -36,7 +37,6 @@ import io.delta.kernel.internal.actions.Protocol;
 import io.delta.kernel.internal.clustering.ClusteringMetadataDomain;
 import io.delta.kernel.internal.types.DataTypeJsonSerDe;
 import io.delta.kernel.internal.util.ColumnMapping;
-import io.delta.kernel.internal.util.Tuple2;
 import io.delta.kernel.types.*;
 import io.delta.kernel.utils.CloseableIterator;
 import io.delta.kernel.utils.FileStatus;
@@ -164,7 +164,7 @@ public class UnityCatalogUtils {
    * @throws IllegalArgumentException if the snapshot is not version 0
    */
   public static Map<String, String> getPropertiesForCreate(
-      Engine engine, SnapshotImpl postCreateSnapshot) {
+      Engine engine, Snapshot postCreateSnapshot) {
     if (postCreateSnapshot.getVersion() != 0) {
       throw new IllegalArgumentException(
           String.format(
@@ -196,10 +196,15 @@ public class UnityCatalogUtils {
    *
    * @return clustering properties if present, otherwise empty map
    */
-  private static Map<String, String> extractClusteringProperties(SnapshotImpl snapshot) {
+  private static Map<String, String> extractClusteringProperties(Snapshot snapshot) {
     return snapshot
-        .getPhysicalClusteringColumns()
-        .map(cols -> serializeClusteringColumns(cols, snapshot.getSchema()))
+        .getClusteringColumnInfos()
+        .map(
+            infos ->
+                serializeLogicalClusteringColumns(
+                    infos.stream()
+                        .map(ClusteringColumnInfo::getLogicalColumn)
+                        .collect(Collectors.toList())))
         .orElse(Collections.emptyMap());
   }
 
@@ -229,23 +234,29 @@ public class UnityCatalogUtils {
   }
 
   /**
-   * Converts physical clustering columns to logical column names and serializes them as a JSON
-   * property map. Shared by both the SnapshotImpl and DomainMetadata extraction paths.
+   * Resolves physical clustering columns against {@code schema} and serializes them as a JSON
+   * property map. Used by the DomainMetadata extraction path, which holds physical references; the
+   * snapshot path reads already-resolved logical references off {@link ClusteringColumnInfo}.
    */
   private static Map<String, String> serializeClusteringColumns(
       List<Column> physicalClusteringCols, StructType schema) {
-    final List<List<String>> logicalClusteringCols =
+    return serializeLogicalClusteringColumns(
         physicalClusteringCols.stream()
             .map(
-                physicalCol -> {
-                  final Tuple2<Column, DataType> logicalColumnAndType =
-                      ColumnMapping.getLogicalColumnNameAndDataType(schema, physicalCol);
-                  return Arrays.asList(logicalColumnAndType._1.getNames());
-                })
+                physicalCol ->
+                    ColumnMapping.getLogicalColumnNameAndDataType(schema, physicalCol)._1)
+            .collect(Collectors.toList()));
+  }
+
+  /** Serializes logical clustering column references as the UC clustering-columns property. */
+  private static Map<String, String> serializeLogicalClusteringColumns(
+      List<Column> logicalClusteringCols) {
+    final List<List<String>> nameParts =
+        logicalClusteringCols.stream()
+            .map(logicalCol -> Arrays.asList(logicalCol.getNames()))
             .collect(Collectors.toList());
     try {
-      return Map.of(
-          UC_PROP_CLUSTERING_COLUMNS, OBJECT_MAPPER.writeValueAsString(logicalClusteringCols));
+      return Map.of(UC_PROP_CLUSTERING_COLUMNS, OBJECT_MAPPER.writeValueAsString(nameParts));
     } catch (JsonProcessingException ex) {
       throw new RuntimeException("Failed to serialize clustering columns to JSON", ex);
     }
@@ -256,9 +267,7 @@ public class UnityCatalogUtils {
   // which has no post-commit snapshot)
   // ---------------------------------------------------------------------------
 
-  /**
-   * Same as {@link #getPropertiesForCreate(Engine, SnapshotImpl)} but reads from CommitMetadata.
-   */
+  /** Same as {@link #getPropertiesForCreate(Engine, Snapshot)} but reads from CommitMetadata. */
   public static Map<String, String> getPropertiesForCreate(CommitMetadata commitMetadata) {
     if (commitMetadata.getVersion() != 0) {
       throw new IllegalArgumentException(

--- a/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/UCE2ESuite.scala
+++ b/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/UCE2ESuite.scala
@@ -153,7 +153,7 @@ class UCE2ESuite extends AnyFunSuite with UCCatalogManagedTestUtils {
       // Step 4a: PUBLISH v1.json and v2.json -- Note that this does NOT update UC
       val postPublishSnapshot = postCommitSnapshot2.publish(engine).asInstanceOf[SnapshotImpl]
       assert(postCommitSnapshot2.getVersion == 2)
-      assert(postCommitSnapshot2.asInstanceOf[SnapshotImpl]
+      assert(postCommitSnapshot2
         .getLogSegment.getMaxPublishedDeltaVersion == Optional.of(0L))
 
       // All versions will be published in the post publish snapshot
@@ -275,7 +275,7 @@ class UCE2ESuite extends AnyFunSuite with UCCatalogManagedTestUtils {
       // Capture expected values from the post-commit snapshot
       // Assert CRC is present in post-commit snapshot
       assert(currentSnapshot.getStatistics.getChecksumWriteMode.get == ChecksumWriteMode.SIMPLE)
-      val postCommitCrc = currentSnapshot.asInstanceOf[SnapshotImpl].getCurrentCrcInfo()
+      val postCommitCrc = currentSnapshot.getCurrentCrcInfo()
       assert(postCommitCrc.isPresent)
       val expectedNumFiles = postCommitCrc.get().getNumFiles
       val expectedTableSizeBytes = postCommitCrc.get().getTableSizeBytes

--- a/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/UnityCatalogUtilsSuite.scala
+++ b/kernel/unitycatalog/src/test/scala/io/delta/kernel/unitycatalog/UnityCatalogUtilsSuite.scala
@@ -21,7 +21,6 @@ import java.io.{File, PrintWriter}
 import scala.jdk.CollectionConverters._
 
 import io.delta.kernel.expressions.Column
-import io.delta.kernel.internal.SnapshotImpl
 import io.delta.kernel.internal.actions.DomainMetadata
 import io.delta.kernel.internal.clustering.ClusteringMetadataDomain
 import io.delta.kernel.internal.fs.Path
@@ -85,7 +84,6 @@ class UnityCatalogUtilsSuite
         .commit(engine, CloseableIterable.emptyIterable())
         .getPostCommitSnapshot
         .get()
-        .asInstanceOf[SnapshotImpl]
 
       val snapshotTimestamp = snapshot.getTimestamp(engine)
 
@@ -160,7 +158,6 @@ class UnityCatalogUtilsSuite
         .commit(engine, CloseableIterable.emptyIterable())
         .getPostCommitSnapshot
         .get()
-        .asInstanceOf[SnapshotImpl]
 
       // The CommitMetadata-based overload was called by finalizeTableInCatalog during commit.
       // Verify its output (captured in FinalizeCreateRecord) matches the snapshot-based overload.
@@ -201,10 +198,33 @@ class UnityCatalogUtilsSuite
         .commit(engine, CloseableIterable.emptyIterable())
         .getPostCommitSnapshot
         .get()
-        .asInstanceOf[SnapshotImpl]
 
       val props = UnityCatalogUtils.getPropertiesForCreate(engine, snapshot).asScala
       assert(props("clusteringColumns") == "[]")
+    }
+  }
+
+  test("getPropertiesForCreate: unclustered table omits the clusteringColumns property") {
+    withTempDirAndEngine { case (tablePathUnresolved, engine) =>
+      val ucClient = new InMemoryUCClient("ucMetastoreId")
+      val ucCatalogManagedClient = new UCCatalogManagedClient(ucClient)
+      val tablePath = engine.getFileSystemClient.resolvePath(tablePathUnresolved)
+
+      val ucTableIdentifier = new UCTableIdentifier("cat", "sch", "tbl")
+      val snapshot = ucCatalogManagedClient
+        .buildCreateTableTransaction(
+          testUcTableId,
+          tablePath,
+          testSchema,
+          "test-engine",
+          ucTableIdentifier)
+        .build(engine)
+        .commit(engine, CloseableIterable.emptyIterable())
+        .getPostCommitSnapshot
+        .get()
+
+      val props = UnityCatalogUtils.getPropertiesForCreate(engine, snapshot).asScala
+      assert(!props.contains("clusteringColumns"))
     }
   }
 

--- a/spark-unified/src/main/scala/org/apache/spark/sql/delta/v2/interop/DeltaV2Snapshot.scala
+++ b/spark-unified/src/main/scala/org/apache/spark/sql/delta/v2/interop/DeltaV2Snapshot.scala
@@ -33,9 +33,9 @@ import org.apache.spark.sql.delta.actions.{
 import org.apache.spark.sql.delta.coordinatedcommits.TableCommitCoordinatorClient
 import org.apache.spark.sql.delta.stats.{DeltaStatsColumnSpec, StatisticsCollection}
 import org.apache.hadoop.fs.Path
+import io.delta.kernel.{Snapshot => KernelSnapshot}
 import io.delta.kernel.defaults.engine.DefaultEngine
 import io.delta.kernel.engine.Engine
-import io.delta.kernel.internal.{SnapshotImpl => KernelSnapshot}
 
 import org.apache.spark.sql.{DataFrame, Dataset, SparkSession}
 
@@ -49,10 +49,7 @@ import org.apache.spark.sql.{DataFrame, Dataset, SparkSession}
  * reconstruction (`stateDF` etc.) is not wired to Kernel yet and throws.
  */
 private[v2] class DeltaV2Snapshot(
-    // Typed as the internal SnapshotImpl (aliased KernelSnapshot), not the public Kernel
-    // `Snapshot` interface: the decoded data path is only exposed on SnapshotImpl in the
-    // OSS-published Kernel. The public io.delta.kernel.Snapshot has no `getDataPath`, and its
-    // `getPath` is URL-encoded, which breaks Hadoop `Path` for table roots containing spaces.
+    // Typed as the public Kernel `Snapshot` interface (aliased KernelSnapshot).
     kernelSnapshot: KernelSnapshot,
     sparkSession: SparkSession,
     // Kernel engine for reading scan files and the commit timestamp -- owned and passed by the
@@ -64,8 +61,8 @@ private[v2] class DeltaV2Snapshot(
     kernelEngine: Engine
   )
   extends Snapshot(
-    // toString keeps this compiling across Kernel versions: getDataPath returns String in the
-    // currently pinned Kernel and io.delta.kernel.internal.fs.Path in newer Kernels.
+    // Path.toString, not toUri.toString: the latter percent-encodes special characters and breaks
+    // Hadoop Path resolution for table roots containing spaces.
     path = new Path(kernelSnapshot.getDataPath.toString),
     version = kernelSnapshot.getVersion,
     // A DeltaV2Snapshot must not depend on the V1 LogSegment or DeltaLog. Both are null; the

--- a/spark-unified/src/main/scala/org/apache/spark/sql/delta/v2/interop/KernelSnapshotUtils.scala
+++ b/spark-unified/src/main/scala/org/apache/spark/sql/delta/v2/interop/KernelSnapshotUtils.scala
@@ -24,9 +24,9 @@ import org.apache.spark.sql.delta.actions.{
   DeletionVectorDescriptor => V1DeletionVectorDescriptor
 }
 import org.apache.spark.sql.delta.implicits._
+import io.delta.kernel.Snapshot
 import io.delta.kernel.data.MapValue
 import io.delta.kernel.engine.Engine
-import io.delta.kernel.internal.{ScanImpl, SnapshotImpl}
 import io.delta.kernel.internal.actions.{AddFile => KernelAddFile}
 
 import org.apache.spark.sql.{Dataset, SparkSession}
@@ -48,7 +48,7 @@ private[delta] object KernelSnapshotUtils {
    * The Engine reads the file metadata from Kernel.
    */
   def buildAllFiles(
-      kernelSnapshot: SnapshotImpl,
+      kernelSnapshot: Snapshot,
       spark: SparkSession,
       engine: Engine): Dataset[AddFile] = {
     spark.createDataset(collectV1AddFiles(kernelSnapshot, engine))
@@ -61,9 +61,9 @@ private[delta] object KernelSnapshotUtils {
    * are available. Kernel returns the files in batches, and this method collects them.
    */
   private def collectV1AddFiles(
-      kernelSnapshot: SnapshotImpl,
+      kernelSnapshot: Snapshot,
       engine: Engine): Seq[AddFile] = {
-    val scan = kernelSnapshot.getScanBuilder.build().asInstanceOf[ScanImpl]
+    val scan = kernelSnapshot.getScanBuilder.build()
     val scanFileBatches = scan.getScanFiles(engine, true /* includeStats */)
     try {
       val files = ArrayBuffer.empty[AddFile]

--- a/spark-unified/src/test/scala/io/delta/internal/ApplyV2ReadOptionsSuite.scala
+++ b/spark-unified/src/test/scala/io/delta/internal/ApplyV2ReadOptionsSuite.scala
@@ -21,7 +21,6 @@ import java.util.{HashMap => JHashMap}
 
 import scala.jdk.CollectionConverters._
 
-import io.delta.kernel.internal.SnapshotImpl
 import io.delta.spark.internal.v2.catalog.DeltaV2Table
 import io.delta.spark.internal.v2.snapshot.PathBasedSnapshotManager
 import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorClient
@@ -273,7 +272,7 @@ class ApplyV2ReadOptionsSuite extends DeltaSQLCommandTest {
     val snapshotManager =
       new PathBasedSnapshotManager(tablePath, deltaLog.newDeltaHadoopConf())
     val tableId =
-      snapshotManager.loadLatestSnapshot.asInstanceOf[SnapshotImpl].getMetadata.getId
+      snapshotManager.loadLatestSnapshot.getMetadata.getId
     val trackingLog = DeltaSourceMetadataTrackingLog.create(
       spark, schemaLogPath, tableId, tablePath, parameters = Map.empty[String, String])
     val customSchemaJson =

--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/v2/interop/KernelSnapshotUtilsSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/v2/interop/KernelSnapshotUtilsSuite.scala
@@ -20,10 +20,9 @@ import org.apache.spark.sql.delta.{DeltaConfigs, DeltaLog}
 import org.apache.spark.sql.delta.actions.AddFile
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
-import io.delta.kernel.TableManager
+import io.delta.kernel.{Snapshot, TableManager}
 import io.delta.kernel.defaults.engine.DefaultEngine
 import io.delta.kernel.engine.Engine
-import io.delta.kernel.internal.SnapshotImpl
 
 class KernelSnapshotUtilsSuite extends DeltaSQLCommandTest {
 
@@ -31,8 +30,8 @@ class KernelSnapshotUtilsSuite extends DeltaSQLCommandTest {
   private def engine: Engine = DefaultEngine.create(spark.sessionState.newHadoopConf())
   // scalastyle:on deltahadoopconfiguration
 
-  private def kernelSnapshotFor(path: String, engine: Engine): SnapshotImpl =
-    TableManager.loadSnapshot(path).build(engine).asInstanceOf[SnapshotImpl]
+  private def kernelSnapshotFor(path: String, engine: Engine): Snapshot =
+    TableManager.loadSnapshot(path).build(engine)
 
   private def allFilesFor(path: String): (Array[AddFile], Array[AddFile]) = {
     val kernelEngine = engine

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCKernelDeltaTablesLiveE2ETest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCKernelDeltaTablesLiveE2ETest.java
@@ -23,6 +23,7 @@ import io.delta.kernel.Operation;
 import io.delta.kernel.Scan;
 import io.delta.kernel.Snapshot;
 import io.delta.kernel.Transaction;
+import io.delta.kernel.clustering.ClusteringColumnInfo;
 import io.delta.kernel.data.ColumnVector;
 import io.delta.kernel.data.ColumnarBatch;
 import io.delta.kernel.data.FilteredColumnarBatch;
@@ -33,7 +34,6 @@ import io.delta.kernel.defaults.internal.data.vector.DefaultGenericVector;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.expressions.Column;
 import io.delta.kernel.internal.InternalScanFileUtils;
-import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.internal.actions.Protocol;
 import io.delta.kernel.internal.data.ScanStateRow;
 import io.delta.kernel.internal.util.Utils;
@@ -174,7 +174,7 @@ public class UCKernelDeltaTablesLiveE2ETest extends UnityCatalogSupport {
     assertThat(snapshot.getSchema().fieldNames())
         .containsExactlyElementsOf(TEST_SCHEMA.fieldNames());
 
-    Protocol protocol = ((SnapshotImpl) snapshot).getProtocol();
+    Protocol protocol = snapshot.getProtocol();
     assertThat(protocol.getMinReaderVersion()).isGreaterThanOrEqualTo(3);
     assertThat(protocol.getMinWriterVersion()).isGreaterThanOrEqualTo(7);
     assertThat(protocol.getWriterFeatures()).contains("catalogManaged");
@@ -207,8 +207,7 @@ public class UCKernelDeltaTablesLiveE2ETest extends UnityCatalogSupport {
     assertThat(serverProps).containsKey("clusteringColumns");
 
     Snapshot snapshot = loadAtVersion(catalogClient, table, 0L);
-    Optional<List<Column>> clusteringColumns =
-        ((SnapshotImpl) snapshot).getPhysicalClusteringColumns();
+    Optional<List<ClusteringColumnInfo>> clusteringColumns = snapshot.getClusteringColumnInfos();
     assertThat(clusteringColumns).isPresent();
     assertThat(clusteringColumns.get()).hasSize(1);
   }

--- a/spark/v2/src/main/java-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogBatch.java
+++ b/spark/v2/src/main/java-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogBatch.java
@@ -11,7 +11,6 @@ import io.delta.kernel.internal.actions.AddFile;
 import io.delta.kernel.internal.actions.DeletionVectorDescriptor;
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.actions.RemoveFile;
-import io.delta.kernel.internal.commitrange.CommitRangeImpl;
 import io.delta.kernel.utils.CloseableIterator;
 import io.delta.spark.internal.v2.utils.PartitionUtils;
 import io.delta.spark.internal.v2.utils.SchemaUtils;
@@ -89,7 +88,7 @@ public class DeltaChangelogBatch implements Batch {
     // Pre-check catches schema drift between start and end. The per-commit loop below catches
     // in-range Metadata commits.
     StructType startSchema = SchemaUtils.convertKernelSchemaToSparkSchema(snapshot.getSchema());
-    requireReadCompatible(startSchema, ((CommitRangeImpl) commitRange).getStartVersion());
+    requireReadCompatible(startSchema, commitRange.getStartVersion());
 
     // TODO: Remove StreamingHelper usage. The helper is generic, only the class name is
     // streaming-flavored.
@@ -98,7 +97,7 @@ public class DeltaChangelogBatch implements Batch {
     // declares it. Unchecked exceptions pass through unchanged.
     try (CloseableIterator<CommitActions> commitsIter =
         StreamingHelper.getCommitActionsFromRangeUnsafe(
-            engine, (CommitRangeImpl) commitRange, snapshot.getPath(), CHANGELOG_ACTION_SET)) {
+            engine, commitRange, snapshot.getPath(), CHANGELOG_ACTION_SET)) {
       while (commitsIter.hasNext()) {
         // Emit RemoveFiles before AddFiles per commit. The Spark analyzer re-sorts anyway, but
         // direct-batch tests iterate in emission order and rely on the preimage-then-postimage

--- a/spark/v2/src/main/java-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogScanBuilder.java
+++ b/spark/v2/src/main/java-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogScanBuilder.java
@@ -4,7 +4,6 @@ import io.delta.kernel.CommitRange;
 import io.delta.kernel.Snapshot;
 import io.delta.kernel.defaults.engine.DefaultEngine;
 import io.delta.kernel.engine.Engine;
-import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.internal.rowtracking.RowTracking;
 import io.delta.spark.internal.v2.catalog.DeltaV2Table;
 import io.delta.spark.internal.v2.snapshot.DeltaSnapshotManager;
@@ -55,14 +54,12 @@ public class DeltaChangelogScanBuilder implements ScanBuilder {
     // but the start does not, the toggle happened within the range -- emit
     // DELTA_CHANGELOG_ROW_TRACKING_DISABLED_IN_RANGE with the offending start version.
     Snapshot startSnapshot = snapshotManager.loadSnapshotAt(startVersion);
-    SnapshotImpl startSnapshotImpl = (SnapshotImpl) startSnapshot;
     Snapshot endSnapshot = snapshotManager.loadSnapshotAt(endVersion);
-    SnapshotImpl endSnapshotImpl = (SnapshotImpl) endSnapshot;
     StructType endSchema = SchemaUtils.convertKernelSchemaToSparkSchema(endSnapshot.getSchema());
-    if (!RowTracking.isEnabled(endSnapshotImpl.getProtocol(), endSnapshotImpl.getMetadata())) {
+    if (!RowTracking.isEnabled(endSnapshot.getProtocol(), endSnapshot.getMetadata())) {
       DeltaErrors.throwChangelogRequiresRowTracking(sparkTable.name());
     }
-    if (!RowTracking.isEnabled(startSnapshotImpl.getProtocol(), startSnapshotImpl.getMetadata())) {
+    if (!RowTracking.isEnabled(startSnapshot.getProtocol(), startSnapshot.getMetadata())) {
       DeltaErrors.throwChangelogRowTrackingDisabledInRange(startVersion);
     }
 

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
@@ -24,7 +24,6 @@ import io.delta.kernel.Snapshot;
 import io.delta.kernel.defaults.engine.DefaultEngine;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.internal.DeltaHistoryManager;
-import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.internal.rowtracking.RowTracking;
 import io.delta.spark.internal.v2.adapters.KernelMetadataAdapter;
 import io.delta.spark.internal.v2.adapters.KernelProtocolAdapter;
@@ -247,11 +246,7 @@ public class DeltaV2Table extends DeltaV2TableShims
 
     Optional<PersistedMetadata> persistedMetadata =
         MetadataEvolutionHandler.getPersistedMetadataForMicroBatchStream(
-            SparkSession.active(),
-            (SnapshotImpl) initialSnapshot,
-            options,
-            snapshotManager,
-            kernelEngine);
+            SparkSession.active(), initialSnapshot, options, snapshotManager, kernelEngine);
 
     StructType rawSchema;
     List<String> partitionColumnNames;
@@ -333,12 +328,12 @@ public class DeltaV2Table extends DeltaV2TableShims
 
   /** The table protocol from the initial snapshot. */
   protected AbstractProtocol protocol() {
-    return new KernelProtocolAdapter(((SnapshotImpl) initialSnapshot).getProtocol());
+    return new KernelProtocolAdapter(initialSnapshot.getProtocol());
   }
 
   /** The table metadata from the initial snapshot. */
   protected AbstractMetadata metadata() {
-    return new KernelMetadataAdapter(((SnapshotImpl) initialSnapshot).getMetadata());
+    return new KernelMetadataAdapter(initialSnapshot.getMetadata());
   }
 
   /** Returns a copy of this table pinned to {@code version}. */
@@ -449,9 +444,8 @@ public class DeltaV2Table extends DeltaV2TableShims
    */
   @Override
   public MetadataColumn[] metadataColumns() {
-    SnapshotImpl snapshotImpl = (SnapshotImpl) initialSnapshot;
     boolean rowTrackingEnabled =
-        RowTracking.isEnabled(snapshotImpl.getProtocol(), snapshotImpl.getMetadata());
+        RowTracking.isEnabled(initialSnapshot.getProtocol(), initialSnapshot.getMetadata());
 
     StructType metadataType = new StructType();
     for (StructField field :

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2MicroBatchStream.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2MicroBatchStream.java
@@ -32,7 +32,6 @@ import io.delta.kernel.exceptions.UnsupportedProtocolVersionException;
 import io.delta.kernel.exceptions.UnsupportedTableFeatureException;
 import io.delta.kernel.internal.DeltaHistoryManager;
 import io.delta.kernel.internal.DeltaLogActionUtils.DeltaAction;
-import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.internal.actions.AddFile;
 import io.delta.kernel.internal.actions.CommitInfo;
 import io.delta.kernel.internal.actions.Metadata;
@@ -149,9 +148,9 @@ class DeltaV2MicroBatchStream
   private final DeltaOptions options;
   private final boolean ignoreFileDeletion;
   private final boolean skipChangeCommits;
-  private final SnapshotImpl snapshotAtSourceInit;
+  private final Snapshot snapshotAtSourceInit;
   private final String tableId;
-  private final SnapshotImpl readSnapshotAtSourceInit;
+  private final Snapshot readSnapshotAtSourceInit;
   private final StructType readSchemaAtSourceInit;
   private final boolean shouldValidateOffsets;
   private final Optional<Regex> excludeRegex;
@@ -273,7 +272,7 @@ class DeltaV2MicroBatchStream
     this.sqlConf = SQLConf.get();
     this.scalaOptions = Objects.requireNonNull(scalaOptions, "scalaOptions is null");
 
-    this.snapshotAtSourceInit = (SnapshotImpl) snapshotAtSourceInit;
+    this.snapshotAtSourceInit = snapshotAtSourceInit;
     this.tableId = this.snapshotAtSourceInit.getMetadata().getId();
 
     // The effective snapshot for reading, mirroring v1's readSnapshotDescriptor. When schema
@@ -1125,12 +1124,12 @@ class DeltaV2MicroBatchStream
     if (cdfEnabledOnStreamStartValidated) {
       return;
     }
-    SnapshotImpl startSnapshot;
+    Snapshot startSnapshot;
     if (startVersion == snapshotAtSourceInit.getVersion()) {
       startSnapshot = snapshotAtSourceInit;
     } else {
       try {
-        startSnapshot = (SnapshotImpl) snapshotManager.loadSnapshotAt(startVersion);
+        startSnapshot = snapshotManager.loadSnapshotAt(startVersion);
       } catch (io.delta.kernel.exceptions.KernelException e) {
         // startVersion may not yet exist (e.g. startingVersion=latest resolves to latest+1).
         // TODO(#6745): narrow this catch once kernel exposes a specific exception subclass
@@ -1248,10 +1247,7 @@ class DeltaV2MicroBatchStream
     // 2. This matches DSv1 behavior which uses snapshotAtSourceInit's P&M to interpret all
     //    AddFile actions and performs per-commit protocol validation.
     return StreamingHelper.getCommitActionsFromRangeUnsafe(
-        engine,
-        (io.delta.kernel.internal.commitrange.CommitRangeImpl) commitRange,
-        snapshotAtSourceInit.getPath(),
-        actionSet);
+        engine, commitRange, snapshotAtSourceInit.getPath(), actionSet);
   }
 
   /**
@@ -1695,10 +1691,10 @@ class DeltaV2MicroBatchStream
 
     if (hasCheckedReadIncompatibleSchemaChangesOnStreamStart) return;
 
-    SnapshotImpl startVersionSnapshot = null;
+    Snapshot startVersionSnapshot = null;
     Exception err = null;
     try {
-      startVersionSnapshot = (SnapshotImpl) snapshotManager.loadSnapshotAt(batchStartVersion);
+      startVersionSnapshot = snapshotManager.loadSnapshotAt(batchStartVersion);
     } catch (Exception e) {
       err = e;
     }
@@ -1870,7 +1866,7 @@ class DeltaV2MicroBatchStream
   private DataFrameSnapshotCache buildDataFrameSnapshotCache(long version) {
     // May differ from snapshotAtSourceInit on checkpoint restart. loadSnapshotAt is
     // metadata-only on driver; log replay runs on executors via ScanFileRDD.
-    SnapshotImpl snapshot = (SnapshotImpl) snapshotManager.loadSnapshotAt(version);
+    Snapshot snapshot = snapshotManager.loadSnapshotAt(version);
     SerializableReadOnlySnapshot serSnapshot =
         SerializableReadOnlySnapshot.fromSnapshot(snapshot, hadoopConf);
 
@@ -1951,7 +1947,7 @@ class DeltaV2MicroBatchStream
 
   /** Loads snapshot files at the specified version. */
   private InitialSnapshotCache loadAndValidateSnapshot(long version) {
-    SnapshotImpl snapshot = (SnapshotImpl) snapshotManager.loadSnapshotAt(version);
+    Snapshot snapshot = snapshotManager.loadSnapshotAt(version);
     // If schema tracking is already active and the initial snapshot has advanced since the tracked
     // read snapshot, replace the tracked metadata/protocol before reading snapshot files.
     if (metadataEvolutionHandler.shouldTrackMetadataChange()

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2Scan.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2Scan.java
@@ -23,7 +23,6 @@ import io.delta.kernel.data.Row;
 import io.delta.kernel.defaults.engine.DefaultEngine;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.expressions.Predicate;
-import io.delta.kernel.internal.ScanImpl;
 import io.delta.kernel.internal.actions.AddFile;
 import io.delta.kernel.internal.actions.DeletionVectorDescriptor;
 import io.delta.kernel.internal.data.ScanStateRow;
@@ -240,7 +239,7 @@ class DeltaV2Scan implements Scan, SupportsReportStatistics, SupportsRuntimeV2Fi
     Option<DeltaSourceMetadataTrackingLog> metadataTrackingLog =
         MetadataEvolutionHandler.getMetadataTrackingLogForMicroBatchStream(
             spark,
-            (io.delta.kernel.internal.SnapshotImpl) latestSnapshot,
+            latestSnapshot,
             options,
             snapshotManager,
             DefaultEngine.create(hadoopConf),
@@ -462,20 +461,14 @@ class DeltaV2Scan implements Scan, SupportsReportStatistics, SupportsRuntimeV2Fi
     final Engine tableEngine = DefaultEngine.create(hadoopConf);
     final String tablePath = getTablePath();
 
-    // TODO: Promote getScanFiles(Engine, boolean includeStats) to the public Scan interface to
-    // avoid coupling to the kernel-internal ScanImpl class. Until that API is available, this
-    // instanceof check is the only way to request per-file statistics from the kernel.
-    //
     // Read per-file stats JSON when either:
     //  - the optimizer will use numRows (CBO or planStats enabled), matching V1's behavior
     //    (LogicalRelation.computeStats()), or
     //  - a limit is pushed, in which case we need numRecords to decide when to stop planning.
-    // Both require the kernel scan to be a ScanImpl (the only path that supports includeStats).
-    final boolean scanIsStatsCapable = kernelScan instanceof ScanImpl;
-    final boolean includeStats = scanIsStatsCapable && (arePlanStatsEnabled() || isLimitPushed());
+    final boolean includeStats = arePlanStatsEnabled() || isLimitPushed();
     final CloseableIterator<FilteredColumnarBatch> scanFileBatches;
     if (includeStats) {
-      scanFileBatches = ((ScanImpl) kernelScan).getScanFiles(tableEngine, true /* includeStats */);
+      scanFileBatches = kernelScan.getScanFiles(tableEngine, true /* includeStats */);
       // Only participate in CBO numRows reporting when the optimizer actually consumes it, matching
       // V1's LogicalRelation.computeStats() gate. A limit alone forces stats to be read (for
       // termination via logicalRowCount) but must not start surfacing numRows when CBO is off.

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/MetadataEvolutionHandler.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/MetadataEvolutionHandler.java
@@ -16,6 +16,8 @@
 package io.delta.spark.internal.v2.read;
 
 import io.delta.kernel.CommitActions;
+import io.delta.kernel.CommitRange;
+import io.delta.kernel.Snapshot;
 import io.delta.kernel.data.ColumnVector;
 import io.delta.kernel.data.ColumnarBatch;
 import io.delta.kernel.engine.Engine;
@@ -24,7 +26,6 @@ import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.actions.Protocol;
 import io.delta.kernel.internal.checksum.CRCInfo;
-import io.delta.kernel.internal.commitrange.CommitRangeImpl;
 import io.delta.kernel.internal.lang.Lazy;
 import io.delta.kernel.internal.metrics.SnapshotQueryContext;
 import io.delta.kernel.internal.replay.LogReplay;
@@ -340,7 +341,7 @@ public class MetadataEvolutionHandler {
       metadata = validated.metadata;
       protocol = validated.protocol;
     } else {
-      SnapshotImpl snapshot = (SnapshotImpl) snapshotManager.loadSnapshotAt(batchStartVersion);
+      Snapshot snapshot = snapshotManager.loadSnapshotAt(batchStartVersion);
       version = snapshot.getVersion();
       metadata = snapshot.getMetadata();
       protocol = snapshot.getProtocol();
@@ -429,7 +430,7 @@ public class MetadataEvolutionHandler {
       long startVersion, long endVersion) {
     List<Metadata> metadataChanges =
         new ArrayList<>(collectMetadataActions(startVersion, endVersion).values());
-    SnapshotImpl startSnapshot = (SnapshotImpl) snapshotManager.loadSnapshotAt(startVersion);
+    Snapshot startSnapshot = snapshotManager.loadSnapshotAt(startVersion);
     Metadata startMetadata = startSnapshot.getMetadata();
 
     // Try to find rename or drop columns in between, or nullability/datatype changes by using
@@ -510,7 +511,7 @@ public class MetadataEvolutionHandler {
    */
   public static Optional<PersistedMetadata> getPersistedMetadataForMicroBatchStream(
       SparkSession spark,
-      SnapshotImpl snapshot,
+      Snapshot snapshot,
       Map<String, String> options,
       DeltaSnapshotManager snapshotManager,
       Engine engine) {
@@ -571,7 +572,7 @@ public class MetadataEvolutionHandler {
    * call {@link DeltaSnapshotManager#loadSnapshotAt} instead.
    */
   public static SnapshotImpl buildReadSnapshotFromPersistedMetadata(
-      SnapshotImpl snapshotAtSourceInit, Engine engine, PersistedMetadata customMetadata) {
+      Snapshot snapshotAtSourceInit, Engine engine, PersistedMetadata customMetadata) {
     Metadata sourceMetadata = snapshotAtSourceInit.getMetadata();
 
     Map<String, String> readConfigurations;
@@ -663,7 +664,7 @@ public class MetadataEvolutionHandler {
    */
   public static Option<DeltaSourceMetadataTrackingLog> getMetadataTrackingLogForMicroBatchStream(
       SparkSession spark,
-      SnapshotImpl snapshot,
+      Snapshot snapshot,
       Map<String, String> options,
       DeltaSnapshotManager snapshotManager,
       Engine engine,
@@ -715,9 +716,8 @@ public class MetadataEvolutionHandler {
     Metadata mergedMetadata = null;
     Protocol mergedProtocol = null;
 
-    CommitRangeImpl commitRange =
-        (CommitRangeImpl)
-            snapshotManager.getTableChanges(engine, currentMetadataVersion, Optional.empty());
+    CommitRange commitRange =
+        snapshotManager.getTableChanges(engine, currentMetadataVersion, Optional.empty());
 
     try (CloseableIterator<CommitActions> commitsIter =
         // Always include CDC: the merger must stop on any file action

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/snapshot/PathBasedSnapshotManager.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/snapshot/PathBasedSnapshotManager.java
@@ -24,7 +24,6 @@ import io.delta.kernel.TableManager;
 import io.delta.kernel.defaults.engine.DefaultEngine;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.internal.DeltaHistoryManager;
-import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.spark.internal.v2.exception.VersionNotFoundException;
 import java.util.ArrayList;
 import java.util.Optional;
@@ -89,7 +88,7 @@ public class PathBasedSnapshotManager implements DeltaSnapshotManager {
       boolean canReturnLastCommit,
       boolean mustBeRecreatable,
       boolean canReturnEarliestCommit) {
-    SnapshotImpl snapshot = (SnapshotImpl) loadLatestSnapshot();
+    Snapshot snapshot = loadLatestSnapshot();
     return DeltaHistoryManager.getActiveCommitAtTimestamp(
         kernelEngine,
         snapshot,
@@ -114,7 +113,7 @@ public class PathBasedSnapshotManager implements DeltaSnapshotManager {
   @Override
   public void checkVersionExists(long version, boolean mustBeRecreatable, boolean allowOutOfRange)
       throws VersionNotFoundException {
-    SnapshotImpl snapshot = (SnapshotImpl) loadLatestSnapshot();
+    Snapshot snapshot = loadLatestSnapshot();
     long earliest =
         mustBeRecreatable
             ? DeltaHistoryManager.getEarliestRecreatableCommit(

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/snapshot/unitycatalog/UCManagedTableSnapshotManager.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/snapshot/unitycatalog/UCManagedTableSnapshotManager.java
@@ -21,7 +21,6 @@ import io.delta.kernel.CommitRange;
 import io.delta.kernel.Snapshot;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.internal.DeltaHistoryManager;
-import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.internal.files.ParsedCatalogCommitData;
 import io.delta.kernel.unitycatalog.UCCatalogManagedClient;
 import io.delta.kernel.unitycatalog.UCTableIdentifier;
@@ -108,7 +107,7 @@ public class UCManagedTableSnapshotManager implements DeltaSnapshotManager {
       boolean canReturnLastCommit,
       boolean mustBeRecreatable,
       boolean canReturnEarliestCommit) {
-    SnapshotImpl snapshot = (SnapshotImpl) loadLatestSnapshot();
+    Snapshot snapshot = loadLatestSnapshot();
     List<ParsedCatalogCommitData> catalogCommits = snapshot.getLogSegment().getAllCatalogCommits();
     return DeltaHistoryManager.getActiveCommitAtTimestamp(
         engine,
@@ -138,7 +137,7 @@ public class UCManagedTableSnapshotManager implements DeltaSnapshotManager {
   public void checkVersionExists(long version, boolean mustBeRecreatable, boolean allowOutOfRange)
       throws VersionNotFoundException {
     // Load latest to get the current version bounds
-    SnapshotImpl snapshot = (SnapshotImpl) loadLatestSnapshot();
+    Snapshot snapshot = loadLatestSnapshot();
     // Latest version visible in this UC-managed snapshot.
     long latestSnapshotVersion = snapshot.getVersion();
 

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/PartitionUtils.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/PartitionUtils.java
@@ -17,7 +17,6 @@ package io.delta.spark.internal.v2.utils;
 
 import io.delta.kernel.Snapshot;
 import io.delta.kernel.data.MapValue;
-import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.internal.actions.AddFile;
 import io.delta.kernel.internal.actions.DeletionVectorDescriptor;
 import io.delta.kernel.internal.actions.Metadata;
@@ -83,9 +82,8 @@ public class PartitionUtils {
    * format is Parquet.
    */
   public static boolean tableSupportsDeletionVectors(Snapshot snapshot) {
-    SnapshotImpl snapshotImpl = (SnapshotImpl) snapshot;
-    Protocol protocol = snapshotImpl.getProtocol();
-    Metadata metadata = snapshotImpl.getMetadata();
+    Protocol protocol = snapshot.getProtocol();
+    Metadata metadata = snapshot.getMetadata();
     return protocol.supportsFeature(TableFeatures.DELETION_VECTORS_RW_FEATURE)
         && "parquet".equalsIgnoreCase(metadata.getFormat().getProvider());
   }
@@ -347,11 +345,10 @@ public class PartitionUtils {
       Configuration hadoopConf,
       SQLConf sqlConf,
       boolean isWriteTimeCDCRead) {
-    SnapshotImpl snapshotImpl = (SnapshotImpl) snapshot;
     // Use Path.toString() instead of toUri().toString() to avoid URL encoding issues.
     // toUri().toString() encodes special characters (e.g., space -> %20), which causes
     // DV file path resolution failures.
-    String tablePath = snapshotImpl.getDataPath().toString();
+    String tablePath = snapshot.getDataPath().toString();
 
     // Preserve the caller-provided readDataSchema (pre-DV/RT/CDC augmentation) for the final
     // column-reorder wrapper below.
@@ -387,7 +384,7 @@ public class PartitionUtils {
     // and the per-field MetadataValueSetterBuilder array used to materialise values per row.
     Optional<MetadataStructSchemaContext> metadataSchemaContext =
         MetadataStructSchemaContext.forSchema(
-            readDataSchema, partitionSchema, deltaFormat, snapshotImpl.getMetadata());
+            readDataSchema, partitionSchema, deltaFormat, snapshot.getMetadata());
     if (metadataSchemaContext.isPresent()) {
       readDataSchema = metadataSchemaContext.get().getParquetReadSchema();
     }
@@ -474,7 +471,7 @@ public class PartitionUtils {
    * Creates a {@link DeltaParquetFileFormatV2} from a snapshot. Shared between the read path
    * ({@link #createDeltaParquetReaderFactory}) and the write path (BatchWrite).
    *
-   * @param snapshot the Delta table snapshot (must be a SnapshotImpl)
+   * @param snapshot the Delta table snapshot
    * @param tablePath the table root path
    * @param optimizationsEnabled whether to enable file splitting and predicate pushdown
    * @param useMetadataRowIndex explicit control over _metadata.row_index for DV filtering
@@ -494,10 +491,9 @@ public class PartitionUtils {
       boolean optimizationsEnabled,
       Option<Boolean> useMetadataRowIndex,
       boolean isCDCRead) {
-    SnapshotImpl snapshotImpl = (SnapshotImpl) snapshot;
     return new DeltaParquetFileFormatV2(
-        snapshotImpl.getProtocol(),
-        snapshotImpl.getMetadata(),
+        snapshot.getProtocol(),
+        snapshot.getMetadata(),
         /* nullableRowTrackingConstantFields */ false,
         /* nullableRowTrackingGeneratedFields */ false,
         optimizationsEnabled,

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/SerializableReadOnlySnapshot.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/SerializableReadOnlySnapshot.java
@@ -16,10 +16,10 @@
 package io.delta.spark.internal.v2.utils;
 
 import io.delta.kernel.Scan;
+import io.delta.kernel.Snapshot;
 import io.delta.kernel.defaults.engine.DefaultEngine;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.internal.ScanImpl;
-import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.actions.Protocol;
 import io.delta.kernel.internal.checksum.CRCInfo;
@@ -37,8 +37,8 @@ import org.apache.spark.util.SerializableConfiguration;
 
 /**
  * Serializable carrier for a Delta snapshot's state. Created on the driver from an existing {@link
- * SnapshotImpl} (zero I/O), and reconstructed on the executor as a read-only {@link Scan} via
- * {@link #toScan(Configuration)}. The returned {@code Scan} interface exposes only read operations,
+ * Snapshot} (zero I/O), and reconstructed on the executor as a read-only {@link Scan} via {@link
+ * #toScan(Configuration)}. The returned {@code Scan} interface exposes only read operations,
  * preventing accidental misuse of write-path APIs (e.g. {@code Committer}).
  *
  * <p>TODO: This class relies on 10 {@code io.delta.kernel.internal.*} packages which have no
@@ -93,11 +93,11 @@ public class SerializableReadOnlySnapshot implements Serializable {
   }
 
   /**
-   * Driver-side: extract the snapshot state from an existing Kernel {@link SnapshotImpl}. This
-   * performs zero I/O — all data is already in memory on the driver.
+   * Driver-side: extract the snapshot state from an existing Kernel {@link Snapshot}. This performs
+   * zero I/O — all data is already in memory on the driver.
    */
   public static SerializableReadOnlySnapshot fromSnapshot(
-      SnapshotImpl snapshot, Configuration hadoopConf) {
+      Snapshot snapshot, Configuration hadoopConf) {
     LogSegment logSegment = snapshot.getLogSegment();
     return new SerializableReadOnlySnapshot(
         snapshot.getDataPath().toString(),

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/StreamingHelper.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/StreamingHelper.java
@@ -19,6 +19,7 @@ import static io.delta.kernel.internal.util.Preconditions.checkArgument;
 import static io.delta.kernel.internal.util.Preconditions.checkState;
 
 import io.delta.kernel.CommitActions;
+import io.delta.kernel.CommitRange;
 import io.delta.kernel.data.ColumnVector;
 import io.delta.kernel.data.ColumnarBatch;
 import io.delta.kernel.data.FilteredColumnarBatch;
@@ -30,7 +31,6 @@ import io.delta.kernel.internal.actions.CommitInfo;
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.actions.Protocol;
 import io.delta.kernel.internal.actions.RemoveFile;
-import io.delta.kernel.internal.commitrange.CommitRangeImpl;
 import io.delta.kernel.internal.data.StructRow;
 import io.delta.kernel.internal.util.Preconditions;
 import io.delta.kernel.utils.CloseableIterator;
@@ -190,7 +190,7 @@ public class StreamingHelper {
   // no-Snapshot overload added alongside this comment makes this helper obsolete.
   public static CloseableIterator<CommitActions> getCommitActionsFromRangeUnsafe(
       Engine engine,
-      CommitRangeImpl commitRange,
+      CommitRange commitRange,
       String tablePath,
       Set<DeltaLogActionUtils.DeltaAction> actionSet) {
     return DeltaLogActionUtils.getActionsFromCommitFilesWithProtocolValidation(
@@ -288,8 +288,7 @@ public class StreamingHelper {
       String tablePath,
       DeltaLogActionUtils.DeltaAction actionType,
       RowExtractor<T> extractor) {
-    CommitRangeImpl commitRange =
-        (CommitRangeImpl) snapshotManager.getTableChanges(engine, startVersion, endVersionOpt);
+    CommitRange commitRange = snapshotManager.getTableChanges(engine, startVersion, endVersionOpt);
     // LinkedHashMap to preserve insertion order
     Map<Long, T> versionToAction = new LinkedHashMap<>();
 

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2StreamingWrite.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2StreamingWrite.java
@@ -23,7 +23,6 @@ import io.delta.kernel.Transaction;
 import io.delta.kernel.data.Row;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.exceptions.ConcurrentTransactionException;
-import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.internal.actions.Protocol;
 import io.delta.kernel.types.StructType;
 import io.delta.kernel.utils.CloseableIterable;
@@ -88,7 +87,7 @@ class DeltaV2StreamingWrite implements StreamingWrite {
     this.queryId = requireNonNull(queryId, "queryId is null");
     requireNonNull(dataWriterFactoryBuilder, "dataWriterFactoryBuilder is null");
     this.writeSchema = initialSnapshot.getSchema();
-    this.writeProtocol = ((SnapshotImpl) initialSnapshot).getProtocol();
+    this.writeProtocol = initialSnapshot.getProtocol();
     // We only need this transaction's serialized write context for the factory, not the commit
     // (commit() builds its own per epoch).
     Transaction stateTxn =
@@ -121,8 +120,7 @@ class DeltaV2StreamingWrite implements StreamingWrite {
     //  as a blind append, skipping the conflict check V1 gets via readWholeTable().
 
     // Skip an already-committed epoch. Its executor-written files are then orphaned (VACUUM'd).
-    long committedEpoch =
-        ((SnapshotImpl) latestSnapshot).getLatestTransactionVersion(engine, queryId).orElse(-1L);
+    long committedEpoch = latestSnapshot.getLatestTransactionVersion(engine, queryId).orElse(-1L);
     if (committedEpoch >= epochId) {
       logger.info("Skipping already committed epoch {} for query {}", epochId, queryId);
       return;
@@ -156,7 +154,7 @@ class DeltaV2StreamingWrite implements StreamingWrite {
               + " cannot continue: the table schema changed after the stream started. Restart the "
               + "query to pick up the new schema.");
     }
-    if (!writeProtocol.equals(((SnapshotImpl) latestSnapshot).getProtocol())) {
+    if (!writeProtocol.equals(latestSnapshot.getProtocol())) {
       throw new IllegalStateException(
           "DSv2 streaming write to query "
               + queryId

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/catalog/DeltaV2TableTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/catalog/DeltaV2TableTest.java
@@ -25,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.delta.kernel.internal.SnapshotImpl;
+import io.delta.kernel.Snapshot;
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.actions.Protocol;
 import io.delta.spark.internal.v2.DeltaV2TestBase;
@@ -796,7 +796,7 @@ public class DeltaV2TableTest extends DeltaV2TestBase {
     // Capture v0 metadata BEFORE evolving the table.
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(tablePath, spark.sessionState().newHadoopConf());
-    SnapshotImpl snapshotV0 = (SnapshotImpl) snapshotManager.loadSnapshotAt(0L);
+    Snapshot snapshotV0 = snapshotManager.loadSnapshotAt(0L);
     Metadata metadataV0 = snapshotV0.getMetadata();
     Protocol protocolV0 = snapshotV0.getProtocol();
     String tableId = metadataV0.getId();

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2MicroBatchStreamCDCTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2MicroBatchStreamCDCTest.java
@@ -25,7 +25,6 @@ import io.delta.kernel.defaults.engine.DefaultEngine;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.internal.DeltaLogActionUtils.DeltaAction;
 import io.delta.kernel.internal.actions.AddFile;
-import io.delta.kernel.internal.commitrange.CommitRangeImpl;
 import io.delta.kernel.utils.CloseableIterator;
 import io.delta.spark.internal.v2.DeltaV2TestBase;
 import io.delta.spark.internal.v2.snapshot.PathBasedSnapshotManager;
@@ -1035,10 +1034,8 @@ class DeltaV2MicroBatchStreamCDCTest extends DeltaV2TestBase {
         ScalaUtils.toScalaMap(javaOptions);
     DeltaOptions deltaOptions = new DeltaOptions(scalaOptions, spark.sessionState().conf());
 
-    io.delta.kernel.internal.SnapshotImpl latestSnapshot =
-        (io.delta.kernel.internal.SnapshotImpl) snapshotManager.loadLatestSnapshot();
-    io.delta.kernel.internal.SnapshotImpl seededSnapshot =
-        (io.delta.kernel.internal.SnapshotImpl) snapshotManager.loadSnapshotAt(seededVersion);
+    io.delta.kernel.Snapshot latestSnapshot = snapshotManager.loadLatestSnapshot();
+    io.delta.kernel.Snapshot seededSnapshot = snapshotManager.loadSnapshotAt(seededVersion);
 
     org.apache.spark.sql.delta.sources.DeltaSourceMetadataTrackingLog trackingLog =
         MetadataEvolutionHandler.getMetadataTrackingLogForMicroBatchStream(
@@ -1219,7 +1216,7 @@ class DeltaV2MicroBatchStreamCDCTest extends DeltaV2TestBase {
 
     try (CloseableIterator<CommitActions> iter =
         StreamingHelper.getCommitActionsFromRangeUnsafe(
-            engine, (CommitRangeImpl) commitRange, tablePath, CDC_ACTION_SET)) {
+            engine, commitRange, tablePath, CDC_ACTION_SET)) {
       assertTrue(iter.hasNext(), "Expected at least one commit at version " + version);
       return iter.next();
     } catch (Exception e) {

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2MicroBatchStreamTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2MicroBatchStreamTest.java
@@ -4293,7 +4293,7 @@ public class DeltaV2MicroBatchStreamTest extends DeltaV2TestBase {
   private DeltaV2MicroBatchStream createTestStreamWithDefaults(
       PathBasedSnapshotManager snapshotManager, Configuration hadoopConf, DeltaOptions options) {
     io.delta.kernel.Snapshot snapshot = snapshotManager.loadLatestSnapshot();
-    String tablePath = ((io.delta.kernel.internal.SnapshotImpl) snapshot).getPath();
+    String tablePath = snapshot.getPath();
     StructType tableSchema =
         io.delta.spark.internal.v2.utils.SchemaUtils.convertKernelSchemaToSparkSchema(
             snapshot.getSchema());
@@ -4349,8 +4349,7 @@ public class DeltaV2MicroBatchStreamTest extends DeltaV2TestBase {
       String schemaTrackingLocation,
       String checkpointLocation,
       java.util.Map<String, String> optionMap) {
-    io.delta.kernel.internal.SnapshotImpl snapshot =
-        (io.delta.kernel.internal.SnapshotImpl) snapshotManager.loadLatestSnapshot();
+    io.delta.kernel.Snapshot snapshot = snapshotManager.loadLatestSnapshot();
     return DeltaSourceMetadataTrackingLog.create(
         spark,
         schemaTrackingLocation,

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/MetadataEvolutionHandlerTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/MetadataEvolutionHandlerTest.java
@@ -197,7 +197,7 @@ public class MetadataEvolutionHandlerTest extends DeltaV2TestBase {
       String tablePath, long initVersion, boolean seedLogWithInitEntry) {
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(tablePath, spark.sessionState().newHadoopConf());
-    SnapshotImpl snapshot = (SnapshotImpl) snapshotManager.loadSnapshotAt(initVersion);
+    Snapshot snapshot = snapshotManager.loadSnapshotAt(initVersion);
     Metadata tableMetadata = snapshot.getMetadata();
     Protocol tableProtocol = snapshot.getProtocol();
     KernelMetadataAdapter adapter = new KernelMetadataAdapter(tableMetadata);
@@ -996,7 +996,7 @@ public class MetadataEvolutionHandlerTest extends DeltaV2TestBase {
     createEmptyTestTable(tablePath, tableName);
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(tablePath, spark.sessionState().newHadoopConf());
-    SnapshotImpl snapshot = (SnapshotImpl) snapshotManager.loadLatestSnapshot();
+    Snapshot snapshot = snapshotManager.loadLatestSnapshot();
     return MetadataEvolutionHandler.getMetadataTrackingLogForMicroBatchStream(
         spark,
         snapshot,
@@ -1136,7 +1136,7 @@ public class MetadataEvolutionHandlerTest extends DeltaV2TestBase {
     createEmptyTestTable(tablePath, tableName);
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(tablePath, spark.sessionState().newHadoopConf());
-    SnapshotImpl snapshot = (SnapshotImpl) snapshotManager.loadLatestSnapshot();
+    Snapshot snapshot = snapshotManager.loadLatestSnapshot();
     return MetadataEvolutionHandler.getPersistedMetadataForMicroBatchStream(
         spark, snapshot, options, snapshotManager, defaultEngine);
   }
@@ -1158,7 +1158,7 @@ public class MetadataEvolutionHandlerTest extends DeltaV2TestBase {
     createEmptyTestTable(tablePath, tableName);
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(tablePath, spark.sessionState().newHadoopConf());
-    SnapshotImpl snapshot = (SnapshotImpl) snapshotManager.loadLatestSnapshot();
+    Snapshot snapshot = snapshotManager.loadLatestSnapshot();
 
     String schemaLogPath = new File(tempDir, "schema_log").getAbsolutePath();
     Map<String, String> options = new HashMap<>();
@@ -1206,13 +1206,13 @@ public class MetadataEvolutionHandlerTest extends DeltaV2TestBase {
   // ---------------------------------------------------------------------------
 
   /** Loads the latest snapshot from a fresh empty Delta table created at {@code tempDir/table}. */
-  private SnapshotImpl loadSourceSnapshot(File tempDir) {
+  private Snapshot loadSourceSnapshot(File tempDir) {
     String tablePath = new File(tempDir, "table").getAbsolutePath();
     String tableName = "t_" + UUID.randomUUID().toString().replace('-', '_');
     createEmptyTestTable(tablePath, tableName);
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(tablePath, spark.sessionState().newHadoopConf());
-    return (SnapshotImpl) snapshotManager.loadLatestSnapshot();
+    return snapshotManager.loadLatestSnapshot();
   }
 
   /** Persisted metadata with schema, protocol, and configuration distinct from the source. */
@@ -1241,7 +1241,7 @@ public class MetadataEvolutionHandlerTest extends DeltaV2TestBase {
   /** Happy path: persisted metadata overlays version, schema, protocol, and configuration. */
   @Test
   public void testBuildReadSnapshot_overlaysCustomMetadataAndProtocol(@TempDir File tempDir) {
-    SnapshotImpl source = loadSourceSnapshot(tempDir);
+    Snapshot source = loadSourceSnapshot(tempDir);
     long persistedVersion = source.getVersion() + 100; // distinct from source version
     PersistedMetadata persisted = persistedMetadataWithMarker(persistedVersion);
 
@@ -1259,7 +1259,7 @@ public class MetadataEvolutionHandlerTest extends DeltaV2TestBase {
   /** When {@code protocolJson} is absent on the persisted entry, fall back to the source's. */
   @Test
   public void testBuildReadSnapshot_fallsBackToSnapshotProtocolWhenAbsent(@TempDir File tempDir) {
-    SnapshotImpl source = loadSourceSnapshot(tempDir);
+    Snapshot source = loadSourceSnapshot(tempDir);
     PersistedMetadata withBoth = persistedMetadataWithMarker(42L);
     PersistedMetadata withoutProtocol =
         new PersistedMetadata(
@@ -1288,7 +1288,7 @@ public class MetadataEvolutionHandlerTest extends DeltaV2TestBase {
   @Test
   public void testBuildReadSnapshot_fallsBackToSnapshotConfigurationWhenAbsent(
       @TempDir File tempDir) {
-    SnapshotImpl source = loadSourceSnapshot(tempDir);
+    Snapshot source = loadSourceSnapshot(tempDir);
     PersistedMetadata withBoth = persistedMetadataWithMarker(42L);
     PersistedMetadata withoutConfig =
         new PersistedMetadata(
@@ -1316,7 +1316,7 @@ public class MetadataEvolutionHandlerTest extends DeltaV2TestBase {
    */
   @Test
   public void testBuildReadSnapshot_trapsLogReplayAccess(@TempDir File tempDir) {
-    SnapshotImpl source = loadSourceSnapshot(tempDir);
+    Snapshot source = loadSourceSnapshot(tempDir);
     PersistedMetadata persisted = persistedMetadataWithMarker(42L);
 
     SnapshotImpl read =
@@ -1348,7 +1348,7 @@ public class MetadataEvolutionHandlerTest extends DeltaV2TestBase {
   /** Builds a {@link PersistedMetadata} snapshot of the table state at v0. */
   private PersistedMetadata buildCurrentMetadataAtV0(
       String tablePath, PathBasedSnapshotManager snapshotManager) {
-    SnapshotImpl v0 = (SnapshotImpl) snapshotManager.loadSnapshotAt(0L);
+    Snapshot v0 = snapshotManager.loadSnapshotAt(0L);
     return PersistedMetadata.apply(
         "test-table-id",
         0L,
@@ -1439,8 +1439,7 @@ public class MetadataEvolutionHandlerTest extends DeltaV2TestBase {
     // version. We build the "expected" PersistedMetadata directly from the snapshot at that
     // version — if the merger captured the right metadata/protocol actions, the JSONs will match.
     assertTrue(result.isDefined());
-    SnapshotImpl mergedSnapshot =
-        (SnapshotImpl) snapshotManager.loadSnapshotAt(expectedMergedVersion);
+    Snapshot mergedSnapshot = snapshotManager.loadSnapshotAt(expectedMergedVersion);
     PersistedMetadata expected =
         PersistedMetadata.apply(
             "test-table-id",
@@ -1481,7 +1480,7 @@ public class MetadataEvolutionHandlerTest extends DeltaV2TestBase {
         new PathBasedSnapshotManager(tablePath, spark.sessionState().newHadoopConf());
 
     // current = v2 (the ALTER ADD COLUMN). Merger walks forward from here.
-    SnapshotImpl v2Snapshot = (SnapshotImpl) snapshotManager.loadSnapshotAt(2L);
+    Snapshot v2Snapshot = snapshotManager.loadSnapshotAt(2L);
     PersistedMetadata current =
         PersistedMetadata.apply(
             "test-table-id",
@@ -1498,7 +1497,7 @@ public class MetadataEvolutionHandlerTest extends DeltaV2TestBase {
     assertTrue(result.isDefined());
     assertEquals(3L, result.get().deltaCommitVersion());
 
-    SnapshotImpl v3Snapshot = (SnapshotImpl) snapshotManager.loadSnapshotAt(3L);
+    Snapshot v3Snapshot = snapshotManager.loadSnapshotAt(3L);
     assertEquals(v3Snapshot.getMetadata().getSchemaString(), result.get().dataSchemaJson());
   }
 }

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/ScanFileRDDTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/ScanFileRDDTest.java
@@ -20,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.delta.kernel.internal.SnapshotImpl;
+import io.delta.kernel.Snapshot;
 import io.delta.spark.internal.v2.DeltaV2TestBase;
 import io.delta.spark.internal.v2.snapshot.PathBasedSnapshotManager;
 import io.delta.spark.internal.v2.utils.SerializableReadOnlySnapshot;
@@ -42,7 +42,7 @@ public class ScanFileRDDTest extends DeltaV2TestBase {
 
     Configuration hadoopConf = spark.sessionState().newHadoopConf();
     PathBasedSnapshotManager mgr = new PathBasedSnapshotManager(tablePath, hadoopConf);
-    SnapshotImpl snapshot = (SnapshotImpl) mgr.loadLatestSnapshot();
+    Snapshot snapshot = mgr.loadLatestSnapshot();
 
     SerializableReadOnlySnapshot serializable =
         SerializableReadOnlySnapshot.fromSnapshot(snapshot, hadoopConf);
@@ -67,7 +67,7 @@ public class ScanFileRDDTest extends DeltaV2TestBase {
 
     Configuration hadoopConf = spark.sessionState().newHadoopConf();
     PathBasedSnapshotManager mgr = new PathBasedSnapshotManager(tablePath, hadoopConf);
-    SnapshotImpl snapshot = (SnapshotImpl) mgr.loadLatestSnapshot();
+    Snapshot snapshot = mgr.loadLatestSnapshot();
 
     SerializableReadOnlySnapshot serializable =
         SerializableReadOnlySnapshot.fromSnapshot(snapshot, hadoopConf);

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/SerializableReadOnlySnapshotTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/SerializableReadOnlySnapshotTest.java
@@ -20,10 +20,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import io.delta.kernel.Scan;
+import io.delta.kernel.Snapshot;
 import io.delta.kernel.data.FilteredColumnarBatch;
 import io.delta.kernel.defaults.engine.DefaultEngine;
 import io.delta.kernel.engine.Engine;
-import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.utils.CloseableIterator;
 import io.delta.spark.internal.v2.DeltaV2TestBase;
 import io.delta.spark.internal.v2.snapshot.PathBasedSnapshotManager;
@@ -48,7 +48,7 @@ public class SerializableReadOnlySnapshotTest extends DeltaV2TestBase {
 
     Configuration hadoopConf = spark.sessionState().newHadoopConf();
     PathBasedSnapshotManager mgr = new PathBasedSnapshotManager(tablePath, hadoopConf);
-    SnapshotImpl snapshot = (SnapshotImpl) mgr.loadLatestSnapshot();
+    Snapshot snapshot = mgr.loadLatestSnapshot();
 
     SerializableReadOnlySnapshot original =
         SerializableReadOnlySnapshot.fromSnapshot(snapshot, hadoopConf);
@@ -88,7 +88,7 @@ public class SerializableReadOnlySnapshotTest extends DeltaV2TestBase {
 
     Configuration hadoopConf = spark.sessionState().newHadoopConf();
     PathBasedSnapshotManager mgr = new PathBasedSnapshotManager(tablePath, hadoopConf);
-    SnapshotImpl snapshot = (SnapshotImpl) mgr.loadLatestSnapshot();
+    Snapshot snapshot = mgr.loadLatestSnapshot();
 
     SerializableReadOnlySnapshot serializable =
         SerializableReadOnlySnapshot.fromSnapshot(snapshot, hadoopConf);


### PR DESCRIPTION
Follow-up to #7269: now that the accessors are on the public interfaces, drop the `io.delta.kernel.internal.*Impl` downcasts in Delta Spark, Flink, and Kernel's own UC module, plus the casts that became redundant inside `kernel-api`.

## Summary

**Connectors** — type against `Snapshot` instead of `SnapshotImpl`: `PathBasedSnapshotManager`, `UCManagedTableSnapshotManager`, `DeltaV2MicroBatchStream`, Flink's `CheckpointWriter` (and with it the `instanceof SnapshotImpl` guard in `MaintenanceListener`, which existed only to protect that cast). `DeltaV2MicroBatchStream` is unblocked by widening two helper *parameters* — `MetadataEvolutionHandler.buildReadSnapshotFromPersistedMetadata` and `SerializableReadOnlySnapshot.fromSnapshot`; both keep their return types, since they construct `SnapshotImpl` / `ScanImpl`.

**`UnityCatalogUtils`** — reads clustering columns via the public `Snapshot.getClusteringColumnInfos()` + `ClusteringColumnInfo.getLogicalColumn()` rather than the `Impl`-only `getPhysicalClusteringColumns()`. The emitted `clusteringColumns` property is unchanged: both paths resolve through `ColumnMapping.getLogicalColumnNameAndDataType` against the same schema in the same order. `serializeClusteringColumns` splits into a physical-resolving half (still used by the CommitMetadata path, which holds physical refs) and a logical-serializing half.

**`kernel-api`** — `TransactionCommitResult`'s constructor takes `Optional<? extends Snapshot>` instead of `Optional<SnapshotImpl>`; `JsonMetadataDomain.fromSnapshot` and the row-tracking / clustering domain wrappers take `Snapshot`; `CommitRangeBuilder.atTimestamp` and `SnapshotBuilderImpl.atTimestamp` no longer assert `instanceof SnapshotImpl` (nothing downstream needs it); redundant casts removed from `CommitRangeFactory`, `CommitRangeBuilderImpl`, and `TableImpl`.

**Tests** — removed every cast that guarded only promoted members, across `ChecksumUtilsSuite`, `CreateCheckpointSuite`, `DeltaTableSchemaEvolutionSuite`, `LogCompactionWriterSuite`, `TestUtils`, `UCE2ESuite`, `UnityCatalogUtilsSuite`, the Flink table tests, and the spark-unified interop suites.

Not de-cast, and why: `Checkpointer.checkpoint` still takes `SnapshotImpl` because its log-cleanup check reads the unpromoted `wasBuiltAsLatest()`. Casts that survive are the ones that genuinely need an `Impl`-only member (`getPhysicalClusteringColumns`, `getActiveDomainMetadataMap`, `wasBuiltAsLatest`, `getSnapshotReport`, `getLazyLogSegment`) or that feed a helper whose parameter is still `SnapshotImpl`-typed (`assertMetadataProp`, `verifyClusteringDomainMetadata`, `getSnapshotAtLatest`) — retyping those helpers is a wider refactor left out of scope.

## Test plan
- [x] compile (main + test): `kernelApi`, `kernelDefaults`, `kernelUnityCatalog`, `sparkV2`, `flink`, `spark-unified`; javafmt/checkstyle clean
- [x] `UnityCatalogUtilsSuite` (12, incl. a new assertion that an unclustered table omits `clusteringColumns`), `CommitRangeBuilderSuite` (1161), `PostCommitSnapshotSuite` + `CreateCheckpointSuite` (36), `ScanSuite` (63)
- [ ] CI

## Does this PR introduce any user-facing changes?
No — internal typing only. `TransactionCommitResult`'s public constructor accepts a wider parameter type, which is source-compatible for existing callers.
