### PR TITLE
Populate LastManifestCommit in CommitInfo and VersionChecksum upon commit

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/Checksum.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Checksum.scala
@@ -368,6 +368,7 @@ trait RecordChecksum extends DeltaLogging {
     var numFiles = oldVersionChecksum.numFiles
     var protocol = oldVersionChecksum.protocol
     var metadata = oldVersionChecksum.metadata
+    var lastManifestCommit: Option[LastManifestCommit] = oldVersionChecksum.lastManifestCommit
     val fileSizeHistogram = if (spark.conf.get(DeltaSQLConf.DELTA_FILE_SIZE_HISTOGRAM_ENABLED)) {
       oldVersionChecksum.fileSizeHistogram.map { h =>
         FileSizeHistogram(h.sortedBinBoundaries, h.fileCounts.clone(), h.totalBytes.clone())
@@ -454,6 +455,7 @@ trait RecordChecksum extends DeltaLogging {
         metadata = m
       case ci: CommitInfo =>
         inCommitTimestamp = ci.inCommitTimestamp
+        lastManifestCommit = ci.lastManifestCommit
       case _ =>
     }
 
@@ -549,7 +551,7 @@ trait RecordChecksum extends DeltaLogging {
       allFiles = allFiles,
       deletedRecordCountsHistogramOpt = deletedRecordCountsHistogramOpt,
       fileSizeHistogram = fileSizeHistogram,
-      lastManifestCommit = None
+      lastManifestCommit = lastManifestCommit
     ))
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
@@ -24,6 +24,7 @@ import scala.collection.mutable
 import org.apache.spark.sql.delta.DeltaOperations.{OP_SET_TBLPROPERTIES, ROW_TRACKING_BACKFILL_OPERATION_NAME, ROW_TRACKING_UNBACKFILL_OPERATION_NAME}
 import org.apache.spark.sql.delta.RowId.RowTrackingMetadataDomain
 import org.apache.spark.sql.delta.actions._
+import org.apache.spark.sql.delta.amt.AMTUtils
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.metering.DeltaLogging
@@ -310,12 +311,8 @@ private[delta] class ConflictChecker(
     checkForDeletedFilesAgainstCurrentTxnDeletedFiles()
     resolveTimestampOrderingConflicts()
 
-    // If the winning commit emitted an inline AMT checkpoint, it is now the latest checkpoint
-    // before the next commit attempt.
-    winningCommitSummary.amtCheckpoint.foreach { checkpoint =>
-      currentTransactionInfo =
-        currentTransactionInfo.copy(preCommitLatestAMTCheckpointOpt = Some(checkpoint))
-    }
+    currentTransactionInfo = AMTUtils.updateCurrentTransactionInfo(
+      currentTransactionInfo, winningCommitSummary)
 
     logMetrics()
     currentTransactionInfo

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -37,7 +37,7 @@ import org.apache.spark.sql.delta.DeltaGeoSpatial
 import org.apache.spark.sql.delta.DeltaOperations.{ChangeColumn, ChangeColumns, CreateTable, Operation, ReplaceColumns, ReplaceTable, UpdateSchema}
 import org.apache.spark.sql.delta.RowId.RowTrackingMetadataDomain
 import org.apache.spark.sql.delta.actions._
-import org.apache.spark.sql.delta.amt.{AMTCheckpointProvider, AMTWriteMetrics, AMTWriteResult, AMTWriterManager}
+import org.apache.spark.sql.delta.amt.{AMTCheckpointProvider, AMTUtils, AMTWriteMetrics, AMTWriteResult, AMTWriterManager}
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.commands.DeletionVectorUtils
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
@@ -1909,7 +1909,10 @@ trait OptimisticTransactionImpl extends TransactionHelper
         operationMetrics = getOperationMetrics(op),
         userMetadata = getUserMetadata(op),
         tags = if (allTags.nonEmpty) Some(allTags) else None,
-        txnId = Some(txnId))
+        txnId = Some(txnId),
+        // We initialize lastManifestCommit by carrying forward the previous one. If this commit
+        // writes a new AMT checkpoint, the commitInfo will be updated afterwards.
+        lastManifestCommit = snapshot.lastManifestCommitOpt)
 
       val firstAttemptVersion = getFirstAttemptVersion
       val metadataUpdatedWithCoordinatedCommitsInfo = updateMetadataWithCoordinatedCommitsConfs()
@@ -2128,7 +2131,10 @@ trait OptimisticTransactionImpl extends TransactionHelper
         Some(metrics),
         userMetadata = getUserMetadata(op),
         tags = if (tags.nonEmpty) Some(tags) else None,
-        txnId = Some(txnId))
+        txnId = Some(txnId),
+        // `commitLarge` never emits an inline AMT checkpoint, so it only carries the read
+        // snapshot's lastManifestCommitOpt forward.
+        lastManifestCommit = snapshot.lastManifestCommitOpt)
 
       val assertDeletionVectorWellFormed = getAssertDeletionVectorWellFormedFunc(spark, op)
       updateMetadataWithCoordinatedCommitsConfs()
