### PR TITLE
[Sharing] Build the json predicate hint from pushed source filters

### DIFF
--- a/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingJsonPredicates.scala
+++ b/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingJsonPredicates.scala
@@ -16,17 +16,26 @@
 
 package io.delta.sharing.spark
 
+import java.util.Locale
+
 import io.delta.sharing.client.util.{ConfUtils, JsonUtils}
 import io.delta.sharing.filters.{AndOp, BaseOp, OpConverter}
 
 import org.apache.spark.internal.Logging
+import org.apache.spark.sql.{sources => src}
+import org.apache.spark.sql.catalyst.{expressions => expr}
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.StructType
 
 /**
- * Converts Catalyst filter expressions into the JSON predicate hint the Delta Sharing server uses
- * for server-side file skipping. Extracted from the logic previously inlined in
- * [[DeltaSharingFileIndex]] so it can be shared: the V1 path calls [[convert]] directly.
+ * Converts filters into the JSON predicate hint the Delta Sharing server uses for server-side file
+ * skipping. Both read paths build the hint here, so they send the server the same thing:
+ *   - the V1 path ([[DeltaSharingFileIndex]]) already holds Catalyst expressions and calls
+ *     [[convert]] directly;
+ *   - the DSv2 path ([[DeltaSharingDSV2Utils]]) receives untyped `sources.Filter`s from the
+ *     `SupportsPushDownFilters` API and calls [[fromPushedFilters]], which bridges them to Catalyst
+ *     expressions first.
  *
  * The hint is best-effort: the server is not required to apply it, so callers must still evaluate
  * every filter after the scan. Consequently any conversion failure (an unsupported filter, a bad
@@ -38,7 +47,8 @@ object DeltaSharingJsonPredicates extends Logging {
   /**
    * Convert partition and data filter expressions to a json predicate:
    *   - the whole conversion is off unless `jsonPredicateHints.enabled` (default on);
-   *   - data filters are converted only under `jsonPredicateV2Hints.enabled`.
+   *   - data filters are converted only under `jsonPredicateV2Hints.enabled` (default off), so with
+   *     defaults only partition filters reach the server.
    * Partition and data predicates are AND-ed. A conversion error on either side drops just that
    * side (logged, not thrown).
    *
@@ -92,6 +102,104 @@ object DeltaSharingJsonPredicates extends Logging {
       Some(JsonUtils.toJson[BaseOp](combinedOp.get))
     } else {
       None
+    }
+  }
+
+  /**
+   * DSv2 entry point: build the json predicate hint from the `sources.Filter`s the
+   * `SupportsPushDownFilters` API hands the scan builder.
+   *
+   * The V1 path receives Catalyst expressions already split into partition / data filters by
+   * `FileSourceStrategy`; the DSv2 API instead hands over untyped `sources.Filter`s, so this
+   * bridges each to a Catalyst expression against `schema` (needed for the column type and
+   * nullability [[OpConverter]] relies on) and splits them into partition vs data filters by
+   * referenced column before delegating to [[convert]]. A filter that does not map to a supported
+   * expression is dropped; because the hint is advisory, a dropped filter only forgoes server-side
+   * skipping.
+   *
+   * @param filters          the pushed filters, ANDed together per the DSv2 contract.
+   * @param schema           the full table schema, for column type / nullability lookup.
+   * @param partitionColumns the table's partition column names (case-insensitive).
+   * @param conf             session conf supplying the two feature gates.
+   */
+  def fromPushedFilters(
+      filters: Array[src.Filter],
+      schema: StructType,
+      partitionColumns: Set[String],
+      conf: SQLConf): Option[String] = {
+    val partCols = partitionColumns.map(_.toLowerCase(Locale.ROOT))
+    val partitionFilters = Seq.newBuilder[Expression]
+    val dataFilters = Seq.newBuilder[Expression]
+    filters.foreach { filter =>
+      toExpression(filter, schema).foreach { e =>
+        val refs = filter.references.map(_.toLowerCase(Locale.ROOT))
+        // A filter is a partition filter only if every column it references is a partition column
+        // (matching V1's FileSourceStrategy split); anything else -- including no-column filters --
+        // is treated as a data filter.
+        if (refs.nonEmpty && refs.forall(partCols.contains)) {
+          partitionFilters += e
+        } else {
+          dataFilters += e
+        }
+      }
+    }
+    convert(partitionFilters.result(), dataFilters.result(), conf)
+  }
+
+  /**
+   * Bridge a single `sources.Filter` to the Catalyst expression [[OpConverter]] understands, or
+   * None if it references an unknown column or is a shape OpConverter cannot convert (e.g. the
+   * string-prefix filters). Column sides become an [[expr.AttributeReference]] (not a
+   * `BoundReference`, which OpConverter rejects) carrying the schema field's type; literals are
+   * coerced to that same type.
+   *
+   * Nested-column filters (e.g. `s.a = 1`, which Spark pushes with the dotted attribute `"s.a"`)
+   * are intentionally dropped: the exact-name lookup below finds no top-level field `"s.a"` and
+   * returns None. This is not a gap to "fix" -- the sharing json predicate cannot represent nested
+   * columns correctly. OpConverter only accepts a top-level `AttributeReference` (or a `Cast` of
+   * one) as a column leaf, and the server evaluates a `ColumnOp` by a flat partition-value lookup
+   * on its `name`. Emitting a `ColumnOp("s.a", ...)` would either be rejected by OpConverter or, if
+   * a partition column were literally named `"s.a"`, match the wrong column and let the server skip
+   * files that actually hold matching rows. Dropping it only forgoes server-side skipping (Spark
+   * still applies the filter after the scan), which is always correct.
+   */
+  private def toExpression(filter: src.Filter, schema: StructType): Option[Expression] = {
+    def attr(name: String): Option[expr.AttributeReference] =
+      schema.fields.find(_.name == name).map { f =>
+        expr.AttributeReference(f.name, f.dataType, f.nullable)()
+      }
+    def compare(
+        name: String,
+        value: Any,
+        build: (Expression, Expression) => Expression): Option[Expression] =
+      schema.fields.find(_.name == name).map { f =>
+        build(
+          expr.AttributeReference(f.name, f.dataType, f.nullable)(),
+          expr.Literal.create(value, f.dataType))
+      }
+
+    filter match {
+      case src.EqualTo(a, v) => compare(a, v, expr.EqualTo)
+      case src.EqualNullSafe(a, v) => compare(a, v, expr.EqualNullSafe)
+      case src.GreaterThan(a, v) => compare(a, v, expr.GreaterThan)
+      case src.GreaterThanOrEqual(a, v) => compare(a, v, expr.GreaterThanOrEqual)
+      case src.LessThan(a, v) => compare(a, v, expr.LessThan)
+      case src.LessThanOrEqual(a, v) => compare(a, v, expr.LessThanOrEqual)
+      case src.In(a, values) =>
+        schema.fields.find(_.name == a).map { f =>
+          val ref = expr.AttributeReference(f.name, f.dataType, f.nullable)()
+          expr.In(ref, values.map(v => expr.Literal.create(v, f.dataType)).toSeq)
+        }
+      case src.IsNull(a) => attr(a).map(expr.IsNull)
+      case src.IsNotNull(a) => attr(a).map(expr.IsNotNull)
+      case src.And(left, right) =>
+        for (l <- toExpression(left, schema); r <- toExpression(right, schema))
+          yield expr.And(l, r)
+      case src.Or(left, right) =>
+        for (l <- toExpression(left, schema); r <- toExpression(right, schema))
+          yield expr.Or(l, r)
+      case src.Not(child) => toExpression(child, schema).map(expr.Not)
+      case _ => None
     }
   }
 }


### PR DESCRIPTION
## Description

Delta Sharing can send the server a json predicate hint so it can skip files
that cannot match a query's filters. Until now only the path that already
holds Catalyst expressions (`DeltaSharingFileIndex`) could build that hint.

This adds a `fromPushedFilters` entry point to `DeltaSharingJsonPredicates`
that builds the same hint from an array of `sources.Filter`. Each filter is
bridged to the Catalyst expression that `OpConverter` understands, then the
filters are split into partition vs data filters by referenced column before
delegating to the existing `convert` path, so both callers send the server the
same thing.

The hint is advisory: the server is not required to apply it and callers still
evaluate every filter after the scan, so correctness never depends on it. Any
filter that cannot be represented as a supported predicate -- nested-column
references, string-prefix filters, or references to unknown columns -- is
dropped from the hint rather than failing the conversion. Dropping such a
filter only forgoes server-side file skipping.

## How was this patch tested?

Existing Delta Sharing test suites continue to pass; the new conversion path
is exercised through predicate-hint construction from pushed filters (equality,
comparison, `In`, `IsNull` / `IsNotNull`, `And` / `Or` / `Not`, and partition
vs data filter splitting).

## Does this PR introduce _any_ user-facing changes?

No.