### PR TITLE
[Spark] Row-level concurrency conflict rebasing

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -724,12 +724,12 @@
     "subClass" : {
       "WITHOUT_HINT" : {
         "message" : [
-          "The concurrent operation modified data that should have been read by this operation. Please retry the operation. Refer to <docLink> for more information."
+          "The concurrent operation modified data that should have been read by this operation. Please retry the operation. Refer to <docLink> for more information.<additionalHint>"
         ]
       },
       "WITH_PARTITION_HINT" : {
         "message" : [
-          "The concurrent operation modified data in the partition <partitionValues> that should have been read by this operation. Please retry the operation. Refer to <docLink> for more information."
+          "The concurrent operation modified data in the partition <partitionValues> that should have been read by this operation. Please retry the operation. Refer to <docLink> for more information.<additionalHint>"
         ]
       }
     },
@@ -742,12 +742,12 @@
     "subClass" : {
       "WITHOUT_HINT" : {
         "message" : [
-          "The concurrent operation deleted data that was read by this operation. Please retry the operation. Refer to <docLink> for more information."
+          "The concurrent operation deleted data that was read by this operation. Please retry the operation. Refer to <docLink> for more information.<additionalHint>"
         ]
       },
       "WITH_PARTITION_HINT" : {
         "message" : [
-          "The concurrent operation deleted data in the partition <partitionValues> that was read by this operation. Please retry the operation. Refer to <docLink> for more information."
+          "The concurrent operation deleted data in the partition <partitionValues> that was read by this operation. Please retry the operation. Refer to <docLink> for more information.<additionalHint>"
         ]
       }
     },
@@ -760,12 +760,12 @@
     "subClass" : {
       "WITHOUT_HINT" : {
         "message" : [
-          "The concurrent operation deleted data that was read by this operation. Please retry the operation. Refer to <docLink> for more information."
+          "The concurrent operation deleted data that was read by this operation. Please retry the operation. Refer to <docLink> for more information.<additionalHint>"
         ]
       },
       "WITH_PARTITION_HINT" : {
         "message" : [
-          "The concurrent operation deleted data in the partition <partitionValues> that was read by this operation. Please retry the operation. Refer to <docLink> for more information."
+          "The concurrent operation deleted data in the partition <partitionValues> that was read by this operation. Please retry the operation. Refer to <docLink> for more information.<additionalHint>"
         ]
       }
     },

--- a/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
@@ -20,8 +20,9 @@ package org.apache.spark.sql.delta
 import java.util.concurrent.TimeUnit
 
 import scala.collection.mutable
+import scala.util.control.NonFatal
 
-import org.apache.spark.sql.delta.DeltaOperations.{OP_SET_TBLPROPERTIES, ROW_TRACKING_BACKFILL_OPERATION_NAME, ROW_TRACKING_UNBACKFILL_OPERATION_NAME}
+import org.apache.spark.sql.delta.DeltaOperations.{ROW_TRACKING_BACKFILL_OPERATION_NAME, ROW_TRACKING_UNBACKFILL_OPERATION_NAME}
 import org.apache.spark.sql.delta.RowId.RowTrackingMetadataDomain
 import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
