### PR TITLE
Populate LastManifestCommit via the P&M reconstruction path in Snapshot

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
@@ -26,6 +26,7 @@ import scala.util.Try
 import com.databricks.spark.util.TagDefinition
 import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.actions.Action.logSchema
+import org.apache.spark.sql.delta.amt.{AMTCheckpointProvider, AMTUsageLogs}
 import org.apache.spark.sql.delta.ClassicColumnConversions._
 import org.apache.spark.sql.delta.coordinatedcommits.{CatalogOwnedTableUtils, CommitCoordinatorClient, CommitCoordinatorProvider, CoordinatedCommitsUsageLogs, CoordinatedCommitsUtils, TableCommitCoordinatorClient}
 import org.apache.spark.sql.delta.expressions.EncodeNestedVariantAsZ85String
@@ -178,44 +179,79 @@ class Snapshot(
     getInCommitTimestampOpt.getOrElse(logSegment.lastCommitFileModificationTimestamp)
 
   /**
+   * The [[CommitInfo]] of this snapshot's version. Marked `lazy` to avoid I/O unless needed.
+   */
+  private lazy val commitInfoForVersionOpt: Option[CommitInfo] =
+    DeltaHistoryManager.getCommitInfoOpt(
+      deltaLog.store,
+      DeltaCommitFileProvider(this).deltaFile(version),
+      deltaLog.newDeltaHadoopConf())
+
+  /**
+   * Accesses and extracts from [[commitInfoForVersionOpt]] with telemetry.
+   */
+  private def readFromCommitInfoWithLogging[T](
+      opType: String, callSite: String)(extract: Option[CommitInfo] => T): T = {
+    val startTime = System.currentTimeMillis()
+    var exception = Option.empty[Throwable]
+    try {
+      extract(commitInfoForVersionOpt)
+    } catch {
+      case e: Throwable =>
+        exception = Some(e)
+        throw e
+    } finally {
+      recordDeltaEvent(
+        deltaLog,
+        opType,
+        data = Map(
+          "version" -> version,
+          "callSite" -> callSite,
+          "checkpointVersion" -> logSegment.checkpointProvider.version,
+          "durationMs" -> (System.currentTimeMillis() - startTime),
+          "exceptionMessage" -> exception.map(_.getMessage).getOrElse(""),
+          "exceptionStackTrace" ->
+            exception.map(_.getStackTrace.mkString("\n")).getOrElse(""),
+          "isCRCPresent" -> checksumOpt.isDefined
+        )
+      )
+    }
+  }
+
+  /**
    * Returns the inCommitTimestamp if ICT is enabled, otherwise returns None.
-   * This potentially triggers an IO operation to read the inCommitTimestamp.
+   * This potentially triggers an I/O operation to read the inCommitTimestamp.
    * This is a lazy val, so repeated calls will not trigger multiple IO operations.
    */
-  protected lazy val getInCommitTimestampOpt: Option[Long] =
+  protected[delta] lazy val getInCommitTimestampOpt: Option[Long] =
     Option.when(DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.fromMetaData(metadata)) {
-      _reconstructedProtocolMetadataAndICT.inCommitTimestamp
-        .getOrElse {
-          val startTime = System.currentTimeMillis()
-          var exception = Option.empty[Throwable]
-          try {
-            val commitInfoOpt = DeltaHistoryManager.getCommitInfoOpt(
-              deltaLog.store,
-              DeltaCommitFileProvider(this).deltaFile(version),
-              deltaLog.newDeltaHadoopConf())
-            CommitInfo.getRequiredInCommitTimestamp(commitInfoOpt, version.toString)
-          } catch {
-            case e: Throwable =>
-              exception = Some(e)
-              throw e
-          } finally {
-            recordDeltaEvent(
-              deltaLog,
-              "delta.inCommitTimestamp.read",
-              data = Map(
-                "version" -> version,
-                "callSite" -> "Snapshot.getInCommitTimestampOpt",
-                "checkpointVersion" -> logSegment.checkpointProvider.version,
-                "durationMs" -> (System.currentTimeMillis() - startTime),
-                "exceptionMessage" -> exception.map(_.getMessage).getOrElse(""),
-                "exceptionStackTrace" ->
-                  exception.map(_.getStackTrace.mkString("\n")).getOrElse(""),
-                "isCRCPresent" -> checksumOpt.isDefined
-              )
-            )
-          }
+      _reconstructedProtocolMetadataICTAndLMC.bestEffortInCommitTimestamp.getOrElse {
+        readFromCommitInfoWithLogging(
+            opType = "delta.inCommitTimestamp.read",
+            callSite = "Snapshot.getInCommitTimestampOpt") { commitInfoOpt =>
+          CommitInfo.getRequiredInCommitTimestamp(commitInfoOpt, version.toString)
         }
+      }
     }
+
+  /** Returns the lastManifestCommit reliably for this snapshot's version. */
+  lazy val lastManifestCommitOpt: Option[LastManifestCommit] =
+    Option.when(protocol.isFeatureSupported(AdaptiveMetadataTableFeature)) {
+      _reconstructedProtocolMetadataICTAndLMC.bestEffortLastManifestCommit.orElse {
+        // Only fallback to direct CommitInfo read if there are no trailing deltas.
+        // This avoids unnecessary I/O when there isn't any AMT checkpoint yet.
+        Option.when(logSegment.deltas.isEmpty) {
+          readFromCommitInfoWithLogging(
+              opType = AMTUsageLogs.LAST_MANIFEST_COMMIT_READ_FROM_COMMIT_INFO,
+              callSite = "Snapshot.lastManifestCommitOpt") { commitInfoOpt =>
+            commitInfoOpt.getOrElse {
+              throw DeltaErrors.missingCommitInfo(
+                AdaptiveMetadataTableFeature.name, version.toString)
+            }.lastManifestCommit
+          }
+        }.flatten
+      }
+    }.flatten
 
 
   private[delta] lazy val nonFileActions: Seq[Action] = {
@@ -306,29 +342,50 @@ class Snapshot(
   }
 
   /**
-   * Protocol, Metadata, and In-Commit Timestamp retrieved through
-   * `protocolMetadataAndICTReconstruction` which skips a full state reconstruction.
+   * Protocol, Metadata, In-Commit Timestamp, and Last Manifest Commit retrieved through
+   * `protocolMetadataICTAndLMCReconstruction` which skips a full state reconstruction.
+   *
+   * `protocol` and `metadata` are always populated (reconstruction fails if either is missing).
+   * ICT and LMC are best-effort because they come from the snapshot version's `commitInfo`, and
+   * checkpoints don't have `commitInfo`, so if the snapshot sits exactly on a checkpoint (without
+   * trailing deltas) without a CRC, they cannot be populated via reconstruction. A `commitInfo`
+   * read at the snapshot version is needed as a fallback.
+   *
+   * @param bestEffortInCommitTimestamp None means it is either genuinely absent from CommitInfo,
+   *                                    or cannot be computed by the P&M query.
+   * @param bestEffortLastManifestCommit Same as above.
    */
-  case class ReconstructedProtocolMetadataAndICT(
+  case class ReconstructedProtocolMetadataICTAndLMC(
       protocol: Protocol,
       metadata: Metadata,
-      inCommitTimestamp: Option[Long])
+      bestEffortInCommitTimestamp: Option[Long],
+      bestEffortLastManifestCommit: Option[LastManifestCommit])
 
   /**
    * Generate the protocol and metadata for this snapshot. This is usually cheaper than a
    * full state reconstruction, but still only compute it when necessary.
    */
-  private lazy val _reconstructedProtocolMetadataAndICT: ReconstructedProtocolMetadataAndICT =
-      {
+  private lazy val _reconstructedProtocolMetadataICTAndLMC
+    : ReconstructedProtocolMetadataICTAndLMC = {
     // Should be small. At most 'checkpointInterval' rows, unless new commits are coming
     // in before a checkpoint can be written
     var protocol: Protocol = null
     var metadata: Metadata = null
     var inCommitTimestamp: Option[Long] = None
-    protocolMetadataAndICTReconstruction().foreach {
-      case ReconstructedProtocolMetadataAndICT(p: Protocol, _, _) => protocol = p
-      case ReconstructedProtocolMetadataAndICT(_, m: Metadata, _) => metadata = m
-      case ReconstructedProtocolMetadataAndICT(_, _, ict: Option[Long]) => inCommitTimestamp = ict
+    var lastManifestCommit: Option[LastManifestCommit] = None
+    protocolMetadataICTAndLMCReconstruction().foreach { row =>
+      // There will be three rows from reconstruction: one for the protocol, one for the metadata,
+      // and one for both the ICT and LMC.
+      if (row.protocol != null) { protocol = row.protocol }
+      else if (row.metadata != null) { metadata = row.metadata }
+      else {
+        if (row.bestEffortInCommitTimestamp.isDefined) {
+          inCommitTimestamp = row.bestEffortInCommitTimestamp
+        }
+        if (row.bestEffortLastManifestCommit.isDefined) {
+          lastManifestCommit = row.bestEffortLastManifestCommit
+        }
+      }
     }
 
     if (protocol == null) {
@@ -349,7 +406,8 @@ class Snapshot(
       throw DeltaErrors.actionNotFoundException("metadata", version)
     }
 
-    ReconstructedProtocolMetadataAndICT(protocol, metadata, inCommitTimestamp)
+    ReconstructedProtocolMetadataICTAndLMC(
+      protocol, metadata, inCommitTimestamp, lastManifestCommit)
   }
 
   /**
@@ -446,27 +504,33 @@ class Snapshot(
 
   def checkpointSizeInBytes(): Long = checkpointProvider.effectiveCheckpointSizeInBytes()
 
-  override def metadata: Metadata = _reconstructedProtocolMetadataAndICT.metadata
+  override def metadata: Metadata = _reconstructedProtocolMetadataICTAndLMC.metadata
 
-  override def protocol: Protocol = _reconstructedProtocolMetadataAndICT.protocol
+  override def protocol: Protocol = _reconstructedProtocolMetadataICTAndLMC.protocol
 
   /**
    * Tries to retrieve the protocol, metadata, and in-commit-timestamp (if needed) from the
    * checksum file. If the checksum file is not present or if the protocol or metadata is missing
    * this will return None.
    */
-  protected def getProtocolMetadataAndIctFromCrc(checksumOpt: Option[VersionChecksum]):
-    Option[Array[ReconstructedProtocolMetadataAndICT]] = {
+  protected def getProtocolMetadataICTAndLMCFromCrc(checksumOpt: Option[VersionChecksum])
+    : Option[Array[ReconstructedProtocolMetadataICTAndLMC]] = {
       if (!spark.sessionState.conf.getConf(
           DeltaSQLConf.USE_PROTOCOL_AND_METADATA_FROM_CHECKSUM_ENABLED)) {
         return None
       }
-      checksumOpt.map(c => (c.protocol, c.metadata, c.inCommitTimestampOpt)).flatMap {
-        case (p: Protocol, m: Metadata, ict: Option[Long]) =>
-          Some(Array((p, null, None), (null, m, None), (null, null, ict))
-            .map(ReconstructedProtocolMetadataAndICT.tupled))
+      checksumOpt.map { c =>
+        (c.protocol, c.metadata, c.inCommitTimestampOpt, c.lastManifestCommit)
+      }.flatMap {
+        case (p: Protocol, m: Metadata, ict: Option[Long], lmc: Option[LastManifestCommit]) =>
+          // Emit ICT and LMC on the SAME row to match the reconstruction logic.
+          Some(Array(
+            (p, null, None, None),
+            (null, m, None, None),
+            (null, null, ict, lmc)
+          ).map(ReconstructedProtocolMetadataICTAndLMC.tupled))
 
-        case (p, m, _) if p != null || m != null =>
+        case (p, m, _, _) if p != null || m != null =>
           // One was missing from the .crc file... warn and fall back to an optimized query
           val protocolStr = Option(p).map(_.toString).getOrElse("null")
           val metadataStr = Option(m).map(_.toString).getOrElse("null")
@@ -493,32 +557,38 @@ class Snapshot(
    * in-commit-timestamp of the latest commit if available.
    *
    * Also this method should only access methods defined in [[UninitializedCheckpointProvider]]
-   * which are not present in [[CheckpointProvider]]. This is because initialization of
-   * [[Snapshot.checkpointProvider]] depends on [[Snapshot.protocolMetadataAndICTReconstruction()]]
-   * and so if [[Snapshot.protocolMetadataAndICTReconstruction()]] starts depending on
+   * which are not present in [[CheckpointProvider]], because [[Snapshot.checkpointProvider]]'s
+   * initialization depends on [[Snapshot.protocolMetadataICTAndLMCReconstruction()]]
+   * and so if [[Snapshot.protocolMetadataICTAndLMCReconstruction()]] starts depending on
    * [[Snapshot.checkpointProvider]] then there will be cyclic dependency.
    */
-  protected def protocolMetadataAndICTReconstruction():
-      Array[ReconstructedProtocolMetadataAndICT] = {
+  protected def protocolMetadataICTAndLMCReconstruction():
+      Array[ReconstructedProtocolMetadataICTAndLMC] = {
     import implicits._
 
-    getProtocolMetadataAndIctFromCrc(checksumOpt).foreach { protocolMetadataAndIctFromCrc =>
-      return protocolMetadataAndIctFromCrc
+    getProtocolMetadataICTAndLMCFromCrc(checksumOpt).foreach { protocolMetadataICTAndLMCFromCrc =>
+      return protocolMetadataICTAndLMCFromCrc
     }
 
     val schemaToUse = Snapshot.pAndMQuerySchema
-    val checkpointOpt =
-      checkpointProvider.loadProtocolMetadataActions(spark, deltaLog)
+    val checkpointOpt = checkpointProvider.loadProtocolMetadataActions(spark, deltaLog)
     (checkpointOpt ++ deltaFileIndexOpt.map(deltaLog.loadIndex(_, schemaToUse)).toSeq)
       .reduceOption(_.union(_)).getOrElse(emptyDF)
-      .select("protocol", "metaData", "commitInfo.inCommitTimestamp", COMMIT_VERSION_COLUMN)
+      .select(
+        "protocol",
+        "metaData",
+        "commitInfo.inCommitTimestamp",
+        "commitInfo.lastManifestCommit",
+        COMMIT_VERSION_COLUMN
+      )
       .where("protocol.minReaderVersion is not null or metaData.id is not null " +
-        s"or (commitInfo.inCommitTimestamp is not null and version = $version)")
-      .as[(Protocol, Metadata, Option[Long], Long)]
+        s"or (commitInfo.inCommitTimestamp is not null and version = $version) " +
+        s"or (commitInfo.lastManifestCommit is not null and version = $version)")
+      .as[(Protocol, Metadata, Option[Long], Option[LastManifestCommit], Long)]
       .collect()
-      .sortBy(_._4)
+      .sortBy(_._5)
       .map {
-        case (p, m, ict, _) => ReconstructedProtocolMetadataAndICT(p, m, ict)
+        case (p, m, ict, lmc, _) => ReconstructedProtocolMetadataICTAndLMC(p, m, ict, lmc)
       }
   }
 
@@ -748,7 +818,7 @@ class Snapshot(
 
   // These logging methods must NOT read `this.metadata`: they are invoked *during* P&M
   // reconstruction (e.g. the usage log on the incremental-checksum path) and during snapshot
-  // construction, where reading `metadata` re-enters the `_reconstructedProtocolMetadataAndICT`
+  // construction, where reading `metadata` re-enters the `_reconstructedProtocolMetadataICTAndLMC`
   // lazy val on the same thread and overflows the stack. Use the DeltaLog's cached id instead.
   def logInfo(msg: MessageWithContext): Unit = {
     super.logInfo(log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, tableId)}] " + msg)
@@ -985,7 +1055,9 @@ class DummySnapshot(
 
   override def domainMetadata: Seq[DomainMetadata] = domainMetadataOpt.getOrElse(Seq.empty)
   override protected lazy val computedState: SnapshotState = initialState(metadata, protocol)
-  override protected lazy val getInCommitTimestampOpt: Option[Long] = None
+  override protected[delta] lazy val getInCommitTimestampOpt: Option[Long] = None
+  /* A dummy snapshot never has a manifest commit. */
+  override lazy val lastManifestCommitOpt: Option[LastManifestCommit] = None
   _computedStateTriggered = true
 
   // The [[InitialSnapshot]] is not backed by any external commit-coordinator.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTUsageLogs.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTUsageLogs.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.amt
+
+/** Usage logs emitted by the AMT (`adaptiveMetadata-preview`) code paths. */
+object AMTUsageLogs {
+  /** Common prefix for all AMT usage logs. */
+  val PREFIX = "delta.v4amt"
+
+  /**
+   * Usage log emitted when [[Snapshot.lastManifestCommitOpt]] reads `CommitInfo` as a fallback.
+   */
+  val LAST_MANIFEST_COMMIT_READ_FROM_COMMIT_INFO =
+    s"$PREFIX.lastManifestCommit.readFromCommitInfo"
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/DeltaEncoders.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/DeltaEncoders.scala
@@ -81,8 +81,12 @@ private[delta] trait DeltaEncoders {
   private lazy val _addCdcFileEncoder = new DeltaEncoder[AddCDCFile]
   implicit def addCdcFileEncoder: Encoder[AddCDCFile] = _addCdcFileEncoder.get
 
-  private lazy val _pmtvEncoder = new DeltaEncoder[(Protocol, Metadata, Option[Long], Long)]
-  implicit def pmtvEncoder: Encoder[(Protocol, Metadata, Option[Long], Long)] = _pmtvEncoder.get
+  /** Params: Protocol, Metadata, Option[InCommitTimestamp], Option[LastManifestCommit], Version */
+  private lazy val _pmtlvEncoder =
+    new DeltaEncoder[(Protocol, Metadata, Option[Long], Option[LastManifestCommit], Long)]
+  implicit def pmtlvEncoder:
+    Encoder[(Protocol, Metadata, Option[Long], Option[LastManifestCommit], Long)] =
+      _pmtlvEncoder.get
 
   private lazy val _v2CheckpointActionsEncoder = new DeltaEncoder[(CheckpointMetadata, SidecarFile)]
   implicit def v2CheckpointActionsEncoder: Encoder[(CheckpointMetadata, SidecarFile)] =

--- a/spark/src/test/scala/org/apache/spark/sql/delta/InCommitTimestampSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/InCommitTimestampSuite.scala
@@ -963,8 +963,8 @@ class InCommitTimestampSuite
     }
   }
 
-  test("postCommitSnapshot.timestamp should be populated by protocolMetadataAndICTReconstruction " +
-     "when the table has no checkpoints") {
+  test("postCommitSnapshot.timestamp should be populated by " +
+      "protocolMetadataICTAndLMCReconstruction when the table has no checkpoints") {
     // Make sure that we don't retrieve the time from the CRC.
     withSQLConf(DeltaSQLConf.DELTA_WRITE_CHECKSUM_ENABLED.key -> "false") {
       withTempTable(createTable = false) { tableName =>
@@ -983,7 +983,7 @@ class InCommitTimestampSuite
     }
   }
 
-  test("snapshot.timestamp should be populated by protocolMetadataAndICTReconstruction " +
+  test("snapshot.timestamp should be populated by protocolMetadataICTAndLMCReconstruction " +
      "during cold reads of checkpoints + deltas") {
     // Make sure that we don't retrieve the time from the CRC.
     withSQLConf(DeltaSQLConf.DELTA_WRITE_CHECKSUM_ENABLED.key -> "false") {
@@ -1009,7 +1009,7 @@ class InCommitTimestampSuite
     }
   }
 
-  test("snapshot.timestamp cannot be populated by protocolMetadataAndICTReconstruction " +
+  test("snapshot.timestamp cannot be populated by protocolMetadataICTAndLMCReconstruction " +
      "during cold reads of checkpoints") {
     // Make sure that we don't retrieve the time from the CRC.
     withSQLConf(DeltaSQLConf.DELTA_WRITE_CHECKSUM_ENABLED.key -> "false") {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/SnapshotLastManifestCommitSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/SnapshotLastManifestCommitSuite.scala
@@ -1,0 +1,221 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.amt
+
+import com.databricks.spark.util.{Log4jUsageLogger, UsageRecord}
+import org.apache.spark.sql.delta.{DeltaLog, DeltaTestUtils, Snapshot}
+import org.apache.spark.sql.delta.actions.{Action, CommitInfo, LastManifestCommit}
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.util.{DeltaCommitFileProvider, FileNames, JsonUtils}
+
+import org.apache.spark.SparkConf
+
+/**
+ * Tests that [[LastManifestCommit]] is surfaced reliably by [[Snapshot.lastManifestCommitOpt]].
+ */
+trait SnapshotLastManifestCommitSuiteBase extends AMTCheckpointTestBase {
+
+  override protected def sparkConf: SparkConf = super.sparkConf
+    // Inline every manifest commit instead of deferring to a follow-up OPTIMIZE CHECKPOINT commit.
+    // This simplifies the test suite as the deferring is not the primary focus of the suite.
+    .set(DeltaSQLConf.AMT_LARGE_COMMIT_ACTIONS_COUNT_THRESHOLD_FOR_INLINE_MANIFEST_COMMIT.key, "1")
+
+  /** Whether this suite runs with `.crc` files enabled, read from the effective conf. */
+  protected def writeChecksumEnabled: Boolean =
+    spark.conf.get(DeltaSQLConf.DELTA_WRITE_CHECKSUM_ENABLED)
+
+  /**
+   * Seeds `lmc` onto every source that exists for this suite's mode. Always rewrites the delta-file
+   * `CommitInfo`; the CRC-enabled suite additionally rewrites the `.crc`.
+   */
+  protected def injectLmc(deltaLog: DeltaLog, version: Long, lmc: Option[LastManifestCommit]): Unit
+
+  /** Rewrites the `CommitInfo` at `version` to carry `lmc`, preserving all other actions. */
+  protected def injectLmcIntoCommitInfo(
+      deltaLog: DeltaLog, version: Long, lmc: Option[LastManifestCommit]): Unit = {
+    val commitPath = DeltaCommitFileProvider(deltaLog.unsafeVolatileSnapshot).deltaFile(version)
+    val hadoopConf = deltaLog.newDeltaHadoopConf()
+    val rewritten = deltaLog.store.readAsIterator(commitPath, hadoopConf).toList
+      .map(Action.fromJson)
+      .map {
+        case ci: CommitInfo => ci.copy(lastManifestCommit = lmc).json
+        case other => other.json
+      }
+    deltaLog.store.write(commitPath, rewritten.toIterator, overwrite = true, hadoopConf)
+  }
+
+  /** Rewrites the CRC at `version` to carry `lmc`. Requires the CRC to already exist. */
+  protected def injectLmcIntoCrc(
+      deltaLog: DeltaLog, version: Long, lmc: Option[LastManifestCommit]): Unit = {
+    val checksum = deltaLog.readChecksum(version).getOrElse(
+      fail(s"Expected a CRC at version $version to rewrite."))
+    val rewritten = JsonUtils.toJson(checksum.copy(lastManifestCommit = lmc))
+    deltaLog.store.write(
+      FileNames.checksumFile(deltaLog.logPath, version),
+      Seq(rewritten).toIterator,
+      overwrite = true,
+      deltaLog.newDeltaHadoopConf())
+  }
+
+  /** Drops the [[DeltaLog]] cache and cold-loads the snapshot at `version` for a fresh read. */
+  protected def freshSnapshotAt(tableName: String, version: Long): Snapshot = {
+    DeltaLog.clearCache()
+    deltaLogForName(tableName).getSnapshotAt(version)
+  }
+
+  /**
+   * Asserts that `opType` was (or was not) emitted among the in-scope captured `usageLogs`. Wrap
+   * the code under test in `implicit val usageLogs = Log4jUsageLogger.track { ... }` first.
+   */
+  protected def assertUsageLog(opType: String, isPresent: Boolean)(
+      implicit usageLogs: Seq[UsageRecord]): Unit = {
+    val emitted = DeltaTestUtils.filterUsageRecords(usageLogs, opType).nonEmpty
+    assert(emitted == isPresent,
+      s"Expected usage log '$opType' ${if (isPresent) "to" else "not to"} be emitted.")
+  }
+
+  test("lastManifestCommitOpt resolves via reconstruction across commits with trailing deltas") {
+    withTable("amt_lmc_reconstruction") {
+      val name = "amt_lmc_reconstruction"
+      createAMTTable(name, checkpointInterval = 100)
+      sql(s"INSERT INTO $name VALUES (1)")
+      sql(s"INSERT INTO $name VALUES (2)")
+      sql(s"INSERT INTO $name VALUES (3)")
+
+      val deltaLog = deltaLogForName(name)
+      val lmcV1 = LastManifestCommit(version = 1, contentRootVersion = 1)
+      val lmcV3 = LastManifestCommit(version = 3, contentRootVersion = 3)
+      injectLmc(deltaLog, version = 1, lmc = Some(lmcV1)) // v1: carries a reference.
+      // v2: no reference.
+      injectLmc(deltaLog, version = 3, lmc = Some(lmcV3)) // v3: carries a different reference.
+
+      /** Assert each snapshot resolves to its own version's reference with the expected path. */
+      def assertResolves(version: Long, expected: Option[LastManifestCommit]): Unit = {
+        implicit val usageLogs: Seq[UsageRecord] = Log4jUsageLogger.track {
+          assert(freshSnapshotAt(name, version).lastManifestCommitOpt == expected)
+        }
+        // There are trailing deltas, so the CommitInfo fallback is never reached.
+        assertUsageLog(AMTUsageLogs.LAST_MANIFEST_COMMIT_READ_FROM_COMMIT_INFO, isPresent = false)
+      }
+
+      assertResolves(1, Some(lmcV1))
+      // v2 carries no reference, and v1's must not leak into v2's reconstruction.
+      assertResolves(2, None)
+      assertResolves(3, Some(lmcV3))
+    }
+  }
+
+  test("in-commit-timestamp and last-manifest-commit both resolve when present together") {
+    // The in-commit-timestamp and last-manifest-commit are sibling fields in CommitInfo, so a
+    // single commit carries both on one reconstruction row; both must survive. Catalog-managed
+    // tables have in-commit timestamps enabled by default, so no explicit enablement is needed.
+    val lmc = LastManifestCommit(version = 7, contentRootVersion = 5)
+    withTable("amt_lmc_ict") {
+      val name = "amt_lmc_ict"
+      createAMTTable(name, checkpointInterval = 100)
+      sql(s"INSERT INTO $name VALUES (1)") // trailing delta carrying both ICT and (injected) LMC.
+
+      val deltaLog = deltaLogForName(name)
+      val version = deltaLog.unsafeVolatileSnapshot.version
+      // The true in-commit-timestamp before injection; both injectors preserve it.
+      val expectedIct = deltaLog.unsafeVolatileSnapshot.getInCommitTimestampOpt.getOrElse {
+        fail("Expected a non-None in-commit-timestamp.")
+      }
+      injectLmc(deltaLog, version, lmc = Some(lmc))
+
+      val snapshot = freshSnapshotAt(name, version)
+      assert(snapshot.lastManifestCommitOpt.contains(lmc),
+        "LMC must survive on a row that also carries an in-commit-timestamp.")
+      assert(snapshot.getInCommitTimestampOpt.contains(expectedIct),
+        "The in-commit-timestamp must still be resolved from the same row.")
+    }
+  }
+
+  test("lastManifestCommitOpt is None when no reference is recorded") {
+    withTable("amt_lmc_none") {
+      val name = "amt_lmc_none"
+      createAMTTable(name, checkpointInterval = 100)
+      sql(s"INSERT INTO $name VALUES (1)")
+      // No manifest-commit reference is recorded on either the CommitInfo or the CRC.
+      assert(freshSnapshotAt(name, 1).lastManifestCommitOpt.isEmpty)
+    }
+  }
+}
+
+/** Runs the shared cases with `.crc` files enabled; the reference is seeded to CommitInfo + CRC. */
+class SnapshotLastManifestCommitSuite extends SnapshotLastManifestCommitSuiteBase {
+  override protected def sparkConf: SparkConf = super.sparkConf
+    .set(DeltaSQLConf.DELTA_WRITE_CHECKSUM_ENABLED.key, "true")
+
+  override protected def injectLmc(
+      deltaLog: DeltaLog, version: Long, lmc: Option[LastManifestCommit]): Unit = {
+    injectLmcIntoCommitInfo(deltaLog, version, lmc)
+    injectLmcIntoCrc(deltaLog, version, lmc)
+  }
+}
+
+/** Runs the shared cases with `.crc` files disabled; the reference is seeded to CommitInfo only. */
+class SnapshotLastManifestCommitWithoutCRCSuite extends SnapshotLastManifestCommitSuiteBase {
+  override protected def sparkConf: SparkConf = super.sparkConf
+    .set(DeltaSQLConf.DELTA_WRITE_CHECKSUM_ENABLED.key, "false")
+
+  override protected def injectLmc(
+      deltaLog: DeltaLog, version: Long, lmc: Option[LastManifestCommit]): Unit = {
+    injectLmcIntoCommitInfo(deltaLog, version, lmc)
+  }
+
+  test("lastManifestCommitOpt falls back to CommitInfo when no other source carries the ref") {
+    // With CRC unavailable, when the snapshot sits on an AMT checkpoint, there is no trailing delta
+    // to provide the CommitInfo during P&M query, so we must fallback to a direct CommitInfo read.
+    val lmc = LastManifestCommit(version = 7, contentRootVersion = 5)
+    withTable("amt_lmc_fallback") {
+      val name = "amt_lmc_fallback"
+      createAMTTable(name, checkpointInterval = 2)
+      sql(s"INSERT INTO $name VALUES (1)")
+      sql(s"INSERT INTO $name VALUES (2)") // v2: emit; carries the inline checkpoint action.
+
+      val deltaLog = deltaLogForName(name)
+      injectLmc(deltaLog, version = 2, lmc = Some(lmc))
+
+      // Build the AMT provider from v2's emitted checkpoint action and stub it into a fresh
+      // snapshot's log segment, trimming the version's delta as cold discovery eventually will.
+      val checkpoint = checkpointsAt(deltaLog, 2).headOption.getOrElse {
+        fail("v2 must emit an inline AMT checkpoint action.")
+      }
+      val provider = AMTCheckpointProvider.fromCheckpoint(spark, deltaLog, checkpoint)
+      val coldSnapshot = freshSnapshotAt(name, 2)
+      val segment = coldSnapshot.logSegment.copy(checkpointProvider = provider, deltas = Nil)
+      val snapshot = new Snapshot(
+        path = coldSnapshot.path,
+        version = coldSnapshot.version,
+        logSegment = segment,
+        deltaLog = coldSnapshot.deltaLog,
+        checksumOpt = None // No CRC, so reconstruction has no source other than the CommitInfo.
+      )
+
+      assert(amtProvider(snapshot).isDefined, "Snapshot must carry the (stubbed) AMT provider.")
+      assert(snapshot.logSegment.deltas.isEmpty, "Segment must have no trailing deltas.")
+      assert(snapshot.checksumOpt.isEmpty, "Snapshot must have no CRC.")
+
+      implicit val usageLogs: Seq[UsageRecord] = Log4jUsageLogger.track {
+        assert(snapshot.lastManifestCommitOpt.contains(lmc),
+          "The CommitInfo fallback must resolve the reference.")
+      }
+      assertUsageLog(AMTUsageLogs.LAST_MANIFEST_COMMIT_READ_FROM_COMMIT_INFO, isPresent = true)
+    }
+  }
+}


### PR DESCRIPTION
## Description

This change lets `Snapshot` obtain the `LastManifestCommit` (LMC) through the same
Protocol & Metadata (P&M) reconstruction path that already provides the In-Commit
Timestamp (ICT), so no additional I/O is introduced in the common case.

Concretely:
- `ReconstructedProtocolMetadataAndICT` is generalized to
  `ReconstructedProtocolMetadataICTAndLMC`, carrying a best-effort
  `LastManifestCommit` alongside the best-effort ICT. Both are derived from the
  snapshot version's `commitInfo`, so they are populated opportunistically during
  reconstruction and read from the CRC when available.
- The reconstruction query (`protocolMetadataICTAndLMCReconstruction`) now also
  selects `commitInfo.lastManifestCommit`, and the CRC fast-path
  (`getProtocolMetadataICTAndLMCFromCrc`) emits ICT and LMC on the same row.
- A new public API `Snapshot.lastManifestCommitOpt` serves as the source of truth
  for the last manifest commit at a snapshot's version. It only falls back to a
  direct `CommitInfo` read when there is no way to derive it from reconstruction
  (snapshot sitting exactly on a checkpoint with no trailing deltas and no CRC),
  avoiding unnecessary I/O.
- A shared `readFromCommitInfoWithLogging` helper factors out the telemetry and
  error handling that both the ICT and LMC fallback reads use.
- Adds the corresponding encoder in `DeltaEncoders`, a small `AMTUsageLogs` object
  for the usage log emitted on the fallback path, and a new
  `SnapshotLastManifestCommitSuite` covering reconstruction, CRC, CommitInfo
  fallback, and the ICT+LMC-on-one-row cases.

## How was this patch tested?

New `SnapshotLastManifestCommitSuite` exercises `Snapshot.lastManifestCommitOpt`
across the reconstruction path, the CRC path, the direct `CommitInfo` fallback
(snapshot on a checkpoint with no trailing deltas and no CRC), the combined
ICT + LMC single-row case, and the absent-reference case. Existing
`InCommitTimestampSuite` cases (updated for the renamed reconstruction method)
continue to validate that the snapshot timestamp is populated through the
reconstruction path.

## Does this PR introduce _any_ user-facing change?

No.