### PR TITLE
[Spark] Add the clustered manifest-tree write path for full AMT checkpoints

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
@@ -45,6 +45,7 @@ import org.apache.spark.TaskContext
 import org.apache.spark.internal.MDC
 import org.apache.spark.paths.SparkPath
 import org.apache.spark.sql.{Column, DataFrame, Dataset, Row, SparkSession}
+import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.catalyst.expressions.{Cast, ElementAt, Literal}
@@ -58,8 +59,7 @@ import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
 import org.apache.spark.sql.functions.{coalesce, col, struct, when}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.StructType
-import org.apache.spark.util.SerializableConfiguration
-import org.apache.spark.util.Utils
+import org.apache.spark.util.{LongAccumulator, SerializableConfiguration, Utils}
 
 /**
  * A class to help with comparing checkpoints with each other, where we may have had concurrent
@@ -802,12 +802,9 @@ object Checkpoints
           useRename = useRename,
           partition = partition,
           expectedNumParts = actualNumParts,
-          runWriteInNewThreadOnGCS = true) { writer =>
-            iter.foreach { row =>
-              checkpointRowCount.add(1)
-              writer.write(row)
-          }
-        }
+          rows = iter,
+          rowsWrittenAccumulatorOpt = Some(checkpointRowCount),
+          runWriteInNewThreadOnGCS = true)
         Iterator(status)
       }.collect()
 
@@ -1089,9 +1086,8 @@ object Checkpoints
           finalPath = finalPath,
           useRename = useRename,
           partition = partition,
-          expectedNumParts = 1) { writer =>
-            iter.foreach(writer.write)
-          }
+          expectedNumParts = 1,
+          rows = iter)
         Iterator(status)
       }.collect()
     schema
@@ -1112,10 +1108,11 @@ object Checkpoints
    * @param partition The partition id (used for the task attempt id and profiling label).
    * @param expectedNumParts The expected partition count; a mismatch with the task's actual
    *                  partition count is logged as a warning.
+   * @param rows      The [[InternalRow]]s to write into the file. Consumed exactly once.
+   * @param rowsWrittenAccumulatorOpt Optional accumulator incremented once per written row.
    * @param runWriteInNewThreadOnGCS When the target is a GCS path, run the write (create/write/
    *                  close) in a fresh thread so it cannot be interrupted -- GCS may upload an
    *                  incomplete file when the writing thread is interrupted.
-   * @param writeRows The only behavioral seam: writes the partition's rows into the writer.
    * @return The [[SerializableFileStatus]] of the final file
    */
   private[delta] def writeSingleFileOnExecutor(
@@ -1127,8 +1124,10 @@ object Checkpoints
       useRename: Boolean,
       partition: Int,
       expectedNumParts: Int,
+      rows: Iterator[InternalRow],
+      rowsWrittenAccumulatorOpt: Option[LongAccumulator] = None,
       runWriteInNewThreadOnGCS: Boolean = false
-    )(writeRows: OutputWriter => Unit): SerializableFileStatus = {
+    ): SerializableFileStatus = {
 
     val fs = writePath.getFileSystem(conf)
     val attemptId = 0
@@ -1145,7 +1144,10 @@ object Checkpoints
         taskAttemptContext))
 
       val writer = writerOpt.get
-      writeRows(writer)
+      rows.foreach { row =>
+        rowsWrittenAccumulatorOpt.foreach(_.add(1))
+        writer.write(row)
+      }
       // Note: `writer.close()` is not put in a `finally` clause because we don't want to
       // close it when an exception happens. Closing the file would flush the content to the
       // storage and create an incomplete file. A concurrent reader might see it and fail.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriteHelper.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriteHelper.scala
@@ -18,23 +18,34 @@ package org.apache.spark.sql.delta.amt
 
 import java.util.concurrent.TimeUnit.NANOSECONDS
 
-import org.apache.spark.sql.delta.{Checkpoints, Snapshot}
-import org.apache.spark.sql.delta.actions.{Action, AddFile, Checkpoint, ContentRoot, InMemoryLogReplay, Metadata, Protocol}
+// scalastyle:off import.ordering.noEmptyLine
+import org.apache.spark.sql.delta.{Checkpoints, DeltaLog, Snapshot}
+import org.apache.spark.sql.delta.actions.{Action, AddFile, Checkpoint, ContentRoot, DomainMetadata, InMemoryLogReplay, Metadata, Protocol, SetTransaction}
+import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.FileNames
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
+import org.apache.hadoop.mapreduce.Job
 