@@ -39,7 +40,7 @@ import org.apache.hadoop.fs.FileStatus
 import org.apache.spark.internal.{MDC, MessageWithContext}
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
-import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionSet, Or}
+import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionSet}
 import org.apache.spark.sql.types.{Metadata => FieldMetadata, MetadataBuilder, StructType}
 
 /**
@@ -232,7 +233,146 @@ private[delta] class ConflictChecker(
 
   protected var currentTransactionInfo: CurrentTransactionInfo = initialCurrentTransactionInfo
 
+  protected var rlcResolvedWinnerAdds: Set[AddFile] = Set.empty
+  protected var rlcResolvedWinnerRemoves: Set[RemoveFile] = Set.empty
+  private var successfulRlcResult: Option[RowLevelConcurrency.RebaseResult] = None
+
   protected def recordSkippedPhase(phase: String): Unit = timingStats += phase -> 0
+
+  protected def checkRowLevelConflicts(): Unit = {
+    val startNs = System.nanoTime()
+    try {
+      val snapshot = currentTransactionInfo.readSnapshot
+      val eligible = RowLevelConcurrency.isCommitEligible(
+        spark,
+        snapshot,
+        currentTransactionInfo.actions)
+
+      if (!eligible) {
+        return
+      }
+
+      val summary = RowLevelConcurrency.wouldResolve(
+        currentTransactionInfo.actions,
+        winningCommitSummary.addedFiles,
+        winningCommitSummary.removedFiles)
+
+      if (summary.candidateFileCount > 0 || summary.skipReasons.nonEmpty) {
+        recordDeltaEvent(
+          deltaLog,
+          opType = RowLevelConcurrency.TELEMETRY_WOULD_RESOLVE,
+          data = Map(
+            "winningCommitVersion" -> winningCommitVersion,
+            "candidateFileCount" -> summary.candidateFileCount,
+            "candidatePaths" -> summary.candidatePaths,
+            "skipReasons" -> summary.skipReasons,
+            "isolationLevel" -> isolationLevel.toString))
+      }
+
+      if (summary.candidateFileCount > 0) {
+        attemptRowLevelConcurrencyRebase()
+      } else if (summary.skipReasons.nonEmpty) {
+        recordDeltaEvent(
+          deltaLog,
+          opType = RowLevelConcurrency.TELEMETRY_ABORTED_SHAPE,
+          data = Map(
+            "winningCommitVersion" -> winningCommitVersion,
+            "skipReasons" -> summary.skipReasons,
+            "isolationLevel" -> isolationLevel.toString))
+      }
+    } catch {
+      case NonFatal(e) =>
+        recordDeltaEvent(
+          deltaLog,
+          opType = RowLevelConcurrency.TELEMETRY_ABORTED_UNEXPECTED,
+          data = Map(
+            "winningCommitVersion" -> winningCommitVersion,
+            "errorClass" -> e.getClass.getName,
+            "errorMessage" -> Option(e.getMessage).getOrElse(""),
+            "isolationLevel" -> isolationLevel.toString))
+    } finally {
+      recordTime(
+        "checkRowLevelConflicts",
+        TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNs))
+    }
+  }
+
+  private def attemptRowLevelConcurrencyRebase(): Unit = {
+    val conf = spark.sessionState.conf
+    val deadlineNanos = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(
+      conf.getConf(DeltaSQLConf.ROW_LEVEL_CONCURRENCY_MAX_RESOLUTION_TIME_MS))
+    val budgets = RowLevelConcurrency.RebaseBudgets(
+      maxDvBytesPerFile = conf.getConf(
+        DeltaSQLConf.ROW_LEVEL_CONCURRENCY_MAX_DV_BYTES_PER_FILE),
+      maxDvReads = conf.getConf(
+        DeltaSQLConf.ROW_LEVEL_CONCURRENCY_MAX_DV_READS_PER_COMMIT),
+      deadlineNanos = deadlineNanos)
+
+    val result = RowLevelConcurrency.tryRebase(
+      loserActions = currentTransactionInfo.actions,
+      winnerAddedFiles = winningCommitSummary.addedFiles,
+      winnerRemovedFiles = winningCommitSummary.removedFiles,
+      tablePath = deltaLog.dataPath,
+      hadoopConf = deltaLog.newDeltaHadoopConf(),
+      budgets = budgets)
+
+    if (result.status == RowLevelConcurrency.RebaseStatus.Succeeded) {
+      currentTransactionInfo = currentTransactionInfo.copy(
+        actions = result.newActions,
+        readFiles = currentTransactionInfo.readFiles ++ result.resolvedAddFiles)
+      // Only same-path AddFiles have action-level lineage to the rebased files. New-path
+      // additions remain subject to normal Serializable conflict detection because
+      // CommitInfo operation names and metrics are not correctness guarantees.
+      rlcResolvedWinnerAdds = result.resolvedAddFiles.toSet
+      rlcResolvedWinnerRemoves = result.resolvedRemoveFiles.toSet
+      successfulRlcResult = Some(result)
+    } else if (result.failure.nonEmpty) {
+      val opType = result.failure.get match {
+        case RowLevelConcurrency.RebaseFailure.Overlap =>
+          RowLevelConcurrency.TELEMETRY_ABORTED_OVERLAP
+        case RowLevelConcurrency.RebaseFailure.ByteBudgetExceeded |
+             RowLevelConcurrency.RebaseFailure.DvReadBudgetExceeded |
+             RowLevelConcurrency.RebaseFailure.DeadlineExceeded =>
+          RowLevelConcurrency.TELEMETRY_ABORTED_BUDGET
+        case RowLevelConcurrency.RebaseFailure.DecodeFailure =>
+          RowLevelConcurrency.TELEMETRY_ABORTED_DECODE_FAILURE
+        case RowLevelConcurrency.RebaseFailure.DvReadFailure =>
+          RowLevelConcurrency.TELEMETRY_ABORTED_DV_READ_FAILURE
+        case RowLevelConcurrency.RebaseFailure.DvWriteFailure =>
+          RowLevelConcurrency.TELEMETRY_ABORTED_DV_WRITE_FAILURE
+        case _ =>
+          RowLevelConcurrency.TELEMETRY_ABORTED_SHAPE
+      }
+      recordDeltaEvent(
+        deltaLog,
+        opType = opType,
+        data = Map(
+          "winningCommitVersion" -> winningCommitVersion,
+          "failure" -> result.failure.get.name,
+          "numDvFilesRead" -> result.stats.numDvFilesRead,
+          "numDvBytesRead" -> result.stats.numDvBytesRead,
+          "numDvFilesWritten" -> result.stats.numDvFilesWritten,
+          "isolationLevel" -> isolationLevel.toString))
+    }
+  }
+
+  protected def winningChangedDataAddedFilesForConflictCheck(): Seq[AddFile] = {
+    winningCommitSummary.changedDataAddedFiles.filterNot(rlcResolvedWinnerAdds.contains)
+  }
+
+  protected def winningBlindAppendAddedFilesForConflictCheck(): Seq[AddFile] = {
+    winningCommitSummary.blindAppendAddedFiles.filterNot(rlcResolvedWinnerAdds.contains)
+  }
+
+  protected def winningRemovedFilesForConflictCheck(): Seq[RemoveFile] = {
+    winningCommitSummary.removedFiles.filterNot(rlcResolvedWinnerRemoves.contains)
+  }
+
+  protected def rlcEnablementHint(): String = {
+    RowLevelConcurrency.enablementHintIfMissing(
+      currentTransactionInfo.readSnapshot,
+      spark.sessionState.conf)
+  }
 
   /**
    * This function checks conflict of the `initialCurrentTransactionInfo` against the
@@ -241,12 +381,42 @@ private[delta] class ConflictChecker(
    * validates the actions.
    */
   def checkConflictsAndValidateActions(): CurrentTransactionInfo = {
-    val updatedInfo = checkConflicts()
+    try {
+      val updatedInfo = checkConflicts()
 
-    // In case the actions of the current transaction changed, re-run the invariant
-    // checks against the rebased action set.
-    checkInvariants(updatedInfo)
-    updatedInfo
+      // In case the actions of the current transaction changed, re-run the invariant
+      // checks against the rebased action set.
+      checkInvariants(updatedInfo)
+      successfulRlcResult.foreach { result =>
+        recordDeltaEvent(
+          deltaLog,
+          opType = RowLevelConcurrency.TELEMETRY_RESOLVED,
+          data = Map(
+            "winningCommitVersion" -> winningCommitVersion,
+            "resolvedFileCount" -> result.resolvedFileCount,
+            "numDvFilesRead" -> result.stats.numDvFilesRead,
+            "numDvBytesRead" -> result.stats.numDvBytesRead,
+            "numDvFilesWritten" -> result.stats.numDvFilesWritten,
+            "isolationLevel" -> isolationLevel.toString))
+      }
+      updatedInfo
+    } catch {
+      case NonFatal(e) =>
+        successfulRlcResult.foreach { result =>
+          recordDeltaEvent(
+            deltaLog,
+            opType = RowLevelConcurrency.TELEMETRY_ABORTED_AFTER_REBASE,
+            data = Map(
+              "winningCommitVersion" -> winningCommitVersion,
+              "resolvedFileCount" -> result.resolvedFileCount,
+              "numDvFilesRead" -> result.stats.numDvFilesRead,
+              "numDvBytesRead" -> result.stats.numDvBytesRead,
+              "numDvFilesWritten" -> result.stats.numDvFilesWritten,
+              "errorClass" -> e.getClass.getName,
+              "isolationLevel" -> isolationLevel.toString))
+        }
+        throw e
+    }
   }
 
   /**
@@ -294,6 +464,7 @@ private[delta] class ConflictChecker(
 
     resolveRowTrackingBackfillConflicts()
     resolveRowTrackingUnBackfillConflicts()
+    checkRowLevelConflicts()
     // Row Tracking reconciliation. We perform this before the file checks to ensure that
     // no files have duplicate row IDs and avoid interacting with files that don't comply with
     // the protocol.
@@ -1142,9 +1313,10 @@ private[delta] class ConflictChecker(
       // Fail if new files have been added that the txn should have read.
       val addedFilesToCheckForConflicts = isolationLevel match {
         case WriteSerializable if !currentTransactionInfo.metadataChanged =>
-          winningCommitSummary.changedDataAddedFiles // don't conflict with blind appends
+          winningChangedDataAddedFilesForConflictCheck() // don't conflict with blind appends
         case Serializable | WriteSerializable =>
-          winningCommitSummary.changedDataAddedFiles ++ winningCommitSummary.blindAppendAddedFiles
+          winningChangedDataAddedFilesForConflictCheck() ++
+            winningBlindAppendAddedFilesForConflictCheck()
         case SnapshotIsolation =>
           Seq.empty
       }
@@ -1157,7 +1329,8 @@ private[delta] class ConflictChecker(
           winningCommitSummary.commitInfo,
           getTableNameOrPath,
           winningCommitVersion,
-          getPrettyPartitionMessage(fileMatchingPartitionReadPredicates.get.partitionValues))
+          getPrettyPartitionMessage(fileMatchingPartitionReadPredicates.get.partitionValues),
+          additionalHint = rlcEnablementHint())
       }
     }
   }
@@ -1171,7 +1344,7 @@ private[delta] class ConflictChecker(
       // Fail if files have been deleted that the txn read.
       val readFilePaths = currentTransactionInfo.readFiles.map(
         f => f.path -> f.partitionValues).toMap
-      val deleteReadOverlap = winningCommitSummary.removedFiles
+      val deleteReadOverlap = winningRemovedFilesForConflictCheck()
         .find(r => readFilePaths.contains(r.path))
       if (deleteReadOverlap.nonEmpty) {
         val partitionOpt = getPrettyPartitionMessage(readFilePaths(deleteReadOverlap.get.path))
@@ -1179,14 +1352,16 @@ private[delta] class ConflictChecker(
           winningCommitSummary.commitInfo,
           getTableNameOrPath,
           winningCommitVersion,
-          partitionOpt)
+          partitionOpt,
+          additionalHint = rlcEnablementHint())
       }
-      if (winningCommitSummary.removedFiles.nonEmpty && currentTransactionInfo.readWholeTable) {
+      if (winningRemovedFilesForConflictCheck().nonEmpty && currentTransactionInfo.readWholeTable) {
         throw DeltaErrors.concurrentDeleteReadException(
           winningCommitSummary.commitInfo,
           getTableNameOrPath,
           winningCommitVersion,
-          partitionOpt = None)
+          partitionOpt = None,
+          additionalHint = rlcEnablementHint())
       }
     }
   }
@@ -1201,7 +1376,7 @@ private[delta] class ConflictChecker(
       val deletedFilePaths = currentTransactionInfo.actions
         .collect { case r: RemoveFile => r.path -> r.partitionValues }
         .toMap
-      val deleteOverlap = winningCommitSummary.removedFiles
+      val deleteOverlap = winningRemovedFilesForConflictCheck()
         .find(r => deletedFilePaths.contains(r.path))
       if (deleteOverlap.nonEmpty) {
         val partitionOpt = getPrettyPartitionMessage(deletedFilePaths(deleteOverlap.get.path))
@@ -1209,7 +1384,8 @@ private[delta] class ConflictChecker(
           winningCommitSummary.commitInfo,
           getTableNameOrPath,
           winningCommitVersion,
-          partitionOpt)
+          partitionOpt,
+          additionalHint = rlcEnablementHint())
       }
     }
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -2903,7 +2903,8 @@ trait DeltaErrorsBase
       commitInfo: Option[CommitInfo],
       tableName: String,
       version: Long,
-      partitionOpt: Option[String]): io.delta.exceptions.ConcurrentAppendException = {
+      partitionOpt: Option[String],
+      additionalHint: String = ""): io.delta.exceptions.ConcurrentAppendException = {
     val operation = commitInfo.map(_.operation).getOrElse("TRANSACTION")
     val docLink = DeltaErrors.generateDocsLink(SparkEnv.get.conf, "/concurrency-control.html")
     val subClass = if (partitionOpt.nonEmpty) {
@@ -2913,9 +2914,10 @@ trait DeltaErrorsBase
     }
     val messageParameters = subClass match {
       case "WITH_PARTITION_HINT" =>
-        Array(operation, tableName, version.toString, partitionOpt.getOrElse(""), docLink)
+        Array(operation, tableName, version.toString, partitionOpt.getOrElse(""), docLink,
+          additionalHint)
       case _ =>
-        Array(operation, tableName, version.toString, docLink)
+        Array(operation, tableName, version.toString, docLink, additionalHint)
     }
     io.delta.exceptions.ConcurrentAppendException(subClass, messageParameters)
   }
@@ -2924,7 +2926,8 @@ trait DeltaErrorsBase
       commitInfo: Option[CommitInfo],
       tableName: String,
       version: Long,
-      partitionOpt: Option[String]): io.delta.exceptions.ConcurrentDeleteReadException = {
+      partitionOpt: Option[String],
+      additionalHint: String = ""): io.delta.exceptions.ConcurrentDeleteReadException = {
     val operation = commitInfo.map(_.operation).getOrElse("TRANSACTION")
     val docLink = DeltaErrors.generateDocsLink(SparkEnv.get.conf, "/concurrency-control.html")
     val subClass = if (partitionOpt.nonEmpty) {
@@ -2934,9 +2937,10 @@ trait DeltaErrorsBase
     }
     val messageParameters = subClass match {
       case "WITH_PARTITION_HINT" =>
-        Array(operation, tableName, version.toString, partitionOpt.getOrElse(""), docLink)
+        Array(operation, tableName, version.toString, partitionOpt.getOrElse(""), docLink,
+          additionalHint)
       case _ =>
-        Array(operation, tableName, version.toString, docLink)
+        Array(operation, tableName, version.toString, docLink, additionalHint)
     }
     io.delta.exceptions.ConcurrentDeleteReadException(subClass, messageParameters)
   }
@@ -2945,7 +2949,8 @@ trait DeltaErrorsBase
       commitInfo: Option[CommitInfo],
       tableName: String,
       version: Long,
-      partitionOpt: Option[String]): io.delta.exceptions.ConcurrentDeleteDeleteException = {
+      partitionOpt: Option[String],
+      additionalHint: String = ""): io.delta.exceptions.ConcurrentDeleteDeleteException = {
     val operation = commitInfo.map(_.operation).getOrElse("TRANSACTION")
     val docLink = DeltaErrors.generateDocsLink(SparkEnv.get.conf, "/concurrency-control.html")
     val subClass = if (partitionOpt.nonEmpty) {
@@ -2955,9 +2960,10 @@ trait DeltaErrorsBase
     }
     val messageParameters = subClass match {
       case "WITH_PARTITION_HINT" =>
-        Array(operation, tableName, version.toString, partitionOpt.getOrElse(""), docLink)
+        Array(operation, tableName, version.toString, partitionOpt.getOrElse(""), docLink,
+          additionalHint)
       case _ =>
-        Array(operation, tableName, version.toString, docLink)
+        Array(operation, tableName, version.toString, docLink, additionalHint)
     }
     io.delta.exceptions.ConcurrentDeleteDeleteException(subClass, messageParameters)
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/RowLevelConcurrency.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/RowLevelConcurrency.scala
@@ -1,0 +1,638 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import java.io.IOException
+import java.util.UUID
+
+import scala.collection.mutable
+import scala.util.control.NonFatal
+
+import org.apache.spark.sql.delta.actions.{Action, AddFile, DeletionVectorDescriptor, Metadata, RemoveFile}
+import org.apache.spark.sql.delta.commands.DeletionVectorUtils
+import org.apache.spark.sql.delta.deletionvectors.{RoaringBitmapArray, RoaringBitmapArrayFormat}
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.storage.dv.DeletionVectorStore
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.internal.SQLConf
+
+/**
+ * Utilities for Row-Level Concurrency (RLC) conflict resolution.
+ *
+ * RLC allows concurrent DML operations (DELETE/UPDATE/MERGE) that touch disjoint rows in the
+ * same physical file to commit without aborting. It works by decoding the Deletion Vector
+ * bitmaps from both the winner and loser transactions, checking row-set disjointness, and
+ * rebasing the loser's DV on top of the winner's post-image when the rows are disjoint.
+ *
+ * RLC is strictly opportunistic: it only converts a "would-abort" outcome into a
+ * "commits cleanly" outcome, never the reverse. When preconditions fail, the existing
+ * file-level conflict checking behavior is preserved exactly.
+ *
+ * @see [[isSnapshotEligible]] for the table-level eligibility predicates.
+ * @see [[tryRebase]] for the rebase algorithm and its preconditions.
+ */
+object RowLevelConcurrency {
+
+  // ---------------------------------------------------------------------------
+  // Telemetry event names
+  // ---------------------------------------------------------------------------
+
+  /** Prefix for all RLC-related Delta telemetry events. */
+  val TELEMETRY_PREFIX = "delta.conflictDetection.rowLevelConcurrency"
+
+  /** Fired when one or more same-file DV conflicts are successfully resolved. */
+  val TELEMETRY_RESOLVED = s"$TELEMETRY_PREFIX.resolved"
+
+  /** Fired for each file where P4 (disjoint delta) fails -- true row-level overlap. */
+  val TELEMETRY_ABORTED_OVERLAP = s"$TELEMETRY_PREFIX.abortedOverlap"
+
+  /** Fired when DV decode or resolution exceeds the configured budget. */
+  val TELEMETRY_ABORTED_BUDGET = s"$TELEMETRY_PREFIX.abortedBudget"
+
+  /** Fired when winner action shape fails preconditions P1/P2/P3. */
+  val TELEMETRY_ABORTED_SHAPE = s"$TELEMETRY_PREFIX.abortedShape"
+
+  /** Fired when DV bytes cannot be read (404, permission, network error). */
+  val TELEMETRY_ABORTED_DV_READ_FAILURE = s"$TELEMETRY_PREFIX.abortedDvReadFailure"
+
+  /** Fired when DV bytes are present but cannot be decoded. */
+  val TELEMETRY_ABORTED_DECODE_FAILURE = s"$TELEMETRY_PREFIX.abortedDecodeFailure"
+
+  /** Fired when a rebased DV cannot be written. */
+  val TELEMETRY_ABORTED_DV_WRITE_FAILURE = s"$TELEMETRY_PREFIX.abortedDvWriteFailure"
+
+  /** Fired when an unexpected, non-fatal error makes RLC fall back to legacy detection. */
+  val TELEMETRY_ABORTED_UNEXPECTED = s"$TELEMETRY_PREFIX.abortedUnexpected"
+
+  /** Fired when a successful rebase is followed by another conflict-check failure. */
+  val TELEMETRY_ABORTED_AFTER_REBASE = s"$TELEMETRY_PREFIX.abortedAfterRebase"
+
+  /** Detect-only: records what *would* have resolved, without mutating actions. */
+  val TELEMETRY_WOULD_RESOLVE = s"$TELEMETRY_PREFIX.wouldResolve"
+
+  // ---------------------------------------------------------------------------
+  // Eligibility predicates
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Snapshot-level eligibility: does the table support RLC at all?
+   *
+   * A table is eligible when ALL of the following hold:
+   *  1. The RLC master switch is enabled.
+   *  2. Deletion Vectors are writable on the table.
+   *  3. Row Tracking is enabled (required for correct baseRowId handling).
+   *  4. The table is unpartitioned (P0 only -- partitioned tables bypass RLC).
+   *  5. The table has no identity columns.
+   *
+   * NOTE: RLC engages at BOTH `Serializable` and `WriteSerializable`; the isolation level
+   * controls blind-INSERT vs. DML conflict semantics, not whether RLC engages. Here
+   * `DeltaConfigs.ISOLATION_LEVEL` only accepts `Serializable` (see `DeltaConfig.scala`),
+   * so the snapshot's table-level isolation is always `Serializable` and there is no
+   * isolation-level gate to apply.
+   *
+   * Persistent-DV mode requires no extra gating: the per-op confs
+   * `DELETE/UPDATE/MERGE_USE_PERSISTENT_DELETION_VECTORS` already default to `true`, and
+   * each DML command additionally gates DV usage on
+   * [[DeletionVectorUtils.deletionVectorsWritable]] at runtime (see
+   * `DeleteCommand.shouldWritePersistentDeletionVectors`), which is exactly the
+   * "DV mode when the table supports it" behavior RLC needs.
+   */
+  def isSnapshotEligible(spark: SparkSession, snapshot: Snapshot): Boolean = {
+    spark.sessionState.conf.getConf(DeltaSQLConf.ROW_LEVEL_CONCURRENCY_ENABLED) &&
+    DeletionVectorUtils.deletionVectorsWritable(snapshot) &&
+    RowTracking.isEnabled(snapshot.protocol, snapshot.metadata) &&
+    snapshot.metadata.partitionColumns.isEmpty &&
+    !ColumnWithDefaultExprUtils.hasIdentityColumn(snapshot.schema)
+  }
+
+  /**
+   * Operation-level eligibility: does *this* commit's action set safely admit RLC?
+   *
+   * This refines the snapshot-level check with commit-specific guards:
+   *  1. No divergent Metadata mutation (the only safe Metadata is byte-identical to the
+   *     read snapshot's metadata).
+   *
+   * @param snapshot the read snapshot for this transaction
+   * @param actions  the prepared actions for this transaction
+   */
+  def isCommitEligible(
+      spark: SparkSession,
+      snapshot: Snapshot,
+      actions: Seq[Action]): Boolean = {
+    isSnapshotEligible(spark, snapshot) &&
+    !actions.exists {
+      case m: Metadata => m != snapshot.metadata
+      case _ => false
+    }
+  }
+
+  /**
+   * Returns a user-facing hint suggesting how to enable Row-Level Concurrency on this table
+   * when the RLC SQL conf is on but the loser's snapshot is missing one or both required
+   * table features (Deletion Vectors and/or Row Tracking). Returns `""` when no actionable
+   * hint applies: RLC is disabled, both features are already enabled, OR the table is
+   * partitioned or contains identity columns.
+   *
+   * The result is a single-line parenthetical phrase suitable for appending after the
+   * docLink in an error message such as
+   *   "Refer to <docLink> (...hint...) for more information."
+   * It must remain single-line so it can flow through the OSS error-class `docLink`
+   * parameter slot, which the error-class machinery and tests assume contains no newlines.
+   *
+   * @param snapshot the read snapshot for the failing transaction
+   * @param conf the active session's SQLConf
+   */
+  def enablementHintIfMissing(snapshot: Snapshot, conf: SQLConf): String = {
+    if (!conf.getConf(DeltaSQLConf.ROW_LEVEL_CONCURRENCY_ENABLED)) return ""
+    // Partitioned tables aren't supported by RLC, and partitioning isn't a feature the user
+    // can toggle without rewriting the table. Suppress the hint to avoid noise.
+    if (snapshot.metadata.partitionColumns.nonEmpty) return ""
+    // Identity-column tables are intentionally unsupported. Do not suggest enabling table
+    // features that would still leave the transaction ineligible.
+    if (ColumnWithDefaultExprUtils.hasIdentityColumn(snapshot.schema)) return ""
+
+    val dvOff = !DeletionVectorUtils.deletionVectorsWritable(snapshot)
+    val rtOff = !RowTracking.isEnabled(snapshot.protocol, snapshot.metadata)
+    if (!dvOff && !rtOff) return ""
+
+    val missing = mutable.ArrayBuffer.empty[String]
+    val tblPropFixes = mutable.ArrayBuffer.empty[String]
+    if (dvOff) {
+      missing += "Deletion Vectors"
+      tblPropFixes += s"'${DeltaConfigs.ENABLE_DELETION_VECTORS_CREATION.key}' = 'true'"
+    }
+    if (rtOff) {
+      missing += "Row Tracking"
+      tblPropFixes += s"'${DeltaConfigs.ROW_TRACKING_ENABLED.key}' = 'true'"
+    }
+
+    s" (enabling Row-Level Concurrency could allow this DML to commit if its row changes are" +
+      s" disjoint from the concurrent write -- missing feature(s): ${missing.mkString(" and ")};" +
+      s" enable with: ALTER TABLE <table> SET TBLPROPERTIES (${tblPropFixes.mkString(", ")}))"
+  }
+
+  // ---------------------------------------------------------------------------
+  // Detect-only analysis (no I/O, no DV decode)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Skip reasons recorded by [[wouldResolve]] when a candidate path is rejected from RLC
+   * resolution at the action-shape level.
+   */
+  object SkipReason {
+
+    /** Winner emitted more than one (or zero) AddFile for the path -- not a DV-only mod. */
+    val WinnerNotDvOnly = "winner_not_dv_only"
+
+    /** Winner's AddFile path differs from RemoveFile path -- copy-on-write or OPTIMIZE. */
+    val WinnerCowOrCompacted = "winner_cow_or_compacted"
+
+    /** Loser has a RemoveFile for the path but no matching AddFile -- not a DV-only mod. */
+    val LoserNoSamePathAdd = "loser_no_same_path_add"
+  }
+
+  /**
+   * Summary of what [[wouldResolve]] found: used to emit telemetry without performing any
+   * I/O or action mutation.
+   *
+   * @param candidateFileCount number of files where action shapes would allow rebase
+   * @param candidatePaths     the candidate paths themselves (capped to avoid log blowup)
+   * @param skipReasons        per-reason counts for paths skipped at the shape level
+   */
+  case class WouldResolveSummary(
+      candidateFileCount: Int,
+      candidatePaths: Seq[String],
+      skipReasons: Map[String, Int])
+
+  private val MAX_CANDIDATE_PATHS_LOGGED = 16
+
+  /**
+   * Detect-only analysis: walk the loser's and winner's actions and identify files where
+   * the action SHAPE would allow row-level conflict resolution. Does NOT decode DVs, does
+   * NOT mutate actions, does NOT issue I/O.
+   *
+   * Resolution preconditions P2 (winner monotonicity) and P4 (disjointness) are NOT checked
+   * here -- they require DV bytes, which only [[tryRebase]] reads.
+   *
+   * A path is a candidate when BOTH of the following hold:
+   *  - Loser emits `RemoveFile(path)` AND exactly one `AddFile(path)` (DV-only mod shape)
+   *  - Winner emits `RemoveFile(path)` AND exactly one `AddFile(path)` (DV-only mod shape)
+   */
+  def wouldResolve(
+      loserActions: Seq[Action],
+      winnerAddedFiles: Seq[AddFile],
+      winnerRemovedFiles: Seq[RemoveFile]): WouldResolveSummary = {
+    val loserRemovesByPath = loserActions.collect { case r: RemoveFile => r.path -> r }.toMap
+    val loserAddsByPath = loserActions.collect { case a: AddFile => a }.groupBy(_.path)
+    val winnerRemovesByPath = winnerRemovedFiles.map(r => r.path -> r).toMap
+    val winnerAddsByPath = winnerAddedFiles.groupBy(_.path)
+
+    val sharedPaths = loserRemovesByPath.keySet.intersect(winnerRemovesByPath.keySet)
+
+    val candidates = scala.collection.mutable.ArrayBuffer.empty[String]
+    val skipReasons = scala.collection.mutable.HashMap.empty[String, Int].withDefaultValue(0)
+
+    sharedPaths.foreach { path =>
+      val wAdds = winnerAddsByPath.getOrElse(path, Seq.empty)
+      val lAdds = loserAddsByPath.getOrElse(path, Seq.empty)
+
+      if (wAdds.isEmpty) {
+        // Winner is a full-delete or CoW that rewrote to a different path.
+        skipReasons(SkipReason.WinnerCowOrCompacted) += 1
+      } else if (wAdds.size != 1) {
+        // Winner produced multiple AddFiles for the path -- not a DV-only mod shape.
+        skipReasons(SkipReason.WinnerNotDvOnly) += 1
+      } else if (lAdds.size != 1) {
+        // Loser does not have exactly one AddFile for the path -- not a DV-only mod shape.
+        skipReasons(SkipReason.LoserNoSamePathAdd) += 1
+      } else {
+        candidates += path
+      }
+    }
+
+    WouldResolveSummary(
+      candidateFileCount = candidates.size,
+      candidatePaths = candidates.take(MAX_CANDIDATE_PATHS_LOGGED).toSeq,
+      skipReasons = skipReasons.toMap)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Atomic rebase
+  // ---------------------------------------------------------------------------
+
+  sealed trait RebaseFailure {
+    def name: String
+  }
+
+  object RebaseFailure {
+    case object WinnerCowOrCompacted extends RebaseFailure {
+      override val name: String = SkipReason.WinnerCowOrCompacted
+    }
+    case object WinnerNotDvOnly extends RebaseFailure {
+      override val name: String = SkipReason.WinnerNotDvOnly
+    }
+    case object LoserNotDvOnly extends RebaseFailure {
+      override val name: String = SkipReason.LoserNoSamePathAdd
+    }
+    case object DifferentBaseDv extends RebaseFailure {
+      override val name: String = "different_base_dv"
+    }
+    case object WinnerShrunkDv extends RebaseFailure {
+      override val name: String = "winner_shrunk_dv"
+    }
+    case object LoserShrunkDv extends RebaseFailure {
+      override val name: String = "loser_shrunk_dv"
+    }
+    case object Overlap extends RebaseFailure {
+      override val name: String = "overlap"
+    }
+    case object ByteBudgetExceeded extends RebaseFailure {
+      override val name: String = "byte_budget_exceeded"
+    }
+    case object DvReadBudgetExceeded extends RebaseFailure {
+      override val name: String = "dv_read_budget_exceeded"
+    }
+    case object DeadlineExceeded extends RebaseFailure {
+      override val name: String = "deadline_exceeded"
+    }
+    case object DecodeFailure extends RebaseFailure {
+      override val name: String = "decode_failure"
+    }
+    case object DvReadFailure extends RebaseFailure {
+      override val name: String = "dv_read_failure"
+    }
+    case object DvWriteFailure extends RebaseFailure {
+      override val name: String = "dv_write_failure"
+    }
+  }
+
+  sealed trait RebaseStatus
+  object RebaseStatus {
+    case object NoSharedPaths extends RebaseStatus
+    case object Succeeded extends RebaseStatus
+    case object Aborted extends RebaseStatus
+  }
+
+  case class RebaseStats(
+      numDvFilesRead: Int = 0,
+      numDvBytesRead: Long = 0L,
+      numDvFilesWritten: Int = 0)
+
+  /**
+   * A winning commit is applied only when every shared physical path can be rebased. On
+   * [[RebaseStatus.Aborted]], `newActions` is always the original action sequence and the
+   * resolved winner action lists are empty.
+   */
+  case class RebaseResult(
+      status: RebaseStatus,
+      newActions: Seq[Action],
+      resolvedAddFiles: Seq[AddFile],
+      resolvedRemoveFiles: Seq[RemoveFile],
+      failure: Option[RebaseFailure],
+      stats: RebaseStats) {
+    def resolvedFileCount: Int = resolvedAddFiles.size
+    def numDvFilesWritten: Int = stats.numDvFilesWritten
+    def skipReasons: Map[String, Int] = failure.map(f => Map(f.name -> 1)).getOrElse(Map.empty)
+  }
+
+  /**
+   * @param maxDvBytesPerFile maximum serialized size of any DV decoded during the rebase
+   * @param maxDvReads maximum number of distinct on-disk DV reads per winning commit
+   * @param deadlineNanos absolute deadline in the same time source as `nanoTime`
+   * @param nanoTime injectable monotonic time source for deterministic tests
+   */
+  case class RebaseBudgets(
+      maxDvBytesPerFile: Long,
+      maxDvReads: Int,
+      deadlineNanos: Long,
+      nanoTime: () => Long = () => System.nanoTime())
+
+  object RebaseBudgets {
+    def unbounded: RebaseBudgets =
+      RebaseBudgets(
+        maxDvBytesPerFile = Long.MaxValue,
+        maxDvReads = Int.MaxValue,
+        deadlineNanos = Long.MaxValue)
+  }
+
+  private case class RebaseCandidate(
+      path: String,
+      loserRemove: RemoveFile,
+      loserAdd: AddFile,
+      winnerRemove: RemoveFile,
+      winnerAdd: AddFile)
+
+  private case class PreparedRebase(
+      candidate: RebaseCandidate,
+      loserDelta: RoaringBitmapArray,
+      unionedDv: RoaringBitmapArray)
+
+  private class MutableRebaseStats {
+    var numDvFilesRead: Int = 0
+    var numDvBytesRead: Long = 0L
+    var numDvFilesWritten: Int = 0
+
+    def result: RebaseStats =
+      RebaseStats(numDvFilesRead, numDvBytesRead, numDvFilesWritten)
+  }
+
+  /**
+   * Rebase all same-file conflicts against one winning commit. Shape and DV contents are
+   * fully preflighted before any DV is written. If any shared path fails preflight, or if
+   * any write fails, the original actions are returned and no winner actions are resolved.
+   * A failed write can leave an unreferenced DV file, as with other failed Delta writes, but
+   * it can never produce a partially mutated transaction action set.
+   */
+  def tryRebase(
+      loserActions: Seq[Action],
+      winnerAddedFiles: Seq[AddFile],
+      winnerRemovedFiles: Seq[RemoveFile],
+      tablePath: Path,
+      hadoopConf: Configuration,
+      budgets: RebaseBudgets): RebaseResult = {
+    val stats = new MutableRebaseStats
+
+    def aborted(failure: RebaseFailure): RebaseResult = RebaseResult(
+      status = RebaseStatus.Aborted,
+      newActions = loserActions,
+      resolvedAddFiles = Seq.empty,
+      resolvedRemoveFiles = Seq.empty,
+      failure = Some(failure),
+      stats = stats.result)
+
+    val loserRemovesByPath = loserActions.collect { case r: RemoveFile => r }.groupBy(_.path)
+    val loserAddsByPath = loserActions.collect { case a: AddFile => a }.groupBy(_.path)
+    val winnerRemovesByPath = winnerRemovedFiles.groupBy(_.path)
+    val winnerAddsByPath = winnerAddedFiles.groupBy(_.path)
+    val sharedPaths = loserRemovesByPath.keySet.intersect(winnerRemovesByPath.keySet).toSeq.sorted
+
+    if (sharedPaths.isEmpty) {
+      return RebaseResult(
+        status = RebaseStatus.NoSharedPaths,
+        newActions = loserActions,
+        resolvedAddFiles = Seq.empty,
+        resolvedRemoveFiles = Seq.empty,
+        failure = None,
+        stats = stats.result)
+    }
+
+    val candidates = mutable.ArrayBuffer.empty[RebaseCandidate]
+    sharedPaths.foreach { path =>
+      val loserRemoves = loserRemovesByPath(path)
+      val loserAdds = loserAddsByPath.getOrElse(path, Seq.empty)
+      val winnerRemoves = winnerRemovesByPath(path)
+      val winnerAdds = winnerAddsByPath.getOrElse(path, Seq.empty)
+
+      if (winnerAdds.isEmpty) return aborted(RebaseFailure.WinnerCowOrCompacted)
+      if (winnerRemoves.size != 1 || winnerAdds.size != 1) {
+        return aborted(RebaseFailure.WinnerNotDvOnly)
+      }
+      if (loserRemoves.size != 1 || loserAdds.size != 1) {
+        return aborted(RebaseFailure.LoserNotDvOnly)
+      }
+
+      val candidate = RebaseCandidate(
+        path,
+        loserRemoves.head,
+        loserAdds.head,
+        winnerRemoves.head,
+        winnerAdds.head)
+      if (dvOrEmpty(candidate.loserRemove.deletionVector) !=
+          dvOrEmpty(candidate.winnerRemove.deletionVector)) {
+        return aborted(RebaseFailure.DifferentBaseDv)
+      }
+      candidates += candidate
+    }
+
+    val distinctDvs = candidates.iterator.flatMap { candidate =>
+      Iterator(
+        dvOrEmpty(candidate.winnerRemove.deletionVector),
+        dvOrEmpty(candidate.winnerAdd.deletionVector),
+        dvOrEmpty(candidate.loserAdd.deletionVector))
+    }.toSet
+    if (distinctDvs.exists(_.sizeInBytes > budgets.maxDvBytesPerFile)) {
+      return aborted(RebaseFailure.ByteBudgetExceeded)
+    }
+    if (distinctDvs.count(_.isOnDisk) > budgets.maxDvReads) {
+      return aborted(RebaseFailure.DvReadBudgetExceeded)
+    }
+
+    if (deadlineExceeded(budgets)) return aborted(RebaseFailure.DeadlineExceeded)
+
+    val dvStore = try {
+      DeletionVectorStore.createInstance(hadoopConf)
+    } catch {
+      case NonFatal(_) => return aborted(RebaseFailure.DvReadFailure)
+    }
+    val decoded = mutable.HashMap.empty[DeletionVectorDescriptor, RoaringBitmapArray]
+
+    def decodeDv(
+        dv: DeletionVectorDescriptor): Either[RebaseFailure, RoaringBitmapArray] = {
+      decoded.get(dv) match {
+        case Some(bitmap) => Right(bitmap)
+        case None =>
+          if (deadlineExceeded(budgets)) return Left(RebaseFailure.DeadlineExceeded)
+          if (dv.isOnDisk) {
+            stats.numDvFilesRead += 1
+            stats.numDvBytesRead += dv.sizeInBytes
+          }
+          val bitmap = try {
+            dvStore.read(dv, tablePath)
+          } catch {
+            case _: IOException => return Left(RebaseFailure.DvReadFailure)
+            case NonFatal(_) => return Left(RebaseFailure.DecodeFailure)
+          }
+          if (deadlineExceeded(budgets)) return Left(RebaseFailure.DeadlineExceeded)
+          decoded(dv) = bitmap
+          Right(bitmap)
+      }
+    }
+
+    val prepared = mutable.ArrayBuffer.empty[PreparedRebase]
+    candidates.foreach { candidate =>
+      val prior = decodeDv(dvOrEmpty(candidate.winnerRemove.deletionVector)) match {
+        case Right(bitmap) => bitmap
+        case Left(failure) => return aborted(failure)
+      }
+      val winner = decodeDv(dvOrEmpty(candidate.winnerAdd.deletionVector)) match {
+        case Right(bitmap) => bitmap
+        case Left(failure) => return aborted(failure)
+      }
+      val loser = decodeDv(dvOrEmpty(candidate.loserAdd.deletionVector)) match {
+        case Right(bitmap) => bitmap
+        case Left(failure) => return aborted(failure)
+      }
+
+      val priorMinusWinner = prior.copy()
+      priorMinusWinner.andNot(winner)
+      if (!priorMinusWinner.isEmpty) return aborted(RebaseFailure.WinnerShrunkDv)
+
+      val priorMinusLoser = prior.copy()
+      priorMinusLoser.andNot(loser)
+      if (!priorMinusLoser.isEmpty) return aborted(RebaseFailure.LoserShrunkDv)
+
+      val winnerDelta = winner.copy()
+      winnerDelta.andNot(prior)
+      val loserDelta = loser.copy()
+      loserDelta.andNot(prior)
+      val intersection = loserDelta.copy()
+      intersection.and(winnerDelta)
+      if (!intersection.isEmpty) return aborted(RebaseFailure.Overlap)
+
+      val unioned = winner.copy()
+      unioned.or(loserDelta)
+      prepared += PreparedRebase(candidate, loserDelta, unioned)
+    }
+
+    val replacements = mutable.HashMap.empty[String, (RemoveFile, AddFile)]
+    prepared.foreach { item =>
+      val descriptor = writeDv(item.unionedDv, tablePath, dvStore, budgets, stats) match {
+        case Right(dv) => dv
+        case Left(failure) => return aborted(failure)
+      }
+      val newRemove =
+        item.candidate.loserRemove.copy(deletionVector = item.candidate.winnerAdd.deletionVector)
+      val withNewDv = item.candidate.winnerAdd.copy(deletionVector = descriptor)
+      val newAdd =
+        if (item.loserDelta.isEmpty) withNewDv else withNewDv.withoutTightBoundStats
+      replacements(item.candidate.path) = (newRemove, newAdd)
+    }
+
+    val newActions = loserActions.map {
+      case remove: RemoveFile if replacements.contains(remove.path) =>
+        replacements(remove.path)._1
+      case add: AddFile if replacements.contains(add.path) =>
+        replacements(add.path)._2
+      case action => action
+    }
+    RebaseResult(
+      status = RebaseStatus.Succeeded,
+      newActions = newActions,
+      resolvedAddFiles = candidates.map(_.winnerAdd).toSeq,
+      resolvedRemoveFiles = candidates.map(_.winnerRemove).toSeq,
+      failure = None,
+      stats = stats.result)
+  }
+
+  /**
+   * Convenience overload for callers that only need a per-DV byte budget and no read or
+   * time limits. Used by unit tests that exercise rebase semantics in isolation.
+   */
+  def tryRebase(
+      loserActions: Seq[Action],
+      winnerAddedFiles: Seq[AddFile],
+      winnerRemovedFiles: Seq[RemoveFile],
+      tablePath: Path,
+      hadoopConf: Configuration,
+      maxDvBytes: Long): RebaseResult =
+    tryRebase(
+      loserActions = loserActions,
+      winnerAddedFiles = winnerAddedFiles,
+      winnerRemovedFiles = winnerRemovedFiles,
+      tablePath = tablePath,
+      hadoopConf = hadoopConf,
+      budgets = RebaseBudgets.unbounded.copy(maxDvBytesPerFile = maxDvBytes))
+
+  private def dvOrEmpty(dv: DeletionVectorDescriptor): DeletionVectorDescriptor =
+    if (dv == null) DeletionVectorDescriptor.EMPTY else dv
+
+  private def deadlineExceeded(budgets: RebaseBudgets): Boolean =
+    budgets.nanoTime() > budgets.deadlineNanos
+
+  private def writeDv(
+      bitmap: RoaringBitmapArray,
+      tablePath: Path,
+      dvStore: DeletionVectorStore,
+      budgets: RebaseBudgets,
+      stats: MutableRebaseStats): Either[RebaseFailure, DeletionVectorDescriptor] = {
+    if (deadlineExceeded(budgets)) return Left(RebaseFailure.DeadlineExceeded)
+    if (bitmap.isEmpty) return Right(DeletionVectorDescriptor.EMPTY)
+
+    val serialized = try {
+      DeletionVectorUtils.serialize(
+        bitmap,
+        RoaringBitmapArrayFormat.Portable,
+        tablePath = Some(tablePath))
+    } catch {
+      case NonFatal(_) => return Left(RebaseFailure.DvWriteFailure)
+    }
+    if (deadlineExceeded(budgets)) return Left(RebaseFailure.DeadlineExceeded)
+
+    val descriptor = try {
+      val tablePathWithFS = dvStore.pathWithFileSystem(tablePath)
+      val fileId = UUID.randomUUID()
+      val writer = dvStore.createWriter(dvStore.generateFileNameInTable(tablePathWithFS, fileId))
+      val range = try {
+        writer.write(serialized)
+      } finally {
+        writer.close()
+      }
+      stats.numDvFilesWritten += 1
+      DeletionVectorDescriptor.onDiskWithRelativePath(
+        id = fileId,
+        sizeInBytes = serialized.length,
+        cardinality = bitmap.cardinality,
+        offset = Some(range.offset))
+    } catch {
+      case NonFatal(_) => return Left(RebaseFailure.DvWriteFailure)
+    }
+    if (deadlineExceeded(budgets)) Left(RebaseFailure.DeadlineExceeded) else Right(descriptor)
+  }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -3592,6 +3592,57 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .stringConf
       .checkValues(SQLConf.ParquetOutputTimestampType.values.map(_.toString))
       .createWithDefault(SQLConf.ParquetOutputTimestampType.TIMESTAMP_MICROS.toString)
+
+  //////////////////////////////
+  // Row-Level Concurrency (RLC)
+  //////////////////////////////
+
+  val ROW_LEVEL_CONCURRENCY_ENABLED =
+    buildConf("rowLevelConcurrency.enabled")
+      .internal()
+      .doc(
+        """Master switch for row-level concurrency conflict resolution. When enabled,
+          |concurrent DML operations (DELETE/UPDATE/MERGE) that touch disjoint rows in the
+          |same physical file can commit without aborting, provided the table is
+          |RLC-eligible (DVs writable, Row Tracking enabled, unpartitioned, and no
+          |identity columns). Intended as an emergency switch to disable the
+          |feature.""".stripMargin)
+      .booleanConf
+      .createWithDefault(true)
+
+  val ROW_LEVEL_CONCURRENCY_MAX_DV_BYTES_PER_FILE =
+    buildConf("rowLevelConcurrency.maxDvBytesPerFile")
+      .internal()
+      .doc(
+        """Maximum serialized size of any Deletion Vector decoded during RLC conflict
+          |resolution. Exceeding the budget aborts the entire winning-commit rebase and
+          |falls back to the default file-level conflict detection.""".stripMargin)
+      .longConf
+      .checkValue(_ > 0, "maxDvBytesPerFile must be positive")
+      .createWithDefault(1048576L) // 1 MiB
+
+  val ROW_LEVEL_CONCURRENCY_MAX_DV_READS_PER_COMMIT =
+    buildConf("rowLevelConcurrency.maxDvReadsPerCommit")
+      .internal()
+      .doc(
+        """Maximum number of distinct external Deletion Vector reads performed while
+          |rebasing one winning commit. Inline DVs and cached duplicate descriptors do not
+          |consume this budget. Exceeding it falls back to default conflict
+          |detection.""".stripMargin)
+      .intConf
+      .checkValue(_ > 0, "maxDvReadsPerCommit must be positive")
+      .createWithDefault(64)
+
+  val ROW_LEVEL_CONCURRENCY_MAX_RESOLUTION_TIME_MS =
+    buildConf("rowLevelConcurrency.maxResolutionTimeMs")
+      .internal()
+      .doc(
+        """Wall-clock budget in milliseconds for rebasing one winning commit. The deadline
+          |is checked before and after DV reads and writes. If exceeded, the entire rebase
+          |falls back to default conflict detection.""".stripMargin)
+      .longConf
+      .checkValue(_ > 0, "maxResolutionTimeMs must be positive")
+      .createWithDefault(2000L)
 }
 
 object DeltaSQLConf extends DeltaSQLConfBase

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -2830,7 +2830,8 @@ trait DeltaErrorsSuiteBase
       checkError(e, "DELTA_CONCURRENT_APPEND.WITHOUT_HINT", "2D521",
         Map(
           "operation" -> "TRANSACTION", "tableName" -> "t", "version" -> "-1",
-          "docLink" -> generateDocsLink("/concurrency-control.html")
+          "docLink" -> generateDocsLink("/concurrency-control.html"),
+          "additionalHint" -> ""
         )
       )
     }
