### PR TITLE
Emit historical protocols for Delta Sharing streaming queries

### DIFF
--- a/sharing/src/main/scala/io/delta/sharing/spark/DeltaFormatSharingSource.scala
+++ b/sharing/src/main/scala/io/delta/sharing/spark/DeltaFormatSharingSource.scala
@@ -844,18 +844,26 @@ case class DeltaFormatSharingSource(
     } else {
       // If isStartingVersion is false, it means to fetch files for data changes since fromVersion,
       // not including files from previous versions.
+      // includeHistoricalProtocol requests a Protocol action for each protocol change inside the
+      // version range, so a mid-range protocol upgrade (e.g. enabling deletionVectors) is reflected
+      // in the local delta log instead of leaving the client on a stale head protocol. Gated by a
+      // default-off flag; when off the client keeps the legacy single-head-protocol behavior.
+      val includeHistoricalProtocol =
+        sqlConf.getConf(DeltaSQLConf.DELTA_SHARING_STREAMING_ENABLE_HISTORICAL_PROTOCOL)
       val tableFiles = client.getFiles(
         table = table,
         startingVersion = startingOffset.reservoirVersion,
         endingVersion = Some(endingVersionForQuery),
-        fileIdHash = fileIdHash
+        fileIdHash = fileIdHash,
+        includeHistoricalProtocol = includeHistoricalProtocol
       )
       val refreshFunc = DeltaSharingUtils.getRefresherForGetFilesWithStartingVersion(
         client = client,
         table = table,
         startingVersion = startingOffset.reservoirVersion,
         endingVersion = Some(endingVersionForQuery),
-        fileIdHash = fileIdHash
+        fileIdHash = fileIdHash,
+        includeHistoricalProtocol = includeHistoricalProtocol
       )
       logInfo(
         s"Fetched ${tableFiles.lines.size} lines from startingVersion " +

--- a/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingLogFileSystem.scala
+++ b/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingLogFileSystem.scala
@@ -571,6 +571,7 @@ private[sharing] object DeltaSharingLogFileSystem extends Logging {
     val versionToDeltaSharingFileActions =
       scala.collection.mutable.Map[Long, ArrayBuffer[model.DeltaSharingFileAction]]()
     val versionToMetadata = scala.collection.mutable.Map[Long, model.DeltaSharingMetadata]()
+    val versionToProtocol = scala.collection.mutable.Map[Long, model.DeltaSharingProtocol]()
     val versionToJsonLogBuilderMap = scala.collection.mutable.Map[Long, ArrayBuffer[String]]()
     val versionToJsonLogSize = scala.collection.mutable.Map[Long, Long]().withDefaultValue(0L)
     var numFileActionsInMinVersion = 0
@@ -603,7 +604,23 @@ private[sharing] object DeltaSharingLogFileSystem extends Logging {
             startingMetadataLineOpt = Some(metadata.deltaMetadata.json + "\n")
           }
         case protocol: model.DeltaSharingProtocol =>
-          startingProtocolLineOpt = Some(protocol.deltaProtocol.json + "\n")
+          if (protocol.version != null) {
+            // This is to handle the cdf and streaming query result when the client opts in to
+            // historical protocols: the server streams a Protocol for each protocol change inside
+            // the version range, each carrying the version it was committed at. Mirror the
+            // versioned metadata handling above: the head protocol (at minVersion) seeds
+            // minVersion.json, and later protocol changes are written to their own version.json.
+            minVersion = minVersion.min(protocol.version)
+            maxVersion = maxVersion.max(protocol.version)
+            versionToProtocol(protocol.version) = protocol
+            if (protocol.version == minVersion) {
+              startingProtocolLineOpt = Some(protocol.deltaProtocol.json + "\n")
+            }
+          } else {
+            // This is to handle the snapshot query result, or the response of a server that
+            // doesn't emit historical protocols: a single head protocol with no version.
+            startingProtocolLineOpt = Some(protocol.deltaProtocol.json + "\n")
+          }
         case _ => // do nothing, ignore the line.
       }
     }
@@ -642,6 +659,20 @@ private[sharing] object DeltaSharingLogFileSystem extends Logging {
             ArrayBuffer[String]()
           ) += metadataStr
           versionToJsonLogSize(version) += metadataStr.getBytes(StandardCharsets.UTF_8).length
+        }
+    }
+    // Write historical protocols to the delta log json file. The head protocol at minVersion is
+    // already seeded into minVersion.json above (via startingProtocolLineOpt), so only later
+    // protocol changes are written here, mirroring the historical metadata handling.
+    versionToProtocol.foreach {
+      case (version, protocol) =>
+        if (version != minVersion) {
+          val protocolStr = protocol.deltaProtocol.json + "\n"
+          versionToJsonLogBuilderMap.getOrElseUpdate(
+            version,
+            ArrayBuffer[String]()
+          ) += protocolStr
+          versionToJsonLogSize(version) += protocolStr.getBytes(StandardCharsets.UTF_8).length
         }
     }
     // Write file actions to the delta log json file.

