### PR TITLE
[Spark] Add more and fix DSv2 time travel tests

### DIFF
--- a/spark-unified/src/main/scala/org/apache/spark/sql/delta/v2/interop/DeltaV2ErrorInterop.scala
+++ b/spark-unified/src/main/scala/org/apache/spark/sql/delta/v2/interop/DeltaV2ErrorInterop.scala
@@ -20,7 +20,8 @@ import java.sql.Timestamp
 
 import org.apache.spark.sql.delta.{DeltaErrors, VersionNotFoundException => V1VersionNotFoundException}
 import org.apache.spark.sql.delta.util.{DateTimeUtils, TimestampFormatter}
-import io.delta.spark.internal.v2.exception.{TableNotFoundException, TimestampOutOfRangeException, VersionNotFoundException}
+import io.delta.spark.internal.v2.exception.{NoRecreatableHistoryException, TableNotFoundException, TimestampOutOfRangeException, VersionNotFoundException}
+import org.apache.hadoop.fs.Path
 
 import org.apache.spark.sql.internal.SQLConf
 
@@ -51,4 +52,7 @@ object DeltaV2ErrorInterop {
 
   def throwAsDeltaError(e: TableNotFoundException): Nothing =
     throw DeltaErrors.pathNotExistsException(e.getTablePath)
+
+  def throwAsDeltaError(e: NoRecreatableHistoryException): Nothing =
+    throw DeltaErrors.noRecreatableHistoryFound(new Path(e.getTablePath))
 }

--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaHistoryManagerV2Suite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaHistoryManagerV2Suite.scala
@@ -21,7 +21,7 @@ import java.sql.Timestamp
 
 import scala.concurrent.duration._
 
