### PR TITLE
Extract Delta Sharing JSON predicate conversion into a shared helper

### DIFF
--- a/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingFileIndex.scala
+++ b/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingFileIndex.scala
@@ -22,8 +22,6 @@ import org.apache.spark.sql.delta.{DeltaFileFormat, DeltaLog}
 import org.apache.spark.sql.delta.files.{SupportsRowIndexFilters, TahoeLogFileIndex}
 import io.delta.sharing.client.DeltaSharingClient
 import io.delta.sharing.client.model.{Table => DeltaSharingTable}
-import io.delta.sharing.client.util.{ConfUtils, JsonUtils}
-import io.delta.sharing.filters.{AndOp, BaseOp, OpConverter}
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.internal.Logging
@@ -96,7 +94,8 @@ case class DeltaSharingFileIndex(
       partitionFilters: Seq[Expression],
       dataFilters: Seq[Expression],
       overrideLimit: Option[Long]): DeltaLog = {
-    val jsonPredicateHints = convertToJsonPredicate(partitionFilters, dataFilters)
+    val jsonPredicateHints = DeltaSharingJsonPredicates.convert(
+      partitionFilters, dataFilters, params.spark.sessionState.conf)
     val queryParamsHashId = DeltaSharingUtils.getQueryParamsHashId(
       params.options,
       // Using .sql instead of toString because it doesn't include class pointer, which
@@ -171,57 +170,4 @@ case class DeltaSharingFileIndex(
     asTahoeFileIndex(partitionFilters, dataFilters).listFiles(partitionFilters, dataFilters)
   }
 
-  // Converts the specified SQL expressions to a json predicate.
-  //
-  // If jsonPredicatesV2 are enabled, converts both partition and data filters
-  // and combines them using an AND.
-  //
-  // If the conversion fails, returns a None, which will imply that we will
-  // not perform json predicate based filtering.
-  private def convertToJsonPredicate(
-      partitionFilters: Seq[Expression],
-      dataFilters: Seq[Expression]): Option[String] = {
-    if (!ConfUtils.jsonPredicatesEnabled(params.spark.sessionState.conf)) {
-      return None
-    }
-
-    // Convert the partition filters.
-    val partitionOp = try {
-      OpConverter.convert(partitionFilters)
-    } catch {
-      case e: Exception =>
-        log.error("Error while converting partition filters: " + e)
-        None
-    }
-
-    // If V2 predicates are enabled, also convert the data filters.
-    val dataOp = try {
-      if (ConfUtils.jsonPredicatesV2Enabled(params.spark.sessionState.conf)) {
-        log.info("Converting data filters")
-        OpConverter.convert(dataFilters)
-      } else {
-        None
-      }
-    } catch {
-      case e: Exception =>
-        log.error("Error while converting data filters: " + e)
-        None
-    }
-
-    // Combine partition and data filters using an AND operation.
-    val combinedOp = if (partitionOp.isDefined && dataOp.isDefined) {
-      Some(AndOp(Seq(partitionOp.get, dataOp.get)))
-    } else if (partitionOp.isDefined) {
-      partitionOp
-    } else {
-      dataOp
-    }
-    log.info("Using combined predicate: " + combinedOp)
-
-    if (combinedOp.isDefined) {
-      Some(JsonUtils.toJson[BaseOp](combinedOp.get))
-    } else {
-      None
-    }
-  }
 }

--- a/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingJsonPredicates.scala
+++ b/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingJsonPredicates.scala
@@ -1,0 +1,97 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.sharing.spark
+
+import io.delta.sharing.client.util.{ConfUtils, JsonUtils}
+import io.delta.sharing.filters.{AndOp, BaseOp, OpConverter}
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.internal.SQLConf
+
+/**
+ * Converts Catalyst filter expressions into the JSON predicate hint the Delta Sharing server uses
+ * for server-side file skipping. Extracted from the logic previously inlined in
+ * [[DeltaSharingFileIndex]] so it can be shared: the V1 path calls [[convert]] directly.
+ *
+ * The hint is best-effort: the server is not required to apply it, so callers must still evaluate
+ * every filter after the scan. Consequently any conversion failure (an unsupported filter, a bad
+ * expression) degrades to [[None]] rather than erroring -- a missing hint only forgoes server-side
+ * skipping, never correctness.
+ */
+object DeltaSharingJsonPredicates extends Logging {
+
+  /**
+   * Convert partition and data filter expressions to a json predicate:
+   *   - the whole conversion is off unless `jsonPredicateHints.enabled` (default on);
+   *   - data filters are converted only under `jsonPredicateV2Hints.enabled`.
+   * Partition and data predicates are AND-ed. A conversion error on either side drops just that
+   * side (logged, not thrown).
+   *
+   * @param partitionFilters filters referencing only partition columns.
+   * @param dataFilters      filters referencing at least one non-partition column.
+   * @param conf             session conf supplying the two feature gates.
+   * @return the serialized json predicate, or None when disabled or nothing converted.
+   */
+  def convert(
+      partitionFilters: Seq[Expression],
+      dataFilters: Seq[Expression],
+      conf: SQLConf): Option[String] = {
+    if (!ConfUtils.jsonPredicatesEnabled(conf)) {
+      return None
+    }
+
+    // Convert the partition filters.
+    val partitionOp = try {
+      OpConverter.convert(partitionFilters)
+    } catch {
+      case e: Exception =>
+        logError("Error while converting partition filters: " + e)
+        None
+    }
+
+    // If V2 predicates are enabled, also convert the data filters.
+    val dataOp = try {
+      if (ConfUtils.jsonPredicatesV2Enabled(conf)) {
+        logInfo("Converting data filters")
+        OpConverter.convert(dataFilters)
+      } else {
+        None
+      }
+    } catch {
+      case e: Exception =>
+        logError("Error while converting data filters: " + e)
+        None
+    }
+
+    // Combine partition and data filters using an AND operation.
+    val combinedOp = if (partitionOp.isDefined && dataOp.isDefined) {
+      Some(AndOp(Seq(partitionOp.get, dataOp.get)))
+    } else if (partitionOp.isDefined) {
+      partitionOp
+    } else {
+      dataOp
+    }
+    logInfo("Using combined predicate: " + combinedOp)
+
+    if (combinedOp.isDefined) {
+      Some(JsonUtils.toJson[BaseOp](combinedOp.get))
+    } else {
+      None
+    }
+  }
+}


### PR DESCRIPTION
## Description

The conversion of Catalyst filter expressions into the JSON predicate hint that the Delta
Sharing server uses for server-side file skipping was previously inlined as a private method
in `DeltaSharingFileIndex`. This PR extracts that logic into a standalone
`DeltaSharingJsonPredicates.convert` helper.

No behavior change. The two feature gates (`jsonPredicateHints.enabled`,
`jsonPredicateV2Hints.enabled`), the AND-combination of partition and data predicates, and the
best-effort "log and drop on conversion failure" semantics are all preserved exactly.
`DeltaSharingFileIndex` now delegates to the shared helper.

Extracting the converter lets it be reused rather than reimplemented, and gives the conversion
a clear home with documentation of its best-effort contract (a missing hint only forgoes
server-side skipping and never affects correctness, since callers still evaluate every filter
after the scan).

## How was this patch tested?

Existing Delta Sharing suites that exercise the conversion continue to pass unchanged
(`DeltaSharingFileIndexSuite`, `DeltaSharingDataSourceDeltaSuite`), including their exact
JSON-predicate assertions.

## Does this PR introduce _any_ user-facing change?

No.