@@ -2883,7 +2889,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
     // If the table requires atomic Iceberg metadata generation
     // , generate iceberg metadata and update the transaction info.
     var icebergMetadataGenerationDurationMsOpt: Option[Long] = None
-    val updatedCurrentTransactionInfo =
+    var updatedCurrentTransactionInfo =
       targetCatalogTable
       .map { table =>
         val startNanos = System.nanoTime()
@@ -2911,7 +2917,18 @@ trait OptimisticTransactionImpl extends TransactionHelper
       case Some(result) if !result.includeActionsInCommitJson =>
         throw new UnsupportedOperationException(
           "Omitting file actions from the commit JSON is not yet supported.")
-      case Some(result) => baseActions :+ result.checkpoint
+      case Some(result) =>
+        // When we have become a manifest commit, update the reference in the current commitInfo so
+        // the persisted commit (and its derived CRC) records where the AMT checkpoint lives.
+        updatedCurrentTransactionInfo = AMTUtils.updateCurrentTransactionInfo(
+          updatedCurrentTransactionInfo,
+          newLastManifestCommit = LastManifestCommit(
+            version = attemptVersion,
+            contentRootVersion = result.contentRootVersion)
+        )
+        // Recompute the actions from the patched txn info so the committed CommitInfo carries the
+        // reference, then append the inline checkpoint action.
+        updatedCurrentTransactionInfo.finalActionsToCommit :+ result.checkpoint
       case None => baseActions
     }
     logInfo(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
@@ -742,7 +742,7 @@ class Snapshot(
       checksumOpt.flatMap(_.fileSizeHistogram)
         .orElse(Option.when(_computedStateTriggered)(fileSizeHistogram).flatten)
     }.flatten,
-    lastManifestCommit = None
+    lastManifestCommit = lastManifestCommitOpt
   )
 
   /** Returns the data schema of the table, used for reading stats */

--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -1511,9 +1511,23 @@ object CommitInfo {
       operationMetrics: Option[Map[String, String]],
       userMetadata: Option[String],
       tags: Option[Map[String, String]],
-      txnId: Option[String]): CommitInfo = {
-    apply(None, time, operation, inCommitTimestamp, operationParameters, commandContext,
-      readVersion, isolationLevel, isBlindAppend, operationMetrics, userMetadata, tags, txnId)
+      txnId: Option[String],
+      lastManifestCommit: Option[LastManifestCommit]): CommitInfo = {
+    apply(
+      version = None,
+      time,
+      operation,
+      inCommitTimestamp,
+      operationParameters,
+      commandContext,
+      readVersion,
+      isolationLevel,
+      isBlindAppend,
+      operationMetrics,
+      userMetadata,
+      tags,
+      txnId,
+      lastManifestCommit)
   }
 
   def apply(
@@ -1529,7 +1543,8 @@ object CommitInfo {
       operationMetrics: Option[Map[String, String]],
       userMetadata: Option[String],
       tags: Option[Map[String, String]],
-      txnId: Option[String]): CommitInfo = {
+      txnId: Option[String],
+      lastManifestCommit: Option[LastManifestCommit]): CommitInfo = {
 
     val getUserName = commandContext.get("user").flatMap {
       case "unknown" => None
@@ -1555,7 +1570,7 @@ object CommitInfo {
       tags,
       getEngineInfo,
       txnId,
-      lastManifestCommit = None)
+      lastManifestCommit)
   }
   // scalastyle:on argcount
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTUtils.scala
@@ -16,6 +16,8 @@
 
 package org.apache.spark.sql.delta.amt
 
+import org.apache.spark.sql.delta.{CurrentTransactionInfo, WinningCommitSummary}
+import org.apache.spark.sql.delta.actions.LastManifestCommit
 import org.apache.spark.sql.delta.deletionvectors.{RoaringBitmapArray, RoaringBitmapArrayFormat}
 import org.apache.spark.sql.delta.util.DeltaFileOperations
 import org.apache.hadoop.fs.{FileSystem, Path}
@@ -48,6 +50,39 @@ object AMTUtils {
     val child = new Path(location)
     if (child.toUri.getScheme != null || child.isAbsolute) child
     else new Path(tableRoot, child)
+  }
+
+  /** Returns a copy of the passed-in current transaction info with `lastManifestCommit` updated. */
+  def updateCurrentTransactionInfo(
+      currentTransactionInfo: CurrentTransactionInfo,
+      newLastManifestCommit: LastManifestCommit): CurrentTransactionInfo = {
+    currentTransactionInfo.copy(
+      commitInfo = currentTransactionInfo.commitInfo.map(_.copy(
+        lastManifestCommit = Some(newLastManifestCommit)))
+    )
+  }
+
+  /**
+   * Returns a copy of the passed-in current transaction info with the AMT fields updated to reflect
+   * the winning commit.
+   */
+  def updateCurrentTransactionInfo(
+      currentTransactionInfo: CurrentTransactionInfo,
+      winningCommitSummary: WinningCommitSummary): CurrentTransactionInfo = {
+    // If the winning commit emitted an inline AMT checkpoint, it is now the latest checkpoint
+    // before the next commit attempt.
+    winningCommitSummary.amtCheckpoint.map { winningAMTCheckpoint =>
+      currentTransactionInfo.copy(
+        // If the winning commit emitted an inline AMT checkpoint, it is now the latest checkpoint
+        // before the next commit attempt.
+        preCommitLatestAMTCheckpointOpt = Some(winningAMTCheckpoint),
+        // Update the current commitInfo to reflect the winning manifest commit.
+        commitInfo = currentTransactionInfo.commitInfo.map(_.copy(
+          lastManifestCommit = Some(LastManifestCommit(
+            version = winningCommitSummary.commitVersion,
+            contentRootVersion = winningAMTCheckpoint.version))))
+      )
+    }.getOrElse(currentTransactionInfo)
   }
 
   // Serializes a Manifest Deletion Vector to the on-disk byte form carried in `manifest_info.dv`.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriterManager.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriterManager.scala
@@ -109,6 +109,7 @@ class AMTWriterManager(
    * @param commitVersion       the version this attempt targets
    * @param currentTransactionInfo the in-flight transaction (its actions, protocol, metadata)
    * @param preCommitLogSegment the log segment prior to this commit
+   * @return the AMT write result; `None` if no AMT write is triggered or it's a non-AMT table.
    */
   def writeAMT(
       commitVersion: Long,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/ActionSerializerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/ActionSerializerSuite.scala
@@ -193,14 +193,17 @@ class ActionSerializerSuite extends QueryTest with SharedSparkSession with Delta
       operationMetrics = Some(Map("m1" -> "v1", "m2" -> "v2")),
       userMetadata = Some("123"),
       tags = None,
-      txnId = None).copy(engineInfo = None)
+      txnId = None,
+      lastManifestCommit = Some(LastManifestCommit(version = 43, contentRootVersion = 41))
+    ).copy(engineInfo = None)
 
     // json of commit info actions without tag or engineInfo field
     val json1 =
       """{"commitInfo":{"inCommitTimestamp":123,"timestamp":123,"operation":"CONVERT",""" +
         """"operationParameters":{},"readVersion":23,""" +
         """"isolationLevel":"SnapshotIsolation","isBlindAppend":true,""" +
-        """"operationMetrics":{"m1":"v1","m2":"v2"},"userMetadata":"123"}}""".stripMargin
+        """"operationMetrics":{"m1":"v1","m2":"v2"},"userMetadata":"123",""" +
+        """"lastManifestCommit":{"version":43,"contentRootVersion":41}}}""".stripMargin
     assert(Action.fromJson(json1) === expectedCommitInfo)
   }
 
