### PR TITLE
Stamp Iceberg V4 field IDs on adaptive-metadata checkpoint Parquet files

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
@@ -40,6 +40,7 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, FileSystem, Path}
 import org.apache.hadoop.mapred.{JobConf, TaskAttemptContextImpl, TaskAttemptID}
 import org.apache.hadoop.mapreduce.{Job, TaskType}
+import org.apache.parquet.hadoop.ParquetOutputFormat
 
 import org.apache.spark.TaskContext
 import org.apache.spark.internal.MDC
@@ -1037,27 +1038,45 @@ object Checkpoints
    * concurrent (zombie) task, the existing file is reused rather than failing the write --
    * all writers of a given path are expected to produce identical content.
    *
-   * @param df        DataFrame to write. Its schema (after `asNullable`) is the on-disk
-   *                  schema and is returned to the caller.
+   * @param df        DataFrame supplying the rows to write. Only its rows are used; the on-disk
+   *                  schema is `outputSchema` (below).
    * @param finalPath The exact final path of the parquet file. Custom-named files are
    *                  supported -- callers control the basename.
    * @param useRename Write to a `.<finalPath>.<uuid>.tmp` first, then atomic-rename to
    *                  `finalPath`. Required for log stores where partial writes are visible
    *                  to concurrent readers.
