### PR TITLE
[kernel-spark] Support partitioned writes in the Spark DSv2 sink

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSinkSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSinkSuite.scala
@@ -34,8 +34,10 @@ import org.scalatest.time.SpanSugar._
 import org.apache.spark.SparkConf
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.connector.expressions.IdentityTransform
 import org.apache.spark.sql.execution.DataSourceScanExec
 import org.apache.spark.sql.execution.datasources._
+import org.apache.spark.sql.execution.datasources.v2.{BatchScanExec, DataSourceV2Relation}
 import org.apache.spark.sql.execution.streaming.sources.WriteToMicroBatchDataSourceV1
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.streaming._
@@ -83,22 +85,31 @@ class DeltaSinkSuite
   import testImplicits._
 
   /**
-   * When false, sink tests address the target by filesystem path (the original DSv1 access path).
-   * When true, they address it by catalog name via `toTable` (required to exercise the DSv2 sink,
-   * which has no path-based seam). Overridden by [[DeltaSinkNameBasedSuite]].
+   * When true, reads and writes route through the V2 Kernel connector (DeltaV2Table) instead of V1
+   * (under V2_ENABLE_MODE=STRICT). Implies [[useNameBasedAccess]] -- the V2 connector has no
+   * path-based seam -- hence it is the default for that flag.
    */
   protected def useDsv2: Boolean = false
 
   /**
+   * When false, sink tests address the target by filesystem path (the original DSv1 access path).
+   * When true, they address it by catalog name via `toTable` (required to exercise the DSv2 sink,
+   * which has no path-based seam). Defaults to [[useDsv2]] since V2-connector access is inherently
+   * name-based, but can be set independently to run name-based access on the V1 connector.
+   */
+  protected def useNameBasedAccess: Boolean = useDsv2
+
+  /**
    * Run a sink test against a target table, providing the `target` identifier in the form the
-   * current mode expects: a catalog name when [[useDsv2]] is true, otherwise a filesystem path.
+   * current mode expects: a catalog name when [[useNameBasedAccess]] is true, otherwise a
+   * filesystem path.
    * The companion helpers ([[startStream]], [[readTarget]], [[deltaLogForTarget]],
    * [[deltaTableForTarget]]) interpret `target` accordingly, so a single test body covers both
    * modes.
    */
   protected def withSinkTarget(f: (String, File) => Unit): Unit = {
     withTempDir { checkpointDir =>
-      if (useDsv2) {
+      if (useNameBasedAccess) {
         // Unique table name per invocation: the target is a managed table at a deterministic
         // warehouse path, so a fixed name leaks state across tests (stale data / DeltaLog cache).
         val table = "test_delta_sink_" + checkpointDir.getName.replaceAll("[^A-Za-z0-9]", "")
@@ -115,20 +126,20 @@ class DeltaSinkSuite
 
   /** Start the stream against `target`, routing to `toTable` (DSv2) or `start` (path-based). */
   protected def startStream(writer: DataStreamWriter[_], target: String): StreamingQuery =
-    if (useDsv2) writer.toTable(target) else writer.start(target)
+    if (useNameBasedAccess) writer.toTable(target) else writer.start(target)
 
   /** Batch-read `target`, by catalog name (DSv2) or by path (path-based). */
   protected def readTarget(target: String): DataFrame =
-    if (useDsv2) spark.read.table(target) else spark.read.format("delta").load(target)
+    if (useNameBasedAccess) spark.read.table(target) else spark.read.format("delta").load(target)
 
   /** Resolve the [[DeltaLog]] for `target`, by catalog name (DSv2) or by path (path-based). */
   protected def deltaLogForTarget(target: String): DeltaLog =
-    if (useDsv2) DeltaLog.forTable(spark, TableIdentifier(target))
+    if (useNameBasedAccess) DeltaLog.forTable(spark, TableIdentifier(target))
     else DeltaLog.forTable(spark, target)
 
   /** Resolve the [[DeltaTable]] for `target`, by name (DSv2) or path. */
   protected def deltaTableForTarget(target: String): IODeltaTable =
-    if (useDsv2) IODeltaTable.forName(spark, target)
+    if (useNameBasedAccess) IODeltaTable.forName(spark, target)
     else IODeltaTable.forPath(spark, target)
 
   test("append mode") {
@@ -303,15 +314,17 @@ class DeltaSinkSuite
     withSinkTarget { (target, checkpointDir) =>
       val inputData = MemoryStream[Int]
       val ds = inputData.toDS()
-      val query =
-        startStream(
-          ds.map(i => (i, i * 1000))
-            .toDF("id", "value")
-            .writeStream
-            .partitionBy("id")
-            .option("checkpointLocation", checkpointDir.getCanonicalPath)
-            .format("delta"),
-          target)
+      def startPartitionedQuery(): StreamingQuery = startStream(
+        ds.map(i => (i, i * 1000))
+          .toDF("id", "value")
+          .writeStream
+          .partitionBy("id")
+          .option("checkpointLocation", checkpointDir.getCanonicalPath)
+          .format("delta"),
+        target)
+      // `var` so the restart phase below can swap in a fresh query on the same checkpoint while
+      // the `finally` still stops whichever query is currently running.
+      var query = startPartitionedQuery()
       try {
 
         inputData.addData(1, 2, 3)
@@ -319,21 +332,38 @@ class DeltaSinkSuite
           query.processAllAvailable()
         }
 
-        val outputDf = readTarget(target)
+        def outputDf: DataFrame = readTarget(target)
         val expectedSchema = new StructType()
           .add(StructField("id", IntegerType))
           .add(StructField("value", IntegerType))
         assert(outputDf.schema === expectedSchema)
 
-        // Verify the correct partitioning schema has been inferred
-        val hadoopFsRelations = outputDf.queryExecution.analyzed.collect {
-          case LogicalRelationWithTable(baseRelation, _) if
-              baseRelation.isInstanceOf[HadoopFsRelation] =>
-            baseRelation.asInstanceOf[HadoopFsRelation]
+        // Verify the correct partitioning schema has been inferred. The V1 and V2 connectors
+        // expose it through different plan nodes, so branch on the read connector.
+        if (useDsv2) {
+          // V2: the analyzed plan holds a DataSourceV2Relation whose table advertises the
+          // partition columns as identity transforms; data columns are the rest of the schema.
+          val v2Relations = outputDf.queryExecution.analyzed.collect {
+            case r: DataSourceV2Relation => r
+          }
+          assert(v2Relations.size === 1)
+          val table = v2Relations.head.table
+          val partitionCols = table.partitioning().collect {
+            case it: IdentityTransform => it.reference.fieldNames.mkString(".")
+          }.toSet
+          val dataCols = table.columns().map(_.name).toSet -- partitionCols
+          assert(partitionCols.contains("id"))
+          assert(dataCols.contains("value"))
+        } else {
+          val hadoopFsRelations = outputDf.queryExecution.analyzed.collect {
+            case LogicalRelationWithTable(baseRelation, _) if
+                baseRelation.isInstanceOf[HadoopFsRelation] =>
+              baseRelation.asInstanceOf[HadoopFsRelation]
+          }
+          assert(hadoopFsRelations.size === 1)
+          assert(hadoopFsRelations.head.partitionSchema.exists(_.name == "id"))
+          assert(hadoopFsRelations.head.dataSchema.exists(_.name == "value"))
         }
-        assert(hadoopFsRelations.size === 1)
-        assert(hadoopFsRelations.head.partitionSchema.exists(_.name == "id"))
-        assert(hadoopFsRelations.head.dataSchema.exists(_.name == "value"))
 
         // Verify the data is correctly read
         checkDatasetUnorderly(
@@ -345,7 +375,11 @@ class DeltaSinkSuite
           val filePartitions = df.queryExecution.executedPlan.collect {
             case scan: DataSourceScanExec if scan.inputRDDs().head.isInstanceOf[FileScanRDD] =>
               scan.inputRDDs().head.asInstanceOf[FileScanRDD].filePartitions
-          }.flatten
+            case scan: BatchScanExec =>
+              // V2 (Kernel): DeltaV2Batch plans FilePartitions carrying the same per-file
+              // partitionValues as V1, so the assertions below are connector-agnostic.
+              scan.batch.planInputPartitions().collect { case fp: FilePartition => fp }.toSeq
+          }.flatMap(identity)
           if (filePartitions.isEmpty) {
             fail(s"No FileScan in query\n${df.queryExecution}")
           }
@@ -372,6 +406,21 @@ class DeltaSinkSuite
           assert(filesToBeRead.forall(_.partitionValues.getInt(0) != 3))
           assert(filesToBeRead.map(_.partitionValues).distinct.size === 2)
         }
+
+        // Restart from the same checkpoint: the partitioned sink must recover exactly-once. The
+        // already-committed batch is not reprocessed (no duplicate rows / partition files), and new
+        // data after the restart appends into the correct partition directories.
+        query.stop()
+        query = startPartitionedQuery()
+        query.processAllAvailable()
+        checkDatasetUnorderly(outputDf.as[(Int, Int)], (1, 1000), (2, 2000), (3, 3000))
+
+        inputData.addData(4)
+        failAfter(streamingTimeout) {
+          query.processAllAvailable()
+        }
+        checkDatasetUnorderly(
+          outputDf.as[(Int, Int)], (1, 1000), (2, 2000), (3, 3000), (4, 4000))
       } finally {
         if (query != null) {
           query.stop()
@@ -456,7 +505,7 @@ class DeltaSinkSuite
           .format("delta")
           .partitionBy("id", "by4")
           .mode("append")
-        if (useDsv2) {
+        if (useNameBasedAccess) {
           // Name-based: the partition-column mismatch surfaces from the catalog as an
           // IllegalArgumentException with a different message than the path-based DataSource.
           val e = intercept[IllegalArgumentException] {
@@ -567,7 +616,7 @@ class DeltaSinkSuite
           .partitionBy("id", "value")
           .option("checkpointLocation", checkpointDir.getCanonicalPath)
           .format("delta")
-      if (useDsv2) {
+      if (useNameBasedAccess) {
         // Name-based: creating a table partitioned by all of its columns is rejected up front (at
         // table creation), rather than surfacing as a StreamingQueryException once the stream runs.
         val e = intercept[AnalysisException] {
@@ -737,7 +786,7 @@ class DeltaSinkSuite
       columns: Seq[StructField]
   ): Unit = {
     val builder = IODeltaTable.create(spark)
-    if (useDsv2) builder.tableName(target) else builder.location(target)
+    if (useNameBasedAccess) builder.tableName(target) else builder.location(target)
     columns.foreach(builder.addColumn)
     builder.execute()
   }
@@ -884,7 +933,7 @@ class DeltaSinkSuite
 // by path, exercising the same behaviors through the name-based write seam required by the DSv2
 // sink.
 class DeltaSinkNameBasedSuite extends DeltaSinkSuite {
-  override protected def useDsv2: Boolean = true
+  override protected def useNameBasedAccess: Boolean = true
 }
 
 class DeltaSinkWithCatalogManagedBatch1Suite extends DeltaSinkSuite {

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
@@ -538,6 +538,7 @@ public class DeltaV2Table extends DeltaV2TableShims
         initialSnapshot,
         snapshotManager,
         schemaProvider.getDataSchema(),
+        schemaProvider.getPartitionSchema(),
         info);
   }
 

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/PartitionUtils.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/PartitionUtils.java
@@ -17,12 +17,14 @@ package io.delta.spark.internal.v2.utils;
 
 import io.delta.kernel.Snapshot;
 import io.delta.kernel.data.MapValue;
+import io.delta.kernel.expressions.Literal;
 import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.internal.actions.AddFile;
 import io.delta.kernel.internal.actions.DeletionVectorDescriptor;
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.actions.Protocol;
 import io.delta.kernel.internal.tablefeatures.TableFeatures;
+import io.delta.kernel.types.DataType;
 import io.delta.spark.internal.v2.read.ColumnReorderReadFunction;
 import io.delta.spark.internal.v2.read.DeltaParquetFileFormatV2;
 import io.delta.spark.internal.v2.read.DeltaV2ScanUtils;
@@ -35,8 +37,10 @@ import io.delta.spark.internal.v2.read.metadata.MetadataStructSchemaContext;
 import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.conf.Configuration;
@@ -61,9 +65,22 @@ import org.apache.spark.sql.execution.datasources.PartitioningUtils;
 import org.apache.spark.sql.execution.datasources.parquet.ParquetUtils;
 import org.apache.spark.sql.internal.SQLConf;
 import org.apache.spark.sql.sources.Filter;
+import org.apache.spark.sql.types.BinaryType;
+import org.apache.spark.sql.types.BooleanType;
+import org.apache.spark.sql.types.ByteType;
+import org.apache.spark.sql.types.DateType;
+import org.apache.spark.sql.types.Decimal;
+import org.apache.spark.sql.types.DecimalType;
+import org.apache.spark.sql.types.DoubleType;
+import org.apache.spark.sql.types.FloatType;
+import org.apache.spark.sql.types.IntegerType;
+import org.apache.spark.sql.types.LongType;
+import org.apache.spark.sql.types.ShortType;
 import org.apache.spark.sql.types.StringType;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.types.TimestampNTZType;
+import org.apache.spark.sql.types.TimestampType;
 import org.apache.spark.unsafe.types.UTF8String;
 import scala.Function1;
 import scala.Option;
@@ -183,6 +200,133 @@ public class PartitionUtils {
       }
     }
     return new GenericInternalRow(values);
+  }
+
+  /**
+   * Build the typed Kernel {@link Literal} map (logical column name -> value) for the partition
+   * columns of {@code row}, as required by {@code Transaction.getWriteContext}. Insertion order
+   * follows {@code partitionSchema}.
+   *
+   * <p>TODO(#7140): key by physical name to support column mapping (safe today as build() rejects
+   * column-mapped tables).
+   *
+   * @param row the full write row Spark hands the writer
+   * @param partitionSchema the partition columns (in partition order)
+   * @param partitionOrdinals the ordinal of each partition column within {@code row}, parallel to
+   *     {@code partitionSchema}
+   */
+  public static Map<String, Literal> buildPartitionLiterals(
+      InternalRow row, StructType partitionSchema, int[] partitionOrdinals) {
+    final StructField[] fields = partitionSchema.fields();
+    assert partitionOrdinals.length == fields.length
+        : String.format(
+            java.util.Locale.ROOT,
+            "Partition ordinals size %d != partition columns size %d",
+            partitionOrdinals.length,
+            fields.length);
+    final Map<String, Literal> literals = new LinkedHashMap<>();
+    for (int i = 0; i < partitionOrdinals.length; i++) {
+      final StructField field = fields[i];
+      literals.put(
+          field.name(),
+          convertRowValueToKernelLiteral(row, partitionOrdinals[i], field.dataType()));
+    }
+    return literals;
+  }
+
+  /**
+   * Extract the partition-column values of {@code row} (in {@code partitionSchema} order) for
+   * detecting a partition boundary, compared with {@link #partitionValuesEqual}. Keyed on the
+   * decoded {@link Literal#getValue()}, not the {@link Literal}: kernel {@code Literal.equals}
+   * compares {@code byte[]} by identity, so binary values need {@code deepEquals} instead.
+   */
+  public static Object[] extractPartitionValues(
+      InternalRow row, StructType partitionSchema, int[] partitionOrdinals) {
+    final StructField[] fields = partitionSchema.fields();
+    assert partitionOrdinals.length == fields.length
+        : String.format(
+            java.util.Locale.ROOT,
+            "Partition ordinals size %d != partition columns size %d",
+            partitionOrdinals.length,
+            fields.length);
+    final Object[] values = new Object[partitionOrdinals.length];
+    for (int i = 0; i < partitionOrdinals.length; i++) {
+      final Literal literal =
+          convertRowValueToKernelLiteral(row, partitionOrdinals[i], fields[i].dataType());
+      values[i] = literal.getValue();
+    }
+    return values;
+  }
+
+  /**
+   * Compare two partition-value arrays from {@link #extractPartitionValues}. Uses {@link
+   * Objects#deepEquals} so {@code byte[]} (binary partition columns) compare by content, not
+   * identity.
+   */
+  public static boolean partitionValuesEqual(Object[] a, Object[] b) {
+    if (a == b) {
+      return true;
+    }
+    if (a == null || b == null || a.length != b.length) {
+      return false;
+    }
+    for (int i = 0; i < a.length; i++) {
+      if (!Objects.deepEquals(a[i], b[i])) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Build the Kernel {@link Literal} for a partition-column value in {@code row}; a null value
+   * becomes {@code Literal.ofNull(kernelType)}. See also {@code
+   * ExpressionUtils.convertValueToKernelLiteral} (the value-based, read-side counterpart).
+   */
+  private static Literal convertRowValueToKernelLiteral(
+      InternalRow row, int ordinal, org.apache.spark.sql.types.DataType type) {
+    if (row.isNullAt(ordinal)) {
+      final DataType kernelType = SchemaUtils.convertSparkDataTypeToKernelDataType(type);
+      return Literal.ofNull(kernelType);
+    }
+    if (type instanceof IntegerType) {
+      return Literal.ofInt(row.getInt(ordinal));
+    } else if (type instanceof DateType) {
+      return Literal.ofDate(row.getInt(ordinal));
+    } else if (type instanceof LongType) {
+      return Literal.ofLong(row.getLong(ordinal));
+    } else if (type instanceof TimestampType) {
+      // TODO(#7140): Kernel logs timestamp partition values in plain session-tz form, not V1's
+      // UTC-normalized ISO-8601, so the two engines diverge for timestamp-partitioned tables.
+      return Literal.ofTimestamp(row.getLong(ordinal));
+    } else if (type instanceof TimestampNTZType) {
+      return Literal.ofTimestampNtz(row.getLong(ordinal));
+    } else if (type instanceof ShortType) {
+      return Literal.ofShort(row.getShort(ordinal));
+    } else if (type instanceof ByteType) {
+      return Literal.ofByte(row.getByte(ordinal));
+    } else if (type instanceof BooleanType) {
+      return Literal.ofBoolean(row.getBoolean(ordinal));
+    } else if (type instanceof FloatType) {
+      return Literal.ofFloat(row.getFloat(ordinal));
+    } else if (type instanceof DoubleType) {
+      return Literal.ofDouble(row.getDouble(ordinal));
+    } else if (type instanceof StringType) {
+      // Empty string maps to null, as V1 does (Empty2Null), so "" and null share a partition.
+      final String str = row.getUTF8String(ordinal).toString();
+      if (str.isEmpty()) {
+        return Literal.ofNull(SchemaUtils.convertSparkDataTypeToKernelDataType(type));
+      }
+      return Literal.ofString(str);
+    } else if (type instanceof BinaryType) {
+      return Literal.ofBinary(row.getBinary(ordinal));
+    } else if (type instanceof DecimalType) {
+      final DecimalType dt = (DecimalType) type;
+      final Decimal decimal = row.getDecimal(ordinal, dt.precision(), dt.scale());
+      return Literal.ofDecimal(decimal.toJavaBigDecimal(), dt.precision(), dt.scale());
+    }
+    throw new UnsupportedOperationException(
+        "Unsupported partition column type for DSv2 write: " + type.catalogString());
   }
 
   /**

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2BatchWrite.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2BatchWrite.java
@@ -24,7 +24,6 @@ import io.delta.kernel.internal.util.Utils;
 import io.delta.kernel.utils.CloseableIterable;
 import io.delta.spark.internal.v2.utils.SerializableKernelRowWrapper;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.spark.sql.connector.write.BatchWrite;
@@ -39,13 +38,14 @@ import org.slf4j.LoggerFactory;
 
 /**
  * BatchWrite for DSv2 batch append using Spark's Parquet path. Creates a Kernel transaction on the
- * driver, obtains the target directory from the Kernel write context, creates a Spark Parquet
- * OutputWriterFactory via the shared {@link PartitionUtils#createDeltaParquetFileFormat} factory,
- * and serializes everything into a {@link DeltaV2DataWriterFactory} for executor transport.
+ * driver (via {@link DeltaV2BatchWriteContext}) and builds the executor write state -- a {@link
+ * DeltaV2DataWriterFactory} -- through the shared {@link
+ * DeltaV2WriteContext#buildDataWriterFactory} so batch and streaming produce the factory the same
+ * way.
  *
  * <p>The {@link Transaction} object lives only on the driver and is never serialized. Executors
- * receive only serializable state: transaction state row, Hadoop conf, OutputWriterFactory, schema,
- * and target directory.
+ * receive only serializable state: transaction state row, Hadoop conf, OutputWriterFactory, and
+ * schema/partition ordinals; the per-partition target directory is derived on the executor.
  */
 class DeltaV2BatchWrite implements Write, BatchWrite {
 
@@ -56,7 +56,6 @@ class DeltaV2BatchWrite implements Write, BatchWrite {
   }
 
   private final DeltaV2BatchWriteContext context;
-  private final String targetDirectory;
 
   DeltaV2BatchWrite(
       Engine engine,
@@ -64,11 +63,11 @@ class DeltaV2BatchWrite implements Write, BatchWrite {
       String tablePath,
       Snapshot initialSnapshot,
       StructType dataSchema,
+      StructType partitionSchema,
       LogicalWriteInfo writeInfo) {
     this.context =
         DeltaV2BatchWriteContext.create(
-            engine, hadoopConf, tablePath, initialSnapshot, dataSchema, writeInfo);
-    this.targetDirectory = context.getTargetDirectory(Collections.emptyMap());
+            engine, hadoopConf, tablePath, initialSnapshot, dataSchema, partitionSchema, writeInfo);
   }
 
   @Override
@@ -78,12 +77,7 @@ class DeltaV2BatchWrite implements Write, BatchWrite {
 
   @Override
   public DataWriterFactory createBatchWriterFactory(PhysicalWriteInfo physicalWriteInfo) {
-    return new DeltaV2DataWriterFactory(
-        targetDirectory,
-        context.getSerializableHadoopConf(),
-        context.getSerializedTxnState(),
-        context.getDataSchema(),
-        context.getOutputWriterFactory());
+    return context.buildDataWriterFactory(context.getTransaction());
   }
 
   @Override

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2BatchWriteContext.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2BatchWriteContext.java
@@ -45,9 +45,10 @@ class DeltaV2BatchWriteContext extends DeltaV2WriteContext {
       String tablePath,
       Snapshot initialSnapshot,
       StructType dataSchema,
+      StructType partitionSchema,
       LogicalWriteInfo writeInfo) {
     return new DeltaV2BatchWriteContext(
-        engine, hadoopConf, tablePath, initialSnapshot, dataSchema, writeInfo);
+        engine, hadoopConf, tablePath, initialSnapshot, dataSchema, partitionSchema, writeInfo);
   }
 
   private DeltaV2BatchWriteContext(
@@ -56,8 +57,9 @@ class DeltaV2BatchWriteContext extends DeltaV2WriteContext {
       String tablePath,
       Snapshot initialSnapshot,
       StructType dataSchema,
+      StructType partitionSchema,
       LogicalWriteInfo writeInfo) {
-    super(engine, hadoopConf, tablePath, initialSnapshot, dataSchema, writeInfo);
+    super(engine, hadoopConf, tablePath, initialSnapshot, dataSchema, partitionSchema, writeInfo);
     this.transaction =
         initialSnapshot
             .buildUpdateTableTransaction(getEngineInfo(), Operation.WRITE)

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2DataWriter.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2DataWriter.java
@@ -20,15 +20,18 @@ import io.delta.kernel.Transaction;
 import io.delta.kernel.data.Row;
 import io.delta.kernel.defaults.engine.DefaultEngine;
 import io.delta.kernel.engine.Engine;
+import io.delta.kernel.expressions.Literal;
 import io.delta.kernel.internal.util.Utils;
 import io.delta.kernel.statistics.DataFileStatistics;
 import io.delta.kernel.utils.CloseableIterator;
 import io.delta.kernel.utils.DataFileStatus;
+import io.delta.spark.internal.v2.utils.PartitionUtils;
 import io.delta.spark.internal.v2.utils.SerializableKernelRowWrapper;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
@@ -39,18 +42,25 @@ import org.apache.hadoop.mapred.TaskAttemptContextImpl;
 import org.apache.hadoop.mapred.TaskAttemptID;
 import org.apache.hadoop.mapreduce.TaskType;
 import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 import org.apache.spark.sql.connector.write.DataWriter;
 import org.apache.spark.sql.connector.write.WriterCommitMessage;
 import org.apache.spark.sql.execution.datasources.OutputWriter;
 import org.apache.spark.sql.execution.datasources.OutputWriterFactory;
+import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.util.SerializableConfiguration;
 
 /**
  * DSv2 {@link DataWriter} that writes {@link InternalRow}s to Parquet via Spark's {@link
  * OutputWriter}, then calls Kernel's {@link Transaction#generateAppendActions} to produce Delta log
- * actions (e.g. AddFile). The writer is lazily initialized on the first {@link #write} call and
- * rows stream through directly without buffering.
+ * actions (e.g. AddFile). Writers are opened lazily on the first row of each partition and rows
+ * stream through directly without buffering.
+ *
+ * <p><b>Partitioned writes:</b> rows arrive grouped by partition (see {@link DeltaV2Write}), so
+ * this writer keeps one open file and rotates it when the partition key changes. The target
+ * directory comes from {@link Transaction#getWriteContext}; partition columns are not written into
+ * the file.
  *
  * <p><b>V1 reuse:</b> The {@link OutputWriterFactory} is the same one produced by V1's {@code
  * DeltaParquetFileFormatBase.prepareWrite} (via {@code DeltaParquetFileFormatV2}), and file naming
@@ -64,30 +74,51 @@ import org.apache.spark.util.SerializableConfiguration;
  */
 class DeltaV2DataWriter implements DataWriter<InternalRow> {
 
-  private final String targetDirectory;
   private final SerializableConfiguration hadoopConf;
   private final SerializableKernelRowWrapper serializedTxnState;
   private final StructType dataSchema;
+  private final StructType partitionSchema;
+  private final int[] dataOrdinals;
+  private final int[] partitionOrdinals;
+  private final boolean partitioned;
   private final OutputWriterFactory outputWriterFactory;
   private final int partitionId;
   private final long taskId;
 
+  // Kernel driver state, reconstituted once on the executor.
+  private Engine engine;
+  private Row txnState;
+
+  // Current open file: the context it was opened under (reused to generate its actions at close)
+  // and its partition values (to detect the boundary).
   private OutputWriter writer;
   private Path outputPath;
+  private DataWriteContext currentWriteContext;
+  private Object[] currentPartitionValues;
+
+  // Accumulated across all files closed by this task.
+  private final List<SerializableKernelRowWrapper> actionRows = new ArrayList<>();
+  private final List<Path> writtenPaths = new ArrayList<>();
+  // Rows in the currently-open file; reset on each rotation, recorded as the AddFile numRecords.
   private long rowCount;
 
   DeltaV2DataWriter(
-      String targetDirectory,
       SerializableConfiguration hadoopConf,
       SerializableKernelRowWrapper serializedTxnState,
       StructType dataSchema,
+      StructType partitionSchema,
+      int[] dataOrdinals,
+      int[] partitionOrdinals,
       OutputWriterFactory outputWriterFactory,
       int partitionId,
       long taskId) {
-    this.targetDirectory = targetDirectory;
     this.hadoopConf = hadoopConf;
     this.serializedTxnState = serializedTxnState;
     this.dataSchema = dataSchema;
+    this.partitionSchema = partitionSchema;
+    this.dataOrdinals = dataOrdinals;
+    this.partitionOrdinals = partitionOrdinals;
+    this.partitioned = partitionOrdinals.length > 0;
     this.outputWriterFactory = outputWriterFactory;
     this.partitionId = partitionId;
     this.taskId = taskId;
@@ -96,30 +127,40 @@ class DeltaV2DataWriter implements DataWriter<InternalRow> {
 
   @Override
   public void write(InternalRow record) throws IOException {
-    if (writer == null) {
-      initWriter();
+    // TODO(#7140): honor maxRecordsPerFile -- we never split a partition's rows by row count.
+    if (partitioned) {
+      Object[] partitionValues =
+          PartitionUtils.extractPartitionValues(record, partitionSchema, partitionOrdinals);
+      if (writer == null
+          || !PartitionUtils.partitionValuesEqual(partitionValues, currentPartitionValues)) {
+        releaseCurrentWriter();
+        newOutputWriter(
+            PartitionUtils.buildPartitionLiterals(record, partitionSchema, partitionOrdinals),
+            partitionValues);
+      }
+      writer.write(getOutputRow(record));
+    } else {
+      if (writer == null) {
+        newOutputWriter(Collections.emptyMap(), /* partitionValues */ null);
+      }
+      writer.write(record);
     }
-    writer.write(record);
     rowCount++;
   }
 
   @Override
   public WriterCommitMessage commit() throws IOException {
-    if (rowCount == 0) {
-      return new DeltaV2WriterCommitMessage(Collections.emptyList());
-    }
-
-    writer.close();
-    writer = null;
-
-    List<SerializableKernelRowWrapper> actionRows = generateActionRows();
-    return new DeltaV2WriterCommitMessage(actionRows);
+    // Flush the last open file; a no-op (empty actions) if no rows were written.
+    releaseCurrentWriter();
+    return new DeltaV2WriterCommitMessage(new ArrayList<>(actionRows));
   }
 
   @Override
   public void abort() throws IOException {
     closeWriterQuietly();
-    tryDeleteOutputFile();
+    for (Path writtenPath : writtenPaths) {
+      tryDeleteOutputFile(writtenPath);
+    }
   }
 
   @Override
@@ -128,16 +169,60 @@ class DeltaV2DataWriter implements DataWriter<InternalRow> {
   }
 
   /**
+   * Opens a new Parquet {@link OutputWriter} under {@code partitionLiterals}' target directory.
+   *
+   * <p>V2 port of V1's {@code SingleDirectoryDataWriter.newOutputWriter}.
+   */
+  private void newOutputWriter(Map<String, Literal> partitionLiterals, Object[] partitionValues) {
+    // The previous file must be closed first; otherwise its writer is orphaned and its rows are
+    // never committed (silent data loss). Every caller closes before opening -- pin that invariant.
+    if (writer != null) {
+      throw new IllegalStateException("newOutputWriter called with an open writer; close it first");
+    }
+    ensureEngine();
+    Configuration conf = hadoopConf.value();
+
+    DataWriteContext writeContext =
+        Transaction.getWriteContext(engine, txnState, partitionLiterals);
+
+    TaskAttemptContextImpl taskAttemptContext =
+        new TaskAttemptContextImpl(
+            new JobConf(conf), new TaskAttemptID("", 0, TaskType.MAP, partitionId, 0));
+
+    String ext = outputWriterFactory.getFileExtension(taskAttemptContext);
+    // buildFileName embeds a UUID, so reusing partitionId across a task's files stays unique.
+    String fileName =
+        org.apache.spark.sql.delta.files.DelayedCommitProtocol.buildFileName(
+            partitionId, ext, /* isCdc */ false);
+    outputPath = new Path(writeContext.getTargetDirectory(), fileName);
+    writtenPaths.add(outputPath);
+    currentWriteContext = writeContext;
+    currentPartitionValues = partitionValues;
+    rowCount = 0;
+
+    writer = outputWriterFactory.newInstance(outputPath.toString(), dataSchema, taskAttemptContext);
+  }
+
+  /**
+   * Closes the current file (if any) and appends its Delta log actions to {@link #actionRows}.
+   *
+   * <p>V2 port of V1's {@code FileFormatDataWriter.releaseCurrentWriter}.
+   */
+  private void releaseCurrentWriter() throws IOException {
+    if (writer == null) {
+      return;
+    }
+    writer.close();
+    writer = null;
+    actionRows.addAll(generateActionRows());
+  }
+
+  /**
    * Builds a {@link DataFileStatus} for the written file and calls Kernel's generateAppendActions
    * to produce the Delta log action rows.
    */
   private List<SerializableKernelRowWrapper> generateActionRows() throws IOException {
     Configuration conf = hadoopConf.value();
-    Engine engine = DefaultEngine.create(conf);
-    Row txnState = serializedTxnState.getRow();
-    DataWriteContext writeContext =
-        Transaction.getWriteContext(engine, txnState, Collections.emptyMap());
-
     FileSystem fs = outputPath.getFileSystem(conf);
     FileStatus fileStatus = fs.getFileStatus(outputPath);
     // Populate numRecords so AddFile.stats is non-null: metadata-only count(*) and
@@ -160,7 +245,7 @@ class DeltaV2DataWriter implements DataWriter<InternalRow> {
         Utils.toCloseableIterator(Collections.singletonList(dataFileStatus).iterator());
 
     CloseableIterator<Row> actionRowsIter =
-        Transaction.generateAppendActions(engine, txnState, dataFilesIter, writeContext);
+        Transaction.generateAppendActions(engine, txnState, dataFilesIter, currentWriteContext);
 
     List<SerializableKernelRowWrapper> actionRows = new ArrayList<>();
     try {
@@ -171,6 +256,28 @@ class DeltaV2DataWriter implements DataWriter<InternalRow> {
       actionRowsIter.close();
     }
     return actionRows;
+  }
+
+  /** Reconstitutes the Kernel engine and transaction state once, on first use on the executor. */
+  private void ensureEngine() {
+    if (engine == null) {
+      engine = DefaultEngine.create(hadoopConf.value());
+      txnState = serializedTxnState.getRow();
+    }
+  }
+
+  /**
+   * Projects the row to the data columns in {@code dataSchema} order (what the writer expects).
+   *
+   * <p>V2 port of V1's {@code BaseDynamicPartitionDataWriter.getOutputRow}.
+   */
+  private InternalRow getOutputRow(InternalRow record) {
+    Object[] values = new Object[dataOrdinals.length];
+    StructField[] fields = dataSchema.fields();
+    for (int i = 0; i < dataOrdinals.length; i++) {
+      values[i] = record.get(dataOrdinals[i], fields[i].dataType());
+    }
+    return new GenericInternalRow(values);
   }
 
   private void closeWriterQuietly() {
@@ -184,35 +291,14 @@ class DeltaV2DataWriter implements DataWriter<InternalRow> {
     }
   }
 
-  private void tryDeleteOutputFile() {
-    if (outputPath != null) {
+  private void tryDeleteOutputFile(Path writtenPath) {
+    if (writtenPath != null) {
       try {
-        FileSystem fs = outputPath.getFileSystem(hadoopConf.value());
-        fs.delete(outputPath, false);
+        FileSystem fs = writtenPath.getFileSystem(hadoopConf.value());
+        fs.delete(writtenPath, false);
       } catch (Exception e) {
         // best-effort cleanup
       }
     }
-  }
-
-  /**
-   * Lazily initializes the Parquet OutputWriter. File naming reuses V1's {@link
-   * org.apache.spark.sql.delta.files.DelayedCommitProtocol#buildFileName} to stay in sync with V1
-   * naming conventions (test prefix, CDC prefix, split numbering).
-   */
-  private void initWriter() {
-    Configuration conf = hadoopConf.value();
-
-    TaskAttemptContextImpl taskAttemptContext =
-        new TaskAttemptContextImpl(
-            new JobConf(conf), new TaskAttemptID("", 0, TaskType.MAP, partitionId, 0));
-
-    String ext = outputWriterFactory.getFileExtension(taskAttemptContext);
-    String fileName =
-        org.apache.spark.sql.delta.files.DelayedCommitProtocol.buildFileName(
-            partitionId, ext, /* isCdc */ false);
-    outputPath = new Path(targetDirectory, fileName);
-
-    writer = outputWriterFactory.newInstance(outputPath.toString(), dataSchema, taskAttemptContext);
   }
 }

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2DataWriterFactory.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2DataWriterFactory.java
@@ -27,40 +27,47 @@ import org.apache.spark.util.SerializableConfiguration;
 
 /**
  * Serializable factory sent to executors to create {@link DeltaV2DataWriter} instances. Carries the
- * serialized Hadoop config and Kernel transaction state needed by each writer. Serves both batch
- * and streaming writes -- the {@link DeltaV2DataWriter} is epoch-agnostic, so the streaming
- * overload ignores {@code epochId} (the epoch only scopes the driver-side commit, not the per-task
- * write).
+ * serialized Hadoop config, Kernel transaction state, and partition layout needed by each writer.
+ * Serves both batch and streaming writes -- the {@link DeltaV2DataWriter} is epoch-agnostic, so the
+ * streaming overload ignores {@code epochId}.
  */
 class DeltaV2DataWriterFactory
     implements DataWriterFactory, StreamingDataWriterFactory, Serializable {
 
-  private final String targetDirectory;
   private final SerializableConfiguration hadoopConf;
   private final SerializableKernelRowWrapper serializedTxnState;
   private final StructType dataSchema;
+  private final StructType partitionSchema;
+  private final int[] dataOrdinals;
+  private final int[] partitionOrdinals;
   private final OutputWriterFactory outputWriterFactory;
 
   DeltaV2DataWriterFactory(
-      String targetDirectory,
       SerializableConfiguration hadoopConf,
       SerializableKernelRowWrapper serializedTxnState,
       StructType dataSchema,
+      StructType partitionSchema,
+      int[] dataOrdinals,
+      int[] partitionOrdinals,
       OutputWriterFactory outputWriterFactory) {
-    this.targetDirectory = targetDirectory;
     this.hadoopConf = hadoopConf;
     this.serializedTxnState = serializedTxnState;
     this.dataSchema = dataSchema;
+    this.partitionSchema = partitionSchema;
+    this.dataOrdinals = dataOrdinals;
+    this.partitionOrdinals = partitionOrdinals;
     this.outputWriterFactory = outputWriterFactory;
   }
 
   @Override
   public DataWriter<InternalRow> createWriter(int partitionId, long taskId) {
     return new DeltaV2DataWriter(
-        targetDirectory,
         hadoopConf,
         serializedTxnState,
         dataSchema,
+        partitionSchema,
+        dataOrdinals,
+        partitionOrdinals,
         outputWriterFactory,
         partitionId,
         taskId);

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2Write.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2Write.java
@@ -25,8 +25,14 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.spark.sql.connector.distributions.Distribution;
+import org.apache.spark.sql.connector.distributions.Distributions;
+import org.apache.spark.sql.connector.expressions.Expressions;
+import org.apache.spark.sql.connector.expressions.SortDirection;
+import org.apache.spark.sql.connector.expressions.SortOrder;
 import org.apache.spark.sql.connector.write.BatchWrite;
 import org.apache.spark.sql.connector.write.LogicalWriteInfo;
+import org.apache.spark.sql.connector.write.RequiresDistributionAndOrdering;
 import org.apache.spark.sql.connector.write.Write;
 import org.apache.spark.sql.connector.write.streaming.StreamingWrite;
 import org.apache.spark.sql.delta.DeltaOptions;
@@ -47,8 +53,12 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
  *
  * <p>Only append is supported: the builder advertises no overwrite capability, so Spark does not
  * route overwrite, truncate, Complete, or Update here.
+ *
+ * <p><b>Partitioned writes:</b> implements {@link RequiresDistributionAndOrdering} to request Spark
+ * to perform a local sort of rows by the partition columns, so each partition's rows reach {@link
+ * DeltaV2DataWriter} contiguously. An unpartitioned table requests no ordering.
  */
-class DeltaV2Write implements Write {
+class DeltaV2Write implements Write, RequiresDistributionAndOrdering {
 
   // Streaming-write options the sink does not honor; rejected rather than silently ignored.
   // DeltaV2WriteTest asserts over this exact list instead of a drifting copy. Referencing the
@@ -72,6 +82,7 @@ class DeltaV2Write implements Write {
   private final Snapshot initialSnapshot;
   private final DeltaSnapshotManager snapshotManager;
   private final StructType dataSchema;
+  private final StructType partitionSchema;
   private final String queryId;
   private final LogicalWriteInfo writeInfo;
 
@@ -80,6 +91,8 @@ class DeltaV2Write implements Write {
    *     streaming guard's schema/protocol baseline)
    * @param snapshotManager reloads the latest snapshot per epoch on the streaming path; unused by
    *     the batch path (a single commit off {@code initialSnapshot})
+   * @param dataSchema the non-partition columns (the Parquet file body)
+   * @param partitionSchema the partition columns in partition order (empty when unpartitioned)
    */
   DeltaV2Write(
       Engine engine,
@@ -88,6 +101,7 @@ class DeltaV2Write implements Write {
       Snapshot initialSnapshot,
       DeltaSnapshotManager snapshotManager,
       StructType dataSchema,
+      StructType partitionSchema,
       LogicalWriteInfo writeInfo) {
     this.engine = requireNonNull(engine, "engine is null");
     this.hadoopConf = requireNonNull(hadoopConf, "hadoopConf is null");
@@ -95,23 +109,9 @@ class DeltaV2Write implements Write {
     this.initialSnapshot = requireNonNull(initialSnapshot, "initialSnapshot is null");
     this.snapshotManager = requireNonNull(snapshotManager, "snapshotManager is null");
     this.dataSchema = requireNonNull(dataSchema, "dataSchema is null");
+    this.partitionSchema = requireNonNull(partitionSchema, "partitionSchema is null");
     this.writeInfo = requireNonNull(writeInfo, "writeInfo is null");
     this.queryId = requireNonNull(writeInfo.queryId(), "queryId is null");
-    rejectPartitionedTable();
-  }
-
-  /**
-   * Rejects partitioned tables (batch and streaming). The write always targets the table root with
-   * empty partition values, so a partitioned target would misplace every file -- silent corruption.
-   */
-  private void rejectPartitionedTable() {
-    List<String> partitionColumns = initialSnapshot.getPartitionColumnNames();
-    if (!partitionColumns.isEmpty()) {
-      throw new UnsupportedOperationException(
-          "DSv2 writes to Delta do not support partitioned tables (partition columns: "
-              + partitionColumns
-              + "). Use the V1 write path (format(\"delta\")) instead.");
-    }
   }
 
   /**
@@ -127,7 +127,7 @@ class DeltaV2Write implements Write {
     // The batch path builds its own driver-side context (DeltaV2BatchWriteContext) and commits a
     // single transaction off initialSnapshot.
     return new DeltaV2BatchWrite(
-        engine, hadoopConf, tablePath, initialSnapshot, dataSchema, writeInfo);
+        engine, hadoopConf, tablePath, initialSnapshot, dataSchema, partitionSchema, writeInfo);
   }
 
   @Override
@@ -138,9 +138,31 @@ class DeltaV2Write implements Write {
     // produce the executor write state -- the same setup the batch path uses, no duplication.
     DeltaV2WriteContext context =
         DeltaV2WriteContext.create(
-            engine, hadoopConf, tablePath, initialSnapshot, dataSchema, writeInfo);
+            engine, hadoopConf, tablePath, initialSnapshot, dataSchema, partitionSchema, writeInfo);
     return new DeltaV2StreamingWrite(
         engine, initialSnapshot, snapshotManager, queryId, context::buildDataWriterFactory);
+  }
+
+  /**
+   * No distribution: we do not repartition the input, matching V1's default sink.
+   *
+   * <p>TODO(#7140): support optimized write (V1's {@code optimizeWrite}) to consolidate small
+   * files.
+   */
+  @Override
+  public Distribution requiredDistribution() {
+    return Distributions.unspecified();
+  }
+
+  /**
+   * Sorts by the partition columns so each partition's rows are contiguous (empty when
+   * unpartitioned).
+   */
+  @Override
+  public SortOrder[] requiredOrdering() {
+    return Arrays.stream(partitionSchema.fields())
+        .map(f -> Expressions.sort(Expressions.column(f.name()), SortDirection.ASCENDING))
+        .toArray(SortOrder[]::new);
   }
 
   /**

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2WriteBuilder.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2WriteBuilder.java
@@ -19,6 +19,8 @@ import static java.util.Objects.requireNonNull;
 
 import io.delta.kernel.Snapshot;
 import io.delta.kernel.engine.Engine;
+import io.delta.kernel.internal.util.ColumnMapping;
+import io.delta.kernel.internal.util.ColumnMapping.ColumnMappingMode;
 import io.delta.spark.internal.v2.snapshot.DeltaSnapshotManager;
 import io.delta.spark.internal.v2.utils.SchemaUtils;
 import org.apache.hadoop.conf.Configuration;
@@ -47,6 +49,7 @@ public class DeltaV2WriteBuilder implements WriteBuilder {
   private final Snapshot initialSnapshot;
   private final DeltaSnapshotManager snapshotManager;
   private final StructType dataSchema;
+  private final StructType partitionSchema;
   private final LogicalWriteInfo writeInfo;
 
   /**
@@ -57,6 +60,8 @@ public class DeltaV2WriteBuilder implements WriteBuilder {
    * @param snapshotManager reloads the latest snapshot; used by the streaming write to build each
    *     epoch's commit against the current table state (see {@link DeltaV2StreamingWrite})
    * @param dataSchema the table's data (non-partition) schema, from DeltaV2Table's SchemaProvider
+   * @param partitionSchema the table's partition columns in partition order (empty if
+   *     unpartitioned), from DeltaV2Table's SchemaProvider
    * @param writeInfo Spark's logical write info (schema, queryId, options)
    */
   public DeltaV2WriteBuilder(
@@ -66,6 +71,7 @@ public class DeltaV2WriteBuilder implements WriteBuilder {
       Snapshot initialSnapshot,
       DeltaSnapshotManager snapshotManager,
       StructType dataSchema,
+      StructType partitionSchema,
       LogicalWriteInfo writeInfo) {
     this.engine = requireNonNull(engine, "engine is null");
     this.tablePath = requireNonNull(tablePath, "tablePath is null");
@@ -73,6 +79,7 @@ public class DeltaV2WriteBuilder implements WriteBuilder {
     this.initialSnapshot = requireNonNull(initialSnapshot, "initialSnapshot is null");
     this.snapshotManager = requireNonNull(snapshotManager, "snapshotManager is null");
     this.dataSchema = requireNonNull(dataSchema, "dataSchema is null");
+    this.partitionSchema = requireNonNull(partitionSchema, "partitionSchema is null");
     this.writeInfo = requireNonNull(writeInfo, "writeInfo is null");
   }
 
@@ -80,11 +87,32 @@ public class DeltaV2WriteBuilder implements WriteBuilder {
   public Write build() {
     validateDataSchema(initialSnapshot, writeInfo.schema());
 
+    // TODO(#7140): support partitioned writes to column-mapped tables. Unpartitioned is supported;
+    // partitioned writes need partition values keyed by physical name, so reject for now.
+    if (!partitionSchema.isEmpty()) {
+      ColumnMappingMode cmMode =
+          ColumnMapping.getColumnMappingMode(initialSnapshot.getTableProperties());
+      if (cmMode != ColumnMappingMode.NONE) {
+        throw new UnsupportedOperationException(
+            "DSv2 partitioned writes are not supported on column-mapped Delta tables "
+                + "(delta.columnMapping.mode = "
+                + cmMode
+                + "). Use the V1 write path (format(\"delta\").write()) instead.");
+      }
+    }
+
     // Returns a mode-dispatching Write: toBatch() -> DeltaV2BatchWrite (batch commit off
     // initialSnapshot), toStreaming() -> DeltaV2StreamingWrite (per-epoch commit off the latest
     // snapshot via snapshotManager). Both modes share the executor-side write-state construction.
     return new DeltaV2Write(
-        engine, hadoopConf, tablePath, initialSnapshot, snapshotManager, dataSchema, writeInfo);
+        engine,
+        hadoopConf,
+        tablePath,
+        initialSnapshot,
+        snapshotManager,
+        dataSchema,
+        partitionSchema,
+        writeInfo);
   }
 
   static void validateDataSchema(Snapshot initialSnapshot, StructType dataSchema) {

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2WriteContext.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2WriteContext.java
@@ -22,18 +22,20 @@ import io.delta.kernel.engine.Engine;
 import io.delta.spark.internal.v2.read.DeltaParquetFileFormatV2;
 import io.delta.spark.internal.v2.utils.PartitionUtils;
 import io.delta.spark.internal.v2.utils.ScalaUtils;
-import io.delta.spark.internal.v2.utils.SchemaUtils;
 import io.delta.spark.internal.v2.utils.SerializableKernelRowWrapper;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.time.ZoneId;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.connector.write.LogicalWriteInfo;
 import org.apache.spark.sql.execution.datasources.OutputWriterFactory;
+import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.util.SerializableConfiguration;
 import scala.Option;
@@ -62,7 +64,14 @@ class DeltaV2WriteContext {
 
   private final Engine engine;
   private final StructType dataSchema;
+  // Logical (pre-column-mapping) data schema. Column ordinals are matched against writeSchema by
+  // logical name, so with column mapping this must stay logical even though dataSchema is physical
+  // (via prepareSchemaForWrite) for the Parquet writer.
+  private final StructType logicalDataSchema;
   private final StructType partitionSchema;
+  // The full incoming write-row schema (data + partition columns), used to compute the ordinals of
+  // the data / partition columns within each row for the executor writer.
+  private final StructType writeSchema;
   private final io.delta.kernel.types.StructType kernelTableSchema;
   private final OutputWriterFactory outputWriterFactory;
   private final SerializableConfiguration serializableHadoopConf;
@@ -74,9 +83,10 @@ class DeltaV2WriteContext {
       String tablePath,
       Snapshot initialSnapshot,
       StructType dataSchema,
+      StructType partitionSchema,
       LogicalWriteInfo writeInfo) {
     return new DeltaV2WriteContext(
-        engine, hadoopConf, tablePath, initialSnapshot, dataSchema, writeInfo);
+        engine, hadoopConf, tablePath, initialSnapshot, dataSchema, partitionSchema, writeInfo);
   }
 
   private static void verifySchemaForWrite(DeltaParquetFileFormatV2 format, StructType dataSchema) {
@@ -129,20 +139,10 @@ class DeltaV2WriteContext {
       String tablePath,
       Snapshot initialSnapshot,
       StructType dataSchema,
+      StructType partitionSchema,
       LogicalWriteInfo writeInfo) {
     this.engine = engine;
-
     this.kernelTableSchema = initialSnapshot.getSchema();
-    StructType tableSchema = SchemaUtils.convertKernelSchemaToSparkSchema(kernelTableSchema);
-    java.util.Set<String> partitionCols =
-        new java.util.HashSet<>(initialSnapshot.getPartitionColumnNames());
-    this.partitionSchema =
-        partitionCols.isEmpty()
-            ? new StructType()
-            : new StructType(
-                java.util.Arrays.stream(tableSchema.fields())
-                    .filter(field -> partitionCols.contains(field.name()))
-                    .toArray(org.apache.spark.sql.types.StructField[]::new));
 
     SparkSession session =
         SparkSession.getActiveSession()
@@ -166,7 +166,10 @@ class DeltaV2WriteContext {
             /* optimizationsEnabled */ true,
             /* useMetadataRowIndex */ Option.empty(),
             /* isCDCRead */ false);
+    this.logicalDataSchema = dataSchema;
     this.dataSchema = format.prepareSchemaForWrite(dataSchema);
+    this.partitionSchema = partitionSchema;
+    this.writeSchema = writeInfo.schema();
     verifySchemaForWrite(format, this.dataSchema);
     org.apache.spark.sql.execution.datasources.DataSourceUtils.checkFieldNames(
         format, this.dataSchema);
@@ -189,16 +192,46 @@ class DeltaV2WriteContext {
   DeltaV2DataWriterFactory buildDataWriterFactory(Transaction transaction) {
     Row txnState = transaction.getTransactionState(engine);
     SerializableKernelRowWrapper serializedTxnState = new SerializableKernelRowWrapper(txnState);
-    // TODO(#7140): pass real partitionValues to support partitioned writes.
-    String targetDirectory =
-        Transaction.getWriteContext(engine, txnState, /* partitionValues */ Collections.emptyMap())
-            .getTargetDirectory();
+
+    // Ordinals of the partition/data columns within the full incoming write row (writeSchema).
+    // The per-partition target directory is not computed here (it depends on each row's partition
+    // values); the executor writer derives it via Transaction.getWriteContext.
+    // Match by logical name: writeSchema and partitionSchema carry logical names, so dataSchema
+    // (physical under column mapping, via prepareSchemaForWrite) cannot be used here. The physical
+    // dataSchema has the same field order, so the ordinals apply to it unchanged on the executor.
+    int[] dataOrdinals = ordinalsOf(writeSchema, logicalDataSchema);
+    int[] partitionOrdinals = ordinalsOf(writeSchema, partitionSchema);
+
     return new DeltaV2DataWriterFactory(
-        targetDirectory,
         serializableHadoopConf,
         serializedTxnState,
         dataSchema,
+        partitionSchema,
+        dataOrdinals,
+        partitionOrdinals,
         outputWriterFactory);
+  }
+
+  /**
+   * Ordinals of {@code subSchema}'s fields within {@code fullSchema}, by name, in subSchema order.
+   * Case-insensitive to match {@code validateDataSchema} (which merges with caseSensitive=false).
+   */
+  private static int[] ordinalsOf(StructType fullSchema, StructType subSchema) {
+    Map<String, Integer> ordinalByLowerName = new HashMap<>();
+    StructField[] fullFields = fullSchema.fields();
+    for (int i = 0; i < fullFields.length; i++) {
+      ordinalByLowerName.put(fullFields[i].name().toLowerCase(Locale.ROOT), i);
+    }
+    int[] ordinals = new int[subSchema.fields().length];
+    for (int i = 0; i < ordinals.length; i++) {
+      String name = subSchema.fields()[i].name();
+      Integer ordinal = ordinalByLowerName.get(name.toLowerCase(Locale.ROOT));
+      if (ordinal == null) {
+        throw new IllegalArgumentException("Column " + name + " not found in write schema");
+      }
+      ordinals[i] = ordinal;
+    }
+    return ordinals;
   }
 
   Engine getEngine() {

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/write/DeltaV2BatchWriteContextTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/write/DeltaV2BatchWriteContextTest.java
@@ -53,7 +53,13 @@ public class DeltaV2BatchWriteContextTest extends DeltaV2TestBase {
 
     DeltaV2BatchWriteContext context =
         DeltaV2BatchWriteContext.create(
-            engine, hadoopConf, path, snapshot, tableSchema, new TestLogicalWriteInfo(tableSchema));
+            engine,
+            hadoopConf,
+            path,
+            snapshot,
+            tableSchema,
+            new StructType(),
+            new TestLogicalWriteInfo(tableSchema));
 
     assertSame(engine, context.getEngine());
     assertNotNull(context.getTransaction());

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/write/DeltaV2BatchWriteTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/write/DeltaV2BatchWriteTest.java
@@ -19,13 +19,22 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.delta.kernel.Snapshot;
+import io.delta.kernel.data.MapValue;
+import io.delta.kernel.internal.actions.AddFile;
 import io.delta.spark.internal.v2.DeltaV2TestBase;
 import io.delta.spark.internal.v2.InternalRowTestUtils;
 import io.delta.spark.internal.v2.snapshot.PathBasedSnapshotManager;
+import io.delta.spark.internal.v2.utils.SerializableKernelRowWrapper;
 import java.io.File;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
 import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.util.DateTimeUtils;
 import org.apache.spark.sql.connector.write.DataWriter;
 import org.apache.spark.sql.connector.write.DataWriterFactory;
 import org.apache.spark.sql.connector.write.LogicalWriteInfo;
@@ -131,6 +140,503 @@ public class DeltaV2BatchWriteTest extends DeltaV2TestBase {
     assertEquals("Carol", rows.get(1).getString(1));
   }
 
+  // ---- Partitioned writes ----
+
+  // Table (value INT) partitioned by (part STRING). The write row layout is the full table schema
+  // [value, part]; the writer projects [value] into the Parquet body and routes on [part].
+  private static final StructType PARTITIONED_FULL_SCHEMA =
+      DataTypes.createStructType(
+          new StructField[] {
+            DataTypes.createStructField("value", DataTypes.IntegerType, true),
+            DataTypes.createStructField("part", DataTypes.StringType, true)
+          });
+  private static final StructType PARTITIONED_DATA_SCHEMA =
+      DataTypes.createStructType(
+          new StructField[] {DataTypes.createStructField("value", DataTypes.IntegerType, true)});
+  private static final StructType PARTITIONED_PART_SCHEMA =
+      DataTypes.createStructType(
+          new StructField[] {DataTypes.createStructField("part", DataTypes.StringType, true)});
+
+  @Test
+  public void testCommit_partitioned_routesRowsAndRoundTrips(@TempDir File tempDir)
+      throws Exception {
+    String path = createPartitionedTable(tempDir, "batch_part_roundtrip");
+    DeltaV2BatchWrite write = newPartitionedWrite(path);
+    // Two partitions in one task (rows pre-sorted by part), so the writer rotates at the boundary.
+    WriterCommitMessage msg = writePartitionedFile(write, 10, "a", 11, "a", 20, "b");
+
+    // One data file per partition value the task saw: the single-writer rotates once per boundary,
+    // so 2 distinct partitions -> 2 AddFile actions (both "a" rows share one file). This is a
+    // per-task invariant, not a claim of cluster-wide file-count parity with V1 (which varies with
+    // task count / maxRecordsPerFile).
+    assertEquals(2, ((DeltaV2WriterCommitMessage) msg).getActionRows().size());
+
+    // Pin the recorded AddFile.partitionValues directly (not only via the read-back below).
+    assertEquals(List.of(Map.of("part", "a"), Map.of("part", "b")), partitionValuesOf(msg));
+
+    write.commit(new WriterCommitMessage[] {msg});
+
+    List<Row> rows = spark.read().format("delta").load(path).orderBy("value").collectAsList();
+    assertEquals(3, rows.size());
+    assertEquals(10, rows.get(0).getInt(rows.get(0).fieldIndex("value")));
+    assertEquals("a", rows.get(0).getString(rows.get(0).fieldIndex("part")));
+    assertEquals(20, rows.get(2).getInt(rows.get(2).fieldIndex("value")));
+    assertEquals("b", rows.get(2).getString(rows.get(2).fieldIndex("part")));
+
+    // Hive-style partition directories exist on disk (Kernel owns the col=val/ encoding).
+    assertTrue(new File(path, "part=a").isDirectory(), "expected partition dir part=a");
+    assertTrue(new File(path, "part=b").isDirectory(), "expected partition dir part=b");
+
+    // Partition-predicate read returns only that partition, proving AddFile.partitionValues were
+    // recorded (pruning couldn't select by partition otherwise).
+    List<Row> onlyB = spark.read().format("delta").load(path).filter("part = 'b'").collectAsList();
+    assertEquals(1, onlyB.size());
+    assertEquals(20, onlyB.get(0).getInt(onlyB.get(0).fieldIndex("value")));
+  }
+
+  /**
+   * Regression test for the AddFile numRecords stat. Without it the native (Rust) Kernel scan
+   * returns zero rows for a partitioned table (silent wrong results); this fails on {@code _ffi} if
+   * the stat is dropped.
+   */
+  @Test
+  public void testCommit_partitioned_predicateReadReturnsMatchingRows(@TempDir File tempDir)
+      throws Exception {
+    String path = createPartitionedTable(tempDir, "batch_part_pred_read");
+    DeltaV2BatchWrite write = newPartitionedWrite(path);
+    write.commit(new WriterCommitMessage[] {writePartitionedFile(write, 1, "a", 2, "a", 3, "b")});
+
+    // Full scan sees all rows; partition-pruned reads return exactly the matching rows, not zero.
+    assertEquals(3, spark.read().format("delta").load(path).count());
+    assertEquals(2, spark.read().format("delta").load(path).filter("part = 'a'").count());
+    assertEquals(1, spark.read().format("delta").load(path).filter("part = 'b'").count());
+  }
+
+  /**
+   * DSv2 (Kernel) and DSv1 record the same timestamp partition value differently: V1 uses UTC
+   * ISO-8601, Kernel plain session-local form. Timezone is pinned so the strings are deterministic.
+   */
+  @Test
+  public void testCommit_partitioned_timestampPartitionValueDivergesFromV1(@TempDir File tempDir)
+      throws Exception {
+    withSQLConf(
+        "spark.sql.session.timeZone",
+        "UTC",
+        () -> {
+          String v1Path = new File(tempDir, "v1").getAbsolutePath();
+          String v2Path = new File(tempDir, "v2").getAbsolutePath();
+          StructType schema =
+              new StructType(
+                  new StructField[] {
+                    DataTypes.createStructField("value", DataTypes.IntegerType, true),
+                    DataTypes.createStructField("part", DataTypes.TimestampType, true)
+                  });
+          Timestamp ts = Timestamp.valueOf("2025-06-15 10:30:00");
+
+          // Same row written by V1 and DSv2.
+          spark
+              .createDataFrame(List.of(RowFactory.create(1, ts)), schema)
+              .write()
+              .format("delta")
+              .partitionBy("part")
+              .save(v1Path);
+          spark.sql(
+              String.format(
+                  "CREATE TABLE t_ts_v2_%d (value INT, part TIMESTAMP) USING delta "
+                      + "PARTITIONED BY (part) LOCATION '%s'",
+                  System.nanoTime(), v2Path));
+          DeltaV2BatchWrite write = newTimestampPartWrite(v2Path);
+          write.commit(
+              new WriterCommitMessage[] {writeFile(write, 1, DateTimeUtils.fromJavaTimestamp(ts))});
+
+          // TODO(#7140): once Kernel aligns with V1, assert the two are equal instead.
+          assertEquals("2025-06-15T10:30:00.000000Z", loggedPartitionValue(v1Path, "part"));
+          assertEquals("2025-06-15 10:30:00.000000", loggedPartitionValue(v2Path, "part"));
+        });
+  }
+
+  @Test
+  public void testCommit_partitioned_nullPartitionValue(@TempDir File tempDir) throws Exception {
+    String path = createPartitionedTable(tempDir, "batch_part_null");
+    DeltaV2BatchWrite write = newPartitionedWrite(path);
+    // A null partition value lands in Hive's __HIVE_DEFAULT_PARTITION__ directory and reads back
+    // as null.
+    WriterCommitMessage msg = writePartitionedFile(write, 1, null, 2, "x");
+
+    write.commit(new WriterCommitMessage[] {msg});
+
+    assertTrue(
+        new File(path, "part=__HIVE_DEFAULT_PARTITION__").isDirectory(),
+        "expected default-partition dir for the null value");
+    List<Row> nullRows =
+        spark.read().format("delta").load(path).filter("part is null").collectAsList();
+    assertEquals(1, nullRows.size());
+    assertEquals(1, nullRows.get(0).getInt(nullRows.get(0).fieldIndex("value")));
+  }
+
+  @Test
+  public void testCommit_partitioned_emptyStringPartitionValueParity(@TempDir File tempDir)
+      throws Exception {
+    String v1Path = new File(tempDir, "v1").getAbsolutePath();
+    String v2Path = new File(tempDir, "v2").getAbsolutePath();
+    StructType schema =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField("value", DataTypes.IntegerType, true),
+              DataTypes.createStructField("part", DataTypes.StringType, true)
+            });
+
+    // DSv1 write of an empty-string and a non-empty partition value.
+    spark
+        .createDataFrame(List.of(RowFactory.create(1, ""), RowFactory.create(2, "x")), schema)
+        .write()
+        .format("delta")
+        .partitionBy("part")
+        .save(v1Path);
+
+    // DSv2 write of the same rows.
+    spark.sql(
+        String.format(
+            "CREATE TABLE t_empty_v2_%d (value INT, part STRING) USING delta "
+                + "PARTITIONED BY (part) LOCATION '%s'",
+            System.nanoTime(), v2Path));
+    DeltaV2BatchWrite write = newPartitionedWrite(v2Path);
+    write.commit(new WriterCommitMessage[] {writePartitionedFile(write, 1, "", 2, "x")});
+
+    // Same partition directories on disk and same rows on read-back under both engines.
+    assertEquals(partitionDirs(v1Path), partitionDirs(v2Path));
+    List<Row> v1Rows = spark.read().format("delta").load(v1Path).orderBy("value").collectAsList();
+    List<Row> v2Rows = spark.read().format("delta").load(v2Path).orderBy("value").collectAsList();
+    assertEquals(v1Rows.toString(), v2Rows.toString());
+  }
+
+  @Test
+  public void testCommit_partitioned_valueNeedingPathEscaping(@TempDir File tempDir)
+      throws Exception {
+    String path = createPartitionedTable(tempDir, "batch_part_escape");
+    DeltaV2BatchWrite write = newPartitionedWrite(path);
+    // A space in the partition value must be Hive-escaped in the path but preserved on read back
+    // (mirrors the base suite's SPARK-21167 case).
+    WriterCommitMessage msg = writePartitionedFile(write, 7, "hello world");
+
+    write.commit(new WriterCommitMessage[] {msg});
+
+    List<Row> rows =
+        spark.read().format("delta").load(path).filter("part = 'hello world'").collectAsList();
+    assertEquals(1, rows.size());
+    assertEquals(7, rows.get(0).getInt(rows.get(0).fieldIndex("value")));
+  }
+
+  @Test
+  public void testCommit_partitioned_interleavedInputProducesFilePerRun(@TempDir File tempDir)
+      throws Exception {
+    String path = createPartitionedTable(tempDir, "batch_part_interleaved");
+    DeltaV2BatchWrite write = newPartitionedWrite(path);
+    // The single-writer rotates on each partition-key CHANGE, not per distinct value: it has no
+    // memory of partitions it already closed. Unsorted input a,b,a therefore yields 3 files (a run
+    // of "a", a run of "b", another run of "a"), documenting the requiredOrdering dependency -- a
+    // sorted a,a,b would produce 2. Data is still correct either way.
+    WriterCommitMessage msg = writePartitionedFile(write, 1, "a", 2, "b", 3, "a");
+    assertEquals(3, ((DeltaV2WriterCommitMessage) msg).getActionRows().size());
+
+    write.commit(new WriterCommitMessage[] {msg});
+
+    List<Row> rows = spark.read().format("delta").load(path).orderBy("value").collectAsList();
+    assertEquals(3, rows.size());
+    List<Row> partA =
+        spark
+            .read()
+            .format("delta")
+            .load(path)
+            .filter("part = 'a'")
+            .orderBy("value")
+            .collectAsList();
+    assertEquals(2, partA.size());
+    assertEquals(1, partA.get(0).getInt(partA.get(0).fieldIndex("value")));
+    assertEquals(3, partA.get(1).getInt(partA.get(1).fieldIndex("value")));
+  }
+
+  @Test
+  public void testAbort_partitioned_deletesAllPartitionFiles(@TempDir File tempDir)
+      throws Exception {
+    String path = createPartitionedTable(tempDir, "batch_part_abort");
+    DeltaV2BatchWrite write = newPartitionedWrite(path);
+    // Stage a write spanning two partitions (two files), then abort: both files must be removed,
+    // not just the last one opened.
+    DataWriter<InternalRow> writer =
+        write.createBatchWriterFactory(WriteTestUtils.physicalWriteInfo(1)).createWriter(0, 0L);
+    writer.write(InternalRowTestUtils.row(10, "a"));
+    writer.write(InternalRowTestUtils.row(20, "b"));
+    writer.abort();
+
+    for (String dir : new String[] {"part=a", "part=b"}) {
+      File[] parquet = new File(path, dir).listFiles((d, n) -> n.endsWith(".parquet"));
+      assertTrue(parquet == null || parquet.length == 0, "aborted files must be deleted in " + dir);
+    }
+    assertEquals(0L, spark.read().format("delta").load(path).count(), "abort must not commit data");
+  }
+
+  @Test
+  public void testCommit_partitioned_multipleColumns(@TempDir File tempDir) throws Exception {
+    String path = tempDir.getAbsolutePath();
+    spark.sql(
+        String.format(
+            "CREATE TABLE t_multicol_%d (value INT, p1 STRING, p2 INT) USING delta "
+                + "PARTITIONED BY (p1, p2) LOCATION '%s'",
+            System.nanoTime(), path));
+    // Full row layout [value, p1, p2]; data schema [value], partition schema [p1, p2].
+    StructType full =
+        DataTypes.createStructType(
+            new StructField[] {
+              DataTypes.createStructField("value", DataTypes.IntegerType, true),
+              DataTypes.createStructField("p1", DataTypes.StringType, true),
+              DataTypes.createStructField("p2", DataTypes.IntegerType, true)
+            });
+    StructType data =
+        DataTypes.createStructType(
+            new StructField[] {DataTypes.createStructField("value", DataTypes.IntegerType, true)});
+    StructType part =
+        DataTypes.createStructType(
+            new StructField[] {
+              DataTypes.createStructField("p1", DataTypes.StringType, true),
+              DataTypes.createStructField("p2", DataTypes.IntegerType, true)
+            });
+    PathBasedSnapshotManager mgr =
+        new PathBasedSnapshotManager(path, spark.sessionState().newHadoopConf());
+    DeltaV2BatchWrite write =
+        (DeltaV2BatchWrite)
+            new DeltaV2Write(
+                    defaultEngine,
+                    spark.sessionState().newHadoopConf(),
+                    path,
+                    mgr.loadLatestSnapshot(),
+                    mgr,
+                    data,
+                    part,
+                    WriteTestUtils.logicalWriteInfo(full, CaseInsensitiveStringMap.empty()))
+                .toBatch();
+
+    DataWriter<InternalRow> writer =
+        write.createBatchWriterFactory(WriteTestUtils.physicalWriteInfo(1)).createWriter(0, 0L);
+    writer.write(InternalRowTestUtils.row(1, "x", 7));
+    WriterCommitMessage msg = writer.commit();
+    write.commit(new WriterCommitMessage[] {msg});
+
+    // Nested Hive-style directory p1=x/p2=7/.
+    assertTrue(
+        new File(path, "p1=x/p2=7").isDirectory(), "expected nested partition dir p1=x/p2=7");
+    List<Row> rows = spark.read().format("delta").load(path).collectAsList();
+    assertEquals(1, rows.size());
+    assertEquals("x", rows.get(0).getString(rows.get(0).fieldIndex("p1")));
+    assertEquals(7, rows.get(0).getInt(rows.get(0).fieldIndex("p2")));
+  }
+
+  @Test
+  public void testCommit_partitioned_multipleColumns_boundaryScenarios(@TempDir File tempDir)
+      throws Exception {
+    String path = tempDir.getAbsolutePath();
+    spark.sql(
+        String.format(
+            "CREATE TABLE t_multicol_bounds_%d (value INT, p1 STRING, p2 INT) USING delta "
+                + "PARTITIONED BY (p1, p2) LOCATION '%s'",
+            System.nanoTime(), path));
+    DeltaV2BatchWrite write = newMultiColWrite(path);
+
+    // Rows pre-sorted by (p1, p2): inner-only change (x,1)->(x,2), outer change ->(y,5),
+    // one null column (y,null), all-null (null,null). Each key change is its own AddFile.
+    DataWriter<InternalRow> writer =
+        write.createBatchWriterFactory(WriteTestUtils.physicalWriteInfo(1)).createWriter(0, 0L);
+    writer.write(InternalRowTestUtils.row(1, "x", 1));
+    writer.write(InternalRowTestUtils.row(2, "x", 2));
+    writer.write(InternalRowTestUtils.row(3, "y", 5));
+    writer.write(InternalRowTestUtils.row(4, "y", null));
+    writer.write(InternalRowTestUtils.row(5, null, null));
+    WriterCommitMessage msg = writer.commit();
+
+    // A null partition value is recorded as a null map value (not the on-disk sentinel).
+    assertEquals(
+        List.of(
+            partMap("x", "1"),
+            partMap("x", "2"),
+            partMap("y", "5"),
+            partMap("y", null),
+            partMap(null, null)),
+        partitionValuesOf(msg));
+
+    write.commit(new WriterCommitMessage[] {msg});
+
+    List<Row> rows = spark.read().format("delta").load(path).orderBy("value").collectAsList();
+    assertEquals(5, rows.size());
+    assertEquals("y", rows.get(3).getString(rows.get(3).fieldIndex("p1")));
+    assertTrue(rows.get(3).isNullAt(rows.get(3).fieldIndex("p2")));
+    assertTrue(rows.get(4).isNullAt(rows.get(4).fieldIndex("p1")));
+    assertTrue(rows.get(4).isNullAt(rows.get(4).fieldIndex("p2")));
+    assertEquals(2, spark.read().format("delta").load(path).filter("p1 = 'x'").count());
+    assertEquals(
+        1, spark.read().format("delta").load(path).filter("p1 = 'y' and p2 is null").count());
+    assertEquals(1, spark.read().format("delta").load(path).filter("p1 is null").count());
+  }
+
+  /** Builds a batch write for the (value INT, p1 STRING, p2 INT) PARTITIONED BY (p1, p2) table. */
+  private DeltaV2BatchWrite newMultiColWrite(String path) {
+    StructType full =
+        DataTypes.createStructType(
+            new StructField[] {
+              DataTypes.createStructField("value", DataTypes.IntegerType, true),
+              DataTypes.createStructField("p1", DataTypes.StringType, true),
+              DataTypes.createStructField("p2", DataTypes.IntegerType, true)
+            });
+    StructType data =
+        DataTypes.createStructType(
+            new StructField[] {DataTypes.createStructField("value", DataTypes.IntegerType, true)});
+    StructType part =
+        DataTypes.createStructType(
+            new StructField[] {
+              DataTypes.createStructField("p1", DataTypes.StringType, true),
+              DataTypes.createStructField("p2", DataTypes.IntegerType, true)
+            });
+    PathBasedSnapshotManager mgr =
+        new PathBasedSnapshotManager(path, spark.sessionState().newHadoopConf());
+    return (DeltaV2BatchWrite)
+        new DeltaV2Write(
+                defaultEngine,
+                spark.sessionState().newHadoopConf(),
+                path,
+                mgr.loadLatestSnapshot(),
+                mgr,
+                data,
+                part,
+                WriteTestUtils.logicalWriteInfo(full, CaseInsensitiveStringMap.empty()))
+            .toBatch();
+  }
+
+  /** Reads the single AddFile's recorded value for partition column {@code col} from the log. */
+  private String loggedPartitionValue(String tablePath, String col) {
+    List<Row> adds =
+        spark
+            .read()
+            .json(tablePath + "/_delta_log/*.json")
+            .where("add is not null")
+            .select("add.partitionValues." + col)
+            .collectAsList();
+    assertEquals(1, adds.size(), "expected exactly one AddFile in the log");
+    return adds.get(0).getString(0);
+  }
+
+  /** Builds a batch write for the (value INT, part TIMESTAMP) PARTITIONED BY (part) table. */
+  private DeltaV2BatchWrite newTimestampPartWrite(String path) {
+    StructType full =
+        DataTypes.createStructType(
+            new StructField[] {
+              DataTypes.createStructField("value", DataTypes.IntegerType, true),
+              DataTypes.createStructField("part", DataTypes.TimestampType, true)
+            });
+    StructType data =
+        DataTypes.createStructType(
+            new StructField[] {DataTypes.createStructField("value", DataTypes.IntegerType, true)});
+    StructType part =
+        DataTypes.createStructType(
+            new StructField[] {DataTypes.createStructField("part", DataTypes.TimestampType, true)});
+    PathBasedSnapshotManager mgr =
+        new PathBasedSnapshotManager(path, spark.sessionState().newHadoopConf());
+    return (DeltaV2BatchWrite)
+        new DeltaV2Write(
+                defaultEngine,
+                spark.sessionState().newHadoopConf(),
+                path,
+                mgr.loadLatestSnapshot(),
+                mgr,
+                data,
+                part,
+                WriteTestUtils.logicalWriteInfo(full, CaseInsensitiveStringMap.empty()))
+            .toBatch();
+  }
+
+  private String createPartitionedTable(File tempDir, String tableName) {
+    String path = tempDir.getAbsolutePath();
+    spark.sql(
+        String.format(
+            "CREATE TABLE %s (value INT, part STRING) USING delta PARTITIONED BY (part) "
+                + "LOCATION '%s'",
+            tableName, path));
+    return path;
+  }
+
+  private DeltaV2BatchWrite newPartitionedWrite(String path) {
+    PathBasedSnapshotManager snapshotManager =
+        new PathBasedSnapshotManager(path, spark.sessionState().newHadoopConf());
+    Snapshot snapshot = snapshotManager.loadLatestSnapshot();
+    LogicalWriteInfo info =
+        WriteTestUtils.logicalWriteInfo(PARTITIONED_FULL_SCHEMA, CaseInsensitiveStringMap.empty());
+    DeltaV2Write write =
+        new DeltaV2Write(
+            defaultEngine,
+            spark.sessionState().newHadoopConf(),
+            path,
+            snapshot,
+            snapshotManager,
+            PARTITIONED_DATA_SCHEMA,
+            PARTITIONED_PART_SCHEMA,
+            info);
+    return (DeltaV2BatchWrite) write.toBatch();
+  }
+
+  /**
+   * Writes full rows [value, part] at partition 0 / task 0. {@code valuePartPairs} is a flat list
+   * of (int value, String part), supplied already sorted by {@code part} (as Spark would deliver).
+   */
+  private WriterCommitMessage writePartitionedFile(
+      DeltaV2BatchWrite write, Object... valuePartPairs) throws Exception {
+    DataWriter<InternalRow> writer =
+        write.createBatchWriterFactory(WriteTestUtils.physicalWriteInfo(1)).createWriter(0, 0L);
+    for (int i = 0; i < valuePartPairs.length; i += 2) {
+      writer.write(InternalRowTestUtils.row(valuePartPairs[i], valuePartPairs[i + 1]));
+    }
+    return writer.commit();
+  }
+
+  /** Builds an expected (p1, p2) partition-values map, allowing null values (unlike Map.of). */
+  private static Map<String, String> partMap(String p1, String p2) {
+    Map<String, String> map = new LinkedHashMap<>();
+    map.put("p1", p1);
+    map.put("p2", p2);
+    return map;
+  }
+
+  /** Sorted list of Hive-style partition directory names (e.g. {@code part=x}) under a table. */
+  private static List<String> partitionDirs(String tablePath) {
+    File[] dirs = new File(tablePath).listFiles((d, n) -> n.contains("="));
+    List<String> names = new ArrayList<>();
+    if (dirs != null) {
+      for (File dir : dirs) {
+        names.add(dir.getName());
+      }
+    }
+    java.util.Collections.sort(names);
+    return names;
+  }
+
+  /** Extracts each AddFile's partitionValues from a commit message's action rows, in order. */
+  private static List<Map<String, String>> partitionValuesOf(WriterCommitMessage msg) {
+    List<Map<String, String>> result = new ArrayList<>();
+    for (SerializableKernelRowWrapper wrapper :
+        ((DeltaV2WriterCommitMessage) msg).getActionRows()) {
+      io.delta.kernel.data.Row singleAction = wrapper.getRow();
+      int addOrdinal = singleAction.getSchema().indexOf("add");
+      AddFile addFile = new AddFile(singleAction.getStruct(addOrdinal));
+      MapValue values = addFile.getPartitionValues();
+      Map<String, String> map = new LinkedHashMap<>();
+      for (int i = 0; i < values.getSize(); i++) {
+        // A null partition value is stored as an actual null in the map (the
+        // __HIVE_DEFAULT_PARTITION__ sentinel is only the on-disk directory name).
+        String value = values.getValues().isNullAt(i) ? null : values.getValues().getString(i);
+        map.put(values.getKeys().getString(i), value);
+      }
+      result.add(map);
+    }
+    return result;
+  }
+
   /** Runs the executor-side writer at partition 0 / task 0 and returns its commit message. */
   private WriterCommitMessage writeFile(DeltaV2BatchWrite write, Object... idNamePairs)
       throws Exception {
@@ -163,6 +669,12 @@ public class DeltaV2BatchWriteTest extends DeltaV2TestBase {
     LogicalWriteInfo info =
         WriteTestUtils.logicalWriteInfo(TABLE_SCHEMA, CaseInsensitiveStringMap.empty());
     return new DeltaV2BatchWrite(
-        defaultEngine, spark.sessionState().newHadoopConf(), path, snapshot, TABLE_SCHEMA, info);
+        defaultEngine,
+        spark.sessionState().newHadoopConf(),
+        path,
+        snapshot,
+        TABLE_SCHEMA,
+        new StructType(),
+        info);
   }
 }

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/write/DeltaV2StreamingWriteTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/write/DeltaV2StreamingWriteTest.java
@@ -51,6 +51,21 @@ public class DeltaV2StreamingWriteTest extends DeltaV2TestBase {
             DataTypes.createStructField("name", DataTypes.StringType, true)
           });
 
+  // Table (value INT) partitioned by (part STRING). The write row layout is the full table schema
+  // [value, part]; the writer projects [value] into the Parquet body and routes on [part].
+  private static final StructType PARTITIONED_FULL_SCHEMA =
+      DataTypes.createStructType(
+          new StructField[] {
+            DataTypes.createStructField("value", DataTypes.IntegerType, true),
+            DataTypes.createStructField("part", DataTypes.StringType, true)
+          });
+  private static final StructType PARTITIONED_DATA_SCHEMA =
+      DataTypes.createStructType(
+          new StructField[] {DataTypes.createStructField("value", DataTypes.IntegerType, true)});
+  private static final StructType PARTITIONED_PART_SCHEMA =
+      DataTypes.createStructType(
+          new StructField[] {DataTypes.createStructField("part", DataTypes.StringType, true)});
+
   @Test
   public void testUseCommitCoordinator_isFalse(@TempDir File tempDir) {
     DeltaV2StreamingWrite write = newWrite(createTable(tempDir, "streaming_no_coordinator"));
@@ -206,6 +221,76 @@ public class DeltaV2StreamingWriteTest extends DeltaV2TestBase {
   }
 
   /**
+   * Partitioned streaming write across two epochs. The partition routing lives in the shared
+   * DeltaV2DataWriter (covered in depth by DeltaV2BatchWriteTest); this asserts it also holds on
+   * the streaming path -- each epoch rotates files at the partition boundary and records partition
+   * values, so distinct epochs accumulate into the right Hive-style directories.
+   */
+  @Test
+  public void testCommit_partitioned_appendsAcrossEpochs(@TempDir File tempDir) throws Exception {
+    String path = createPartitionedTable(tempDir, "streaming_partitioned");
+    DeltaV2StreamingWrite write = newPartitionedWrite(path);
+
+    // Each epoch spans two partitions (rows pre-sorted by part, as Spark's required ordering
+    // delivers), so the writer must rotate the open file at the boundary within an epoch.
+    write.commit(
+        0L, new WriterCommitMessage[] {writePartitionedEpoch(write, 0L, 10, "a", 20, "b")});
+    write.commit(
+        1L, new WriterCommitMessage[] {writePartitionedEpoch(write, 1L, 11, "a", 30, "c")});
+
+    List<Row> rows = spark.read().format("delta").load(path).orderBy("value").collectAsList();
+    assertEquals(4, rows.size(), "distinct epochs must accumulate");
+    assertEquals(10, rows.get(0).getInt(rows.get(0).fieldIndex("value")));
+    assertEquals("a", rows.get(0).getString(rows.get(0).fieldIndex("part")));
+
+    // Partition directories from both epochs exist (Kernel owns the col=val/ encoding).
+    assertTrue(new File(path, "part=a").isDirectory(), "expected partition dir part=a");
+    assertTrue(new File(path, "part=b").isDirectory(), "expected partition dir part=b");
+    assertTrue(new File(path, "part=c").isDirectory(), "expected partition dir part=c");
+
+    // Partition-predicate read returns only that partition (across both epochs), proving
+    // AddFile.partitionValues were recorded on the streaming path.
+    List<Row> onlyA =
+        spark
+            .read()
+            .format("delta")
+            .load(path)
+            .filter("part = 'a'")
+            .orderBy("value")
+            .collectAsList();
+    assertEquals(2, onlyA.size());
+    assertEquals(10, onlyA.get(0).getInt(onlyA.get(0).fieldIndex("value")));
+    assertEquals(11, onlyA.get(1).getInt(onlyA.get(1).fieldIndex("value")));
+  }
+
+  /**
+   * The same partition value arriving in separate epochs accumulates into the one partition
+   * directory; the writer holds no cross-epoch memory, so each epoch independently routes to it.
+   */
+  @Test
+  public void testCommit_partitioned_samePartitionValueAcrossEpochs(@TempDir File tempDir)
+      throws Exception {
+    String path = createPartitionedTable(tempDir, "streaming_partitioned_same_value");
+    DeltaV2StreamingWrite write = newPartitionedWrite(path);
+
+    write.commit(0L, new WriterCommitMessage[] {writePartitionedEpoch(write, 0L, 10, "a")});
+    write.commit(1L, new WriterCommitMessage[] {writePartitionedEpoch(write, 1L, 11, "a")});
+
+    assertTrue(new File(path, "part=a").isDirectory(), "expected partition dir part=a");
+    List<Row> partA =
+        spark
+            .read()
+            .format("delta")
+            .load(path)
+            .filter("part = 'a'")
+            .orderBy("value")
+            .collectAsList();
+    assertEquals(2, partA.size(), "same partition value across epochs must accumulate");
+    assertEquals(10, partA.get(0).getInt(partA.get(0).fieldIndex("value")));
+    assertEquals(11, partA.get(1).getInt(partA.get(1).fieldIndex("value")));
+  }
+
+  /**
    * Runs the executor-side writer for one epoch and returns its commit message. {@code idNamePairs}
    * is a flat list of (int id, String name) values.
    */
@@ -217,6 +302,23 @@ public class DeltaV2StreamingWriteTest extends DeltaV2TestBase {
             .createWriter(0, 0L, epochId);
     for (int i = 0; i < idNamePairs.length; i += 2) {
       writer.write(InternalRowTestUtils.row(idNamePairs[i], idNamePairs[i + 1]));
+    }
+    return writer.commit();
+  }
+
+  /**
+   * Runs the executor-side writer for one epoch over full rows [value, part]. {@code
+   * valuePartPairs} is a flat list of (int value, String part), supplied already sorted by {@code
+   * part}.
+   */
+  private WriterCommitMessage writePartitionedEpoch(
+      DeltaV2StreamingWrite write, long epochId, Object... valuePartPairs) throws Exception {
+    DataWriter<InternalRow> writer =
+        write
+            .createStreamingWriterFactory(WriteTestUtils.physicalWriteInfo(1))
+            .createWriter(0, 0L, epochId);
+    for (int i = 0; i < valuePartPairs.length; i += 2) {
+      writer.write(InternalRowTestUtils.row(valuePartPairs[i], valuePartPairs[i + 1]));
     }
     return writer.commit();
   }
@@ -243,6 +345,36 @@ public class DeltaV2StreamingWriteTest extends DeltaV2TestBase {
             snapshot,
             snapshotManager,
             TABLE_SCHEMA,
+            new StructType(),
+            info);
+    return (DeltaV2StreamingWrite) write.toStreaming();
+  }
+
+  private String createPartitionedTable(File tempDir, String tableName) {
+    String path = tempDir.getAbsolutePath();
+    spark.sql(
+        String.format(
+            "CREATE TABLE %s (value INT, part STRING) USING delta PARTITIONED BY (part) "
+                + "LOCATION '%s'",
+            tableName, path));
+    return path;
+  }
+
+  private DeltaV2StreamingWrite newPartitionedWrite(String path) {
+    PathBasedSnapshotManager snapshotManager =
+        new PathBasedSnapshotManager(path, spark.sessionState().newHadoopConf());
+    Snapshot snapshot = snapshotManager.loadLatestSnapshot();
+    LogicalWriteInfo info =
+        WriteTestUtils.logicalWriteInfo(PARTITIONED_FULL_SCHEMA, CaseInsensitiveStringMap.empty());
+    DeltaV2Write write =
+        new DeltaV2Write(
+            defaultEngine,
+            spark.sessionState().newHadoopConf(),
+            path,
+            snapshot,
+            snapshotManager,
+            PARTITIONED_DATA_SCHEMA,
+            PARTITIONED_PART_SCHEMA,
             info);
     return (DeltaV2StreamingWrite) write.toStreaming();
   }

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/write/DeltaV2WriteContextTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/write/DeltaV2WriteContextTest.java
@@ -59,7 +59,13 @@ public class DeltaV2WriteContextTest extends DeltaV2TestBase {
 
     DeltaV2WriteContext context =
         DeltaV2WriteContext.create(
-            engine, hadoopConf, path, snapshot, tableSchema, new TestLogicalWriteInfo(tableSchema));
+            engine,
+            hadoopConf,
+            path,
+            snapshot,
+            tableSchema,
+            new StructType(),
+            new TestLogicalWriteInfo(tableSchema));
 
     assertSame(engine, context.getEngine());
     assertNotNull(context.getOutputWriterFactory());
@@ -87,7 +93,13 @@ public class DeltaV2WriteContextTest extends DeltaV2TestBase {
 
     DeltaV2WriteContext context =
         DeltaV2WriteContext.create(
-            engine, hadoopConf, path, snapshot, tableSchema, new TestLogicalWriteInfo(tableSchema));
+            engine,
+            hadoopConf,
+            path,
+            snapshot,
+            tableSchema,
+            new StructType(),
+            new TestLogicalWriteInfo(tableSchema));
 
     // The base is operation-independent: any transaction (here a WRITE txn off the snapshot) can be
     // turned into the executor-side factory. A real factory with a serialized txn state proves the
@@ -98,6 +110,77 @@ public class DeltaV2WriteContextTest extends DeltaV2TestBase {
             .build(engine);
     DeltaV2DataWriterFactory factory = context.buildDataWriterFactory(txn);
     assertNotNull(factory);
+  }
+
+  @Test
+  public void wiredPartitionSchemaIsPreserved(@TempDir File tempDir) throws Exception {
+    // Table (value INT) partitioned by (part STRING). The data / partition schema split is wired in
+    // from DeltaV2Table's SchemaProvider; the context preserves it rather than re-deriving.
+    String path = tempDir.getAbsolutePath();
+    spark.sql(
+        String.format(
+            "CREATE TABLE part_ctx (value INT, part STRING) USING delta PARTITIONED BY (part) "
+                + "LOCATION '%s'",
+            path));
+    StructType fullSchema =
+        new StructType().add("value", DataTypes.IntegerType).add("part", DataTypes.StringType);
+    StructType dataSchema = new StructType().add("value", DataTypes.IntegerType);
+    StructType partitionSchema = new StructType().add("part", DataTypes.StringType);
+
+    Configuration hadoopConf = spark.sessionState().newHadoopConf();
+    Engine engine = DefaultEngine.create(hadoopConf);
+    Snapshot snapshot = TableManager.loadSnapshot(path).build(engine);
+
+    DeltaV2WriteContext context =
+        DeltaV2WriteContext.create(
+            engine,
+            hadoopConf,
+            path,
+            snapshot,
+            dataSchema,
+            partitionSchema,
+            new TestLogicalWriteInfo(fullSchema));
+
+    assertArrayEquals(dataSchema.fieldNames(), context.getDataSchema().fieldNames());
+    assertArrayEquals(partitionSchema.fieldNames(), context.getPartitionSchema().fieldNames());
+  }
+
+  @Test
+  public void buildDataWriterFactoryResolvesColumnsCaseInsensitively(@TempDir File tempDir)
+      throws Exception {
+    // Table (value INT) partitioned by (part STRING), but the incoming write schema uses a
+    // different case for both columns. Column resolution must be case-insensitive (matching
+    // validateDataSchema) so the writer factory builds instead of throwing on exact-case lookup.
+    String path = tempDir.getAbsolutePath();
+    spark.sql(
+        String.format(
+            "CREATE TABLE part_ci (value INT, part STRING) USING delta PARTITIONED BY (part) "
+                + "LOCATION '%s'",
+            path));
+    StructType mixedCaseWriteSchema =
+        new StructType().add("VALUE", DataTypes.IntegerType).add("PART", DataTypes.StringType);
+    StructType dataSchema = new StructType().add("value", DataTypes.IntegerType);
+    StructType partitionSchema = new StructType().add("part", DataTypes.StringType);
+
+    Configuration hadoopConf = spark.sessionState().newHadoopConf();
+    Engine engine = DefaultEngine.create(hadoopConf);
+    Snapshot snapshot = TableManager.loadSnapshot(path).build(engine);
+
+    DeltaV2WriteContext context =
+        DeltaV2WriteContext.create(
+            engine,
+            hadoopConf,
+            path,
+            snapshot,
+            dataSchema,
+            partitionSchema,
+            new TestLogicalWriteInfo(mixedCaseWriteSchema));
+
+    Transaction txn =
+        snapshot
+            .buildUpdateTableTransaction(DeltaV2WriteContext.getEngineInfo(), Operation.WRITE)
+            .build(engine);
+    assertNotNull(context.buildDataWriterFactory(txn));
   }
 
   @Test

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/write/DeltaV2WriteTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/write/DeltaV2WriteTest.java
@@ -15,6 +15,9 @@
  */
 package io.delta.spark.internal.v2.write;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -23,6 +26,9 @@ import io.delta.spark.internal.v2.DeltaV2TestBase;
 import io.delta.spark.internal.v2.snapshot.PathBasedSnapshotManager;
 import java.io.File;
 import java.util.Map;
+import org.apache.spark.sql.connector.distributions.UnspecifiedDistribution;
+import org.apache.spark.sql.connector.expressions.NamedReference;
+import org.apache.spark.sql.connector.expressions.SortOrder;
 import org.apache.spark.sql.connector.write.LogicalWriteInfo;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructField;
@@ -73,6 +79,101 @@ public class DeltaV2WriteTest extends DeltaV2TestBase {
     }
   }
 
+  @Test
+  public void testDistributionAndOrdering_unpartitionedRequestsNeither(@TempDir File tempDir) {
+    String path = createTable(tempDir, "write_dist_unpartitioned");
+    DeltaV2Write write = newWrite(path, CaseInsensitiveStringMap.empty());
+
+    // Unpartitioned: no distribution (never a shuffle) and no ordering.
+    assertInstanceOf(UnspecifiedDistribution.class, write.requiredDistribution());
+    assertEquals(0, write.requiredOrdering().length);
+  }
+
+  @Test
+  public void testDistributionAndOrdering_partitionedSortsWithoutDistribution(
+      @TempDir File tempDir) {
+    // Table (id, name) partitioned by (name). We still request no distribution (no shuffle), only a
+    // local sort on the partition column.
+    String path = tempDir.getAbsolutePath();
+    spark.sql(
+        String.format(
+            "CREATE TABLE write_dist_part_%d (id INT, name STRING) USING delta "
+                + "PARTITIONED BY (name) LOCATION '%s'",
+            System.nanoTime(), path));
+    StructType dataSchema =
+        DataTypes.createStructType(
+            new StructField[] {DataTypes.createStructField("id", DataTypes.IntegerType, true)});
+    StructType partitionSchema =
+        DataTypes.createStructType(
+            new StructField[] {DataTypes.createStructField("name", DataTypes.StringType, true)});
+    PathBasedSnapshotManager mgr =
+        new PathBasedSnapshotManager(path, spark.sessionState().newHadoopConf());
+    DeltaV2Write write =
+        new DeltaV2Write(
+            defaultEngine,
+            spark.sessionState().newHadoopConf(),
+            path,
+            mgr.loadLatestSnapshot(),
+            mgr,
+            dataSchema,
+            partitionSchema,
+            WriteTestUtils.logicalWriteInfo(TABLE_SCHEMA, CaseInsensitiveStringMap.empty()));
+
+    assertInstanceOf(UnspecifiedDistribution.class, write.requiredDistribution());
+    SortOrder[] ordering = write.requiredOrdering();
+    assertEquals(1, ordering.length);
+    NamedReference ref = (NamedReference) ordering[0].expression();
+    assertArrayEquals(new String[] {"name"}, ref.fieldNames());
+  }
+
+  @Test
+  public void testDistributionAndOrdering_multipleColumnsSortInPartitionOrder(
+      @TempDir File tempDir) {
+    // Partition schema (p2, p1): the ordering must follow partition-schema order, not table order.
+    String path = tempDir.getAbsolutePath();
+    spark.sql(
+        String.format(
+            "CREATE TABLE write_dist_multi_%d (id INT, p1 STRING, p2 INT) USING delta "
+                + "PARTITIONED BY (p2, p1) LOCATION '%s'",
+            System.nanoTime(), path));
+    StructType dataSchema =
+        DataTypes.createStructType(
+            new StructField[] {DataTypes.createStructField("id", DataTypes.IntegerType, true)});
+    StructType partitionSchema =
+        DataTypes.createStructType(
+            new StructField[] {
+              DataTypes.createStructField("p2", DataTypes.IntegerType, true),
+              DataTypes.createStructField("p1", DataTypes.StringType, true)
+            });
+    StructType fullSchema =
+        DataTypes.createStructType(
+            new StructField[] {
+              DataTypes.createStructField("id", DataTypes.IntegerType, true),
+              DataTypes.createStructField("p1", DataTypes.StringType, true),
+              DataTypes.createStructField("p2", DataTypes.IntegerType, true)
+            });
+    PathBasedSnapshotManager mgr =
+        new PathBasedSnapshotManager(path, spark.sessionState().newHadoopConf());
+    DeltaV2Write write =
+        new DeltaV2Write(
+            defaultEngine,
+            spark.sessionState().newHadoopConf(),
+            path,
+            mgr.loadLatestSnapshot(),
+            mgr,
+            dataSchema,
+            partitionSchema,
+            WriteTestUtils.logicalWriteInfo(fullSchema, CaseInsensitiveStringMap.empty()));
+
+    assertInstanceOf(UnspecifiedDistribution.class, write.requiredDistribution());
+    SortOrder[] ordering = write.requiredOrdering();
+    assertEquals(2, ordering.length);
+    assertArrayEquals(
+        new String[] {"p2"}, ((NamedReference) ordering[0].expression()).fieldNames());
+    assertArrayEquals(
+        new String[] {"p1"}, ((NamedReference) ordering[1].expression()).fieldNames());
+  }
+
   private String createTable(File tempDir, String tableName) {
     String path = tempDir.getAbsolutePath();
     spark.sql(
@@ -93,6 +194,7 @@ public class DeltaV2WriteTest extends DeltaV2TestBase {
         snapshot,
         snapshotManager,
         TABLE_SCHEMA,
+        new StructType(),
         info);
   }
 }

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/write/DeltaV2WriterCommitMessageTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/write/DeltaV2WriterCommitMessageTest.java
@@ -129,6 +129,7 @@ public class DeltaV2WriterCommitMessageTest extends DeltaV2TestBase {
             path,
             snapshot,
             TABLE_SCHEMA,
+            new StructType(),
             WriteTestUtils.logicalWriteInfo(TABLE_SCHEMA, CaseInsensitiveStringMap.empty()));
     return (DeltaV2DataWriterFactory)
         write.createBatchWriterFactory(WriteTestUtils.physicalWriteInfo(1));


### PR DESCRIPTION
## Description

Adds partitioned write support to the Spark DSv2 (Kernel) sink, which previously wrote all data to the table root with empty partition values.

- `DeltaV2Write` implements `RequiresDistributionAndOrdering`, requesting a local sort on the partition columns (no distribution / no shuffle) so each partition's rows reach the writer contiguously.
- `DeltaV2DataWriter` keeps one open file and rotates it on a partition-key change, deriving each partition's target directory from Kernel's `Transaction.getWriteContext` and recording per-file `partitionValues`. Partition columns are not written into the Parquet body (matching the V1 default).
- The partition-value helpers (Spark `InternalRow` -> Kernel `Literal`, boundary-key extraction) live in `PartitionUtils`, alongside the read-side `getPartitionRow`.

## How was this patch tested?

New unit tests (`DeltaV2BatchWriteTest`, `DeltaV2StreamingWriteTest`, `DeltaV2WriteTest`, `PartitionUtilsTest`): multi-partition routing and round-trip, multi-column / null / escaped / typed partition values, one-file-per-partition and interleaved-input file-per-run, multi-partition abort cleanup, and the distribution/ordering contract.

Enabled the previously-disabled partitioned e2e tests in `DeltaSinkSuite` (`partitioned writing and batch reading`, `SPARK-21167: encode and decode path correctly`, and the partition-mismatch test), and extended `partitioned writing and batch reading` to also cover recovery from a checkpoint. Confirmed the V1 `DeltaSinkSuite` / `DeltaSinkNameBasedSuite` still pass.

## Does this PR introduce _any_ user-facing changes?

No.