@@ -2842,7 +2843,8 @@ trait DeltaErrorsSuiteBase
       checkError(e, "DELTA_CONCURRENT_APPEND.WITH_PARTITION_HINT", "2D521",
         Map("operation" -> "TRANSACTION", "tableName" -> "t", "version" -> "-1",
           "partitionValues" -> "p1",
-          "docLink" -> generateDocsLink("/concurrency-control.html")))
+          "docLink" -> generateDocsLink("/concurrency-control.html"),
+          "additionalHint" -> ""))
     }
     {
       val e = intercept[io.delta.exceptions.ConcurrentDeleteReadException] {
@@ -2851,7 +2853,8 @@ trait DeltaErrorsSuiteBase
       }
       checkError(e, "DELTA_CONCURRENT_DELETE_READ.WITHOUT_HINT", "2D521",
         Map("operation" -> "TRANSACTION", "tableName" -> "t", "version" -> "-1",
-          "docLink" -> generateDocsLink("/concurrency-control.html")))
+          "docLink" -> generateDocsLink("/concurrency-control.html"),
+          "additionalHint" -> ""))
     }
     {
       val e = intercept[io.delta.exceptions.ConcurrentDeleteReadException] {
@@ -2861,7 +2864,8 @@ trait DeltaErrorsSuiteBase
       checkError(e, "DELTA_CONCURRENT_DELETE_READ.WITH_PARTITION_HINT", "2D521",
         Map("operation" -> "TRANSACTION", "tableName" -> "t", "version" -> "-1",
           "partitionValues" -> "p1",
-          "docLink" -> generateDocsLink("/concurrency-control.html")))
+          "docLink" -> generateDocsLink("/concurrency-control.html"),
+          "additionalHint" -> ""))
     }
     {
       val e = intercept[io.delta.exceptions.ConcurrentDeleteDeleteException] {
@@ -2870,7 +2874,8 @@ trait DeltaErrorsSuiteBase
       }
       checkError(e, "DELTA_CONCURRENT_DELETE_DELETE.WITHOUT_HINT", "2D521",
         Map("operation" -> "TRANSACTION", "tableName" -> "t", "version" -> "-1",
-          "docLink" -> generateDocsLink("/concurrency-control.html")))
+          "docLink" -> generateDocsLink("/concurrency-control.html"),
+          "additionalHint" -> ""))
     }
     {
       val e = intercept[io.delta.exceptions.ConcurrentDeleteDeleteException] {
@@ -2880,7 +2885,8 @@ trait DeltaErrorsSuiteBase
       checkError(e, "DELTA_CONCURRENT_DELETE_DELETE.WITH_PARTITION_HINT", "2D521",
         Map("operation" -> "TRANSACTION", "tableName" -> "t", "version" -> "-1",
           "partitionValues" -> "p1",
-          "docLink" -> generateDocsLink("/concurrency-control.html")))
+          "docLink" -> generateDocsLink("/concurrency-control.html"),
+          "additionalHint" -> ""))
     }
     {
       val e = intercept[io.delta.exceptions.ConcurrentTransactionException] {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
@@ -147,7 +147,8 @@ class OptimisticTransactionSuite
       "operation" -> "TRUNCATE",
       "version" -> "1",
       "partitionValues" -> "\\[x=1\\]",
-      "docLink" -> ".*"
+      "docLink" -> ".*",
+      "additionalHint" -> ".*"
     )))
 
   check(
@@ -217,7 +218,8 @@ class OptimisticTransactionSuite
       "operation" -> "TRUNCATE",
       "version" -> "2",
       "partitionValues" -> "\\[x=1\\]",
-      "docLink" -> ".*"
+      "docLink" -> ".*",
+      "additionalHint" -> ".*"
     )))
 
   check(
@@ -794,7 +796,8 @@ class OptimisticTransactionSuite
       "operation" -> "Manual Update",
       "partitionValues" -> s"\\[$partCol=0\\]",
       "version" -> "2",
-      "docLink" -> ".*"
+      "docLink" -> ".*",
+      "additionalHint" -> ".*"
     )
   )
 
@@ -812,7 +815,8 @@ class OptimisticTransactionSuite
       "operation" -> "Manual Update",
       "partitionValues" -> s"\\[$partCol=0\\]",
       "version" -> "2",