--- a/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingUtils.scala
+++ b/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingUtils.scala
@@ -244,14 +244,16 @@ object DeltaSharingUtils extends Logging {
       table: Table,
       startingVersion: Long,
       endingVersion: Option[Long],
-      fileIdHash: Option[String] = None): RefresherFunction = { (_: Option[String]) =>
+      fileIdHash: Option[String] = None,
+      includeHistoricalProtocol: Boolean = false): RefresherFunction = { (_: Option[String]) =>
     {
       val tableFiles = client
         .getFiles(
           table = table,
           startingVersion = startingVersion,
           endingVersion = endingVersion,
-          fileIdHash = fileIdHash
+          fileIdHash = fileIdHash,
+          includeHistoricalProtocol = includeHistoricalProtocol
         )
       getTableRefreshResult(tableFiles)
     }

--- a/sharing/src/main/scala/io/delta/sharing/spark/model.scala
+++ b/sharing/src/main/scala/io/delta/sharing/spark/model.scala
@@ -63,10 +63,18 @@ case class DeltaSharingSingleAction(
 }
 
 /**
- * The delta sharing protocol from the response of a rpc. It only wraps a delta protocol now, but
- * can be extended with additional delta sharing fields if needed later.
+ * The delta sharing protocol from the response of a rpc.
+ * It wraps a delta protocol, and adds one delta sharing field:
+ *     - version: the version the protocol was committed at, used to generate the faked delta log
+ *                file on the client side. It is null for a snapshot query (single head protocol)
+ *                and for the response of a server that doesn't emit historical protocols; it is set
+ *                for each protocol change streamed by a cdf/streaming query when the client opts in
+ *                via includeHistoricalProtocol.
  */
-case class DeltaSharingProtocol(deltaProtocol: Protocol) extends DeltaSharingAction {
+case class DeltaSharingProtocol(
+    deltaProtocol: Protocol,
+    version: java.lang.Long = null)
+    extends DeltaSharingAction {
 
   override def wrap: DeltaSharingSingleAction = DeltaSharingSingleAction(protocol = this)
 }

--- a/sharing/src/test/scala/io/delta/sharing/spark/DeltaFormatSharingSourceSuite.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/DeltaFormatSharingSourceSuite.scala
@@ -18,7 +18,7 @@ package io.delta.sharing.spark
 
 import java.time.LocalDateTime
 
-import org.apache.spark.sql.delta.{DeltaIllegalStateException, DeltaLog}
+import org.apache.spark.sql.delta.{DeltaIllegalStateException, DeltaLog, DeltaTableFeatureException}
 import org.apache.spark.sql.delta.DeltaOptions.{
   IGNORE_CHANGES_OPTION,
   IGNORE_DELETES_OPTION,
@@ -154,6 +154,45 @@ class DeltaFormatSharingSourceSuite
     val offsetContent =
       s"v1\n$offsetMetadataJson\n$legacyOffsetJson"
         .getBytes(java.nio.charset.StandardCharsets.UTF_8)
+    val offsetPath = new Path(new Path(checkpointPath, offsetsDir), batchId.toString)
+    val offsetOut = fileManager.createAtomic(offsetPath, overwriteIfPossible = true)
+    offsetOut.write(offsetContent)
+    offsetOut.close()
+    val commitContent = s"v1\n${CommitMetadata(batchId).json}"
+      .getBytes(java.nio.charset.StandardCharsets.UTF_8)
+    val commitPath = new Path(new Path(checkpointPath, commitsDir), batchId.toString)
+    val commitOut = fileManager.createAtomic(commitPath, overwriteIfPossible = true)
+    commitOut.write(commitContent)
+    commitOut.close()
+  }
+
+  /**
+   * Write a (non-legacy) DeltaSourceOffset and its corresponding commit entry into a streaming
+   * checkpoint directory, so a stream started against that checkpoint resumes from the given offset
+   * instead of loading an initial snapshot. Uses the real DeltaSourceOffset serialization so the
+   * offset parses as delta-format (carrying reservoirId), exercising the incremental
+   * getFiles(startingVersion, endingVersion) path.
+   */
+  private def writeDeltaSourceOffsetAndCommit(
+      fileManager: CheckpointFileManager,
+      checkpointPath: Path,
+      batchId: Long,
+      tableId: String,
+      reservoirVersion: Long): Unit = {
+    val offsetMetadataJson =
+      """{"batchWatermarkMs":0,"batchTimestampMs":0,"conf":{},"sourceMetadataInfo":{}}"""
+    // index=BASE_INDEX, isInitialSnapshot=false => "consumed through reservoirVersion - 1, ready
+    // to start reservoirVersion", i.e. the resume fetches the incremental range from that version.
+    val offsetJson = DeltaSourceOffset(
+      reservoirId = tableId,
+      reservoirVersion = reservoirVersion,
+      index = DeltaSourceOffset.BASE_INDEX,
+      isInitialSnapshot = false
+    ).json
+    val offsetsDir = StreamingCheckpointConstants.DIR_NAME_OFFSETS
+    val commitsDir = StreamingCheckpointConstants.DIR_NAME_COMMITS
+    val offsetContent =
+      s"v1\n$offsetMetadataJson\n$offsetJson".getBytes(java.nio.charset.StandardCharsets.UTF_8)
     val offsetPath = new Path(new Path(checkpointPath, offsetsDir), batchId.toString)
     val offsetOut = fileManager.createAtomic(offsetPath, overwriteIfPossible = true)
     offsetOut.write(offsetContent)
@@ -1602,6 +1641,117 @@ class DeltaFormatSharingSourceSuite
             CheckAnswer(1, 2, 3)
           )
           assertBlocksAreCleanedUp()
+        }
+      }
+    }
+  }
+
+  // A resumed streaming query reads an incremental range that crosses a protocol upgrade: v2
+  // enables deletionVectors (protocol upgrade + metadata change, no DV file), v3 inserts a row.
+  // The resume takes the getFiles(startingVersion, endingVersion) path where the flag applies. The
+  // v2 Metadata is always streamed; the v2 Protocol only when the flag is on. Flag on -> the local
+  // delta log is a consistent (protocol, metadata) pair and the stream reads. Flag off -> the log
+  // has DV-enabled metadata on a stale protocol lacking the DV feature, rejected with
+  // DELTA_FEATURES_PROTOCOL_METADATA_MISMATCH.
+  Seq(true, false).foreach { flagOn =>
+    test("DeltaFormatSharingSource streaming: protocol upgrade within incremental range " +
+      s"[historicalProtocol=$flagOn]") {
+      withTempDirs { (inputDir, outputDir, checkpointDir) =>
+        val deltaTableName = "delta_table_streaming_protocol_upgrade"
+        withTable(deltaTableName) {
+          // Create at writer=7 (via rowTracking) with no DV. writer=7 is required: the
+          // protocol/metadata consistency check is a no-op on writer<7. DV is off so enabling it
+          // later is a real protocol upgrade (the test env otherwise enables DV by default).
+          sql(s"""CREATE TABLE $deltaTableName (c1 INT) USING DELTA
+                 |TBLPROPERTIES (
+                 |  'delta.enableRowTracking' = 'true',
+                 |  'delta.enableDeletionVectors' = 'false'
+                 |)""".stripMargin)
+          // v1: pre-upgrade insert (already consumed by the seeded checkpoint).
+          sql(s"""INSERT INTO $deltaTableName VALUES (1), (2)""")
+
+          val tableId = DeltaLog.forTable(spark, new TableIdentifier(deltaTableName))
+            .update().metadata.id
+          val sharedTableName = "shared_streaming_protocol_upgrade"
+          // getMetadata is captured pre-upgrade, so the v2 upgrade reaches the local delta log only
+          // through the getFiles response.
+          prepareMockedClientMetadata(deltaTableName, sharedTableName)
+
+          // v2: enable DV -> protocol upgrade + metadata change (no DV file). v3: plain insert.
+          sql(s"""ALTER TABLE $deltaTableName
+                 |SET TBLPROPERTIES ('delta.enableDeletionVectors' = 'true')""".stripMargin)
+          sql(s"""INSERT INTO $deltaTableName VALUES (3)""")
+
+          // Sanity check: minReaderVersion is 1 before the upgrade and increases after it.
+          val log = DeltaLog.forTable(spark, new TableIdentifier(deltaTableName))
+          assert(log.getSnapshotAt(1).protocol.minReaderVersion == 1,
+            "Test setup expects minReaderVersion=1 before the deletionVectors upgrade.")
+          assert(log.getSnapshotAt(3).protocol.minReaderVersion > 1,
+            "Test setup expects minReaderVersion to increase after the deletionVectors upgrade.")
+
+          // Seed a checkpoint at v1 (isStartingVersion=false) so the resume skips the initial
+          // snapshot and fetches the incremental range from v2.
+          val (checkpointPath, fileManager) = initCheckpointDirs(checkpointDir)
+          writeDeltaSourceOffsetAndCommit(fileManager, checkpointPath,
+            batchId = 0, tableId, reservoirVersion = 1)
+
+          // Incremental response for [1, 3], carrying the v2 Protocol upgrade (gated by the flag)
+          // and the v2 DV-enabled metadata.
+          prepareMockedClientAndFileSystemResultForStreaming(
+            deltaTableName, sharedTableName, startingVersion = 1, endingVersion = 3)
+          prepareMockedClientGetTableVersion(deltaTableName, sharedTableName)
+
+          val profileFile = prepareProfileFile(inputDir)
+          withSQLConf(
+            (getDeltaSharingClassesSQLConf ++ Map(
+              DeltaSQLConf.DELTA_SHARING_STREAMING_ENABLE_HISTORICAL_PROTOCOL.key -> flagOn.toString
+            )).toSeq: _*
+          ) {
+            val tablePath = profileFile.getCanonicalPath + s"#share1.default.$sharedTableName"
+            def runStream(): Unit = {
+              val q = spark.readStream
+                .format("deltaSharing")
+                .option("responseFormat", "delta")
+                // startingVersion pins the resume to the incremental path (no initial snapshot).
+                .option("startingVersion", "1")
+                // ignoreChanges lets the stream proceed past the metadata-only migration commit.
+                .option("ignoreChanges", "true")
+                .load(tablePath)
+                .select("c1")
+                .writeStream
+                .format("delta")
+                .option("checkpointLocation", checkpointDir.toString)
+                .start(outputDir.toString)
+              try {
+                q.processAllAvailable()
+              } finally {
+                q.stop()
+              }
+            }
+
+            if (flagOn) {
+              // Consistent (protocol, metadata) pair -> the stream reads.
+              runStream()
+              assert(spark.read.format("delta").load(outputDir.getCanonicalPath).count() >= 1)
+            } else {
+              // DV-enabled metadata on a stale protocol lacking the DV feature ->
+              // assertTableFeaturesMatchMetadata rejects the pair.
+              val e = intercept[Exception] {
+                runStream()
+              }
+              val rootMsg = Iterator
+                .iterate[Throwable](e)(_.getCause)
+                .takeWhile(_ != null)
+                .map(t => Option(t.getMessage).getOrElse(""))
+                .mkString(" | ")
+              assert(
+                rootMsg.contains("DELTA_FEATURES_PROTOCOL_METADATA_MISMATCH"),
+                s"Expected DELTA_FEATURES_PROTOCOL_METADATA_MISMATCH in error chain, got: $rootMsg")
+              assert(
+                rootMsg.contains("deletionVectors"),
+                s"Expected deletionVectors mentioned in error chain, got: $rootMsg")
+            }
+          }
         }
       }
     }

--- a/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingDataSourceDeltaTestUtils.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingDataSourceDeltaTestUtils.scala
@@ -29,6 +29,7 @@ import org.apache.spark.sql.delta.actions.{
   AddFile,
   DeletionVectorDescriptor,
   Metadata,
+  Protocol,
   RemoveFile
 }
 import org.apache.spark.sql.delta.deletionvectors.{
@@ -483,7 +484,12 @@ trait DeltaSharingDataSourceDeltaTestUtils extends SharedSparkSession {
 
     val deltaLog = DeltaLog.forTable(spark, new TableIdentifier(deltaTable))
     val startingSnapshot = deltaLog.getSnapshotAt(startingVersion)
-    actionLines += DeltaSharingProtocol(deltaProtocol = startingSnapshot.protocol).json
+    // The head protocol is stamped with startingVersion, matching the head metadata, mirroring how
+    // the server stamps the head Protocol for historical-protocol responses.
+    actionLines += DeltaSharingProtocol(
+      deltaProtocol = startingSnapshot.protocol,
+      version = startingVersion
+    ).json
     actionLines += DeltaSharingMetadata(
       deltaMetadata = startingSnapshot.metadata,
       version = startingVersion
@@ -497,13 +503,20 @@ trait DeltaSharingDataSourceDeltaTestUtils extends SharedSparkSession {
         val version = FileNames.getFileVersion(new Path(f.getName))
         if (version >= startingVersion && version <= endingVersion) {
           // protocol/metadata are processed from startingSnapshot, only process versions greater
-          // than startingVersion for real actions and possible metadata changes.
+          // than startingVersion for real actions and possible metadata/protocol changes.
           maxVersion = maxVersion.max(version)
           val timestamp = f.lastModified
 
           FileUtils.readLines(f).asScala.foreach { l =>
             val action = Action.fromJson(l)
             action match {
+              case p: Protocol if version > startingVersion =>
+                // A protocol change committed inside the range (e.g. enabling deletionVectors)
+                // is streamed as its own versioned Protocol, mirroring historical metadata.
+                actionLines += DeltaSharingProtocol(
+                  deltaProtocol = p,
+                  version = version
+                ).json
               case m: Metadata =>
                 actionLines += DeltaSharingMetadata(
                   deltaMetadata = m,

--- a/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingUtilsSuite.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingUtilsSuite.scala
@@ -18,13 +18,22 @@ package io.delta.sharing.spark
 
 import scala.reflect.ClassTag
 
-import org.apache.spark.sql.delta.GeoSpatialTableFeature
+import org.apache.spark.sql.delta.{
+  AppendOnlyTableFeature,
+  DeletionVectorsTableFeature,
+  GeoSpatialTableFeature
+}
+import org.apache.spark.sql.delta.actions.{Metadata, Protocol}
+import org.apache.spark.sql.delta.util.FileNames
 import io.delta.sharing.client.{DeltaSharingClient, DeltaSharingRestClient}
 import io.delta.sharing.client.model.{DeltaTableFiles, DeltaTableMetadata, Table, TemporaryCredentials}
 import io.delta.sharing.spark.DeltaSharingUtils._
+import io.delta.sharing.spark.model.{DeltaSharingMetadata, DeltaSharingProtocol}
+import org.apache.hadoop.fs.Path
 
 import org.apache.spark.{SharedSparkContext, SparkEnv, SparkFunSuite}
 import org.apache.spark.delta.sharing.TableRefreshResult
+import org.apache.spark.sql.types.StructType
 import org.apache.spark.storage.BlockId
 
 class DeltaSharingUtilsSuite extends SparkFunSuite with SharedSparkContext {
@@ -349,5 +358,88 @@ class DeltaSharingUtilsSuite extends SparkFunSuite with SharedSparkContext {
     funcWithoutRefreshToken(testRefreshToken)
     assert(client.lastRefreshToken == None,
       "When useRefreshToken=false, the refresh token should be ignored and None should be used")
+  }
+
+  // Reads back the json lines of a locally-constructed delta log file (as stored in the block
+  // manager by DeltaSharingLogFileSystem) for the given version.
+  private def readLocalDeltaLogVersion(customTablePath: String, version: Long): Seq[String] = {
+    val deltaLogPath = s"${DeltaSharingLogFileSystem.encode(customTablePath).toString}/_delta_log"
+    val jsonFilePath = FileNames.unsafeDeltaFile(new Path(deltaLogPath), version).toString
+    getSeqFromBlockManager[String](
+      DeltaSharingLogFileSystem.getDeltaSharingLogBlockId(jsonFilePath)
+    ).flatMap(_.split("\n")).filter(_.nonEmpty)
+  }
+
+  test("constructLocalDeltaLogAcrossVersions writes historical protocols to their own versions") {
+    val customTablePath = "constructHistoricalProtocol/table"
+    // A version range [1, 3] where the protocol is upgraded at v2 by enabling a reader/writer table
+    // feature (deletionVectors): the head protocol is stamped with the starting version (1), and
+    // the upgrade at v2 is streamed as its own versioned protocol, mirroring how historical
+    // metadata is streamed. Both protocols carry reader/writer feature lists (table-features
+    // protocol, minReaderVersion 3 / minWriterVersion 7) so the test exercises a realistic
+    // feature-list change, not just a version-number bump.
+    val headProtocol = Protocol(minReaderVersion = 1, minWriterVersion = 2)
+      .merge(Protocol.forTableFeature(AppendOnlyTableFeature))
+    val upgradedProtocol = headProtocol
+      .merge(Protocol.forTableFeature(DeletionVectorsTableFeature))
+    val metadata = Metadata(schemaString = new StructType().add("c1", "long").json)
+
+    val lines = Seq(
+      DeltaSharingProtocol(deltaProtocol = headProtocol, version = 1L).json,
+      DeltaSharingMetadata(deltaMetadata = metadata, version = 1L).json,
+      DeltaSharingProtocol(deltaProtocol = upgradedProtocol, version = 2L).json
+    )
+
+    DeltaSharingLogFileSystem.constructLocalDeltaLogAcrossVersions(
+      lines = lines,
+      customTablePath = customTablePath,
+      startingVersionOpt = Some(1L),
+      endingVersionOpt = Some(3L)
+    )
+
+    // The head protocol (and metadata) seed the starting version's json file.
+    val v1Lines = readLocalDeltaLogVersion(customTablePath, 1L)
+    assert(v1Lines.contains(headProtocol.json),
+      s"v1 log should contain the head protocol, got: $v1Lines")
+    assert(v1Lines.contains(metadata.json),
+      s"v1 log should contain the head metadata, got: $v1Lines")
+    assert(!v1Lines.contains(upgradedProtocol.json),
+      s"v1 log should not contain the v2 protocol upgrade, got: $v1Lines")
+
+    // The protocol upgrade is written to v2's own json file (not left on the stale head protocol).
+    val v2Lines = readLocalDeltaLogVersion(customTablePath, 2L)
+    assert(v2Lines.contains(upgradedProtocol.json),
+      s"v2 log should contain the protocol upgrade, got: $v2Lines")
+    assert(!v2Lines.contains(headProtocol.json),
+      s"v2 log should not repeat the head protocol, got: $v2Lines")
+
+    // A version with no protocol change carries no protocol action at all.
+    val v3Lines = readLocalDeltaLogVersion(customTablePath, 3L)
+    assert(!v3Lines.contains(headProtocol.json) && !v3Lines.contains(upgradedProtocol.json),
+      s"v3 log should carry no protocol action, got: $v3Lines")
+  }
+
+  test("constructLocalDeltaLogAcrossVersions keeps a single head protocol when unversioned") {
+    val customTablePath = "constructUnversionedProtocol/table"
+    // A server that doesn't emit historical protocols (or the flag/opt-in is off) returns a single
+    // protocol with no version. It must still seed the starting version's json file unchanged.
+    val headProtocol = Protocol(minReaderVersion = 1, minWriterVersion = 2)
+    val metadata = Metadata(schemaString = new StructType().add("c1", "long").json)
+
+    val lines = Seq(
+      DeltaSharingProtocol(deltaProtocol = headProtocol).json,
+      DeltaSharingMetadata(deltaMetadata = metadata, version = 1L).json
+    )
+
+    DeltaSharingLogFileSystem.constructLocalDeltaLogAcrossVersions(
+      lines = lines,
+      customTablePath = customTablePath,
+      startingVersionOpt = Some(1L),
+      endingVersionOpt = Some(2L)
+    )
+
+    val v1Lines = readLocalDeltaLogVersion(customTablePath, 1L)
+    assert(v1Lines.contains(headProtocol.json),
+      s"v1 log should contain the unversioned head protocol, got: $v1Lines")
   }
 }

--- a/sharing/src/test/scala/io/delta/sharing/spark/TestClientForDeltaFormatSharing.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/TestClientForDeltaFormatSharing.scala
@@ -37,6 +37,10 @@ import io.delta.sharing.client.model.{
   Table,
   TemporaryCredentials
 }
+import io.delta.sharing.spark.model.{
+  DeltaSharingProtocol,
+  DeltaSharingSingleAction
+}
 
 import org.apache.spark.SparkEnv
 import org.apache.spark.storage.BlockId
@@ -259,7 +263,8 @@ private[spark] class TestClientForDeltaFormatSharing(
     }
     DeltaTableFiles(
       version = getTableVersion(table),
-      lines = linesBuilder.result(),
+      lines = TestClientForDeltaFormatSharing.maybeDropHistoricalProtocols(
+        linesBuilder.result(), includeHistoricalProtocol),
       respondedFormat = DeltaSharingRestClient.RESPONSE_FORMAT_DELTA
     )
   }
@@ -328,7 +333,8 @@ private[spark] class TestClientForDeltaFormatSharing(
     } else {
       DeltaTableFiles(
         version = getTableVersion(table),
-        lines = linesBuilder.result(),
+        lines = TestClientForDeltaFormatSharing.maybeDropHistoricalProtocols(
+          linesBuilder.result(), includeHistoricalProtocol),
         respondedFormat = DeltaSharingRestClient.RESPONSE_FORMAT_DELTA
       )
     }
@@ -346,6 +352,38 @@ private[spark] class TestClientForDeltaFormatSharing(
 }
 
 object TestClientForDeltaFormatSharing {
+  // Mimics a delta-sharing server's handling of includeHistoricalProtocol on a delta-format
+  // response. When the client opts in, the server streams a Protocol for each protocol change in
+  // the range (the mocked lines already contain them). When the client does NOT opt in (or the
+  // server doesn't support it), only the head protocol is returned: this drops every historical
+  // Protocol line except the one at the smallest protocol version, so tests can exercise the
+  // legacy stale-head-protocol behavior.
+  private[spark] def maybeDropHistoricalProtocols(
+      lines: Seq[String],
+      includeHistoricalProtocol: Boolean): Seq[String] = {
+    if (includeHistoricalProtocol) {
+      return lines
+    }
+    val protocolVersions = lines.flatMap { line =>
+      JsonUtils.fromJson[DeltaSharingSingleAction](line).unwrap match {
+        case p: DeltaSharingProtocol if p.version != null => Some(p.version.longValue())
+        case _ => None
+      }
+    }
+    if (protocolVersions.isEmpty) {
+      return lines
+    }
+    val headProtocolVersion = protocolVersions.min
+    lines.filter { line =>
+      JsonUtils.fromJson[DeltaSharingSingleAction](line).unwrap match {
+        // Keep the head protocol and any unversioned protocol; drop later protocol changes.
+        case p: DeltaSharingProtocol =>
+          p.version == null || p.version.longValue() == headProtocolVersion
+        case _ => true
+      }
+    }
+  }
+
   def getBlockId(
       sharedTableName: String,
       queryType: String,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -3293,6 +3293,18 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .booleanConf
       .createWithDefault(false)
 
+  val DELTA_SHARING_STREAMING_ENABLE_HISTORICAL_PROTOCOL =
+    buildConf("spark.sql.delta.sharing.streamingEnableHistoricalProtocol")
+      .doc("When true, a Delta Sharing streaming query (non-CDF, incremental getFiles) requests " +
+        "includeHistoricalProtocol so the server streams a Protocol for each protocol change " +
+        "inside the version range, keeping the locally constructed delta log's protocol accurate " +
+        "across a mid-range protocol upgrade. When false, the client keeps the legacy " +
+        "single-head-protocol behavior. Gates the non-CDF streaming path independently from the " +
+        "CDF path controlled by spark.sql.delta.sharing.cdfEnableHistoricalProtocol.")
+      .internal()
+      .booleanConf
+      .createWithDefault(false)
+
   val DELTA_SHARING_ENABLE_AUTO_RESOLVE_FOR_CDF =
     buildConf("spark.sql.delta.sharing.enableAutoResolveForCdf")
       .doc("When true, Delta Sharing CDF queries without an explicit responseFormat will " +


### PR DESCRIPTION
## Description

A Delta Sharing streaming query that resumes mid-stream reads an incremental
version range via `getFiles(startingVersion, endingVersion)`. Until now the
response carried only a single head `Protocol`, so if the protocol was upgraded
inside the range (for example, enabling `deletionVectors`, which is a protocol
upgrade plus a metadata change), the locally reconstructed Delta log ended up
with the new metadata sitting on a stale head protocol that lacks the required
table feature. Reading such a log fails the protocol/metadata consistency check
with `DELTA_FEATURES_PROTOCOL_METADATA_MISMATCH`.

This change lets the streaming client opt in to receiving historical protocols:

- A new internal conf `spark.sql.delta.sharing.streamingEnableHistoricalProtocol`
  (default `false`). When enabled, the non-CDF incremental `getFiles` call passes
  `includeHistoricalProtocol = true`, so the server streams a `Protocol` action
  for each protocol change inside the version range, each stamped with the version
  it was committed at.
- `DeltaSharingProtocol` gains an optional `version` field (null for a snapshot
  query or a server that does not emit historical protocols).
- `DeltaSharingLogFileSystem.constructLocalDeltaLogAcrossVersions` writes each
  historical protocol into its own `version.json`, mirroring the existing
  historical-metadata handling: the head protocol seeds `minVersion.json` and
  later protocol changes are written to their own version. When the protocol is
  unversioned, the previous single-head-protocol behavior is preserved.

The flag is off by default, so existing behavior is unchanged unless it is
enabled.

## How was this patch tested?

- `DeltaFormatSharingSourceSuite`: a streaming query that resumes into an
  incremental range crossing a protocol upgrade (v2 enables `deletionVectors`,
  v3 inserts a row). With the flag on, the reconstructed log is a consistent
  (protocol, metadata) pair and the stream reads; with the flag off, the log has
  DV-enabled metadata on a stale protocol and the read is rejected with
  `DELTA_FEATURES_PROTOCOL_METADATA_MISMATCH`.
- `DeltaSharingUtilsSuite`: `constructLocalDeltaLogAcrossVersions` writes a
  mid-range protocol upgrade to its own version's log file and keeps the head
  protocol at the starting version; a separate case verifies an unversioned
  protocol still seeds the starting version unchanged.

## Does this PR introduce _any_ user-facing change?

Yes. A new internal SQL conf `spark.sql.delta.sharing.streamingEnableHistoricalProtocol`
(default `false`) is added to control whether Delta Sharing streaming queries request
historical protocols for the incremental version range.
