### PR TITLE
Preserve Iceberg snapshot lineage during v3 upgrades

### DIFF
--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConversionTransaction.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConversionTransaction.scala
@@ -224,6 +224,13 @@ class IcebergConversionTransaction(
 
     override def opType: String = "rewrite"
 
+    def replaceDataFile(existingDataFile: DataFile, replacement: AddFile): Unit = {
+      writeSize += replacement.size
+      assert(!replacement.dataChange, "Rewrite operation should not add data")
+      rewriter.deleteFile(existingDataFile)
+      rewriter.addFile(replacement.toDataFile)
+    }
+
     override def add(add: AddFile): Unit = {
       writeSize += add.size
       assert(!add.dataChange, "Rewrite operation should not add data")
@@ -392,6 +399,10 @@ class IcebergConversionTransaction(
     val ret = new RewriteHelper(txn.newRewrite())
     fileUpdates += ret
     ret
+  }
+
+  def setNextRowId(nextRowId: Long): Unit = {
+    IcebergTransactionUtils.setIcebergTxnNextRowId(txn, nextRowId)
   }
 
   def getRowDeltaHelper: RowDeltaHelper = {

--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConverter.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConverter.scala
@@ -38,7 +38,7 @@ import org.apache.spark.sql.delta.util.TransactionHelper
 import io.delta.storage.commit.{CommitFailedException => DeltaCommitFailedException}
 import org.apache.commons.lang3.exception.ExceptionUtils
 import org.apache.hadoop.fs.Path
-import shadedForDelta.org.apache.iceberg.{Table => IcebergTable, TableProperties}
+import shadedForDelta.org.apache.iceberg.{DataFile, Table => IcebergTable, TableProperties}
 import shadedForDelta.org.apache.iceberg.BaseTable
 import shadedForDelta.org.apache.iceberg.exceptions.CommitFailedException
 import shadedForDelta.org.apache.iceberg.hadoop.HadoopTables
@@ -380,10 +380,9 @@ class IcebergConverter
         isRowTrackingJustEnabled(
           snapshotToConvert, prevConvertedSnapshotOpt, lastConvertedIcebergTable)
       val tableOp = (lastDeltaVersionConverted, prevConvertedSnapshotOpt) match {
-        case (Some(_), _) if rowTrackingJustEnabled => REPLACE_TABLE
         case (Some(_), Some(_)) => WRITE_TABLE
         case (Some(_), None) => REPLACE_TABLE
-        case (None, None) => CREATE_TABLE
+        case (None, _) => CREATE_TABLE
       }
 
       val icebergTxn = new IcebergConversionTransaction(
@@ -396,14 +395,20 @@ class IcebergConverter
         // will first be triggered, adding one or more ROW TRACKING BACKFILL commits
         // to the table. After backfilling completes, here we must regenerate the entire
         // Iceberg metadata to keep the snapshot version in sync.
-        case _ if rowTrackingJustEnabled =>
-          val commitInfos = createSnapshotsForReplaceTable(
+        case Some(prevSnapshot) if rowTrackingJustEnabled =>
+          icebergTxn.updateTableMetadata(prevSnapshot.metadata)
+          createSnapshotsForRowTrackingUpgrade(
+            snapshotToConvert,
+            lastConvertedIcebergTable.getOrElse {
+              throw new IllegalStateException(
+                "Row Tracking upgrade requires a previous Iceberg table to exist.")
+            },
+            icebergTxn,
+            snapshotToConvert.version)
+        case None if rowTrackingJustEnabled =>
+          createSnapshotsForReplaceTable(
             snapshotToConvert, prevConvertedSnapshotOpt, icebergTxn, catalogTable,
             snapshotToConvert.version, useRowTrackingVersion = true)
-          prevConvertedSnapshotOpt.foreach { prevSnapshot =>
-            icebergTxn.updateTableMetadata(prevSnapshot.metadata)
-          }
-          commitInfos
         case Some(prevSnapshot) =>
           // Read the actions directly from the delta json files.
           // TODO: Run this as a spark job on executors
@@ -659,6 +664,96 @@ class IcebergConverter
       // Either this is first time to enable Uniform or upgrade from lower version
       (prevConvertedSnapshotOpt.isEmpty || lastConvertedIcebergTable.exists(
         _.asInstanceOf[BaseTable].operations().current().formatVersion() <= 2))
+  }
+
+  /** Returns the active Iceberg data files indexed by path. */
+  private def loadActiveIcebergDataFilesByPath(
+      icebergTable: IcebergTable): Map[String, DataFile] = {
+    val scanTasks = icebergTable.newScan().planFiles()
+    val activeDataFiles = try {
+      scanTasks.iterator().asScala.map(_.file()).toSeq
+    } finally {
+      scanTasks.close()
+    }
+    activeDataFiles
+      .groupBy(_.path().toString)
+      .map { case (path, files) =>
+        if (files.size != 1) {
+          throw new IllegalStateException(
+            s"Cannot preserve Iceberg snapshot lineage while upgrading Row Tracking: " +
+              s"found ${files.size} active data files for path $path.")
+        }
+        path -> files.head
+      }
+  }
+
+  /** Fails the upgrade rather than adding or dropping a data file. */
+  private def validateRowTrackingUpgradePaths(
+      deltaPaths: Set[String],
+      icebergPaths: Set[String]): Unit = {
+    if (deltaPaths != icebergPaths) {
+      throw new IllegalStateException(
+        "Cannot preserve Iceberg snapshot lineage while upgrading Row Tracking: " +
+          s"${deltaPaths.diff(icebergPaths).size} Delta files are missing from Iceberg and " +
+          s"${icebergPaths.diff(deltaPaths).size} Iceberg files are missing from Delta.")
+    }
+  }
+
+  /**
+   * Adds Row Tracking metadata to existing Iceberg data files while preserving the table's
+   * snapshot lineage.
+   *
+   * Row Tracking backfill updates the metadata of every active Delta AddFile without changing
+   * its logical data. RewriteFiles represents the same operation in Iceberg: each existing data
+   * file is replaced by a descriptor for the same path carrying its v3 first-row-id. The rewrites
+   * are grouped by defaultRowCommitVersion so Iceberg sequence numbers remain aligned with Delta.
+   *
+   * @param snapshotToConvert Delta snapshot after the Row Tracking backfill
+   * @param existingIcebergTable Iceberg table whose snapshot lineage must be preserved
+   * @param icebergTxn transaction opened against the existing Iceberg table
+   * @param fallbackVersion version for files without a defaultRowCommitVersion
+   */
+  protected def createSnapshotsForRowTrackingUpgrade(
+      snapshotToConvert: Snapshot,
+      existingIcebergTable: IcebergTable,
+      icebergTxn: IcebergConversionTransaction,
+      fallbackVersion: Long): Seq[Option[CommitInfo]] = {
+    val existingDataFilesByPath = loadActiveIcebergDataFilesByPath(existingIcebergTable)
+
+    val versionedFiles = snapshotToConvert.allFiles.rdd.map { add =>
+      val version = add.defaultRowCommitVersion.getOrElse(fallbackVersion)
+      version -> add.wrap.unwrap.asInstanceOf[AddFile]
+    }.cache()
+    val rowCommitVersions = versionedFiles.keys.distinct().collect().sorted
+    val filesByVersion = versionedFiles.groupByKey().cache()
+    val tablePath = snapshotToConvert.dataPath
+    val deltaPaths = versionedFiles.values
+      .map(add => IcebergTransactionUtils.canonicalizeFilePath(add, tablePath))
+      .collect()
+      .toSet
+    validateRowTrackingUpgradePaths(deltaPaths, existingDataFilesByPath.keySet)
+    rowCommitVersions.toSeq.map { version =>
+      val filesToRewrite = filesByVersion
+        .lookup(version)
+        .headOption
+        .map(_.iterator.toSeq)
+        .getOrElse(throw new IllegalStateException(s"No files found for version $version"))
+      val rewriteHelper = icebergTxn.getRewriteHelper
+      filesToRewrite.foreach { add =>
+        val canonicalPath =
+          IcebergTransactionUtils.canonicalizeFilePath(add, tablePath)
+        rewriteHelper.replaceDataFile(
+          existingDataFilesByPath(canonicalPath),
+          add.copy(dataChange = false))
+      }
+
+      val firstRowIds = filesToRewrite.flatMap(_.baseRowId)
+      if (firstRowIds.nonEmpty) {
+        icebergTxn.setNextRowId(firstRowIds.min)
+      }
+      rewriteHelper.commit(version)
+      None
+    }
   }
 
   /**

--- a/iceberg/src/test/scala/org/apache/spark/sql/delta/uniform/UniversalFormatSuite.scala
+++ b/iceberg/src/test/scala/org/apache/spark/sql/delta/uniform/UniversalFormatSuite.scala
@@ -18,6 +18,8 @@ package org.apache.spark.sql.delta.uniform
 
 import java.util.UUID
 
+import scala.collection.JavaConverters._
+
 import org.apache.spark.sql.delta.{
   DeltaLog,
   IcebergCompatBase,
@@ -30,6 +32,7 @@ import org.apache.spark.sql.delta.{
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.commands.DeltaReorgTableCommand
 import org.apache.spark.sql.delta.icebergShaded.IcebergTransactionUtils
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.uniform.UniFormIcebergVerifier
 import org.apache.hadoop.fs.Path
 
@@ -117,6 +120,58 @@ class UniFormWithIcebergCompatV3Suite
       val icebergTable = UniFormIcebergVerifier.loadIcebergTableFromUC(id)
 
       new UniFormIcebergVerifier(spark, deltaLog, table.catalogTable, icebergTable).verify()
+    }
+  }
+
+  test("V2 to V3 upgrade preserves Iceberg snapshot lineage") {
+    withTempTableAndDir { case (id, _) =>
+      withSQLConf(
+        DeltaSQLConf.DELTA_ROW_TRACKING_BACKFILL_MAX_NUM_FILES_PER_COMMIT.key -> "1") {
+        executeSql(
+          s"""
+             |CREATE TABLE $id (ID INT) USING DELTA TBLPROPERTIES (
+             |  'delta.universalFormat.enabledFormats' = 'iceberg',
+             |  'delta.enableIcebergCompatV2' = 'true'
+             |  $requiredTableProperties
+             |)""".stripMargin)
+        executeSql(s"INSERT INTO $id VALUES (1), (2), (3)")
+        executeSql(s"INSERT INTO $id VALUES (4), (5), (6)")
+
+        val tableBeforeUpgrade = UniFormIcebergVerifier.loadIcebergTableFromUC(id)
+        val snapshotsBeforeUpgrade = tableBeforeUpgrade.snapshots().asScala.toSeq
+        val snapshotIdsBeforeUpgrade = snapshotsBeforeUpgrade.map(_.snapshotId()).toSet
+        val checkpointSnapshotId = snapshotsBeforeUpgrade.minBy(_.sequenceNumber()).snapshotId()
+        val currentSnapshotId = tableBeforeUpgrade.currentSnapshot().snapshotId()
+        assert(
+          checkpointSnapshotId != currentSnapshotId,
+          "Test setup requires a streaming checkpoint behind the current Iceberg snapshot.")
+
+        executeSql(
+          s"""
+             |ALTER TABLE $id SET TBLPROPERTIES (
+             |  'delta.enableIcebergCompatV2' = 'false',
+             |  'delta.enableIcebergCompatV3' = 'true'
+             |)""".stripMargin)
+
+        val tableAfterUpgrade = UniFormIcebergVerifier.loadIcebergTableFromUC(id)
+        val snapshotsAfterUpgrade = tableAfterUpgrade.snapshots().asScala.toSeq
+        assert(
+          snapshotIdsBeforeUpgrade.subsetOf(snapshotsAfterUpgrade.map(_.snapshotId()).toSet),
+          "The upgrade must retain snapshots that may be referenced by streaming checkpoints.")
+        assert(
+          tableAfterUpgrade.snapshot(checkpointSnapshotId) != null,
+          "The snapshot stored in a streaming checkpoint must remain resolvable.")
+
+        val upgradeSnapshots = snapshotsAfterUpgrade
+          .filterNot(snapshot => snapshotIdsBeforeUpgrade.contains(snapshot.snapshotId()))
+        assert(upgradeSnapshots.nonEmpty, "The upgrade should commit at least one snapshot.")
+        assert(
+          upgradeSnapshots.forall(_.operation() == "replace"),
+          "Row Tracking backfill must use metadata-only replace snapshots.")
+        assert(
+          upgradeSnapshots.minBy(_.sequenceNumber()).parentId() == currentSnapshotId,
+          "The first upgrade snapshot must extend the pre-upgrade snapshot chain.")
+      }
     }
   }
 }


### PR DESCRIPTION
## Description

Upgrading a non-empty UniForm table from Iceberg compatibility v2 to v3 rebuilt the table metadata. That removed pre-upgrade snapshot IDs, so Structured Streaming readers checkpointed on those snapshots could not resume.

This change keeps the existing Iceberg table and uses `RewriteFiles` snapshots to replace each active data-file descriptor with the descriptor for the same path containing its v3 row-tracking metadata. Rewrites remain grouped by row commit version, preserving the existing sequence-number behavior while retaining the old snapshot lineage.

The upgrade first verifies that the active Delta and Iceberg file paths match. It fails instead of silently adding or dropping data if the two representations have diverged.

## How was this patch tested?