-import org.apache.spark.sql.delta.{DeltaErrors, DeltaLog, DeltaTimeTravelTestHelpers, VersionNotFoundException}
+import org.apache.spark.sql.delta.{DeltaErrors, DeltaFileNotFoundException, DeltaLog, DeltaTimeTravelTestHelpers, InCommitTimestampTestUtils, VersionNotFoundException}
 import org.apache.spark.sql.delta.DeltaTestUtils.modifyCommitTimestamp
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.FileNames
@@ -34,6 +34,7 @@ import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.execution.FileSourceScanExec
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
+import org.apache.spark.sql.functions
 
 /**
  * DSv2 parity tests for time travel queries exercising the STRICT-mode Kernel-backed connector
@@ -288,6 +289,52 @@ class DeltaHistoryManagerV2Suite extends DeltaTimeTravelTestHelpers {
         },
         "expected a missing-data-file read failure, got:\n" +
           causes.map(c => s"  [${c.getClass.getName}] ${c.getMessage}").mkString("\n"))
+    }
+  }
+
+  test("SQL catalog multi-version self-join reads two distinct pinned snapshots") {
+    val tbl = "delta_tt_v2_cat_multiversion"
+    withTable(tbl) {
+      inV1 {
+        // v0 empty, v1 keys 0-4, v2 keys 0-9.
+        sql(s"CREATE TABLE $tbl (key LONG, value LONG) USING delta")
+        sql(s"INSERT INTO $tbl SELECT id AS key, id * 10 AS value FROM range(0, 5)")
+        sql(s"INSERT INTO $tbl SELECT id AS key, id * 10 AS value FROM range(5, 10)")
+      }
+      checkAnswer(
+        sql(s"SELECT b.key FROM $tbl VERSION AS OF 1 a FULL OUTER JOIN $tbl VERSION AS OF 2 b " +
+          "ON a.key = b.key WHERE a.key IS NULL"),
+        (5 until 10).map(Row(_)))
+    }
+  }
+
+  test("SQL catalog versionAsOf on a partitioned table prunes at the pinned version") {
+    val tbl = "delta_tt_v2_cat_partition"
+    withTable(tbl) {
+      inV1 {
+        // v0 empty, v1 ids 0-9, v2 ids 0-19.
+        sql(s"CREATE TABLE $tbl (id LONG, part LONG) USING delta PARTITIONED BY (part)")
+        sql(s"INSERT INTO $tbl SELECT id, id % 2 AS part FROM range(0, 10)")
+        sql(s"INSERT INTO $tbl SELECT id, id % 2 AS part FROM range(10, 20)")
+      }
+      checkAnswer(
+        sql(s"SELECT id FROM $tbl VERSION AS OF 1 WHERE part = 0"),
+        (0 until 10 by 2).map(Row(_)))
+    }
+  }
+
+  test("SQL catalog versionAsOf reflects the historical schema before a column was added") {
+    val tbl = "delta_tt_v2_cat_schema_scan"
+    withTable(tbl) {
+      inV1 {
+        sql(s"CREATE TABLE $tbl (id INT) USING delta")
+        sql(s"INSERT INTO $tbl VALUES (1)")
+        sql(s"ALTER TABLE $tbl ADD COLUMNS (name STRING)")
+        sql(s"INSERT INTO $tbl VALUES (2, 'b')")
+      }
+      val atV1 = sql(s"SELECT * FROM $tbl VERSION AS OF 1")
+      assert(atV1.schema.fieldNames.toSeq === Seq("id"))
+      checkAnswer(atV1, Row(1))
     }
   }
 
@@ -810,6 +857,39 @@ class DeltaHistoryManagerV2Suite extends DeltaTimeTravelTestHelpers {
     }
   }
 
+  test("SQL path versionAsOf on deletion-vector table ignores DVs added later") {
+    withTempDir { dir =>
+      val tbl = "delta_tt_v2_path_dv"
+      val path = dir.getCanonicalPath
+      withTable(tbl) {
+        inV1 {
+          sql(s"CREATE TABLE $tbl (id LONG) USING delta LOCATION '$path' " +
+            "TBLPROPERTIES ('delta.enableDeletionVectors' = 'true')")
+          sql(s"INSERT INTO $tbl SELECT id FROM range(0, 10)")
+          sql(s"DELETE FROM delta.`$path` WHERE id < 5")
+        }
+        checkAnswer(sql(s"SELECT * FROM delta.`$path` VERSION AS OF 1"), (0 until 10).map(Row(_)))
+        checkAnswer(sql(s"SELECT * FROM delta.`$path` VERSION AS OF 2"), (5 until 10).map(Row(_)))
+      }
+    }
+  }
+
+  test("SQL path versionAsOf at an exact checkpoint version reads the pinned version") {
+    withTempDir { dir =>
+      val tbl = "delta_tt_v2_path_checkpoint"
+      val path = dir.getCanonicalPath
+      withTable(tbl) {
+        val start = System.currentTimeMillis() - 5.days.toMillis
+        inV1 {
+          generateCommitsAtPath(tbl, path, start, start + 20.minutes, start + 40.minutes)
+          val deltaLog = DeltaLog.forTable(spark, path)
+          deltaLog.checkpoint(deltaLog.update())
+        }
+        checkAnswer(sql(s"SELECT * FROM delta.`$path` VERSION AS OF 2"), (0 until 30).map(Row(_)))
+      }
+    }
+  }
+
   test("SQL path @-syntax VERSION returns the historical snapshot") {
     withTempDir { dir =>
       val tbl = "delta_tt_v2_at_ver"
@@ -901,4 +981,5 @@ class DeltaHistoryManagerV2Suite extends DeltaTimeTravelTestHelpers {
       }
     }
   }
+
 }

--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaTimeTravelV2Suite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaTimeTravelV2Suite.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.delta.DeltaTimeTravelSuite
  *
  * Table setup is rerouted to the V1 connector via [[DeltaTimeTravelSuite.setupSql]] /
  * [[DeltaTimeTravelSuite.runSetup]], so the time travel read itself is what runs under V2.
- * [[V2ForceTest]] also ensures that no test is silently executing a V1 file-source scan.
+ * [[V2ForceTest]] attempts to guard against a test silently executing a V1 Delta file-source scan.
  */
 class DeltaTimeTravelV2Suite extends DeltaTimeTravelSuite with V2ForceTest {
 
@@ -54,20 +54,21 @@ class DeltaTimeTravelV2Suite extends DeltaTimeTravelSuite with V2ForceTest {
   )
 
   override protected def shouldFailTests: Set[String] = Set(
-    // Path-based time travel not supported yet.
+    // Writes to a directory named `base@v0` and both assertions are regular reads, so whole test
+    // stays in V1.
     "don't time travel a valid delta path with @ syntax",
-    "scans on different versions of same table are executed correctly",
-    // Path-based schema/partition-evolution reads.
-    "time travel with schema changes - should instantiate old schema",
-    "time travel with partition changes - should instantiate old schema",
+    // Path-based DataFrame reads not supported
     "as of timestamp in between commits should use commit before timestamp",
     "as of timestamp on exact timestamp",
     "as of timestamp on invalid timestamp",
     "as of exact timestamp after last commit should fail",
-    "as of with versions",
     "time travelling with adjusted timestamps",
-    // Catalog reads cross-checked against a path-based V1 oracle.
+    "scans on different versions of same table are executed correctly",
     "time travel support in SQL",
+    "as of with versions",
+    // Path-based schema/partition-evolution reads.
+    "time travel with schema changes - should instantiate old schema",
+    "time travel with partition changes - should instantiate old schema",
     // Write / maintenance surfaces not supported.
     "Block time travel beyond deletedFileRetention",
     "Block CDC beyond deletedFileRetention",

--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/V2ForceTest.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/V2ForceTest.scala
@@ -48,8 +48,8 @@ trait V2ForceTest extends DeltaSQLCommandTest with AdaptiveSparkPlanHelper {
   private val testsRun: mutable.Set[String] = mutable.Set.empty
 
   /**
-   * When true, each `shouldPass` test additionally asserts that it does not silently fall back to
-   * the V1 Delta file-source scan under STRICT mode. Off by default.
+   * When true, each `shouldPass` test additionally checks that no executed plan contains a V1
+   * Delta file-source scan (this does not catch reads that are metadata-only). Off by default.
    */
   protected def assertNoV1Fallback: Boolean = false
 

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
@@ -28,6 +28,7 @@ import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.internal.rowtracking.RowTracking;
 import io.delta.spark.internal.v2.adapters.KernelMetadataAdapter;
 import io.delta.spark.internal.v2.adapters.KernelProtocolAdapter;
+import io.delta.spark.internal.v2.exception.NoRecreatableHistoryException;
 import io.delta.spark.internal.v2.exception.TableNotFoundException;
 import io.delta.spark.internal.v2.exception.TimestampOutOfRangeException;
 import io.delta.spark.internal.v2.read.DeltaV2ScanUtils;
@@ -96,6 +97,7 @@ public class DeltaV2Table extends DeltaV2TableShims
       RowCommitVersion$.MODULE$.METADATA_STRUCT_FIELD_NAME();
 
   private static final Set<TableCapability> CAPABILITIES = buildCapabilities();
+  private static final Set<TableCapability> READ_ONLY_CAPABILITIES = buildReadOnlyCapabilities();
 
   private static Set<TableCapability> buildCapabilities() {
     EnumSet<TableCapability> caps =
@@ -106,6 +108,11 @@ public class DeltaV2Table extends DeltaV2TableShims
             TableCapability.STREAMING_WRITE);
     DeltaV2TableShims.schemaEvolutionCapability().ifPresent(caps::add);
     return Collections.unmodifiableSet(caps);
+  }
+
+  private static Set<TableCapability> buildReadOnlyCapabilities() {
+    return Collections.unmodifiableSet(
+        EnumSet.of(TableCapability.BATCH_READ, TableCapability.MICRO_BATCH_READ));
   }
 
   private final Identifier identifier;
@@ -121,6 +128,8 @@ public class DeltaV2Table extends DeltaV2TableShims
   private final SchemaProvider schemaProvider;
   private final Optional<CatalogTable> catalogTable;
   private final boolean isCDCRead;
+  // True when this table is pinned to a time travel version.
+  private final boolean isTimeTravel;
 
   /**
    * Creates a DeltaV2Table from a filesystem path without a catalog table.
@@ -247,9 +256,17 @@ public class DeltaV2Table extends DeltaV2TableShims
     } catch (io.delta.kernel.exceptions.TableNotFoundException e) {
       // Rethrow as the Delta-module wrapper so catalog/interop layer never names a Kernel type.
       throw new TableNotFoundException(tablePath);
+    } catch (io.delta.kernel.exceptions.KernelException e) {
+      // Missing earliest commit file surfaces as a base KernelException, so match on its message.
+      String reason = e.getMessage();
+      if (reason != null && reason.contains("Missing delta file")) {
+        throw new NoRecreatableHistoryException(tablePath);
+      }
+      throw e;
     }
 
     this.isCDCRead = CDCReader.isCDCRead(new CaseInsensitiveStringMap(this.options));
+    this.isTimeTravel = timeTravelVersion.isPresent();
 
     Optional<PersistedMetadata> persistedMetadata =
         MetadataEvolutionHandler.getPersistedMetadataForMicroBatchStream(
@@ -426,7 +443,9 @@ public class DeltaV2Table extends DeltaV2TableShims
 
   @Override
   public Set<TableCapability> capabilities() {
-    return CAPABILITIES;
+    // A time travel pin cannot be written to. Dropping the write capabilities makes writes fall
+    // back to the v1 path.
+    return isTimeTravel ? READ_ONLY_CAPABILITIES : CAPABILITIES;
   }
 
   /**

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/exception/NoRecreatableHistoryException.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/exception/NoRecreatableHistoryException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.exception;
+
+/** Exception thrown when the Delta log has no recreatable history at the requested path. */
+public class NoRecreatableHistoryException extends RuntimeException {
+
+  private final String tablePath;
+
+  public NoRecreatableHistoryException(String tablePath) {
+    super(String.format("No recreatable commits found at path: %s.", tablePath));
+    this.tablePath = tablePath;
+  }
+
+  public String getTablePath() {
+    return tablePath;
+  }
+}

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/catalog/DeltaV2TableTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/catalog/DeltaV2TableTest.java
@@ -17,6 +17,7 @@ package io.delta.spark.internal.v2.catalog;
 
 import static org.apache.spark.sql.connector.catalog.TableCapability.BATCH_READ;
 import static org.apache.spark.sql.connector.catalog.TableCapability.BATCH_WRITE;
+import static org.apache.spark.sql.connector.catalog.TableCapability.STREAMING_WRITE;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -942,6 +943,27 @@ public class DeltaV2TableTest extends DeltaV2TestBase {
     // The original table is unaffected.
     assertEquals(2, latest.schema().fields().length);
     assertNotEquals(latest, pinned);
+    assertEquals("1", latest.version(), "latest table should resolve to v1");
+    assertEquals("0", pinned.version(), "pinned table should report v0");
+  }
+
+  /** A time travel pinned table is read-only (it drops its write capabilities). */
+  @Test
+  public void testTimeTravelPinnedTableIsReadOnly(@TempDir File tempDir) {
+    String path = tempDir.getAbsolutePath();
+    spark.sql(
+        String.format("CREATE TABLE test_pin_readonly (id INT) USING delta LOCATION '%s'", path));
+    spark.sql("INSERT INTO test_pin_readonly VALUES (1)");
+
+    Identifier identifier = Identifier.of(new String[] {"default"}, "test_pin_readonly");
+    DeltaV2Table latest = new DeltaV2Table(identifier, path);
+    assertTrue(latest.capabilities().contains(BATCH_WRITE), "latest table is writable");
+    assertTrue(latest.capabilities().contains(STREAMING_WRITE), "latest table is writable");
+
+    DeltaV2Table pinned = latest.withVersion(0L);
+    assertTrue(pinned.capabilities().contains(BATCH_READ), "pinned table stays readable");
+    assertFalse(pinned.capabilities().contains(BATCH_WRITE), "pinned table drops batch write");
+    assertFalse(pinned.capabilities().contains(STREAMING_WRITE), "pinned table drops stream write");
   }
 
   /** withVersion fails when the requested version is out of range. */
@@ -993,6 +1015,7 @@ public class DeltaV2TableTest extends DeltaV2TestBase {
     // The original table is unaffected.
     assertEquals(2, latest.schema().fields().length);
     assertNotEquals(latest, pinned);
+    assertEquals("0", pinned.version(), "pinned table should report v0");
   }
 
   /** withTimestamp fails when the requested timestamp is out of range. */


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Adds and fixes DSv2 time travel tests:

- New `DeltaHistoryManagerV2Suite` cases for catalog and path-based SQL `VERSION AS OF` / `TIMESTAMP AS OF` queries.
- When the earliest required commit is missing, the connector now throws `noRecreatableHistoryFound` (new `NoRecreatableHistoryException`).

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

Unit tests in `DeltaHistoryManagerV2Suite` and `DeltaTimeTravelV2Suite`.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No