### PR TITLE
Add a full-vs-incremental rewrite policy for adaptive metadata checkpoints

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/CommittedTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/CommittedTransaction.scala
@@ -19,9 +19,35 @@ package org.apache.spark.sql.delta
 import scala.collection.mutable
 
 import org.apache.spark.sql.delta.actions.{Action, AddFile, CommitInfo}
+import org.apache.spark.sql.delta.amt.AMTTriggerMode
 import org.apache.spark.sql.delta.hooks.PostCommitHook
 
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
+
+/**
+ * Describes the log-maintenance work a committed transaction has decided is needed after it
+ * commits. Populated during the commit and carried on [[CommittedTransaction]] for the
+ * post-commit hooks to act on.
+ *
+ * For a non-AMT table this is derived from the checkpoint/minor-compaction decision
+ * (`CheckpointTrigger`). For an AMT table it is set by `AMTWriterManager`, which also picks the
+ * trigger mode driving the follow-up manifest commit.
+ *
+ * @param shouldCheckpoint  whether a checkpoint should be written after the commit. For an AMT
+ *                          table this means a follow-up `OPTIMIZE CHECKPOINT` commit rewrites the
+ *                          manifest tree; for a non-AMT table it means a standalone V2 checkpoint.
+ * @param amtTriggerModeOpt for an AMT checkpoint, the [[AMTTriggerMode]] that scheduled it (it
+ *                          carries whether the rewrite is incremental and the name recorded in the
+ *                          AMT write metrics). `None` when `shouldCheckpoint` is false or the table
+ *                          is not AMT.
+ */
+case class MaintenanceOperation(
+    shouldCheckpoint: Boolean = false,
+    amtTriggerModeOpt: Option[AMTTriggerMode] = None) {
+  // A trigger mode only makes sense when a checkpoint is scheduled.
+  require(amtTriggerModeOpt.isEmpty || shouldCheckpoint,
+    "amtTriggerModeOpt must be empty when shouldCheckpoint is false.")
+}
 
 /**
  * Represents a successfully committed transaction.
@@ -44,7 +70,8 @@ import org.apache.spark.sql.catalyst.catalog.CatalogTable
  *                              commits were written while the snapshot was computed.
  * @param postCommitHooks       the list of post-commit hooks to run after the commit.
  * @param txnExecutionTimeMs    the time taken to execute the transaction.
- * @param needsCheckpoint       whether a checkpoint is needed after the commit.
+ * @param maintenanceOperation  the log-maintenance work (checkpoint etc.) this
+ *                              commit decided is needed, for the post-commit hooks to act on.
  * @param partitionsAddedToOpt  the partitions that this txn added new files to.
  * @param isBlindAppend         whether this transaction was a blind append.
  */
@@ -58,7 +85,7 @@ case class CommittedTransaction(
     postCommitSnapshot: Snapshot,
     postCommitHooks: Seq[PostCommitHook],
     txnExecutionTimeMs: Long,
-    needsCheckpoint: Boolean,
+    maintenanceOperation: MaintenanceOperation,
     partitionsAddedToOpt: Option[mutable.HashSet[Map[String, String]]],
     isBlindAppend: Boolean
 )

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
@@ -880,9 +880,13 @@ object DeltaOperations {
     override def canChangePartitionColumns: Boolean = false
   }
 
-  /** Recorded for manifest commits made just for AMT maintenance. */
-  case class OptimizeCheckpoint() extends Operation("OPTIMIZE CHECKPOINT") {
-    override val parameters: Map[String, Any] = Map.empty
+  /**
+   * Recorded for manifest commits made just for AMT maintenance.
+   */
+  case class OptimizeCheckpoint(incremental: Boolean, triggerName: String)
+    extends Operation("OPTIMIZE CHECKPOINT") {
+    override val parameters: Map[String, Any] =
+      Map("incremental" -> incremental, "triggerName" -> triggerName)
 
     // This operation only rewrites the manifest tree; it commits no new AddFile actions.
     override def checkAddFileWithDeletionVectorStatsAreNotTightBounds: Boolean = false

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -399,8 +399,8 @@ trait OptimisticTransactionImpl extends TransactionHelper
   protected var commitInfo: CommitInfo = _
   def getCommitInfo: CommitInfo = commitInfo
 
-  /** Whether the txn should trigger a checkpoint after the commit */
-  private[delta] var needsCheckpoint = false
+  /** The log-maintenance work this txn decided after committing. */
+  private[delta] var maintenanceOperation: MaintenanceOperation = MaintenanceOperation()
 
   // Whether this transaction is creating a new table.
   private var isCreatingNewTable: Boolean = false
@@ -2867,7 +2867,19 @@ trait OptimisticTransactionImpl extends TransactionHelper
       catalogTableForPostCommitSnapshot,
       amtCheckpointOpt = amtWriteResultOpt.map(_.checkpoint))
     val postCommitReconstructionTime = System.nanoTime()
-    needsCheckpoint = isCheckpointNeeded(attemptVersion, postCommitSnapshot)
+    maintenanceOperation = if (
+        !postCommitSnapshot.protocol.isFeatureSupported(AdaptiveMetadataTableFeature)) {
+      MaintenanceOperation(
+        shouldCheckpoint = isCheckpointNeeded(attemptVersion, postCommitSnapshot))
+    } else if (amtWriteResultOpt.isEmpty) {
+      // The AMT writer did not write inline, so schedule a follow-up OPTIMIZE CHECKPOINT commit
+      // (issued by the post-commit checkpoint hook)
+      // if needed.
+      amtWriterManager.planMaintenance(attemptVersion, postCommitSnapshot)
+    } else {
+      // The AMT was written inline with this commit; no follow-up maintenance is needed.
+      MaintenanceOperation()
+    }
     val commitStatsComputer = new CommitStatsComputer()
     // Add to commit stats and consume the returned iterator.
     commitStatsComputer.addToCommitStats(actions.toIterator).foreach(_ => ())
@@ -2884,7 +2896,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
       stateReconstructionDurationMs =
         NANOSECONDS.toMillis(postCommitReconstructionTime - commitEndNano),
       postCommitSnapshot = postCommitSnapshot,
-      computedNeedsCheckpoint = needsCheckpoint,
+      computedNeedsCheckpoint = maintenanceOperation.shouldCheckpoint,
       isolationLevel = isolationLevel,
       // We don't use postCommitSnapshot.fileSizeHistogram here
       // because it can trigger full state reconstruction.
@@ -3217,7 +3229,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
       postCommitSnapshot = postCommitSnapshot,
       postCommitHooks = postCommitHooks.toSeq,
       txnExecutionTimeMs = txnExecutionTimeMs.get,
-      needsCheckpoint = needsCheckpoint,
+      maintenanceOperation = maintenanceOperation,
       partitionsAddedToOpt = partitionsAddedToOpt,
       isBlindAppend = isBlindAppend
     ))

--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -1575,10 +1575,52 @@ sealed trait CheckpointOnlyAction extends Action
  *
  * @param path        root manifest path, relative to the table root.
  * @param sizeInBytes size of the root manifest file in bytes.
