### PR TITLE
Plumb Adaptive Metadata Tree back references onto file actions

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
@@ -1266,7 +1266,7 @@ object Checkpoints
       additionalCols ++= partitionValues
       additionalCols ++= Checkpoints.extractStats(snapshot.statsSchema, "add.stats")
     }
-    state.withColumn("add",
+    val withAdd = state.withColumn("add",
       when(col("add").isNotNull, struct(Seq(
         col("add.path"),
         col("add.partitionValues"),
@@ -1281,6 +1281,27 @@ object Checkpoints
         additionalCols: _*
       ))
     )
+    if (sessionConf.getConf(DeltaSQLConf.CHECKPOINT_DROP_BACK_REFERENCE_ENABLED)) {
+      dropStructField(withAdd, "remove", "backReference")
+    } else {
+      withAdd
+    }
+  }
+
+  /**
+   * Returns `df` with `field` removed from the top-level struct column `column`.
+   */
+  private def dropStructField(df: DataFrame, column: String, field: String): DataFrame = {
+    val structType = df.schema(column).dataType.asInstanceOf[StructType]
+    if (!structType.fieldNames.contains(field)) {
+      df
+    } else {
+      val keptCols = structType.fieldNames.iterator
+        .filterNot(_ == field)
+        .map(name => col(s"$column.$name"))
+        .toSeq
+      df.withColumn(column, when(col(column).isNotNull, struct(keptCols: _*)))
+    }
   }
 
   def shouldWriteStatsAsStruct(conf: SQLConf, snapshot: SnapshotDescriptor): Boolean = {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
@@ -564,7 +564,8 @@ class Snapshot(
             col("add.deletionVector"),
             col("add.baseRowId"),
             col("add.defaultRowCommitVersion"),
-            col("add.clusteringProvider")
+            col("add.clusteringProvider"),
+            col("add.backReference")
           )))
         .withColumn("remove", when(
           col("remove.path").isNotNull,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -33,7 +33,7 @@ import org.apache.spark.sql.delta.ClassicColumnConversions._
 import org.apache.spark.sql.delta.commands.DeletionVectorUtils
 import org.apache.spark.sql.delta.metering.{DeltaLogging, DeltaLoggingProvider}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
-import org.apache.spark.sql.delta.util.{DeltaFileOperations, JsonUtils, Utils => DeltaUtils}
+import org.apache.spark.sql.delta.util.{DeltaEncoder, DeltaFileOperations, JsonUtils, Utils => DeltaUtils}
 import org.apache.spark.sql.delta.util.FileNames
 import org.apache.spark.sql.delta.util.PartitionUtils
 import com.fasterxml.jackson.annotation._
@@ -915,7 +915,8 @@ case class AddFile(
     baseRowId: Option[Long] = None,
     @JsonDeserialize(contentAs = classOf[java.lang.Long])
     defaultRowCommitVersion: Option[Long] = None,
-    clusteringProvider: Option[String] = None
+    clusteringProvider: Option[String] = None,
+    backReference: Option[BackReference] = None
 ) extends FileAction with HasNumRecords {
   require(path.nonEmpty)
 
@@ -935,7 +936,8 @@ case class AddFile(
       deletionVector = deletionVector,
       baseRowId = baseRowId,
       defaultRowCommitVersion = defaultRowCommitVersion,
-      stats = stats
+      stats = stats,
+      backReference = backReference
     )
     // scalastyle:on
   }
@@ -1126,6 +1128,29 @@ object AddFile {
 }
 
 /**
+ * A back reference points a file action at the exact location of its source entry inside a
+ * Adaptive Metadata Tree (AMT) leaf manifest.
+ *
+ * @param manifest The canonical path of the AMT leaf manifest that held the source entry (the leaf
+ *                 DATA_MANIFEST `location`).
+ * @param pos      The 0-based position of the entry within that leaf. This equals the parquet
+ *                 `_metadata.row_index` of the leaf row, which is the same ordinal the MDV bitmap
+ *                 indexes.
+ */
+case class BackReference(
+    manifest: String,
+    pos: Long)
+
+object BackReference {
+
+  final lazy val STRUCT_TYPE: StructType =
+    Action.addFileSchema("backReference").dataType.asInstanceOf[StructType]
+
+  private lazy val _encoder = new DeltaEncoder[BackReference]
+  implicit def encoder: Encoder[BackReference] = _encoder.get
+}
+
+/**
  * Logical removal of a given file from the reservoir. Acts as a tombstone before a file is
  * deleted permanently.
  *
@@ -1155,7 +1180,8 @@ case class RemoveFile(
     baseRowId: Option[Long] = None,
     @JsonDeserialize(contentAs = classOf[java.lang.Long])
     defaultRowCommitVersion: Option[Long] = None,
-    override val stats: String = null
+    override val stats: String = null,
+    backReference: Option[BackReference] = None
 ) extends FileAction with HasNumRecords {
   override def wrap: SingleAction = SingleAction(remove = this)
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTCheckpointProvider.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTCheckpointProvider.scala
@@ -18,11 +18,15 @@ package org.apache.spark.sql.delta.amt
 
 import org.apache.spark.sql.delta.{CheckpointPolicy, CheckpointProvider, DeltaLog, DeltaLogFileIndex, Snapshot}
 import org.apache.spark.sql.delta.DeltaLogFileIndex.COMMIT_VERSION_COLUMN
-import org.apache.spark.sql.delta.actions.{Checkpoint, ContentRoot, SingleAction}
+import org.apache.spark.sql.delta.actions.{BackReference, Checkpoint, ContentRoot, SingleAction}
+import org.apache.spark.sql.delta.util.DeltaEncoder
 import org.apache.hadoop.fs.{FileStatus, Path}
 
-import org.apache.spark.sql.{DataFrame, Dataset, SparkSession}
-import org.apache.spark.sql.functions.{col, lit}
+import org.apache.spark.paths.SparkPath
+import org.apache.spark.sql.{DataFrame, Dataset, Encoder, SparkSession}
+import org.apache.spark.sql.execution.datasources.FileFormat.{FILE_PATH, METADATA_NAME}
+import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
+import org.apache.spark.sql.functions.{col, lit, struct}
 import org.apache.spark.sql.types.StructType
 
 /**
@@ -118,11 +122,20 @@ final class AMTCheckpointProvider(
     import org.apache.spark.sql.delta.implicits._
     val tableRoot = deltaLog.dataPath
     val paths = new Path(contentRoot.path) +: leaves.map(l => new Path(l.path))
-    AMTCheckpointProvider.loadEntries(spark, deltaLog, paths)
-      .where(col("content_type") === lit(AMTSingleAction.ContentType.Type.Data))
-      .map { entry =>
-        entry.unwrap match {
-          case data: DataEntry => SingleAction(add = data.toAddFile(tableRoot))
+    val encodedRootPath = SparkPath.fromPathString(contentRoot.path).urlEncoded
+    AMTCheckpointProvider.loadEntriesWithLocation(spark, deltaLog, paths)
+      .where(col("entry.content_type") === lit(AMTSingleAction.ContentType.Type.Data))
+      .map { entryWithLoc =>
+        entryWithLoc.entry.unwrap match {
+          case data: DataEntry =>
+            val backReference = if (entryWithLoc.leafPath == encodedRootPath) {
+              None
+            } else {
+              Some(BackReference(
+                SparkPath.fromUrlString(entryWithLoc.leafPath).toPath.toString, entryWithLoc.pos))
+            }
+            val add = data.toAddFile(tableRoot).copy(backReference = backReference)
+            SingleAction(add = add)
           case other => throw new IllegalStateException(
             s"Expected a DATA entry after filtering, got ${other.getClass.getSimpleName}.")
         }
@@ -140,6 +153,20 @@ object AMTCheckpointProvider {
    * @param numEntries  Number of content entries the leaf holds (`record_count`).
    */
   case class LeafInfo(path: String, sizeInBytes: Long, numEntries: Long)
+
+  /**
+   * An [[AMTSingleAction]] entry paired with its physical read location in its manifest parquet.
+   *
+   * @param entry    The manifest content entry.
+   * @param leafPath The URL-encoded absolute path of the manifest parquet the entry was read from
+   *                 (Spark's `_metadata.file_path`).
+   * @param pos      The 0-based position of the entry inside the manifest (Spark's
+   *                 `_metadata.row_index`).
+   */
+  case class AMTDataEntryWithLocation(entry: AMTSingleAction, leafPath: String, pos: Long)
+
+  private lazy val amtDataEntryWithLocationEncoder: Encoder[AMTDataEntryWithLocation] =
+    new DeltaEncoder[AMTDataEntryWithLocation].get
 
   /**
    * Builds a provider from an emitted [[Checkpoint]] action by reading the leaf pointers out of the
@@ -178,5 +205,26 @@ object AMTCheckpointProvider {
     val index = DeltaLogFileIndex(DeltaLogFileIndex.CHECKPOINT_FILE_FORMAT_PARQUET, fs, paths)
     deltaLog.loadIndex(index, spark.emptyDataset[AMTSingleAction].schema)
       .as[AMTSingleAction]
+  }
+
+  /**
+   * Like [[loadEntries]], but also captures each row's physical read location.
+   */
+  private def loadEntriesWithLocation(
+      spark: SparkSession,
+      deltaLog: DeltaLog,
+      paths: Seq[Path]): Dataset[AMTDataEntryWithLocation] = {
+    import org.apache.spark.sql.delta.implicits._
+    implicit val entryLocEncoder: Encoder[AMTDataEntryWithLocation] =
+      amtDataEntryWithLocationEncoder
+    val fs = paths.head.getFileSystem(deltaLog.newDeltaHadoopConf())
+    val index = DeltaLogFileIndex(DeltaLogFileIndex.CHECKPOINT_FILE_FORMAT_PARQUET, fs, paths)
+    val amtSchema = spark.emptyDataset[AMTSingleAction].schema
+    deltaLog.loadIndex(index, amtSchema)
+      .select(
+        struct(amtSchema.fieldNames.toIndexedSeq.map(col): _*).as("entry"),
+        col(s"$METADATA_NAME.$FILE_PATH").as("leafPath"),
+        col(s"$METADATA_NAME.${ParquetFileFormat.ROW_INDEX}").as("pos"))
+      .as[AMTDataEntryWithLocation]
   }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -1483,6 +1483,17 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .booleanConf
       .createOptional
 
+  val CHECKPOINT_DROP_BACK_REFERENCE_ENABLED =
+    buildConf("checkpoint.dropBackReference.enabled")
+      .internal()
+      .doc("""
+          |When enabled, the Adaptive Metadata Tree `backReference` field is stripped from
+          |the add/remove structs before a classic/V2 checkpoint is written, so that non-AMT
+          |checkpoints stay byte-identical to before the AMT back-reference feature.
+          |""".stripMargin)
+      .booleanConf
+      .createWithDefault(true)
+
   val LAST_CHECKPOINT_SIDECARS_THRESHOLD =
     buildConf("lastCheckpoint.sidecars.threshold")
       .internal()

--- a/spark/src/test/scala/org/apache/spark/sql/delta/ActionSerializerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/ActionSerializerSuite.scala
@@ -103,6 +103,47 @@ class ActionSerializerSuite extends QueryTest with SharedSparkSession with Delta
     assert(action2.json === json2.replaceAll("\\s", ""))
   }
 
+  test("AddFile - backReference json serialization/deserialization") {
+    val withBackRef = AddFile(
+      path = "a",
+      partitionValues = Map.empty,
+      size = 1,
+      modificationTime = 2,
+      dataChange = false,
+      backReference = Some(BackReference(manifest = "metadata/leaf-1.parquet", pos = 7L)))
+    assert(withBackRef.json.contains("\"backReference\":{\"manifest\":" +
+      "\"metadata/leaf-1.parquet\",\"pos\":7}"))
+    assert(Action.fromJson(withBackRef.json) === withBackRef)
+
+    // Absent (default None) -> omitted from the serialized action.
+    val withoutBackRef = AddFile("a", Map.empty, 1, 2, dataChange = false)
+    assert(!withoutBackRef.json.contains("backReference"))
+    assert(Action.fromJson(withoutBackRef.json).asInstanceOf[AddFile].backReference.isEmpty)
+  }
+
+  test("RemoveFile - backReference json serialization/deserialization") {
+    val withBackRef = RemoveFile(
+      path = "a",
+      deletionTimestamp = Some(1L),
+      backReference = Some(BackReference(manifest = "metadata/leaf-2.parquet", pos = 3L)))
+    assert(withBackRef.json.contains("\"backReference\":{\"manifest\":" +
+      "\"metadata/leaf-2.parquet\",\"pos\":3}"))
+    assert(Action.fromJson(withBackRef.json) === withBackRef)
+
+    val withoutBackRef = RemoveFile("a", Some(1L))
+    assert(!withoutBackRef.json.contains("backReference"))
+    assert(Action.fromJson(withoutBackRef.json).asInstanceOf[RemoveFile].backReference.isEmpty)
+  }
+
+  test("AddFile back reference propagates to removeWithTimestamp and copy") {
+    val backRef = Some(BackReference(manifest = "metadata/leaf-3.parquet", pos = 11L))
+    val add = AddFile("a", Map.empty, 1, 2, dataChange = true, backReference = backRef)
+    // removeWithTimestamp -> tombstone inherits the back reference.
+    assert(add.removeWithTimestamp().backReference == backRef)
+    // copy (the mechanism the superseding AddFile of removeRows relies on) preserves it.
+    assert(add.copy(dataChange = false).backReference == backRef)
+  }
+
   // This is the same test as "removefile" in OSS, but due to a Jackson library upgrade the behavior
   // has diverged between Spark 3.1 and Spark 3.2.
   // We don't believe this is a practical issue because all extant versions of Delta explicitly

--- a/spark/src/test/scala/org/apache/spark/sql/delta/CheckpointsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CheckpointsSuite.scala
@@ -45,7 +45,7 @@ import org.apache.hadoop.util.Progressable
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.{QueryTest, Row}
 import org.apache.spark.sql.catalyst.TableIdentifier
-import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.functions.{col, lit, when}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.StructType
@@ -723,6 +723,43 @@ class CheckpointsSuite
     }
   }
 
