### PR TITLE
Add partitionCDCFiles helper with exhaustiveness assert for DML rewrites

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DMLUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DMLUtils.scala
@@ -17,7 +17,7 @@
 package org.apache.spark.sql.delta.commands
 
 import org.apache.spark.sql.delta.DeltaCommitTag
-import org.apache.spark.sql.delta.actions.{Action, FileAction}
+import org.apache.spark.sql.delta.actions.{Action, AddCDCFile, AddFile, FileAction}
 
 object DMLUtils {
 
@@ -36,5 +36,13 @@ object DMLUtils {
 
   object TaggedCommitData {
     def empty[A <: Action]: TaggedCommitData[A] = TaggedCommitData(Seq.empty[A])
+  }
+
+  /** Partition [[FileAction]]s to [[AddFile]]s and [[AddCDCFile]]s. */
+  def partitionCDCFiles(actions: Seq[FileAction]): (Seq[AddFile], Seq[AddCDCFile]) = {
+    val addFiles = actions.collect { case a: AddFile => a }
+    val cdcFiles = actions.collect { case a: AddCDCFile => a }
+    assert(addFiles.length + cdcFiles.length == actions.length)
+    (addFiles, cdcFiles)
   }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
@@ -23,7 +23,7 @@ import scala.util.control.NonFatal
 import org.apache.spark.sql.delta.metric.IncrementMetric
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.ClassicColumnConversions._
-import org.apache.spark.sql.delta.actions.{Action, AddCDCFile, AddFile, FileAction}
+import org.apache.spark.sql.delta.actions.{Action, AddFile, FileAction}
 import org.apache.spark.sql.delta.commands.DeleteCommand.{rewritingFilesMsg, FINDING_TOUCHED_FILES_MSG}
 import org.apache.spark.sql.delta.commands.MergeIntoCommandBase.totalBytesAndDistinctPartitionValues
 import org.apache.spark.sql.delta.files.TahoeBatchFileIndex
@@ -352,8 +352,7 @@ case class DeleteCommand(
                 snapshot = txn.snapshot)
               val filterCond = Not(EqualNullSafe(cond, Literal.TrueLiteral))
               val rewrittenActions = rewriteFiles(txn, targetDF, filterCond, filesToRewrite.length)
-              val (changeFiles, rewrittenFiles) = rewrittenActions
-                .partition(_.isInstanceOf[AddCDCFile])
+              val (rewrittenFiles, changeFiles) = DMLUtils.partitionCDCFiles(rewrittenActions)
               numAddedFiles = rewrittenFiles.size
               val removedFiles = filesToRewrite.map(f =>
                 getTouchedFile(deltaLog.dataPath, f, nameToAddFileMap))
@@ -368,7 +367,7 @@ case class DeleteCommand(
                 numPartitionsAddedTo = Some(rewrittenPartitions)
               }
               numAddedChangeFiles = changeFiles.size
-              changeFileBytes = changeFiles.collect { case f: AddCDCFile => f.size }.sum
+              changeFileBytes = changeFiles.map(_.size).sum
               rewriteTimeMs =
                 TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime) - scanTimeMs
               numDeletedRows = Some(metrics("numDeletedRows").value)


### PR DESCRIPTION
## Description

`DMLUtils.partitionCDCFiles` splits a `Seq[FileAction]` into its `AddFile`s and `AddCDCFile`s and asserts that every action landed in exactly one bucket:

```scala
assert(addFiles.length + cdcFiles.length == actions.length)
```

Previously, command code split rewrite actions inline with a bare `partition(_.isInstanceOf[AddCDCFile])` and had no guard against an unexpected `FileAction` subtype being silently dropped from a DML rewrite.

This PR:
- Adds `partitionCDCFiles` (and the `AddFile` / `AddCDCFile` imports it needs) to `DMLUtils`, so the helper and its exhaustiveness assertion are available to DML commands.
- Wires it into the `DeleteCommand` rewrite split site, replacing the bare `rewrittenActions.partition(_.isInstanceOf[AddCDCFile])` and dropping the now-redundant `collect { case f: AddCDCFile => f.size }` re-collect when summing change-file bytes.

`DeleteCommand` is the only command whose rewrite output is a genuine adds-vs-CDC split (`UpdateCommand`'s action set also contains removes, and `OptimizeTableCommand` splits adds vs removes), so the `adds + cdc == total` invariant only applies there.

## How was this patch tested?

Existing DELETE/CDC coverage exercises this path. No behavior change: the assertion only fires on an internal invariant violation that should never occur in practice, and the `DeleteCommand` split is equivalent to the previous inline partition.

## Does this PR introduce _any_ user-facing changes?

No.