@@ -216,14 +219,17 @@ class ActionSerializerSuite extends QueryTest with SharedSparkSession with Delta
       operationMetrics = Some(Map("m1" -> "v1", "m2" -> "v2")),
       userMetadata = Some("123"),
       tags = None,
-      txnId = None).copy(engineInfo = None)
+      txnId = None,
+      lastManifestCommit = Some(LastManifestCommit(version = 43, contentRootVersion = 41))
+    ).copy(engineInfo = None)
 
     // json of commit info actions without tag or engineInfo field
     val json1 =
       """{"commitInfo":{"timestamp":123,"operation":"CONVERT",""" +
         """"operationParameters":{},"readVersion":23,""" +
         """"isolationLevel":"SnapshotIsolation","isBlindAppend":true,""" +
-        """"operationMetrics":{"m1":"v1","m2":"v2"},"userMetadata":"123"}}""".stripMargin
+        """"operationMetrics":{"m1":"v1","m2":"v2"},"userMetadata":"123",""" +
+        """"lastManifestCommit":{"version":43,"contentRootVersion":41}}}""".stripMargin
     assert(Action.fromJson(json1) === expectedCommitInfo)
   }
 
@@ -747,7 +753,8 @@ class ActionSerializerSuite extends QueryTest with SharedSparkSession with Delta
       operationMetrics = Some(Map("m1" -> "v1", "m2" -> "v2")),
       userMetadata = Some("123"),
       tags = Some(Map("k1" -> "v1")),
