### PR TITLE
[Build] Bump pinned Unity Catalog SHA to 163045b

### DIFF
--- a/project/scripts/setup_unitycatalog_main.sh
+++ b/project/scripts/setup_unitycatalog_main.sh
@@ -83,7 +83,7 @@ set -euo pipefail
 # The pin. Bump both lines together if UC's version.sbt changed at the new SHA. build.sbt's
 # `unityCatalogVersion` is obtained by running this script with `--print-version`, so these two
 # values are the single source of truth.
-UC_PIN_SHA=b11188d2a92c9bf1395d03be4235706af26b2c45
+UC_PIN_SHA=163045b949760c08dfb9a1883d6fec5ac53663a9
 UC_BASE_VERSION=0.6.0-SNAPSHOT
 # ---------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
## Description

Advances the pinned `unitycatalog/unitycatalog` commit in `project/scripts/setup_unitycatalog_main.sh` from `b11188d2a` to `163045b949760c08dfb9a1883d6fec5ac53663a9` (current UC `main`).

New commits picked up (2):
- [`163045b94`](https://github.com/unitycatalog/unitycatalog/commit/163045b949760c08dfb9a1883d6fec5ac53663a9) Add configurable expiry for UC access tokens issued by token exchange (#1689)
- [`ed504deea`](https://github.com/unitycatalog/unitycatalog/commit/ed504deea) [Server] Fail-closed guard for PAYLOAD-source authorization (#1494)

UC's `version.sbt` is still `0.6.0-SNAPSHOT` at the new SHA, so `UC_BASE_VERSION` is unchanged (only the SHA line moves). The new SHA is a fast-forward descendant of the previous pin on UC `main`.

## How was this patch tested?

Pin-bump only; relies on CI to build the UC jars from the new SHA and run the Spark/kernel UC suites.