### PR TITLE
Store AMT manifest tree pointers relative to the table root

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -30,6 +30,7 @@ import scala.util.control.NonFatal
 import com.databricks.spark.util.TagDefinition
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.ClassicColumnConversions._
+import org.apache.spark.sql.delta.amt.AMTUtils
 import org.apache.spark.sql.delta.commands.DeletionVectorUtils
 import org.apache.spark.sql.delta.metering.{DeltaLogging, DeltaLoggingProvider}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
@@ -1617,6 +1618,11 @@ case class ContentRoot(
   /** The version of the most recent full (non-incremental) manifest rewrite, if recorded. */
   def lastManifestCommitWithFullRewrite: Option[Long] =
     tag(ContentRoot.Tags.LAST_MANIFEST_COMMIT_WITH_FULL_REWRITE).map(_.toLong)
+
+  /** Absolute [[Path]] to the root manifest, resolving `path` against `tableRoot`. */
+  @JsonIgnore
+  def getAbsolutePath(tableRoot: Path): Path =
+    AMTUtils.absolutePathForManifestFile(tableRoot, path)
 }
 
 object ContentRoot {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTCheckpointProvider.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTCheckpointProvider.scala
@@ -37,11 +37,15 @@ import org.apache.spark.sql.types.StructType
  *
  * @param checkpointAction The inline-emitted Checkpoint action this tree was committed with;
  *                         carries the version, contentRoot, and inline non-file state.
- * @param leaves           Pointer metadata for each leaf reachable from the root.
+ * @param leaves           The root's `DATA_MANIFEST` pointer entries, one per leaf reachable from
+ *                         the root. Each entry's `location` is stored table-root-relative; use
+ *                         [[leafManifestAbsolutePaths]] to resolve them against the table root.
+ * @param tableRoot        The table's data path.
  */
 final class AMTCheckpointProvider(
     val checkpointAction: Checkpoint,
-    val leaves: Seq[AMTCheckpointProvider.LeafInfo])
+    val leaves: Seq[DataManifestEntry],
+    val tableRoot: Path)
   extends CheckpointProvider {
 
   /** The table version the manifest tree describes. */
@@ -50,10 +54,15 @@ final class AMTCheckpointProvider(
   /** Pointer to the root manifest parquet. */
   private def contentRoot: ContentRoot = checkpointAction.contentRoot
 
+  /** Absolute [[Path]] to the root manifest parquet, resolved against the table root. */
+  private val rootManifestAbsolutePath: Path = contentRoot.getAbsolutePath(tableRoot)
+
+  /** Absolute [[Path]]s to the leaf manifest parquet files, resolved against the table root. */
+  lazy val leafManifestAbsolutePaths: Seq[Path] = leaves.map(_.getAbsolutePath(tableRoot))
+
   override def version: Long = checkpointAction.version
 
   override def topLevelFiles: Seq[FileStatus] = {
-    val rootPath = new Path(contentRoot.path)
     Seq(new FileStatus(
       /* length = */ contentRoot.sizeInBytes,
       /* isdir = */ false,
@@ -62,11 +71,11 @@ final class AMTCheckpointProvider(
       // modificationTime is not tracked on the ContentRoot, so report 0.
       // This should not impact readers.
       /* modification_time = */ 0L,
-      rootPath))
+      rootManifestAbsolutePath))
   }
 
   override def effectiveCheckpointSizeInBytes(): Long =
-    contentRoot.sizeInBytes + leaves.map(_.sizeInBytes).sum
+    contentRoot.sizeInBytes + leaves.map(_.file_size_in_bytes).sum
 
   override def checkpointPolicyForLogging: Option[CheckpointPolicy.Policy] = None
 
@@ -120,9 +129,10 @@ final class AMTCheckpointProvider(
   private def liveAddSingleActions(
       spark: SparkSession, deltaLog: DeltaLog): Dataset[SingleAction] = {
     import org.apache.spark.sql.delta.implicits._
-    val tableRoot = deltaLog.dataPath
-    val paths = new Path(contentRoot.path) +: leaves.map(l => new Path(l.path))
-    val encodedRootPath = SparkPath.fromPathString(contentRoot.path).urlEncoded
+    // Bind to a local so the `map` closure captures it, not the (non-serializable) provider.
+    val localTableRoot = deltaLog.dataPath
+    val paths = rootManifestAbsolutePath +: leafManifestAbsolutePaths
+    val encodedRootPath = SparkPath.fromPath(rootManifestAbsolutePath).urlEncoded
     AMTCheckpointProvider.loadEntriesWithLocation(spark, deltaLog, paths)
       .where(col("entry.content_type") === lit(AMTSingleAction.ContentType.Type.Data))
       .map { entryWithLoc =>
@@ -134,7 +144,7 @@ final class AMTCheckpointProvider(
               Some(BackReference(
                 SparkPath.fromUrlString(entryWithLoc.leafPath).toPath.toString, entryWithLoc.pos))
             }
-            val add = data.toAddFile(tableRoot).copy(backReference = backReference)
+            val add = data.toAddFile(localTableRoot).copy(backReference = backReference)
             SingleAction(add = add)
           case other => throw new IllegalStateException(
             s"Expected a DATA entry after filtering, got ${other.getClass.getSimpleName}.")
@@ -144,15 +154,6 @@ final class AMTCheckpointProvider(
 }
 
 object AMTCheckpointProvider {
-
-  /**
-   * Pointer-only view of a single leaf, derived from the `DATA_MANIFEST` row.
-   *
-   * @param path        Path to the leaf parquet file (the root entry's `location`).
-   * @param sizeInBytes On-disk size of the leaf parquet file (`file_size_in_bytes`).
-   * @param numEntries  Number of content entries the leaf holds (`record_count`).
-   */
-  case class LeafInfo(path: String, sizeInBytes: Long, numEntries: Long)
 
   /**
    * An [[AMTSingleAction]] entry paired with its physical read location in its manifest parquet.
@@ -182,16 +183,14 @@ object AMTCheckpointProvider {
       spark: SparkSession,
       deltaLog: DeltaLog,
       checkpoint: Checkpoint): AMTCheckpointProvider = {
+    val tableRoot = deltaLog.dataPath
+    val rootPath = checkpoint.contentRoot.getAbsolutePath(tableRoot)
     // The root manifest is small (one row per leaf), so collect it to the driver to enumerate the
     // leaf pointers.
-    val rootPath = new Path(checkpoint.contentRoot.path)
     val leaves = loadEntries(spark, deltaLog, Seq(rootPath)).collect().toSeq
       .filter(_.content_type == AMTSingleAction.ContentType.Type.DataManifest)
-      .map(row => LeafInfo(
-        path = row.location,
-        sizeInBytes = row.file_size_in_bytes,
-        numEntries = row.record_count))
-    new AMTCheckpointProvider(checkpointAction = checkpoint, leaves = leaves)
+      .map(_.unwrap.asInstanceOf[DataManifestEntry])
+    new AMTCheckpointProvider(checkpointAction = checkpoint, leaves = leaves, tableRoot = tableRoot)
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTUtils.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.amt
+
+import org.apache.spark.sql.delta.util.DeltaFileOperations
+import org.apache.hadoop.fs.{FileSystem, Path}
+
+/**
+ * Path helpers for AMT (Adaptive Metadata Tree) manifest files.
+ *
+ * AMT manifest `location` / `contentRoot.path` fields follow the Iceberg V4 manifest path rules:
+ * they hold raw (non-URL-encoded) literal path strings, stored relative to the table root when the
+ * file lives under it and resolved back by string concatenation (`tableRoot + "/" + relative`).
+ * This differs from Delta's `AddFile.path`, which is URL-encoded.
+ */
+object AMTUtils {
+
+  /**
+   * Relativizes an AMT manifest file `path` against `tableRoot`, returning the raw
+   * (non-URL-encoded) string to store in a manifest `location` / `contentRoot.path`. Paths under
+   * the table root become relative; paths elsewhere are returned absolute.
+   */
+  def relativizeManifestPathToTableRoot(fs: FileSystem, tableRoot: Path, path: Path): String =
+    DeltaFileOperations.tryRelativizePath(fs, tableRoot, path).toString
+
+  /**
+   * Resolves a manifest `location` / `contentRoot.path` back to an absolute [[Path]] against
+   * `tableRoot`: a location carrying a URI scheme (or an absolute path) is used as-is; otherwise it
+   * is a raw path relative to the table root and is joined onto it. The location is a literal
+   * (non-URL-encoded) string.
+   */
+  def absolutePathForManifestFile(tableRoot: Path, location: String): Path = {
+    val child = new Path(location)
+    if (child.toUri.getScheme != null || child.isAbsolute) child
+    else new Path(tableRoot, child)
+  }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriteHelper.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriteHelper.scala
@@ -155,7 +155,7 @@ object AMTWriteHelper extends DeltaLogging {
   private def buildResult(
       contentStateVersion: Long,
       contentRoot: ContentRoot,
-      leaves: Seq[AMTCheckpointProvider.LeafInfo],
+      leaves: Seq[DataManifestEntry],
       postCommitProtocol: Protocol,
       postCommitMetadata: Metadata,
       domainMetadata: Seq[DomainMetadata],
@@ -215,7 +215,7 @@ object AMTWriteHelper extends DeltaLogging {
       hadoopConf: Configuration,
       tableRoot: Path,
       liveAddFiles: Seq[AddFile],
-      entriesPerLeaf: Int): (ContentRoot, Seq[AMTCheckpointProvider.LeafInfo]) = {
+      entriesPerLeaf: Int): (ContentRoot, Seq[DataManifestEntry]) = {
     require(entriesPerLeaf > 0, "entriesPerLeaf must be positive.")
 
     val fs = tableRoot.getFileSystem(hadoopConf)
@@ -233,36 +233,26 @@ object AMTWriteHelper extends DeltaLogging {
       liveAddFiles.grouped(entriesPerLeaf).toSeq
     }
 
-    val leafPointers = leafBatches.map { batch =>
+    val leafEntries = leafBatches.map { batch =>
       writeLeaf(spark, fs, hadoopConf, tableRoot, metadataDir, batch)
     }
 
-    val contentRoot = writeRoot(spark, fs, hadoopConf, metadataDir, leafPointers)
-    (contentRoot, leafInfosFor(leafPointers))
+    val contentRoot = writeRoot(spark, fs, hadoopConf, tableRoot, metadataDir, leafEntries)
+    (contentRoot, leafEntries)
   }
-
-  // Builds the pointer-only [[AMTCheckpointProvider.LeafInfo]] view from the written leaf pointers.
-  private def leafInfosFor(
-      leafPointers: Seq[LeafPointer]): Seq[AMTCheckpointProvider.LeafInfo] =
-    leafPointers.map { leaf =>
-      AMTCheckpointProvider.LeafInfo(
-        path = leaf.path,
-        sizeInBytes = leaf.sizeInBytes,
-        numEntries = leaf.manifestInfo.added_files_count.toLong)
-    }
 
   /**
    * Writes a clustered AMT manifest tree for a full checkpoint of `readSnapshot`'s live files.
    * All files are clustered and flushed into leaf manifests -- one leaf per Spark partition,
    * written by executors. The root lists only leaf pointers (no inline data entries). Returns the
-   * [[ContentRoot]] plus the per-leaf [[AMTCheckpointProvider.LeafInfo]] pointers.
+   * [[ContentRoot]] plus the per-leaf [[DataManifestEntry]] pointers.
    */
   private def writeClusteredManifestTree(
       spark: SparkSession,
       deltaLog: DeltaLog,
       readSnapshot: Snapshot,
       hadoopConf: Configuration,
-      entriesPerLeaf: Int): (ContentRoot, Seq[AMTCheckpointProvider.LeafInfo]) = {
+      entriesPerLeaf: Int): (ContentRoot, Seq[DataManifestEntry]) = {
     require(entriesPerLeaf > 0, "entriesPerLeaf must be positive.")
     val tableRoot = deltaLog.dataPath
     val fs = tableRoot.getFileSystem(hadoopConf)
@@ -274,15 +264,15 @@ object AMTWriteHelper extends DeltaLogging {
     val addFilesDf =
       readSnapshot.allFiles.toDF().repartition(desiredNumLeaves, col("path"))
 
-    val leafPointers = writeLeavesDistributed(
+    val leafEntries = writeLeavesDistributed(
       spark = spark,
       hadoopConf = hadoopConf,
       tableRoot = tableRoot,
       metadataDir = metadataDir,
       addFilesDf = addFilesDf,
       desiredNumLeaves = desiredNumLeaves)
-    val contentRoot = writeRoot(spark, fs, hadoopConf, metadataDir, leafPointers)
-    (contentRoot, leafInfosFor(leafPointers))
+    val contentRoot = writeRoot(spark, fs, hadoopConf, tableRoot, metadataDir, leafEntries)
+    (contentRoot, leafEntries)
   }
 
 
@@ -292,7 +282,7 @@ object AMTWriteHelper extends DeltaLogging {
       tableRoot: Path,
       metadataDir: Path,
       addFilesDf: DataFrame,
-      desiredNumLeaves: Int): Seq[LeafPointer] = {
+      desiredNumLeaves: Int): Seq[DataManifestEntry] = {
     import org.apache.spark.sql.delta.implicits._
     val addFilesDs = addFilesDf.as[AddFile]
 
@@ -334,24 +324,21 @@ object AMTWriteHelper extends DeltaLogging {
             expectedNumParts = desiredNumLeaves,
             rows = iter
           )
-          Iterator.single(LeafPointer(
-            path = leafFile.toString,
-            sizeInBytes = status.length,
-            // TODO: populate the per-leaf summary for the distributed write path.
-            manifestInfo = manifestInfoFor(Seq.empty)))
+          val leafFs = leafFile.getFileSystem(conf)
+          Iterator.single(DataManifestEntry(
+            location = AMTUtils.relativizeManifestPathToTableRoot(
+              leafFs, tableRootSparkPath.toPath, leafFile),
+            file_format = AMTSingleAction.FileFormatParquet,
+            // The root pointer to this leaf is newly ADDED, even though the leaf's own DATA
+            // entries are EXISTING (the referenced data files already lived in the table).
+            tracking = trackingWithStatus(Tracking.Status.Added),
+            record_count = 0L,
+            file_size_in_bytes = status.length,
+            manifest_info = manifestInfoFor(Seq.empty)))
         }
       }.collect().toSeq
     }
   }
-
-  /**
-   * Pointer to one written leaf, used to build the root's `DATA_MANIFEST` entry for it.
-   *
-   * @param path         Absolute path to the leaf parquet file.
-   * @param sizeInBytes  Size of the leaf parquet file on disk.
-   * @param manifestInfo Per-leaf summary (file/row counts by status) for the root pointer.
-   */
-  private case class LeafPointer(path: String, sizeInBytes: Long, manifestInfo: ManifestInfo)
 
   // Tracking envelope for a freshly written entry with the given status, no lineage/sequence
   // numbers yet.
@@ -366,7 +353,8 @@ object AMTWriteHelper extends DeltaLogging {
     replaced_positions = None)
 
   /**
-   * Writes a single leaf parquet file (DATA entries) and returns a pointer row for it.
+   * Writes a single leaf parquet file (DATA entries) and returns the DataManifestEntry
+   * corresponding to it.
    */
   private def writeLeaf(
       spark: SparkSession,
@@ -374,7 +362,7 @@ object AMTWriteHelper extends DeltaLogging {
       hadoopConf: Configuration,
       tableRoot: Path,
       metadataDir: Path,
-      batch: Seq[AddFile]): LeafPointer = {
+      batch: Seq[AddFile]): DataManifestEntry = {
     val leafFile = FileNames.newAMTLeafManifestFile(metadataDir)
     val rows: Seq[AMTSingleAction] =
       batch.map(add =>
@@ -388,37 +376,34 @@ object AMTWriteHelper extends DeltaLogging {
       )
     writeAMTParquet(spark, hadoopConf, leafFile, rows)
     val status = fs.getFileStatus(leafFile)
-    LeafPointer(
-      path = leafFile.toString,
-      sizeInBytes = status.getLen,
-      manifestInfo = manifestInfoFor(rows)
-    )
+    val manifestInfo = manifestInfoFor(rows)
+    DataManifestEntry(
+      location = AMTUtils.relativizeManifestPathToTableRoot(fs, tableRoot, leafFile),
+      file_format = AMTSingleAction.FileFormatParquet,
+      tracking = trackingWithStatus(Tracking.Status.Added),
+      // Number of content entries the referenced leaf manifest holds.
+      record_count = manifestInfo.added_files_count.toLong,
+      file_size_in_bytes = status.getLen,
+      manifest_info = manifestInfo)
   }
 
   /**
-   * Writes the root parquet file (DATA_MANIFEST pointers only) and returns the ContentRoot.
+   * Writes the root parquet file (DATA_MANIFEST pointers only) and returns the ContentRoot. The
+   * root pointer follows the same table-root-relative (raw) convention as the leaf pointers.
    */
   private def writeRoot(
       spark: SparkSession,
       fs: FileSystem,
       hadoopConf: Configuration,
+      tableRoot: Path,
       metadataDir: Path,
-      leafPointers: Seq[LeafPointer]): ContentRoot = {
+      leafEntries: Seq[DataManifestEntry]): ContentRoot = {
     val rootFile = FileNames.newAMTRootManifestFile(metadataDir)
-    val rows: Seq[AMTSingleAction] = leafPointers.map { leaf =>
-      DataManifestEntry(
-        location = leaf.path,
-        file_format = AMTSingleAction.FileFormatParquet,
-        tracking = trackingWithStatus(Tracking.Status.Added),
-        // Number of content entries the referenced leaf manifest holds.
-        record_count = leaf.manifestInfo.added_files_count.toLong,
-        file_size_in_bytes = leaf.sizeInBytes,
-        manifest_info = leaf.manifestInfo).wrap
-    }
+    val rows: Seq[AMTSingleAction] = leafEntries.map(_.wrap)
     writeAMTParquet(spark, hadoopConf, rootFile, rows)
     val status = fs.getFileStatus(rootFile)
     ContentRoot(
-      path = rootFile.toString,
+      path = AMTUtils.relativizeManifestPathToTableRoot(fs, tableRoot, rootFile),
       sizeInBytes = status.getLen)
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriterManager.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriterManager.scala
@@ -66,14 +66,14 @@ case class SingleAMTWriteMetrics(
  *
  * @param contentRootVersion          the table version the manifest tree describes
  * @param checkpoint                  the inline [[Checkpoint]] action to embed in the commit JSON
- * @param leaves                      pointer metadata for each leaf written
+ * @param leaves                      the root's `DATA_MANIFEST` pointer entries, one per leaf
  * @param includeActionsInCommitJson  whether the transaction should still write the commit's file
  *                                    actions inline in the commit JSON.
  */
 case class AMTWriteResult(
     contentRootVersion: Long,
     checkpoint: Checkpoint,
-    leaves: Seq[AMTCheckpointProvider.LeafInfo],
+    leaves: Seq[DataManifestEntry],
     includeActionsInCommitJson: Boolean)
 
 /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/actions.scala
@@ -23,6 +23,7 @@ import scala.util.Try
 import org.apache.spark.sql.delta.actions.{AddFile, DeletionVectorDescriptor}
 import org.apache.spark.sql.delta.stats.DeltaStatistics
 import org.apache.spark.sql.delta.storage.dv.DeletionVectorStore
+import com.fasterxml.jackson.annotation.JsonIgnore
 import org.apache.hadoop.fs.Path
 
 /**
@@ -347,6 +348,11 @@ case class DataManifestEntry(
     key_metadata = key_metadata,
     split_offsets = split_offsets,
     column_files = column_files)
+
+  /** Absolute [[Path]] to the referenced leaf manifest, resolving `location` against the root. */
+  @JsonIgnore
+  def getAbsolutePath(tableRoot: Path): Path =
+    AMTUtils.absolutePathForManifestFile(tableRoot, location)
 }
 
 /**

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointTestBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointTestBase.scala
@@ -69,9 +69,14 @@ trait AMTCheckpointTestBase
   protected def tablePath(tableName: String): String =
     new File(deltaLogForName(tableName).dataPath.toUri).getCanonicalPath
 
-  protected def createAMTTable(tableName: String, checkpointInterval: Int = 2): Unit = {
+  protected def createAMTTable(
+      tableName: String,
+      checkpointInterval: Int = 2,
+      location: Option[String] = None): Unit = {
+    val locationClause = location.map(l => s"LOCATION '$l'").getOrElse("")
     sql(
       s"""CREATE TABLE $tableName (id INT) USING DELTA
+         |$locationClause
          |TBLPROPERTIES (
          |  '${propertyKey(AdaptiveMetadataTableFeature)}' = '$FEATURE_PROP_SUPPORTED',
          |  'delta.columnMapping.mode' = 'id',
@@ -149,8 +154,8 @@ trait AMTCheckpointTestBase
   protected def currentLeafDataEntries(snapshot: Snapshot): Long = {
     val provider = amtProvider(snapshot)
       .getOrElse(fail("Snapshot has no AMTCheckpointProvider."))
-      provider.leaves.map { leaf =>
-        spark.read.parquet(leaf.path)
+      provider.leafManifestAbsolutePaths.map { leafPath =>
+        spark.read.parquet(leafPath.toString)
           .where(col("content_type") === AMTSingleAction.ContentType.Type.Data)
           .count()
       }.sum

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointWriteSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointWriteSuite.scala
@@ -20,14 +20,20 @@ import java.io.File
 
 // scalastyle:off import.ordering.noEmptyLine
 import com.databricks.spark.util.{Log4jUsageLogger, MetricDefinitions}
-import org.apache.spark.sql.delta.{CommitStats, CurrentTransactionInfo, DeltaOperations, Snapshot}
-import org.apache.spark.sql.delta.actions.{AddFile, Checkpoint}
+import org.apache.spark.sql.delta.{Checkpoints, CommitStats, CurrentTransactionInfo, DeltaOperations, Snapshot}
+import org.apache.spark.sql.delta.actions.{AddFile, Checkpoint, ContentRoot}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
-import org.apache.spark.sql.delta.util.JsonUtils
+import org.apache.spark.sql.delta.util.{FileNames, JsonUtils}
+import org.apache.hadoop.fs.Path
 
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.functions.col
 
 class AMTCheckpointWriteSuite extends AMTCheckpointTestBase {
+
+  import testImplicits._
+
 
   test("interval boundary emits a follow-up OPTIMIZE CHECKPOINT commit carrying the Checkpoint") {
     withTable("amt_inline_emit") {
@@ -66,6 +72,173 @@ class AMTCheckpointWriteSuite extends AMTCheckpointTestBase {
       assert(isRootFileName(rootName),
         s"contentRoot must point at a root manifest file; got ${checkpoints.head.contentRoot.path}")
       assert(rootFiles(path).exists(_.getName == rootName))
+    }
+  }
+
+  test("manifest pointers are stored relative to the table root") {
+    withTable("amt_relative_pointers") {
+      val name = "amt_relative_pointers"
+      createAMTTable(name, checkpointInterval = 2)
+      withSQLConf(DeltaSQLConf.AMT_ENTRIES_PER_LEAF.key -> "1") {
+        sql(s"INSERT INTO $name VALUES (1)") // v1: one data file.
+        sql(s"INSERT INTO $name VALUES (2)") // v2: interval boundary -> triggers AMT emission.
+      }
+
+      val deltaLog = deltaLogForName(name)
+      val snapshot = deltaLog.update()
+      val provider = amtProvider(snapshot).getOrElse(fail("expected AMTCheckpointProvider"))
+
+      // The Checkpoint's contentRoot pointer is stored relative to the table root, i.e.
+      // `metadata/root-<uuid>.parquet`, not an absolute URI.
+      val rootPointer = provider.checkpointAction.contentRoot.path
+      assert(rootPointer == s"${FileNames.AMT_METADATA_DIR_NAME}/${new File(rootPointer).getName}",
+        s"contentRoot.path must be table-root-relative; got $rootPointer")
+      assert(!new Path(rootPointer).isAbsolute,
+        s"contentRoot.path must not be absolute; got $rootPointer")
+      assert(isRootFileName(new File(rootPointer).getName))
+
+      // Every leaf pointer stored in the root manifest is likewise table-root-relative.
+      val rootDf = spark.read.parquet(new File(new File(tablePath(name),
+        FileNames.AMT_METADATA_DIR_NAME), new File(rootPointer).getName).toString)
+      val leafLocations = rootDf
+        .where(col("content_type") === AMTSingleAction.ContentType.Type.DataManifest)
+        .select("location").as[String].collect().toSeq
+      // The clustered writer decides leaf count by partitioning, so assert at least one leaf
+      // pointer rather than an exact count; every pointer must be table-root-relative.
+      assert(leafLocations.nonEmpty, s"Expected at least one leaf pointer, got $leafLocations")
+      leafLocations.foreach { loc =>
+        assert(loc == s"${FileNames.AMT_METADATA_DIR_NAME}/${new File(loc).getName}",
+          s"leaf pointer must be table-root-relative; got $loc")
+        assert(isLeafFileName(new File(loc).getName))
+      }
+
+      // The pointers are stored relative on disk; the provider re-absolutizes them via
+      // `leafManifestAbsolutePaths`, and reconstruction driven off the manifest tree (root +
+      // leaves, both stored relative) surfaces exactly the two committed data files.
+      val leafLocs = provider.leaves.map(_.location)
+      assert(leafLocs.forall(loc =>
+        loc == s"${FileNames.AMT_METADATA_DIR_NAME}/${new File(loc).getName}"),
+        s"leaf pointer locations must be table-root-relative; got $leafLocs")
+      assert(provider.leafManifestAbsolutePaths.forall(_.isAbsolute),
+        s"resolved leaf manifest paths must be absolute; got ${provider.leafManifestAbsolutePaths}")
+      val reconstructed = provider.loadActionsForStateReconstruction(spark, deltaLog)
+        .getOrElse(fail("AMT provider must contribute reconstructed actions."))
+      assert(reconstructed.where("add is not null").count() == 2,
+        "Reconstruction from the relative-pointer manifest tree must surface both committed files.")
+      checkAnswer(spark.table(name), Seq(Row(1), Row(2)))
+    }
+  }
+
+  test("manifest tree round-trips when the table root contains spaces") {
+    withTempDir { baseDir =>
+      // A table location with a space exercises raw (non-URL-encoded) manifest path handling: the
+      // stored relative pointers (`metadata/leaf-<uuid>.parquet`) must resolve back by literal join
+      // onto the spaced root, not URI parsing (which would turn the space into %20 or fail).
+      val tableRoot = new File(baseDir, "amt table with spaces")
+      withTable("amt_spaced_root") {
+        val name = "amt_spaced_root"
+        createAMTTable(name, checkpointInterval = 2, location = Some(tableRoot.toString))
+        withSQLConf(DeltaSQLConf.AMT_ENTRIES_PER_LEAF.key -> "1") {
+          sql(s"INSERT INTO $name VALUES (1)") // v1: one data file.
+          sql(s"INSERT INTO $name VALUES (2)") // v2: interval boundary -> triggers AMT emission.
+        }
+
+        val deltaLog = deltaLogForName(name)
+        val snapshot = deltaLog.update()
+        val provider = amtProvider(snapshot).getOrElse(fail("expected AMTCheckpointProvider"))
+
+        // The table root really does contain a space, and it is not percent-encoded on disk.
+        assert(deltaLog.dataPath.toString.contains("amt table with spaces"),
+          s"table root must contain a space; got ${deltaLog.dataPath}")
+        assert(!deltaLog.dataPath.toString.contains("%20"),
+          s"table root must not be URL-encoded; got ${deltaLog.dataPath}")
+
+        // The root pointer is stored table-root-relative (raw).
+        val rootPointer = provider.checkpointAction.contentRoot.path
+        assert(
+          rootPointer == s"${FileNames.AMT_METADATA_DIR_NAME}/${new File(rootPointer).getName}",
+          s"contentRoot.path must be table-root-relative; got $rootPointer")
+        // The provider re-absolutizes leaf pointers to paths that live under the spaced root and
+        // are not percent-encoded.
+        provider.leafManifestAbsolutePaths.foreach { leafPath =>
+          assert(leafPath.isAbsolute && leafPath.toString.contains("amt table with spaces"),
+            s"resolved leaf path must live under the spaced table root; got $leafPath")
+          assert(!leafPath.toString.contains("%20"),
+            s"resolved leaf path must stay raw, not URL-encoded; got $leafPath")
+        }
+
+        // The tree reconstructs end-to-end through the spaced paths.
+        val reconstructed = provider.loadActionsForStateReconstruction(spark, deltaLog)
+          .getOrElse(fail("AMT provider must contribute reconstructed actions."))
+        assert(reconstructed.where("add is not null").count() == 2,
+          "Reconstruction from the spaced-path manifest tree must surface both committed files.")
+        checkAnswer(spark.table(name), Seq(Row(1), Row(2)))
+      }
+    }
+  }
+
+  test("manifest tree round-trips when the manifest file names contain spaces") {
+    withTable("amt_spaced_manifest") {
+      val name = "amt_spaced_manifest"
+      createAMTTable(name, checkpointInterval = 2)
+      sql(s"INSERT INTO $name VALUES (1)") // v1.
+      sql(s"INSERT INTO $name VALUES (2)") // v2: triggers a real AMT emission we then override.
+
+      val deltaLog = deltaLogForName(name)
+      val base = amtProvider(deltaLog.update())
+        .getOrElse(fail("expected AMTCheckpointProvider")).checkpointAction
+      val dataPath = deltaLog.dataPath
+      val hadoopConf = deltaLog.newDeltaHadoopConf()
+      val metadataDir = FileNames.amtMetadataDirPath(dataPath)
+      val enc = org.apache.spark.sql.delta.implicits.amtSingleActionEncoder
+
+      // The production writer names manifests `leaf-<uuid>`/`root-<uuid>`, so a normal write never
+      // yields a spaced manifest file name. Synthesize a tree whose leaf and root file names
+      // contain spaces, storing raw table-root-relative pointers, to prove the pointer round-trips.
+      def writeManifest(fileName: String, rows: Seq[AMTSingleAction]): (String, Long) = {
+        val file = new Path(metadataDir, fileName)
+        val df = spark.createDataset(rows)(enc).toDF()
+        Checkpoints.writeAtomicCheckpointParquetFile(spark, df, file, hadoopConf, useRename = false)
+        val relative = AMTUtils.relativizeManifestPathToTableRoot(
+          file.getFileSystem(hadoopConf), dataPath, file)
+        assert(relative == s"${FileNames.AMT_METADATA_DIR_NAME}/$fileName" &&
+          !relative.contains("%20"),
+          s"stored pointer must be raw and table-root-relative; got $relative")
+        (relative, file.getFileSystem(hadoopConf).getFileStatus(file).getLen)
+      }
+
+      val dataAdd = AddFile(path = "part-0.parquet", partitionValues = Map.empty, size = 128L,
+        modificationTime = 0L, dataChange = false, stats = s"""{"numRecords":3}""")
+      val (leafLoc, leafSize) = writeManifest(
+        "leaf with space.parquet",
+        Seq(AMTSingleAction.fromAddFile(dataAdd, addedTracking, dataPath)))
+      val leafPointer = DataManifestEntry(
+        location = leafLoc,
+        file_format = AMTSingleAction.FileFormatParquet,
+        tracking = addedTracking,
+        record_count = 1L,
+        file_size_in_bytes = leafSize,
+        manifest_info = emptyManifestInfo.copy(added_files_count = 1))
+      val (rootLoc, rootSize) = writeManifest("root with space.parquet", Seq(leafPointer.wrap))
+      val checkpoint = base.copy(contentRoot = ContentRoot(path = rootLoc, sizeInBytes = rootSize))
+
+      // The synthesized pointers really do carry spaces and are not URL-encoded.
+      assert(rootLoc.contains("root with space.parquet") && !rootLoc.contains("%20"))
+      assert(leafLoc.contains("leaf with space.parquet") && !leafLoc.contains("%20"))
+
+      val provider = AMTCheckpointProvider.fromCheckpoint(spark, deltaLog, checkpoint)
+      // The provider resolves the spaced pointers to absolute, raw paths under the table root.
+      assert(provider.leafManifestAbsolutePaths.forall(p =>
+        p.isAbsolute && p.toString.contains("leaf with space.parquet") &&
+          !p.toString.contains("%20")),
+        s"resolved leaf paths must stay raw; got ${provider.leafManifestAbsolutePaths}")
+
+      // Reconstruction reads the DATA entry back through the spaced leaf path.
+      val reconstructed = provider.loadActionsForStateReconstruction(spark, deltaLog)
+        .getOrElse(fail("AMT provider must contribute reconstructed actions."))
+      val addPaths = reconstructed.where("add is not null").select("add.path").as[String].collect()
+      assert(addPaths.toSeq == Seq("part-0.parquet"),
+        s"reconstruction from the spaced-manifest tree must surface the DATA entry; got $addPaths")
     }
   }
 
@@ -246,4 +419,29 @@ class AMTCheckpointWriteSuite extends AMTCheckpointTestBase {
         "Commit stats must not carry AMT write metrics when no AMT is emitted.")
     }
   }
+
+  /** An ADDED tracking envelope with no lineage/sequence numbers, matching the AMT writer. */
+  private def addedTracking: Tracking = Tracking(
+    status = Tracking.Status.Added,
+    snapshot_id = None,
+    dv_snapshot_id = None,
+    sequence_number = None,
+    file_sequence_number = None,
+    first_row_id = None,
+    deleted_positions = None,
+    replaced_positions = None)
+
+  /** A zeroed [[ManifestInfo]]; tests set only the counts they assert on via `copy`. */
+  private def emptyManifestInfo: ManifestInfo = ManifestInfo(
+    added_files_count = 0,
+    existing_files_count = 0,
+    deleted_files_count = 0,
+    replaced_files_count = 0,
+    added_rows_count = 0L,
+    existing_rows_count = 0L,
+    deleted_rows_count = 0L,
+    replaced_rows_count = 0L,
+    min_sequence_number = 0L,
+    dv = None,
+    dv_cardinality = None)
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTUtilsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTUtilsSuite.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.amt
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.SparkFunSuite
+
+class AMTUtilsSuite extends SparkFunSuite {
+
+  private val tableRoot = new Path("file:/tables/t1")
+  private val fs = tableRoot.getFileSystem(new Configuration())
+
+  test("relativizeManifestPathToTableRoot: a file under the table root becomes relative") {
+    val leaf = new Path("file:/tables/t1/metadata/leaf-1.parquet")
+    assert(AMTUtils.relativizeManifestPathToTableRoot(fs, tableRoot, leaf) ===
+      "metadata/leaf-1.parquet")
+  }
+
+  test("relativizeManifestPathToTableRoot: a file outside the table root stays absolute") {
+    val outside = new Path("file:/other/metadata/leaf-1.parquet")
+    assert(AMTUtils.relativizeManifestPathToTableRoot(fs, tableRoot, outside) ===
+      "file:/other/metadata/leaf-1.parquet")
+  }
+
+  test("relativizeManifestPathToTableRoot: result is raw, not URL-encoded") {
+    val leaf = new Path("file:/tables/t1/metadata/leaf a.parquet")
+    val relative = AMTUtils.relativizeManifestPathToTableRoot(fs, tableRoot, leaf)
+    assert(relative === "metadata/leaf a.parquet",
+      s"space must stay raw, not percent-encoded; got $relative")
+    assert(!relative.contains("%20"))
+  }
+
+  test("absolutePathForManifestFile: a relative location joins raw onto the table root") {
+    val resolved = AMTUtils.absolutePathForManifestFile(
+      new Path("s3://bucket/tables/t1"), "metadata/leaf a.parquet")
+    assert(resolved === new Path("s3://bucket/tables/t1/metadata/leaf a.parquet"))
+    assert(!resolved.toString.contains("%20"),
+      s"relative location must resolve raw, not URL-encoded; got $resolved")
+  }
+
+  test("absolutePathForManifestFile: a location with a URI scheme is used as-is") {
+    val resolved = AMTUtils.absolutePathForManifestFile(
+      new Path("s3://bucket/tables/t1"), "s3://other/manifests/root x.parquet")
+    assert(resolved === new Path("s3://other/manifests/root x.parquet"))
+  }
+
+  test("relativize then absolutize round-trips a file under the table root") {
+    val root = new Path("file:/tables/t1")
+    val leaf = new Path("file:/tables/t1/metadata/leaf-1.parquet")
+    val relative = AMTUtils.relativizeManifestPathToTableRoot(fs, root, leaf)
+    assert(AMTUtils.absolutePathForManifestFile(root, relative) === leaf)
+  }
+}


### PR DESCRIPTION
## Description

AMT (Adaptive Metadata Tree) manifest-tree pointers were persisted as absolute paths. Per the Iceberg V4 manifest spec, the manifest `location` and `contentRoot.path` fields are stored as raw (non-URL-encoded) literal paths relative to the table root, resolved back by joining onto the table root (`tableRoot + "/" + relative`), with scheme-carrying (absolute) paths used as-is.

On the write path, the manifest writer relativizes both the root pointer and every leaf pointer against the table root via a new `AMTUtils.relativizeManifestPathToTableRoot` helper (falling back to an absolute path when the referenced file is not under the root). On the read path, `AMTCheckpointProvider` re-absolutizes pointers via `AMTUtils.absolutePathForManifestFile`; `ContentRoot` and `DataManifestEntry` expose `getAbsolutePath(dataPath)` for this. Paths are stored and resolved raw (never URL-encoded), so manifests remain valid across table relocation and interoperate with the Iceberg literal-path model.

## How was this patch tested?

Added `AMTUtilsSuite` (relativize / absolutize / raw-path / round-trip unit tests) and new cases in `AMTCheckpointWriteSuite` verifying pointers are stored table-root-relative and that a manifest tree round-trips when the table root or manifest file names contain spaces. Existing AMT suites continue to pass.

## Does this PR introduce any user-facing changes?

No.
