### PR TITLE
Add DeltaV2OptimisticTransaction for Kernel backed transaction implementation

### DIFF
--- a/spark-unified/src/main/scala/org/apache/spark/sql/delta/v2/interop/DeltaV2OptimisticTransaction.scala
+++ b/spark-unified/src/main/scala/org/apache/spark/sql/delta/v2/interop/DeltaV2OptimisticTransaction.scala
@@ -1,0 +1,93 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.v2.interop
+
+import org.apache.spark.sql.delta.{
+  CurrentTransactionInfo,
+  DeltaLog,
+  LogSegment,
+  OptimisticTransaction,
+  VersionChecksum
+}
+import io.delta.storage.commit.Commit
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
+import org.apache.spark.util.{Clock, SystemClock}
+
+/**
+ * OptimisticTransaction backed by Delta Kernel.
+ *
+ * Extends V1 [[org.apache.spark.sql.delta.OptimisticTransaction]] directly.
+ * Constructed with `deltaLog = null`: the transaction must not depend on the V1 DeltaLog,
+ * so any missed V1 reach surfaces loudly instead of silently using V1 state.
+ *
+ * This is a skeleton: it wires up only the construction path so the transaction can be built and
+ * its read state (`readVersion`, `metadata`, `protocol`, `snapshot`) resolved from the Kernel
+ * snapshot. The commit lifecycle ([[writeCommitFile]] and the rest of the Kernel commit path) is
+ * intentionally left unimplemented and fails loudly; it is a follow-up.
+ */
+private[v2] class DeltaV2OptimisticTransaction(
+    catalogTable: Option[CatalogTable],
+    val deltaV2Snapshot: DeltaV2Snapshot)
+  extends OptimisticTransaction(
+    null.asInstanceOf[DeltaLog],
+    catalogTable,
+    deltaV2Snapshot) {
+
+  // Opt in to the base null-deltaLog guardrail: this transaction legitimately has no V1 DeltaLog
+  override protected def allowNullDeltaLog: Boolean = true
+
+  // Kernel-sourced path / conf.
+  override def dataPath: Path = deltaV2Snapshot.dataPath
+
+  override def logPath: Path = deltaV2Snapshot.logPath
+
+  // No V1 deltaLog to source a Hadoop conf from, so use the session Hadoop conf.
+  // scalastyle:off deltahadoopconfiguration
+  override def newDeltaHadoopConf(): Configuration = spark.sessionState.newHadoopConf()
+  // scalastyle:on deltahadoopconfiguration
+
+  // A Kernel-backed transaction maintains no V1 incremental-commit CRC state currently.
+  override protected def computeIncrementalCommitEnabled: Boolean = false
+  override protected def computeShouldVerifyIncrementalCommit: Boolean = false
+
+  // A Kernel-backed transaction has no V1 LogSegment (its snapshot's `logSegment` is null), so
+  // seed the pre-commit segment as null
+  override protected def initialPreCommitLogSegment: LogSegment = null
+
+  // Kernel snapshots have no V1 segment or commits to backfill.
+  // TODO: Before supporting coordinated commits or FsToCC, add Kernel recovery for interrupted
+  // CC->FS downgrades to prevent gaps in the backfilled commit sequence.
+  override protected def maybeBackfillOnConstruction(): Unit = ()
+
+  // A Kernel-backed transaction has no V1 DeltaLog to source a clock from; use a system clock
+  override def clock: Clock = new SystemClock
+
+
+  /**
+   * Commit-IO seam. Not implemented in this skeleton yet.
+   */
+  override protected[interop] def writeCommitFile(
+      attemptVersion: Long,
+      jsonActions: Iterator[String],
+      currentTransactionInfo: CurrentTransactionInfo)
+      : (Option[VersionChecksum], Commit, CurrentTransactionInfo) =
+    throw new UnsupportedOperationException(
+      "DeltaV2OptimisticTransaction commit is not implemented yet")
+}

