### PR TITLE
[Kernel] Parse _last_checkpoint into a typed LastCheckpointInfo

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checkpoints/Checkpointer.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checkpoints/Checkpointer.java
@@ -293,16 +293,7 @@ public class Checkpointer {
    * Reads {@code _last_checkpoint} and parses it into a fully-typed {@link LastCheckpointInfo}.
    *
    * <p>Unlike {@link #readLastCheckpointFile}, which projects only the classic columnar fields,
-   * this exposes the whole on-disk pointer -- {@code sizeInBytes}, {@code numOfAddFiles}, {@code
-   * checkpointSchema} (as raw JSON), {@code checksum}, and the {@code v2Checkpoint} block -- by
-   * parsing the raw blob returned by {@link #readLastCheckpointSerialized} as a JSON tree. This is
-   * for callers (e.g. the metadata-cache path) that need to mirror those fields; it reuses the same
-   * retry / torn-read handling as the serialized read.
-   *
-   * @return the parsed pointer, or {@link Optional#empty()} when {@code _last_checkpoint} is
-   *     absent.
-   * @throws IllegalArgumentException if the blob is present but not a valid pointer (missing {@code
-   *     version} / {@code size}, or not a JSON object).
+   * this exposes the whole on-disk pointer by parsing the raw blob as a JSON tree.
    */
   public Optional<LastCheckpointInfo> readLastCheckpointInfo(Engine engine) {
     return readLastCheckpointSerialized(engine)

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checkpoints/Checkpointer.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checkpoints/Checkpointer.java
@@ -290,6 +290,26 @@ public class Checkpointer {
   }
 
   /**
+   * Reads {@code _last_checkpoint} and parses it into a fully-typed {@link LastCheckpointInfo}.
+   *
+   * <p>Unlike {@link #readLastCheckpointFile}, which projects only the classic columnar fields,
+   * this exposes the whole on-disk pointer -- {@code sizeInBytes}, {@code numOfAddFiles}, {@code
+   * checkpointSchema} (as raw JSON), {@code checksum}, and the {@code v2Checkpoint} block -- by
+   * parsing the raw blob returned by {@link #readLastCheckpointSerialized} as a JSON tree. This is
+   * for callers (e.g. the metadata-cache path) that need to mirror those fields; it reuses the same
+   * retry / torn-read handling as the serialized read.
+   *
+   * @return the parsed pointer, or {@link Optional#empty()} when {@code _last_checkpoint} is
+   *     absent.
+   * @throws IllegalArgumentException if the blob is present but not a valid pointer (missing {@code
+   *     version} / {@code size}, or not a JSON object).
+   */
+  public Optional<LastCheckpointInfo> readLastCheckpointInfo(Engine engine) {
+    return readLastCheckpointSerialized(engine)
+        .map(serialized -> LastCheckpointInfo.fromJson(serialized.json()));
+  }
+
+  /**
    * Write the given data to last checkpoint metadata file.
    *
    * @param engine {@link Engine} instance to use for writing

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checkpoints/LastCheckpointInfo.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checkpoints/LastCheckpointInfo.java
@@ -28,27 +28,10 @@ import java.util.Optional;
 
 /**
  * Parsed, typed view of a {@code _last_checkpoint} file.
- *
- * <p>{@link CheckpointMetaData} projects only the classic columnar fields ({@code version}, {@code
- * size}, {@code parts}, {@code tags}) because the columnar JSON reader cannot express the on-disk
- * pointer's optional and recursive fields (notably {@code checkpointSchema}, a schema-of-schema).
- * This type is the counterpart for callers that need the full pointer -- e.g. the SoftStore /
- * metadata-cache path that mirrors these fields into a wire format. It is produced from the raw
- * blob (see {@link LastCheckpointSerialized}) via a plain JSON tree walk, so no field has to be
- * projectable into a fixed columnar schema.
- *
- * <p>The field set mirrors DBR's {@code LastCheckpointInfo} case class one-for-one, except for the
- * Edge-only {@code checkpointFiles} / {@code consecutiveCompactedFiles}, which are not JSON
- * serialized into {@code _last_checkpoint} and so are never present in the blob.
- *
- * <p>{@code checkpointSchema} is deliberately kept as its raw JSON string ({@code StructType.json})
- * rather than decoded into a {@code StructType}: it round-trips losslessly and semantically, and it
- * avoids eagerly decoding a recursive schema-of-schema that most callers relay verbatim. Callers
- * that want the structural type can parse it with {@code DataTypeJsonSerDe.deserializeStructType}.
  */
 public final class LastCheckpointInfo {
 
-  // ----- _last_checkpoint field names (must match DBR LastCheckpointInfo's JSON) -----
+  // ----- _last_checkpoint field names -----
   private static final String VERSION = "version";
   private static final String SIZE = "size";
   private static final String PARTS = "parts";
@@ -60,12 +43,6 @@ public final class LastCheckpointInfo {
 
   /**
    * Parses a {@code _last_checkpoint} JSON blob into a {@link LastCheckpointInfo}.
-   *
-   * @param json the raw {@code _last_checkpoint} contents (see {@link
-   *     LastCheckpointSerialized#json()})
-   * @return the parsed pointer
-   * @throws IllegalArgumentException if the blob is not a JSON object or lacks the required {@code
-   *     version} / {@code size} fields
    */
   public static LastCheckpointInfo fromJson(String json) {
     JsonNode root;
@@ -88,7 +65,7 @@ public final class LastCheckpointInfo {
         optionalInt(root, PARTS),
         optionalLong(root, SIZE_IN_BYTES),
         optionalLong(root, NUM_OF_ADD_FILES),
-        // Keep the schema-of-schema as its raw JSON string; see class doc.
+        // Keep the schema-of-schema as its raw JSON string.
         rawJson(root, CHECKPOINT_SCHEMA),
         optionalString(root, CHECKSUM),
         LastCheckpointV2.fromJsonNode(root.get(V2_CHECKPOINT)));
@@ -142,10 +119,6 @@ public final class LastCheckpointInfo {
     return numOfAddFiles;
   }
 
-  /**
-   * The checkpoint schema as its raw {@code StructType.json} string, or empty when the pointer
-   * omits it. Not decoded into a {@code StructType}; see the class doc for why.
-   */
   public Optional<String> getCheckpointSchemaJson() {
     return checkpointSchemaJson;
   }
@@ -278,7 +251,6 @@ public final class LastCheckpointInfo {
       return modificationTime;
     }
 
-    /** The non-file actions as verbatim per-action JSON objects. See {@link LastCheckpointV2}. */
     public Optional<List<String>> getNonFileActionsJson() {
       return nonFileActionsJson;
     }
@@ -287,11 +259,6 @@ public final class LastCheckpointInfo {
       return sidecarFiles;
     }
 
-    /**
-     * The {@code version} of the {@code checkpointMetadata} action among {@code nonFileActions}, or
-     * empty when the pointer carries no such action. This is the field the metadata-cache path uses
-     * to decide whether a V2 pointer is cacheable.
-     */
     public Optional<Long> getCheckpointMetadataVersion() {
       if (!nonFileActionsJson.isPresent()) {
         return Optional.empty();

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checkpoints/LastCheckpointInfo.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checkpoints/LastCheckpointInfo.java
@@ -1,0 +1,481 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.internal.checkpoints;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.delta.kernel.internal.util.JsonUtils;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Parsed, typed view of a {@code _last_checkpoint} file.
+ *
+ * <p>{@link CheckpointMetaData} projects only the classic columnar fields ({@code version}, {@code
+ * size}, {@code parts}, {@code tags}) because the columnar JSON reader cannot express the on-disk
+ * pointer's optional and recursive fields (notably {@code checkpointSchema}, a schema-of-schema).
+ * This type is the counterpart for callers that need the full pointer -- e.g. the SoftStore /
+ * metadata-cache path that mirrors these fields into a wire format. It is produced from the raw
+ * blob (see {@link LastCheckpointSerialized}) via a plain JSON tree walk, so no field has to be
+ * projectable into a fixed columnar schema.
+ *
+ * <p>The field set mirrors DBR's {@code LastCheckpointInfo} case class one-for-one, except for the
+ * Edge-only {@code checkpointFiles} / {@code consecutiveCompactedFiles}, which are not JSON
+ * serialized into {@code _last_checkpoint} and so are never present in the blob.
+ *
+ * <p>{@code checkpointSchema} is deliberately kept as its raw JSON string ({@code StructType.json})
+ * rather than decoded into a {@code StructType}: it round-trips losslessly and semantically, and it
+ * avoids eagerly decoding a recursive schema-of-schema that most callers relay verbatim. Callers
+ * that want the structural type can parse it with {@code DataTypeJsonSerDe.deserializeStructType}.
+ */
+public final class LastCheckpointInfo {
+
+  // ----- _last_checkpoint field names (must match DBR LastCheckpointInfo's JSON) -----
+  private static final String VERSION = "version";
+  private static final String SIZE = "size";
+  private static final String PARTS = "parts";
+  private static final String SIZE_IN_BYTES = "sizeInBytes";
+  private static final String NUM_OF_ADD_FILES = "numOfAddFiles";
+  private static final String CHECKPOINT_SCHEMA = "checkpointSchema";
+  private static final String CHECKSUM = "checksum";
+  private static final String V2_CHECKPOINT = "v2Checkpoint";
+
+  /**
+   * Parses a {@code _last_checkpoint} JSON blob into a {@link LastCheckpointInfo}.
+   *
+   * @param json the raw {@code _last_checkpoint} contents (see {@link
+   *     LastCheckpointSerialized#json()})
+   * @return the parsed pointer
+   * @throws IllegalArgumentException if the blob is not a JSON object or lacks the required {@code
+   *     version} / {@code size} fields
+   */
+  public static LastCheckpointInfo fromJson(String json) {
+    JsonNode root;
+    try {
+      root = JsonUtils.mapper().readTree(json);
+    } catch (Exception e) {
+      throw new IllegalArgumentException("_last_checkpoint is not parseable JSON", e);
+    }
+    return fromJsonNode(root);
+  }
+
+  /** Parses an already-decoded {@code _last_checkpoint} tree. See {@link #fromJson(String)}. */
+  public static LastCheckpointInfo fromJsonNode(JsonNode root) {
+    if (root == null || !root.isObject()) {
+      throw new IllegalArgumentException("_last_checkpoint must be a JSON object");
+    }
+    return new LastCheckpointInfo(
+        requiredLong(root, VERSION),
+        requiredLong(root, SIZE),
+        optionalInt(root, PARTS),
+        optionalLong(root, SIZE_IN_BYTES),
+        optionalLong(root, NUM_OF_ADD_FILES),
+        // Keep the schema-of-schema as its raw JSON string; see class doc.
+        rawJson(root, CHECKPOINT_SCHEMA),
+        optionalString(root, CHECKSUM),
+        LastCheckpointV2.fromJsonNode(root.get(V2_CHECKPOINT)));
+  }
+
+  private final long version;
+  private final long size;
+  private final Optional<Integer> parts;
+  private final Optional<Long> sizeInBytes;
+  private final Optional<Long> numOfAddFiles;
+  private final Optional<String> checkpointSchemaJson;
+  private final Optional<String> checksum;
+  private final Optional<LastCheckpointV2> v2Checkpoint;
+
+  public LastCheckpointInfo(
+      long version,
+      long size,
+      Optional<Integer> parts,
+      Optional<Long> sizeInBytes,
+      Optional<Long> numOfAddFiles,
+      Optional<String> checkpointSchemaJson,
+      Optional<String> checksum,
+      Optional<LastCheckpointV2> v2Checkpoint) {
+    this.version = version;
+    this.size = size;
+    this.parts = parts;
+    this.sizeInBytes = sizeInBytes;
+    this.numOfAddFiles = numOfAddFiles;
+    this.checkpointSchemaJson = checkpointSchemaJson;
+    this.checksum = checksum;
+    this.v2Checkpoint = v2Checkpoint;
+  }
+
+  public long getVersion() {
+    return version;
+  }
+
+  public long getSize() {
+    return size;
+  }
+
+  public Optional<Integer> getParts() {
+    return parts;
+  }
+
+  public Optional<Long> getSizeInBytes() {
+    return sizeInBytes;
+  }
+
+  public Optional<Long> getNumOfAddFiles() {
+    return numOfAddFiles;
+  }
+
+  /**
+   * The checkpoint schema as its raw {@code StructType.json} string, or empty when the pointer
+   * omits it. Not decoded into a {@code StructType}; see the class doc for why.
+   */
+  public Optional<String> getCheckpointSchemaJson() {
+    return checkpointSchemaJson;
+  }
+
+  public Optional<String> getChecksum() {
+    return checksum;
+  }
+
+  public Optional<LastCheckpointV2> getV2Checkpoint() {
+    return v2Checkpoint;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof LastCheckpointInfo)) {
+      return false;
+    }
+    LastCheckpointInfo that = (LastCheckpointInfo) o;
+    return version == that.version
+        && size == that.size
+        && parts.equals(that.parts)
+        && sizeInBytes.equals(that.sizeInBytes)
+        && numOfAddFiles.equals(that.numOfAddFiles)
+        && checkpointSchemaJson.equals(that.checkpointSchemaJson)
+        && checksum.equals(that.checksum)
+        && v2Checkpoint.equals(that.v2Checkpoint);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        version,
+        size,
+        parts,
+        sizeInBytes,
+        numOfAddFiles,
+        checkpointSchemaJson,
+        checksum,
+        v2Checkpoint);
+  }
+
+  @Override
+  public String toString() {
+    return "LastCheckpointInfo{"
+        + "version="
+        + version
+        + ", size="
+        + size
+        + ", parts="
+        + parts
+        + ", sizeInBytes="
+        + sizeInBytes
+        + ", numOfAddFiles="
+        + numOfAddFiles
+        + ", checkpointSchemaJson="
+        + (checkpointSchemaJson.isPresent() ? "<present>" : "<absent>")
+        + ", checksum="
+        + checksum
+        + ", v2Checkpoint="
+        + v2Checkpoint
+        + '}';
+  }
+
+  /**
+   * The V2-checkpoint pointer nested under {@code v2Checkpoint}. Mirrors DBR's {@code
+   * LastCheckpointV2}.
+   *
+   * <p>{@code nonFileActions} is exposed as the list of verbatim per-action JSON objects (e.g.
+   * {@code {"protocol":{...}}}, {@code {"metaData":{...}}}, {@code {"checkpointMetadata":{...}}}).
+   * Decoding those into fully typed action objects is intentionally left to the consumer: the
+   * action model (Metadata / Protocol / DomainMetadata / ...) is large, and the SoftStore codec
+   * maps them into wire types the kernel has no knowledge of. The single action every consumer
+   * needs -- {@code checkpointMetadata} -- is surfaced directly via {@link
+   * #getCheckpointMetadataVersion()}. {@code sidecarFiles} is fully parsed since it is small.
+   */
+  public static final class LastCheckpointV2 {
+    private static final String PATH = "path";
+    private static final String SIZE_IN_BYTES = "sizeInBytes";
+    private static final String MODIFICATION_TIME = "modificationTime";
+    private static final String NON_FILE_ACTIONS = "nonFileActions";
+    private static final String SIDECAR_FILES = "sidecarFiles";
+    private static final String CHECKPOINT_METADATA = "checkpointMetadata";
+    private static final String VERSION = "version";
+
+    static Optional<LastCheckpointV2> fromJsonNode(JsonNode node) {
+      if (node == null || !node.isObject()) {
+        return Optional.empty();
+      }
+      return Optional.of(
+          new LastCheckpointV2(
+              requiredString(node, PATH),
+              requiredLong(node, SIZE_IN_BYTES),
+              requiredLong(node, MODIFICATION_TIME),
+              rawJsonArrayElements(node.get(NON_FILE_ACTIONS)),
+              SidecarFileInfo.fromArray(node.get(SIDECAR_FILES))));
+    }
+
+    private final String path;
+    private final long sizeInBytes;
+    private final long modificationTime;
+    // Absent (None) vs empty list is preserved: absent = info missing, empty = no such actions.
+    private final Optional<List<String>> nonFileActionsJson;
+    private final Optional<List<SidecarFileInfo>> sidecarFiles;
+
+    public LastCheckpointV2(
+        String path,
+        long sizeInBytes,
+        long modificationTime,
+        Optional<List<String>> nonFileActionsJson,
+        Optional<List<SidecarFileInfo>> sidecarFiles) {
+      this.path = path;
+      this.sizeInBytes = sizeInBytes;
+      this.modificationTime = modificationTime;
+      this.nonFileActionsJson = nonFileActionsJson;
+      this.sidecarFiles = sidecarFiles;
+    }
+
+    public String getPath() {
+      return path;
+    }
+
+    public long getSizeInBytes() {
+      return sizeInBytes;
+    }
+
+    public long getModificationTime() {
+      return modificationTime;
+    }
+
+    /** The non-file actions as verbatim per-action JSON objects. See {@link LastCheckpointV2}. */
+    public Optional<List<String>> getNonFileActionsJson() {
+      return nonFileActionsJson;
+    }
+
+    public Optional<List<SidecarFileInfo>> getSidecarFiles() {
+      return sidecarFiles;
+    }
+
+    /**
+     * The {@code version} of the {@code checkpointMetadata} action among {@code nonFileActions}, or
+     * empty when the pointer carries no such action. This is the field the metadata-cache path uses
+     * to decide whether a V2 pointer is cacheable.
+     */
+    public Optional<Long> getCheckpointMetadataVersion() {
+      if (!nonFileActionsJson.isPresent()) {
+        return Optional.empty();
+      }
+      for (String actionJson : nonFileActionsJson.get()) {
+        JsonNode action;
+        try {
+          action = JsonUtils.mapper().readTree(actionJson);
+        } catch (Exception e) {
+          continue;
+        }
+        JsonNode cm = action.get(CHECKPOINT_METADATA);
+        if (cm != null && cm.isObject()) {
+          return optionalLong(cm, VERSION);
+        }
+      }
+      return Optional.empty();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof LastCheckpointV2)) {
+        return false;
+      }
+      LastCheckpointV2 that = (LastCheckpointV2) o;
+      return sizeInBytes == that.sizeInBytes
+          && modificationTime == that.modificationTime
+          && path.equals(that.path)
+          && nonFileActionsJson.equals(that.nonFileActionsJson)
+          && sidecarFiles.equals(that.sidecarFiles);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(path, sizeInBytes, modificationTime, nonFileActionsJson, sidecarFiles);
+    }
+
+    @Override
+    public String toString() {
+      return "LastCheckpointV2{path=" + path + ", sizeInBytes=" + sizeInBytes + '}';
+    }
+  }
+
+  /** A sidecar-file pointer inside a V2 checkpoint. Mirrors DBR's {@code SidecarFile}. */
+  public static final class SidecarFileInfo {
+    private static final String PATH = "path";
+    private static final String SIZE_IN_BYTES = "sizeInBytes";
+    private static final String MODIFICATION_TIME = "modificationTime";
+    private static final String TAGS = "tags";
+
+    static Optional<List<SidecarFileInfo>> fromArray(JsonNode arrayNode) {
+      if (arrayNode == null || !arrayNode.isArray()) {
+        return Optional.empty();
+      }
+      List<SidecarFileInfo> files = new ArrayList<>();
+      for (JsonNode f : arrayNode) {
+        files.add(
+            new SidecarFileInfo(
+                requiredString(f, PATH),
+                requiredLong(f, SIZE_IN_BYTES),
+                requiredLong(f, MODIFICATION_TIME),
+                stringMap(f.get(TAGS))));
+      }
+      return Optional.of(Collections.unmodifiableList(files));
+    }
+
+    private final String path;
+    private final long sizeInBytes;
+    private final long modificationTime;
+    private final Map<String, String> tags;
+
+    public SidecarFileInfo(
+        String path, long sizeInBytes, long modificationTime, Map<String, String> tags) {
+      this.path = path;
+      this.sizeInBytes = sizeInBytes;
+      this.modificationTime = modificationTime;
+      this.tags = tags;
+    }
+
+    public String getPath() {
+      return path;
+    }
+
+    public long getSizeInBytes() {
+      return sizeInBytes;
+    }
+
+    public long getModificationTime() {
+      return modificationTime;
+    }
+
+    public Map<String, String> getTags() {
+      return tags;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof SidecarFileInfo)) {
+        return false;
+      }
+      SidecarFileInfo that = (SidecarFileInfo) o;
+      return sizeInBytes == that.sizeInBytes
+          && modificationTime == that.modificationTime
+          && path.equals(that.path)
+          && tags.equals(that.tags);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(path, sizeInBytes, modificationTime, tags);
+    }
+
+    @Override
+    public String toString() {
+      return "SidecarFileInfo{path=" + path + ", sizeInBytes=" + sizeInBytes + '}';
+    }
+  }
+
+  // ----- JSON helpers -----
+
+  private static long requiredLong(JsonNode node, String field) {
+    JsonNode v = node.get(field);
+    if (v == null || !v.isNumber()) {
+      throw new IllegalArgumentException(
+          "_last_checkpoint is missing required numeric field: " + field);
+    }
+    return v.asLong();
+  }
+
+  private static String requiredString(JsonNode node, String field) {
+    JsonNode v = node.get(field);
+    if (v == null || !v.isTextual()) {
+      throw new IllegalArgumentException(
+          "_last_checkpoint is missing required string field: " + field);
+    }
+    return v.asText();
+  }
+
+  private static Optional<Long> optionalLong(JsonNode node, String field) {
+    JsonNode v = node.get(field);
+    return (v != null && v.isNumber()) ? Optional.of(v.asLong()) : Optional.empty();
+  }
+
+  private static Optional<Integer> optionalInt(JsonNode node, String field) {
+    JsonNode v = node.get(field);
+    return (v != null && v.isNumber()) ? Optional.of(v.asInt()) : Optional.empty();
+  }
+
+  private static Optional<String> optionalString(JsonNode node, String field) {
+    JsonNode v = node.get(field);
+    return (v != null && v.isTextual()) ? Optional.of(v.asText()) : Optional.empty();
+  }
+
+  /** Returns the compact JSON text of a sub-object field (e.g. {@code checkpointSchema}). */
+  private static Optional<String> rawJson(JsonNode node, String field) {
+    JsonNode v = node.get(field);
+    return (v != null && !v.isNull()) ? Optional.of(v.toString()) : Optional.empty();
+  }
+
+  /** Returns each element of a JSON array as its verbatim JSON text; empty Optional if absent. */
+  private static Optional<List<String>> rawJsonArrayElements(JsonNode arrayNode) {
+    if (arrayNode == null || !arrayNode.isArray()) {
+      return Optional.empty();
+    }
+    List<String> out = new ArrayList<>();
+    for (JsonNode e : arrayNode) {
+      out.add(e.toString());
+    }
+    return Optional.of(Collections.unmodifiableList(out));
+  }
+
+  private static Map<String, String> stringMap(JsonNode node) {
+    if (node == null || !node.isObject()) {
+      return Collections.emptyMap();
+    }
+    Map<String, String> map = new LinkedHashMap<>();
+    ObjectNode obj = (ObjectNode) node;
+    obj.fields().forEachRemaining(e -> map.put(e.getKey(), e.getValue().asText()));
+    return Collections.unmodifiableMap(map);
+  }
+}

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/checkpoints/LastCheckpointInfoSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/checkpoints/LastCheckpointInfoSuite.scala
@@ -15,124 +15,18 @@
  */
 package io.delta.kernel.internal.checkpoints
 
-import io.delta.kernel.internal.types.DataTypeJsonSerDe
-import io.delta.kernel.internal.util.JsonUtils
-
 import org.scalatest.funsuite.AnyFunSuite
 
 /**
- * Unit tests for [[LastCheckpointInfo]] parsing. Uses inline `_last_checkpoint` blobs modeled on
- * the kernel-defaults golden tables (`spark-variant-checkpoint`, `v2-checkpoint-json`) so the parse
- * is exercised without an engine or golden-table dependency.
+ * Unit tests for [[LastCheckpointInfo]] parsing that a real golden file cannot exercise: the parse
+ * contract's error cases (every golden blob is valid) and the `None`-vs-`Some(empty)` distinction
+ * for `nonFileActions` / `sidecarFiles` (no golden blob carries empty arrays).
+ *
+ * The happy-path parse against real on-disk bytes -- classic, V2 (json), and V2 (parquet) pointers,
+ * including `checkpointSchema` and sidecars -- is covered end-to-end by
+ * `LastCheckpointInfoGoldenSuite` in kernel-defaults.
  */
 class LastCheckpointInfoSuite extends AnyFunSuite {
-
-  // Classic (single-file) checkpoint pointer, shaped like spark-variant-checkpoint's
-  // _last_checkpoint: version/size/sizeInBytes/numOfAddFiles/checkpointSchema/checksum, no parts,
-  // no v2Checkpoint.
-  private val classicBlob =
-    """{
-      |  "version": 2,
-      |  "size": 6,
-      |  "sizeInBytes": 21929,
-      |  "numOfAddFiles": 4,
-      |  "checkpointSchema": {
-      |    "type": "struct",
-      |    "fields": [
-      |      {"name": "txn", "type": "string", "nullable": true, "metadata": {}}
-      |    ]
-      |  },
-      |  "checksum": "a8d400a03ead8a86dbb412f2a693e26e"
-      |}""".stripMargin
-
-  // V2 checkpoint pointer, shaped like v2-checkpoint-json's _last_checkpoint: a v2Checkpoint block
-  // with nonFileActions (protocol / metaData / checkpointMetadata) and one sidecar.
-  private val v2Blob =
-    """{
-      |  "version": 4,
-      |  "size": 10,
-      |  "sizeInBytes": 10228,
-      |  "numOfAddFiles": 6,
-      |  "v2Checkpoint": {
-      |    "path": "00000000000000000004.checkpoint.a267.json",
-      |    "sizeInBytes": 717,
-      |    "modificationTime": 1752616673818,
-      |    "nonFileActions": [
-      |      {"protocol": {"minReaderVersion": 3, "minWriterVersion": 7}},
-      |      {"metaData": {"id": "8a390218-e4ee-4341-b6de-4920e27d3f78"}},
-      |      {"checkpointMetadata": {"version": 4}}
-      |    ],
-      |    "sidecarFiles": [
-      |      {
-      |        "path": "00000000000000000004.checkpoint.0000.parquet",
-      |        "sizeInBytes": 9511,
-      |        "modificationTime": 1752616673806
-      |      }
-      |    ]
-      |  },
-      |  "checksum": "e0e16b97d85501a7f67b00c24aaa07f2"
-      |}""".stripMargin
-
-  test("parses a classic checkpoint pointer") {
-    val info = LastCheckpointInfo.fromJson(classicBlob)
-    assert(info.getVersion == 2L)
-    assert(info.getSize == 6L)
-    assert(!info.getParts.isPresent)
-    assert(info.getSizeInBytes.get == 21929L)
-    assert(info.getNumOfAddFiles.get == 4L)
-    assert(info.getChecksum.get == "a8d400a03ead8a86dbb412f2a693e26e")
-    assert(!info.getV2Checkpoint.isPresent)
-  }
-
-  test("checkpointSchema is captured as raw JSON that re-parses into a StructType") {
-    val info = LastCheckpointInfo.fromJson(classicBlob)
-    assert(info.getCheckpointSchemaJson.isPresent)
-    val schemaJson = info.getCheckpointSchemaJson.get
-    // Raw JSON, not decoded eagerly.
-    assert(schemaJson.contains("\"type\":\"struct\""))
-    // ... but it round-trips into the structural type on demand.
-    val parsed = DataTypeJsonSerDe.deserializeStructType(schemaJson)
-    assert(parsed.length() == 1)
-    assert(parsed.fieldNames().contains("txn"))
-  }
-
-  test("parses a V2 checkpoint pointer including sidecars and checkpointMetadata version") {
-    val info = LastCheckpointInfo.fromJson(v2Blob)
-    assert(info.getVersion == 4L)
-    assert(info.getV2Checkpoint.isPresent)
-    val v2 = info.getV2Checkpoint.get
-    assert(v2.getPath == "00000000000000000004.checkpoint.a267.json")
-    assert(v2.getSizeInBytes == 717L)
-
-    // nonFileActions are kept as verbatim per-action JSON.
-    assert(v2.getNonFileActionsJson.isPresent)
-    assert(v2.getNonFileActionsJson.get.size() == 3)
-    assert(v2.getNonFileActionsJson.get.get(0).contains("\"protocol\""))
-
-    // The checkpointMetadata action's version is surfaced directly.
-    assert(v2.getCheckpointMetadataVersion.isPresent)
-    assert(v2.getCheckpointMetadataVersion.get == 4L)
-
-    // Sidecars fully parsed.
-    assert(v2.getSidecarFiles.isPresent)
-    assert(v2.getSidecarFiles.get.size() == 1)
-    val sidecar = v2.getSidecarFiles.get.get(0)
-    assert(sidecar.getPath == "00000000000000000004.checkpoint.0000.parquet")
-    assert(sidecar.getSizeInBytes == 9511L)
-    assert(sidecar.getTags.isEmpty)
-  }
-
-  test("V2 pointer without a checkpointMetadata action yields empty version") {
-    val blob =
-      """{"version": 4, "size": 10, "v2Checkpoint": {
-        |  "path": "p", "sizeInBytes": 1, "modificationTime": 2,
-        |  "nonFileActions": [{"protocol": {"minReaderVersion": 3}}]
-        |}}""".stripMargin
-    val info = LastCheckpointInfo.fromJson(blob)
-    val v2 = info.getV2Checkpoint.get
-    assert(v2.getNonFileActionsJson.get.size() == 1)
-    assert(!v2.getCheckpointMetadataVersion.isPresent)
-  }
 
   test("absent optional fields parse to empty, not defaults") {
     // The minimal legacy pointer: only version/size/parts, as written by kernel's own writer.
@@ -164,6 +58,17 @@ class LastCheckpointInfoSuite extends AnyFunSuite {
     assert(empty.getV2Checkpoint.get.getSidecarFiles.get.isEmpty)
   }
 
+  test("V2 pointer without a checkpointMetadata action yields empty version") {
+    val blob =
+      """{"version": 4, "size": 10, "v2Checkpoint": {
+        |  "path": "p", "sizeInBytes": 1, "modificationTime": 2,
+        |  "nonFileActions": [{"protocol": {"minReaderVersion": 3}}]
+        |}}""".stripMargin
+    val v2 = LastCheckpointInfo.fromJson(blob).getV2Checkpoint.get
+    assert(v2.getNonFileActionsJson.get.size() == 1)
+    assert(!v2.getCheckpointMetadataVersion.isPresent)
+  }
+
   test("sidecar tags are parsed as a string map") {
     val blob =
       """{"version": 1, "size": 1, "v2Checkpoint": {
@@ -176,18 +81,6 @@ class LastCheckpointInfoSuite extends AnyFunSuite {
     assert(tags.size() == 2)
     assert(tags.get("k1") == "v1")
     assert(tags.get("k2") == "v2")
-  }
-
-  test("equality is by value") {
-    assert(LastCheckpointInfo.fromJson(v2Blob) == LastCheckpointInfo.fromJson(v2Blob))
-    assert(LastCheckpointInfo.fromJson(v2Blob) != LastCheckpointInfo.fromJson(classicBlob))
-  }
-
-  test("blob re-serialization keeps checkpointSchema byte-identical to the source subtree") {
-    // Guards the raw-string contract: what we hand back must equal the source node's own JSON.
-    val root = JsonUtils.mapper().readTree(classicBlob)
-    val expected = root.get("checkpointSchema").toString
-    assert(LastCheckpointInfo.fromJson(classicBlob).getCheckpointSchemaJson.get == expected)
   }
 
   test("rejects a non-object blob") {

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/checkpoints/LastCheckpointInfoSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/checkpoints/LastCheckpointInfoSuite.scala
@@ -1,0 +1,206 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.internal.checkpoints
+
+import io.delta.kernel.internal.types.DataTypeJsonSerDe
+import io.delta.kernel.internal.util.JsonUtils
+
+import org.scalatest.funsuite.AnyFunSuite
+
+/**
+ * Unit tests for [[LastCheckpointInfo]] parsing. Uses inline `_last_checkpoint` blobs modeled on
+ * the kernel-defaults golden tables (`spark-variant-checkpoint`, `v2-checkpoint-json`) so the parse
+ * is exercised without an engine or golden-table dependency.
+ */
+class LastCheckpointInfoSuite extends AnyFunSuite {
+
+  // Classic (single-file) checkpoint pointer, shaped like spark-variant-checkpoint's
+  // _last_checkpoint: version/size/sizeInBytes/numOfAddFiles/checkpointSchema/checksum, no parts,
+  // no v2Checkpoint.
+  private val classicBlob =
+    """{
+      |  "version": 2,
+      |  "size": 6,
+      |  "sizeInBytes": 21929,
+      |  "numOfAddFiles": 4,
+      |  "checkpointSchema": {
+      |    "type": "struct",
+      |    "fields": [
+      |      {"name": "txn", "type": "string", "nullable": true, "metadata": {}}
+      |    ]
+      |  },
+      |  "checksum": "a8d400a03ead8a86dbb412f2a693e26e"
+      |}""".stripMargin
+
+  // V2 checkpoint pointer, shaped like v2-checkpoint-json's _last_checkpoint: a v2Checkpoint block
+  // with nonFileActions (protocol / metaData / checkpointMetadata) and one sidecar.
+  private val v2Blob =
+    """{
+      |  "version": 4,
+      |  "size": 10,
+      |  "sizeInBytes": 10228,
+      |  "numOfAddFiles": 6,
+      |  "v2Checkpoint": {
+      |    "path": "00000000000000000004.checkpoint.a267.json",
+      |    "sizeInBytes": 717,
+      |    "modificationTime": 1752616673818,
+      |    "nonFileActions": [
+      |      {"protocol": {"minReaderVersion": 3, "minWriterVersion": 7}},
+      |      {"metaData": {"id": "8a390218-e4ee-4341-b6de-4920e27d3f78"}},
+      |      {"checkpointMetadata": {"version": 4}}
+      |    ],
+      |    "sidecarFiles": [
+      |      {
+      |        "path": "00000000000000000004.checkpoint.0000.parquet",
+      |        "sizeInBytes": 9511,
+      |        "modificationTime": 1752616673806
+      |      }
+      |    ]
+      |  },
+      |  "checksum": "e0e16b97d85501a7f67b00c24aaa07f2"
+      |}""".stripMargin
+
+  test("parses a classic checkpoint pointer") {
+    val info = LastCheckpointInfo.fromJson(classicBlob)
+    assert(info.getVersion == 2L)
+    assert(info.getSize == 6L)
+    assert(!info.getParts.isPresent)
+    assert(info.getSizeInBytes.get == 21929L)
+    assert(info.getNumOfAddFiles.get == 4L)
+    assert(info.getChecksum.get == "a8d400a03ead8a86dbb412f2a693e26e")
+    assert(!info.getV2Checkpoint.isPresent)
+  }
+
+  test("checkpointSchema is captured as raw JSON that re-parses into a StructType") {
+    val info = LastCheckpointInfo.fromJson(classicBlob)
+    assert(info.getCheckpointSchemaJson.isPresent)
+    val schemaJson = info.getCheckpointSchemaJson.get
+    // Raw JSON, not decoded eagerly.
+    assert(schemaJson.contains("\"type\":\"struct\""))
+    // ... but it round-trips into the structural type on demand.
+    val parsed = DataTypeJsonSerDe.deserializeStructType(schemaJson)
+    assert(parsed.length() == 1)
+    assert(parsed.fieldNames().contains("txn"))
+  }
+
+  test("parses a V2 checkpoint pointer including sidecars and checkpointMetadata version") {
+    val info = LastCheckpointInfo.fromJson(v2Blob)
+    assert(info.getVersion == 4L)
+    assert(info.getV2Checkpoint.isPresent)
+    val v2 = info.getV2Checkpoint.get
+    assert(v2.getPath == "00000000000000000004.checkpoint.a267.json")
+    assert(v2.getSizeInBytes == 717L)
+
+    // nonFileActions are kept as verbatim per-action JSON.
+    assert(v2.getNonFileActionsJson.isPresent)
+    assert(v2.getNonFileActionsJson.get.size() == 3)
+    assert(v2.getNonFileActionsJson.get.get(0).contains("\"protocol\""))
+
+    // The checkpointMetadata action's version is surfaced directly.
+    assert(v2.getCheckpointMetadataVersion.isPresent)
+    assert(v2.getCheckpointMetadataVersion.get == 4L)
+
+    // Sidecars fully parsed.
+    assert(v2.getSidecarFiles.isPresent)
+    assert(v2.getSidecarFiles.get.size() == 1)
+    val sidecar = v2.getSidecarFiles.get.get(0)
+    assert(sidecar.getPath == "00000000000000000004.checkpoint.0000.parquet")
+    assert(sidecar.getSizeInBytes == 9511L)
+    assert(sidecar.getTags.isEmpty)
+  }
+
+  test("V2 pointer without a checkpointMetadata action yields empty version") {
+    val blob =
+      """{"version": 4, "size": 10, "v2Checkpoint": {
+        |  "path": "p", "sizeInBytes": 1, "modificationTime": 2,
+        |  "nonFileActions": [{"protocol": {"minReaderVersion": 3}}]
+        |}}""".stripMargin
+    val info = LastCheckpointInfo.fromJson(blob)
+    val v2 = info.getV2Checkpoint.get
+    assert(v2.getNonFileActionsJson.get.size() == 1)
+    assert(!v2.getCheckpointMetadataVersion.isPresent)
+  }
+
+  test("absent optional fields parse to empty, not defaults") {
+    // The minimal legacy pointer: only version/size/parts, as written by kernel's own writer.
+    val info = LastCheckpointInfo.fromJson("""{"version": 7, "size": 3, "parts": 2}""")
+    assert(info.getVersion == 7L)
+    assert(info.getSize == 3L)
+    assert(info.getParts.get == 2)
+    assert(!info.getSizeInBytes.isPresent)
+    assert(!info.getNumOfAddFiles.isPresent)
+    assert(!info.getCheckpointSchemaJson.isPresent)
+    assert(!info.getChecksum.isPresent)
+    assert(!info.getV2Checkpoint.isPresent)
+  }
+
+  test("absent nonFileActions/sidecarFiles are None, distinct from empty") {
+    val absent =
+      LastCheckpointInfo.fromJson(
+        """{"version": 1, "size": 1, "v2Checkpoint":
+          |{"path": "p", "sizeInBytes": 1, "modificationTime": 2}}""".stripMargin)
+    assert(!absent.getV2Checkpoint.get.getNonFileActionsJson.isPresent)
+    assert(!absent.getV2Checkpoint.get.getSidecarFiles.isPresent)
+
+    val empty =
+      LastCheckpointInfo.fromJson(
+        """{"version": 1, "size": 1, "v2Checkpoint":
+          |{"path": "p", "sizeInBytes": 1, "modificationTime": 2,
+          | "nonFileActions": [], "sidecarFiles": []}}""".stripMargin)
+    assert(empty.getV2Checkpoint.get.getNonFileActionsJson.get.isEmpty)
+    assert(empty.getV2Checkpoint.get.getSidecarFiles.get.isEmpty)
+  }
+
+  test("sidecar tags are parsed as a string map") {
+    val blob =
+      """{"version": 1, "size": 1, "v2Checkpoint": {
+        |  "path": "p", "sizeInBytes": 1, "modificationTime": 2,
+        |  "sidecarFiles": [{"path": "s", "sizeInBytes": 3, "modificationTime": 4,
+        |    "tags": {"k1": "v1", "k2": "v2"}}]
+        |}}""".stripMargin
+    val sidecar = LastCheckpointInfo.fromJson(blob).getV2Checkpoint.get.getSidecarFiles.get.get(0)
+    val tags = sidecar.getTags
+    assert(tags.size() == 2)
+    assert(tags.get("k1") == "v1")
+    assert(tags.get("k2") == "v2")
+  }
+
+  test("equality is by value") {
+    assert(LastCheckpointInfo.fromJson(v2Blob) == LastCheckpointInfo.fromJson(v2Blob))
+    assert(LastCheckpointInfo.fromJson(v2Blob) != LastCheckpointInfo.fromJson(classicBlob))
+  }
+
+  test("blob re-serialization keeps checkpointSchema byte-identical to the source subtree") {
+    // Guards the raw-string contract: what we hand back must equal the source node's own JSON.
+    val root = JsonUtils.mapper().readTree(classicBlob)
+    val expected = root.get("checkpointSchema").toString
+    assert(LastCheckpointInfo.fromJson(classicBlob).getCheckpointSchemaJson.get == expected)
+  }
+
+  test("rejects a non-object blob") {
+    val e = intercept[IllegalArgumentException](LastCheckpointInfo.fromJson("[1, 2, 3]"))
+    assert(e.getMessage.contains("must be a JSON object"))
+  }
+
+  test("rejects a blob missing the required version field") {
+    val e = intercept[IllegalArgumentException](LastCheckpointInfo.fromJson("""{"size": 1}"""))
+    assert(e.getMessage.contains("version"))
+  }
+
+  test("rejects unparseable JSON") {
+    intercept[IllegalArgumentException](LastCheckpointInfo.fromJson("not json"))
+  }
+}

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/LastCheckpointInfoGoldenSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/LastCheckpointInfoGoldenSuite.scala
@@ -1,0 +1,117 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.defaults
+
+import io.delta.golden.GoldenTableUtils.goldenTablePath
+import io.delta.kernel.defaults.engine.DefaultEngine
+import io.delta.kernel.internal.checkpoints.Checkpointer
+import io.delta.kernel.internal.fs.Path
+import io.delta.kernel.internal.types.DataTypeJsonSerDe
+
+import org.apache.hadoop.conf.Configuration
+import org.scalatest.funsuite.AnyFunSuite
+
+/**
+ * End-to-end tests for `Checkpointer.readLastCheckpointInfo`, which reads a real `_last_checkpoint`
+ * golden file through the engine and parses it into a typed
+ * [[io.delta.kernel.internal.checkpoints.LastCheckpointInfo]].
+ *
+ * The parse contract's error and `None`-vs-`Some(empty)` cases -- which no valid golden file can
+ * exercise -- are covered by the unit suite `LastCheckpointInfoSuite` in kernel-api.
+ */
+class LastCheckpointInfoGoldenSuite extends AnyFunSuite {
+
+  private val engine = DefaultEngine.create(new Configuration())
+
+  private def logPathFor(goldenTable: String): Path =
+    new Path(new Path(goldenTablePath(goldenTable)), "_delta_log")
+
+  private def readInfo(goldenTable: String) =
+    new Checkpointer(logPathFor(goldenTable)).readLastCheckpointInfo(engine).get()
+
+  test("classic checkpoint pointer (spark-variant-checkpoint)") {
+    val info = readInfo("spark-variant-checkpoint")
+    assert(info.getVersion == 2L)
+    assert(info.getSize == 6L)
+    assert(!info.getParts.isPresent)
+    assert(info.getSizeInBytes.get == 21929L)
+    assert(info.getNumOfAddFiles.get == 4L)
+    assert(info.getChecksum.get == "a8d400a03ead8a86dbb412f2a693e26e")
+    assert(!info.getV2Checkpoint.isPresent)
+
+    // checkpointSchema is kept as raw JSON and re-parses into the checkpoint file schema.
+    assert(info.getCheckpointSchemaJson.isPresent)
+    val schema = DataTypeJsonSerDe.deserializeStructType(info.getCheckpointSchemaJson.get)
+    assert(schema.length() == 6)
+    assert(schema.fieldNames().contains("add"))
+    assert(schema.fieldNames().contains("metaData"))
+  }
+
+  test("V2 (json) checkpoint pointer with sidecars, no top-level checkpointSchema") {
+    val info = readInfo("v2-checkpoint-json")
+    assert(info.getVersion == 2L)
+    assert(info.getSize == 9L)
+    assert(info.getSizeInBytes.get == 19554L)
+    assert(info.getNumOfAddFiles.get == 4L)
+    assert(info.getChecksum.get == "d09f95a326aab562c60d415a32ddd216")
+    // This pointer has no top-level checkpointSchema.
+    assert(!info.getCheckpointSchemaJson.isPresent)
+
+    assert(info.getV2Checkpoint.isPresent)
+    val v2 = info.getV2Checkpoint.get
+    assert(v2.getPath.endsWith(".json"))
+    assert(v2.getSizeInBytes == 891L)
+    assert(v2.getModificationTime == 1714496115810L)
+
+    // nonFileActions: protocol / metaData / checkpointMetadata, kept as verbatim JSON.
+    assert(v2.getNonFileActionsJson.isPresent)
+    assert(v2.getNonFileActionsJson.get.size() == 3)
+    assert(v2.getCheckpointMetadataVersion.get == 2L)
+
+    // Two fully-parsed sidecars.
+    assert(v2.getSidecarFiles.isPresent)
+    val sidecars = v2.getSidecarFiles.get
+    assert(sidecars.size() == 2)
+    assert(sidecars.get(0).getSizeInBytes == 9367L)
+    assert(sidecars.get(1).getSizeInBytes == 9296L)
+    assert(sidecars.get(0).getPath.endsWith(".parquet"))
+  }
+
+  test("V2 (parquet) checkpoint pointer carrying both checkpointSchema and a v2Checkpoint block") {
+    val info = readInfo("v2-checkpoint-parquet")
+    assert(info.getVersion == 2L)
+    assert(info.getSizeInBytes.get == 37269L)
+    assert(info.getNumOfAddFiles.get == 4L)
+
+    // Both the top-level checkpointSchema and the v2Checkpoint block are present.
+    assert(info.getCheckpointSchemaJson.isPresent)
+    assert(DataTypeJsonSerDe.deserializeStructType(info.getCheckpointSchemaJson.get).length() > 0)
+
+    val v2 = info.getV2Checkpoint.get
+    assert(v2.getPath.endsWith(".parquet"))
+    assert(v2.getCheckpointMetadataVersion.get == 2L)
+    assert(v2.getSidecarFiles.get.size() == 2)
+  }
+
+  test("readLastCheckpointInfo matches the fields projected by readLastCheckpointFile") {
+    val cp = new Checkpointer(logPathFor("v2-checkpoint-json"))
+    val info = cp.readLastCheckpointInfo(engine).get()
+    val columnar = cp.readLastCheckpointFile(engine).get()
+    assert(info.getVersion == columnar.version)
+    assert(info.getSize == columnar.size)
+    assert(info.getParts.isPresent == columnar.parts.isPresent)
+  }
+}


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the title. For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

### Context
The Kernel `Checkpointer` can read `_last_checkpoint` in two ways today:
`readLastCheckpointFile`, which projects only the classic columnar fields
(`version`, `size`, `parts`, `tags`) into a `CheckpointMetaData`, and
`readLastCheckpointSerialized`, which returns the whole file as an opaque JSON
blob. Neither gives a caller the *typed, complete* pointer: the columnar
projection cannot express the pointer's optional and recursive fields (notably
`checkpointSchema`, a schema-of-schema), and the serialized form is just a
string.

### What
Add an internal `LastCheckpointInfo` that parses a `_last_checkpoint` blob into
all of its on-disk fields — `version`, `size`, `parts`, `sizeInBytes`,
`numOfAddFiles`, `checkpointSchema`, `checksum`, and the `v2Checkpoint` block
(path/size/mtime, non-file actions, sidecar files) — plus
`Checkpointer.readLastCheckpointInfo(engine)`, which reads and parses in one
call, reusing the existing serialized-read retry / torn-read handling.

The type is parsed off the raw blob as a JSON tree, so no field has to be
projectable into a fixed columnar schema. `checkpointSchema` is captured
losslessly as its raw `StructType.json` string rather than eagerly decoded into
a `StructType` (it round-trips semantically; callers that want the structural
type can parse it with `DataTypeJsonSerDe.deserializeStructType`). The field set
mirrors DBR's `LastCheckpointInfo` one-for-one, except the Edge-only
`checkpointFiles` / `consecutiveCompactedFiles`, which are not JSON serialized
into `_last_checkpoint`.

This lives entirely in `io.delta.kernel.internal.checkpoints` — no public API
surface, and `CheckpointMetaData` is untouched.

### Why
A consumer that mirrors `_last_checkpoint` into a wire format (e.g. a metadata /
snapshot-hint cache) needs the full typed pointer, including `checkpointSchema`.
Capturing it off the blob/JSON-tree path avoids modifying the columnar read path
and keeps the recursive schema-of-schema as a lossless raw string.

## How was this patch tested?
Two suites:

- `LastCheckpointInfoGoldenSuite` (kernel-defaults) drives the real
  `readLastCheckpointInfo(engine)` end-to-end against golden `_last_checkpoint`
  files: `spark-variant-checkpoint` (classic pointer with `checkpointSchema`),
  `v2-checkpoint-json` (V2 pointer with two sidecars and `checkpointMetadata`,
  no top-level schema), and `v2-checkpoint-parquet` (V2 pointer carrying both a
  top-level `checkpointSchema` and a `v2Checkpoint` block). It also asserts the
  parsed pointer agrees with the columnar `readLastCheckpointFile` projection,
  and that `checkpointSchema` re-parses into a `StructType`.
- `LastCheckpointInfoSuite` (kernel-api) covers the cases a valid golden file
  cannot exercise: the parse error cases (non-object blob, missing `version`,
  unparseable JSON) and the `None`-vs-`Some(empty)` distinction for
  `nonFileActions` / `sidecarFiles`.

Existing `CheckpointerSuite` continues to pass. Built and tested with JDK 17.

## Does this PR introduce _any_ user-facing changes?
No. The new class and method are in the `internal` package and add no public
API. Existing behavior is unchanged.