+  test("non-AMT tables do not persist backReference in checkpoint or commit JSON") {
+    withClassicCheckpointPolicyForCatalogOwned {
+      withTempDir { tempDir =>
+        val tablePath = tempDir.getAbsolutePath
+        spark.range(end = 10).write.format("delta").mode("overwrite").save(tablePath)
+        sql(s"DELETE FROM delta.`$tablePath` WHERE id < 5")
+
+        val deltaLog = DeltaLog.forTable(spark, tablePath)
+        deltaLog.checkpoint()
+        val version = deltaLog.snapshot.version
+
+        // 1. The classic checkpoint parquet must not carry backReference on add or remove.
+        val checkpointFile =
+          FileNames.checkpointFileSingular(deltaLog.logPath, version).toString
+        val checkpointSchema = spark.read.format("parquet").load(checkpointFile).schema
+        val addFields =
+          checkpointSchema("add").dataType.asInstanceOf[StructType].fieldNames.toSeq
+        val removeFields =
+          checkpointSchema("remove").dataType.asInstanceOf[StructType].fieldNames.toSeq
+        assert(!addFields.contains("backReference"),
+          s"checkpoint add struct must not contain backReference, got: $addFields")
+        assert(!removeFields.contains("backReference"),
+          s"checkpoint remove struct must not contain backReference, got: $removeFields")
+
+        // 2. No commit JSON should mention backReference (null fields are omitted from JSON).
+        val commitProvider = DeltaCommitFileProvider(deltaLog.unsafeVolatileSnapshot)
+        val hadoopConf = deltaLog.newDeltaHadoopConf()
+        (0L to version).foreach { v =>
+          val deltaFile = commitProvider.deltaFile(v)
+          val content = deltaLog.store.read(deltaFile, hadoopConf)
+          assert(!content.exists(_.contains("backReference")),
+            s"commit JSON for version $v must not contain backReference: ${content.mkString("\n")}")
+        }
+      }
+    }
+  }
+
   test("checkpoint with DVs") {
     for (v2Checkpoint <- Seq(true, false))
     withTempDir { tempDir =>
@@ -1049,6 +1086,12 @@ class CheckpointsSuite
 
     val actionsToWrite = Checkpoints
       .buildCheckpoint(actionsDS, snapshot)
+      // buildCheckpoint drops backReference from the on-disk add/remove shape so we need to
+      // re-materialize it as a null column before .as[SingleAction].
+      .withColumn("add", when(col("add.path").isNotNull,
+        col("add").withField("backReference", lit(null).cast(BackReference.STRUCT_TYPE))))
+      .withColumn("remove", when(col("remove.path").isNotNull,
+        col("remove").withField("backReference", lit(null).cast(BackReference.STRUCT_TYPE))))
       .as[SingleAction]
       .collect()
       .toSeq


### PR DESCRIPTION
## Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other

## Description

This PR adds reader-side plumbing for **Adaptive Metadata Tree (AMT) back references** on Delta file actions.

A back reference points a file action at the exact location of its source entry inside an AMT leaf manifest: the canonical path of the leaf manifest plus the 0-based position of the entry within that leaf. This lets a future manifest-commit writer create a Manifest Deletion Vector (MDV) in O(1) without rescanning the tree.

The change:
- Stamps back-reference info during `AMTCheckpointProvider.loadActionsForStateReconstruction` for each `AddFile` action, capturing the manifest path and row position via `_metadata.file_path` / `_metadata.row_index`.
- Preserves the field across `Snapshot.stateReconstruction`.
- Propagates it to every `RemoveFile` and every superseding `AddFile` through `AddFile.removeWithTimestamp` and `copy`.
- Adds a config (`checkpoint.dropBackReference.enabled`, default `true`) that strips the `backReference` field from add/remove structs before a classic/V2 checkpoint is written, so non-AMT checkpoints stay byte-identical to before this change.

This is **reader-side plumbing only**; no writer consumes the back references yet. The field defaults to `None` and is omitted from JSON when unset, so non-AMT tables and existing logs are unaffected.

## How was this patch tested?

Unit tests:
- `AddFile`/`RemoveFile` back-reference JSON serialization/deserialization, including that the field is omitted when absent.
- Back reference propagation through `removeWithTimestamp` and `copy`.
- Non-AMT tables do not persist `backReference` in checkpoint parquet or commit JSON.

## Does this PR introduce _any_ user-facing changes?

No.
