### PR TITLE
Relax sparkV1Filtered to only exclude DeltaLog classes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -459,10 +459,7 @@ lazy val sparkV1Filtered = (project in file("spark-v1-filtered"))
 
       // Filter out DeltaLog, Snapshot, OptimisticTransaction, and actions.scala classes
       v1Mappings.filterNot { case (file, path) =>
-        path.contains("org/apache/spark/sql/delta/DeltaLog") ||
-        path.contains("org/apache/spark/sql/delta/Snapshot") ||
-        path.contains("org/apache/spark/sql/delta/OptimisticTransaction") ||
-        path.contains("org/apache/spark/sql/delta/actions/actions")
+        path.contains("org/apache/spark/sql/delta/DeltaLog")
       }
     },
   )


### PR DESCRIPTION
## Description

The `sparkV1Filtered` module repackages the `delta-spark-v1` jar with a set of classes removed, and is consumed as the compile-time dependency of the Kernel-based DSv2 connector (`sparkV2`). Its purpose is to constrain which V1 classes the DSv2 connector may compile against.

Previously the filter excluded `DeltaLog`, `Snapshot`, `OptimisticTransaction`, and `actions`. This relaxes the filter to exclude only `DeltaLog`, so the DSv2 connector can compile against the V1 `Snapshot` and `OptimisticTransaction` classes. This unblocks routing the DSv2 batch-write commit through the V1 optimistic-transaction path instead of committing natively through Kernel.

This change only affects `sparkV2`'s compile classpath. The published `delta-spark` jar continues to be assembled by merging the full (unfiltered) `sparkV1` mappings with `sparkV2`, so the `packageBin` duplicate-class detector is unaffected.

## How was this patch tested?

Build-configuration change verified by the existing module build (`sparkV1` / `sparkV1Filtered` / `sparkV2` compilation and the `delta-spark` assembly / duplicate-class check).

## Does this PR introduce _any_ user-facing changes?

No.