### PR TITLE
[Spark] Reorder entries in DeltaV2SourceSuite PassingTests

### DIFF
--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceSuite.scala
@@ -63,8 +63,8 @@ object DeltaV2SourceSuite {
   val PassingTests: Set[String] = Set(
     // ========== Core streaming tests ==========
     "basic",
-    "initial snapshot ends at base index of next version",
     "new commits arrive after stream initialization - with explicit startingVersion",
+    "initial snapshot ends at base index of next version",
     "can consume new data without update",
     "Delta sources don't write offsets with null json",
     "reading from partitioned table succeeds during restart",


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Reorders two adjacent test names in the Core streaming section of
`DeltaV2SourceSuite.PassingTests`. `PassingTests` is a `Set[String]`,
so element order carries no semantic meaning — this is a pure no-op
cleanup with no behavioral change.

## How was this patch tested?

No new tests. The change only reorders existing entries within a `Set`;
the set of tests exercised by `DeltaV2SourceSuite` is unchanged.

## Does this PR introduce _any_ user-facing changes?

No.