### PR TITLE
Refactor DeltaFileProviderUtils to read commits via SingleCommit handles

### DIFF
--- a/hudi/src/main/scala/org/apache/spark/sql/delta/hudi/HudiConverter.scala
+++ b/hudi/src/main/scala/org/apache/spark/sql/delta/hudi/HudiConverter.scala
@@ -255,7 +255,7 @@ class HudiConverter
       case Some(prevSnapshot) =>
         // Read the actions directly from the delta json files.
         // TODO: Run this as a spark job on executors
-        val deltaFiles = DeltaFileProviderUtils.getDeltaFilesInVersionRange(
+        val commits = DeltaFileProviderUtils.getCommitsInVersionRange(
           spark = spark,
           deltaLog = log,
           startVersion = prevSnapshot.version + 1,
@@ -268,18 +268,16 @@ class HudiConverter
           data = Map(
             "fromVersion" -> (prevSnapshot.version + 1),
             "toVersion" -> snapshotToConvert.version,
-            "numDeltaFiles" -> deltaFiles.length
+            "numDeltaFiles" -> commits.length
           )
         )
 
-        val actionsToConvert = DeltaFileProviderUtils.parallelReadAndParseDeltaFilesAsIterator(
-          log, spark, deltaFiles)
-        actionsToConvert.foreach { actionsIter =>
+        val actionIterators =
+          DeltaFileProviderUtils.parallelReadAndParseDeltaFilesAsIterator(spark, log, commits)
+        actionIterators.foreach { actionsIter =>
           try {
-            actionsIter.grouped(actionBatchSize).foreach { actionStrs =>
-              runHudiConversionForActions(
-                hudiTxn,
-                actionStrs.map(Action.fromJson))
+            actionsIter.grouped(actionBatchSize).foreach { actions =>
+              runHudiConversionForActions(hudiTxn, actions)
             }
           } finally {
             actionsIter.close()

--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConverter.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConverter.scala
@@ -412,7 +412,7 @@ class IcebergConverter
               snapshotToConvert.version - 1
             case _ => snapshotToConvert.version
           }
-          val deltaFiles = DeltaFileProviderUtils.getDeltaFilesInVersionRange(
+          val commits = DeltaFileProviderUtils.getCommitsInVersionRange(
             spark = spark,
             deltaLog = log,
             startVersion = prevSnapshot.version + 1,
@@ -425,19 +425,19 @@ class IcebergConverter
             data = Map(
               "fromVersion" -> (prevSnapshot.version + 1),
               "toVersion" -> snapshotToConvert.version,
-              "numDeltaFiles" -> deltaFiles.length
+              "numDeltaFiles" -> commits.length
             )
           )
 
-          val actionsToConvert = DeltaFileProviderUtils.parallelReadAndParseDeltaFilesAsIterator(
-            log, spark, deltaFiles)
+          val actionIterators =
+            DeltaFileProviderUtils.parallelReadAndParseDeltaFilesAsIterator(spark, log, commits)
           var deltaVersion = prevSnapshot.version
-          val commitInfos = actionsToConvert.map { actionsIter =>
+          val commitInfos = actionIterators.map { actionsIter =>
             try {
               deltaVersion += 1
               runIcebergConversionForActions(
                 icebergTxn,
-                actionsIter.map(Action.fromJson).toSeq,
+                actionsIter.toSeq,
                 prevConvertedSnapshotOpt,
                 deltaVersion)
             } finally {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaFileProviderUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaFileProviderUtils.scala
@@ -19,9 +19,6 @@ package org.apache.spark.sql.delta
 import org.apache.spark.sql.delta.actions.Action
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.storage.ClosableIterator
-import org.apache.spark.sql.delta.util.FileNames.DeltaFile
-import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.fs.FileStatus
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
@@ -52,26 +49,23 @@ object DeltaFileProviderUtils extends DeltaLogging {
   }
 
   /**
-   * Get the Delta json files present in the delta log in the range [startVersion, endVersion].
-   * Returns the files in sorted order, and throws if any in the range are missing.
+   * List the commits in the version range [startVersion, endVersion] (both inclusive) as
+   * [[SingleCommit]]. Returns in sorted order, and throws if any in the range are missing.
    */
-  def getDeltaFilesInVersionRange(
+  def getCommitsInVersionRange(
       spark: SparkSession,
       deltaLog: DeltaLog,
       startVersion: Long,
       endVersion: Long,
-      catalogTableOpt: Option[CatalogTable]): Seq[FileStatus] = {
-    // Pass `failOnDataLoss = false` as we are doing an explicit validation on the result ourselves
+      catalogTableOpt: Option[CatalogTable]): Seq[SingleCommit] = {
+    // Pass `failOnDataLoss = false` as we do an explicit contiguity validation on the result below
     // to identify that there are no gaps.
-    val result =
-      deltaLog
-        .getChangeLogFiles(startVersion, endVersion, catalogTableOpt, failOnDataLoss = false)
-        .map(_._2)
-        .collect { case DeltaFile(fs, v) => (fs, v) }
-        .toSeq
-    // Verify that we got the entire range requested
-    if (result.size.toLong != endVersion - startVersion + 1) {
-      // [[unsafeVolatileSnapshot]] maybe null, which needs to be explicitly filtered out.
+    val commits = deltaLog
+      .getChangesIterator(startVersion, endVersion, catalogTableOpt, failOnDataLoss = false)
+      .toSeq
+    // Verify that we got the entire range requested.
+    if (commits.size.toLong != endVersion - startVersion + 1) {
+      // [[unsafeVolatileSnapshot]] may be null, which needs to be explicitly filtered out.
       val snapshot = Some(deltaLog.unsafeVolatileSnapshot).filter(_ != null)
       recordDeltaEvent(
         provider = deltaLog,
@@ -91,7 +85,7 @@ object DeltaFileProviderUtils extends DeltaLogging {
         ))
       throw DeltaErrors.deltaVersionsNotContiguousException(
         spark = spark,
-        deltaVersions = result.map(_._2),
+        deltaVersions = commits.map(_.version),
         startVersion = startVersion,
         endVersion = endVersion,
         // Get the latest snapshot version for visibility when throwing the exception,
@@ -99,27 +93,42 @@ object DeltaFileProviderUtils extends DeltaLogging {
         // we just use the latest snapshot version here.
         versionToLoad = snapshot.map(_.version).getOrElse(-1L))
     }
-    result.map(_._1)
+    commits
   }
 
-  /** Helper method to read and parse the delta files parallelly into [[Action]]s. */
+  /**
+   * Parallel-read a set of commits off the driver, returning one lazy [[ClosableIterator]] of
+   * [[Action]]s per commit, in the input order.
+   */
   def parallelReadAndParseDeltaFilesAsIterator(
+      spark: SparkSession,
       deltaLog: DeltaLog,
-      spark: SparkSession,
-      files: Seq[FileStatus]): Seq[ClosableIterator[String]] = {
-    val hadoopConf = deltaLog.newDeltaHadoopConf()
-    parallelReadDeltaFilesBase(spark, files, hadoopConf, { file: FileStatus =>
-      deltaLog.store.readAsIterator(file, hadoopConf)
-    })
-  }
+      commits: Seq[SingleCommit]): Seq[ClosableIterator[Action]] =
+    parallelReadDeltaFiles(spark, deltaLog, commits)(_.getActionsIterator())
 
-  protected def parallelReadDeltaFilesBase[A](
+  /**
+   * Parallel-read a set of commits off the driver, materializing each commit's [[Action]]s into a
+   * [[Seq]], in the input order.
+   */
+  def parallelReadAndParseDeltaFilesAsSeq(
       spark: SparkSession,
-      files: Seq[FileStatus],
-      hadoopConf: Configuration,
-      f: FileStatus => A): Seq[A] = {
-    readThreadPool.parallelMap(spark, files) { file =>
-      f(file)
+      deltaLog: DeltaLog,
+      commits: Seq[SingleCommit]): Seq[Seq[Action]] =
+    parallelReadDeltaFiles(spark, deltaLog, commits) { commit =>
+      commit.getActionsIterator().processAndClose(_.toSeq)
+    }
+
+  /**
+   * Parallel-read a set of commits off the driver, applying `f` to each. The commits are read
+   * concurrently on the driver delta-log thread pool; results are returned in the input order.
+   */
+  protected def parallelReadDeltaFiles[A](
+      spark: SparkSession,
+      deltaLog: DeltaLog,
+      commits: Seq[SingleCommit])(f: SingleCommit => A): Seq[A] = {
+    val hadoopConf = deltaLog.newDeltaHadoopConf()
+    readThreadPool.parallelMap(spark, commits) { commit =>
+      f(commit)
     }.toSeq
   }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/SingleCommit.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/SingleCommit.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.delta
 import org.apache.spark.sql.delta.actions.Action
 import org.apache.spark.sql.delta.storage.{ClosableIterator, SupportsRewinding}
 import org.apache.spark.sql.delta.storage.ClosableIterator._
-import org.apache.hadoop.fs.FileStatus
+import org.apache.hadoop.fs.{FileStatus, Path}
 
 /**
  * A handle to a single commit in the Delta log, standing in for the raw commit log file that
@@ -29,7 +29,6 @@ import org.apache.hadoop.fs.FileStatus
 class SingleCommit private (
     private val deltaLog: DeltaLog,
     val version: Long,
-    val fileModificationTimestamp: Long,
     private val fileStatus: FileStatus
 ) {
   /**
@@ -43,19 +42,33 @@ class SingleCommit private (
   def getActionsIterator(
       maxInMemoryFileSizeBytes: Long = 0): ClosableIterator[Action] with SupportsRewinding[Action] =
     SingleCommit.createRewindableActionIterator(deltaLog, fileStatus, maxInMemoryFileSizeBytes)
+
+  /**
+   * The modification time of this commit's log file. Delta internal only.
+   */
+  private[delta] def fileModificationTimestamp: Long = fileStatus.getModificationTime
+
+  /**
+   * The size of this commit's log file, in bytes. Delta internal only.
+   */
+  private[delta] def sizeInBytes: Long = fileStatus.getLen
+
+  /**
+   * The commit log file's path. Should used by delta internal only.
+   */
+  private[delta] def path: Path = fileStatus.getPath
 }
 
 object SingleCommit {
-  /** Wrap a commit's log file into a [[SingleCommit]] handle. The commit
-   * `fileModificationTimestamp` is derived from the file's modification time; the raw
-   * [[FileStatus]] stays hidden inside the handle so the log's physical layout is not exposed to
-   * callers.
+  /**
+   * Wrap a commit's log file into a [[SingleCommit]] handle. The raw [[FileStatus]] stays hidden
+   * inside the handle so the log's physical layout is not exposed to callers.
    */
   private[delta] def apply(
       deltaLog: DeltaLog,
       version: Long,
       fileStatus: FileStatus): SingleCommit =
-    new SingleCommit(deltaLog, version, fileStatus.getModificationTime, fileStatus)
+    new SingleCommit(deltaLog, version, fileStatus)
 
   /**
    * Read a single commit's actions into a rewindable, closable iterator, respecting memory

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
@@ -345,7 +345,7 @@ trait DeltaSourceBase extends Source
   }
 
   /** Records a Delta event when a trailing commit goes missing, for fleet visibility before we
-   * throw, mirroring [[DeltaFileProviderUtils.getDeltaFilesInVersionRange]]. */
+   * throw, mirroring [[DeltaFileProviderUtils.getCommitsInVersionRange]]'s contiguity check. */
   protected def recordTrailingCommitMissingEvent(
       startVersion: Long,
       startIndex: Long,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
@@ -774,7 +774,7 @@ class DeltaLogSuite extends QueryTest
     }
   }
 
-  test("DeltaFileProviderUtils.getDeltaFilesInVersionRange") {
+  test("getCommitsInVersionRange returns the requested contiguous version range") {
     withTempDir { dir =>
       val path = dir.getCanonicalPath
       spark.range(0, 1).write.format("delta").mode("overwrite").save(path)
@@ -782,25 +782,36 @@ class DeltaLogSuite extends QueryTest
       spark.range(0, 1).write.format("delta").mode("overwrite").save(path)
       spark.range(0, 1).write.format("delta").mode("overwrite").save(path)
       val log = DeltaLog.forTable(spark, new Path(path))
-      val result = DeltaFileProviderUtils.getDeltaFilesInVersionRange(
+      val commits = DeltaFileProviderUtils.getCommitsInVersionRange(
         spark, log, startVersion = 1, endVersion = 3, catalogTableOpt = None)
-      assert(result.map(FileNames.getFileVersion) === Seq(1, 2, 3))
-      val filesAreUnbackfilledArray = result.map(FileNames.isUnbackfilledDeltaFile)
+      // The range read returns exactly the requested contiguous versions, in ascending order, and
+      // every commit in the range yields a non-empty action list.
+      assert(commits.map(_.version) === Seq(1, 2, 3))
+      assert(commits.forall(_.getActionsIterator().processAndClose(_.nonEmpty)))
+    }
+  }
 
-      val (fileV1, fileV2, fileV3) = (result(0), result(1), result(2))
-      assert(FileNames.getFileVersion(fileV1) === 1)
-      assert(FileNames.getFileVersion(fileV2) === 2)
-      assert(FileNames.getFileVersion(fileV3) === 3)
-
-      val backfillInterval =
-        catalogOwnedCoordinatorBackfillBatchSize.getOrElse(0L)
-      if (backfillInterval == 0 || backfillInterval == 1) {
-        assert(filesAreUnbackfilledArray === Seq(false, false, false))
-      } else if (backfillInterval == 2) {
-        assert(filesAreUnbackfilledArray === Seq(false, false, true))
-      } else {
-        assert(filesAreUnbackfilledArray === Seq(true, true, true))
-      }
+  test("parallelReadAndParseDeltaFilesAsIterator reads the same commits as" +
+      "getCommitsInVersionRange") {
+    withTempDir { dir =>
+      val path = dir.getCanonicalPath
+      spark.range(0, 1).write.format("delta").mode("overwrite").save(path)
+      spark.range(0, 1).write.format("delta").mode("overwrite").save(path)
+      spark.range(0, 1).write.format("delta").mode("overwrite").save(path)
+      spark.range(0, 1).write.format("delta").mode("overwrite").save(path)
+      val log = DeltaLog.forTable(spark, new Path(path))
+      val commits = DeltaFileProviderUtils.getCommitsInVersionRange(
+        spark, log, startVersion = 1, endVersion = 3, catalogTableOpt = None)
+      assert(commits.map(_.version) === Seq(1, 2, 3))
+      // Reading the commits serially and in parallel must yield identical actions per version, and
+      // parallelReadAndParseDeltaFilesAsIterator must preserve the input order.
+      val expected =
+        commits.map(c => c.version -> c.getActionsIterator().processAndClose(_.toList))
+      val parallelActions =
+        DeltaFileProviderUtils.parallelReadAndParseDeltaFilesAsIterator(spark, log, commits)
+          .map(_.processAndClose(_.toList))
+      val actual = commits.map(_.version).zip(parallelActions)
+      assert(actual === expected)
     }
   }
 


### PR DESCRIPTION
## Description

This refactors the parallel commit-reading helpers in `DeltaFileProviderUtils` to work with `SingleCommit` handles instead of raw `FileStatus` objects, so callers no longer depend on the Delta log's physical file layout.

Changes:
- `getDeltaFilesInVersionRange` is replaced by `getCommitsInVersionRange`, which returns a `Seq[SingleCommit]` for the requested `[startVersion, endVersion]` range (still validating that the range is contiguous and throwing if any version is missing).
- The parallel read helpers now operate on `SingleCommit`:
  - `parallelReadAndParseDeltaFilesAsIterator` returns one lazy `ClosableIterator[Action]` per commit, in input order.
  - A new `parallelReadAndParseDeltaFilesAsSeq` materializes each commit's `Action`s into a `Seq`.
  - Both are built on a single `parallelReadDeltaFiles` primitive that reads commits concurrently on the driver thread pool and preserves input order.
- `SingleCommit` now exposes `fileModificationTimestamp`, `sizeInBytes`, and `path` as internal accessors derived from the underlying `FileStatus`, keeping the raw `FileStatus` hidden inside the handle.
- The Hudi and Iceberg converters are updated to consume the new API (they now receive parsed `Action`s directly instead of JSON strings).

## How was this patch tested?

Added unit tests in `DeltaLogSuite`:
- `getCommitsInVersionRange` returns exactly the requested contiguous version range in ascending order, with non-empty actions per commit.
- `parallelReadAndParseDeltaFilesAsIterator` reads the same commits as `getCommitsInVersionRange`, yielding identical actions per version and preserving input order.

## Does this PR introduce _any_ user-facing changes?

No.
