### PR TITLE
Store AMT back-reference manifest as a table-root-relative path

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -1129,11 +1129,12 @@ object AddFile {
 }
 
 /**
- * A back reference points a file action at the exact location of its source entry inside a
+ * A back reference points a file action at the exact location of its source entry inside an
  * Adaptive Metadata Tree (AMT) leaf manifest.
  *
- * @param manifest The canonical path of the AMT leaf manifest that held the source entry (the leaf
- *                 DATA_MANIFEST `location`).
+ * @param manifest The AMT leaf manifest that held the source entry, stored exactly like the leaf's
+ *                 tree `location`: a raw (non-URL-encoded) path relative to the table root. This
+ *                 differs from [[AddFile.path]], which is URL-encoded.
  * @param pos      The 0-based position of the entry within that leaf. This equals the parquet
  *                 `_metadata.row_index` of the leaf row, which is the same ordinal the MDV bitmap
  *                 indexes.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTCheckpointProvider.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTCheckpointProvider.scala
@@ -28,6 +28,7 @@ import org.apache.spark.sql.execution.datasources.FileFormat.{FILE_PATH, METADAT
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
 import org.apache.spark.sql.functions.{col, lit, struct}
 import org.apache.spark.sql.types.StructType
+import org.apache.spark.util.SerializableConfiguration
 
 /**
  * A [[CheckpointProvider]] backed by an AMT (Adaptive Metadata Tree) manifest tree.
@@ -129,25 +130,32 @@ final class AMTCheckpointProvider(
   private def liveAddSingleActions(
       spark: SparkSession, deltaLog: DeltaLog): Dataset[SingleAction] = {
     import org.apache.spark.sql.delta.implicits._
-    // Bind to a local so the `map` closure captures it, not the (non-serializable) provider.
+    // Bind to a local so the `mapPartitions` closure captures it, not the (non-serializable)
+    // provider.
     val localTableRoot = deltaLog.dataPath
     val paths = rootManifestAbsolutePath +: leafManifestAbsolutePaths
     val encodedRootPath = SparkPath.fromPath(rootManifestAbsolutePath).urlEncoded
+    val serializableConf = new SerializableConfiguration(deltaLog.newDeltaHadoopConf())
     AMTCheckpointProvider.loadEntriesWithLocation(spark, deltaLog, paths)
       .where(col("entry.content_type") === lit(AMTSingleAction.ContentType.Type.Data))
-      .map { entryWithLoc =>
-        entryWithLoc.entry.unwrap match {
-          case data: DataEntry =>
-            val backReference = if (entryWithLoc.leafPath == encodedRootPath) {
-              None
-            } else {
-              Some(BackReference(
-                SparkPath.fromUrlString(entryWithLoc.leafPath).toPath.toString, entryWithLoc.pos))
-            }
-            val add = data.toAddFile(localTableRoot).copy(backReference = backReference)
-            SingleAction(add = add)
-          case other => throw new IllegalStateException(
-            s"Expected a DATA entry after filtering, got ${other.getClass.getSimpleName}.")
+      .mapPartitions { entries =>
+        val fs = localTableRoot.getFileSystem(serializableConf.value)
+        entries.map { entryWithLoc =>
+          entryWithLoc.entry.unwrap match {
+            case data: DataEntry =>
+              val backReference = if (entryWithLoc.leafPath == encodedRootPath) {
+                None
+              } else {
+                val absLeaf = SparkPath.fromUrlString(entryWithLoc.leafPath).toPath
+                val relManifest =
+                  AMTUtils.relativizeManifestPathToTableRoot(fs, localTableRoot, absLeaf)
+                Some(BackReference(relManifest, entryWithLoc.pos))
+              }
+              val add = data.toAddFile(localTableRoot).copy(backReference = backReference)
+              SingleAction(add = add)
+            case other => throw new IllegalStateException(
+              s"Expected a DATA entry after filtering, got ${other.getClass.getSimpleName}.")
+          }
         }
       }
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -1488,8 +1488,10 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .internal()
       .doc("""
           |When enabled, the Adaptive Metadata Tree `backReference` field is stripped from
-          |the add/remove structs before a classic/V2 checkpoint is written, so that non-AMT
-          |checkpoints stay byte-identical to before the AMT back-reference feature.
+          |the `remove` struct before a classic/V2 checkpoint is written, so that non-AMT
+          |checkpoints stay byte-identical to before the AMT back-reference feature. The `add`
+          |struct is rebuilt from an explicit column projection that never lists `backReference`,
+          |so it is excluded independently of this flag.
           |""".stripMargin)
       .booleanConf
       .createWithDefault(true)


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other

## Description

Stores the Adaptive Metadata Tree (AMT) back-reference `manifest` as a raw (non-URL-encoded) path relative to the table root, matching how the AMT leaf tree stores its `location`. This differs from `AddFile.path`, which is URL-encoded.

Also includes two small doc clarifications:
- Grammar fix in the `BackReference` scaladoc.
- Clarifies the add/remove asymmetry in the `CHECKPOINT_DROP_BACK_REFERENCE_ENABLED` config doc: the flag strips `backReference` from the `remove` struct, while the `add` struct is rebuilt from an explicit column projection that never lists `backReference` (excluded independently of the flag).

## How was this patch tested?

Unit tests.

## Does this PR introduce _any_ user-facing changes?

No.