-      txnId = Some("123")
+      txnId = Some("123"),
+      lastManifestCommit = Some(LastManifestCommit(version = 43, contentRootVersion = 41))
     ).copy(engineInfo = None)
 
     testActionSerDe(
@@ -758,7 +765,8 @@ class ActionSerializerSuite extends QueryTest with SharedSparkSession with Delta
           """"operationParameters":{},"clusterId":"23","readVersion":23,""" +
           """"isolationLevel":"SnapshotIsolation","isBlindAppend":true,""" +
           """"operationMetrics":{"m1":"v1","m2":"v2"},"userMetadata":"123",""" +
-          """"tags":{"k1":"v1"},"txnId":"123"}}""".stripMargin)
+          """"tags":{"k1":"v1"},"txnId":"123",""" +
+          """"lastManifestCommit":{"version":43,"contentRootVersion":41}}}""".stripMargin)
 
     test("CommitInfo (with operationParameters) - json serialization/deserialization") {
       val operation = DeltaOperations.Convert(
@@ -776,7 +784,8 @@ class ActionSerializerSuite extends QueryTest with SharedSparkSession with Delta
             """"sourceFormat":"parquet","collectStats":false},"clusterId":"23","readVersion"""" +
             """:23,"isolationLevel":"SnapshotIsolation","isBlindAppend":true,""" +
             """"operationMetrics":{"m1":"v1","m2":"v2"},""" +
-            """"userMetadata":"123","tags":{"k1":"v1"},"txnId":"123"}}"""
+            """"userMetadata":"123","tags":{"k1":"v1"},"txnId":"123",""" +
+            """"lastManifestCommit":{"version":43,"contentRootVersion":41}}}"""
         } else {
           """{"commitInfo":{"inCommitTimestamp":123,""" +
             """"timestamp":123,"operation":"CONVERT","operationParameters"""" +
@@ -784,7 +793,8 @@ class ActionSerializerSuite extends QueryTest with SharedSparkSession with Delta
             """"sourceFormat":"parquet","collectStats":false},"clusterId":"23","readVersion""" +
             """":23,"isolationLevel":"SnapshotIsolation","isBlindAppend":true,""" +
             """"operationMetrics":{"m1":"v1","m2":"v2"},""" +
-            """"userMetadata":"123","tags":{"k1":"v1"},"txnId":"123"}}"""
+            """"userMetadata":"123","tags":{"k1":"v1"},"txnId":"123",""" +
+            """"lastManifestCommit":{"version":43,"contentRootVersion":41}}}"""
         }
       assert(commitInfo1.json == expectedCommitInfoJson1)
       val newCommitInfo1 = Action.fromJson(expectedCommitInfoJson1).asInstanceOf[CommitInfo]
@@ -800,7 +810,8 @@ class ActionSerializerSuite extends QueryTest with SharedSparkSession with Delta
           """"isolationLevel":"SnapshotIsolation","isBlindAppend":true,""" +
           """"operationMetrics":{"m1":"v1","m2":"v2"},"userMetadata":"123",""" +
           """"tags":{"k1":"v1"},"engineInfo":"Apache-Spark/3.1.1 Delta-Lake/10.1.0",""" +
-          """"txnId":"123"}}""".stripMargin)
+          """"txnId":"123",""" +
+          """"lastManifestCommit":{"version":43,"contentRootVersion":41}}}""".stripMargin)
   }
 
   test("CommitInfo operationParameters deserialization with primitive types") {
@@ -826,7 +837,8 @@ class ActionSerializerSuite extends QueryTest with SharedSparkSession with Delta
       operationMetrics = Some(Map("numFiles" -> "10")),
       userMetadata = Some("test metadata"),
       tags = Some(Map("source" -> "test")),
-      txnId = Some("txn-123")
+      txnId = Some("txn-123"),
+      lastManifestCommit = Some(LastManifestCommit(version = 43, contentRootVersion = 41))
     )
 
     // Serialize and deserialize to test the JsonMapDeserializer
@@ -865,7 +877,8 @@ class ActionSerializerSuite extends QueryTest with SharedSparkSession with Delta
       operationMetrics = Some(Map("numFiles" -> "25", "numOutputRows" -> "1000")),
       userMetadata = operation.userMetadata,
       tags = Some(Map("environment" -> "production", "team" -> "data-eng")),
-      txnId = Some("txn-write-456")
+      txnId = Some("txn-write-456"),
+      lastManifestCommit = Some(LastManifestCommit(version = 43, contentRootVersion = 41))
     )
 
     // Test round-trip serialization/deserialization

--- a/spark/src/test/scala/org/apache/spark/sql/delta/CommitInfoSerializerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CommitInfoSerializerSuite.scala
@@ -47,7 +47,8 @@ class CommitInfoSerializerSuite extends QueryTest with SharedSparkSession {
       operationMetrics = Some(Map("m1" -> "v1", "m2" -> "v2")),
       userMetadata = Some("123"),
       tags = Some(Map("k1" -> "v1")),
-      txnId = Some("123")
+      txnId = Some("123"),
+      lastManifestCommit = Some(LastManifestCommit(version = 43, contentRootVersion = 41))
     ).copy(engineInfo = None)
 
     val inMemoryCommitInfo = commitInfo.copy(operationParameters = operation.jsonEncodedValues)
@@ -220,6 +221,36 @@ class CommitInfoSerializerSuite extends QueryTest with SharedSparkSession {
     )
   }
 