-   * @return The schema actually written (`df.schema.asNullable`).
+   * @param outputSchema The exact on-disk Parquet schema: field names, types, per-field nullability
+   *                  (a non-nullable field is written as Parquet `REQUIRED`), and any field-id
+   *                  metadata. `df`'s rows must be positionally compatible with it. When `None`
+   *                  (the default, classic-checkpoint behavior) it is `df.schema.asNullable` (fully
+   *                  nullable). The AMT manifest writer passes its id-carrying schema. The resolved
+   *                  schema is the value returned to the caller.
+   * @param useDeltaParquetWriteSupport When true, hooks in [[DeltaParquetWriteSupport]] as the
+   *                  Parquet write support class so that list-element / map key-value field ids
+   *                  carried on `outputSchema` via `parquet.field.nested.ids` are emitted to the
+   *                  file's Parquet schema (the stock `ParquetWriteSupport` does not). Needed for
+   *                  the AMT Iceberg-V4 manifest schema. Default false uses the standard support.
+   * @return The schema actually written.
    */
   def writeAtomicCheckpointParquetFile(
       spark: SparkSession,
       df: DataFrame,
       finalPath: Path,
       hadoopConf: Configuration,
-      useRename: Boolean): StructType =
+      useRename: Boolean,
+      outputSchema: Option[StructType] = None,
+      useDeltaParquetWriteSupport: Boolean = false): StructType =
       recordFrameProfile(
         "Checkpoints", "writeAtomicCheckpointParquetFile") {
-    val schema = df.schema.asNullable
+    val schema = outputSchema.getOrElse(df.schema.asNullable)
     val format = new ParquetFileFormat()
     val job = Job.getInstance(hadoopConf)
     val factory = format.prepareWrite(spark, job, Map.empty, schema)
+    if (useDeltaParquetWriteSupport) {
+      // Emit nested (list-element / map key-value) field ids, which the stock ParquetWriteSupport
+      // does not. Set after prepareWrite so it overrides the write-support class prepareWrite set.
+      ParquetOutputFormat.setWriteSupportClass(job, classOf[DeltaParquetWriteSupport])
+    }
     val serConf = new SerializableConfiguration(job.getConfiguration)
     val finalSparkPath = SparkPath.fromPath(finalPath)
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriteHelper.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriteHelper.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.delta.amt
 import java.util.concurrent.TimeUnit.NANOSECONDS
 
 // scalastyle:off import.ordering.noEmptyLine
-import org.apache.spark.sql.delta.{Checkpoints, DeltaLog, Snapshot}
+import org.apache.spark.sql.delta.{Checkpoints, DeltaLog, DeltaParquetWriteSupport, Snapshot}
 import org.apache.spark.sql.delta.actions.{Action, AddFile, Checkpoint, ContentRoot, DomainMetadata, InMemoryLogReplay, Metadata, Protocol, SetTransaction}
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
@@ -27,6 +27,7 @@ import org.apache.spark.sql.delta.util.FileNames
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.hadoop.mapreduce.Job
+import org.apache.parquet.hadoop.ParquetOutputFormat
 
 import org.apache.spark.TaskContext
 import org.apache.spark.paths.SparkPath
@@ -295,12 +296,15 @@ object AMTWriteHelper extends DeltaLogging {
     val amtDs = addFilesDs.map { add =>
       DataEntry.fromAddFile(add, tracking, tableRootSparkPath.toPath).wrap
     }
-    val schema = amtDs.schema.asNullable
+    val schema = AMTSingleAction.schemaWithFieldId
     val (factory, serConf) = {
       val format = new ParquetFileFormat()
       val job = Job.getInstance(hadoopConf)
-      (format.prepareWrite(spark, job, Map.empty, schema),
-        new SerializableConfiguration(job.getConfiguration))
+      val f = format.prepareWrite(spark, job, Map.empty, schema)
+      // Emit nested (list-element / map key-value) field ids, which the stock ParquetWriteSupport
+      // does not. Set after prepareWrite (before snapshotting the conf) so it flows to executors.
+      ParquetOutputFormat.setWriteSupportClass(job, classOf[DeltaParquetWriteSupport])
+      (f, new SerializableConfiguration(job.getConfiguration))
     }
 
     val qe = amtDs.queryExecution
@@ -427,7 +431,7 @@ object AMTWriteHelper extends DeltaLogging {
   }
 
   /**
-   * Writes a batch of AMTSingleAction rows to `finalPath` as a single parquet file.
+   * Writes a sequence of AMTSingleActions to a Parquet file.
    */
   private def writeAMTParquet(
       spark: SparkSession,
@@ -436,14 +440,13 @@ object AMTWriteHelper extends DeltaLogging {
       rows: Seq[AMTSingleAction]): Unit = {
     import org.apache.spark.sql.delta.implicits._
     val df = spark.createDataset(rows).toDF()
-    // AMT manifest tree files are UUID-named, so we write straight to the final path
-    // (useRename = false): a retried or zombie task never collides with a file already
-    // reported to a Manifest commit.
     Checkpoints.writeAtomicCheckpointParquetFile(
       spark = spark,
       df = df,
       finalPath = finalPath,
       hadoopConf = hadoopConf,
-      useRename = false)
+      useRename = false,
+      outputSchema = Some(AMTSingleAction.schemaWithFieldId),
+      useDeltaParquetWriteSupport = true)
   }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/actions.scala
@@ -20,11 +20,15 @@ import java.util.UUID
 
 import scala.util.Try
 
+import org.apache.spark.sql.delta.DeltaColumnMapping
 import org.apache.spark.sql.delta.actions.{AddFile, DeletionVectorDescriptor}
 import org.apache.spark.sql.delta.stats.DeltaStatistics
 import org.apache.spark.sql.delta.storage.dv.DeletionVectorStore
 import com.fasterxml.jackson.annotation.JsonIgnore
 import org.apache.hadoop.fs.Path
+
+import org.apache.spark.sql.execution.datasources.parquet.ParquetUtils
+import org.apache.spark.sql.types.{MetadataBuilder, StructField, StructType}
 
 /**
  * One entry in any AMT manifest file (leaf or root).
@@ -48,7 +52,6 @@ import org.apache.hadoop.fs.Path
  * @param split_offsets Row-group split offsets (Iceberg field 132); Delta does not generate or
  *                      consume these, but the field is kept in the schema to carry it forward
  *                      for tables written by both Delta and Iceberg.
- * @param column_files Per-column file entries; only content_type in {0,3}.
  */
 case class AMTSingleAction(
     content_type: Int,                          // ID: 134, required.
@@ -65,8 +68,7 @@ case class AMTSingleAction(
     content_stats: Option[ContentStats],        // ID: 146, optional.
     manifest_info: Option[ManifestInfo],        // ID: 150, required for DATA_MANIFEST.
     key_metadata: Option[Array[Byte]],          // ID: 131, optional.
-    split_offsets: Option[Seq[Long]],           // ID: 132, optional.
-    column_files: Option[Seq[ColumnFile]] // ID: TBD (content_type in {0,3}).
+    split_offsets: Option[Seq[Long]]            // ID: 132, optional.
 ) {
   AMTSingleAction.validate(this)
 
@@ -90,7 +92,6 @@ case class AMTSingleAction(
         content_stats = content_stats,
         key_metadata = key_metadata,
         split_offsets = split_offsets,
-        column_files = column_files,
         format_version = format_version)
     case AMTSingleAction.ContentType.Type.DataManifest =>
       DataManifestEntry(
@@ -105,7 +106,6 @@ case class AMTSingleAction(
         content_stats = content_stats,
         key_metadata = key_metadata,
         split_offsets = split_offsets,
-        column_files = column_files,
         format_version = format_version)
     case other =>
       throw new IllegalStateException(s"Unsupported content_type: $other.")
@@ -178,6 +178,211 @@ object AMTSingleAction {
   /** Creates [[AMTSingleAction]] from AddFile. */
   def fromAddFile(add: AddFile, tracking: Tracking, tableRoot: Path): AMTSingleAction =
     DataEntry.fromAddFile(add, tracking, tableRoot).wrap
+
+  /**
+   * The Iceberg V4 spec metadata for one field of an AMT manifest struct: its field id and whether
+   * the spec marks it required. Construct via the [[required]] / [[optional]] factories.
+   */
+  case class AMTFieldSpec private (name: String, id: Long, required: Boolean)
+
+  /** Declares a spec-required field (Parquet `REQUIRED`). */
+  private def required(id: Long, name: String): AMTFieldSpec =
+    AMTFieldSpec(name, id, required = true)
+
+  /** Declares an optional field (Parquet `OPTIONAL`). */
+  private def optional(id: Long, name: String): AMTFieldSpec =
+    AMTFieldSpec(name, id, required = false)
+
+  /** Iceberg V4 field specs for the top-level [[AMTSingleAction]] fields. */
+  private val topLevelFields: Seq[AMTFieldSpec] = Seq(
+    required(134L, "content_type"),
+    required(157L, "format_version"),
+    required(100L, "location"),
+    required(101L, "file_format"),
+    required(147L, "tracking"),
+    optional(148L, "deletion_vector"),
+    optional(141L, "spec_id"),
+    optional(102L, "partition"),
+    optional(140L, "sort_order_id"),
+    required(103L, "record_count"),
+    required(104L, "file_size_in_bytes"),
+    optional(146L, "content_stats"),
+    optional(150L, "manifest_info"),
+    optional(131L, "key_metadata"),
+    optional(132L, "split_offsets"))
+
+  /** Iceberg V4 field specs for the scalar fields of the nested [[Tracking]] struct. */
+  private val trackingFields: Seq[AMTFieldSpec] = Seq(
+    required(0L, "status"),
+    optional(1L, "snapshot_id"),
+    optional(3L, "sequence_number"),
+    optional(4L, "file_sequence_number"),
+    optional(5L, "dv_snapshot_id"),
+    optional(142L, "first_row_id"),
+    optional(6L, "deleted_positions"),
+    optional(7L, "replaced_positions"))
+
+  /** Iceberg V4 field specs for the scalar fields of the nested [[DeletionVector]] struct. */
+  private val deletionVectorFields: Seq[AMTFieldSpec] = Seq(
+    required(155L, "location"),
+    required(144L, "offset"),
+    required(145L, "size_in_bytes"),
+    required(156L, "cardinality"))
+
+  /** Iceberg V4 field specs for the scalar fields of the nested [[ManifestInfo]] struct. */
+  private val manifestInfoFields: Seq[AMTFieldSpec] = Seq(
+    required(504L, "added_files_count"),
+    required(505L, "existing_files_count"),
+    required(506L, "deleted_files_count"),
+    required(520L, "replaced_files_count"),
+    required(512L, "added_rows_count"),
+    required(513L, "existing_rows_count"),
+    required(514L, "deleted_rows_count"),
+    required(521L, "replaced_rows_count"),
+    required(516L, "min_sequence_number"),
+    optional(522L, "dv"),
+    optional(523L, "dv_cardinality"))
+
+  /** Nested-struct field specs, keyed by the top-level field name that carries the struct. */
+  private val nestedStructFields: Map[String, Seq[AMTFieldSpec]] = Map(
+    "tracking" -> trackingFields,
+    "deletion_vector" -> deletionVectorFields,
+    "manifest_info" -> manifestInfoFields)
+
+  /** Iceberg V4 field id for the `split_offsets` list element. */
+  private val SPLIT_OFFSETS_ELEMENT_FIELD_ID: Long = 133L
+  private val PARTITION_VALUES_KEY_PLACEHOLDER_ID: Long = 100002L
+  private val PARTITION_VALUES_VALUE_PLACEHOLDER_ID: Long = 100003L
+
+  /** Top-level specs by name, for lookup during stamping. */
+  private val topLevelFieldByName: Map[String, AMTFieldSpec] =
+    topLevelFields.map(f => f.name -> f).toMap
+
+  /**
+   * Test-only Parquet field-id map for an AMT checkpoint schema, keyed by dotted path. Keys are the
+   * top-level field name (`content_type`), a nested-struct scalar (`tracking.status`), a list
+   * element (`split_offsets.element`), or a map key/value (`partition.values.key`,
+   * `partition.values.value`).
+   */
+  private[amt] val allFieldIdByName: Map[String, Int] = {
+    val topLevel = topLevelFields.map(f => f.name -> f.id.toInt)
+    val nested = nestedStructFields.flatMap { case (parent, children) =>
+      children.map(f => s"$parent.${f.name}" -> f.id.toInt)
+    }
+    val nestedContainers = Map(
+      "split_offsets.element" -> SPLIT_OFFSETS_ELEMENT_FIELD_ID.toInt,
+      "partition.values.key" -> PARTITION_VALUES_KEY_PLACEHOLDER_ID.toInt,
+      "partition.values.value" -> PARTITION_VALUES_VALUE_PLACEHOLDER_ID.toInt)
+    (topLevel ++ nested ++ nestedContainers).toMap
+  }
+
+  /**
+   * The persisted [[AMTSingleAction]] schema with Iceberg field ids stamped onto its Parquet
+   * schema. Everything here is static, so it is computed once.
+   */
+  lazy val schemaWithFieldId: StructType = {
+    import org.apache.spark.sql.delta.implicits._
+    val base = amtSingleActionEncoder.schema
+    StructType(base.map(stampFieldSpec))
+  }
+
+  /**
+   * Applies the Iceberg [[AMTFieldSpec]] to a single top-level [[AMTSingleAction]] field:
+   * stamps the field id (and any nested element/map ids) and sets nullability from
+   * `spec.required`.
+   */
+  private def stampFieldSpec(field: StructField): StructField = {
+    val spec = topLevelFieldByName.getOrElse(field.name,
+      throw new IllegalStateException(
+        s"No Iceberg field spec defined for top-level AMTSingleAction field '${field.name}'."))
+    val builder = new MetadataBuilder()
+      .withMetadata(field.metadata)
+      .putLong(ParquetUtils.FIELD_ID_METADATA_KEY, spec.id)
+    // Attach nested (element) ids for list-bearing fields.
+    // DeltaParquetWriteSupport reads these off the list field itself, keyed `<field>.element`.
+    listElementFieldId(field.name).foreach { elementId =>
+      builder.putMetadata(
+        DeltaColumnMapping.PARQUET_FIELD_NESTED_IDS_METADATA_KEY,
+        new MetadataBuilder()
+          .putLong(
+            Seq(field.name, DeltaColumnMapping.PARQUET_LIST_ELEMENT_FIELD_NAME).mkString("."),
+            elementId)
+          .build())
+    }
+    // Rewrite the field's data type: apply nested-struct field specs (id + nullability).
+    val stampedDataType = field.dataType match {
+      case struct: StructType =>
+        nestedStructFields.get(field.name) match {
+          case Some(specs) => stampNestedStructFieldSpecs(field.name, struct, specs)
+          case None =>
+            assert(field.name == "partition" || field.name == "content_stats",
+              s"Unexpected struct-typed AMTSingleAction field '${field.name}': expected a " +
+                "nested-id struct, partition, or content_stats.")
+            if (field.name == "partition") stampPartitionValuesNestedIds(struct) else struct
+        }
+      case other =>
+        assert(!nestedStructFields.contains(field.name),
+          s"Field '${field.name}' has a nested-id spec but is not struct-typed " +
+            s"(${other.typeName}).")
+        other
+    }
+    // Stamp the field id and set nullability from the spec (even when it matches the encoder),
+    // so every id-stamped field's required/optional is driven by the spec.
+    field.copy(
+      dataType = stampedDataType,
+      nullable = !spec.required,
+      metadata = builder.build())
+  }
+
+  /** List-element field id for a top-level list field, or None if not a list field. */
+  private def listElementFieldId(fieldName: String): Option[Long] = fieldName match {
+    case "split_offsets" => Some(SPLIT_OFFSETS_ELEMENT_FIELD_ID)
+    case _ => None
+  }
+
+  /**
+   * Applies each [[AMTFieldSpec]] to the matching direct child of `struct` by name: stamps
+   * `parquet.field.id` and sets nullability from `spec.required`. Non-recursive. Fails if the
+   * encoder exposes a child with no matching spec (same contract as top-level [[stampFieldSpec]]).
+   */
+  private def stampNestedStructFieldSpecs(
+      parentName: String, struct: StructType, specs: Seq[AMTFieldSpec]): StructType = {
+    val specByName = specs.map(f => f.name -> f).toMap
+    StructType(struct.map { f =>
+      val spec = specByName.getOrElse(f.name,
+        throw new IllegalStateException(
+          s"No Iceberg field spec defined for nested AMT field '$parentName.${f.name}'."))
+      // Stamp the field id and set nullability from the spec (even when it matches the
+      // encoder), so every id-stamped field's required/optional is driven by the spec.
+      f.copy(
+        nullable = !spec.required,
+        metadata = new MetadataBuilder()
+          .withMetadata(f.metadata)
+          .putLong(ParquetUtils.FIELD_ID_METADATA_KEY, spec.id)
+          .build())
+    })
+  }
+
+  /** Stamps placeholder map key/value ids onto the interim `partition.values` field. */
+  private def stampPartitionValuesNestedIds(struct: StructType): StructType =
+    StructType(struct.map { field =>
+      if (field.name == "values") {
+        val nestedIds = new MetadataBuilder()
+          .putLong(
+            Seq("values", DeltaColumnMapping.PARQUET_MAP_KEY_FIELD_NAME).mkString("."),
+            PARTITION_VALUES_KEY_PLACEHOLDER_ID)
+          .putLong(
+            Seq("values", DeltaColumnMapping.PARQUET_MAP_VALUE_FIELD_NAME).mkString("."),
+            PARTITION_VALUES_VALUE_PLACEHOLDER_ID)
+          .build()
+        field.copy(metadata = new MetadataBuilder()
+          .withMetadata(field.metadata)
+          .putMetadata(DeltaColumnMapping.PARQUET_FIELD_NESTED_IDS_METADATA_KEY, nestedIds)
+          .build())
+      } else {
+        field
+      }
+    })
 }
 
 /**
@@ -213,7 +418,6 @@ sealed trait AMTAction {
  * @param split_offsets Row-group split offsets (Iceberg field 132); Delta does not generate or
  *                      consume these, but the field is kept in the schema to carry it forward
  *                      for tables written by both Delta and Iceberg.
- * @param column_files Per-column file entries.
  * @param format_version Iceberg writer format version; 4 for V4.
  */
 case class DataEntry(
@@ -229,7 +433,6 @@ case class DataEntry(
     content_stats: Option[ContentStats] = None,
     key_metadata: Option[Array[Byte]] = None,
     split_offsets: Option[Seq[Long]] = None,
-    column_files: Option[Seq[ColumnFile]] = None,
     format_version: Int = AMTSingleAction.FormatVersionV4)
   extends AMTAction {
 
@@ -250,8 +453,7 @@ case class DataEntry(
     content_stats = content_stats,
     manifest_info = None,
     key_metadata = key_metadata,
-    split_offsets = split_offsets,
-    column_files = column_files)
+    split_offsets = split_offsets)
 
   def toAddFile(tableRoot: Path): AddFile = {
     val dv = deletion_vector.map(DeletionVector.toDescriptor(_, tableRoot)).orNull
@@ -310,7 +512,6 @@ object DataEntry {
  * @param split_offsets Row-group split offsets (Iceberg field 132); Delta does not generate or
  *                      consume these, but the field is kept in the schema to carry it forward
  *                      for tables written by both Delta and Iceberg.
- * @param column_files Per-column file entries.
  * @param format_version Iceberg writer format version; 4 for V4.
  */
 case class DataManifestEntry(
@@ -325,7 +526,6 @@ case class DataManifestEntry(
     content_stats: Option[ContentStats] = None,
     key_metadata: Option[Array[Byte]] = None,
     split_offsets: Option[Seq[Long]] = None,
-    column_files: Option[Seq[ColumnFile]] = None,
     format_version: Int = AMTSingleAction.FormatVersionV4)
   extends AMTAction {
 
@@ -346,8 +546,7 @@ case class DataManifestEntry(
     content_stats = content_stats,
     manifest_info = Some(manifest_info),
     key_metadata = key_metadata,
-    split_offsets = split_offsets,
-    column_files = column_files)
+    split_offsets = split_offsets)
 
   /** Absolute [[Path]] to the referenced leaf manifest, resolving `location` against the root. */
   @JsonIgnore
@@ -542,16 +741,3 @@ case class ManifestInfo(
  */
 case class ContentStats(raw_stats: Option[Array[Byte]] = None)
 
-/**
- * Per-column file entries; shape TBD per the spec.
- *
- * The single nullable `location` field is deliberate: an empty case class encodes to an
- * empty Parquet group, which the Parquet data source rejects
- * (`EMPTY_SCHEMA_NOT_SUPPORTED_FOR_DATASOURCE`). One nullable column keeps
- * `AMTSingleAction` Parquet-writable without committing to the final per-column-file
- * shape; M1 writers leave `column_files` `None`.
- *
- *
- * @param location Per-column file path; M1 writers leave it None.
- */
-case class ColumnFile(location: Option[String] = None)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSingleActionSerializerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSingleActionSerializerSuite.scala
@@ -87,7 +87,7 @@ class AMTSingleActionSerializerSuite extends QueryTest with SharedSparkSession {
       "content_type", "format_version", "location", "file_format", "tracking",
       "deletion_vector", "spec_id", "partition", "sort_order_id", "record_count",
       "file_size_in_bytes", "content_stats", "manifest_info", "key_metadata",
-      "split_offsets", "column_files"))
+      "split_offsets"))
   }
 
   test("closed constant sets match Iceberg V4 integer codes") {
@@ -126,7 +126,6 @@ class AMTSingleActionSerializerSuite extends QueryTest with SharedSparkSession {
     assert(entry.manifest_info.contains(info))
     assert(entry.deletion_vector.isEmpty)
     assert(entry.sort_order_id.isEmpty)
-    assert(entry.column_files.isEmpty)
   }
 
   /** Builds a DATA entry, overriding individual fields to probe invariants. */
@@ -150,8 +149,7 @@ class AMTSingleActionSerializerSuite extends QueryTest with SharedSparkSession {
     content_stats = None,
     manifest_info = manifest_info,
     key_metadata = None,
-    split_offsets = None,
-    column_files = None)
+    split_offsets = None)
 
   private def assertRejected(substring: String)(build: => AMTSingleAction): Unit = {
     val ex = intercept[IllegalArgumentException](build)
@@ -270,8 +268,7 @@ class AMTSingleActionSerializerSuite extends QueryTest with SharedSparkSession {
       record_count = 10L,
       file_size_in_bytes = 100L,
       deletion_vector = Some(DeletionVector("dv", 0L, 8L, 3L)),
-      sort_order_id = Some(2),
-      column_files = Some(Seq(ColumnFile(Some("c0.parquet"))))),
+      sort_order_id = Some(2)),
     DataManifestEntry(
       location = "dm.parquet",
       file_format = AMTSingleAction.FileFormatParquet,


### PR DESCRIPTION
## Description

Stamp the Iceberg V4 field IDs onto the leaf and root manifest Parquet schemas of the adaptive-metadata checkpoint writer, including nested list-element and map key/value IDs, so the manifests are readable as Iceberg V4 content-metadata. Both the incremental (driver-side) and full (clustered) write paths route through the field-id-aware write support, preserving each field'''s spec-prescribed required/optional nullability.

## How was this patch tested?

Added assertions in the adaptive-metadata checkpoint suites that read the written leaf/root Parquet footers back and verify every field carries its expected Iceberg field ID (top-level, nested-struct scalar, and list-element / map key-value), plus a golden test pinning the full stamped schema.

## Does this PR introduce _any_ user-facing change?

No.