-import org.apache.spark.sql.SparkSession
+import org.apache.spark.TaskContext
+import org.apache.spark.paths.SparkPath
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.execution.SQLExecution
+import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
+import org.apache.spark.sql.functions.{col, hash, struct}
+import org.apache.spark.util.SerializableConfiguration
 
 /** Helpers for emitting an inline AMT checkpoint during a commit. */
-object AMTWriteHelper {
+object AMTWriteHelper extends DeltaLogging {
 
   /**
-   * Materializes the full live file set into a fresh manifest tree and builds the inline Checkpoint
-   * action, returning the write result plus its metrics.
+   * Incremental materialization (interval / size triggers): the post-commit live files are packed
+   * into leaves in input order on the driver. `actionsToCommit` are replayed onto the read snapshot
+   * via [[computePostCommitState]] to derive both the live file set and the non-file state. Returns
+   * the write result plus its metrics.
    */
-  def writeFullMaterialization(
+  def writeIncrementalMaterialization(
       spark: SparkSession,
       readSnapshot: Snapshot,
       commitVersion: Long,
@@ -45,22 +56,82 @@ object AMTWriteHelper {
       incremental: Boolean): (AMTWriteResult, SingleAMTWriteMetrics) = {
     val deltaLog = readSnapshot.deltaLog
     val startNanos = System.nanoTime()
-    val postCommitState = computePostCommitState(readSnapshot, actionsToCommit)
     val hadoopConf = deltaLog.newDeltaHadoopConf()
     val entriesPerLeaf = spark.sessionState.conf.getConf(DeltaSQLConf.AMT_ENTRIES_PER_LEAF)
+
+    val postCommitState = computePostCommitState(readSnapshot, actionsToCommit)
     val (contentRootBase, leaves) = writeManifestTree(
       spark = spark,
       hadoopConf = hadoopConf,
       tableRoot = deltaLog.dataPath,
-      useRename = deltaLog.store.isPartialWriteVisible(deltaLog.logPath, hadoopConf),
       liveAddFiles = postCommitState.allFiles,
       entriesPerLeaf = entriesPerLeaf)
     val contentStateVersion =
       if (actionsToCommit.isEmpty) readSnapshot.version else commitVersion
-    // Record how the tree was produced so a reader/maintenance job can tell incremental trees apart
-    // from full re-materializations without inspecting the leaves. A full rewrite resets the
-    // "last full rewrite" marker to this version; an incremental rewrite carries forward the
-    // previous tree's marker.
+    val contentRoot = policyTaggedContentRoot(
+      readSnapshot, contentRootBase, incremental, contentStateVersion)
+    buildResult(
+      contentStateVersion = contentStateVersion,
+      contentRoot = contentRoot,
+      leaves = leaves,
+      postCommitProtocol = postCommitProtocol,
+      postCommitMetadata = postCommitMetadata,
+      domainMetadata = postCommitState.getDomainMetadatas.toSeq,
+      txns = postCommitState.getTransactions.toSeq,
+      trigger = trigger,
+      startNanos = startNanos)
+  }
+
+  /**
+   * Writes a new AMT from scratch representing the readSnapshot content metadata. Unlike the
+   * driver-side incremental path, the live file set is clustered and flushed into leaves by
+   * executors (a distributed rewrite). Always a full (non-incremental) rewrite: the "last full
+   * rewrite" marker is reset to the version the tree describes.
+   */
+  def writeFullMaterialization(
+      spark: SparkSession,
+      readSnapshot: Snapshot,
+      commitVersion: Long,
+      postCommitProtocol: Protocol,
+      postCommitMetadata: Metadata,
+      trigger: String): (AMTWriteResult, SingleAMTWriteMetrics) = {
+    val deltaLog = readSnapshot.deltaLog
+    val startNanos = System.nanoTime()
+    val hadoopConf = deltaLog.newDeltaHadoopConf()
+    val entriesPerLeaf = spark.sessionState.conf.getConf(DeltaSQLConf.AMT_ENTRIES_PER_LEAF)
+
+    val (contentRootBase, leaves) = writeClusteredManifestTree(
+      spark = spark,
+      deltaLog = deltaLog,
+      readSnapshot = readSnapshot,
+      hadoopConf = hadoopConf,
+      entriesPerLeaf = entriesPerLeaf)
+    // A full rewrite of the read snapshot's live files; it carries no commit actions, so the tree
+    // describes the read snapshot's version.
+    val contentStateVersion = readSnapshot.version
+    val contentRoot = policyTaggedContentRoot(
+      readSnapshot, contentRootBase, incremental = false, contentStateVersion)
+    buildResult(
+      contentStateVersion = contentStateVersion,
+      contentRoot = contentRoot,
+      leaves = leaves,
+      postCommitProtocol = postCommitProtocol,
+      postCommitMetadata = postCommitMetadata,
+      domainMetadata = readSnapshot.domainMetadata,
+      txns = readSnapshot.setTransactions,
+      trigger = trigger,
+      startNanos = startNanos)
+  }
+
+  // Tags the freshly written root with how the tree was produced, so a reader/maintenance job can
+  // tell incremental trees apart from full re-materializations without inspecting the leaves. A
+  // full rewrite resets the "last full rewrite" marker to `contentStateVersion`; an incremental
+  // rewrite carries forward the previous tree's marker.
+  private def policyTaggedContentRoot(
+      readSnapshot: Snapshot,
+      contentRootBase: ContentRoot,
+      incremental: Boolean,
+      contentStateVersion: Long): ContentRoot = {
     val lastFullRewriteVersion =
       if (incremental) {
         previousAMTContentRoot(readSnapshot)
@@ -69,18 +140,35 @@ object AMTWriteHelper {
       } else {
         contentStateVersion
       }
-    val contentRoot = ContentRoot(
+    ContentRoot(
       path = contentRootBase.path,
       sizeInBytes = contentRootBase.sizeInBytes,
       isIncremental = incremental,
       lastManifestCommitWithFullRewrite = lastFullRewriteVersion)
+  }
+
+  /**
+   * Assembles the inline Checkpoint action, write result, and metric shared by both materialization
+   * paths. `contentStateVersion` is the table version the tree describes and is stamped on the
+   * checkpoint action and write result.
+   */
+  private def buildResult(
+      contentStateVersion: Long,
+      contentRoot: ContentRoot,
+      leaves: Seq[AMTCheckpointProvider.LeafInfo],
+      postCommitProtocol: Protocol,
+      postCommitMetadata: Metadata,
+      domainMetadata: Seq[DomainMetadata],
+      txns: Seq[SetTransaction],
+      trigger: String,
+      startNanos: Long): (AMTWriteResult, SingleAMTWriteMetrics) = {
     val checkpoint = Checkpoint(
       version = contentStateVersion,
       contentRoot = contentRoot,
       protocol = postCommitProtocol,
       metaData = postCommitMetadata,
-      domainMetadata = postCommitState.getDomainMetadatas.toSeq,
-      txns = postCommitState.getTransactions.toSeq,
+      domainMetadata = domainMetadata,
+      txns = txns,
       sidecars = Seq.empty)
     val result = AMTWriteResult(
       contentRootVersion = contentStateVersion,
@@ -126,7 +214,6 @@ object AMTWriteHelper {
       spark: SparkSession,
       hadoopConf: Configuration,
       tableRoot: Path,
-      useRename: Boolean,
       liveAddFiles: Seq[AddFile],
       entriesPerLeaf: Int): (ContentRoot, Seq[AMTCheckpointProvider.LeafInfo]) = {
     require(entriesPerLeaf > 0, "entriesPerLeaf must be positive.")
@@ -147,17 +234,114 @@ object AMTWriteHelper {
     }
 
     val leafPointers = leafBatches.map { batch =>
-      writeLeaf(spark, fs, hadoopConf, tableRoot, metadataDir, useRename, batch)
+      writeLeaf(spark, fs, hadoopConf, tableRoot, metadataDir, batch)
     }
 
-    val contentRoot = writeRoot(spark, fs, hadoopConf, metadataDir, useRename, leafPointers)
-    val leafInfos = leafPointers.map { leaf =>
+    val contentRoot = writeRoot(spark, fs, hadoopConf, metadataDir, leafPointers)
+    (contentRoot, leafInfosFor(leafPointers))
+  }
+
+  // Builds the pointer-only [[AMTCheckpointProvider.LeafInfo]] view from the written leaf pointers.
+  private def leafInfosFor(
+      leafPointers: Seq[LeafPointer]): Seq[AMTCheckpointProvider.LeafInfo] =
+    leafPointers.map { leaf =>
       AMTCheckpointProvider.LeafInfo(
         path = leaf.path,
         sizeInBytes = leaf.sizeInBytes,
         numEntries = leaf.manifestInfo.added_files_count.toLong)
     }
-    (contentRoot, leafInfos)
+
+  /**
+   * Writes a clustered AMT manifest tree for a full checkpoint of `readSnapshot`'s live files.
+   * All files are clustered and flushed into leaf manifests -- one leaf per Spark partition,
+   * written by executors. The root lists only leaf pointers (no inline data entries). Returns the
+   * [[ContentRoot]] plus the per-leaf [[AMTCheckpointProvider.LeafInfo]] pointers.
+   */
+  private def writeClusteredManifestTree(
+      spark: SparkSession,
+      deltaLog: DeltaLog,
+      readSnapshot: Snapshot,
+      hadoopConf: Configuration,
+      entriesPerLeaf: Int): (ContentRoot, Seq[AMTCheckpointProvider.LeafInfo]) = {
+    require(entriesPerLeaf > 0, "entriesPerLeaf must be positive.")
+    val tableRoot = deltaLog.dataPath
+    val fs = tableRoot.getFileSystem(hadoopConf)
+    val metadataDir = FileNames.amtMetadataDirPath(tableRoot)
+
+    val numFiles = readSnapshot.numOfFiles
+    val desiredNumLeaves =
+      math.max(1, math.ceil(numFiles.toDouble / entriesPerLeaf).toInt)
+    val addFilesDf =
+      readSnapshot.allFiles.toDF().repartition(desiredNumLeaves, col("path"))
+
+    val leafPointers = writeLeavesDistributed(
+      spark = spark,
+      hadoopConf = hadoopConf,
+      tableRoot = tableRoot,
+      metadataDir = metadataDir,
+      addFilesDf = addFilesDf,
+      desiredNumLeaves = desiredNumLeaves)
+    val contentRoot = writeRoot(spark, fs, hadoopConf, metadataDir, leafPointers)
+    (contentRoot, leafInfosFor(leafPointers))
+  }
+
+
+  private def writeLeavesDistributed(
+      spark: SparkSession,
+      hadoopConf: Configuration,
+      tableRoot: Path,
+      metadataDir: Path,
+      addFilesDf: DataFrame,
+      desiredNumLeaves: Int): Seq[LeafPointer] = {
+    import org.apache.spark.sql.delta.implicits._
+    val addFilesDs = addFilesDf.as[AddFile]
+
+    // Capture values so the closures do not reach back into the object / non-serializable Path.
+    // The rewritten files already exist in the table, so their leaf entries are EXISTING.
+    val tracking = trackingWithStatus(Tracking.Status.Existing)
+    val tableRootSparkPath = SparkPath.fromPath(tableRoot)
+    val metadataDirSparkPath = SparkPath.fromPath(metadataDir)
+
+    val amtDs = addFilesDs.map { add =>
+      DataEntry.fromAddFile(add, tracking, tableRootSparkPath.toPath).wrap
+    }
+    val schema = amtDs.schema.asNullable
+    val (factory, serConf) = {
+      val format = new ParquetFileFormat()
+      val job = Job.getInstance(hadoopConf)
+      (format.prepareWrite(spark, job, Map.empty, schema),
+        new SerializableConfiguration(job.getConfiguration))
+    }
+
+    val qe = amtDs.queryExecution
+    SQLExecution.withNewExecutionId(qe, Some("AMT leaf checkpoint")) {
+      qe.executedPlan.execute().mapPartitions { iter =>
+        // Skip empty partitions (so the root never points at an empty leaf for a non-empty table).
+        if (!iter.hasNext) {
+          Iterator.empty
+        } else {
+          val conf = serConf.value
+          val leafFile = FileNames.newAMTLeafManifestFile(metadataDirSparkPath.toPath)
+
+          val status = Checkpoints.writeSingleFileOnExecutor(
+            conf = conf,
+            factory = factory,
+            schema = schema,
+            writePath = leafFile,
+            finalPath = leafFile,
+            useRename = false,
+            partition = TaskContext.getPartitionId(),
+            expectedNumParts = desiredNumLeaves,
+            rows = iter
+          )
+          Iterator.single(LeafPointer(
+            path = leafFile.toString,
+            sizeInBytes = status.length,
+            // TODO: populate the per-leaf summary for the distributed write path.
+            manifestInfo = manifestInfoFor(Seq.empty)))
+        }
+      }.collect().toSeq
+    }
   }
 
   /**
@@ -169,9 +353,10 @@ object AMTWriteHelper {
    */
   private case class LeafPointer(path: String, sizeInBytes: Long, manifestInfo: ManifestInfo)
 
-  // Tracking envelope for a freshly written entry: ADDED, no lineage/sequence numbers yet.
-  private def addedTracking: Tracking = Tracking(
-    status = Tracking.Status.Added,
+  // Tracking envelope for a freshly written entry with the given status, no lineage/sequence
+  // numbers yet.
+  private def trackingWithStatus(status: Int): Tracking = Tracking(
+    status = status,
     snapshot_id = None,
     dv_snapshot_id = None,
     sequence_number = None,
@@ -180,62 +365,73 @@ object AMTWriteHelper {
     deleted_positions = None,
     replaced_positions = None)
 
-  // Writes a single leaf parquet file (DATA entries) and returns a pointer row for it.
+  /**
+   * Writes a single leaf parquet file (DATA entries) and returns a pointer row for it.
+   */
   private def writeLeaf(
       spark: SparkSession,
       fs: FileSystem,
       hadoopConf: Configuration,
       tableRoot: Path,
       metadataDir: Path,
-      useRename: Boolean,
       batch: Seq[AddFile]): LeafPointer = {
     val leafFile = FileNames.newAMTLeafManifestFile(metadataDir)
     val rows: Seq[AMTSingleAction] =
-      batch.map(add => DataEntry.fromAddFile(add, addedTracking, tableRoot).wrap)
-    writeAMTParquet(spark, hadoopConf, leafFile, useRename, rows)
+      batch.map(add =>
+        DataEntry
+          .fromAddFile(
+            add,
+            trackingWithStatus(Tracking.Status.Added),
+            tableRoot
+          )
+          .wrap
+      )
+    writeAMTParquet(spark, hadoopConf, leafFile, rows)
     val status = fs.getFileStatus(leafFile)
     LeafPointer(
       path = leafFile.toString,
       sizeInBytes = status.getLen,
-      manifestInfo = manifestInfoFor(batch))
+      manifestInfo = manifestInfoFor(rows)
+    )
   }
 
-  // Writes the root parquet file (DATA_MANIFEST pointers only) and returns the ContentRoot.
+  /**
+   * Writes the root parquet file (DATA_MANIFEST pointers only) and returns the ContentRoot.
+   */
   private def writeRoot(
       spark: SparkSession,
       fs: FileSystem,
       hadoopConf: Configuration,
       metadataDir: Path,
-      useRename: Boolean,
       leafPointers: Seq[LeafPointer]): ContentRoot = {
     val rootFile = FileNames.newAMTRootManifestFile(metadataDir)
     val rows: Seq[AMTSingleAction] = leafPointers.map { leaf =>
       DataManifestEntry(
         location = leaf.path,
         file_format = AMTSingleAction.FileFormatParquet,
-        tracking = addedTracking,
+        tracking = trackingWithStatus(Tracking.Status.Added),
         // Number of content entries the referenced leaf manifest holds.
         record_count = leaf.manifestInfo.added_files_count.toLong,
         file_size_in_bytes = leaf.sizeInBytes,
         manifest_info = leaf.manifestInfo).wrap
     }
-    writeAMTParquet(spark, hadoopConf, rootFile, useRename, rows)
+    writeAMTParquet(spark, hadoopConf, rootFile, rows)
     val status = fs.getFileStatus(rootFile)
     ContentRoot(
       path = rootFile.toString,
       sizeInBytes = status.getLen)
   }
 
-  // Summarizes a leaf's batch into a ManifestInfo. In this PR every entry is ADDED with no
-  // assigned sequence number, so only the added_* counts are populated.
-  private def manifestInfoFor(batch: Seq[AddFile]): ManifestInfo = {
-    val addedRows = batch.map(_.numLogicalRecords.getOrElse(0L)).sum
+  /**
+   * Summarizes a leaf's batch into a ManifestInfo.
+   */
+  private def manifestInfoFor(batch: Seq[AMTSingleAction]): ManifestInfo = {
     ManifestInfo(
       added_files_count = batch.size,
       existing_files_count = 0,
       deleted_files_count = 0,
       replaced_files_count = 0,
-      added_rows_count = addedRows,
+      added_rows_count = 0L,
       existing_rows_count = 0L,
       deleted_rows_count = 0L,
       replaced_rows_count = 0L,
@@ -245,20 +441,24 @@ object AMTWriteHelper {
       dv_cardinality = None)
   }
 
-  // Writes a batch of AMTSingleAction rows to `finalPath` as a single parquet file.
+  /**
+   * Writes a batch of AMTSingleAction rows to `finalPath` as a single parquet file.
+   */
   private def writeAMTParquet(
       spark: SparkSession,
       hadoopConf: Configuration,
       finalPath: Path,
-      useRename: Boolean,
       rows: Seq[AMTSingleAction]): Unit = {
     import org.apache.spark.sql.delta.implicits._
     val df = spark.createDataset(rows).toDF()
+    // AMT manifest tree files are UUID-named, so we write straight to the final path
+    // (useRename = false): a retried or zombie task never collides with a file already
+    // reported to a Manifest commit.
     Checkpoints.writeAtomicCheckpointParquetFile(
       spark = spark,
       df = df,
       finalPath = finalPath,
       hadoopConf = hadoopConf,
-      useRename = useRename)
+      useRename = false)
   }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriterManager.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriterManager.scala
@@ -133,21 +133,39 @@ class AMTWriterManager(
   private def shouldDoInlineIncrementalCheckpoint(actionsToCommit: Seq[Action]): Boolean =
     actionsToCommit.size.toLong >= largeCommitActionsCountThresholdForInlineManifestCommit
 
-  // Materializes the manifest tree for this commit and records its metrics.
+  // Materializes the manifest tree for this commit and records its metrics. An incremental rewrite
+  // packs the post-commit live files into leaves in input order on the driver; a full rewrite
+  // clusters the read snapshot's live files and flushes them into leaves distributed across
+  // executors.
   private def materialize(
       commitVersion: Long,
       currentTransactionInfo: CurrentTransactionInfo,
       incremental: Boolean,
       trigger: String): AMTWriteResult = {
-    val (result, singleMetric) = AMTWriteHelper.writeFullMaterialization(
-      spark = spark,
-      readSnapshot = readSnapshot,
-      commitVersion = commitVersion,
-      actionsToCommit = currentTransactionInfo.actions,
-      postCommitProtocol = currentTransactionInfo.protocol,
-      postCommitMetadata = currentTransactionInfo.metadata,
-      trigger = trigger,
-      incremental = incremental)
+    val (result, singleMetric) =
+      if (incremental) {
+        AMTWriteHelper.writeIncrementalMaterialization(
+          spark = spark,
+          readSnapshot = readSnapshot,
+          commitVersion = commitVersion,
+          actionsToCommit = currentTransactionInfo.actions,
+          postCommitProtocol = currentTransactionInfo.protocol,
+          postCommitMetadata = currentTransactionInfo.metadata,
+          trigger = trigger,
+          incremental = incremental)
+      } else {
+        // A full rewrite re-materializes the whole live file set; the commit carries no actions.
+        assert(currentTransactionInfo.actions.isEmpty,
+          "A full AMT rewrite must carry no actions, got " +
+            s"${currentTransactionInfo.actions.size}.")
+        AMTWriteHelper.writeFullMaterialization(
+          spark = spark,
+          readSnapshot = readSnapshot,
+          commitVersion = commitVersion,
+          postCommitProtocol = currentTransactionInfo.protocol,
+          postCommitMetadata = currentTransactionInfo.metadata,
+          trigger = trigger)
+      }
     metrics.attempts :+= singleMetric
     result
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointWriteSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointWriteSuite.scala
@@ -18,11 +18,14 @@ package org.apache.spark.sql.delta.amt
 
 import java.io.File
 
+// scalastyle:off import.ordering.noEmptyLine
 import com.databricks.spark.util.{Log4jUsageLogger, MetricDefinitions}
-import org.apache.spark.sql.delta.CommitStats
+import org.apache.spark.sql.delta.{CommitStats, CurrentTransactionInfo, DeltaOperations, Snapshot}
 import org.apache.spark.sql.delta.actions.{AddFile, Checkpoint}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.JsonUtils
+
+import org.apache.spark.sql.functions.col
 
 class AMTCheckpointWriteSuite extends AMTCheckpointTestBase {
 
@@ -101,15 +104,97 @@ class AMTCheckpointWriteSuite extends AMTCheckpointTestBase {
   test("leaf cardinality respects AMT_ENTRIES_PER_LEAF") {
     withTable("amt_entries_per_leaf") {
       val name = "amt_entries_per_leaf"
-      createAMTTable(name, checkpointInterval = 2)
+      // Interval far away so no automatic checkpoint fires; we drive the incremental rewrite
+      // directly. The exact-leaf-count guarantee is a property of the incremental path, which
+      // packs the live files into leaves in input order (grouped by AMT_ENTRIES_PER_LEAF). The
+      // clustered full-rewrite path repartitions by hash and does not guarantee a leaf per group.
+      createAMTTable(name, checkpointInterval = 100)
+      sql(s"INSERT INTO $name VALUES (1)") // v1: one data file.
+      sql(s"INSERT INTO $name VALUES (2)") // v2: one more data file -> 2 live files.
+
       withSQLConf(DeltaSQLConf.AMT_ENTRIES_PER_LEAF.key -> "1") {
-        sql(s"INSERT INTO $name VALUES (1)") // v1: one data file.
-        sql(s"INSERT INTO $name VALUES (2)") // v2: one more data file -> 2 live files.
+        runIncrementalRewrite(name)
       }
       val path = tablePath(name)
       // Two live AddFiles, one per leaf -> two leaves, one root.
       assert(leafFiles(path).size == 2, s"Expected 2 leaves, got ${leafFiles(path).size}.")
       assert(rootFiles(path).size == 1)
+    }
+  }
+
+  /**
+   * Rewrites the whole manifest tree of `tableName` from scratch (the OPTIMIZE-checkpoint write
+   * path) and returns the write result plus the read snapshot it rewrote. `incremental` selects the
+   * driver-side incremental path (packs live files into leaves in input order) vs. the clustered
+   * full-rewrite path (repartitions the live files across executors).
+   */
+  private def runRewrite(
+      tableName: String, incremental: Boolean): (AMTWriteResult, Snapshot) = {
+    val triggerName =
+      if (incremental) AMTTriggerMode.CheckpointIntervalIncremental.name
+      else AMTTriggerMode.CheckpointIntervalFull.name
+    val snapshot = deltaLogForName(tableName).update()
+    val op = DeltaOperations.OptimizeCheckpoint(
+      incremental = incremental, triggerName = triggerName)
+    val manager = new AMTWriterManager(snapshot, op)
+    val txnInfo = new CurrentTransactionInfo(
+      txnId = "txn",
+      readPredicates = Vector.empty,
+      readFiles = Set.empty,
+      readWholeTable = false,
+      readAppIds = Set.empty,
+      metadata = snapshot.metadata,
+      protocol = snapshot.protocol,
+      actions = Seq.empty,
+      readSnapshot = snapshot,
+      commitInfo = None,
+      readRowIdHighWatermark = 0L,
+      catalogTable = None,
+      domainMetadata = Seq.empty,
+      op = op)
+    val result = manager.writeAMT(
+      commitVersion = snapshot.version + 1,
+      currentTransactionInfo = txnInfo,
+      preCommitLogSegment = snapshot.logSegment)
+    assert(result.isDefined, "A rewrite must emit a manifest tree.")
+    (result.get, snapshot)
+  }
+
+  /** Drives the clustered full-rewrite (OPTIMIZE-checkpoint) write path. */
+  private def runFullRewrite(tableName: String): (AMTWriteResult, Snapshot) =
+    runRewrite(tableName, incremental = false)
+
+  /** Drives the driver-side incremental (OPTIMIZE-checkpoint) write path. */
+  private def runIncrementalRewrite(tableName: String): (AMTWriteResult, Snapshot) =
+    runRewrite(tableName, incremental = true)
+
+  test("full rewrite reconstructs identical table state") {
+    withTable("amt_full_rewrite") {
+      val name = "amt_full_rewrite"
+      createAMTTable(name, checkpointInterval = 100) // Interval far away: no incremental emission.
+      sql(s"INSERT INTO $name VALUES (1)") // v1
+      sql(s"INSERT INTO $name VALUES (2)") // v2
+      sql(s"INSERT INTO $name VALUES (3)") // v3 -- 3 live files.
+
+      // Small leaf size so the rewrite splits the files across multiple leaves.
+      withSQLConf(DeltaSQLConf.AMT_ENTRIES_PER_LEAF.key -> "2") {
+        val (result, snapshot) = runFullRewrite(name)
+        val before = snapshot.allFiles.collect().map(_.path).toSet
+
+        // One root, at least one leaf, and the rewritten tree reconstructs the same file set.
+        val provider =
+          AMTCheckpointProvider.fromCheckpoint(spark, deltaLogForName(name), result.checkpoint)
+        assert(rootFiles(tablePath(name)).size == 1)
+        assert(provider.leaves.nonEmpty)
+        val reconstructed = provider
+          .loadActionsForStateReconstruction(spark, deltaLogForName(name)).get
+          .where(col("add").isNotNull)
+          .select("add.path")
+          .collect()
+          .map(_.getString(0))
+          .toSet
+        assert(reconstructed == before, s"File set changed: before=$before after=$reconstructed")
+      }
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTWriterManagerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTWriterManagerSuite.scala
@@ -53,7 +53,7 @@ class AMTWriterManagerSuite extends AMTCheckpointTestBase {
       domainMetadata = Seq.empty,
       op = DeltaOperations.ManualUpdate)
 
-  test("writeAMT materializes a tree for an OPTIMIZE checkpoint operation") {
+  test("writeAMT performs a clustered full rewrite for an OPTIMIZE checkpoint operation") {
     withTable("amt_optimize_ckpt") {
       val name = "amt_optimize_ckpt"
       createAMTTable(name, checkpointInterval = 2)
@@ -66,6 +66,9 @@ class AMTWriterManagerSuite extends AMTCheckpointTestBase {
         currentTransactionInfo = txnInfoFor(snapshot, actions = Seq.empty),
         preCommitLogSegment = snapshot.logSegment).getOrElse(
           fail("OPTIMIZE checkpoint must materialize an AMT."))
+      // A full rewrite flushes the live files into freshly clustered leaves via the distributed
+      // write path, so at least one leaf must be written.
+      assert(result.leaves.nonEmpty, "The clustered rewrite must write at least one leaf.")
       // The commit carries no user actions, so the tree describes state as of the read version.
       assert(result.contentRootVersion == snapshot.version)
       // The metric records the trigger name carried on the operation.


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

The Adaptive Metadata Tree (Iceberg v4 content-metadata) checkpoint writer
previously only supported the driver-side incremental path, which packs the
post-commit live files into leaf manifests in input order.

This PR adds the full-rewrite path used by the OPTIMIZE-checkpoint trigger:

- All live files of the read snapshot are clustered and flushed into leaf
  manifests via a distributed write (one leaf manifest per Spark partition),
  with the root manifest listing only leaf pointers.
- As an optimization, when the whole checkpoint fits in a single manifest the
  content entries are written straight into the root, skipping the leaf level.
- `AMTWriterManager` routes the OPTIMIZE-checkpoint trigger to the new
  `writeFullMaterialization`, while the interval/size triggers continue to use
  `writeIncrementalMaterialization`.

Manifest files are written straight to their final (UUID-named) path: a retried
or zombie task never collides with a file already referenced by a committed
manifest, so no temp-file rename is needed.

## How was this patch tested?

New and existing unit tests in `AMTCheckpointWriteSuite` and
`AMTWriterManagerSuite`, covering the full-rewrite path (clustered leaves, the
single-root case, and state reconstruction from the written tree) alongside the
existing incremental path.

## Does this PR introduce _any_ user-facing change?

No.