+  private def createEmptyCommitInfo(): CommitInfo = {
+    CommitInfo(
+      version = None,
+      time = 0L,
+      operation = null,
+      inCommitTimestamp = None,
+      operationParameters = Map.empty,
+      commandContext = Map.empty,
+      readVersion = None,
+      isolationLevel = None,
+      isBlindAppend = None,
+      operationMetrics = None,
+      userMetadata = None,
+      tags = None,
+      txnId = None,
+      lastManifestCommit = None)
+  }
+
+  test("CommitInfo round-trips lastManifestCommit and omits it when None") {
+    val base = createEmptyCommitInfo()
+    val lmf = LastManifestCommit(version = 43, contentRootVersion = 41)
+
+    assert(!base.json.contains("lastManifestCommit"))
+    val roundTrippedCommitInfo = Action.fromJson(base.json).asInstanceOf[CommitInfo]
+    assert(roundTrippedCommitInfo.lastManifestCommit.isEmpty)
+
+    val baseWithLmf = base.copy(lastManifestCommit = Some(lmf))
+    val roundTrippedCommitInfoWithLmf = Action.fromJson(baseWithLmf.json).asInstanceOf[CommitInfo]
+    assert(roundTrippedCommitInfoWithLmf.lastManifestCommit.contains(lmf))
+  }
 }
 
 /**

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointTestBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointTestBase.scala
@@ -326,6 +326,20 @@ trait AMTCheckpointTestBase
           s"reconstructed=${reconstructed.toSet}")
   }
 
+  /**
+   * Runs the test with inline writes forced (a low action-count threshold).
+   * AMT checkpoints will be emitted in every commit after the first full OPTIMIZE CHECKPOINT.
+   */
+  protected def testInline(testName: String)(body: => Unit): Unit = {
+    test(s"$testName (inline)") {
+      withSQLConf(
+        DeltaSQLConf.AMT_LARGE_COMMIT_ACTIONS_COUNT_THRESHOLD_FOR_INLINE_MANIFEST_COMMIT.key
+          -> "1") {
+        body
+      }
+    }
+  }
+
   /** True iff `name` looks like an AMT leaf parquet file. */
   protected def isLeafFileName(name: String): Boolean =
     name.startsWith("leaf-") && name.endsWith(".parquet")

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotDiscoverySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotDiscoverySuite.scala
@@ -16,6 +16,7 @@
 
 package org.apache.spark.sql.delta.amt
 
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.FileNames
 
 class AMTSnapshotDiscoverySuite extends AMTCheckpointTestBase {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/SnapshotLastManifestCommitSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/SnapshotLastManifestCommitSuite.scala
@@ -23,26 +23,30 @@ import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.{DeltaCommitFileProvider, FileNames, JsonUtils}
 
 import org.apache.spark.SparkConf
+import org.apache.spark.sql.catalyst.TableIdentifier
 
 /**
  * Tests that [[LastManifestCommit]] is surfaced reliably by [[Snapshot.lastManifestCommitOpt]].
  */
 trait SnapshotLastManifestCommitSuiteBase extends AMTCheckpointTestBase {
 
-  override protected def sparkConf: SparkConf = super.sparkConf
-    // Inline every manifest commit instead of deferring to a follow-up OPTIMIZE CHECKPOINT commit.
-    // This simplifies the test suite as the deferring is not the primary focus of the suite.
-    .set(DeltaSQLConf.AMT_LARGE_COMMIT_ACTIONS_COUNT_THRESHOLD_FOR_INLINE_MANIFEST_COMMIT.key, "1")
-
   /** Whether this suite runs with `.crc` files enabled, read from the effective conf. */
   protected def writeChecksumEnabled: Boolean =
     spark.conf.get(DeltaSQLConf.DELTA_WRITE_CHECKSUM_ENABLED)
+
+  ////////////////////////
+  // Fake, Injected LMCs
+  ////////////////////////
 
   /**
    * Seeds `lmc` onto every source that exists for this suite's mode. Always rewrites the delta-file
    * `CommitInfo`; the CRC-enabled suite additionally rewrites the `.crc`.
    */
-  protected def injectLmc(deltaLog: DeltaLog, version: Long, lmc: Option[LastManifestCommit]): Unit
+  protected def injectLmc(
+      deltaLog: DeltaLog, version: Long, lmc: Option[LastManifestCommit]): Unit = {
+    injectLmcIntoCommitInfo(deltaLog, version, lmc)
+    injectLmcIntoCrc(deltaLog, version, lmc)
+  }
 
   /** Rewrites the `CommitInfo` at `version` to carry `lmc`, preserving all other actions. */
   protected def injectLmcIntoCommitInfo(
@@ -154,31 +158,203 @@ trait SnapshotLastManifestCommitSuiteBase extends AMTCheckpointTestBase {
       assert(freshSnapshotAt(name, 1).lastManifestCommitOpt.isEmpty)
     }
   }
-}
 
-/** Runs the shared cases with `.crc` files enabled; the reference is seeded to CommitInfo + CRC. */
-class SnapshotLastManifestCommitSuite extends SnapshotLastManifestCommitSuiteBase {
-  override protected def sparkConf: SparkConf = super.sparkConf
-    .set(DeltaSQLConf.DELTA_WRITE_CHECKSUM_ENABLED.key, "true")
+  ////////////////////////////
+  // Actually Populated LMCs
+  ////////////////////////////
 
-  override protected def injectLmc(
-      deltaLog: DeltaLog, version: Long, lmc: Option[LastManifestCommit]): Unit = {
-    injectLmcIntoCommitInfo(deltaLog, version, lmc)
-    injectLmcIntoCrc(deltaLog, version, lmc)
+  /** The `lastManifestCommit` recorded on the CommitInfo committed at `version`, if any. */
+  private def lastManifestCommitFromCommitInfoAt(
+      deltaLog: DeltaLog, version: Long): Option[LastManifestCommit] = {
+    actionsAt(deltaLog, version)
+      .collectFirst { case ci: CommitInfo => ci }
+      .flatMap(_.lastManifestCommit)
+  }
+
+  /** The `lastManifestCommit` persisted in the CRC at `version`, if the CRC exists. */
+  private def lastManifestCommitFromCrcAt(
+      deltaLog: DeltaLog, version: Long): Option[LastManifestCommit] =
+    deltaLog.readChecksum(version).flatMap(_.lastManifestCommit)
+
+  /** Asserts the commit at `version` has the expected manifest-commit states. */
+  private def assertCommitStates(
+      deltaLog: DeltaLog,
+      version: Long,
+      emitsCheckpoint: Boolean,
+      expected: Option[LastManifestCommit]): Unit = {
+    assert(checkpointAt(deltaLog, version).nonEmpty == emitsCheckpoint,
+      s"v$version checkpoint emission: expected $emitsCheckpoint.")
+    // The CRC only carries the reference when `.crc` files are written for this suite; without
+    // them there is no CRC to inspect.
+    if (writeChecksumEnabled) {
+      assert(lastManifestCommitFromCrcAt(deltaLog, version) == expected,
+        s"v$version CRC must carry LMC $expected.")
+    }
+    assert(lastManifestCommitFromCommitInfoAt(deltaLog, version) == expected,
+      s"v$version CommitInfo must carry LMC $expected.")
+    assert(deltaLog.getSnapshotAt(version).lastManifestCommitOpt == expected,
+      s"v$version snapshot must resolve LMC $expected.")
+  }
+
+  test("manifest commits persist lastManifestCommit to the CRC and CommitInfo, " +
+      "while non-manifest commits carry the previous manifest-commit reference forward") {
+    withTable("amt_lmc_persist") {
+      val name = "amt_lmc_persist"
+      createAMTTable(name, checkpointInterval = 3)
+
+      sql(s"INSERT INTO $name VALUES (1)") // v1: no checkpoint.
+      sql(s"INSERT INTO $name VALUES (2)") // v2: no checkpoint.
+      sql(s"INSERT INTO $name VALUES (3)") // v3: triggers a checkpoint, but not in this commit.
+                                           // v4: AMT checkpoint emitted via hook.
+      sql(s"INSERT INTO $name VALUES (4)") // v5: no checkpoint.
+      sql(s"INSERT INTO $name VALUES (5)") // v6: triggers another checkpoint, not in this commit.
+                                           // v7: AMT checkpoint emitted via hook.
+
+      val deltaLog = deltaLogForName(name)
+
+      // Before the first manifest checkpoint (first emit is v4), there is no reference to record.
+      assertCommitStates(deltaLog, 1, emitsCheckpoint = false, expected = None)
+      assertCommitStates(deltaLog, 2, emitsCheckpoint = false, expected = None)
+
+      // The checkpoint-trigger commit (v3) does not create or store a reference yet.
+      assertCommitStates(deltaLog, 3, emitsCheckpoint = false, expected = None)
+      // The actual manifest commit stores the new reference to the CRC and CommitInfo.
+      // Note that the manifest commit version is 4, but the content root version is 3.
+      val expectedLmcAtV4 = LastManifestCommit(version = 4, contentRootVersion = 3)
+      assertCommitStates(deltaLog, 4, emitsCheckpoint = true, expected = Some(expectedLmcAtV4))
+
+      // The non-manifest commit carries the previous manifest-commit reference forward.
+      assertCommitStates(deltaLog, 5, emitsCheckpoint = false, expected = Some(expectedLmcAtV4))
+
+      // The next checkpoint-trigger commit (v6) does not create or store a new reference yet.
+      assertCommitStates(deltaLog, 6, emitsCheckpoint = false, expected = Some(expectedLmcAtV4))
+      // The actual manifest commit stores the new reference to the CRC and CommitInfo.
+      // Note that the manifest commit version is 7, but the content root version is 6.
+      val expectedLmcAtV7 = LastManifestCommit(version = 7, contentRootVersion = 6)
+      assertCommitStates(deltaLog, 7, emitsCheckpoint = true, expected = Some(expectedLmcAtV7))
+    }
+  }
+
+  testInline("consecutive manifest commits persist lastManifestCommit to the CRC and CommitInfo") {
+    withTable("amt_lmc_persist_inline") {
+      val name = "amt_lmc_persist_inline"
+      createAMTTable(name, checkpointInterval = 2)
+
+      sql(s"INSERT INTO $name VALUES (1)") // v1: no checkpoint (no existing tree to inline into).
+      sql(s"INSERT INTO $name VALUES (2)") // v2: reaches the interval boundary.
+                                            // v3: the FIRST AMT is emitted as a deferred OPTIMIZE
+                                            //     CHECKPOINT (a full rewrite describing state@v2).
+      sql(s"INSERT INTO $name VALUES (3)") // v4: now a tree exists, so this commit emits inline.
+      sql(s"INSERT INTO $name VALUES (4)") // v5: another inline manifest commit.
+
+      val deltaLog = deltaLogForName(name)
+
+      // v1/v2: carry no manifest reference yet: the first AMT has not been written.
+      assertCommitStates(deltaLog, 1, emitsCheckpoint = false, expected = None)
+      assertCommitStates(deltaLog, 2, emitsCheckpoint = false, expected = None)
+
+      // v3: the deferred first AMT. It is a full rewrite of state as of v2, so version=3 but
+      // contentRootVersion=2.
+      val expectedLmcAtV3 = LastManifestCommit(version = 3, contentRootVersion = 2)
+      assertCommitStates(deltaLog, 3, emitsCheckpoint = true, expected = Some(expectedLmcAtV3))
+
+      // v4: with a tree in place, the business commit writes its manifest inline, so version and
+      // contentRootVersion coincide.
+      val expectedLmcAtV4 = LastManifestCommit(version = 4, contentRootVersion = 4)
+      assertCommitStates(deltaLog, 4, emitsCheckpoint = true, expected = Some(expectedLmcAtV4))
+
+      // v5: another inline manifest commit.
+      val expectedLmcAtV5 = LastManifestCommit(version = 5, contentRootVersion = 5)
+      assertCommitStates(deltaLog, 5, emitsCheckpoint = true, expected = Some(expectedLmcAtV5))
+    }
+  }
+
+  test("commitLarge (RESTORE) always carries lastManifestCommit forward") {
+    withTable("amt_lmc_restore") {
+      val name = "amt_lmc_restore"
+      createAMTTable(name, checkpointInterval = 2)
+      sql(s"INSERT INTO $name VALUES (1)")        // v1: no checkpoint
+      sql(s"INSERT INTO $name VALUES (2)")        // v2: reaches the interval boundary
+                                                  // v3: the FIRST AMT is always a deferred OPTIMIZE
+                                                  //     CHECKPOINT (describing state@v2).
+      sql(s"RESTORE TABLE $name VERSION AS OF 1") // v4: RESTORE commit (via commitLarge)
+
+      val (deltaLog, snapshot) = DeltaLog.forTableWithSnapshot(spark, new TableIdentifier(name))
+
+      // RESTORE commits via commitLarge, which never emits AMT checkpoints, even when the
+      // checkpoint interval is reached. The lastManifestCommit valid as of its read snapshot must
+      // be carried forward.
+      assert(snapshot.version == 4, s"RESTORE should commit to v4, but got v${snapshot.version}.")
+      val expectedLmc = LastManifestCommit(version = 3, contentRootVersion = 2)
+
+      assert(checkpointAt(deltaLog, 4).isEmpty, s"v4 must not emit a checkpoint.")
+      // CommitLarge does not write a CRC, so we skip the CRC assertions.
+      assert(
+        lastManifestCommitFromCommitInfoAt(deltaLog, 4).contains(expectedLmc),
+        s"v4 CommitInfo must carry LMC $expectedLmc.")
+      assert(
+        freshSnapshotAt(name, 4).lastManifestCommitOpt.contains(expectedLmc),
+        s"v4 snapshot must resolve LMC $expectedLmc.")
+    }
   }
 }
 
-/** Runs the shared cases with `.crc` files disabled; the reference is seeded to CommitInfo only. */
+/**
+ * With incremental CRC and verification both enabled, the commit discards the incrementally-derived
+ * checksum and verifies against a full reconstruction, so the final CRC file is actually sourced
+ * from reconstruction via [[Snapshot.computeChecksum]], not incremental derivation.
+ */
+class SnapshotLastManifestCommitIncrementalCRCWithVerificationSuite
+  extends SnapshotLastManifestCommitSuiteBase {
+
+  override protected def sparkConf: SparkConf = super.sparkConf
+    .set(DeltaSQLConf.DELTA_WRITE_CHECKSUM_ENABLED.key, "true")
+    .set(DeltaSQLConf.INCREMENTAL_COMMIT_ENABLED.key, "true")
+    .set(DeltaSQLConf.INCREMENTAL_COMMIT_VERIFY.key, "true")
+    .set(DeltaSQLConf.INCREMENTAL_COMMIT_FORCE_VERIFY_IN_TESTS.key, "true")
+}
+
+/**
+ * With incremental CRC enabled but verification off, the commit trusts and caches the
+ * incrementally-derived checksum, so the final CRC file is indeed sourced from incremental
+ * derivation via [[Checksum.computeNewChecksum]]. This matches the production hot path.
+ */
+class SnapshotLastManifestCommitIncrementalCRCWithoutVerificationSuite
+  extends SnapshotLastManifestCommitSuiteBase {
+
+  override protected def sparkConf: SparkConf = super.sparkConf
+    .set(DeltaSQLConf.DELTA_WRITE_CHECKSUM_ENABLED.key, "true")
+    .set(DeltaSQLConf.INCREMENTAL_COMMIT_ENABLED.key, "true")
+    .set(DeltaSQLConf.INCREMENTAL_COMMIT_VERIFY.key, "false")
+    .set(DeltaSQLConf.INCREMENTAL_COMMIT_FORCE_VERIFY_IN_TESTS.key, "false")
+}
+
+/**
+ * With incremental CRC disabled, the final CRC file is sourced directly from reconstruction via
+ * [[Snapshot.computeChecksum]]. No incremental derivation is ever attempted.
+ */
+class SnapshotLastManifestCommitNonIncrementalCRCSuite
+  extends SnapshotLastManifestCommitSuiteBase {
+
+  override protected def sparkConf: SparkConf = super.sparkConf
+    .set(DeltaSQLConf.DELTA_WRITE_CHECKSUM_ENABLED.key, "true")
+    .set(DeltaSQLConf.INCREMENTAL_COMMIT_ENABLED.key, "false")
+    // When incremental CRC is disabled, the verify flags are irrelevant.
+}
+
+/** No CRC files are ever written in this suite. Aims to test the fallback paths. */
 class SnapshotLastManifestCommitWithoutCRCSuite extends SnapshotLastManifestCommitSuiteBase {
   override protected def sparkConf: SparkConf = super.sparkConf
     .set(DeltaSQLConf.DELTA_WRITE_CHECKSUM_ENABLED.key, "false")
+    // When CRC is disabled, the incremental/verify flags are all irrelevant.
 
   override protected def injectLmc(
       deltaLog: DeltaLog, version: Long, lmc: Option[LastManifestCommit]): Unit = {
+    // No CRC files are written, so the only inject lastManifestCommit into the CommitInfo.
     injectLmcIntoCommitInfo(deltaLog, version, lmc)
   }
 
-  test("lastManifestCommitOpt falls back to CommitInfo when no other source carries the ref") {
+  testInline("lastManifestCommitOpt falls back to reading CommitInfo with no other sources") {
     // With CRC unavailable, when the snapshot sits on an AMT checkpoint, there is no trailing delta
     // to provide the CommitInfo during P&M query, so we must fallback to a direct CommitInfo read.
     val lmc = LastManifestCommit(version = 7, contentRootVersion = 5)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/util/JsonUtilsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/util/JsonUtilsSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.delta.util
 import scala.util.Random
 
 import org.apache.spark.sql.delta.DeltaLog
-import org.apache.spark.sql.delta.actions.CommitInfo
+import org.apache.spark.sql.delta.actions.{CommitInfo, LastManifestCommit}
 import org.apache.spark.sql.delta.stats.DataSize
 import com.fasterxml.jackson.core.StreamReadConstraints
 
@@ -64,7 +64,8 @@ class JsonUtilsSuite
       operationMetrics = None,
       userMetadata = Some("I am a test and not a user"),
       tags = None,
-      txnId = Some("Transaction with a veryyyyyyy large commit info")
+      txnId = Some("Transaction with a veryyyyyyy large commit info"),
+      lastManifestCommit = Some(LastManifestCommit(version = 43, contentRootVersion = 41))
     )
 
     val serialized = JsonUtils.toJson(commitInfo)


### PR DESCRIPTION
## Description

This is the write-side counterpart to reading `LastManifestCommit` (LMC) from a
`Snapshot`: it records the last manifest commit reference into both `CommitInfo`
and the `VersionChecksum` (CRC) as commits are made, so that later reads can
resolve it without extra I/O.

Concretely:
- `CommitInfo` gains a `lastManifestCommit: Option[LastManifestCommit]` field, and
  `VersionChecksum` carries it forward as well. Serialization/deserialization is
  updated accordingly (see `actions.scala`, `DeltaEncoders`, and the
  serializer suites).
- `OptimisticTransaction` initializes the commit's `lastManifestCommit` by carrying
  forward the previous snapshot's reference; if the commit writes a new AMT
  checkpoint, the reference is updated to point at it.
- `ConflictChecker` preserves/refreshes the reference when a transaction is
  logically reordered against a winning commit.
- `Checksum` includes the reference in the CRC so it is available on the fast path.
- Adds small `AMTUsageLogs` / `AMTUtils` helpers and a new
  `SnapshotLastManifestCommitSuite` that exercises how the reference is produced
  and resolved end to end.

## How was this patch tested?

New `SnapshotLastManifestCommitSuite` plus updated `ActionSerializerSuite`,
`CommitInfoSerializerSuite`, `InCommitTimestampSuite`, `AMTCheckpointTestBase`,
`AMTSnapshotDiscoverySuite`, and `JsonUtilsSuite` cover serialization round-trips,
carry-forward on commit, conflict-resolution refresh, and CRC population.

## Does this PR introduce _any_ user-facing change?

No.