### PR TITLE
Emit historical protocols for Delta Sharing CDF queries

### DIFF
--- a/sharing/src/main/scala/io/delta/sharing/spark/DeltaFormatSharingSource.scala
+++ b/sharing/src/main/scala/io/delta/sharing/spark/DeltaFormatSharingSource.scala
@@ -903,19 +903,26 @@ case class DeltaFormatSharingSource(
       DeltaSharingOptions.CDF_START_VERSION -> startingOffset.reservoirVersion.toString,
       DeltaSharingOptions.CDF_END_VERSION -> endingVersionForQuery.toString
     )
+    // Requests a Protocol action for each protocol change in the range, so a mid-range protocol
+    // upgrade is reflected in the local delta log instead of a stale head protocol. Gated by a
+    // default-off flag; when off the client keeps the legacy single-head-protocol behavior.
+    val includeHistoricalProtocol =
+      sqlConf.getConf(DeltaSQLConf.DELTA_SHARING_CDF_ENABLE_HISTORICAL_PROTOCOL)
     val tableFiles = client.getCDFFiles(
       table = table,
       cdfOptions = cdfOptions,
       // Requests Metadata actions for schema-changing versions in the range so DeltaSource
       // can detect both backward-compatible and non-backward-compatible schema changes.
       includeHistoricalMetadata = true,
-      fileIdHash = fileIdHash
+      fileIdHash = fileIdHash,
+      includeHistoricalProtocol = includeHistoricalProtocol
     )
     val refreshFunc = DeltaSharingUtils.getRefresherForGetCDFFiles(
       client = client,
       table = table,
       cdfOptions = cdfOptions,
-      fileIdHash = fileIdHash
+      fileIdHash = fileIdHash,
+      includeHistoricalProtocol = includeHistoricalProtocol
     )
     logInfo(
       s"Fetched ${tableFiles.lines.size} CDF lines from startingVersion " +

--- a/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingCDFUtils.scala
+++ b/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingCDFUtils.scala
@@ -20,6 +20,7 @@ import java.lang.ref.WeakReference
 import java.nio.charset.StandardCharsets.UTF_8
 
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import com.google.common.hash.Hashing
 import io.delta.sharing.client.DeltaSharingClient
 import io.delta.sharing.client.model.{Table => DeltaSharingTable}
@@ -52,8 +53,18 @@ object DeltaSharingCDFUtils extends Logging {
     // and also any metadata changes between [startingVersion, endingVersion], to put them in the
     // delta log. This is to allow delta library to check the metadata change and handle it
     // properly -- currently it throws error for column mapping changes.
+    // includeHistoricalProtocol requests a protocol for each protocol change in the same range, so
+    // a mid-range protocol upgrade (e.g. enabling deletionVectors) is reflected in the delta log
+    // instead of leaving the recipient on a stale head protocol. Gated by a default-off flag; when
+    // off the client keeps the legacy single-head-protocol behavior.
+    val includeHistoricalProtocol = sqlContext.sparkSession.sessionState.conf
+      .getConf(DeltaSQLConf.DELTA_SHARING_CDF_ENABLE_HISTORICAL_PROTOCOL)
     val deltaTableFiles = client.getCDFFiles(
-      table, options.cdfOptions, includeHistoricalMetadata = true, fileIdHash = None
+      table,
+      options.cdfOptions,
+      includeHistoricalMetadata = true,
+      fileIdHash = None,
+      includeHistoricalProtocol = includeHistoricalProtocol
     )
     logInfo(
       s"Fetched ${deltaTableFiles.lines.size} lines with cdf options ${options.cdfOptions} " +
@@ -86,7 +97,8 @@ object DeltaSharingCDFUtils extends Logging {
       refresher = DeltaSharingUtils.getRefresherForGetCDFFiles(
         client = client,
         table = table,
-        cdfOptions = options.cdfOptions
+        cdfOptions = options.cdfOptions,
+        includeHistoricalProtocol = includeHistoricalProtocol
       ),
       expirationTimestamp =
         if (CachedTableManager.INSTANCE

--- a/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingUtils.scala
+++ b/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingUtils.scala
@@ -221,13 +221,15 @@ object DeltaSharingUtils extends Logging {
       client: DeltaSharingClient,
       table: Table,
       cdfOptions: Map[String, String],
-      fileIdHash: Option[String] = None): RefresherFunction = { (_: Option[String]) =>
+      fileIdHash: Option[String] = None,
+      includeHistoricalProtocol: Boolean = false): RefresherFunction = { (_: Option[String]) =>
     {
       val tableFiles = client.getCDFFiles(
         table = table,
         cdfOptions = cdfOptions,
         includeHistoricalMetadata = true,
-        fileIdHash = fileIdHash
+        fileIdHash = fileIdHash,
+        includeHistoricalProtocol = includeHistoricalProtocol
       )
       getTableRefreshResult(tableFiles)
     }

--- a/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingDataSourceDeltaSuite.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingDataSourceDeltaSuite.scala
@@ -1048,6 +1048,93 @@ trait DeltaSharingDataSourceDeltaSuiteBase
     }
   }
 
+  // A CDF query whose range spans a protocol upgrade (enabling deletionVectors mid-range) only
+  // reads correctly when the client opts in to historical protocols: with the flag on the server
+  // streams the v2 Protocol upgrade so the local delta log can read the post-upgrade DV files;
+  // with the flag off the recipient is left on the stale head protocol and the read fails.
+  Seq(true, false).foreach { flagOn =>
+    test("DeltaSharingDataSource cdf query spanning a protocol upgrade " +
+      s"[historicalProtocol=$flagOn]") {
+      withTempDir { tempDir =>
+        val deltaTableName = "delta_table_cdf_protocol_upgrade"
+        withTable(deltaTableName) {
+          // v0: create with CDF on and DV explicitly off (overriding any session default that turns
+          // DV on at creation) so the head protocol has no DV reader feature.
+          sql(s"""
+                 |CREATE TABLE $deltaTableName (c1 INT, c2 STRING) USING DELTA
+                 |TBLPROPERTIES (
+                 |  delta.enableChangeDataFeed = true,
+                 |  delta.enableDeletionVectors = false
+                 |)
+                 |""".stripMargin)
+          // v1: inserts before the protocol upgrade.
+          sql(s"""INSERT INTO $deltaTableName VALUES (1, "one"), (2, "two")""")
+          // v2: enable deletionVectors -> a protocol upgrade committed inside the range
+          // (minReaderVersion/minWriterVersion bumped, DV reader/writer feature added).
+          sql(s"""ALTER TABLE $deltaTableName
+                 |SET TBLPROPERTIES (delta.enableDeletionVectors = true)""".stripMargin)
+          // v3: a DV-based delete, only readable with the upgraded protocol.
+          sql(s"""DELETE FROM $deltaTableName WHERE c1 = 2""")
+          // v4: more inserts after the upgrade.
+          sql(s"""INSERT INTO $deltaTableName VALUES (3, "three")""")
+
+          // Sanity check: the protocol actually changed inside the range.
+          val log = DeltaLog.forTable(spark, new TableIdentifier(deltaTableName))
+          assert(log.getSnapshotAt(1).protocol != log.getSnapshotAt(4).protocol,
+            "Test setup expects a protocol upgrade between v1 and v4.")
+
+          val sharedTableName = "shared_table_cdf_protocol_upgrade"
+          prepareMockedClientGetTableVersion(deltaTableName, sharedTableName)
+          prepareMockedClientAndFileSystemResultForCdf(deltaTableName, sharedTableName, 0L)
+
+          withSQLConf(
+            (getDeltaSharingClassesSQLConf ++ Map(
+              DeltaSQLConf.DELTA_SHARING_CDF_ENABLE_HISTORICAL_PROTOCOL.key -> flagOn.toString
+            )).toSeq: _*
+          ) {
+            val profileFile = prepareProfileFile(tempDir)
+            val tablePath = profileFile.getCanonicalPath + s"#share1.default.$sharedTableName"
+            def sharedCdf(): DataFrame = spark.read
+              .format("deltaSharing")
+              .option("responseFormat", "delta")
+              .option("readChangeFeed", "true")
+              .option("startingVersion", 0L)
+              .load(tablePath)
+
+            if (flagOn) {
+              // The v2 protocol upgrade is streamed, so the shared CDF read matches a local read.
+              val expected = spark.read
+                .format("delta")
+                .option("readChangeFeed", "true")
+                .option("startingVersion", 0L)
+                .table(deltaTableName)
+              checkAnswer(sharedCdf(), expected)
+              assert(sharedCdf().count() > 0)
+            } else {
+              // Without the upgrade, the local delta log has DV-enabled metadata on a stale
+              // protocol lacking the DV feature, rejected with
+              // DELTA_FEATURES_PROTOCOL_METADATA_MISMATCH.
+              val e = intercept[Exception] {
+                sharedCdf().collect()
+              }
+              val rootMsg = Iterator
+                .iterate[Throwable](e)(_.getCause)
+                .takeWhile(_ != null)
+                .map(t => Option(t.getMessage).getOrElse(""))
+                .mkString(" | ")
+              assert(
+                rootMsg.contains("DELTA_FEATURES_PROTOCOL_METADATA_MISMATCH"),
+                s"Expected DELTA_FEATURES_PROTOCOL_METADATA_MISMATCH in error chain, got: $rootMsg")
+              assert(
+                rootMsg.contains("deletionVectors"),
+                s"Expected deletionVectors mentioned in error chain, got: $rootMsg")
+            }
+          }
+        }
+      }
+    }
+  }
+
   test("DeltaSharingDataSource auto-resolves responseFormat for cdf query gated by flag") {
     withTempDir { tempDir =>
       for (autoResolveEnabled <- Seq(true, false)) {

--- a/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingDataSourceDeltaTestUtils.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingDataSourceDeltaTestUtils.scala
@@ -631,6 +631,14 @@ trait DeltaSharingDataSourceDeltaTestUtils extends SharedSparkSession {
           val versionHasCdc = versionActions.exists(_.isInstanceOf[AddCDCFile])
           versionActions.foreach { action =>
             action match {
+              case p: Protocol if version > startingVersion && !parquetFormat =>
+                // A protocol change committed inside the range (e.g. enabling deletionVectors) is
+                // streamed as its own versioned Protocol for delta-format responses, mirroring
+                // historical metadata. Parquet responses never emit historical protocols.
+                actionLines += DeltaSharingProtocol(
+                  deltaProtocol = p,
+                  version = version
+                ).json
               case m: Metadata =>
                 if (parquetFormat) {
                   actionLines += JsonUtils.toJson(getClientMetadataForParquet(m).wrap)
@@ -760,7 +768,12 @@ trait DeltaSharingDataSourceDeltaTestUtils extends SharedSparkSession {
       )
     } else {
       Seq(
-        DeltaSharingProtocol(deltaProtocol = startingSnapshot.protocol).json,
+        // The head protocol is stamped with startingVersion, matching the head metadata, mirroring
+        // how the server stamps the head Protocol for historical-protocol responses.
+        DeltaSharingProtocol(
+          deltaProtocol = startingSnapshot.protocol,
+          version = startingVersion
+        ).json,
         DeltaSharingMetadata(
           deltaMetadata = startingSnapshot.metadata,
           version = startingVersion

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -3305,6 +3305,18 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .booleanConf
       .createWithDefault(false)
 
+  val DELTA_SHARING_CDF_ENABLE_HISTORICAL_PROTOCOL =
+    buildConf("spark.sql.delta.sharing.cdfEnableHistoricalProtocol")
+      .doc("When true, a Delta Sharing CDF query (queryTableChanges, both batch and streaming) " +
+        "requests includeHistoricalProtocol so the server streams a Protocol for each protocol " +
+        "change inside the version range, keeping the locally constructed delta log's protocol " +
+        "accurate across a mid-range protocol upgrade. When false, the client keeps the legacy " +
+        "single-head-protocol behavior. Gates the CDF path independently from the non-CDF " +
+        "streaming path controlled by spark.sql.delta.sharing.streamingEnableHistoricalProtocol.")
+      .internal()
+      .booleanConf
+      .createWithDefault(false)
+
   val DELTA_SHARING_ENABLE_AUTO_RESOLVE_FOR_CDF =
     buildConf("spark.sql.delta.sharing.enableAutoResolveForCdf")
       .doc("When true, Delta Sharing CDF queries without an explicit responseFormat will " +


### PR DESCRIPTION
## Description

A Delta Sharing CDF query (`queryTableChanges`, both batch and streaming) reads a
version range via `getCDFFiles`. Until now the response carried only a single head
`Protocol`, so if the protocol was upgraded inside the range (for example, enabling
`deletionVectors`, which bumps the protocol and adds a reader/writer feature), the
locally reconstructed Delta log ended up with post-upgrade files and metadata sitting
on a stale head protocol that lacks the required table feature. Reading such a log
fails the protocol/metadata consistency check with
`DELTA_FEATURES_PROTOCOL_METADATA_MISMATCH`.

This change lets the CDF client opt in to receiving historical protocols, mirroring
the existing historical-metadata handling:

- A new internal conf `spark.sql.delta.sharing.cdfEnableHistoricalProtocol`
  (default `false`). When enabled, `getCDFFiles` is called with
  `includeHistoricalProtocol = true`, so the server streams a `Protocol` action for
  each protocol change inside the version range, each stamped with the version it was
  committed at. The head protocol is stamped with the starting version.

The flag is off by default, so existing behavior is unchanged unless it is enabled.
This gates the CDF path independently from the non-CDF streaming path controlled by
`spark.sql.delta.sharing.streamingEnableHistoricalProtocol`.

## How was this patch tested?

Added a test in `DeltaSharingDataSourceDeltaSuite`: a CDF query whose range spans a
protocol upgrade (v2 enables `deletionVectors`, v3 does a DV-based delete, v4 inserts).
With the flag on, the v2 protocol upgrade is streamed and the shared CDF read matches a
local `readChangeFeed` read; with the flag off, the recipient is left on the stale head
protocol and the read fails with `DELTA_FEATURES_PROTOCOL_METADATA_MISMATCH`.

## Does this PR introduce _any_ user-facing change?

Yes. A new internal SQL conf `spark.sql.delta.sharing.cdfEnableHistoricalProtocol`
(default `false`) is added to control whether Delta Sharing CDF queries request
historical protocols for the version range.