-      "docLink" -> ".*"
+      "docLink" -> ".*",
+      "additionalHint" -> ".*"
     )
   )
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/concurrency/rowlevelconcurrency/RowLevelConcurrencyBudgetsAndFuzzSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/concurrency/rowlevelconcurrency/RowLevelConcurrencyBudgetsAndFuzzSuite.scala
@@ -1,0 +1,394 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.concurrency.rowlevelconcurrency
+
+import java.util.UUID
+
+import scala.util.Random
+
+import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.RowLevelConcurrency.{RebaseBudgets, RebaseFailure, RebaseStatus}
+import org.apache.spark.sql.delta.actions.{Action, AddFile, DeletionVectorDescriptor, RemoveFile}
+import org.apache.spark.sql.delta.commands.DeletionVectorUtils
+import org.apache.spark.sql.delta.deletionvectors.{RoaringBitmapArray, RoaringBitmapArrayFormat}
+import org.apache.spark.sql.delta.storage.dv.DeletionVectorStore
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.test.SharedSparkSession
+
+/**
+ * Unit tests covering the per-commit budgets (file count, wall-clock deadline),
+ * the tightBounds stats degradation, and a 3-writer convergence fuzz test.
+ */
+class RowLevelConcurrencyBudgetsAndFuzzSuite extends QueryTest
+  with SharedSparkSession
+  with DeltaSQLCommandTest {
+
+  // ---------- helpers ----------
+
+  private def bitmap(rows: Long*): RoaringBitmapArray = {
+    val b = new RoaringBitmapArray()
+    rows.foreach(b.add)
+    b
+  }
+
+  private def inlineDv(rows: Long*): DeletionVectorDescriptor = {
+    val b = bitmap(rows: _*)
+    if (b.isEmpty) {
+      DeletionVectorDescriptor.EMPTY
+    } else {
+      val bytes = b.serializeAsByteArray(RoaringBitmapArrayFormat.Portable)
+      DeletionVectorDescriptor.inlineInLog(bytes, b.cardinality)
+    }
+  }
+
+  private def addFile(
+      path: String,
+      dv: DeletionVectorDescriptor = DeletionVectorDescriptor.EMPTY,
+      stats: String = "{\"numRecords\": 100}"): AddFile =
+    AddFile(
+      path = path,
+      partitionValues = Map.empty,
+      size = 1L,
+      modificationTime = 1L,
+      dataChange = true,
+      stats = stats,
+      deletionVector = dv)
+
+  private def removeFile(path: String, dv: DeletionVectorDescriptor): RemoveFile =
+    RemoveFile(
+      path = path,
+      deletionTimestamp = Some(1L),
+      dataChange = true,
+      deletionVector = dv)
+
+  private def newHadoopConf(): org.apache.hadoop.conf.Configuration = {
+    // scalastyle:off deltahadoopconfiguration
+    spark.sessionState.newHadoopConf()
+    // scalastyle:on deltahadoopconfiguration
+  }
+
+  private def onDiskDv(
+      tablePath: Path,
+      hadoopConf: org.apache.hadoop.conf.Configuration,
+      rows: Long*): DeletionVectorDescriptor = {
+    val bitmapArray = bitmap(rows: _*)
+    val store = DeletionVectorStore.createInstance(hadoopConf)
+    val fileId = UUID.randomUUID()
+    val writer = store.createWriter(
+      store.generateFileNameInTable(store.pathWithFileSystem(tablePath), fileId))
+    try {
+      val bytes = DeletionVectorUtils.serialize(
+        bitmapArray,
+        RoaringBitmapArrayFormat.Portable,
+        tablePath = Some(tablePath))
+      val range = writer.write(bytes)
+      DeletionVectorDescriptor.onDiskWithRelativePath(
+        id = fileId,
+        sizeInBytes = bytes.length,
+        cardinality = bitmapArray.cardinality,
+        offset = Some(range.offset))
+    } finally {
+      writer.close()
+    }
+  }
+
+  private def decodedRows(
+      dv: DeletionVectorDescriptor,
+      tablePath: Path,
+      hadoopConf: org.apache.hadoop.conf.Configuration): Set[Long] =
+    DeletionVectorStore.createInstance(hadoopConf).read(dv, tablePath).toArray.toSet
+
+  // ---------- budgets: external DV reads ----------
+
+  test("budget: maxDvReads counts distinct external reads, not candidate paths") {
+    withTempDir { dir =>
+      val tablePath = new Path("file:" + dir.getAbsolutePath)
+      val hadoopConf = newHadoopConf()
+
+      val priorDv = inlineDv()
+      val loserActions: Seq[Action] = Seq(
+        removeFile("f1", priorDv), addFile("f1", onDiskDv(tablePath, hadoopConf, 1L)),
+        removeFile("f2", priorDv), addFile("f2", onDiskDv(tablePath, hadoopConf, 2L)))
+      val winnerAdded = Seq(
+        addFile("f1", onDiskDv(tablePath, hadoopConf, 11L)),
+        addFile("f2", onDiskDv(tablePath, hadoopConf, 12L)))
+      val winnerRemoved = Seq(removeFile("f1", priorDv), removeFile("f2", priorDv))
+
+      val budgets = RebaseBudgets(
+        maxDvBytesPerFile = 1024L * 1024L,
+        maxDvReads = 3,
+        deadlineNanos = Long.MaxValue)
+
+      val result = RowLevelConcurrency.tryRebase(
+        loserActions, winnerAdded, winnerRemoved, tablePath, hadoopConf, budgets)
+
+      assert(result.status == RebaseStatus.Aborted)
+      assert(result.failure.contains(RebaseFailure.DvReadBudgetExceeded))
+      assert(result.stats.numDvFilesRead == 0, "read budget must be preflighted before I/O")
+      assert(result.numDvFilesWritten == 0)
+
+      val exactBudgetResult = RowLevelConcurrency.tryRebase(
+        loserActions, winnerAdded, winnerRemoved, tablePath, hadoopConf,
+        budgets.copy(maxDvReads = 4))
+      assert(exactBudgetResult.status == RebaseStatus.Succeeded)
+      assert(exactBudgetResult.stats.numDvFilesRead == 4)
+    }
+  }
+
+  // ---------- budgets: wall-clock deadline ----------
+
+  test("budget: deadline is checked immediately after each DV read") {
+    withTempDir { dir =>
+      val tablePath = new Path("file:" + dir.getAbsolutePath)
+      val hadoopConf = newHadoopConf()
+
+      val priorDv = onDiskDv(tablePath, hadoopConf, 0L)
+      val loserActions: Seq[Action] =
+        Seq(removeFile("f1", priorDv), addFile("f1", onDiskDv(tablePath, hadoopConf, 0L, 1L)))
+      val winnerAdded = Seq(addFile("f1", onDiskDv(tablePath, hadoopConf, 0L, 2L)))
+      val winnerRemoved = Seq(removeFile("f1", priorDv))
+      var clockReads = 0
+      val clock = () => {
+        clockReads += 1
+        if (clockReads < 3) 0L else 2L
+      }
+      val budgets = RebaseBudgets(
+        maxDvBytesPerFile = 1024L * 1024L,
+        maxDvReads = Int.MaxValue,
+        deadlineNanos = 1L,
+        nanoTime = clock)
+
+      val result = RowLevelConcurrency.tryRebase(
+        loserActions, winnerAdded, winnerRemoved, tablePath, hadoopConf, budgets)
+
+      assert(result.status == RebaseStatus.Aborted)
+      assert(result.failure.contains(RebaseFailure.DeadlineExceeded))
+      assert(result.stats.numDvFilesRead == 1)
+      assert(result.numDvFilesWritten == 0)
+      assert(result.newActions == loserActions)
+    }
+  }
+
+  // ---------- tightBounds degradation ----------
+
+  test("tightBounds: degraded to false when loserDelta is non-empty") {
+    withTempDir { dir =>
+      val tablePath = new Path("file:" + dir.getAbsolutePath)
+      val hadoopConf = newHadoopConf()
+
+      val priorDv = inlineDv(0L)
+      val winnerDv = inlineDv(0L, 1L)
+      val loserDv = inlineDv(0L, 5L)
+
+      // Winner stats claim tightBounds=true; after RLC the rebased file must have
+      // tightBounds=false because the loser's delta marks additional rows as deleted
+      // whose values may have contributed to the tight min/max.
+      val winnerStats =
+        """{"numRecords":100,"minValues":{"x":1},"maxValues":{"x":100},"tightBounds":true}"""
+      val loserActions: Seq[Action] = Seq(removeFile("f1", priorDv), addFile("f1", loserDv))
+      val winnerAdded = Seq(addFile("f1", winnerDv, stats = winnerStats))
+      val winnerRemoved = Seq(removeFile("f1", priorDv))
+
+      val result = RowLevelConcurrency.tryRebase(
+        loserActions, winnerAdded, winnerRemoved, tablePath, hadoopConf, maxDvBytes = 1024L * 1024L)
+
+      assert(result.resolvedFileCount == 1)
+      val rebasedAdd = result.newActions.collect { case a: AddFile => a }
+        .find(_.path == "f1").get
+      assert(rebasedAdd.stats.contains("\"tightBounds\":false"),
+        s"Expected tightBounds=false in rebased stats but got: ${rebasedAdd.stats}")
+    }
+  }
+
+  test("tightBounds: unchanged when loserDelta is empty") {
+    withTempDir { dir =>
+      val tablePath = new Path("file:" + dir.getAbsolutePath)
+      val hadoopConf = newHadoopConf()
+
+      val priorDv = inlineDv(0L)
+      val winnerDv = inlineDv(0L, 1L)
+      val loserDv = priorDv  // Loser made no new deletions
+
+      val winnerStats = """{"numRecords":100,"tightBounds":true}"""
+      val loserActions: Seq[Action] = Seq(removeFile("f1", priorDv), addFile("f1", loserDv))
+      val winnerAdded = Seq(addFile("f1", winnerDv, stats = winnerStats))
+      val winnerRemoved = Seq(removeFile("f1", priorDv))
+
+      val result = RowLevelConcurrency.tryRebase(
+        loserActions, winnerAdded, winnerRemoved, tablePath, hadoopConf, maxDvBytes = 1024L * 1024L)
+
+      assert(result.resolvedFileCount == 1)
+      val rebasedAdd = result.newActions.collect { case a: AddFile => a }
+        .find(_.path == "f1").get
+      assert(rebasedAdd.stats == winnerStats,
+        s"Stats should pass through unchanged when loserDelta is empty")
+    }
+  }
+
+  test("retry: an already rebased pair can rebase against the next winning commit") {
+    withTempDir { dir =>
+      val tablePath = new Path("file:" + dir.getAbsolutePath)
+      val hadoopConf = newHadoopConf()
+      val prior = inlineDv(0L)
+      val loserActions: Seq[Action] =
+        Seq(removeFile("f", prior), addFile("f", inlineDv(0L, 30L)))
+
+      val first = RowLevelConcurrency.tryRebase(
+        loserActions,
+        Seq(addFile("f", inlineDv(0L, 10L))),
+        Seq(removeFile("f", prior)),
+        tablePath,
+        hadoopConf,
+        maxDvBytes = 1024L * 1024L)
+      assert(first.status == RebaseStatus.Succeeded)
+
+      val firstRemove = first.newActions.collectFirst { case remove: RemoveFile => remove }.get
+      val firstAdd = first.newActions.collectFirst { case add: AddFile => add }.get
+      val secondWinnerAdd = addFile("f", inlineDv(0L, 10L, 20L))
+      val second = RowLevelConcurrency.tryRebase(
+        first.newActions,
+        Seq(secondWinnerAdd),
+        Seq(removeFile("f", firstRemove.deletionVector)),
+        tablePath,
+        hadoopConf,
+        maxDvBytes = 1024L * 1024L)
+
+      assert(second.status == RebaseStatus.Succeeded)
+      val finalRemove = second.newActions.collectFirst { case remove: RemoveFile => remove }.get
+      val finalAdd = second.newActions.collectFirst { case add: AddFile => add }.get
+      assert(finalRemove.deletionVector == secondWinnerAdd.deletionVector)
+      assert(decodedRows(finalAdd.deletionVector, tablePath, hadoopConf) ==
+        Set(0L, 10L, 20L, 30L))
+      assert(firstAdd.path == finalAdd.path)
+    }
+  }
+
+  // ---------- 3-writer convergence fuzz ----------
+
+  test("fuzz: 3-writer convergence -- ABC disjoint always commits all 3 after sequencing") {
+    // Property (multi-writer convergence): if three writers A, B, C
+    // touch disjoint row sets in the same physical file, then after the ConflictChecker
+    // loop processes the winning commits one-at-a-time, the final loser's rebased pair
+    // encodes (priorDV union A union B union C) against the latest winner's AddFile.
+    //
+    // The ConflictChecker iterates over winning commits serially (see
+    // OptimisticTransaction.scala:2793-2810): for each winner w, it calls tryRebase with
+    // the *current* (possibly already-rebased) loser actions vs that one winner's
+    // commit summary. We model that loop here:
+    //   1. A commits first (no rebase).
+    //   2. B rebases against A.
+    //   3. C rebases against A, then C-after-rebase rebases against B-after-rebase.
+    val rng = new Random(seed = 42L)
+    withTempDir { dir =>
+      val tablePath = new Path("file:" + dir.getAbsolutePath)
+      val hadoopConf = newHadoopConf()
+
+      for (iter <- 1 to 50) {
+        val rowsPerWriter = 8
+        val universe: IndexedSeq[Long] = (0L until 1000L).toIndexedSeq
+        val shuffled: IndexedSeq[Long] = rng.shuffle(universe)
+        // Three disjoint slices of 8 rows each = 24 unique rows touched.
+        val aRows = shuffled.slice(0, rowsPerWriter)
+        val bRows = shuffled.slice(rowsPerWriter, 2 * rowsPerWriter)
+        val cRows = shuffled.slice(2 * rowsPerWriter, 3 * rowsPerWriter)
+        val priorRows = shuffled.slice(3 * rowsPerWriter, 3 * rowsPerWriter + 5)
+
+        val priorDv = inlineDv(priorRows: _*)
+        val aDv = inlineDv((priorRows ++ aRows): _*)
+        val bDv = inlineDv((priorRows ++ bRows): _*)
+        val cDv = inlineDv((priorRows ++ cRows): _*)
+
+        // Helper: extract the rebased (RemoveFile, AddFile) pair from a rebase result.
+        def extractPair(actions: Seq[Action]): (RemoveFile, AddFile) = {
+          val r = actions.collect { case x: RemoveFile => x }.head
+          val a = actions.collect { case x: AddFile => x }.head
+          (r, a)
+        }
+
+        // Step 1 (no rebase): A commits first.
+        val aAdd = addFile("f", aDv)
+        val aRemove = removeFile("f", priorDv)
+
+        // Step 2: B rebases against A. B starts with (priorDv -> bDv).
+        val bActions: Seq[Action] = Seq(removeFile("f", priorDv), addFile("f", bDv))
+        val bResult = RowLevelConcurrency.tryRebase(
+          bActions, Seq(aAdd), Seq(aRemove), tablePath, hadoopConf,
+          maxDvBytes = 1024L * 1024L)
+        assert(bResult.resolvedFileCount == 1, s"iter=$iter: B should rebase against A")
+        val (bRebasedRemove, bRebasedAdd) = extractPair(bResult.newActions)
+
+        // Step 3a: C rebases against A. C also starts with (priorDv -> cDv).
+        val cActions: Seq[Action] = Seq(removeFile("f", priorDv), addFile("f", cDv))
+        val cVsAResult = RowLevelConcurrency.tryRebase(
+          cActions, Seq(aAdd), Seq(aRemove), tablePath, hadoopConf,
+          maxDvBytes = 1024L * 1024L)
+        assert(cVsAResult.resolvedFileCount == 1,
+          s"iter=$iter: C should rebase against A")
+        val (cAfterARemove, cAfterAAdd) = extractPair(cVsAResult.newActions)
+
+        // Step 3b: C-after-rebase rebases against B-after-rebase. This is the second
+        // iteration of the ConflictChecker loop for C: its loser actions are now the
+        // post-rebase pair from step 3a, and the winner is B's already-rebased pair
+        // from step 2 (since B committed at the next version).
+        val cAfterAActions: Seq[Action] = Seq(cAfterARemove, cAfterAAdd)
+        val cFinalResult = RowLevelConcurrency.tryRebase(
+          cAfterAActions,
+          Seq(bRebasedAdd), Seq(bRebasedRemove),
+          tablePath, hadoopConf, maxDvBytes = 1024L * 1024L)
+        assert(cFinalResult.resolvedFileCount == 1,
+          s"iter=$iter: C-after-A should rebase against B-after-A")
+
+        // Verify the final bitmap exactly equals prior union A union B union C.
+        val (_, finalAdd) = extractPair(cFinalResult.newActions)
+        val expectedAllRows = (priorRows ++ aRows ++ bRows ++ cRows).distinct.toSet
+        val actualRows = decodedRows(finalAdd.deletionVector, tablePath, hadoopConf)
+        assert(actualRows == expectedAllRows,
+          s"iter=$iter: row-set mismatch; missing=${expectedAllRows -- actualRows}, " +
+            s"unexpected=${actualRows -- expectedAllRows}")
+        assert(cFinalResult.newActions.collect {
+          case add: AddFile if add.path == "f" => add
+        }.size == 1, s"iter=$iter: exactly one active AddFile action is required per path")
+      }
+    }
+  }
+
+  test("fuzz: overlap on at least one writer -> not all three converge") {
+    // Property: if A's delta overlaps B's delta (say they both delete row 7), then B's
+    // rebase against A fails and B falls back to the legacy abort path.
+    withTempDir { dir =>
+      val tablePath = new Path("file:" + dir.getAbsolutePath)
+      val hadoopConf = newHadoopConf()
+
+      val priorDv = inlineDv(0L)
+      val aDv = inlineDv(0L, 7L)
+      val bDv = inlineDv(0L, 7L)  // Same row as A -- overlap!
+
+      val bActions: Seq[Action] = Seq(removeFile("f", priorDv), addFile("f", bDv))
+      val aAdded = Seq(addFile("f", aDv))
+      val aRemoved = Seq(removeFile("f", priorDv))
+
+      val result = RowLevelConcurrency.tryRebase(
+        bActions, aAdded, aRemoved, tablePath, hadoopConf, maxDvBytes = 1024L * 1024L)
+
+      assert(result.resolvedFileCount == 0)
+      assert(result.failure.contains(RebaseFailure.Overlap))
+    }
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/concurrency/rowlevelconcurrency/RowLevelConcurrencyDeleteRebaseSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/concurrency/rowlevelconcurrency/RowLevelConcurrencyDeleteRebaseSuite.scala
@@ -1,0 +1,460 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.concurrency.rowlevelconcurrency
+
+import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.RowLevelConcurrency.{RebaseFailure, RebaseStatus}
+import org.apache.spark.sql.delta.actions.{Action, AddFile, DeletionVectorDescriptor, RemoveFile}
+import org.apache.spark.sql.delta.deletionvectors.{RoaringBitmapArray, RoaringBitmapArrayFormat}
+import org.apache.spark.sql.delta.storage.dv.DeletionVectorStore
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.test.SharedSparkSession
+
+/**
+ * Unit tests for [[RowLevelConcurrency.tryRebase]] -- the DELETE rebase
+ * algorithm. These tests construct synthetic Action sequences with inline DVs (so the
+ * decode side does no I/O) and exercise the rebase against a local-filesystem temp dir
+ * (the write side issues real PUTs to a temp DV file).
+ */
+class RowLevelConcurrencyDeleteRebaseSuite extends QueryTest
+  with SharedSparkSession
+  with DeltaSQLCommandTest {
+
+  // ---------- helpers ----------
+
+  /** Build a RoaringBitmapArray containing the given row indices. */
+  private def bitmap(rows: Long*): RoaringBitmapArray = {
+    val b = new RoaringBitmapArray()
+    rows.foreach(b.add)
+    b
+  }
+
+  /** Encode a bitmap as an inline DeletionVectorDescriptor (no I/O required for decode). */
+  private def inlineDv(rows: Long*): DeletionVectorDescriptor = {
+    val b = bitmap(rows: _*)
+    if (b.isEmpty) {
+      DeletionVectorDescriptor.EMPTY
+    } else {
+      val bytes = b.serializeAsByteArray(RoaringBitmapArrayFormat.Portable)
+      DeletionVectorDescriptor.inlineInLog(bytes, b.cardinality)
+    }
+  }
+
+  private def addFile(path: String, dv: DeletionVectorDescriptor): AddFile =
+    AddFile(
+      path = path,
+      partitionValues = Map.empty,
+      size = 1L,
+      modificationTime = 1L,
+      dataChange = true,
+      stats = "{\"numRecords\": 100}",
+      deletionVector = dv)
+
+  private def removeFile(path: String, dv: DeletionVectorDescriptor): RemoveFile =
+    RemoveFile(
+      path = path,
+      deletionTimestamp = Some(1L),
+      dataChange = true,
+      deletionVector = dv)
+
+  private def newHadoopConf(): org.apache.hadoop.conf.Configuration = {
+    // scalastyle:off deltahadoopconfiguration
+    spark.sessionState.newHadoopConf()
+    // scalastyle:on deltahadoopconfiguration
+  }
+
+  private def MAX_DV_BYTES = 1024L * 1024L
+
+  private def decodedRows(
+      dv: DeletionVectorDescriptor,
+      tablePath: Path,
+      hadoopConf: org.apache.hadoop.conf.Configuration): Set[Long] =
+    DeletionVectorStore.createInstance(hadoopConf).read(dv, tablePath).toArray.toSet
+
+  // ---------- happy path ----------
+
+  test("tryRebase: disjoint deltas resolve to unioned DV") {
+    withTempDir { dir =>
+      val tablePath = new Path("file:" + dir.getAbsolutePath)
+      val hadoopConf = newHadoopConf()
+      val path = "f1.parquet"
+
+      // Prior: rows 0,1 deleted. Winner adds row 2 (delta = {2}).
+      // Loser adds row 5 (delta = {5}). Disjoint -> resolvable.
+      val priorDv = inlineDv(0L, 1L)
+      val winnerDv = inlineDv(0L, 1L, 2L)
+      val loserDv = inlineDv(0L, 1L, 5L)
+
+      val loserActions: Seq[Action] = Seq(
+        removeFile(path, priorDv),
+        addFile(path, loserDv))
+      val winnerAdded = Seq(addFile(path, winnerDv))
+      val winnerRemoved = Seq(removeFile(path, priorDv))
+
+      val result = RowLevelConcurrency.tryRebase(
+        loserActions, winnerAdded, winnerRemoved, tablePath, hadoopConf, MAX_DV_BYTES)
+
+      assert(result.resolvedFileCount == 1)
+      assert(result.status == RebaseStatus.Succeeded)
+      assert(result.numDvFilesWritten == 1)  // Non-empty union -> 1 PUT
+      assert(result.skipReasons.isEmpty)
+      assert(result.resolvedAddFiles.size == 1)
+
+      // Verify the new actions: same path RemoveFile + AddFile pair, plus unionedDV
+      val newRemoves = result.newActions.collect { case r: RemoveFile => r }
+      val newAdds = result.newActions.collect { case a: AddFile => a }
+      assert(newRemoves.size == 1)
+      assert(newAdds.size == 1)
+      assert(newRemoves.head.path == path)
+      assert(newAdds.head.path == path)
+      // RemoveFile's DV should point at the winner's AddFile DV (the active version)
+      assert(newRemoves.head.deletionVector == winnerDv)
+      assert(decodedRows(newAdds.head.deletionVector, tablePath, hadoopConf) == Set(0L, 1L, 2L, 5L))
+    }
+  }
+
+  test("tryRebase: no new deletions on either side still rebases to the prior DV") {
+    withTempDir { dir =>
+      val tablePath = new Path("file:" + dir.getAbsolutePath)
+      val hadoopConf = newHadoopConf()
+      val path = "f1.parquet"
+
+      // Neither side added deletions, so the union equals the (non-empty) prior DV.
+      val priorDv = inlineDv(0L, 1L)
+      val winnerDv = priorDv
+      val loserDv = priorDv
+
+      val loserActions: Seq[Action] = Seq(removeFile(path, priorDv), addFile(path, loserDv))
+      val winnerAdded = Seq(addFile(path, winnerDv))
+      val winnerRemoved = Seq(removeFile(path, priorDv))
+
+      val result = RowLevelConcurrency.tryRebase(
+        loserActions, winnerAdded, winnerRemoved, tablePath, hadoopConf, MAX_DV_BYTES)
+
+      assert(result.resolvedFileCount == 1)
+      // The union is non-empty, so it is materialized as a single DV write.
+      assert(result.numDvFilesWritten == 1)
+      val newAdds = result.newActions.collect { case a: AddFile => a }
+      assert(decodedRows(newAdds.head.deletionVector, tablePath, hadoopConf) == Set(0L, 1L))
+    }
+  }
+
+  test("tryRebase: fully empty DVs rebase to the EMPTY descriptor with zero PUTs") {
+    withTempDir { dir =>
+      val tablePath = new Path("file:" + dir.getAbsolutePath)
+      val hadoopConf = newHadoopConf()
+      val path = "f1.parquet"
+
+      val emptyDv = inlineDv()
+      val loserActions: Seq[Action] = Seq(removeFile(path, emptyDv), addFile(path, emptyDv))
+      val winnerAdded = Seq(addFile(path, emptyDv))
+      val winnerRemoved = Seq(removeFile(path, emptyDv))
+
+      val result = RowLevelConcurrency.tryRebase(
+        loserActions, winnerAdded, winnerRemoved, tablePath, hadoopConf, MAX_DV_BYTES)
+
+      assert(result.resolvedFileCount == 1)
+      assert(result.numDvFilesWritten == 0, "An empty union must not write a DV file")
+      val newAdds = result.newActions.collect { case a: AddFile => a }
+      assert(newAdds.head.deletionVector == DeletionVectorDescriptor.EMPTY)
+    }
+  }
+
+  test("tryRebase: loser DV that drops a prior deletion aborts atomically") {
+    withTempDir { dir =>
+      val tablePath = new Path("file:" + dir.getAbsolutePath)
+      val hadoopConf = newHadoopConf()
+      val path = "f1.parquet"
+
+      // The loser's post-image DV omits row 1, which the prior DV already deleted.
+      // Committing it would resurrect a deleted row, so the rebase must abort.
+      val priorDv = inlineDv(0L, 1L)
+      val winnerDv = inlineDv(0L, 1L, 2L)
+      val loserDv = inlineDv(0L)
+
+      val loserActions: Seq[Action] = Seq(removeFile(path, priorDv), addFile(path, loserDv))
+      val winnerAdded = Seq(addFile(path, winnerDv))
+      val winnerRemoved = Seq(removeFile(path, priorDv))
+
+      val result = RowLevelConcurrency.tryRebase(
+        loserActions, winnerAdded, winnerRemoved, tablePath, hadoopConf, MAX_DV_BYTES)
+
+      assert(result.status == RowLevelConcurrency.RebaseStatus.Aborted)
+      assert(result.failure.contains(RowLevelConcurrency.RebaseFailure.LoserShrunkDv))
+      assert(result.resolvedFileCount == 0)
+      assert(result.numDvFilesWritten == 0)
+      assert(result.newActions == loserActions, "Aborted rebase must not mutate actions")
+    }
+  }
+
+  // ---------- precondition failures ----------
+
+  test("tryRebase: overlapping deltas (P4 fail) records Overlap and does not mutate") {
+    withTempDir { dir =>
+      val tablePath = new Path("file:" + dir.getAbsolutePath)
+      val hadoopConf = newHadoopConf()
+      val path = "f1.parquet"
+
+      // Both winner and loser deleted row 2 -- they overlap.
+      val priorDv = inlineDv(0L)
+      val winnerDv = inlineDv(0L, 2L)
+      val loserDv = inlineDv(0L, 2L)
+
+      val loserActions: Seq[Action] = Seq(removeFile(path, priorDv), addFile(path, loserDv))
+      val winnerAdded = Seq(addFile(path, winnerDv))
+      val winnerRemoved = Seq(removeFile(path, priorDv))
+
+      val result = RowLevelConcurrency.tryRebase(
+        loserActions, winnerAdded, winnerRemoved, tablePath, hadoopConf, MAX_DV_BYTES)
+
+      assert(result.resolvedFileCount == 0)
+      assert(result.numDvFilesWritten == 0)
+      assert(result.failure.contains(RebaseFailure.Overlap))
+      assert(result.newActions == loserActions)
+    }
+  }
+
+  test("tryRebase: winner shrinks DV (P2 fail) records WinnerShrunkDv") {
+    // P2 precondition (winner monotonicity): the winner's same-path AddFile DV must
+    // be a SUPERSET of the prior (read-time) RemoveFile DV. If the winner's DV instead
+    // shrinks (e.g. a phantom in-place "undelete" leaked through), RLC must NOT rebase
+    // because the loser's reads may have been against rows the winner has now reverted.
+    // We synthesize that exact shape: prior contains row 5, winner's new DV does not.
+    withTempDir { dir =>
+      val tablePath = new Path("file:" + dir.getAbsolutePath)
+      val hadoopConf = newHadoopConf()
+      val path = "f1.parquet"
+
+      val priorDv = inlineDv(0L, 5L)         // baseline: rows {0, 5}
+      val winnerDv = inlineDv(0L, 1L)        // winner shrinks 5, adds 1 -- prior \ winner != empty
+      val loserDv = inlineDv(0L, 5L, 9L)     // loser added row 9 over the same baseline
+
+      val loserActions: Seq[Action] = Seq(removeFile(path, priorDv), addFile(path, loserDv))
+      val winnerAdded = Seq(addFile(path, winnerDv))
+      val winnerRemoved = Seq(removeFile(path, priorDv))  // same priorDv => P3 passes
+
+      val result = RowLevelConcurrency.tryRebase(
+        loserActions, winnerAdded, winnerRemoved, tablePath, hadoopConf, MAX_DV_BYTES)
+
+      assert(result.resolvedFileCount == 0)
+      assert(result.failure.contains(RebaseFailure.WinnerShrunkDv),
+        s"Expected WinnerShrunkDv but got: ${result.failure}")
+      // P2 fires before P4 -- assert no false "Overlap" or "DifferentBaseDv" reading
+      assert(result.newActions == loserActions)
+    }
+  }
+
+  test("tryRebase: different base DV (P3 fail) records DifferentBaseDv") {
+    withTempDir { dir =>
+      val tablePath = new Path("file:" + dir.getAbsolutePath)
+      val hadoopConf = newHadoopConf()
+      val path = "f1.parquet"
+
+      val loserRemoveDv = inlineDv(0L)
+      val winnerRemoveDv = inlineDv(0L, 1L)  // Different base!
+
+      val loserActions: Seq[Action] = Seq(
+        removeFile(path, loserRemoveDv),
+        addFile(path, inlineDv(0L, 5L)))
+      val winnerAdded = Seq(addFile(path, inlineDv(0L, 1L, 2L)))
+      val winnerRemoved = Seq(removeFile(path, winnerRemoveDv))
+
+      val result = RowLevelConcurrency.tryRebase(
+        loserActions, winnerAdded, winnerRemoved, tablePath, hadoopConf, MAX_DV_BYTES)
+
+      assert(result.resolvedFileCount == 0)
+      assert(result.failure.contains(RebaseFailure.DifferentBaseDv))
+      assert(result.newActions == loserActions)
+    }
+  }
+
+  test("tryRebase: winner CoW (different add path) records WinnerCowOrCompacted") {
+    withTempDir { dir =>
+      val tablePath = new Path("file:" + dir.getAbsolutePath)
+      val hadoopConf = newHadoopConf()
+      val path = "f1.parquet"
+
+      val loserActions: Seq[Action] = Seq(removeFile(path, inlineDv()), addFile(path, inlineDv(5L)))
+      val winnerAdded = Seq(addFile("f1_rewritten.parquet", inlineDv()))
+      val winnerRemoved = Seq(removeFile(path, inlineDv()))
+
+      val result = RowLevelConcurrency.tryRebase(
+        loserActions, winnerAdded, winnerRemoved, tablePath, hadoopConf, MAX_DV_BYTES)
+
+      assert(result.resolvedFileCount == 0)
+      assert(result.failure.contains(RebaseFailure.WinnerCowOrCompacted))
+      assert(result.newActions == loserActions)
+    }
+  }
+
+  // ---------- multi-file ----------
+
+  test("tryRebase: one disjoint and one overlapping path aborts atomically") {
+    withTempDir { dir =>
+      val tablePath = new Path("file:" + dir.getAbsolutePath)
+      val hadoopConf = newHadoopConf()
+
+      // f1: disjoint -> resolved
+      val f1Prior = inlineDv(0L)
+      val f1Winner = inlineDv(0L, 1L)
+      val f1Loser = inlineDv(0L, 5L)
+      // f2: overlap -> skipped
+      val f2Prior = inlineDv(0L)
+      val f2Winner = inlineDv(0L, 2L)
+      val f2Loser = inlineDv(0L, 2L)
+
+      val loserActions: Seq[Action] = Seq(
+        removeFile("f1", f1Prior), addFile("f1", f1Loser),
+        removeFile("f2", f2Prior), addFile("f2", f2Loser))
+      val winnerAdded = Seq(addFile("f1", f1Winner), addFile("f2", f2Winner))
+      val winnerRemoved = Seq(removeFile("f1", f1Prior), removeFile("f2", f2Prior))
+
+      val result = RowLevelConcurrency.tryRebase(
+        loserActions, winnerAdded, winnerRemoved, tablePath, hadoopConf, MAX_DV_BYTES)
+
+      assert(result.status == RebaseStatus.Aborted)
+      assert(result.failure.contains(RebaseFailure.Overlap))
+      assert(result.resolvedFileCount == 0)
+      assert(result.numDvFilesWritten == 0)
+      assert(result.newActions == loserActions)
+    }
+  }
+
+  // ---------- budget enforcement ----------
+
+  test("tryRebase: DV exceeding maxDvBytes aborts with byte-budget outcome") {
+    withTempDir { dir =>
+      val tablePath = new Path("file:" + dir.getAbsolutePath)
+      val hadoopConf = newHadoopConf()
+      val path = "f1.parquet"
+
+      val priorDv = inlineDv(0L)
+      val winnerDv = inlineDv(0L, 1L)
+      val loserDv = inlineDv(0L, 5L)
+
+      val loserActions: Seq[Action] = Seq(removeFile(path, priorDv), addFile(path, loserDv))
+      val winnerAdded = Seq(addFile(path, winnerDv))
+      val winnerRemoved = Seq(removeFile(path, priorDv))
+
+      // Tiny budget: 1 byte. Should reject all decodes for non-empty DVs.
+      val result = RowLevelConcurrency.tryRebase(
+        loserActions, winnerAdded, winnerRemoved, tablePath, hadoopConf, maxDvBytes = 1L)
+
+      assert(result.resolvedFileCount == 0)
+      assert(result.newActions == loserActions)
+      assert(result.failure.contains(RebaseFailure.ByteBudgetExceeded))
+    }
+  }
+
+  test("tryRebase: one resolvable and one byte-budget path aborts atomically") {
+    withTempDir { dir =>
+      val tablePath = new Path("file:" + dir.getAbsolutePath)
+      val hadoopConf = newHadoopConf()
+      val prior = inlineDv()
+      val smallWinner = inlineDv(1L)
+      val smallLoser = inlineDv(2L)
+      val largeWinner = inlineDv((1000L until 2000L): _*)
+      val largeLoser = inlineDv(3L)
+      val loserActions: Seq[Action] = Seq(
+        removeFile("f1", prior), addFile("f1", smallLoser),
+        removeFile("f2", prior), addFile("f2", largeLoser))
+      val winnerAdded = Seq(addFile("f1", smallWinner), addFile("f2", largeWinner))
+      val winnerRemoved = Seq(removeFile("f1", prior), removeFile("f2", prior))
+      val maxBytes = math.max(smallWinner.sizeInBytes, smallLoser.sizeInBytes).toLong
+
+      val result = RowLevelConcurrency.tryRebase(
+        loserActions, winnerAdded, winnerRemoved, tablePath, hadoopConf, maxDvBytes = maxBytes)
+
+      assert(result.status == RebaseStatus.Aborted)
+      assert(result.failure.contains(RebaseFailure.ByteBudgetExceeded))
+      assert(result.stats.numDvFilesRead == 0)
+      assert(result.numDvFilesWritten == 0)
+      assert(result.newActions == loserActions)
+    }
+  }
+
+  test("tryRebase: malformed inline DV reports decode failure") {
+    withTempDir { dir =>
+      val tablePath = new Path("file:" + dir.getAbsolutePath)
+      val hadoopConf = newHadoopConf()
+      val prior = inlineDv()
+      val malformed = DeletionVectorDescriptor.inlineInLog(Array[Byte](1, 2, 3), 1L)
+      val loserActions: Seq[Action] =
+        Seq(removeFile("f", prior), addFile("f", inlineDv(2L)))
+
+      val result = RowLevelConcurrency.tryRebase(
+        loserActions,
+        Seq(addFile("f", malformed)),
+        Seq(removeFile("f", prior)),
+        tablePath,
+        hadoopConf,
+        MAX_DV_BYTES)
+
+      assert(result.failure.contains(RebaseFailure.DecodeFailure))
+      assert(result.newActions == loserActions)
+    }
+  }
+
+  test("tryRebase: missing external DV reports read failure") {
+    withTempDir { dir =>
+      val tablePath = new Path("file:" + dir.getAbsolutePath)
+      val hadoopConf = newHadoopConf()
+      val prior = inlineDv()
+      val missing = DeletionVectorDescriptor.onDiskWithAbsolutePath(
+        path = new Path(tablePath, "missing.dv").toString,
+        sizeInBytes = 32,
+        cardinality = 1L,
+        offset = Some(0))
+      val loserActions: Seq[Action] =
+        Seq(removeFile("f", prior), addFile("f", inlineDv(2L)))
+
+      val result = RowLevelConcurrency.tryRebase(
+        loserActions,
+        Seq(addFile("f", missing)),
+        Seq(removeFile("f", prior)),
+        tablePath,
+        hadoopConf,
+        MAX_DV_BYTES)
+
+      assert(result.failure.contains(RebaseFailure.DvReadFailure))
+      assert(result.stats.numDvFilesRead == 1)
+      assert(result.newActions == loserActions)
+    }
+  }
+
+  test("tryRebase: DV write failure aborts without mutating actions") {
+    val tablePath = new Path("rlc-missing-filesystem://bucket/table")
+    val hadoopConf = newHadoopConf()
+    val prior = inlineDv()
+    val loserActions: Seq[Action] =
+      Seq(removeFile("f", prior), addFile("f", inlineDv(2L)))
+
+    val result = RowLevelConcurrency.tryRebase(
+      loserActions,
+      Seq(addFile("f", inlineDv(1L))),
+      Seq(removeFile("f", prior)),
+      tablePath,
+      hadoopConf,
+      MAX_DV_BYTES)
+
+    assert(result.failure.contains(RebaseFailure.DvWriteFailure))
+    assert(result.newActions == loserActions)
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/concurrency/rowlevelconcurrency/RowLevelConcurrencyE2ESuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/concurrency/rowlevelconcurrency/RowLevelConcurrencyE2ESuite.scala
@@ -1,0 +1,687 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.concurrency.rowlevelconcurrency
+
+import com.databricks.spark.util.Log4jUsageLogger
+import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.GeneratedAsIdentityType.GeneratedByDefault
+import org.apache.spark.sql.delta.actions.{Action, CommitInfo}
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.delta.util.FileNames
+import io.delta.exceptions.DeltaConcurrentModificationException
+
+import org.apache.spark.SparkConf
+import org.apache.spark.SparkException
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.functions.lit
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.LongType
+
+/**
+ * End-to-end concurrent-DML tests for the  Row-Level Concurrency (RLC) feature.
+ *
+ * These tests exercise the full pipeline from SQL DELETE/UPDATE/MERGE statements through
+ * the [[ConflictChecker.checkRowLevelConflicts]] integration, complementing the unit-level
+ * suites that call `tryRebase` directly on synthetic Action sequences.
+ *
+ * Each scenario uses [[ConflictResolutionTestUtils]]:
+ *   1. Create an RLC-eligible table (DV-mode + Row Tracking + unpartitioned) with all rows
+ *      packed into a single physical file -- the prerequisite for same-file RLC rebase.
+ *   2. Start txnA and pause at the precommit barrier.
+ *   3. Run txnB synchronously to completion. txnB becomes the "winning commit" against
+ *      which txnA must conflict-check.
+ *   4. Commit txnA. The result tells us whether RLC successfully rebased the conflict.
+ *   5. Read back the table and assert the final state equals "winner then loser applied".
+ *
+ * Notes on test conventions used here:
+ *  - Auto-compaction and optimize-write are explicitly disabled so the file shape is
+ *    predictable. We assert a single AddFile before each scenario.
+ *  - The `Delete`/`Update`/`Merge` helpers in [[ConflictResolutionTestUtils]] issue real
+ *    SQL with WHERE clauses on `idCol`. With row tracking, each unique idCol corresponds
+ *    to a stable row index in the file, so disjoint idCol sets always produce disjoint DV
+ *    deltas (P4).
+ *  - The legacy Merge helper uses `USING $tableName s` which can trigger a self-read
+ *    ConcurrentDeleteReadException unrelated to RLC. We define a local
+ *    [[InlineSourceMerge]] helper that USES a small inline VALUES source for testing the
+ *    MERGE path of RLC.
+ */
+class RowLevelConcurrencyE2ESuite extends QueryTest
+  with SharedSparkSession
+  with DeltaSQLCommandTest
+  with ConflictResolutionTestUtils {
+
+  import testImplicits._
+
+  override protected def sparkConf: SparkConf =
+    super.sparkConf.set(DeltaSQLConf.DELTA_IDENTITY_COLUMN_ENABLED.key, "true")
+
+  // ---------- helpers ----------
+
+  /**
+   * Confs that produce a deterministic single-file table shape for these tests. We turn
+   * off auto-compaction / optimize-write so the initial INSERT lands in a single file and
+   * subsequent DV-mode DML keeps the file count stable. Row Tracking and DV creation
+   * defaults are inherited from 's defaults but set explicitly here for clarity.
+   */
+  private def baseTableConfs: Seq[(String, String)] = Seq(
+    DeltaConfigs.ROW_TRACKING_ENABLED.defaultTablePropertyKey -> "true",
+    DeltaConfigs.ENABLE_DELETION_VECTORS_CREATION.defaultTablePropertyKey -> "true",
+    DeltaSQLConf.DELTA_AUTO_COMPACT_ENABLED.key -> "false",
+    DeltaSQLConf.DELTA_OPTIMIZE_WRITE_ENABLED.key -> "false")
+
+  /**
+   * Build an RLC-eligible Delta table at `path`:
+   *  - unpartitioned (RLC eligibility predicate rejects partitioned tables)
+   *  - row tracking enabled
+   *  - DV-mode writes enabled
+   *  - exactly one physical AddFile (we coalesce to 1 partition and assert this)
+   */
+  private def createSingleFileTable(path: String, rows: Seq[Long]): DeltaLog = {
+    withSQLConf(baseTableConfs: _*) {
+      rows.toDF(ID_COLUMN)
+        .coalesce(1)
+        .write
+        .format("delta")
+        .mode("overwrite")
+        .save(path)
+    }
+    val deltaLog = DeltaLog.forTable(spark, path)
+    val activeFiles = deltaLog.update().allFiles.collect()
+    assert(activeFiles.length == 1,
+      s"Expected exactly one AddFile after setup, got ${activeFiles.length}")
+    assert(RowLevelConcurrency.isSnapshotEligible(spark, deltaLog.update()),
+      "Table must be RLC-eligible for E2E test")
+    deltaLog
+  }
+
+  private def createIdentitySingleFileTable(path: String, rows: Seq[Long]): DeltaLog = {
+    io.delta.tables.DeltaTable.create(spark)
+      .location(path)
+      .addColumn(IdentityColumnSpec(
+        GeneratedByDefault,
+        colName = ID_COLUMN).structField(spark))
+      .addColumn(TestColumnSpec("value", LongType).structField(spark))
+      .property(DeltaConfigs.ROW_TRACKING_ENABLED.key, "true")
+      .property(DeltaConfigs.ENABLE_DELETION_VECTORS_CREATION.key, "true")
+      .execute()
+    withSQLConf(baseTableConfs: _*) {
+      rows.map(id => (id, id)).toDF(ID_COLUMN, "value")
+        .coalesce(1)
+        .write
+        .format("delta")
+        .mode("append")
+        .save(path)
+    }
+    val deltaLog = DeltaLog.forTable(spark, path)
+    assert(deltaLog.update().allFiles.collect().length == 1)
+    assert(!RowLevelConcurrency.isSnapshotEligible(spark, deltaLog.update()),
+      "Identity-column tables must be ineligible for RLC")
+    deltaLog
+  }
+
+  /** Same as [[createSingleFileTable]] but builds a partitioned table for the
+   * RLC-skipped regression test. */
+  private def createPartitionedTable(path: String, rows: Seq[Long]): DeltaLog = {
+    withSQLConf(baseTableConfs: _*) {
+      rows.toDF(ID_COLUMN)
+        .withColumn(PARTITION_COLUMN, lit(0L))
+        .coalesce(1)
+        .write
+        .format("delta")
+        .partitionBy(PARTITION_COLUMN)
+        .mode("overwrite")
+        .save(path)
+    }
+    DeltaLog.forTable(spark, path)
+  }
+
+  /** Same as [[createSingleFileTable]] but builds a table WITHOUT Deletion Vectors and
+   *  WITHOUT Row Tracking enabled, so RLC eligibility rejects the snapshot and the
+   *  concurrent-write hint helper should fire. */
+  private def createNonRlcEligibleTable(path: String, rows: Seq[Long]): DeltaLog = {
+    withSQLConf(
+      DeltaSQLConf.DELTA_AUTO_COMPACT_ENABLED.key -> "false",
+      DeltaSQLConf.DELTA_OPTIMIZE_WRITE_ENABLED.key -> "false") {
+      rows.toDF(ID_COLUMN)
+        .coalesce(1)
+        .write
+        .format("delta")
+        .mode("overwrite")
+        .save(path)
+    }
+    val deltaLog = DeltaLog.forTable(spark, path)
+    assert(!RowLevelConcurrency.isSnapshotEligible(spark, deltaLog.update()),
+      "Helper precondition: table must NOT be RLC-eligible")
+    deltaLog
+  }
+
+  /**
+   * Read the latest CommitInfo (the most recent commit version) for assertions on
+   * isolationLevel and operation type.
+   */
+  private def latestCommitInfo(deltaLog: DeltaLog): CommitInfo = {
+    val version = deltaLog.update().version
+    val commitFile = FileNames.unsafeDeltaFile(deltaLog.logPath, version)
+    val commitActions = deltaLog.store.read(commitFile, deltaLog.newDeltaHadoopConf())
+      .map(Action.fromJson)
+    commitActions.collectFirst { case ci: CommitInfo => ci }
+      .getOrElse(throw new IllegalStateException(s"No CommitInfo in version $version"))
+  }
+
+  /** Read all rows from the table and return idCol values sorted. */
+  private def selectAllIds(path: String): Seq[Long] = {
+    spark.read.format("delta").load(path)
+      .select(ID_COLUMN)
+      .as[Long]
+      .collect()
+      .sorted
+      .toSeq
+  }
+
+  /**
+   * Custom MERGE helper that uses an inline VALUES source (not a self-read on the target
+   * table) so it never trips the source-side ConcurrentDeleteReadException unrelated to
+   * RLC behavior under test.
+   *
+   * Also overrides [[executeImpl]] to qualify the path with `file:`, since the default
+   * implementation in [[ConflictResolutionTestUtils]] strips the scheme via
+   * `dataPath.toUri.getPath`, causing path resolution to fall through to the cluster's
+   * default FS (Fabric ABFSS in this dev environment).
+   */
+  case class InlineSourceMerge(
+      deleteRows: Seq[Long],
+      sqlConf: Map[String, String] = Map.empty) extends TestTransaction(sqlConf) {
+    override val name: String =
+      s"INLINE_MERGE(${abbreviate(deleteRows.mkString(","), "...", 10)})($sqlConfStr)"
+
+    override def toSQL(tableName: String): String = {
+      val values = deleteRows.map(r => s"($r)").mkString(", ")
+      s"""
+         |MERGE INTO $tableName t
+         |USING (SELECT * FROM (VALUES $values) AS src(${ID_COLUMN})) s
+         |ON t.${ID_COLUMN} = s.${ID_COLUMN}
+         |WHEN MATCHED THEN DELETE
+         |""".stripMargin
+    }
+
+    override def executeImpl(ctx: TestContext): Unit = {
+      spark.sql(toSQL(schemeQualifiedDeltaPath(ctx))).collect()
+    }
+
+    override def dataChange: Boolean = true
+  }
+
+  /**
+   * Mixed MERGE with all three clauses: `WHEN MATCHED THEN DELETE` for `deleteIds`,
+   * `WHEN MATCHED THEN UPDATE` for `updateIds` (re-writes them to a sentinel value),
+   * and `WHEN NOT MATCHED THEN INSERT` for `insertIds`. Used to verify that RLC masks
+   * only the same-path AddFile/RemoveFile pair it actually rebased, while the winner's
+   * new-path outputs stay subject to normal Serializable conflict detection.
+   */
+  case class InlineMixedMerge(
+      deleteIds: Seq[Long],
+      updateIds: Seq[Long],
+      insertIds: Seq[Long],
+      sqlConf: Map[String, String] = Map.empty) extends TestTransaction(sqlConf) {
+    override val name: String =
+      s"INLINE_MIXED_MERGE(d=${deleteIds.mkString(",")};" +
+        s"u=${updateIds.mkString(",")};i=${insertIds.mkString(",")})($sqlConfStr)"
+
+    override def toSQL(tableName: String): String = {
+      // Source rows: union of all matched IDs (for DELETE+UPDATE) and the not-matched
+      // INSERT IDs. We distinguish UPDATE from DELETE via a side column `op`.
+      val rows = deleteIds.map(id => s"($id, 'd')") ++
+        updateIds.map(id => s"($id, 'u')") ++
+        insertIds.map(id => s"($id, 'i')")
+      val values = rows.mkString(", ")
+      s"""
+         |MERGE INTO $tableName t
+         |USING (SELECT * FROM (VALUES $values) AS src(${ID_COLUMN}, op)) s
+         |ON t.${ID_COLUMN} = s.${ID_COLUMN}
+         |WHEN MATCHED AND s.op = 'd' THEN DELETE
+         |WHEN MATCHED AND s.op = 'u' THEN UPDATE SET ${ID_COLUMN} = -t.${ID_COLUMN}
+         |WHEN NOT MATCHED AND s.op = 'i' THEN INSERT (${ID_COLUMN}) VALUES (s.${ID_COLUMN})
+         |""".stripMargin
+    }
+
+    override def executeImpl(ctx: TestContext): Unit = {
+      spark.sql(toSQL(schemeQualifiedDeltaPath(ctx))).collect()
+    }
+
+    override def dataChange: Boolean = true
+  }
+
+
+  /** Returns the table reference `delta.\`<scheme-qualified-path>\`` for SQL. The default
+   * `dataPath.toUri.getPath` strips the scheme, which breaks path resolution when the
+   * cluster default FS is not local. */
+  private def schemeQualifiedDeltaPath(ctx: TestContext): String =
+    s"delta.`${ctx.deltaLog.dataPath.toString}`"
+
+  /** A DELETE transaction that targets the table by its scheme-qualified path (see
+   * [[schemeQualifiedDeltaPath]]). Behaves identically to the base [[Delete]] otherwise. */
+  case class DeleteE2E(
+      rows: Seq[Long],
+      sqlConf: Map[String, String] = Map.empty) extends TestTransaction(sqlConf) {
+    override val name: String =
+      s"DELETE_E2E(${abbreviate(rows.mkString(","), "...", 10)})($sqlConfStr)"
+
+    override def toSQL(tableName: String): String = {
+      val inRowsStr = rows.mkString("(", ", ", ")")
+      s"DELETE FROM $tableName WHERE $ID_COLUMN IN $inRowsStr"
+    }
+
+    override def executeImpl(ctx: TestContext): Unit = {
+      spark.sql(toSQL(schemeQualifiedDeltaPath(ctx))).collect()
+    }
+
+    override def dataChange: Boolean = true
+  }
+
+  /** An UPDATE transaction that targets the table by its scheme-qualified path. */
+  case class UpdateE2E(
+      rows: Seq[Long],
+      setValue: Long = 42,
+      sqlConf: Map[String, String] = Map.empty) extends TestTransaction(sqlConf) {
+    override val name: String =
+      s"UPDATE_E2E(${abbreviate(rows.mkString(","), "...", 10)})($sqlConfStr)"
+
+    override def toSQL(tableName: String): String = {
+      val inRowsStr = rows.mkString("(", ", ", ")")
+      s"UPDATE $tableName SET $ID_COLUMN=$setValue WHERE $ID_COLUMN IN $inRowsStr"
+    }
+
+    override def executeImpl(ctx: TestContext): Unit = {
+      spark.sql(toSQL(schemeQualifiedDeltaPath(ctx))).collect()
+    }
+
+    override def dataChange: Boolean = true
+  }
+
+  /** Common assertion that the rebase telemetry / fall-through happened as expected by
+   * comparing committed transaction count: with RLC, both txns should commit. */
+  private def assertBothCommitted(ctx: TestContext, expectedCount: Int): Unit = {
+    val committed = ctx.getCommittedTransactions
+    assert(committed.size == expectedCount,
+      s"Expected $expectedCount committed transactions, got ${committed.size}: " +
+        s"${committed.map(_.name).mkString("[", ",", "]")}")
+  }
+
+  private def assertOneActiveLogicalVersionPerPath(deltaLog: DeltaLog): Unit = {
+    val duplicatePaths = deltaLog.update().allFiles.collect().groupBy(_.path).collect {
+      case (path, files) if files.length != 1 => path -> files.length
+    }
+    assert(duplicatePaths.isEmpty,
+      s"Expected one active logical version per physical path, found: $duplicatePaths")
+  }
+
+  /** Run `loser` to the precommit barrier, then run `winner` to completion, then commit
+   * `loser`. After this, `loser` has been conflict-checked against `winner`. Returns the
+   * outcome (either a successful commit or a SparkException with the underlying cause). */
+  private def runWinnerThenLoser(
+      ctx: TestContext,
+      loser: TestTransaction,
+      winner: TestTransaction): Either[Throwable, Unit] = {
+    try {
+      loser.interleave(ctx) {
+        winner.execute(ctx)
+      }
+      Right(())
+    } catch {
+      case e: SparkException => Left(if (e.getCause != null) e.getCause else e)
+      case e: Throwable => Left(e)
+    }
+  }
+
+  // ---------- Scenario 1: DELETE + DELETE disjoint, same file ----------
+
+  test("RLC E2E: DELETE + DELETE on disjoint rows of the same file both commit") {
+    withTempDir { dir =>
+      val path = "file:" + dir.getAbsolutePath
+      val deltaLog = createSingleFileTable(path, (0L until 100L).toSeq)
+      val ctx = new TestContext(deltaLog)
+
+      val loser = DeleteE2E(rows = Seq(10L))
+      val winner = DeleteE2E(rows = Seq(20L))
+
+      val outcome = runWinnerThenLoser(ctx, loser = loser, winner = winner)
+      assert(outcome.isRight,
+        s"Loser commit should succeed via RLC, but failed: ${outcome.left.getOrElse("")}")
+
+      assertBothCommitted(ctx, expectedCount = 2)
+
+      val remaining = selectAllIds(path)
+      val expected = (0L until 100L).filterNot(Set(10L, 20L).contains).toSeq
+      assert(remaining == expected,
+        s"Final state should reflect both deletes; missing/extra: " +
+          s"${expected.diff(remaining)} vs ${remaining.diff(expected)}")
+      assertOneActiveLogicalVersionPerPath(deltaLog)
+    }
+  }
+
+  // ---------- Scenario 2: DELETE + DELETE overlapping rows ----------
+
+  test("RLC E2E: DELETE + DELETE on overlapping rows -> loser aborts") {
+    withTempDir { dir =>
+      val path = "file:" + dir.getAbsolutePath
+      val deltaLog = createSingleFileTable(path, (0L until 100L).toSeq)
+      val ctx = new TestContext(deltaLog)
+
+      val loser = DeleteE2E(rows = Seq(10L, 20L))
+      val winner = DeleteE2E(rows = Seq(20L, 30L))
+
+      val outcome = runWinnerThenLoser(ctx, loser = loser, winner = winner)
+      assert(outcome.isLeft,
+        s"Loser must abort on overlapping deletes (P4 fails); got success")
+      val cause = outcome.left.get
+      assert(cause.isInstanceOf[DeltaConcurrentModificationException],
+        s"Expected DeltaConcurrentModificationException, got: " +
+          s"${cause.getClass.getName}: ${cause.getMessage}")
+
+      assertBothCommitted(ctx, expectedCount = 1)
+    }
+  }
+
+  // ---------- Scenario 3: UPDATE + UPDATE disjoint ----------
+
+  test("RLC E2E: UPDATE winner post-image falls back to Serializable conflict detection") {
+    withTempDir { dir =>
+      val path = "file:" + dir.getAbsolutePath
+      val deltaLog = createSingleFileTable(path, (0L until 100L).toSeq)
+      val ctx = new TestContext(deltaLog)
+
+      val loser = UpdateE2E(rows = Seq(10L), setValue = 200L)
+      val winner = UpdateE2E(rows = Seq(20L), setValue = 300L)
+
+      val outcome = runWinnerThenLoser(ctx, loser = loser, winner = winner)
+      assert(outcome.isLeft,
+        "A new-path UPDATE post-image has no action-level lineage and must remain conflicting")
+      assert(outcome.left.get.isInstanceOf[DeltaConcurrentModificationException])
+      assertBothCommitted(ctx, expectedCount = 1)
+
+      val remaining = selectAllIds(path)
+      val expected = ((0L until 100L).filterNot(_ == 20L) :+ 300L).sorted
+      assert(remaining == expected,
+        s"Only the winning UPDATE should be visible; got $remaining")
+    }
+  }
+
+  // ---------- Scenario 4: UPDATE + DELETE disjoint ----------
+
+  test("RLC E2E: UPDATE + DELETE on disjoint rows of the same file both commit") {
+    withTempDir { dir =>
+      val path = "file:" + dir.getAbsolutePath
+      val deltaLog = createSingleFileTable(path, (0L until 100L).toSeq)
+      val ctx = new TestContext(deltaLog)
+
+      val loser = UpdateE2E(rows = Seq(10L), setValue = 999L)
+      val winner = DeleteE2E(rows = Seq(20L))
+
+      val outcome = runWinnerThenLoser(ctx, loser = loser, winner = winner)
+      assert(outcome.isRight,
+        s"Loser commit should succeed via RLC, but failed: ${outcome.left.getOrElse("")}")
+      assertBothCommitted(ctx, expectedCount = 2)
+
+      val remaining = selectAllIds(path)
+      val expected = ((0L until 100L).filterNot(Set(10L, 20L).contains) ++ Seq(999L)).sorted
+      assert(remaining == expected, s"Final state mismatch; got $remaining")
+    }
+  }
+
+  // ---------- Scenario 5: MERGE (delete-only) + DELETE disjoint ----------
+
+  test("RLC E2E: MERGE-delete + DELETE on disjoint rows of the same file both commit") {
+    withTempDir { dir =>
+      val path = "file:" + dir.getAbsolutePath
+      val deltaLog = createSingleFileTable(path, (0L until 100L).toSeq)
+      val ctx = new TestContext(deltaLog)
+
+      val loser = InlineSourceMerge(deleteRows = Seq(10L))
+      val winner = DeleteE2E(rows = Seq(20L))
+
+      val outcome = runWinnerThenLoser(ctx, loser = loser, winner = winner)
+      assert(outcome.isRight,
+        s"Loser MERGE should succeed via RLC, but failed: ${outcome.left.getOrElse("")}")
+      assertBothCommitted(ctx, expectedCount = 2)
+
+      val remaining = selectAllIds(path)
+      val expected = (0L until 100L).filterNot(Set(10L, 20L).contains).toSeq
+      assert(remaining == expected, s"Final state mismatch; got $remaining")
+    }
+  }
+
+  // ---------- Scenario 6: RLC disabled regression guard ----------
+
+  test("RLC E2E: with RLC disabled, disjoint DELETE+DELETE still aborts loser") {
+    withTempDir { dir =>
+      val path = "file:" + dir.getAbsolutePath
+      val deltaLog = createSingleFileTable(path, (0L until 100L).toSeq)
+      val ctx = new TestContext(deltaLog)
+
+      val rlcOff = Map(DeltaSQLConf.ROW_LEVEL_CONCURRENCY_ENABLED.key -> "false")
+      val loser = DeleteE2E(rows = Seq(10L), sqlConf = rlcOff)
+      val winner = DeleteE2E(rows = Seq(20L), sqlConf = rlcOff)
+
+      val outcome = runWinnerThenLoser(ctx, loser = loser, winner = winner)
+      assert(outcome.isLeft,
+        s"With RLC disabled, loser must abort (regression guard)")
+      val cause = outcome.left.get
+      assert(cause.isInstanceOf[DeltaConcurrentModificationException],
+        s"Expected DeltaConcurrentModificationException, got: " +
+          s"${cause.getClass.getName}: ${cause.getMessage}")
+    }
+  }
+
+  // ---------- Scenario 7: Partitioned table -> RLC skipped ----------
+
+  test("RLC E2E: partitioned table -> RLC skipped, loser aborts") {
+    withTempDir { dir =>
+      val path = "file:" + dir.getAbsolutePath
+      val deltaLog = createPartitionedTable(path, (0L until 100L).toSeq)
+      assert(!RowLevelConcurrency.isSnapshotEligible(spark, deltaLog.update()),
+        "Partitioned table must NOT be RLC-eligible")
+      val ctx = new TestContext(deltaLog)
+
+      val loser = DeleteE2E(rows = Seq(10L))
+      val winner = DeleteE2E(rows = Seq(20L))
+
+      val outcome = runWinnerThenLoser(ctx, loser = loser, winner = winner)
+      assert(outcome.isLeft,
+        "Loser must abort on partitioned tables (RLC eligibility rejects)")
+    }
+  }
+
+  // ---------- Scenario 8: CommitInfo isolation level ----------
+
+  test("RLC E2E: post-RLC CommitInfo records the table's isolation level") {
+    withTempDir { dir =>
+      val path = "file:" + dir.getAbsolutePath
+      val deltaLog = createSingleFileTable(path, (0L until 100L).toSeq)
+      val ctx = new TestContext(deltaLog)
+
+      val loser = DeleteE2E(rows = Seq(10L))
+      val winner = DeleteE2E(rows = Seq(20L))
+      val outcome = runWinnerThenLoser(ctx, loser = loser, winner = winner)
+      assert(outcome.isRight, "Sanity: RLC happy path should commit")
+
+      val ci = latestCommitInfo(deltaLog)
+      // The  fork only supports Serializable for the isolation-level config;
+      // -DeltaConfigs.ISOLATION_LEVEL validator at DeltaConfig.scala:785-791
+      // rejects WriteSerializable. So the recorded value is "Serializable".
+      assert(ci.isolationLevel.contains("Serializable"),
+        s"Expected isolationLevel = Some(Serializable*), got ${ci.isolationLevel}")
+    }
+  }
+
+  // ---------- Scenario 9: Non-empty prior DV ----------
+
+  test("RLC E2E: disjoint DELETE+DELETE with a non-empty prior DV both commit") {
+    withTempDir { dir =>
+      val path = "file:" + dir.getAbsolutePath
+      val deltaLog = createSingleFileTable(path, (0L until 100L).toSeq)
+      // Commit an initial DELETE so the file already carries a non-empty DV.
+      withSQLConf(baseTableConfs: _*) {
+        spark.sql(s"DELETE FROM delta.`$path` WHERE ${ID_COLUMN} = 5")
+      }
+      val activeFiles = deltaLog.update().allFiles.collect()
+      assert(activeFiles.length == 1, "Initial DELETE should keep a single file (DV mode)")
+      assert(activeFiles.head.deletionVector != null,
+        "Initial DELETE should produce a non-empty deletion vector")
+
+      val ctx = new TestContext(deltaLog)
+      val loser = DeleteE2E(rows = Seq(10L))
+      val winner = DeleteE2E(rows = Seq(20L))
+
+      val outcome = runWinnerThenLoser(ctx, loser = loser, winner = winner)
+      assert(outcome.isRight,
+        s"RLC should rebase against a non-empty prior DV, but failed: " +
+          s"${outcome.left.getOrElse("")}")
+      assertBothCommitted(ctx, expectedCount = 2)
+
+      val remaining = selectAllIds(path)
+      val expected = (0L until 100L).filterNot(Set(5L, 10L, 20L).contains).toSeq
+      assert(remaining == expected, s"Final state mismatch; got $remaining")
+    }
+  }
+
+  // ---------- Scenario 10: Three-writer convergence (sequential rebase) ----------
+
+  test("RLC E2E: three concurrent disjoint DELETEs all commit (multi-winner rebase)") {
+    withTempDir { dir =>
+      val path = "file:" + dir.getAbsolutePath
+      val deltaLog = createSingleFileTable(path, (0L until 100L).toSeq)
+      val ctx = new TestContext(deltaLog)
+
+      // C is the last to commit and must rebase against A then B serially.
+      // We start B and C first (paused at precommit), then commit them in order:
+      // A first (no conflict), then B (rebases vs A), then C (rebases vs A, then B).
+      val txnA = DeleteE2E(rows = Seq(10L))
+      val txnB = DeleteE2E(rows = Seq(20L))
+      val txnC = DeleteE2E(rows = Seq(30L))
+
+      // Start B and C at the precommit barrier.
+      txnB.start(ctx)
+      txnC.start(ctx)
+      // A: run to completion (winner #1).
+      txnA.execute(ctx)
+      // B: commit (winner #2; rebases against A).
+      txnB.commit(ctx)
+      // C: commit (rebases against A, then B).
+      txnC.commit(ctx)
+
+      assertBothCommitted(ctx, expectedCount = 3)
+      assertOneActiveLogicalVersionPerPath(deltaLog)
+      val remaining = selectAllIds(path)
+      val expected = (0L until 100L).filterNot(Set(10L, 20L, 30L).contains).toSeq
+      assert(remaining == expected, s"Final state mismatch; got $remaining")
+    }
+  }
+
+  // ---------- Scenario 11: enablement hint surfaces in concurrent-write exceptions ----------
+
+  test("RLC E2E: hint surfaces when a conflict aborts on a non-RLC-eligible table") {
+    // When the RLC SQL conf is on (default) but the table is missing DVs/Row Tracking,
+    // a real concurrent-write conflict must surface the enablement hint in the thrown
+    // exception's message, naming the specific feature(s) to enable.
+    withTempDir { dir =>
+      val path = "file:" + dir.getAbsolutePath
+      val deltaLog = createNonRlcEligibleTable(path, (0L until 100L).toSeq)
+      val ctx = new TestContext(deltaLog)
+
+      // Disjoint DELETEs on the same file. Without DV mode each DELETE rewrites
+      // the file, so this fires the CoW conflict path -> ConcurrentDelete*Exception.
+      val loser = DeleteE2E(rows = Seq(10L))
+      val winner = DeleteE2E(rows = Seq(20L))
+
+      val outcome = runWinnerThenLoser(ctx, loser = loser, winner = winner)
+      assert(outcome.isLeft, "Loser must abort on a non-RLC-eligible table")
+      val cause = outcome.left.get
+      assert(cause.isInstanceOf[DeltaConcurrentModificationException],
+        s"Expected DeltaConcurrentModificationException, got: " +
+          s"${cause.getClass.getName}: ${cause.getMessage}")
+      val msg = cause.getMessage
+      assert(msg.contains("Row-Level Concurrency"),
+        s"Hint should mention Row-Level Concurrency; got:\n$msg")
+      assert(msg.contains("Deletion Vectors"),
+        s"Hint should name Deletion Vectors as a missing feature; got:\n$msg")
+      assert(msg.contains("Row Tracking"),
+        s"Hint should name Row Tracking as a missing feature; got:\n$msg")
+      assert(msg.contains("ALTER TABLE"),
+        s"Hint should include an ALTER TABLE remediation example; got:\n$msg")
+    }
+  }
+
+  // ---------- Scenario 12: mixed-MERGE winner (DELETE + UPDATE + INSERT clauses) ----------
+
+  test("RLC E2E: Serializable mixed MERGE insert remains visible to predicate conflicts") {
+    // The same-path DV pair can be rebased, but the winner's WHEN NOT MATCHED INSERT
+    // output is unrelated to that path and must still pass through Serializable append
+    // conflict detection.
+    withTempDir { dir =>
+      val path = "file:" + dir.getAbsolutePath
+      val deltaLog = createSingleFileTable(path, (0L until 100L).toSeq)
+      val ctx = new TestContext(deltaLog)
+
+      // Loser deletes id=10. Winner's MERGE on the same file deletes id=20,
+      // updates id=30 -> -30, and inserts a brand-new id=200 (new-path AddFile).
+      val loser = DeleteE2E(rows = Seq(10L))
+      val winner = InlineMixedMerge(
+        deleteIds = Seq(20L),
+        updateIds = Seq(30L),
+        insertIds = Seq(200L))
+
+      var outcome: Either[Throwable, Unit] = Right(())
+      val usageLogs = Log4jUsageLogger.track {
+        outcome = runWinnerThenLoser(ctx, loser = loser, winner = winner)
+      }
+      assert(outcome.isLeft,
+        "Serializable conflict detection must see mixed-MERGE INSERT output")
+      assert(outcome.left.get.isInstanceOf[DeltaConcurrentModificationException])
+      assertBothCommitted(ctx, expectedCount = 1)
+      val rlcEvents = usageLogs.flatMap(_.tags.get("opType"))
+      assert(!rlcEvents.contains(RowLevelConcurrency.TELEMETRY_RESOLVED),
+        s"Aborted conflict checking must not emit resolved telemetry: $rlcEvents")
+      assert(rlcEvents.contains(RowLevelConcurrency.TELEMETRY_ABORTED_AFTER_REBASE),
+        s"Expected final aborted-after-rebase telemetry, got: $rlcEvents")
+
+      val remaining = selectAllIds(path)
+      val expected = ((0L until 100L).filterNot(Set(20L, 30L).contains) :+ -30L :+ 200L)
+        .sorted
+      assert(remaining == expected, s"Final state mismatch; expected=$expected got=$remaining")
+    }
+  }
+
+  test("RLC E2E: identity-column table falls back to default conflict detection") {
+    withTempDir { dir =>
+      val path = "file:" + dir.getAbsolutePath
+      val deltaLog = createIdentitySingleFileTable(path, (0L until 100L).toSeq)
+      val ctx = new TestContext(deltaLog)
+
+      val outcome = runWinnerThenLoser(
+        ctx,
+        loser = DeleteE2E(rows = Seq(10L)),
+        winner = DeleteE2E(rows = Seq(20L)))
+
+      assert(outcome.isLeft,
+        "Identity-column tables are unsupported by RLC and must use default conflicts")
+      assert(outcome.left.get.isInstanceOf[DeltaConcurrentModificationException])
+      assertBothCommitted(ctx, expectedCount = 1)
+      assert(selectAllIds(path) == (0L until 100L).filterNot(_ == 20L))
+    }
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/concurrency/rowlevelconcurrency/RowLevelConcurrencyEligibilitySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/concurrency/rowlevelconcurrency/RowLevelConcurrencyEligibilitySuite.scala
@@ -1,0 +1,389 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.concurrency.rowlevelconcurrency
+
+import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.GeneratedAsIdentityType.GeneratedByDefault
+import org.apache.spark.sql.delta.actions.Action
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.LongType
+
+/**
+ * Tests for the Row-Level Concurrency eligibility predicates defined in
+ * [[RowLevelConcurrency]]. These predicates gate whether the RLC conflict
+ * resolution phase runs inside [[ConflictChecker]].
+ */
+class RowLevelConcurrencyEligibilitySuite extends QueryTest
+  with SharedSparkSession
+  with DeltaSQLCommandTest {
+
+  override protected def sparkConf: SparkConf =
+    super.sparkConf.set(DeltaSQLConf.DELTA_IDENTITY_COLUMN_ENABLED.key, "true")
+
+  /**
+   * Helper: create an unpartitioned Delta table with DVs + Row Tracking enabled.
+   * Returns the table path.
+   */
+  private def createRlcEligibleTable(dir: java.io.File): String = {
+    val path = "file:" + dir.getAbsolutePath
+    withSQLConf(
+      DeltaConfigs.ROW_TRACKING_ENABLED.defaultTablePropertyKey -> "true",
+      DeltaConfigs.ENABLE_DELETION_VECTORS_CREATION.defaultTablePropertyKey -> "true"
+    ) {
+      spark.range(10).write.format("delta").save(path)
+    }
+    path
+  }
+
+  private def createIdentityTable(dir: java.io.File): String = {
+    val path = "file:" + dir.getAbsolutePath
+    io.delta.tables.DeltaTable.create(spark)
+      .location(path)
+      .addColumn(IdentityColumnSpec(
+        GeneratedByDefault,
+        colName = "idCol").structField(spark))
+      .addColumn(TestColumnSpec("value", LongType).structField(spark))
+      .property(DeltaConfigs.ROW_TRACKING_ENABLED.key, "true")
+      .property(DeltaConfigs.ENABLE_DELETION_VECTORS_CREATION.key, "true")
+      .execute()
+    path
+  }
+
+  // ---------- Snapshot-level eligibility tests ----------
+
+  test("eligible: unpartitioned table with DVs + RT enabled and RLC switch on") {
+    withTempDir { dir =>
+      val path = createRlcEligibleTable(dir)
+      val snapshot = DeltaLog.forTable(spark, path).update()
+      withSQLConf(DeltaSQLConf.ROW_LEVEL_CONCURRENCY_ENABLED.key -> "true") {
+        assert(RowLevelConcurrency.isSnapshotEligible(spark, snapshot))
+      }
+    }
+  }
+
+  test("ineligible: RLC master switch is explicitly off") {
+    withTempDir { dir =>
+      val path = createRlcEligibleTable(dir)
+      val snapshot = DeltaLog.forTable(spark, path).update()
+      withSQLConf(DeltaSQLConf.ROW_LEVEL_CONCURRENCY_ENABLED.key -> "false") {
+        assert(!RowLevelConcurrency.isSnapshotEligible(spark, snapshot))
+      }
+    }
+  }
+
+  test("eligible (default-on): RLC master switch is on by default") {
+    withTempDir { dir =>
+      val path = createRlcEligibleTable(dir)
+      val snapshot = DeltaLog.forTable(spark, path).update()
+      // The master switch defaults to true, so no explicit conf is set here.
+      assert(RowLevelConcurrency.isSnapshotEligible(spark, snapshot))
+    }
+  }
+
+  test("ineligible: DVs not writable") {
+    withTempDir { dir =>
+      val path = "file:" + dir.getAbsolutePath
+      withSQLConf(
+        DeltaConfigs.ROW_TRACKING_ENABLED.defaultTablePropertyKey -> "true",
+        DeltaConfigs.ENABLE_DELETION_VECTORS_CREATION.defaultTablePropertyKey -> "false"
+      ) {
+        spark.range(10).write.format("delta").save(path)
+      }
+      val snapshot = DeltaLog.forTable(spark, path).update()
+      withSQLConf(DeltaSQLConf.ROW_LEVEL_CONCURRENCY_ENABLED.key -> "true") {
+        assert(!RowLevelConcurrency.isSnapshotEligible(spark, snapshot))
+      }
+    }
+  }
+
+  test("ineligible: Row Tracking not enabled") {
+    withTempDir { dir =>
+      val path = "file:" + dir.getAbsolutePath
+      withSQLConf(
+        DeltaConfigs.ROW_TRACKING_ENABLED.defaultTablePropertyKey -> "false",
+        DeltaConfigs.ENABLE_DELETION_VECTORS_CREATION.defaultTablePropertyKey -> "true"
+      ) {
+        spark.range(10).write.format("delta").save(path)
+      }
+      val snapshot = DeltaLog.forTable(spark, path).update()
+      withSQLConf(DeltaSQLConf.ROW_LEVEL_CONCURRENCY_ENABLED.key -> "true") {
+        assert(!RowLevelConcurrency.isSnapshotEligible(spark, snapshot))
+      }
+    }
+  }
+
+  test("ineligible: partitioned table") {
+    withTempDir { dir =>
+      val path = "file:" + dir.getAbsolutePath
+      withSQLConf(
+        DeltaConfigs.ROW_TRACKING_ENABLED.defaultTablePropertyKey -> "true",
+        DeltaConfigs.ENABLE_DELETION_VECTORS_CREATION.defaultTablePropertyKey -> "true"
+      ) {
+        spark.range(10).withColumn("part", org.apache.spark.sql.functions.lit(1))
+          .write.format("delta").partitionBy("part").save(path)
+      }
+      val snapshot = DeltaLog.forTable(spark, path).update()
+      withSQLConf(DeltaSQLConf.ROW_LEVEL_CONCURRENCY_ENABLED.key -> "true") {
+        assert(!RowLevelConcurrency.isSnapshotEligible(spark, snapshot))
+      }
+    }
+  }
+
+  test("ineligible: identity-column table") {
+    withTempDir { dir =>
+      val snapshot = DeltaLog.forTable(spark, createIdentityTable(dir)).update()
+      assert(ColumnWithDefaultExprUtils.hasIdentityColumn(snapshot.schema))
+      assert(!RowLevelConcurrency.isSnapshotEligible(spark, snapshot))
+      assert(!RowLevelConcurrency.isCommitEligible(spark, snapshot, Seq.empty))
+    }
+  }
+
+  // ---------- Commit-level eligibility tests ----------
+
+  test("commit eligible: no metadata mutation") {
+    withTempDir { dir =>
+      val path = createRlcEligibleTable(dir)
+      val log = DeltaLog.forTable(spark, path)
+      val snapshot = log.update()
+      withSQLConf(DeltaSQLConf.ROW_LEVEL_CONCURRENCY_ENABLED.key -> "true") {
+        val txnActions = Seq.empty[Action]
+        assert(RowLevelConcurrency.isCommitEligible(spark, snapshot, txnActions))
+      }
+    }
+  }
+
+  test("commit ineligible: divergent metadata mutation") {
+    withTempDir { dir =>
+      val path = createRlcEligibleTable(dir)
+      val log = DeltaLog.forTable(spark, path)
+      val snapshot = log.update()
+      withSQLConf(DeltaSQLConf.ROW_LEVEL_CONCURRENCY_ENABLED.key -> "true") {
+        // Create a different metadata object
+        val divergentMetadata = snapshot.metadata.copy(description = "changed")
+        val txnActions: Seq[Action] = Seq(divergentMetadata)
+        assert(!RowLevelConcurrency.isCommitEligible(spark, snapshot, txnActions))
+      }
+    }
+  }
+
+  test("commit eligible: byte-identical metadata is allowed") {
+    withTempDir { dir =>
+      val path = createRlcEligibleTable(dir)
+      val log = DeltaLog.forTable(spark, path)
+      val snapshot = log.update()
+      withSQLConf(DeltaSQLConf.ROW_LEVEL_CONCURRENCY_ENABLED.key -> "true") {
+        // Same metadata object as snapshot -- allowed (e.g., no-op metadata echo)
+        val txnActions: Seq[Action] = Seq(snapshot.metadata)
+        assert(RowLevelConcurrency.isCommitEligible(spark, snapshot, txnActions))
+      }
+    }
+  }
+
+  // ---------- SQL conf tests ----------
+
+  test("RLC confs have expected defaults") {
+    assert(spark.sessionState.conf.getConf(DeltaSQLConf.ROW_LEVEL_CONCURRENCY_ENABLED))
+    assert(spark.sessionState.conf.getConf(
+      DeltaSQLConf.ROW_LEVEL_CONCURRENCY_MAX_DV_BYTES_PER_FILE) == 1048576L)
+    assert(spark.sessionState.conf.getConf(
+      DeltaSQLConf.ROW_LEVEL_CONCURRENCY_MAX_DV_READS_PER_COMMIT) == 64)
+    assert(spark.sessionState.conf.getConf(
+      DeltaSQLConf.ROW_LEVEL_CONCURRENCY_MAX_RESOLUTION_TIME_MS) == 2000L)
+  }
+
+  test("RLC confs are settable") {
+    withSQLConf(
+      DeltaSQLConf.ROW_LEVEL_CONCURRENCY_ENABLED.key -> "true",
+      DeltaSQLConf.ROW_LEVEL_CONCURRENCY_MAX_DV_BYTES_PER_FILE.key -> "2097152",
+      DeltaSQLConf.ROW_LEVEL_CONCURRENCY_MAX_DV_READS_PER_COMMIT.key -> "128",
+      DeltaSQLConf.ROW_LEVEL_CONCURRENCY_MAX_RESOLUTION_TIME_MS.key -> "5000"
+    ) {
+      assert(spark.sessionState.conf.getConf(DeltaSQLConf.ROW_LEVEL_CONCURRENCY_ENABLED))
+      assert(spark.sessionState.conf.getConf(
+        DeltaSQLConf.ROW_LEVEL_CONCURRENCY_MAX_DV_BYTES_PER_FILE) == 2097152L)
+      assert(spark.sessionState.conf.getConf(
+        DeltaSQLConf.ROW_LEVEL_CONCURRENCY_MAX_DV_READS_PER_COMMIT) == 128)
+      assert(spark.sessionState.conf.getConf(
+        DeltaSQLConf.ROW_LEVEL_CONCURRENCY_MAX_RESOLUTION_TIME_MS) == 5000L)
+    }
+  }
+
+  // ---------- persistent-DV defaults regression guard ----------
+
+  test("persistent-DV defaults remain true (RLC P0 invariant)") {
+    // RLC can only rebase DV-only modifications, so DML must default to writing persistent
+    // deletion vectors. The per-op confs already default to true; this test guards against
+    // an inadvertent regression that would silently disable RLC by switching DML back to
+    // copy-on-write.
+    assert(spark.sessionState.conf.getConf(
+      DeltaSQLConf.DELETE_USE_PERSISTENT_DELETION_VECTORS),
+      "DELETE_USE_PERSISTENT_DELETION_VECTORS must remain true for RLC")
+    assert(spark.sessionState.conf.getConf(
+      DeltaSQLConf.UPDATE_USE_PERSISTENT_DELETION_VECTORS),
+      "UPDATE_USE_PERSISTENT_DELETION_VECTORS must remain true for RLC")
+    assert(spark.sessionState.conf.getConf(
+      DeltaSQLConf.MERGE_USE_PERSISTENT_DELETION_VECTORS),
+      "MERGE_USE_PERSISTENT_DELETION_VECTORS must remain true for RLC")
+  }
+
+  // ---------- Telemetry constants ----------
+
+  test("telemetry event names are well-formed") {
+    assert(RowLevelConcurrency.TELEMETRY_RESOLVED.startsWith(
+      "delta.conflictDetection.rowLevelConcurrency."))
+    assert(RowLevelConcurrency.TELEMETRY_ABORTED_OVERLAP.startsWith(
+      "delta.conflictDetection.rowLevelConcurrency."))
+    assert(RowLevelConcurrency.TELEMETRY_ABORTED_BUDGET.startsWith(
+      "delta.conflictDetection.rowLevelConcurrency."))
+    assert(RowLevelConcurrency.TELEMETRY_ABORTED_SHAPE.startsWith(
+      "delta.conflictDetection.rowLevelConcurrency."))
+    assert(RowLevelConcurrency.TELEMETRY_ABORTED_DV_READ_FAILURE.startsWith(
+      "delta.conflictDetection.rowLevelConcurrency."))
+    assert(RowLevelConcurrency.TELEMETRY_ABORTED_DECODE_FAILURE.startsWith(
+      "delta.conflictDetection.rowLevelConcurrency."))
+    assert(RowLevelConcurrency.TELEMETRY_ABORTED_DV_WRITE_FAILURE.startsWith(
+      "delta.conflictDetection.rowLevelConcurrency."))
+    assert(RowLevelConcurrency.TELEMETRY_ABORTED_AFTER_REBASE.startsWith(
+      "delta.conflictDetection.rowLevelConcurrency."))
+    assert(RowLevelConcurrency.TELEMETRY_WOULD_RESOLVE.startsWith(
+      "delta.conflictDetection.rowLevelConcurrency."))
+  }
+
+  // ---------- enablementHintIfMissing ----------
+
+  test("hint: empty when RLC switch is off (regardless of features)") {
+    withTempDir { dir =>
+      val path = "file:" + dir.getAbsolutePath
+      // table with NEITHER DVs nor RT
+      spark.range(10).write.format("delta").save(path)
+      val snapshot = DeltaLog.forTable(spark, path).update()
+      withSQLConf(DeltaSQLConf.ROW_LEVEL_CONCURRENCY_ENABLED.key -> "false") {
+        val hint = RowLevelConcurrency.enablementHintIfMissing(
+          snapshot, spark.sessionState.conf)
+        assert(hint == "", s"Hint should be empty when RLC is disabled; got: $hint")
+      }
+    }
+  }
+
+  test("hint: empty when RLC switch is on and all prerequisites are met") {
+    withTempDir { dir =>
+      val path = createRlcEligibleTable(dir)
+      val snapshot = DeltaLog.forTable(spark, path).update()
+      withSQLConf(DeltaSQLConf.ROW_LEVEL_CONCURRENCY_ENABLED.key -> "true") {
+        val hint = RowLevelConcurrency.enablementHintIfMissing(
+          snapshot, spark.sessionState.conf)
+        assert(hint == "",
+          s"Hint should be empty when prerequisites are met; got: $hint")
+      }
+    }
+  }
+
+  test("hint: names both Deletion Vectors and Row Tracking when both are off") {
+    withTempDir { dir =>
+      val path = "file:" + dir.getAbsolutePath
+      spark.range(10).write.format("delta").save(path)
+      val snapshot = DeltaLog.forTable(spark, path).update()
+      withSQLConf(DeltaSQLConf.ROW_LEVEL_CONCURRENCY_ENABLED.key -> "true") {
+        val hint = RowLevelConcurrency.enablementHintIfMissing(
+          snapshot, spark.sessionState.conf)
+        assert(hint.contains("Row-Level Concurrency"), s"missing RLC mention; got: $hint")
+        assert(hint.contains("Deletion Vectors"), s"missing DV mention; got: $hint")
+        assert(hint.contains("Row Tracking"), s"missing RowTracking mention; got: $hint")
+        assert(hint.contains(DeltaConfigs.ENABLE_DELETION_VECTORS_CREATION.key),
+          s"missing DV property key; got: $hint")
+        assert(hint.contains(DeltaConfigs.ROW_TRACKING_ENABLED.key),
+          s"missing RT property key; got: $hint")
+        assert(hint.contains("ALTER TABLE"), s"missing ALTER TABLE example; got: $hint")
+        assert(hint.contains("if its row changes are disjoint"),
+          s"hint must not assert row disjointness before conflict resolution; got: $hint")
+      }
+    }
+  }
+
+  test("hint: names only Deletion Vectors when RT is on but DVs are off") {
+    withTempDir { dir =>
+      val path = "file:" + dir.getAbsolutePath
+      withSQLConf(
+        DeltaConfigs.ROW_TRACKING_ENABLED.defaultTablePropertyKey -> "true"
+      ) {
+        spark.range(10).write.format("delta").save(path)
+      }
+      val snapshot = DeltaLog.forTable(spark, path).update()
+      withSQLConf(DeltaSQLConf.ROW_LEVEL_CONCURRENCY_ENABLED.key -> "true") {
+        val hint = RowLevelConcurrency.enablementHintIfMissing(
+          snapshot, spark.sessionState.conf)
+        assert(hint.contains("Deletion Vectors"), s"missing DV mention; got: $hint")
+        assert(!hint.contains("Row Tracking"),
+          s"should NOT mention Row Tracking when it is enabled; got: $hint")
+      }
+    }
+  }
+
+  test("hint: names only Row Tracking when DVs are on but RT is off") {
+    withTempDir { dir =>
+      val path = "file:" + dir.getAbsolutePath
+      withSQLConf(
+        DeltaConfigs.ENABLE_DELETION_VECTORS_CREATION.defaultTablePropertyKey -> "true"
+      ) {
+        spark.range(10).write.format("delta").save(path)
+      }
+      val snapshot = DeltaLog.forTable(spark, path).update()
+      withSQLConf(DeltaSQLConf.ROW_LEVEL_CONCURRENCY_ENABLED.key -> "true") {
+        val hint = RowLevelConcurrency.enablementHintIfMissing(
+          snapshot, spark.sessionState.conf)
+        assert(hint.contains("Row Tracking"), s"missing RT mention; got: $hint")
+        assert(!hint.contains("Deletion Vectors"),
+          s"should NOT mention Deletion Vectors when they are enabled; got: $hint")
+      }
+    }
+  }
+
+  test("hint: empty when table is partitioned (RLC unavailable, no actionable fix)") {
+    withTempDir { dir =>
+      val path = "file:" + dir.getAbsolutePath
+      withSQLConf(
+        DeltaConfigs.ROW_TRACKING_ENABLED.defaultTablePropertyKey -> "true",
+        DeltaConfigs.ENABLE_DELETION_VECTORS_CREATION.defaultTablePropertyKey -> "true"
+      ) {
+        spark.range(10).withColumn("p", org.apache.spark.sql.functions.col("id").cast("int") % 3)
+          .write.format("delta").partitionBy("p").save(path)
+      }
+      val snapshot = DeltaLog.forTable(spark, path).update()
+      withSQLConf(DeltaSQLConf.ROW_LEVEL_CONCURRENCY_ENABLED.key -> "true") {
+        val hint = RowLevelConcurrency.enablementHintIfMissing(
+          snapshot, spark.sessionState.conf)
+        // Partitioning is not a feature the user can toggle without rewriting the table,
+        // so the hint is suppressed to avoid noise.
+        assert(hint == "", s"Hint should be empty for partitioned tables; got: $hint")
+      }
+    }
+  }
+
+  test("hint: empty when table has identity columns") {
+    withTempDir { dir =>
+      val snapshot = DeltaLog.forTable(spark, createIdentityTable(dir)).update()
+      val hint = RowLevelConcurrency.enablementHintIfMissing(
+        snapshot, spark.sessionState.conf)
+      assert(hint == "", s"Identity-column tables must not receive an RLC enablement hint: $hint")
+    }
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/concurrency/rowlevelconcurrency/RowLevelConcurrencyUpdateMergeRebaseSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/concurrency/rowlevelconcurrency/RowLevelConcurrencyUpdateMergeRebaseSuite.scala
@@ -1,0 +1,213 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.concurrency.rowlevelconcurrency
+
+import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.actions.{Action, AddFile, DeletionVectorDescriptor, RemoveFile}
+import org.apache.spark.sql.delta.deletionvectors.{RoaringBitmapArray, RoaringBitmapArrayFormat}
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.test.SharedSparkSession
+
+/**
+ * Unit tests for [[RowLevelConcurrency.tryRebase]] focused on the
+ * UPDATE/MERGE action shape: the loser may emit additional `AddFile`s with paths that
+ * differ from any `RemoveFile.path`, representing post-image rewritten rows. These
+ * post-image files must pass through the rebase unmodified so the downstream
+ * `reassignOverlappingRowIds` phase can assign fresh baseRowIds to them.
+ */
+class RowLevelConcurrencyUpdateMergeRebaseSuite extends QueryTest
+  with SharedSparkSession
+  with DeltaSQLCommandTest {
+
+  // ---------- helpers ----------
+
+  private def bitmap(rows: Long*): RoaringBitmapArray = {
+    val b = new RoaringBitmapArray()
+    rows.foreach(b.add)
+    b
+  }
+
+  private def inlineDv(rows: Long*): DeletionVectorDescriptor = {
+    val b = bitmap(rows: _*)
+    if (b.isEmpty) {
+      DeletionVectorDescriptor.EMPTY
+    } else {
+      val bytes = b.serializeAsByteArray(RoaringBitmapArrayFormat.Portable)
+      DeletionVectorDescriptor.inlineInLog(bytes, b.cardinality)
+    }
+  }
+
+  private def addFile(
+      path: String,
+      dv: DeletionVectorDescriptor = DeletionVectorDescriptor.EMPTY,
+      baseRowId: Option[Long] = None): AddFile =
+    AddFile(
+      path = path,
+      partitionValues = Map.empty,
+      size = 1L,
+      modificationTime = 1L,
+      dataChange = true,
+      stats = "{\"numRecords\": 100}",
+      deletionVector = dv,
+      baseRowId = baseRowId)
+
+  private def removeFile(path: String, dv: DeletionVectorDescriptor): RemoveFile =
+    RemoveFile(
+      path = path,
+      deletionTimestamp = Some(1L),
+      dataChange = true,
+      deletionVector = dv)
+
+  private def newHadoopConf(): org.apache.hadoop.conf.Configuration = {
+    // scalastyle:off deltahadoopconfiguration
+    spark.sessionState.newHadoopConf()
+    // scalastyle:on deltahadoopconfiguration
+  }
+
+  private def MAX_DV_BYTES = 1024L * 1024L
+
+  // ---------- UPDATE shape: post-image AddFile preserved ----------
+
+  test("tryRebase: UPDATE shape -- post-image AddFile (different path) is preserved") {
+    withTempDir { dir =>
+      val tablePath = new Path("file:" + dir.getAbsolutePath)
+      val hadoopConf = newHadoopConf()
+
+      // UPDATE produces:
+      //   RemoveFile("data1.parquet")  -- original file removed
+      //   AddFile("data1.parquet", DV) -- same file re-added with DV marking updated rows
+      //   AddFile("data1_v2.parquet")  -- post-image: rewritten rows in a new file
+      val priorDv = inlineDv(0L)
+      val winnerDv = inlineDv(0L, 1L)  // winner deleted row 1
+      val loserDv = inlineDv(0L, 5L)   // loser deleted row 5
+
+      val postImageAddFile = addFile("data1_v2.parquet", baseRowId = Some(123L))
+      val loserActions: Seq[Action] = Seq(
+        removeFile("data1.parquet", priorDv),
+        addFile("data1.parquet", loserDv),
+        postImageAddFile)
+
+      val winnerAdded = Seq(addFile("data1.parquet", winnerDv))
+      val winnerRemoved = Seq(removeFile("data1.parquet", priorDv))
+
+      val result = RowLevelConcurrency.tryRebase(
+        loserActions, winnerAdded, winnerRemoved, tablePath, hadoopConf, MAX_DV_BYTES)
+
+      assert(result.resolvedFileCount == 1)
+      assert(result.numDvFilesWritten == 1)
+
+      // Post-image file must still be present in the new action set, unchanged.
+      val newAddFiles = result.newActions.collect { case a: AddFile => a }
+      val newAddPaths = newAddFiles.map(_.path).toSet
+      assert(newAddPaths.contains("data1_v2.parquet"),
+        s"Post-image AddFile missing from rebased actions: $newAddPaths")
+      assert(newAddFiles.exists(a => a.path == "data1_v2.parquet" && a.baseRowId == Some(123L)),
+        "Post-image AddFile must be preserved verbatim including baseRowId")
+    }
+  }
+
+  test("tryRebase: MERGE shape -- multiple post-image AddFiles all preserved") {
+    withTempDir { dir =>
+      val tablePath = new Path("file:" + dir.getAbsolutePath)
+      val hadoopConf = newHadoopConf()
+
+      val priorDv = inlineDv()
+      val winnerDv = inlineDv(1L)
+      val loserDv = inlineDv(5L)
+
+      // MERGE emitting a same-path DV mod plus two new-path post-image files. Only the
+      // same-path pair is rebased here; new-path files must survive untouched.
+      val postImage1 = addFile("merge_out_1.parquet", baseRowId = Some(200L))
+      val postImage2 = addFile("merge_out_2.parquet", baseRowId = Some(300L))
+      val loserActions: Seq[Action] = Seq(
+        removeFile("target.parquet", priorDv),
+        addFile("target.parquet", loserDv),
+        postImage1,
+        postImage2)
+
+      val winnerAdded = Seq(addFile("target.parquet", winnerDv))
+      val winnerRemoved = Seq(removeFile("target.parquet", priorDv))
+
+      val result = RowLevelConcurrency.tryRebase(
+        loserActions, winnerAdded, winnerRemoved, tablePath, hadoopConf, MAX_DV_BYTES)
+
+      assert(result.resolvedFileCount == 1)
+      val newAddPaths = result.newActions.collect { case a: AddFile => a.path }.toSet
+      assert(newAddPaths.contains("merge_out_1.parquet"))
+      assert(newAddPaths.contains("merge_out_2.parquet"))
+      assert(newAddPaths.contains("target.parquet"))  // The rebased same-path AddFile
+    }
+  }
+
+  test("tryRebase: rebased same-path AddFile inherits winner baseRowId") {
+    withTempDir { dir =>
+      val tablePath = new Path("file:" + dir.getAbsolutePath)
+      val hadoopConf = newHadoopConf()
+
+      val priorDv = inlineDv(0L)
+      val winnerDv = inlineDv(0L, 1L)
+      val loserDv = inlineDv(0L, 5L)
+
+      // Winner assigned baseRowId=42 to this file in its commit
+      val winnerAddFile = addFile("data.parquet", winnerDv, baseRowId = Some(42L))
+      // Loser proposes a different baseRowId=99, which the downstream row-id
+      // reassignment phase is allowed to rewrite.
+      val loserAddFile = addFile("data.parquet", loserDv, baseRowId = Some(99L))
+
+      val loserActions: Seq[Action] = Seq(
+        removeFile("data.parquet", priorDv),
+        loserAddFile)
+      val winnerAdded = Seq(winnerAddFile)
+      val winnerRemoved = Seq(removeFile("data.parquet", priorDv))
+
+      val result = RowLevelConcurrency.tryRebase(
+        loserActions, winnerAdded, winnerRemoved, tablePath, hadoopConf, MAX_DV_BYTES)
+
+      assert(result.resolvedFileCount == 1)
+      val rebasedAdd = result.newActions
+        .collect { case a: AddFile => a }
+        .find(_.path == "data.parquet")
+        .get
+      // The rebased same-path AddFile must carry the
+      // winner's baseRowId (the file's physical contents are unchanged from the winner's
+      // post-image; only the DV layered on top of it has been replaced).
+      assert(rebasedAdd.baseRowId == Some(42L),
+        s"Expected baseRowId from winner (42L) but got ${rebasedAdd.baseRowId}")
+    }
+  }
+
+  test("tryRebase: non-shared post-image AddFile + no shared files = no-op") {
+    withTempDir { dir =>
+      val tablePath = new Path("file:" + dir.getAbsolutePath)
+      val hadoopConf = newHadoopConf()
+
+      // UPDATE writes only a post-image file; no shared paths with winner.
+      val loserActions: Seq[Action] = Seq(addFile("only_post_image.parquet"))
+      val winnerAdded = Seq(addFile("winner_only.parquet"))
+      val winnerRemoved = Seq.empty[RemoveFile]
+
+      val result = RowLevelConcurrency.tryRebase(
+        loserActions, winnerAdded, winnerRemoved, tablePath, hadoopConf, MAX_DV_BYTES)
+
+      assert(result.resolvedFileCount == 0)
+      assert(result.newActions == loserActions, "No shared paths means actions unchanged")
+    }
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/concurrency/rowlevelconcurrency/RowLevelConcurrencyWouldResolveSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/concurrency/rowlevelconcurrency/RowLevelConcurrencyWouldResolveSuite.scala
@@ -1,0 +1,171 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.concurrency.rowlevelconcurrency
+
+import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.RowLevelConcurrency.SkipReason
+import org.apache.spark.sql.delta.actions.{Action, AddFile, RemoveFile}
+
+import org.apache.spark.SparkFunSuite
+
+/**
+ * Unit tests for [[RowLevelConcurrency.wouldResolve]] -- the detect-only
+ * action-shape analysis used by the conflict-checker phase. These tests
+ * exercise only synthetic action sequences and do not require a SparkSession or a
+ * Delta table.
+ */
+class RowLevelConcurrencyWouldResolveSuite extends SparkFunSuite {
+
+  // ---------- helpers ----------
+
+  private def addFile(path: String): AddFile =
+    AddFile(
+      path = path,
+      partitionValues = Map.empty,
+      size = 1L,
+      modificationTime = 1L,
+      dataChange = true,
+      stats = "{\"numRecords\": 100}")
+
+  private def removeFile(path: String): RemoveFile =
+    RemoveFile(
+      path = path,
+      deletionTimestamp = Some(1L),
+      dataChange = true)
+
+  // ---------- candidate detection ----------
+
+  test("wouldResolve: single DV-vs-DV same-path candidate is detected") {
+    val path = "f1.parquet"
+
+    val loserActions: Seq[Action] = Seq(removeFile(path), addFile(path))
+    val winnerAdded = Seq(addFile(path))
+    val winnerRemoved = Seq(removeFile(path))
+
+    val summary = RowLevelConcurrency.wouldResolve(
+      loserActions, winnerAdded, winnerRemoved)
+
+    assert(summary.candidateFileCount == 1)
+    assert(summary.candidatePaths == Seq(path))
+    assert(summary.skipReasons.isEmpty)
+  }
+
+  test("wouldResolve: multiple disjoint same-path candidates are detected") {
+    val loserActions: Seq[Action] = (1 to 5).flatMap { i =>
+      Seq(removeFile(s"f$i"), addFile(s"f$i"))
+    }
+    val winnerAdded = (1 to 5).map { i => addFile(s"f$i") }
+    val winnerRemoved = (1 to 5).map { i => removeFile(s"f$i") }
+
+    val summary = RowLevelConcurrency.wouldResolve(
+      loserActions, winnerAdded, winnerRemoved)
+
+    assert(summary.candidateFileCount == 5)
+    assert(summary.candidatePaths.size == 5)
+    assert(summary.skipReasons.isEmpty)
+  }
+
+  // ---------- skip reasons ----------
+
+  test("wouldResolve: winner is CoW (path rewritten) -- WinnerCowOrCompacted") {
+    val loserActions: Seq[Action] = Seq(removeFile("f1"), addFile("f1"))
+    // Winner removed f1 but added a different path (CoW shape).
+    val winnerAdded = Seq(addFile("f1_rewritten"))
+    val winnerRemoved = Seq(removeFile("f1"))
+
+    val summary = RowLevelConcurrency.wouldResolve(
+      loserActions, winnerAdded, winnerRemoved)
+
+    assert(summary.candidateFileCount == 0)
+    assert(summary.skipReasons(SkipReason.WinnerCowOrCompacted) == 1)
+  }
+
+  test("wouldResolve: winner produced multiple AddFiles for same path -- WinnerNotDvOnly") {
+    val loserActions: Seq[Action] = Seq(removeFile("f1"), addFile("f1"))
+    // Pathological: winner produced two AddFiles for the same path.
+    val winnerAdded = Seq(addFile("f1"), addFile("f1"))
+    val winnerRemoved = Seq(removeFile("f1"))
+
+    val summary = RowLevelConcurrency.wouldResolve(
+      loserActions, winnerAdded, winnerRemoved)
+
+    assert(summary.candidateFileCount == 0)
+    assert(summary.skipReasons(SkipReason.WinnerNotDvOnly) == 1)
+  }
+
+  test("wouldResolve: loser removed path but did not re-add it -- LoserNoSamePathAdd") {
+    val loserActions: Seq[Action] = Seq(removeFile("f1"))  // No matching AddFile
+    val winnerAdded = Seq(addFile("f1"))
+    val winnerRemoved = Seq(removeFile("f1"))
+
+    val summary = RowLevelConcurrency.wouldResolve(
+      loserActions, winnerAdded, winnerRemoved)
+
+    assert(summary.candidateFileCount == 0)
+    assert(summary.skipReasons(SkipReason.LoserNoSamePathAdd) == 1)
+  }
+
+  test("wouldResolve: no shared paths returns empty summary") {
+    val loserActions: Seq[Action] = Seq(removeFile("f1"), addFile("f1"))
+    val winnerAdded = Seq(addFile("f2"))
+    val winnerRemoved = Seq(removeFile("f2"))
+
+    val summary = RowLevelConcurrency.wouldResolve(
+      loserActions, winnerAdded, winnerRemoved)
+
+    assert(summary.candidateFileCount == 0)
+    assert(summary.candidatePaths.isEmpty)
+    assert(summary.skipReasons.isEmpty)
+  }
+
+  // ---------- mixed cases ----------
+
+  test("wouldResolve: mixed candidates and skips are recorded separately") {
+    val loserActions: Seq[Action] = Seq(
+      removeFile("f1"), addFile("f1"),  // Candidate
+      removeFile("f2"), addFile("f2"),  // Will be skipped (winner CoW)
+      removeFile("f3"))                  // Will be skipped (loser no add)
+    val winnerAdded = Seq(addFile("f1"), addFile("f2_rewritten"), addFile("f3"))
+    val winnerRemoved = Seq(removeFile("f1"), removeFile("f2"), removeFile("f3"))
+
+    val summary = RowLevelConcurrency.wouldResolve(
+      loserActions, winnerAdded, winnerRemoved)
+
+    assert(summary.candidateFileCount == 1)
+    assert(summary.candidatePaths == Seq("f1"))
+    assert(summary.skipReasons(SkipReason.WinnerCowOrCompacted) == 1)
+    assert(summary.skipReasons(SkipReason.LoserNoSamePathAdd) == 1)
+  }
+
+  // ---------- log cap ----------
+
+  test("wouldResolve: candidatePaths cap prevents log blowup") {
+    // 50 candidate files > 16 cap
+    val n = 50
+    val loserActions: Seq[Action] = (1 to n).flatMap { i =>
+      Seq(removeFile(s"f$i"), addFile(s"f$i"))
+    }
+    val winnerAdded = (1 to n).map { i => addFile(s"f$i") }
+    val winnerRemoved = (1 to n).map { i => removeFile(s"f$i") }
+
+    val summary = RowLevelConcurrency.wouldResolve(
+      loserActions, winnerAdded, winnerRemoved)
+
+    assert(summary.candidateFileCount == n)
+    assert(summary.candidatePaths.size <= 16)
+  }
+}


### PR DESCRIPTION
Two concurrent DML transactions that modify **different rows of the same physical file** currently abort one of the writers with a `ConcurrentAppendException` / `ConcurrentDeleteDeleteException`, because Delta's conflict detection operates at file granularity.

This PR adds **row-level conflict resolution**: when the winning and losing commits both express their change as a deletion-vector (DV) update on the same file, and their deleted row sets are disjoint, the loser's DV is *rebased* onto the winner's post-image (a bitmap union) and the commit proceeds instead of failing.

RLC is **strictly opportunistic**. It can only turn a "would abort" outcome into a "commits cleanly" outcome, never the reverse. Every precondition failure falls back to the existing file-level conflict detection with no behavior change.

#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Closes #7057 

### How it works

`ConflictChecker` gains a new phase, `checkRowLevelConflicts()`, that runs before the existing file-level checks:

1. **Eligibility gate** (`RowLevelConcurrency.isCommitEligible`) — cheap, no I/O.
2. **Shape analysis** (`wouldResolve`) — walks both action sets and identifies paths where the winner and loser each emitted exactly one `RemoveFile(path)` + `AddFile(path)` pair (the DV-only modification shape). No DV bytes are read.
3. **Rebase** (`tryRebase`) — decodes the DVs, verifies the preconditions below, and writes a new DV containing `priorDV ∪ winnerDV ∪ loserDV` for each resolvable file.
4. On success the loser's actions are replaced, and the rebased files are added to `readFiles` so downstream row-id reassignment sees them.

#### Rebase preconditions

| # | Precondition | Failure |
|---|---|---|
| P1 | Both sides modify the path as `RemoveFile` + single same-path `AddFile` | `WinnerNotDvOnly`, `WinnerCowOrCompacted`, `LoserNotDvOnly` |
| P2 | Winner's DV is a **superset** of the read-time DV (monotonic; no "undelete") | `WinnerShrunkDv`, `LoserShrunkDv` |
| P3 | Both sides rebase from the **same** base DV | `DifferentBaseDv` |
| P4 | The two newly-deleted row sets are **disjoint** | `Overlap` |

#### Atomicity

Rebasing is **all-or-nothing per winning commit**. If any file fails a precondition or a budget, the entire attempt is discarded: `newActions` is reference-equal to the original action list and the resolved-file sets are empty. This prevents a partially-rebased action set from suppressing conflicts that were never actually resolved.

#### Conflict-check masking

Only files with **action-level lineage** — the `AddFile`/`RemoveFile` objects `tryRebase` actually rebased — are excluded from the subsequent file-level conflict checks. Masking deliberately does **not** consult `CommitInfo.operation` or `operationMetrics`, which are descriptive metadata and not correctness guarantees. Consequence: a winner UPDATE's *new-path* post-image carries no lineage, so a concurrent loser still aborts. This preserves Serializable semantics and is asserted by a dedicated E2E test.

### Eligibility

A table is RLC-eligible when **all** hold:

- `spark.databricks.delta.rowLevelConcurrency.enabled` is on
- Deletion Vectors are writable on the table
- Row Tracking is enabled
- The table is **unpartitioned**
- The table has **no identity columns**

Identity columns are explicitly unsupported: their high-watermark bookkeeping is not rebased, so such tables fall back to default conflict detection (covered by an E2E test).

When a conflict aborts on a table that *could* have been eligible, the exception message now carries a one-line hint naming the table properties to enable. The hint is empty when it would not help (RLC disabled, partitioned table, identity columns, or DV + Row Tracking already on).

### Configuration

All confs are `.internal()`.

| Conf | Type | Default | Purpose |
|---|---|---|---|
| `rowLevelConcurrency.enabled` | boolean | `true` | Master switch / emergency kill switch |
| `rowLevelConcurrency.maxDvBytesPerFile` | long | `1048576` (1 MiB) | Caps the serialized size of any DV decoded during resolution |
| `rowLevelConcurrency.maxDvReadsPerCommit` | int | `64` | Caps distinct external DV reads per winning commit (inline and cached DVs are free) |
| `rowLevelConcurrency.maxResolutionTimeMs` | long | `2000` | Wall-clock budget per winning commit, checked around each DV read/write |

Exceeding any budget aborts the rebase and falls back to default conflict detection.

### Telemetry

Events under `delta.conflictDetection.rowLevelConcurrency.*`: `resolved`, `wouldResolve`, `abortedOverlap`, `abortedBudget`, `abortedShape`, `abortedDvReadFailure`, `abortedDecodeFailure`, `abortedDvWriteFailure`, `abortedUnexpected`, `abortedAfterRebase`.

Each carries the winning commit version, the typed failure name, DV read/write counts and byte totals, and the isolation level — so aborts are attributable to a specific precondition rather than a generic bucket. `abortedAfterRebase` distinguishes "rebase worked but a later check still failed" from "rebase itself failed".

### Error-message change

`DELTA_CONCURRENT_APPEND`, `DELTA_CONCURRENT_DELETE_READ` and `DELTA_CONCURRENT_DELETE_DELETE` gain a new `<additionalHint>` message parameter (all 6 subclasses). Previously the hint would have had to be concatenated into `<docLink>`, which is documented as a URL. Expectation maps in `DeltaErrorsSuite` and `OptimisticTransactionSuite` are updated accordingly.

## How was this patch tested?

67 new tests across 6 suites in `spark/src/test/scala/org/apache/spark/sql/delta/concurrency/rowlevelconcurrency/`:

| Suite | Tests | Scope |
|---|---|---|
| `RowLevelConcurrencyE2ESuite` | 13 | Real SQL DELETE/UPDATE/MERGE through `ConflictChecker`, incl. identity fallback, mixed-MERGE Serializable abort, hint surfacing |
| `RowLevelConcurrencyDeleteRebaseSuite` | 14 | `tryRebase` on synthetic DELETE action shapes, incl. empty-DV and shrunk-DV aborts |
| `RowLevelConcurrencyEligibilitySuite` | 21 | Eligibility predicates, conf plumbing, persistent-DV default guard |
| `RowLevelConcurrencyWouldResolveSuite` | 8 | Detect-only shape analysis (no SparkSession) |
| `RowLevelConcurrencyBudgetsAndFuzzSuite` | 7 | Budgets, `tightBounds` degradation, 3-writer convergence fuzz |
| `RowLevelConcurrencyUpdateMergeRebaseSuite` | 4 | New-path post-image handling and `baseRowId` propagation |

Determinism: the fuzz test uses a fixed seed (42); the deadline test injects a fake clock rather than sleeping.

**Regression runs (all green):** the 6 RLC suites plus `DeltaErrorsSuite`,
`OptimisticTransactionSuite`, `DeltaConcurrentExceptionsSuite` (224/224),
`RowTrackingBackfillConflictsSuite` (44/44), and `IdentityColumnConflictScalaSuite` (27/27).

## Does this PR introduce _any_ user-facing changes?

While RLC enabled by default, RLC only engages on any DV + Row-Tracking, unpartitioned table. While we could do default-off first, users already need to opt-in to DV + row tracking so it's already gated behind non-default features. There aren't any protocol or on-disk format changes.