--- a/spark-unified/src/main/scala/org/apache/spark/sql/delta/v2/interop/DeltaV2Snapshot.scala
+++ b/spark-unified/src/main/scala/org/apache/spark/sql/delta/v2/interop/DeltaV2Snapshot.scala
@@ -125,6 +125,10 @@ private[v2] class DeltaV2Snapshot(
   // dereference the null deltaLog.
   override def dataPath: Path = path
 
+  // The Delta log directory path, sourced from Kernel (parallels `dataPath`). Overrides the base
+  // SnapshotDescriptor.logPath
+  override def logPath: Path = new Path(kernelSnapshot.getLogPath.toString)
+
 
   // --- SnapshotDescriptor / state surface ----------------------------------------------------
 
@@ -172,6 +176,9 @@ private[v2] class DeltaV2Snapshot(
   override lazy val statsColumnSpec: DeltaStatsColumnSpec =
     StatisticsCollection.configuredDeltaStatsColumnSpec(metadata)
 
+
+  // --- ValidateChecksum: Kernel has no V1 checksum to validate; no-op ------------------------
+  override def validateChecksum(contextInfo: Map[String, String]): Boolean = true
 
   // --- V1 state-reconstruction paths: not yet used --------------------------------------------
   // The DeltaV2 read path sources its files from Kernel (`allFiles`), not from V1 log-replay state

--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/v2/interop/DeltaV2OptimisticTransactionSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/v2/interop/DeltaV2OptimisticTransactionSuite.scala
@@ -1,0 +1,136 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.v2.interop
+
+import java.io.File
+
+import org.apache.spark.sql.delta.DeltaLog
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import io.delta.kernel.Table
+import io.delta.kernel.defaults.engine.DefaultEngine
+import io.delta.kernel.internal.SnapshotImpl
+
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.util.SystemClock
+
+/**
+ * Tests for the [[DeltaV2OptimisticTransaction]] skeleton. This suite exercises the construction
+ * path only: a transaction can be built over a Kernel snapshot (with a null V1 `deltaLog`) and its
+ * read state (`readVersion`, `metadata`, `protocol`, `snapshot`) resolves from the wrapped
+ * [[DeltaV2Snapshot]]. The commit lifecycle is not yet implemented and must fail loudly.
+ */
+class DeltaV2OptimisticTransactionSuite
+    extends QueryTest
+    with SharedSparkSession
+    with DeltaSQLCommandTest {
+
+  /** Builds a Kernel-backed transaction over the latest snapshot of the table at `dir`. */
+  private def startKernelTxn(dir: File): DeltaV2OptimisticTransaction = {
+    // scalastyle:off deltahadoopconfiguration
+    // No DeltaLog here (the snapshot is loaded via Kernel), so use the session Hadoop conf.
+    val engine = DefaultEngine.create(spark.sessionState.newHadoopConf())
+    // scalastyle:on deltahadoopconfiguration
+    val kernelSnap = Table
+      .forPath(engine, dir.getCanonicalPath)
+      .getLatestSnapshot(engine)
+      .asInstanceOf[SnapshotImpl]
+    val deltaV2Snapshot = new DeltaV2Snapshot(kernelSnap, spark)
+    new DeltaV2OptimisticTransaction(catalogTable = None, deltaV2Snapshot)
+  }
+
+  /** Seeds a simple (unpartitioned) V1 Delta table at `dir`. */
+  private def seedTable(dir: File): Unit = {
+    spark.range(0, 5).toDF("id").coalesce(1)
+      .write.format("delta").save(dir.getCanonicalPath)
+  }
+
+  test("constructor succeeds and readVersion matches the seeded version") {
+    withTempDir { dir =>
+      seedTable(dir) // version 0
+      assert(startKernelTxn(dir).readVersion === 0L)
+
+      spark.range(0, 1).toDF("id")
+        .write.format("delta").mode("append").save(dir.getCanonicalPath) // version 1
+      assert(startKernelTxn(dir).readVersion === 1L)
+    }
+  }
+
+  test("metadata and protocol resolve from the Kernel snapshot and match V1") {
+    withTempDir { dir =>
+      seedTable(dir)
+      val txn = startKernelTxn(dir)
+      val log = DeltaLog.forTable(spark, dir.getCanonicalPath)
+      val v1 = log.update()
+
+      assert(txn.metadata.id === v1.metadata.id)
+      assert(txn.metadata.schemaString === v1.metadata.schemaString)
+      assert(txn.metadata.partitionColumns === v1.metadata.partitionColumns)
+      assert(txn.protocol === v1.protocol)
+
+      // The Kernel-sourced path overrides match the V1 DeltaLog's paths.
+      assert(txn.dataPath === log.dataPath)
+      assert(txn.logPath === log.logPath)
+    }
+  }
+
+  test("null-deltaLog construction overrides resolve without a V1 DeltaLog") {
+    withTempDir { dir =>
+      seedTable(dir)
+      val txn = startKernelTxn(dir)
+
+      // newDeltaHadoopConf: sourced from the session conf (no V1 deltaLog); non-null and usable.
+      val conf = txn.newDeltaHadoopConf()
+      assert(conf != null)
+      // Usable as a real Hadoop conf: can resolve a FileSystem for the table path.
+      assert(txn.dataPath.getFileSystem(conf) != null)
+
+      // clock: a Kernel-backed txn has no V1 DeltaLog clock; defaults to a SystemClock.
+      assert(txn.clock.isInstanceOf[SystemClock])
+
+    }
+  }
+
+  test("snapshot is the supplied DeltaV2Snapshot; construction works for a partitioned table") {
+    withTempDir { dir =>
+      spark.range(0, 6).toDF("id")
+        .selectExpr("id", "id % 2 as p")
+        .write.format("delta").partitionBy("p").save(dir.getCanonicalPath)
+
+      val txn = startKernelTxn(dir)
+      assert(txn.snapshot eq txn.deltaV2Snapshot)
+      assert(txn.deltaV2Snapshot.isInstanceOf[DeltaV2Snapshot])
+      assert(txn.metadata.partitionColumns === Seq("p"))
+    }
+  }
+
+  test("commit path is not implemented and fails loudly") {
+    withTempDir { dir =>
+      seedTable(dir)
+      val txn = startKernelTxn(dir)
+      // Call the commit chokepoint directly: going through txn.commit(...) would first reach the
+      // V1 prepareCommit machinery, which NPEs on the null deltaLog before this seam.
+      val e = intercept[UnsupportedOperationException] {
+        txn.writeCommitFile(
+          attemptVersion = txn.readVersion + 1L,
+          jsonActions = Iterator.empty,
+          currentTransactionInfo = null)
+      }
+      assert(e.getMessage.contains("not implemented"))
+    }
+  }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -279,6 +279,21 @@ trait OptimisticTransactionImpl extends TransactionHelper
   with DeltaLoggingProvider {
 
   /**
+   * Whether this transaction may be constructed without a V1 [[DeltaLog]]. Defaults to `false`:
+   * a V1 transaction must always have a real `deltaLog`. Only the Kernel-backed
+   * [[org.apache.spark.sql.delta.v2.interop.DeltaV2OptimisticTransaction]] legitimately
+   * has none and opts in by overriding this.
+   */
+  protected def allowNullDeltaLog: Boolean = false
+
+  // Invariant: a V1 OptimisticTransaction must always be constructed with a non-null deltaLog.
+  // Guards against accidentally constructing one with null deltaLog which would otherwise
+  // surface as a confusing NPE deep in the commit path rather than at construction.
+  require(
+    allowNullDeltaLog || deltaLog != null,
+    "A V1 OptimisticTransaction must be constructed with a non-null deltaLog.")
+
+  /**
    * Recording tags for this transaction, anchored to the read snapshot's `metadata.id`. Lets
    * `recordDeltaEvent(txn, ...)` attribute events to the table being mutated without reaching
    * through `txn.deltaLog`.
@@ -290,8 +305,12 @@ trait OptimisticTransactionImpl extends TransactionHelper
 
   // Intentionally cache the values of these configs to ensure stable commit code path
   // and avoid race conditions between committing and dynamic config changes.
-  protected val incrementalCommitEnabled = deltaLog.incrementalCommitEnabled
-  protected val shouldVerifyIncrementalCommit = deltaLog.shouldVerifyIncrementalCommit
+  // The cached vals are initialized from overridable compute-hooks.
+  protected def computeIncrementalCommitEnabled: Boolean = deltaLog.incrementalCommitEnabled
+  protected def computeShouldVerifyIncrementalCommit: Boolean =
+    deltaLog.shouldVerifyIncrementalCommit
+  protected val incrementalCommitEnabled = computeIncrementalCommitEnabled
+  protected val shouldVerifyIncrementalCommit = computeShouldVerifyIncrementalCommit
   protected val forcedChecksumValidationInterval =
     spark.conf.get(DeltaSQLConf.FORCED_CHECKSUM_VALIDATION_INTERVAL)
   protected val forcedChecksumValidationMinTimeIntervalMinutes =
@@ -302,6 +321,8 @@ trait OptimisticTransactionImpl extends TransactionHelper
   override def dataPath: Path = deltaLog.dataPath
 
   override def logPath: Path = deltaLog.logPath
+
+  override def newDeltaHadoopConf(): Configuration = deltaLog.newDeltaHadoopConf()
 
   // This would be a quick operation if we already validated the checksum
   // Otherwise, we should at least perform the validation here.
@@ -567,11 +588,17 @@ trait OptimisticTransactionImpl extends TransactionHelper
   protected[delta] var isBlindAppend: Boolean = false
 
   /**
+   * The initial value of [[preCommitLogSegment]]. V1 copies the read snapshot's own
+   * [[LogSegment]].
+   */
+  protected def initialPreCommitLogSegment: LogSegment =
+    snapshot.logSegment.copy(checkpointProvider = snapshot.checkpointProvider)
+
+  /**
    * The logSegment of the snapshot prior to the commit.
    * Will be updated only when retrying due to a conflict.
    */
-  private[delta] var preCommitLogSegment: LogSegment =
-    snapshot.logSegment.copy(checkpointProvider = snapshot.checkpointProvider)
+  private[delta] var preCommitLogSegment: LogSegment = initialPreCommitLogSegment
 
   /** The end to end execution time of this transaction. */
   def txnExecutionTimeMs: Option[Long] = if (commitEndNano == -1) {
@@ -1733,7 +1760,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
   ): Unit = {
     // If this transaction commits to the redirect destination location, then there is no
     // need to validate the subsequent no-redirect rules.
-    val configuration = deltaLog.newDeltaHadoopConf()
+    val configuration = newDeltaHadoopConf()
     val tableDataPath = dataPath.toUri.getPath
     val catalog = spark.sessionState.catalog
     val isRedirectDest = redirectConfig.spec.isRedirectDest(catalog, configuration, tableDataPath)
@@ -2249,7 +2276,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
               deltaLog.update(catalogTableOpt = catalogTable))
             val logs = deltaLog.store.readAsIterator(
               fileProvider.deltaFile(attemptVersion),
-              deltaLog.newDeltaHadoopConf())
+              newDeltaHadoopConf())
             try {
               val winningCommitActions = logs.map(Action.fromJson)
               val commitInfo = winningCommitActions.collectFirst { case a: CommitInfo => a }
@@ -2676,7 +2703,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
 
   private[delta] def isCommitLockEnabled: Boolean = {
     spark.sessionState.conf.getConf(DeltaSQLConf.DELTA_COMMIT_LOCK_ENABLED).getOrElse(
-      deltaLog.store.isPartialWriteVisible(logPath, deltaLog.newDeltaHadoopConf()))
+      deltaLog.store.isPartialWriteVisible(logPath, newDeltaHadoopConf()))
   }
 
   private def lockCommitIfEnabled[T](body: => T): T = {
@@ -3414,5 +3441,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
 
   // Backfill any unbackfilled commits if coordinated commits are disabled -- in the Optimistic
   // Transaction constructor.
-  CoordinatedCommitsUtils.backfillWhenCoordinatedCommitsDisabled(snapshot)
+  protected def maybeBackfillOnConstruction(): Unit =
+    CoordinatedCommitsUtils.backfillWhenCoordinatedCommitsDisabled(snapshot)
+  maybeBackfillOnConstruction()
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/TransactionHelper.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/TransactionHelper.scala
@@ -33,6 +33,7 @@ import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.stats.{FileSizeHistogram, FileSizeHistogramUtils}
 import org.apache.spark.sql.util.ScalaExtensions._
+import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.internal.MDC
@@ -50,6 +51,9 @@ trait TransactionHelper extends DeltaLogging {
 
   /** The path to the Delta log directory. */
   def logPath: Path
+
+  /** The Hadoop [[Configuration]] used to access the Delta log. */
+  def newDeltaHadoopConf(): Configuration = deltaLog.newDeltaHadoopConf()
 
   def catalogTable: Option[CatalogTable]
   def snapshot: Snapshot

--- a/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
@@ -334,6 +334,16 @@ class OptimisticTransactionSuite
     }
   }
 
+  test("newDeltaHadoopConf resolves to deltaLog.newDeltaHadoopConf") {
+    withTempDir { tempDir =>
+      val log = DeltaLog.forTable(spark, new Path(tempDir.getCanonicalPath))
+      val txn = log.startTransaction()
+      def asMap(conf: org.apache.hadoop.conf.Configuration): Map[String, String] =
+        conf.iterator().asScala.map(e => e.getKey -> e.getValue).toMap
+      assert(asMap(txn.newDeltaHadoopConf()) === asMap(log.newDeltaHadoopConf()))
+    }
+  }
+
   test("enabling Coordinated Commits on an existing table should create commit dir") {
     withTempDir { tempDir =>
       val log = DeltaLog.forTable(spark, new Path(tempDir.getAbsolutePath))


### PR DESCRIPTION
## Description

This change refactors `OptimisticTransaction` to introduce a few overridable seams so that alternative transaction backends can reuse the shared commit machinery without requiring a concrete `DeltaLog`:

- Add a `allowNullDeltaLog` hook (default `false`) plus a construction-time `require` that a transaction always has a non-null `deltaLog` unless a subclass explicitly opts out.
- Route `incrementalCommitEnabled` / `shouldVerifyIncrementalCommit` through overridable `compute*` hooks instead of reading `deltaLog` directly.
- Extract `initialPreCommitLogSegment` and `maybeBackfillOnConstruction()` as overridable members so subclasses can supply their own initialization.
- Add `newDeltaHadoopConf()` on `TransactionHelper` (defaulting to `deltaLog.newDeltaHadoopConf()`) and route existing call sites through it.
- Override `logPath` on the Kernel-backed snapshot to source the log directory from the snapshot.

These are additive, behavior-preserving refactors for the default path: existing transactions continue to read everything from `deltaLog`.

## How was this patch tested?

Added a unit test asserting `OptimisticTransaction.newDeltaHadoopConf()` resolves to `deltaLog.newDeltaHadoopConf()`. Existing `OptimisticTransactionSuite` coverage exercises the unchanged default commit path.

## Does this PR introduce _any_ user-facing changes?

No.
