### PR TITLE
Use getChangesIterator in table feature checks

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
@@ -1486,13 +1486,11 @@ object CheckpointProtectionTableFeature
       catalogTableOpt: Option[CatalogTable],
       toVersion: Long): Boolean = {
     deltaLog
-      .getChangeLogFiles(
+      .getChangesIterator(
         startVersion = 0,
         endVersion = toVersion,
         catalogTableOpt = catalogTableOpt,
         failOnDataLoss = false)
-      .map { case (_, file) => file }
-      .filter(FileNames.isDeltaFile)
       .take(1).isEmpty
   }
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
`deltasUpToVersionAreTruncated` in `CheckpointProtectionTableFeature` only needs to know whether any commits exist in the range `[0, toVersion]`. It previously called `getChangeLogFiles`, then mapped to the file status and filtered with `FileNames.isDeltaFile` before taking the first element.

This switches the check to `getChangesIterator`, which iterates the commit actions directly. The `filter(FileNames.isDeltaFile)` step was effectively a no-op here: the listed log files are either checkpoint files or delta commit files, and neither is removed by that predicate. Dropping the redundant map/filter simplifies the helper without changing its result.

## How was this patch tested?
Existing unit tests.

## Does this PR introduce _any_ user-facing changes?
No.