+ * @param tags        additional metadata about the AMT. See [[ContentRoot.Tags]] for known keys.
  */
 case class ContentRoot(
     path: String,
-    sizeInBytes: Long)
+    sizeInBytes: Long,
+    tags: Map[String, String] = null) {
+
+  private def tag(key: ContentRoot.Tags.KeyType): Option[String] =
+    Option(tags).flatMap(_.get(key.name))
+
+  /** Whether this manifest tree was built incrementally, if recorded. */
+  def isIncremental: Option[Boolean] = tag(ContentRoot.Tags.IS_INCREMENTAL).map(_.toBoolean)
+
+  /** The version of the most recent full (non-incremental) manifest rewrite, if recorded. */
+  def lastManifestCommitWithFullRewrite: Option[Long] =
+    tag(ContentRoot.Tags.LAST_MANIFEST_COMMIT_WITH_FULL_REWRITE).map(_.toLong)
+}
+
+object ContentRoot {
+
+  def apply(
+      path: String,
+      sizeInBytes: Long,
+      isIncremental: Boolean,
+      lastManifestCommitWithFullRewrite: Long): ContentRoot = {
+    ContentRoot(
+      path = path,
+      sizeInBytes = sizeInBytes,
+      tags = Map(
+        Tags.IS_INCREMENTAL.name -> isIncremental.toString,
+        Tags.LAST_MANIFEST_COMMIT_WITH_FULL_REWRITE.name ->
+          lastManifestCommitWithFullRewrite.toString
+      )
+    )
+  }
+
+  object Tags {
+    sealed abstract class KeyType(val name: String)
+
+    /** Whether the tree was built incrementally (`"true"`/`"false"`). */
+    object IS_INCREMENTAL extends KeyType("isIncremental")
+    /** The version of the most recent full (non-incremental) manifest rewrite. */
+    object LAST_MANIFEST_COMMIT_WITH_FULL_REWRITE
+      extends KeyType("lastManifestCommitWithFullRewrite")
+  }
+}
 
 /**
  * Closed set of values for [[SidecarFile.sidecarType]] under the `adaptiveMetadata-preview`

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriteHelper.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriteHelper.scala
@@ -41,21 +41,41 @@ object AMTWriteHelper {
       actionsToCommit: Seq[Action],
       postCommitProtocol: Protocol,
       postCommitMetadata: Metadata,
-      trigger: AmtTrigger): (AMTWriteResult, SingleAMTWriteMetrics) = {
+      trigger: String,
+      incremental: Boolean): (AMTWriteResult, SingleAMTWriteMetrics) = {
     val deltaLog = readSnapshot.deltaLog
     val startNanos = System.nanoTime()
     val postCommitState = computePostCommitState(readSnapshot, actionsToCommit)
     val hadoopConf = deltaLog.newDeltaHadoopConf()
     val entriesPerLeaf = spark.sessionState.conf.getConf(DeltaSQLConf.AMT_ENTRIES_PER_LEAF)
-    val (contentRoot, leaves) = writeManifestTree(
+    val (contentRootBase, leaves) = writeManifestTree(
       spark = spark,
       hadoopConf = hadoopConf,
       tableRoot = deltaLog.dataPath,
       useRename = deltaLog.store.isPartialWriteVisible(deltaLog.logPath, hadoopConf),
       liveAddFiles = postCommitState.allFiles,
       entriesPerLeaf = entriesPerLeaf)
+    val contentStateVersion =
+      if (actionsToCommit.isEmpty) readSnapshot.version else commitVersion
+    // Record how the tree was produced so a reader/maintenance job can tell incremental trees apart
+    // from full re-materializations without inspecting the leaves. A full rewrite resets the
+    // "last full rewrite" marker to this version; an incremental rewrite carries forward the
+    // previous tree's marker.
+    val lastFullRewriteVersion =
+      if (incremental) {
+        previousAMTContentRoot(readSnapshot)
+          .flatMap(_.lastManifestCommitWithFullRewrite)
+          .getOrElse(contentStateVersion)
+      } else {
+        contentStateVersion
+      }
+    val contentRoot = ContentRoot(
+      path = contentRootBase.path,
+      sizeInBytes = contentRootBase.sizeInBytes,
+      isIncremental = incremental,
+      lastManifestCommitWithFullRewrite = lastFullRewriteVersion)
     val checkpoint = Checkpoint(
-      version = commitVersion,
+      version = contentStateVersion,
       contentRoot = contentRoot,
       protocol = postCommitProtocol,
       metaData = postCommitMetadata,
@@ -63,15 +83,23 @@ object AMTWriteHelper {
       txns = postCommitState.getTransactions.toSeq,
       sidecars = Seq.empty)
     val result = AMTWriteResult(
-      contentRootVersion = commitVersion,
+      contentRootVersion = contentStateVersion,
       checkpoint = checkpoint,
       leaves = leaves,
       includeActionsInCommitJson = true)
     val singleMetric = SingleAMTWriteMetrics(
-      trigger = trigger.toString,
+      trigger = trigger,
       materializeDurationMs = NANOSECONDS.toMillis(System.nanoTime() - startNanos))
     (result, singleMetric)
   }
+
+  // The ContentRoot of the AMT tree `snapshot` is already backed by, if any. Used to carry forward
+  // the "last full rewrite" marker across an incremental rewrite and to decide the next trigger.
+  def previousAMTContentRoot(snapshot: Snapshot): Option[ContentRoot] =
+    snapshot.checkpointProvider match {
+      case amt: AMTCheckpointProvider => Some(amt.checkpointAction.contentRoot)
+      case _ => None
+    }
 
   // Post-commit table state = the read snapshot's state with this commit's actions applied,
   // computed via InMemoryLogReplay (the same machinery snapshot state reconstruction uses).

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriterManager.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriterManager.scala
@@ -16,21 +16,40 @@
 
 package org.apache.spark.sql.delta.amt
 
-import org.apache.spark.sql.delta.{AdaptiveMetadataTableFeature, CurrentTransactionInfo, DeltaErrors, DeltaLog, DeltaOperations, LogSegment, Snapshot}
-import org.apache.spark.sql.delta.actions.{Action, Checkpoint, Metadata, Protocol}
+import org.apache.spark.sql.delta.{AdaptiveMetadataTableFeature, CurrentTransactionInfo, DeltaErrors, DeltaLog, DeltaOperations, LogSegment, MaintenanceOperation, Snapshot}
+import org.apache.spark.sql.delta.actions.{Action, Checkpoint}
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
 
 import org.apache.spark.sql.SparkSession
 
-/** What made an AMT write happen. */
-sealed abstract class AmtTrigger(val name: String) {
+/**
+ * Describes a trigger for AMT.
+ *
+ * @param name          stable string recorded in metrics.
+ * @param isIncremental whether the manifest tree is rebuilt incrementally (true) or fully
+ *                      re-materialized from the live file set (false).
+ */
+sealed abstract class AMTTriggerMode(
+    val name: String,
+    val isIncremental: Boolean) {
   override def toString: String = name
 }
 
-object AmtTrigger {
-  /** An OPTIMIZE checkpoint forced a full manifest-tree rewrite. */
-  case object OptimizeCheckpoint extends AmtTrigger("OPTIMIZE_CHECKPOINT")
-  /** Commits since the last AMT reached the table's checkpoint interval. */
-  case object CheckpointInterval extends AmtTrigger("CHECKPOINT_INTERVAL")
+object AMTTriggerMode {
+  /** Commits since the last AMT reached the checkpoint interval: incremental follow-up rewrite. */
+  case object CheckpointIntervalIncremental extends AMTTriggerMode(
+      name = "CHECKPOINT_INTERVAL_INCREMENTAL",
+      isIncremental = true)
+
+  /** Commits since the last full AMT reached the full checkpoint interval: full rewrite. */
+  case object CheckpointIntervalFull extends AMTTriggerMode(
+    name = "CHECKPOINT_INTERVAL_FULL",
+    isIncremental = false)
+
+  /** A large business commit writes its AMT inline: incremental inline rewrite. */
+  case object InlineWithLargeCommitIncremental extends AMTTriggerMode(
+    name = "INLINE_WITH_LARGE_COMMIT_INCREMENTAL",
+    isIncremental = true)
 }
 
 /** Metrics describing an AMT (Adaptive Metadata Tree) write, one entry per attempt. */
@@ -68,7 +87,6 @@ class AMTWriterManager(
   private def deltaLog: DeltaLog = readSnapshot.deltaLog
 
   val metrics = AMTWriteMetrics()
-
   private var lastAMTWriteResultOpt: Option[AMTWriteResult] = None
 
   /**
@@ -88,29 +106,106 @@ class AMTWriterManager(
       throw DeltaErrors.concurrentWriteException(conflictingCommit = None)
     }
     val actionsToCommit = currentTransactionInfo.actions
-    val resultOpt = getAMTTriggerMode(
-      commitVersion, actionsToCommit, preCommitLogSegment, currentTransactionInfo.metadata)
-      .map {
-        case AmtTrigger.OptimizeCheckpoint =>
-          // An OPTIMIZE checkpoint only rewrites the manifest tree; it commits no user actions.
-          assert(actionsToCommit.isEmpty,
-            s"OPTIMIZE checkpoint commit must carry no actions, got ${actionsToCommit.size}.")
-          throw new UnsupportedOperationException(
-            "Full AMT rewrite for OPTIMIZE checkpoints is not yet supported.")
-        case trigger =>
-          val (result, singleMetric) = AMTWriteHelper.writeFullMaterialization(
-            spark = spark,
-            readSnapshot = readSnapshot,
-            commitVersion = commitVersion,
-            actionsToCommit = actionsToCommit,
-            postCommitProtocol = currentTransactionInfo.protocol,
-            postCommitMetadata = currentTransactionInfo.metadata,
-            trigger = trigger)
-          metrics.attempts :+= singleMetric
-          result
-      }
+    val resultOpt = initialOperation match {
+      case optimize: DeltaOperations.OptimizeCheckpoint =>
+        assert(actionsToCommit.isEmpty,
+          s"OPTIMIZE checkpoint commit must carry no actions, got ${actionsToCommit.size}.")
+        Some(materialize(
+          commitVersion, currentTransactionInfo,
+          incremental = optimize.incremental, trigger = optimize.triggerName))
+      case _ if shouldDoInlineIncrementalCheckpoint(actionsToCommit) =>
+        // A large business commit rebuilds its manifest tree inline (incrementally).
+        val mode = AMTTriggerMode.InlineWithLargeCommitIncremental
+        Some(materialize(
+          commitVersion, currentTransactionInfo,
+          incremental = mode.isIncremental, trigger = mode.name))
+      case _ =>
+        None
+    }
     lastAMTWriteResultOpt = resultOpt
     resultOpt
+  }
+
+  /**
+   * Whether this business commit is large enough (by action count) to write its
+   * changed actions as part of new AMT.
+   */
+  private def shouldDoInlineIncrementalCheckpoint(actionsToCommit: Seq[Action]): Boolean =
+    actionsToCommit.size.toLong >= largeCommitActionsCountThresholdForInlineManifestCommit
+
+  // Materializes the manifest tree for this commit and records its metrics.
+  private def materialize(
+      commitVersion: Long,
+      currentTransactionInfo: CurrentTransactionInfo,
+      incremental: Boolean,
+      trigger: String): AMTWriteResult = {
+    val (result, singleMetric) = AMTWriteHelper.writeFullMaterialization(
+      spark = spark,
+      readSnapshot = readSnapshot,
+      commitVersion = commitVersion,
+      actionsToCommit = currentTransactionInfo.actions,
+      postCommitProtocol = currentTransactionInfo.protocol,
+      postCommitMetadata = currentTransactionInfo.metadata,
+      trigger = trigger,
+      incremental = incremental)
+    metrics.attempts :+= singleMetric
+    result
+  }
+
+  /**
+   * The maintenance work a committed transaction should schedule for after it commits.
+   * The maintenance work will be done by CheckpointHook
+   */
+  def planMaintenance(
+      commitVersion: Long,
+      postCommitSnapshot: Snapshot): MaintenanceOperation = {
+    // if the commit itself was to do a checkpoint, don't schedule any maintenance as part
+    // of its post-commit hook.
+    if (!amtEnabled(commitVersion)
+        || initialOperation.isInstanceOf[DeltaOperations.OptimizeCheckpoint]) {
+      return MaintenanceOperation()
+    }
+
+
+    val amtTriggerModeOpt = followUpTriggerMode(commitVersion, postCommitSnapshot)
+    MaintenanceOperation(
+      shouldCheckpoint = amtTriggerModeOpt.isDefined,
+      amtTriggerModeOpt = amtTriggerModeOpt)
+  }
+
+  /** [[AMTTriggerMode]] for a followup AMT Checkpoint commit if any. */
+  private def followUpTriggerMode(
+      commitVersion: Long,
+      postCommitSnapshot: Snapshot): Option[AMTTriggerMode] = {
+    val checkpointInterval = deltaLog.checkpointInterval(postCommitSnapshot.metadata)
+    // -- case-1 --
+    // Assume v0 has an AMT. This is to make sure future AMTs land on even boundaries
+    // e.g. 10/20/30 instead of 9/19/29 (as classic checkpoints do).
+    val lastCheckpointVersion = postCommitSnapshot.logSegment.checkpointProvider.version
+    val lastAMTVersion = math.max(0L, lastCheckpointVersion)
+    val versionDiff = commitVersion - lastAMTVersion
+    // Emit only on the exact interval boundary (versionDiff a positive multiple of the interval),
+    // not >= the interval. This is what CheckpointTrigger does: if v10's follow-up AMT has not
+    // landed yet, a racing v11 still sees lastAMTVersion == 0, but 11 % 10 != 0 so it does not
+    // re-trigger; only v10, v20, ... do.
+    if (versionDiff > 0 && versionDiff % checkpointInterval == 0) {
+      // If checkpointInterval is 200 and fullRewriteCheckpointIntervalMultiplier is 5
+      // Then if 10220 is full tree, then 10420, 10620, 10820, 11020 will be incremental
+      // and then 11220 will be full tree again.
+      val fullRewriteSpan = checkpointInterval.toLong * fullRewriteCheckpointIntervalMultiplier
+      val needsFullRewrite = AMTWriteHelper.previousAMTContentRoot(postCommitSnapshot)
+        .flatMap(_.lastManifestCommitWithFullRewrite)
+        .forall(lastFull => commitVersion - lastFull >= fullRewriteSpan)
+      return Some(
+        if (needsFullRewrite) {
+          AMTTriggerMode.CheckpointIntervalFull
+        } else {
+          AMTTriggerMode.CheckpointIntervalIncremental
+        })
+    }
+
+
+    None
   }
 
   /**
@@ -122,31 +217,11 @@ class AMTWriterManager(
     readSnapshot.protocol.isFeatureSupported(AdaptiveMetadataTableFeature)
   }
 
-  /**
-   * The trigger reason for why an AMT write is needed for this commit, or `None` if AMT write is
-   * not needed.
-   */
-  private def getAMTTriggerMode(
-      commitVersion: Long,
-      actionsToCommit: Seq[Action],
-      preCommitLogSegment: LogSegment,
-      postCommitMetadata: Metadata): Option[AmtTrigger] = {
-    if (!amtEnabled(commitVersion)) return None
-    // -- case-1 --
-    if (initialOperation.isInstanceOf[DeltaOperations.OptimizeCheckpoint]) {
-      return Some(AmtTrigger.OptimizeCheckpoint)
-    }
+  private def largeCommitActionsCountThresholdForInlineManifestCommit: Long =
+    spark.sessionState.conf.getConf(
+      DeltaSQLConf.AMT_LARGE_COMMIT_ACTIONS_COUNT_THRESHOLD_FOR_INLINE_MANIFEST_COMMIT)
 
-    // -- case-2 --
-    // Assume 0 as version -- this is to make sure future AMTs are at even boundaries e.g.
-    // 10/20/30 instead of 9/19/29. (similar logic in checkpoints as well)
-    val lastAMTVersion = math.max(0L, preCommitLogSegment.checkpointProvider.version)
-    val commitsSinceLastAMT = commitVersion - lastAMTVersion
-    if (commitsSinceLastAMT >= deltaLog.checkpointInterval(postCommitMetadata)) {
-      return Some(AmtTrigger.CheckpointInterval)
-    }
-
-
-    None
-  }
+  private def fullRewriteCheckpointIntervalMultiplier: Int =
+    spark.sessionState.conf.getConf(
+      DeltaSQLConf.AMT_FULL_REWRITE_CHECKPOINT_INTERVAL_MULTIPLIER)
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/hooks/CheckpointHook.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/hooks/CheckpointHook.scala
@@ -16,7 +16,7 @@
 
 package org.apache.spark.sql.delta.hooks
 
-import org.apache.spark.sql.delta.{AdaptiveMetadataTableFeature, CommittedTransaction}
+import org.apache.spark.sql.delta.{AdaptiveMetadataTableFeature, CommittedTransaction, DeltaOperations}
 
 import org.apache.spark.sql.SparkSession
 
@@ -25,11 +25,19 @@ object CheckpointHook extends PostCommitHook {
   override val name: String = "Post commit checkpoint trigger"
 
   override def run(spark: SparkSession, txn: CommittedTransaction): Unit = {
-    if (!txn.needsCheckpoint) return
+    if (!txn.maintenanceOperation.shouldCheckpoint) return
 
-    // AMT tables carry their checkpoint as an inline action in the commit json file.
-    // So exit checkpoint hook early.
-    if (txn.postCommitSnapshot.protocol.isFeatureSupported(AdaptiveMetadataTableFeature)) return
+    // AMT tables checkpoint by rewriting their manifest tree via a follow-up OPTIMIZE CHECKPOINT
+    // commit rather than a standalone checkpoint file.
+    if (txn.postCommitSnapshot.protocol.isFeatureSupported(AdaptiveMetadataTableFeature)) {
+      val triggerMode = txn.maintenanceOperation.amtTriggerModeOpt.getOrElse {
+        throw new IllegalStateException(
+          "An AMT table scheduled a checkpoint but carries no AMTTriggerMode.")
+      }
+      writeAMTCheckpoint(
+        txn, incremental = triggerMode.isIncremental, triggerName = triggerMode.name)
+      return
+    }
 
     // Since the postCommitSnapshot isn't guaranteed to match committedVersion, we have to
     // explicitly checkpoint the snapshot at the committedVersion.
@@ -41,5 +49,15 @@ object CheckpointHook extends PostCommitHook {
       catalogTableOpt = txn.catalogTable,
       enforceTimeTravelWithinDeletedFileRetention = false)
     txn.deltaLog.checkpoint(snapshotToCheckpoint, txn.catalogTable)
+  }
+
+  /**
+   * Attempts a Manifest Commit on the table.
+   */
+  private def writeAMTCheckpoint(
+      txn: CommittedTransaction, incremental: Boolean, triggerName: String): Unit = {
+    val checkpointTxn =
+      txn.deltaLog.startTransaction(txn.catalogTable, Some(txn.postCommitSnapshot))
+    checkpointTxn.commit(Seq.empty, DeltaOperations.OptimizeCheckpoint(incremental, triggerName))
   }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -581,6 +581,27 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .checkValue(_ > 0, "entriesPerLeaf must be positive.")
       .createWithDefault(50000)
 
+  val AMT_LARGE_COMMIT_ACTIONS_COUNT_THRESHOLD_FOR_INLINE_MANIFEST_COMMIT =
+    buildConf("amt.largeCommitActionsCountThresholdForInlineManifestCommit")
+      .internal()
+      .doc("When a writer commits at least this many actions, its AMT manifest " +
+        "tree is written inline within that commit (the Checkpoint action rides in the same " +
+        "commit JSON) rather than deferred to a follow-up OPTIMIZE CHECKPOINT commit. Defaults " +
+        "to Long.MaxValue, i.e. inline manifest commits are effectively disabled.")
+      .longConf
+      .createWithDefault(Long.MaxValue)
+
+  val AMT_FULL_REWRITE_CHECKPOINT_INTERVAL_MULTIPLIER =
+    buildConf("amt.fullRewriteCheckpointIntervalMultiplier")
+      .internal()
+      .doc("AMT manifest trees are emitted every checkpoint interval. Every Nth of those (N = " +
+        "this multiplier) is a full re-materialization of the live file set; the rest are " +
+        "incremental. A full rewrite happens when the commit version is a multiple of " +
+        "multiplier * checkpoint interval.")
+      .intConf
+      .checkValue(_ > 0, "fullRewriteCheckpointIntervalMultiplier must be positive.")
+      .createWithDefault(5)
+
   val UNSUPPORTED_TESTING_FEATURES_ENABLED =
     buildConf("tableFeatures.dev.unsupportedTableFeatures.enabled")
       .internal()

--- a/spark/src/test/scala/org/apache/spark/sql/delta/CommitInfoSerializerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CommitInfoSerializerSuite.scala
@@ -172,7 +172,8 @@ class CommitInfoSerializerSuite extends QueryTest with SharedSparkSession {
       auto = true,
       clusterBy = Some(Seq("col3")),
       isFull = false)),
-    "OptimizeCheckpoint" -> (() => DeltaOperations.OptimizeCheckpoint()),
+    "OptimizeCheckpoint" -> (() =>
+      DeltaOperations.OptimizeCheckpoint(incremental = false, triggerName = "CHECKPOINT_INTERVAL")),
     "Clone" -> (() => DeltaOperations.Clone(
       source = "s3://bucket/path/to/table",
       sourceVersion = 10L)),

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointPolicySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointPolicySuite.scala
@@ -1,0 +1,240 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.amt
+
+import com.databricks.spark.util.{Log4jUsageLogger, MetricDefinitions}
+import org.apache.spark.sql.delta.{AdaptiveMetadataTableFeature, CommitStats, DeltaLog}
+import org.apache.spark.sql.delta.actions.Checkpoint
+import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils._
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.util.JsonUtils
+
+/**
+ * Emission-policy scenarios for AMT (`adaptiveMetadata-preview`): the checkpoint-interval trigger
+ * (deferred to a follow-up OPTIMIZE CHECKPOINT commit), the full-vs-incremental rewrite cadence.
+ */
+class AMTCheckpointPolicySuite extends AMTCheckpointTestBase {
+
+  /** The Checkpoint action emitted at exactly `version`, or fails. */
+  private def checkpointAt(deltaLog: DeltaLog, version: Long): Checkpoint =
+    checkpointsAt(deltaLog, version) match {
+      case Seq(cp) => cp
+      case other => fail(s"Expected exactly one Checkpoint at v$version, got: $other")
+    }
+
+  /** Every AMT [[Checkpoint]] emitted in `[0, latestVersion]`, in commit order. */
+  private def allCheckpoints(deltaLog: DeltaLog): Seq[Checkpoint] =
+    allCheckpointsWithCommitVersion(deltaLog).map(_._2)
+
+  /**
+   * Every AMT [[Checkpoint]] emitted in `[0, latestVersion]`, paired with the version of the commit
+   * that carries it (the manifest commit version), in commit order.
+   */
+  private def allCheckpointsWithCommitVersion(deltaLog: DeltaLog): Seq[(Long, Checkpoint)] = {
+    val latest = deltaLog.update().version
+    (0L to latest).flatMap(v => checkpointsAt(deltaLog, v).map(cp => (v, cp)))
+  }
+
+  /** The trigger name recorded in the AMT write metrics of the commit `f` produces at `version`. */
+  private def amtTriggerNameAt(f: => Unit, version: Long): String = {
+    Log4jUsageLogger.track(f)
+      .filter(e => e.metric == MetricDefinitions.EVENT_TAHOE.name &&
+        e.tags.get("opType").contains("delta.commit.stats"))
+      .map(e => JsonUtils.fromJson[CommitStats](e.blob))
+      .find(_.commitVersion == version)
+      .flatMap(_.amtWriteMetrics)
+      .flatMap(_.attempts.headOption)
+      .map(_.trigger)
+      .getOrElse(fail(s"No AMT write metrics logged for version $version."))
+  }
+
+
+  /**
+   * One expected AMT checkpoint in a deterministic emission timeline.
+   *
+   * @param describedVersion      the table version the emitted Checkpoint describes (the
+   *                              triggering business commit)
+   * @param manifestCommitVersion the version of the commit that carries the Checkpoint action -- in
+   *                              deferred mode the follow-up OPTIMIZE CHECKPOINT commit, which
+   *                              lands at describedVersion + 1
+   * @param incremental           whether the rewrite is incremental (false = full rewrite)
+   * @param lastFullRewrite       expected `lastManifestCommitWithFullRewrite` marker on the
+   *                              checkpoint
+   */
+  private case class ExpectedCheckpoint(
+      describedVersion: Long,
+      manifestCommitVersion: Long,
+      incremental: Boolean,
+      lastFullRewrite: Long)
+
+  /**
+   * Asserts that the AMT checkpoints emitted on `deltaLog` over `[0, latest]` are exactly
+   * `expected`, in order, matching on described version, manifest commit version, incremental flag,
+   * and last-full-rewrite marker. Because every checkpoint is read back off disk, this verifies the
+   * full-vs-incremental cadence and the marker tracking across the whole timeline in one shot.
+   */
+  private def assertCheckpointTimeline(
+      deltaLog: DeltaLog, expected: Seq[ExpectedCheckpoint]): Unit = {
+    val checkpoints = allCheckpointsWithCommitVersion(deltaLog)
+    assert(checkpoints.map(_._2.version) == expected.map(_.describedVersion),
+      s"Emitted checkpoint versions ${checkpoints.map(_._2.version)} must match " +
+        s"${expected.map(_.describedVersion)}.")
+    assert(checkpoints.map(_._1) == expected.map(_.manifestCommitVersion),
+      s"Manifest commit versions ${checkpoints.map(_._1)} must match " +
+        s"${expected.map(_.manifestCommitVersion)}.")
+    checkpoints.zip(expected).foreach { case ((_, cp), exp) =>
+      assert(cp.contentRoot.isIncremental.contains(exp.incremental),
+        s"Checkpoint describing v${exp.describedVersion}: expected incremental=" +
+          s"${exp.incremental}, got ${cp.contentRoot.isIncremental}")
+      assert(cp.contentRoot.lastManifestCommitWithFullRewrite.contains(exp.lastFullRewrite),
+        s"Checkpoint describing v${exp.describedVersion}: expected lastFullRewrite=" +
+          s"${exp.lastFullRewrite}, got ${cp.contentRoot.lastManifestCommitWithFullRewrite}")
+    }
+  }
+
+  test("no AMT is emitted below the checkpoint interval") {
+    withTable("amt_below_interval") {
+      val name = "amt_below_interval"
+      createAMTTable(name, checkpointInterval = 10)
+      sql(s"INSERT INTO $name VALUES (1)") // v1: 1 % 10 != 0.
+
+      val deltaLog = deltaLogForName(name)
+      val path = tablePath(name)
+      assert(deltaLog.update().version == 1, "No follow-up commit below the interval.")
+      assert(rootFiles(path).isEmpty && leafFiles(path).isEmpty, "No manifest tree written.")
+      assert(amtProvider(deltaLog.update()).isEmpty)
+    }
+  }
+
+  test("the interval boundary emits a follow-up OPTIMIZE CHECKPOINT commit at V+1") {
+    withTable("amt_interval_followup") {
+      val name = "amt_interval_followup"
+      createAMTTable(name, checkpointInterval = 2)
+      sql(s"INSERT INTO $name VALUES (1)") // v1.
+      sql(s"INSERT INTO $name VALUES (2)") // v2: boundary -> follow-up at v3.
+
+      val deltaLog = deltaLogForName(name)
+      assert(deltaLog.update().version == 3, "The follow-up OPTIMIZE CHECKPOINT lands at v3.")
+      assert(checkpointsAt(deltaLog, 2).isEmpty, "v2 (business commit) carries no Checkpoint.")
+      // The Checkpoint rides in v3 and describes state as of v2.
+      assert(checkpointAt(deltaLog, 3).version == 2)
+      assert(amtProvider(deltaLog.update()).isDefined)
+    }
+  }
+
+  test("the first AMT is a full rewrite even off the full-rewrite boundary") {
+    withTable("amt_first_full") {
+      val name = "amt_first_full"
+      // interval 2, default multiplier 5 -> v2 is NOT a 5x boundary, but it is the first AMT.
+      createAMTTable(name, checkpointInterval = 2)
+      sql(s"INSERT INTO $name VALUES (1)")
+      val v3Trigger = amtTriggerNameAt(sql(s"INSERT INTO $name VALUES (2)"), version = 3)
+      assert(v3Trigger == AMTTriggerMode.CheckpointIntervalFull.name,
+        s"The first AMT must be a full rewrite; got $v3Trigger")
+
+      // The full rewrite records its own version as the last-full-rewrite marker.
+      val deltaLog = deltaLogForName(name)
+      assert(checkpointAt(deltaLog, 3).contentRoot.lastManifestCommitWithFullRewrite.contains(2L))
+      assert(checkpointAt(deltaLog, 3).contentRoot.isIncremental.contains(false))
+    }
+  }
+
+  test("an incremental rewrite happens off the full-rewrite boundary; a full one lands on it") {
+    withTable("amt_full_vs_incremental") {
+      val name = "amt_full_vs_incremental"
+      // interval 2, multiplier 2 -> fullRewriteSpan = 4. Timeline (deferred follow-up commits):
+      //   commit 0             CREATE TABLE
+      //   commit 1  INSERT-1
+      //   commit 2  INSERT-2   (interval boundary -> full checkpoint; first AMT)
+      //   commit 3  full checkpoint          (describes v2,  lastFull=2)
+      //   commit 4  INSERT-3   (interval boundary -> incremental checkpoint)
+      //   commit 5  incremental checkpoint   (describes v4,  lastFull=2)
+      //   commit 6  INSERT-4   (interval boundary -> full checkpoint)
+      //   commit 7  full checkpoint          (describes v6,  lastFull=6)
+      //   commit 8  INSERT-5   (interval boundary -> incremental checkpoint)
+      //   commit 9  incremental checkpoint   (describes v8,  lastFull=6)
+      //   commit 10 INSERT-6   (interval boundary -> full checkpoint)
+      //   commit 11 full checkpoint          (describes v10, lastFull=10)
+      //   commit 12 INSERT-7   (interval boundary -> incremental checkpoint)
+      //   commit 13 incremental checkpoint   (describes v12, lastFull=10)
+      //   commit 14 INSERT-8   (interval boundary -> full checkpoint)
+      //   commit 15 full checkpoint          (describes v14, lastFull=14)
+      //   commit 16 INSERT-9   (interval boundary -> incremental checkpoint)
+      //   commit 17 incremental checkpoint   (describes v16, lastFull=14)
+      createAMTTable(name, checkpointInterval = 2)
+      val deltaLog = deltaLogForName(name)
+      withSQLConf(DeltaSQLConf.AMT_FULL_REWRITE_CHECKPOINT_INTERVAL_MULTIPLIER.key -> "2") {
+        // 9 single-row INSERTs. INSERT-1 lands at v1 (below the boundary); INSERT-2..INSERT-9 each
+        // land on an interval boundary (v2, v4, ..., v16) and trigger a follow-up checkpoint.
+        (1 to 9).foreach(i => sql(s"INSERT INTO $name VALUES ($i)"))
+      }
+      // ExpectedCheckpoint(describedVersion, manifestCommitVersion, incremental, lastFullRewrite).
+      assertCheckpointTimeline(deltaLog, Seq(
+        ExpectedCheckpoint(2, 3, incremental = false, lastFullRewrite = 2),
+        ExpectedCheckpoint(4, 5, incremental = true, lastFullRewrite = 2),
+        ExpectedCheckpoint(6, 7, incremental = false, lastFullRewrite = 6),
+        ExpectedCheckpoint(8, 9, incremental = true, lastFullRewrite = 6),
+        ExpectedCheckpoint(10, 11, incremental = false, lastFullRewrite = 10),
+        ExpectedCheckpoint(12, 13, incremental = true, lastFullRewrite = 10),
+        ExpectedCheckpoint(14, 15, incremental = false, lastFullRewrite = 14),
+        ExpectedCheckpoint(16, 17, incremental = true, lastFullRewrite = 14)))
+    }
+  }
+
+  test("lastManifestCommitWithFullRewrite tracks the most recent full rewrite") {
+    withTable("amt_last_full_rewrite") {
+      val name = "amt_last_full_rewrite"
+      // interval 2, multiplier 3 -> fullRewriteSpan = 6. Timeline (deferred follow-up commits):
+      //   commit 0             CREATE TABLE
+      //   commit 1  INSERT-1
+      //   commit 2  INSERT-2   (interval boundary -> full checkpoint; first AMT)
+      //   commit 3  full checkpoint          (describes v2,  lastFull=2)
+      //   commit 4  INSERT-3   (interval boundary -> incremental checkpoint)
+      //   commit 5  incremental checkpoint   (describes v4,  lastFull=2)
+      //   commit 6  INSERT-4   (interval boundary -> incremental checkpoint)
+      //   commit 7  incremental checkpoint   (describes v6,  lastFull=2)
+      //   commit 8  INSERT-5   (interval boundary -> full checkpoint)
+      //   commit 9  full checkpoint          (describes v8,  lastFull=8)
+      //   commit 10 INSERT-6   (interval boundary -> incremental checkpoint)
+      //   commit 11 incremental checkpoint   (describes v10, lastFull=8)
+      //   commit 12 INSERT-7   (interval boundary -> incremental checkpoint)
+      //   commit 13 incremental checkpoint   (describes v12, lastFull=8)
+      //   commit 14 INSERT-8   (interval boundary -> full checkpoint)
+      //   commit 15 full checkpoint          (describes v14, lastFull=14)
+      //   commit 16 INSERT-9   (interval boundary -> incremental checkpoint)
+      //   commit 17 incremental checkpoint   (describes v16, lastFull=14)
+      createAMTTable(name, checkpointInterval = 2)
+      val deltaLog = deltaLogForName(name)
+      withSQLConf(DeltaSQLConf.AMT_FULL_REWRITE_CHECKPOINT_INTERVAL_MULTIPLIER.key -> "3") {
+        // 9 single-row INSERTs. INSERT-1 lands at v1 (below the boundary); INSERT-2..INSERT-9 each
+        // land on an interval boundary (v2, v4, ..., v16) and trigger a follow-up checkpoint.
+        (1 to 9).foreach(i => sql(s"INSERT INTO $name VALUES ($i)"))
+      }
+      // ExpectedCheckpoint(describedVersion, manifestCommitVersion, incremental, lastFullRewrite).
+      assertCheckpointTimeline(deltaLog, Seq(
+        ExpectedCheckpoint(2, 3, incremental = false, lastFullRewrite = 2),
+        ExpectedCheckpoint(4, 5, incremental = true, lastFullRewrite = 2),
+        ExpectedCheckpoint(6, 7, incremental = true, lastFullRewrite = 2),
+        ExpectedCheckpoint(8, 9, incremental = false, lastFullRewrite = 8),
+        ExpectedCheckpoint(10, 11, incremental = true, lastFullRewrite = 8),
+        ExpectedCheckpoint(12, 13, incremental = true, lastFullRewrite = 8),
+        ExpectedCheckpoint(14, 15, incremental = false, lastFullRewrite = 14),
+        ExpectedCheckpoint(16, 17, incremental = true, lastFullRewrite = 14)))
+    }
+  }
+
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointTestBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointTestBase.scala
@@ -79,6 +79,40 @@ trait AMTCheckpointTestBase
          |  'delta.checkpointInterval' = '$checkpointInterval')""".stripMargin)
   }
 
+  /**
+   * How an AMT is emitted for a triggering commit. In [[AMTWriteMode.Inline]] the manifest tree
+   * rides in the business commit itself; in [[AMTWriteMode.Deferred]] a follow-up OPTIMIZE
+   * CHECKPOINT commit (issued by the post-commit hook) lands it one version later.
+   */
+  protected sealed trait AMTWriteMode {
+    /** Number of extra commits the AMT emission adds after a triggering business commit. */
+    def followUpCommits: Int
+  }
+  protected object AMTWriteMode {
+    case object Inline extends AMTWriteMode { val followUpCommits = 0 }
+    case object Deferred extends AMTWriteMode { val followUpCommits = 1 }
+  }
+
+  /**
+   * Registers a test in both AMT write modes. The body runs once with inline writes forced (a low
+   * action-count threshold) and once with the default deferred follow-up-commit path, so behavior
+   * is covered in both. The body receives the active [[AMTWriteMode]] for any version-relative
+   * assertions.
+   */
+  protected def testInlineAndDeferred(testName: String)(body: AMTWriteMode => Unit): Unit = {
+    test(s"$testName (inline)") {
+      withSQLConf(
+          DeltaSQLConf.AMT_LARGE_COMMIT_ACTIONS_COUNT_THRESHOLD_FOR_INLINE_MANIFEST_COMMIT.key
+            -> "1") {
+        body(AMTWriteMode.Inline)
+      }
+    }
+    test(s"$testName (deferred)") {
+      // Default threshold (Long.MaxValue) keeps business commits from writing inline.
+      body(AMTWriteMode.Deferred)
+    }
+  }
+
   /** True iff `name` looks like an AMT leaf parquet file. */
   protected def isLeafFileName(name: String): Boolean =
     name.startsWith("leaf-") && name.endsWith(".parquet")

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointWriteSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointWriteSuite.scala
@@ -26,27 +26,37 @@ import org.apache.spark.sql.delta.util.JsonUtils
 
 class AMTCheckpointWriteSuite extends AMTCheckpointTestBase {
 
-  test("inline emission embeds a Checkpoint action in the same commit at the interval boundary") {
+  test("interval boundary emits a follow-up OPTIMIZE CHECKPOINT commit carrying the Checkpoint") {
     withTable("amt_inline_emit") {
       val name = "amt_inline_emit"
       createAMTTable(name, checkpointInterval = 2)
       sql(s"INSERT INTO $name VALUES (1)") // v1: not an interval boundary.
-      sql(s"INSERT INTO $name VALUES (2)") // v2: interval boundary -> emit.
+      sql(s"INSERT INTO $name VALUES (2)") // v2: interval boundary -> schedule maintenance.
 
       val deltaLog = deltaLogForName(name)
       val path = tablePath(name)
       val snapshot = deltaLog.update()
-      assert(snapshot.version == 2, "No follow-up commit: emission rides in the v2 commit itself.")
+      // The AMT is written by a follow-up OPTIMIZE CHECKPOINT commit at v3, not inline at v2.
+      assert(snapshot.version == 3, "A follow-up OPTIMIZE CHECKPOINT commit lands at v3.")
 
       // Manifest tree exists on disk: exactly one root, at least one leaf.
       assert(rootFiles(path).size == 1, "Exactly one root manifest must be written.")
       assert(leafFiles(path).nonEmpty, "At least one leaf manifest must be written.")
 
-      // The v2 commit JSON carries BOTH the user's AddFile and a single Checkpoint action.
+      // The v2 business commit carries only the user AddFile, no Checkpoint.
       val v2Actions = actionsAt(deltaLog, 2)
-      val checkpoints = v2Actions.collect { case c: Checkpoint => c }
-      assert(checkpoints.size == 1, s"Expected one Checkpoint action at v2, got: $v2Actions")
-      assert(v2Actions.exists(_.isInstanceOf[AddFile]), "User AddFile must be in the same commit.")
+      assert(v2Actions.exists(_.isInstanceOf[AddFile]), "v2 carries the user AddFile.")
+      assert(v2Actions.collect { case c: Checkpoint => c }.isEmpty,
+        s"v2 must not carry a Checkpoint action; got: $v2Actions")
+
+      // The v3 follow-up commit carries a single Checkpoint action and no user AddFile.
+      val v3Actions = actionsAt(deltaLog, 3)
+      val checkpoints = v3Actions.collect { case c: Checkpoint => c }
+      assert(checkpoints.size == 1, s"Expected one Checkpoint action at v3, got: $v3Actions")
+      assert(!v3Actions.exists(_.isInstanceOf[AddFile]), "v3 carries no user AddFile.")
+      // The Checkpoint describes state as of v2 (the version whose maintenance it fulfills).
+      assert(checkpoints.head.version == 2,
+        s"Checkpoint must describe state as of v2; got ${checkpoints.head.version}")
 
       // The Checkpoint's contentRoot points at the on-disk root file.
       val rootName = new File(checkpoints.head.contentRoot.path).getName
@@ -113,19 +123,29 @@ class AMTCheckpointWriteSuite extends AMTCheckpointTestBase {
       .getOrElse(fail(s"No commit stats logged for version $version."))
   }
 
-  test("commit stats carry AMT write metrics when an AMT is emitted") {
+  test("the follow-up OPTIMIZE CHECKPOINT commit stats carry AMT write metrics") {
     withTable("amt_commit_stats") {
       val name = "amt_commit_stats"
       createAMTTable(name, checkpointInterval = 2)
-      sql(s"INSERT INTO $name VALUES (1)") // v1: below the interval, no AMT.
+      sql(s"INSERT INTO $name VALUES (1)") // v1: below the interval, no maintenance.
 
-      // v2 hits the interval boundary and emits an AMT; capture that commit's stats.
-      val commitStats = commitStatsAt(sql(s"INSERT INTO $name VALUES (2)"), version = 2)
+      // v2 hits the interval boundary; the AMT is written by the follow-up commit at v3, so the
+      // AMT write metrics are recorded on v3's stats, not v2's.
+      val allStats = Log4jUsageLogger.track {
+        sql(s"INSERT INTO $name VALUES (2)")
+      }.filter(e => e.metric == MetricDefinitions.EVENT_TAHOE.name &&
+          e.tags.get("opType").contains("delta.commit.stats"))
+        .map(e => JsonUtils.fromJson[CommitStats](e.blob))
 
-      val metrics = commitStats.amtWriteMetrics
-        .getOrElse(fail("Commit stats should carry AMT write metrics when an AMT is emitted."))
+      val v2Stats = allStats.find(_.commitVersion == 2).getOrElse(fail("No stats for v2."))
+      assert(v2Stats.amtWriteMetrics.isEmpty, "v2 defers the AMT; its stats carry no AMT metrics.")
+
+      val v3Stats = allStats.find(_.commitVersion == 3).getOrElse(fail("No stats for v3."))
+      val metrics = v3Stats.amtWriteMetrics
+        .getOrElse(fail("The follow-up commit's stats should carry AMT write metrics."))
       assert(metrics.attempts.size == 1, s"Expected one AMT write attempt, got ${metrics.attempts}")
-      assert(metrics.attempts.head.trigger == AmtTrigger.CheckpointInterval.toString)
+      // The first AMT has no prior tree to build on, so it is always a full rewrite.
+      assert(metrics.attempts.head.trigger == AMTTriggerMode.CheckpointIntervalFull.name)
       assert(metrics.attempts.head.materializeDurationMs >= 0L)
     }
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotDiscoverySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotDiscoverySuite.scala
@@ -33,55 +33,52 @@ class AMTSnapshotDiscoverySuite extends AMTCheckpointTestBase {
   // Post commit snapshot
   ///////////////////////////
 
-  test("inline emission installs an AMTCheckpointProvider on the post-commit snapshot") {
+  testInlineAndDeferred("emission installs an AMTCheckpointProvider on the post-commit snapshot") {
+    mode =>
     withTable("amt_provider_install") {
       val name = "amt_provider_install"
       createAMTTable(name, checkpointInterval = 2)
       sql(s"INSERT INTO $name VALUES (1)")
-      sql(s"INSERT INTO $name VALUES (2)") // v2: emit.
+      sql(s"INSERT INTO $name VALUES (2)") // v2: interval boundary.
+      // Inline: the AMT rides in the v2 business commit (checkpointVersion == 2).
+      // Deferred: a follow-up OPTIMIZE CHECKPOINT commit lands at v3 describing state as of v2.
+      val checkpointVersion = 2L
+      val snapshotVersion = checkpointVersion + mode.followUpCommits
 
       val deltaLog = deltaLogForName(name)
       val snapshot = deltaLog.unsafeVolatileSnapshot
-      assert(snapshot.version == 2)
+      assert(snapshot.version == snapshotVersion)
       val provider = amtProvider(snapshot)
       assert(provider.isDefined, "Post-emission snapshot must expose an AMTCheckpointProvider.")
-      assert(provider.get.checkpointVersion == 2)
+      assert(provider.get.checkpointVersion == checkpointVersion)
       assert(provider.get.checkpointAction.contentRoot.path ==
-        checkpointsAt(deltaLog, 2).head.contentRoot.path)
+        checkpointsAt(deltaLog, snapshotVersion).head.contentRoot.path)
       assert(provider.get.leaves.nonEmpty, "Provider must list the tree's leaves.")
     }
   }
 
-  test("post-commit LogSegment carries the AMT provider and only post-checkpoint deltas") {
+  testInlineAndDeferred("an emitted AMT installs the provider and trims the log segment") { mode =>
     withTable("amt_log_segment") {
       val name = "amt_log_segment"
       createAMTTable(name, checkpointInterval = 3)
-      // After each commit, the post-commit snapshot's log segment holds the deltas after the latest
-      // checkpoint. A checkpoint emits at every interval boundary (v3, v6); the provider persists
-      // across the intervening commits (deltaLog.update() is a no-op for AMT, so the cached
-      // post-commit snapshot is returned as-is). Expected (version -> delta count):
-      //   v0=1, v1=2, v2=3, v3=0 (checkpoint), v4=1, v5=2, v6=0 (checkpoint).
-      val expected = Seq(0L -> 1, 1L -> 2, 2L -> 3, 3L -> 0, 4L -> 1, 5L -> 2, 6L -> 0)
+      // The interval boundary is v3. Inline: the AMT rides in the v3 business commit. Deferred: a
+      // follow-up OPTIMIZE CHECKPOINT commit lands at v4 describing state as of v3. Either way the
+      // Checkpoint describes state as of v3, and the log segment trims to deltas after v3.
+      (1 to 3).foreach(i => sql(s"INSERT INTO $name VALUES ($i)"))
+      val checkpointVersion = 3L
+      val snapshotVersion = checkpointVersion + mode.followUpCommits
+
       val deltaLog = deltaLogForName(name)
-
-      def assertSegment(snapshot: Snapshot, expectedVersion: Long, expectedDeltas: Int): Unit = {
-        assert(snapshot.version == expectedVersion)
-        assert(snapshot.logSegment.deltas.size == expectedDeltas,
-          s"v$expectedVersion: expected $expectedDeltas deltas, " +
-          s"got ${snapshot.logSegment.deltas.map(f => FileNames.deltaVersion(f))}.")
-        // A provider is installed exactly on the checkpoint-boundary commits (v3, v6).
-        val isBoundary = expectedVersion > 0 && expectedVersion % 3 == 0
-        if (isBoundary) {
-          assert(amtProvider(snapshot).exists(_.checkpointVersion == expectedVersion),
-            s"v$expectedVersion: expected an AMT provider at this checkpoint version.")
-        }
-      }
-
-      assertSegment(deltaLog.unsafeVolatileSnapshot, expected.head._1, expected.head._2)
-      expected.tail.foreach { case (version, deltas) =>
-        sql(s"INSERT INTO $name VALUES ($version)")
-        assertSegment(deltaLogForName(name).unsafeVolatileSnapshot, version, deltas)
-      }
+      val snapshot = deltaLog.unsafeVolatileSnapshot
+      assert(snapshot.version == snapshotVersion)
+      val provider = amtProvider(snapshot).getOrElse(
+        fail("The post-emission snapshot must expose an AMTCheckpointProvider."))
+      assert(provider.checkpointVersion == checkpointVersion,
+        "The Checkpoint describes state as of v3.")
+      // The log segment keeps only deltas strictly after the checkpoint version (v3).
+      val segmentDeltaVersions = snapshot.logSegment.deltas.map(f => FileNames.deltaVersion(f))
+      assert(segmentDeltaVersions.forall(_ > checkpointVersion),
+        s"Log segment must trim deltas up to the checkpoint version; got $segmentDeltaVersions.")
     }
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotSuite.scala
@@ -37,21 +37,21 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
   // Post commit snapshot
   ///////////////////////////
 
-  test("snapshot.allFiles reflects a DELETE that lands on the checkpoint boundary") {
+  testInlineAndDeferred("snapshot.allFiles reflects a DELETE on the checkpoint boundary") {
+    _ =>
     withTable("amt_delete_boundary") {
       val name = "amt_delete_boundary"
-      createAMTTable(name, checkpointInterval = 2)
-      sql(s"INSERT INTO $name VALUES (1)")   // v1: 1 file.
-      sql(s"INSERT INTO $name VALUES (2)")   // v2: emit; 2 live files.
-      // Sanity: snapshot state and leaves agree at the first checkpoint.
-      assert(deltaLogForName(name).unsafeVolatileSnapshot.allFiles.count() == 2)
-
-      sql(s"INSERT INTO $name VALUES (3)")   // v3: 3 live files (not a boundary).
-      sql(s"DELETE FROM $name WHERE id = 1") // v4: emit; live set drops id=1.
+      // Interval 1 so every commit is a boundary; combined with inline mode this makes the last
+      // DML AMT-backed in both modes regardless of the follow-up commit's version bookkeeping.
+      createAMTTable(name, checkpointInterval = 1)
+      sql(s"INSERT INTO $name VALUES (1)")
+      sql(s"INSERT INTO $name VALUES (2)")
+      sql(s"INSERT INTO $name VALUES (3)")
+      sql(s"DELETE FROM $name WHERE id = 1") // removes id=1; triggers an AMT (inline or follow-up).
 
       val snapshot = deltaLogForName(name).unsafeVolatileSnapshot
-      assert(snapshot.version == 4)
-      assert(amtProvider(snapshot).isDefined)
+      assert(amtProvider(snapshot).isDefined,
+        "The post-DELETE snapshot must be AMT-backed.")
       // allFiles must reflect the DELETE: the removed file is gone from the post-commit live set.
       checkAnswer(spark.read.table(name), Seq(Row(2), Row(3)))
       // The manifest tree written at the checkpoint captures exactly the post-DELETE live files
@@ -61,17 +61,18 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
     }
   }
 
-  test("snapshot.allFiles matches leaves across insert/overwrite/delete before a checkpoint") {
+  testInlineAndDeferred(
+      "snapshot.allFiles matches leaves across insert/overwrite/delete before a checkpoint") { _ =>
     withTable("amt_overwrite") {
       val name = "amt_overwrite"
-      createAMTTable(name, checkpointInterval = 4)
-      sql(s"INSERT INTO $name VALUES (1)")            // v1.
-      sql(s"INSERT INTO $name VALUES (2)")            // v2.
-      sql(s"INSERT OVERWRITE $name VALUES (10), (20)") // v3: replaces all prior files.
-      sql(s"DELETE FROM $name WHERE id = 10")         // v4: emit; removes one.
+      // Interval 1 so the final DELETE triggers an AMT in both modes.
+      createAMTTable(name, checkpointInterval = 1)
+      sql(s"INSERT INTO $name VALUES (1)")
+      sql(s"INSERT INTO $name VALUES (2)")
+      sql(s"INSERT OVERWRITE $name VALUES (10), (20)") // replaces all prior files.
+      sql(s"DELETE FROM $name WHERE id = 10")          // removes one; triggers an AMT.
 
       val snapshot = deltaLogForName(name).unsafeVolatileSnapshot
-      assert(snapshot.version == 4)
       assert(amtProvider(snapshot).isDefined)
       checkAnswer(spark.read.table(name), Seq(Row(20)))
       assert(snapshot.allFiles.count() == 1, "Only the surviving overwrite file should be live.")
@@ -80,14 +81,15 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
     }
   }
 
-  test("filtered scan is correct after emission (reconstruction from trimmed deltas + leaves)") {
+  testInlineAndDeferred(
+      "filtered scan is correct after emission (trimmed deltas + leaves)") { _ =>
     withTable("amt_filtered_scan") {
       val name = "amt_filtered_scan"
-      createAMTTable(name, checkpointInterval = 2)
+      createAMTTable(name, checkpointInterval = 1)
       sql(s"INSERT INTO $name VALUES (1)")
-      sql(s"INSERT INTO $name VALUES (2)")   // v2: emit; provider is AMT.
-      sql(s"INSERT INTO $name VALUES (3)")   // v3.
-      sql(s"DELETE FROM $name WHERE id = 1") // v4: emit again.
+      sql(s"INSERT INTO $name VALUES (2)")
+      sql(s"INSERT INTO $name VALUES (3)")
+      sql(s"DELETE FROM $name WHERE id = 1") // removes id=1; triggers an AMT.
 
       // SQL data-skipping reconstruction is disabled for AMT tables, so reads go through the
       // allFiles-based reconstruction: the leaves supply state up to the checkpoint and the
@@ -103,13 +105,13 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
   test("deletion vector round-trips through the leaves with a matching uniqueId") {
     withTable("amt_dv") {
       val name = "amt_dv"
-      createAMTTable(name, checkpointInterval = 2)
+      // Interval 1 so the DV commit triggers an AMT (via its follow-up OPTIMIZE CHECKPOINT commit).
+      createAMTTable(name, checkpointInterval = 1)
       Seq(1, 2).toDF("id").coalesce(1)
-        .write.mode("append").insertInto(name) // v1: one file, two rows.
+        .write.mode("append").insertInto(name) // one file, two rows.
 
       // Attach a persistent DV directly rather than relying on DELETE's DV-vs-rewrite heuristic:
       // write a DV marking row 0 deleted and commit the resulting AddFile (with DV) + RemoveFile.
-      // v2 is a checkpoint boundary -> emit.
       val log = deltaLogForName(name)
       val fileToDv = log.unsafeVolatileSnapshot.allFiles.collect()
       assert(fileToDv.length == 1, "The two rows must land in a single file.")
@@ -121,7 +123,6 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
       }
 
       val snapshot = deltaLogForName(name).unsafeVolatileSnapshot
-      assert(snapshot.version == 2)
       val provider = amtProvider(snapshot).getOrElse(fail("expected AMTCheckpointProvider"))
       checkAnswer(spark.read.table(name), Seq(Row(2)))
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTWriterManagerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTWriterManagerSuite.scala
@@ -53,58 +53,28 @@ class AMTWriterManagerSuite extends AMTCheckpointTestBase {
       domainMetadata = Seq.empty,
       op = DeltaOperations.ManualUpdate)
 
-  test("writeAMT throws UnsupportedOperationException for an OPTIMIZE checkpoint operation") {
+  test("writeAMT materializes a tree for an OPTIMIZE checkpoint operation") {
     withTable("amt_optimize_ckpt") {
       val name = "amt_optimize_ckpt"
       createAMTTable(name, checkpointInterval = 2)
       sql(s"INSERT INTO $name VALUES (1)")
 
-      val (manager, snapshot) = managerFor(name, DeltaOperations.OptimizeCheckpoint())
-      val ex = intercept[UnsupportedOperationException] {
-        manager.writeAMT(
-          commitVersion = snapshot.version + 1,
-          currentTransactionInfo = txnInfoFor(snapshot, actions = Seq.empty),
-          preCommitLogSegment = snapshot.logSegment)
-      }
-      assert(ex.getMessage.contains("OPTIMIZE checkpoints"))
+      val (manager, snapshot) = managerFor(name, DeltaOperations.OptimizeCheckpoint(
+        incremental = false, triggerName = AMTTriggerMode.CheckpointIntervalFull.name))
+      val result = manager.writeAMT(
+        commitVersion = snapshot.version + 1,
+        currentTransactionInfo = txnInfoFor(snapshot, actions = Seq.empty),
+        preCommitLogSegment = snapshot.logSegment).getOrElse(
+          fail("OPTIMIZE checkpoint must materialize an AMT."))
+      // The commit carries no user actions, so the tree describes state as of the read version.
+      assert(result.contentRootVersion == snapshot.version)
+      // The metric records the trigger name carried on the operation.
+      assert(manager.metrics.attempts.head.trigger == AMTTriggerMode.CheckpointIntervalFull.name)
     }
   }
 
-  test("emits AMT when commit count since last checkpoint reaches the checkpoint interval") {
-    withTable("amt_count_trigger") {
-      val name = "amt_count_trigger"
-      createAMTTable(name, checkpointInterval = 3)
-      sql(s"INSERT INTO $name VALUES (1)") // v1: 1 commit since genesis, < 3.
-      sql(s"INSERT INTO $name VALUES (2)") // v2: 2 commits since genesis, < 3.
-      sql(s"INSERT INTO $name VALUES (3)") // v3: 3 commits since genesis, >= 3 -> emit.
-
-      val deltaLog = deltaLogForName(name)
-      val path = tablePath(name)
-      assert(checkpointsAt(deltaLog, 1).isEmpty, "v1 is below the interval; no emission.")
-      assert(checkpointsAt(deltaLog, 2).isEmpty, "v2 is below the interval; no emission.")
-      assert(checkpointsAt(deltaLog, 3).size == 1, "v3 reaches the interval; AMT must be emitted.")
-      assert(rootFiles(path).size == 1 && leafFiles(path).nonEmpty,
-        "A manifest tree must be written at the interval boundary.")
-      assert(amtProvider(deltaLog.update()).isDefined)
-    }
-  }
-
-
-  test("does not emit AMT when no trigger fires") {
-    withTable("amt_no_trigger") {
-      val name = "amt_no_trigger"
-      // Interval far away, and a tiny commit stays well below the default size threshold, so
-      // neither the count nor the (edge-only) size trigger fires.
-      createAMTTable(name, checkpointInterval = 1000)
-      sql(s"INSERT INTO $name VALUES (1)")
-
-      val deltaLog = deltaLogForName(name)
-      val path = tablePath(name)
-      assert(checkpointsAt(deltaLog, 1).isEmpty, "No trigger fires; no emission.")
-      assert(rootFiles(path).isEmpty && leafFiles(path).isEmpty, "No manifest tree written.")
-      assert(amtProvider(deltaLog.update()).isEmpty)
-    }
-  }
+  // End-to-end emission-policy scenarios (interval / full-rewrite cadence / size trigger / minor
+  // compaction) live in AMTCheckpointPolicySuite. This suite covers writeAMT's direct behavior.
 
   test("writeAMT hard-fails an AMT table on a conflict-resolution retry") {
     withTable("amt_conflict_fail") {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AdaptiveMetadataActionsSerializerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AdaptiveMetadataActionsSerializerSuite.scala
@@ -80,6 +80,25 @@ class AdaptiveMetadataActionsSerializerSuite extends SparkFunSuite {
     assert(roundTripped === root)
   }
 
+  test("ContentRoot: tags round-trip and expose typed accessors") {
+    val root = ContentRoot(
+      path = "metadata/root-abc.parquet",
+      sizeInBytes = 4096L,
+      isIncremental = true,
+      lastManifestCommitWithFullRewrite = 7L)
+    assert(root.isIncremental === Some(true))
+    assert(root.lastManifestCommitWithFullRewrite === Some(7L))
+    val roundTripped = JsonUtils.fromJson[ContentRoot](JsonUtils.toJson(root))
+    assert(roundTripped === root)
+    assert(roundTripped.isIncremental === Some(true))
+    assert(roundTripped.lastManifestCommitWithFullRewrite === Some(7L))
+  }
+
+  test("ContentRoot: accessors are None when tags are absent") {
+    assert(sampleRoot.isIncremental.isEmpty)
+    assert(sampleRoot.lastManifestCommitWithFullRewrite.isEmpty)
+  }
+
   // ============================================================================================
   // SidecarType enum
   // ============================================================================================

--- a/spark/src/test/scala/org/apache/spark/sql/delta/hooks/metrics/UpdateMetricsHookSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/hooks/metrics/UpdateMetricsHookSuite.scala
@@ -25,7 +25,7 @@ import scala.collection.JavaConverters._
 
 import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorClient
 
-import org.apache.spark.sql.delta.{CommittedTransaction, DeltaLog, DeltaOperations}
+import org.apache.spark.sql.delta.{CommittedTransaction, DeltaLog, DeltaOperations, MaintenanceOperation}
 import org.apache.spark.sql.delta.actions.{Action, AddFile, CommitInfo, RemoveFile}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
@@ -62,7 +62,7 @@ class UpdateMetricsHookSuite extends QueryTest
       committedVersion = 0L, committedActions = actions,
       postCommitSnapshot = deltaLog.snapshot,
       postCommitHooks = Seq.empty, txnExecutionTimeMs = 0L,
-      needsCheckpoint = false, partitionsAddedToOpt = None,
+      maintenanceOperation = MaintenanceOperation(), partitionsAddedToOpt = None,
       isBlindAppend = true)
   }
 


### PR DESCRIPTION
## Description

Adds a full-vs-incremental rewrite policy for adaptive metadata (AMT) manifest-tree checkpoints.

Previously an adaptive metadata checkpoint was always materialized the same way. This change lets a checkpoint be rewritten either fully (re-materializing the live file set into a fresh manifest tree) or incrementally, and selects between them with an anchored cadence: a full rewrite recurs once a configurable multiple of the checkpoint interval has elapsed since the last full rewrite, with incremental rewrites in between. Two config knobs control this — the actions-count threshold above which a large commit writes its manifest tree inline, and the multiplier that sets how often a full rewrite happens relative to the checkpoint interval.

The chosen mode and the version of the last full rewrite are recorded as tags on the checkpoint's `ContentRoot`, so a reader or maintenance job can distinguish an incremental tree from a full re-materialization without inspecting the leaves. The checkpoint itself can be emitted either inline within a large business commit or deferred to a follow-up `OPTIMIZE CHECKPOINT` commit.

## How was this patch tested?

Added `AMTCheckpointPolicySuite` covering the interval trigger, the full-vs-incremental cadence, first-checkpoint-is-full behavior, and last-full-rewrite marker tracking, plus updates to the existing adaptive-metadata snapshot and writer suites. All adaptive-metadata suites pass.

## Does this PR introduce _any_ user-facing changes?

No.
