### PR TITLE
[Kernel] Widen literalForPartitionValue access to public

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/PartitionUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/PartitionUtils.java
@@ -476,7 +476,14 @@ public class PartitionUtils {
         () -> DeltaErrorsInternal.invalidTimestampFormatForPartitionValue(partitionValue));
   }
 
-  protected static Literal literalForPartitionValue(DataType dataType, String partitionValue) {
+  /**
+   * Create a Literal object for the given partition value and data type.
+   *
+   * @param dataType The data type of the partition value.
+   * @param partitionValue The partition value to create the Literal object for.
+   * @return The Literal object for the given partition value and data type.
+   */
+  public static Literal literalForPartitionValue(DataType dataType, String partitionValue) {
     if (partitionValue == null) {
       return Literal.ofNull(dataType);
     }


### PR DESCRIPTION
## Description

Changes `PartitionUtils.literalForPartitionValue` from `protected static` to `public static` so it can be reused by callers outside the `io.delta.kernel.internal.util` package and adds Javadoc for the method.

Widening visibility is source- and binary-compatible, so no existing caller is affected.

## How was this patch tested?

- `kernelApi/compile` succeeds (Java + Scala, checkstyle, scalastyle all clean)
- `PartitionUtilsSuite` passes (95/95 tests)

## Does this PR introduce _any_ user-facing changes?

No.

This pull request and its description were written by Isaac.