### PR TITLE
[Sharing] Split presigned-url cache registration out of snapshot log building

### DIFF
--- a/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingDeltaLogBuilder.scala
+++ b/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingDeltaLogBuilder.scala
@@ -18,7 +18,7 @@ package io.delta.sharing.spark
 
 import java.lang.ref.WeakReference
 
-import io.delta.sharing.client.DeltaSharingClient
+import io.delta.sharing.client.{DeltaSharingClient, DeltaSharingProfileProvider}
 import io.delta.sharing.client.model.{Table => DeltaSharingTable}
 import org.apache.hadoop.fs.Path
 
@@ -28,10 +28,37 @@ import org.apache.spark.internal.Logging
 object DeltaSharingDeltaLogBuilder extends Logging {
 
   /**
+   * A built synthetic Delta log with its [[CachedTableManager]] registration deferred to
+   * [[registerPreSignedUrls]]. Pure data: it carries exactly what that call hands to
+   * `CachedTableManager.register`, already computed. Splitting registration out lets the DSV2 path
+   * build the Kernel scan first and anchor the cache entry to the scan's snapshot manager (see
+   * [[DeltaSharingDSV2Utils.buildScan]]); safe to defer because nothing between building the log
+   * and executor read consults the presigned-url cache.
+   *
+   * @param encodedPath the encoded `delta-sharing-log://` [[Path]] to open.
+   * @param registrationTablePath table path + hash, the cache key (CachedTableManager customizes
+   *   it).
+   * @param idToUrl the file-id -> presigned-url mapping to cache.
+   * @param minUrlExpirationTimestamp the earliest url expiration, for the cache entry's expiration.
+   * @param refreshToken optional refresh token from getFiles, forwarded to the refresher.
+   * @param profileProvider the sharing client's profile provider.
+   * @param refresher the presigned-url refresher, built next to getFiles so the two cannot drift.
+   */
+  case class UnregisteredSnapshotDeltaLog private[spark] (
+      encodedPath: Path,
+      registrationTablePath: String,
+      idToUrl: Map[String, String],
+      minUrlExpirationTimestamp: Option[Long],
+      refreshToken: Option[String],
+      profileProvider: DeltaSharingProfileProvider,
+      refresher: DeltaSharingUtils.RefresherFunction)
+
+  /**
    * Build the synthetic Delta log for a single-version (snapshot) Delta Sharing read: issue the
-   * getFiles RPC, fabricate a version-0 Delta log in the BlockManager (served back through the
-   * synthetic `delta-sharing-log://` Hadoop FS), register the file-id -> presigned-url mapping with
-   * the [[CachedTableManager]], and return the encoded `delta-sharing-log://` [[Path]].
+   * getFiles RPC and fabricate a version-0 Delta log in the BlockManager (served back through the
+   * synthetic `delta-sharing-log://` Hadoop FS). The [[CachedTableManager]] registration is
+   * deferred to [[registerPreSignedUrls]] so the caller can pick the anchor once it holds a durable
+   * per-query object.
    *
    * Snapshot construction is left to the caller: the V1 path ([[DeltaSharingFileIndex]]) feeds the
    * path to classic `DeltaLog.forTable`; the DSV2 scan feeds `.toString` to Delta Kernel's
@@ -46,16 +73,10 @@ object DeltaSharingDeltaLogBuilder extends Logging {
    *   and the cache key so different query shapes on the same table stay distinct.
    * @param jsonPredicateHints optional server-side filter hints forwarded to getFiles.
    * @param limit optional row limit forwarded to getFiles.
-   * @param anchor object whose lifetime bounds the [[CachedTableManager]] entry. A
-   *   [[WeakReference]] to it is registered, so the cached presigned URLs become collectable once
-   *   the anchor is unreachable. The anchor must be a per-query object: V1 passes the per-query
-   *   [[DeltaSharingFileIndex]]; the DSV2 path must pass the per-query `Scan`, not the per-table
-   *   `Table`. A `Table` is cached by the catalog and outlives the query, so anchoring to it would
-   *   pin stale presigned URLs in the cache.
    * @param logPrefix caller tag for the fetch log line, so the shared loader does not hard-code a
    *   DSV2 tag onto plain V1 reads.
    */
-  def buildSnapshotDeltaLogPath(
+  def buildSnapshotDeltaLog(
       client: DeltaSharingClient,
       table: DeltaSharingTable,
       options: DeltaSharingOptions,
@@ -63,9 +84,9 @@ object DeltaSharingDeltaLogBuilder extends Logging {
       queryParamsHashId: String,
       jsonPredicateHints: Option[String],
       limit: Option[Long],
-      anchor: AnyRef,
-      logPrefix: String): Path = {
-    // 1. Call client.getFiles.
+      logPrefix: String): UnregisteredSnapshotDeltaLog = {
+    // 1. Call client.getFiles, and build the matching refresher next to it so the two share the
+    // same params.
     val startTime = System.currentTimeMillis()
     val deltaTableFiles = client.getFiles(
       table = table,
@@ -76,6 +97,16 @@ object DeltaSharingDeltaLogBuilder extends Logging {
       jsonPredicateHints = jsonPredicateHints,
       refreshToken = None,
       fileIdHash = None
+    )
+    val refresher = DeltaSharingUtils.getRefresherForGetFiles(
+      client = client,
+      table = table,
+      predicates = Nil,
+      limit = limit,
+      versionAsOf = options.versionAsOf,
+      timestampAsOf = options.timestampAsOf,
+      jsonPredicateHints = jsonPredicateHints,
+      useRefreshToken = true
     )
     logInfo(
       s"$logPrefix: fetched ${deltaTableFiles.lines.size} lines for table $table with version " +
@@ -93,33 +124,73 @@ object DeltaSharingDeltaLogBuilder extends Logging {
       tablePathWithHashIdSuffix
     )
 
-    // 3. Register parquet file id to url mapping.
-    CachedTableManager.INSTANCE.register(
+    // 3. Carry the (pre-computed) registration inputs; registerPreSignedUrls does the register.
+    UnregisteredSnapshotDeltaLog(
+      encodedPath = DeltaSharingLogFileSystem.encode(tablePathWithHashIdSuffix),
       // Using tablePath directly because it will be customized within CachedTableManager.
-      tablePath = DeltaSharingUtils.getTablePathWithIdSuffix(tablePath, queryParamsHashId),
+      registrationTablePath =
+        DeltaSharingUtils.getTablePathWithIdSuffix(tablePath, queryParamsHashId),
       idToUrl = deltaLogMetadata.idToUrl,
-      refs = Seq(new WeakReference(anchor)),
+      minUrlExpirationTimestamp = deltaLogMetadata.minUrlExpirationTimestamp,
+      refreshToken = deltaTableFiles.refreshToken,
       profileProvider = client.getProfileProvider,
-      refresher = DeltaSharingUtils.getRefresherForGetFiles(
-        client = client,
-        table = table,
-        predicates = Nil,
-        limit = limit,
-        versionAsOf = options.versionAsOf,
-        timestampAsOf = options.timestampAsOf,
-        jsonPredicateHints = jsonPredicateHints,
-        useRefreshToken = true
-      ),
+      refresher = refresher
+    )
+  }
+
+  /**
+   * Register parquet file-id to presigned-url mapping with the [[CachedTableManager]], keyed to
+   * the lifetime of `anchor` via a [[WeakReference]]: the cached URLs (and their background
+   * refresh) become collectable once `anchor` is unreachable.
+   *
+   * @param anchor a per-query object bounding the cache entry: V1 passes its
+   *   [[DeltaSharingFileIndex]], DSV2 the scan's snapshot manager. A per-table object (e.g. a
+   *   catalog-cached `Table`) would outlive the query and pin stale URLs.
+   */
+  def registerPreSignedUrls(unregistered: UnregisteredSnapshotDeltaLog, anchor: AnyRef): Unit = {
+    CachedTableManager.INSTANCE.register(
+      tablePath = unregistered.registrationTablePath,
+      idToUrl = unregistered.idToUrl,
+      refs = Seq(new WeakReference(anchor)),
+      profileProvider = unregistered.profileProvider,
+      refresher = unregistered.refresher,
       expirationTimestamp =
         if (CachedTableManager.INSTANCE
-            .isValidUrlExpirationTime(deltaLogMetadata.minUrlExpirationTimestamp)) {
-          deltaLogMetadata.minUrlExpirationTimestamp.get
+            .isValidUrlExpirationTime(unregistered.minUrlExpirationTimestamp)) {
+          unregistered.minUrlExpirationTimestamp.get
         } else {
           System.currentTimeMillis() + CachedTableManager.INSTANCE.preSignedUrlExpirationMs
         },
-      refreshToken = deltaTableFiles.refreshToken
+      refreshToken = unregistered.refreshToken
     )
+  }
 
-    DeltaSharingLogFileSystem.encode(tablePathWithHashIdSuffix)
+  /**
+   * Build the synthetic Delta log and register its presigned URLs against `anchor` in one step,
+   * returning the encoded `delta-sharing-log://` [[Path]]. Used by the V1 path
+   * ([[DeltaSharingFileIndex]]), whose anchor (its FileIndex) already exists at call time.
+   */
+  def buildSnapshotDeltaLogPath(
+      client: DeltaSharingClient,
+      table: DeltaSharingTable,
+      options: DeltaSharingOptions,
+      tablePath: String,
+      queryParamsHashId: String,
+      jsonPredicateHints: Option[String],
+      limit: Option[Long],
+      anchor: AnyRef,
+      logPrefix: String): Path = {
+    val unregistered = buildSnapshotDeltaLog(
+      client = client,
+      table = table,
+      options = options,
+      tablePath = tablePath,
+      queryParamsHashId = queryParamsHashId,
+      jsonPredicateHints = jsonPredicateHints,
+      limit = limit,
+      logPrefix = logPrefix
+    )
+    registerPreSignedUrls(unregistered, anchor)
+    unregistered.encodedPath
   }
 }


### PR DESCRIPTION
## Description

Refactors `DeltaSharingDeltaLogBuilder.buildSnapshotDeltaLogPath` into two reusable pieces so a caller can build the synthetic Delta log first and choose the presigned-url cache anchor separately, once it holds a durable per-query object:

- `buildSnapshotDeltaLog` issues the getFiles RPC and fabricates the synthetic version-0 Delta log, returning an `UnregisteredSnapshotDeltaLog` that carries the pre-computed inputs for `CachedTableManager` registration.
- `registerPreSignedUrls` performs the `CachedTableManager` registration, taking the anchor object whose lifetime bounds the cache entry (a `WeakReference` to it), so the cached presigned URLs become collectable once the anchor is unreachable.

The combined `buildSnapshotDeltaLogPath` is retained for callers whose anchor already exists at call time, so their behavior is unchanged.

## How was this patch tested?

Existing unit tests for the snapshot Delta log builder, which exercise the retained combined `buildSnapshotDeltaLogPath` and the presigned-url cache registration.

## Does this PR introduce _any_ user-facing change?

No.
