### PR TITLE
Keep the adaptive metadata full-rewrite cadence alive across inline writes

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -2904,8 +2904,11 @@ trait OptimisticTransactionImpl extends TransactionHelper
       // if needed.
       amtWriterManager.planMaintenance(attemptVersion, postCommitSnapshot)
     } else {
-      // The AMT was written inline with this commit; no follow-up maintenance is needed.
-      MaintenanceOperation()
+      // The AMT was written inline with this commit (always incremental). A full rewrite is never
+      // inlined, so schedule a follow-up full OPTIMIZE CHECKPOINT commit when the full-rewrite
+      // cadence is due -- otherwise a table whose commits consistently inline would never get a
+      // full tree.
+      amtWriterManager.planMaintenanceAfterInlineWrite(attemptVersion, postCommitSnapshot)
     }
     val commitStatsComputer = new CommitStatsComputer()
     // Add to commit stats and consume the returned iterator.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriteHelper.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriteHelper.scala
@@ -178,6 +178,7 @@ object AMTWriteHelper extends DeltaLogging {
       includeActionsInCommitJson = true)
     val singleMetric = SingleAMTWriteMetrics(
       trigger = trigger,
+      incremental = contentRoot.isIncremental.map(_.toString).getOrElse("UNKNOWN"),
       materializeDurationMs = NANOSECONDS.toMillis(System.nanoTime() - startNanos))
     (result, singleMetric)
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriterManager.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriterManager.scala
@@ -59,6 +59,7 @@ case class AMTWriteMetrics(
 /** Metrics for a single AMT write attempt (one per commit attempt that materializes a tree). */
 case class SingleAMTWriteMetrics(
     trigger: String,
+    incremental: String,
     materializeDurationMs: Long)
 
 /**
@@ -110,9 +111,13 @@ class AMTWriterManager(
       case optimize: DeltaOperations.OptimizeCheckpoint =>
         assert(actionsToCommit.isEmpty,
           s"OPTIMIZE checkpoint commit must carry no actions, got ${actionsToCommit.size}.")
+        // An incremental rewrite must extend an existing tree, so the first AMT is always a full
+        // rewrite even when the trigger requested incremental (e.g. the JSON-size threshold).
+        val incremental =
+          optimize.incremental && AMTWriteHelper.previousAMTContentRoot(readSnapshot).isDefined
         Some(materialize(
           commitVersion, currentTransactionInfo,
-          incremental = optimize.incremental, trigger = optimize.triggerName))
+          incremental = incremental, trigger = optimize.triggerName))
       case _ if shouldDoInlineIncrementalCheckpoint(actionsToCommit) =>
         // A large business commit rebuilds its manifest tree inline (incrementally).
         val mode = AMTTriggerMode.InlineWithLargeCommitIncremental
@@ -127,11 +132,13 @@ class AMTWriterManager(
   }
 
   /**
-   * Whether this business commit is large enough (by action count) to write its
-   * changed actions as part of new AMT.
+   * Whether this Writer should write its changed actions inline as part of a new AMT.
+   * True only when the commit is large enough (by action count) AND the table already has a full
+   * AMT to build on.
    */
   private def shouldDoInlineIncrementalCheckpoint(actionsToCommit: Seq[Action]): Boolean =
-    actionsToCommit.size.toLong >= largeCommitActionsCountThresholdForInlineManifestCommit
+    actionsToCommit.size.toLong >= largeCommitActionsCountThresholdForInlineManifestCommit &&
+      AMTWriteHelper.previousAMTContentRoot(readSnapshot).isDefined
 
   // Materializes the manifest tree for this commit and records its metrics. An incremental rewrite
   // packs the post-commit live files into leaves in input order on the driver; a full rewrite
@@ -189,6 +196,39 @@ class AMTWriterManager(
     MaintenanceOperation(
       shouldCheckpoint = amtTriggerModeOpt.isDefined,
       amtTriggerModeOpt = amtTriggerModeOpt)
+  }
+
+  /**
+   * The maintenance work to schedule after a large commit wrote its AMT inline.
+   *
+   * An inline write is always incremental. If a table keeps getting inline AMTs, we still want it
+   * to get a full AMT once in a while when the last full AMT was older than
+   * checkpointInterval * fullRewriteCheckpointIntervalMultiplier.
+   */
+  def planMaintenanceAfterInlineWrite(
+      commitVersion: Long,
+      postCommitSnapshot: Snapshot): MaintenanceOperation = {
+    // The follow-up OPTIMIZE CHECKPOINT commit itself must never schedule more maintenance.
+    if (!amtEnabled(commitVersion)
+        || initialOperation.isInstanceOf[DeltaOperations.OptimizeCheckpoint]) {
+      return MaintenanceOperation()
+    }
+    val checkpointInterval = deltaLog.checkpointInterval(postCommitSnapshot.metadata)
+    val fullRewriteSpan = checkpointInterval.toLong * fullRewriteCheckpointIntervalMultiplier
+    val scheduleFull = AMTWriteHelper.previousAMTContentRoot(postCommitSnapshot)
+      .flatMap(_.lastManifestCommitWithFullRewrite)
+      .exists { lastFull =>
+        val versionsSinceFull = commitVersion - lastFull
+        versionsSinceFull > 0 && versionsSinceFull % checkpointInterval == 0 &&
+          versionsSinceFull >= fullRewriteSpan
+      }
+    if (scheduleFull) {
+      MaintenanceOperation(
+        shouldCheckpoint = true,
+        amtTriggerModeOpt = Some(AMTTriggerMode.CheckpointIntervalFull))
+    } else {
+      MaintenanceOperation()
+    }
   }
 
   /** [[AMTTriggerMode]] for a followup AMT Checkpoint commit if any. */

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointPolicySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointPolicySuite.scala
@@ -50,7 +50,11 @@ class AMTCheckpointPolicySuite extends AMTCheckpointTestBase {
   }
 
   /** The trigger name recorded in the AMT write metrics of the commit `f` produces at `version`. */
-  private def amtTriggerNameAt(f: => Unit, version: Long): String = {
+  private def amtTriggerNameAt(f: => Unit, version: Long): String =
+    amtWriteMetricsAt(f, version).trigger
+
+  /** The AMT write metrics logged for the commit `f` produces at `version`. */
+  private def amtWriteMetricsAt(f: => Unit, version: Long): SingleAMTWriteMetrics = {
     Log4jUsageLogger.track(f)
       .filter(e => e.metric == MetricDefinitions.EVENT_TAHOE.name &&
         e.tags.get("opType").contains("delta.commit.stats"))
@@ -58,7 +62,6 @@ class AMTCheckpointPolicySuite extends AMTCheckpointTestBase {
       .find(_.commitVersion == version)
       .flatMap(_.amtWriteMetrics)
       .flatMap(_.attempts.headOption)
-      .map(_.trigger)
       .getOrElse(fail(s"No AMT write metrics logged for version $version."))
   }
 
@@ -234,6 +237,74 @@ class AMTCheckpointPolicySuite extends AMTCheckpointTestBase {
         ExpectedCheckpoint(12, 13, incremental = true, lastFullRewrite = 8),
         ExpectedCheckpoint(14, 15, incremental = false, lastFullRewrite = 14),
         ExpectedCheckpoint(16, 17, incremental = true, lastFullRewrite = 14)))
+    }
+  }
+
+  test("a large commit does not write AMT inline until a full AMT already exists") {
+    withTable("amt_inline_needs_full") {
+      val name = "amt_inline_needs_full"
+      // Threshold 1 so every commit is "large" enough to inline. Interval 2.
+      createAMTTable(name, checkpointInterval = 2)
+      withSQLConf(
+          DeltaSQLConf.AMT_LARGE_COMMIT_ACTIONS_COUNT_THRESHOLD_FOR_INLINE_MANIFEST_COMMIT.key
+            -> "1") {
+        // v1 is the first commit: no prior AMT, so it must NOT inline even though it is "large".
+        sql(s"INSERT INTO $name VALUES (1)")
+        val deltaLog = deltaLogForName(name)
+        assert(checkpointsAt(deltaLog, 1).isEmpty,
+          "The first large commit must not write an AMT inline (no full AMT exists yet).")
+
+        // v2 is the interval boundary: the first (full) AMT is emitted via the deferred follow-up
+        // OPTIMIZE CHECKPOINT commit at v3, not inline in v2.
+        sql(s"INSERT INTO $name VALUES (2)")
+        assert(checkpointsAt(deltaLog, 2).isEmpty, "v2 must not write an AMT inline.")
+        assert(deltaLog.update().version == 3, "The first full AMT lands as a follow-up at v3.")
+        assert(checkpointAt(deltaLog, 3).contentRoot.isIncremental.contains(false),
+          "The first AMT is a full rewrite.")
+
+        // Now a full AMT exists. The next large commit (v4) writes its AMT inline (incrementally).
+        val v4Metrics = amtWriteMetricsAt(sql(s"INSERT INTO $name VALUES (3)"), version = 4)
+        assert(v4Metrics.trigger == AMTTriggerMode.InlineWithLargeCommitIncremental.name,
+          s"Once a full AMT exists, a large commit inlines its AMT; got ${v4Metrics.trigger}")
+        assert(v4Metrics.incremental == "true",
+          "The usage log must report incremental=true for the inline AMT write.")
+        assert(checkpointAt(deltaLog, 4).contentRoot.isIncremental.contains(true),
+          "The inline AMT is incremental.")
+      }
+    }
+  }
+
+  test("a full rewrite follows up when inline writes cross the full-rewrite span") {
+    withTable("amt_inline_full_followup") {
+      val name = "amt_inline_full_followup"
+      // Interval 2, multiplier 2 -> fullRewriteSpan = 4. Threshold 1 so every large commit inlines
+      // once a full AMT exists. The first full AMT is the deferred follow-up; subsequent large
+      // commits inline incrementally, and when an inline commit lands a full span past the last
+      // full rewrite a follow-up full OPTIMIZE CHECKPOINT commit is scheduled.
+      createAMTTable(name, checkpointInterval = 2)
+      val deltaLog = deltaLogForName(name)
+      withSQLConf(
+          DeltaSQLConf.AMT_FULL_REWRITE_CHECKPOINT_INTERVAL_MULTIPLIER.key -> "2",
+          DeltaSQLConf.AMT_LARGE_COMMIT_ACTIONS_COUNT_THRESHOLD_FOR_INLINE_MANIFEST_COMMIT.key
+            -> "1") {
+        (1 to 8).foreach(i => sql(s"INSERT INTO $name VALUES ($i)"))
+      }
+      // At least one full rewrite lands after the first, driven by the inline-triggered follow-up,
+      // and it correctly advances the last-full-rewrite marker.
+      val checkpoints = allCheckpoints(deltaLog)
+      val fulls = checkpoints.filter(_.contentRoot.isIncremental.contains(false))
+      assert(fulls.size >= 2,
+        s"Expected a follow-up full rewrite after inline writes crossed the span; got " +
+          s"${checkpoints.map(cp => (cp.version, cp.contentRoot.isIncremental))}.")
+      // Every full rewrite is at least a span past the previous one (anchored, not per-commit).
+      val fullRewriteSpan = 2 * 2
+      fulls.map(_.version).sliding(2).foreach {
+        case Seq(prev, next) =>
+          assert(next - prev >= fullRewriteSpan,
+            s"Full rewrite at v$next is only ${next - prev} versions after v$prev (span " +
+              s"$fullRewriteSpan).")
+        case _ => ()
+      }
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointWriteSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointWriteSuite.scala
@@ -277,20 +277,31 @@ class AMTCheckpointWriteSuite extends AMTCheckpointTestBase {
   test("leaf cardinality respects AMT_ENTRIES_PER_LEAF") {
     withTable("amt_entries_per_leaf") {
       val name = "amt_entries_per_leaf"
-      // Interval far away so no automatic checkpoint fires; we drive the incremental rewrite
-      // directly. The exact-leaf-count guarantee is a property of the incremental path, which
-      // packs the live files into leaves in input order (grouped by AMT_ENTRIES_PER_LEAF). The
-      // clustered full-rewrite path repartitions by hash and does not guarantee a leaf per group.
+      // Interval far away so no automatic checkpoint fires; we drive the rewrite directly. With no
+      // prior AMT tree, the rewrite clusters the live files across ceil(numFiles / entriesPerLeaf)
+      // leaves, distributing them by hash. The clustered path does not guarantee a leaf per
+      // contiguous group, but it targets exactly that many leaves and drops empty partitions -- so
+      // with enough files per leaf that no hash bucket comes out empty, the leaf count lands on the
+      // target. 21 files at 7 per leaf targets 3 leaves, and 21 paths spread across 3 buckets leave
+      // none empty.
       createAMTTable(name, checkpointInterval = 100)
-      sql(s"INSERT INTO $name VALUES (1)") // v1: one data file.
-      sql(s"INSERT INTO $name VALUES (2)") // v2: one more data file -> 2 live files.
+      // One commit of 21 rows, one row per file (maxRecordsPerFile = 1), so a single INSERT lands
+      // 21 live data files. optimizeWrite is disabled so it does not coalesce them back.
+      withSQLConf(
+          "spark.sql.files.maxRecordsPerFile" -> "1",
+          DeltaSQLConf.DELTA_OPTIMIZE_WRITE_ENABLED.key -> "false") {
+        sql(s"INSERT INTO $name SELECT * FROM range(21)")
+      }
+      val deltaLog = deltaLogForName(name)
+      assert(deltaLog.update().allFiles.count() == 21,
+        s"Expected 21 live files, got ${deltaLog.update().allFiles.count()}.")
 
-      withSQLConf(DeltaSQLConf.AMT_ENTRIES_PER_LEAF.key -> "1") {
+      withSQLConf(DeltaSQLConf.AMT_ENTRIES_PER_LEAF.key -> "7") {
         runIncrementalRewrite(name)
       }
       val path = tablePath(name)
-      // Two live AddFiles, one per leaf -> two leaves, one root.
-      assert(leafFiles(path).size == 2, s"Expected 2 leaves, got ${leafFiles(path).size}.")
+      // 21 live AddFiles, ceil(21 / 7) = 3 leaves (none empty), one root.
+      assert(leafFiles(path).size == 3, s"Expected 3 leaves, got ${leafFiles(path).size}.")
       assert(rootFiles(path).size == 1)
     }
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotDiscoverySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotDiscoverySuite.scala
@@ -17,6 +17,7 @@
 package org.apache.spark.sql.delta.amt
 
 import org.apache.spark.sql.delta.Snapshot
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.FileNames
 
 class AMTSnapshotDiscoverySuite extends AMTCheckpointTestBase {
@@ -33,17 +34,16 @@ class AMTSnapshotDiscoverySuite extends AMTCheckpointTestBase {
   // Post commit snapshot
   ///////////////////////////
 
-  testInlineAndDeferred("emission installs an AMTCheckpointProvider on the post-commit snapshot") {
-    mode =>
+  test("emission installs an AMTCheckpointProvider on the post-commit snapshot") {
     withTable("amt_provider_install") {
       val name = "amt_provider_install"
       createAMTTable(name, checkpointInterval = 2)
       sql(s"INSERT INTO $name VALUES (1)")
       sql(s"INSERT INTO $name VALUES (2)") // v2: interval boundary.
-      // Inline: the AMT rides in the v2 business commit (checkpointVersion == 2).
-      // Deferred: a follow-up OPTIMIZE CHECKPOINT commit lands at v3 describing state as of v2.
+      // The first AMT is always a deferred follow-up OPTIMIZE CHECKPOINT commit: it lands at v3
+      // describing state as of v2 (the first, full AMT can never be inline).
       val checkpointVersion = 2L
-      val snapshotVersion = checkpointVersion + mode.followUpCommits
+      val snapshotVersion = 3L
 
       val deltaLog = deltaLogForName(name)
       val snapshot = deltaLog.unsafeVolatileSnapshot
@@ -54,19 +54,34 @@ class AMTSnapshotDiscoverySuite extends AMTCheckpointTestBase {
       assert(provider.get.checkpointAction.contentRoot.path ==
         checkpointsAt(deltaLog, snapshotVersion).head.contentRoot.path)
       assert(provider.get.leaves.nonEmpty, "Provider must list the tree's leaves.")
+
+      // Now that a full AMT exists, force an inline AMT commit and assert the provider installs
+      // from that business commit itself (no follow-up commit). Threshold 1 makes v4 inline.
+      withSQLConf(
+          DeltaSQLConf.AMT_LARGE_COMMIT_ACTIONS_COUNT_THRESHOLD_FOR_INLINE_MANIFEST_COMMIT.key
+            -> "1") {
+        sql(s"INSERT INTO $name VALUES (3)") // v4: inline AMT, no follow-up.
+      }
+      val inlineSnapshot = deltaLog.unsafeVolatileSnapshot
+      assert(inlineSnapshot.version == 4L, "The inline AMT rides in the v4 business commit.")
+      val inlineProvider = amtProvider(inlineSnapshot).getOrElse(
+        fail("The inline-emission snapshot must expose an AMTCheckpointProvider."))
+      assert(inlineProvider.checkpointVersion == 4L, "The inline Checkpoint describes v4.")
+      assert(inlineProvider.checkpointAction.contentRoot.path ==
+        checkpointsAt(deltaLog, 4L).head.contentRoot.path)
+      assert(inlineProvider.leaves.nonEmpty, "Provider must list the tree's leaves.")
     }
   }
 
-  testInlineAndDeferred("an emitted AMT installs the provider and trims the log segment") { mode =>
+  test("an emitted AMT installs the provider and trims the log segment") {
     withTable("amt_log_segment") {
       val name = "amt_log_segment"
       createAMTTable(name, checkpointInterval = 3)
-      // The interval boundary is v3. Inline: the AMT rides in the v3 business commit. Deferred: a
-      // follow-up OPTIMIZE CHECKPOINT commit lands at v4 describing state as of v3. Either way the
-      // Checkpoint describes state as of v3, and the log segment trims to deltas after v3.
+      // The interval boundary is v3; the first AMT is a deferred follow-up OPTIMIZE CHECKPOINT
+      // commit at v4 describing state as of v3, and the log segment trims to deltas after v3.
       (1 to 3).foreach(i => sql(s"INSERT INTO $name VALUES ($i)"))
       val checkpointVersion = 3L
-      val snapshotVersion = checkpointVersion + mode.followUpCommits
+      val snapshotVersion = 4L
 
       val deltaLog = deltaLogForName(name)
       val snapshot = deltaLog.unsafeVolatileSnapshot
@@ -79,6 +94,23 @@ class AMTSnapshotDiscoverySuite extends AMTCheckpointTestBase {
       val segmentDeltaVersions = snapshot.logSegment.deltas.map(f => FileNames.deltaVersion(f))
       assert(segmentDeltaVersions.forall(_ > checkpointVersion),
         s"Log segment must trim deltas up to the checkpoint version; got $segmentDeltaVersions.")
+
+      // Now that a full AMT exists, force an inline AMT commit and assert the same install + trim
+      // behavior when the Checkpoint rides in the business commit. Threshold 1 makes v5 inline.
+      withSQLConf(
+          DeltaSQLConf.AMT_LARGE_COMMIT_ACTIONS_COUNT_THRESHOLD_FOR_INLINE_MANIFEST_COMMIT.key
+            -> "1") {
+        sql(s"INSERT INTO $name VALUES (4)") // v5: inline AMT, no follow-up.
+      }
+      val inlineSnapshot = deltaLog.unsafeVolatileSnapshot
+      assert(inlineSnapshot.version == 5L, "The inline AMT rides in the v5 business commit.")
+      val inlineProvider = amtProvider(inlineSnapshot).getOrElse(
+        fail("The inline-emission snapshot must expose an AMTCheckpointProvider."))
+      assert(inlineProvider.checkpointVersion == 5L, "The inline Checkpoint describes v5.")
+      val inlineDeltaVersions = inlineSnapshot.logSegment.deltas.map(f => FileNames.deltaVersion(f))
+      assert(inlineDeltaVersions.forall(_ > 5L),
+        s"Log segment must trim deltas up to the inline checkpoint version; got " +
+          s"$inlineDeltaVersions.")
     }
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/SnapshotLastManifestCommitSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/SnapshotLastManifestCommitSuite.scala
@@ -185,19 +185,26 @@ class SnapshotLastManifestCommitWithoutCRCSuite extends SnapshotLastManifestComm
     withTable("amt_lmc_fallback") {
       val name = "amt_lmc_fallback"
       createAMTTable(name, checkpointInterval = 2)
-      sql(s"INSERT INTO $name VALUES (1)")
-      sql(s"INSERT INTO $name VALUES (2)") // v2: emit; carries the inline checkpoint action.
+      // The first AMT is always a full, deferred rewrite (an inline write is incremental and needs
+      // a full tree to build on). v2 is the interval boundary, so the first (full) AMT lands as a
+      // follow-up OPTIMIZE CHECKPOINT commit at v3. v4 is the next interval boundary and, now that
+      // a full tree exists, carries its AMT checkpoint action inline (this suite forces inline via
+      // a threshold of 1). This test needs an inline checkpoint action to build the provider from,
+      // so it uses v4.
+      sql(s"INSERT INTO $name VALUES (1)") // v1.
+      sql(s"INSERT INTO $name VALUES (2)") // v2: boundary -> deferred full AMT follow-up at v3.
+      sql(s"INSERT INTO $name VALUES (3)") // v4: boundary -> inline AMT checkpoint action.
 
       val deltaLog = deltaLogForName(name)
-      injectLmc(deltaLog, version = 2, lmc = Some(lmc))
+      injectLmc(deltaLog, version = 4, lmc = Some(lmc))
 
-      // Build the AMT provider from v2's emitted checkpoint action and stub it into a fresh
+      // Build the AMT provider from v4's emitted inline checkpoint action and stub it into a fresh
       // snapshot's log segment, trimming the version's delta as cold discovery eventually will.
-      val checkpoint = checkpointsAt(deltaLog, 2).headOption.getOrElse {
-        fail("v2 must emit an inline AMT checkpoint action.")
+      val checkpoint = checkpointsAt(deltaLog, 4).headOption.getOrElse {
+        fail("v4 must emit an inline AMT checkpoint action.")
       }
       val provider = AMTCheckpointProvider.fromCheckpoint(spark, deltaLog, checkpoint)
-      val coldSnapshot = freshSnapshotAt(name, 2)
+      val coldSnapshot = freshSnapshotAt(name, 4)
       val segment = coldSnapshot.logSegment.copy(checkpointProvider = provider, deltas = Nil)
       val snapshot = new Snapshot(
         path = coldSnapshot.path,


### PR DESCRIPTION
## Description

An inline adaptive metadata (AMT) manifest-tree write is always incremental. Without any
additional handling, a table whose commits are consistently large enough to write their manifest
tree inline would never produce a full rewrite, so the tree would grow without ever being
re-materialized.

This change keeps the full-vs-incremental rewrite cadence alive across inline writes:

- A commit only writes its manifest tree inline once a full tree already exists for the table. An
  incremental rewrite must extend an existing tree, so the first (full) tree is always materialized
  through the deferred follow-up `OPTIMIZE CHECKPOINT` path before any inline write is allowed.
- After an inline write, a follow-up full `OPTIMIZE CHECKPOINT` commit is scheduled once the last
  full rewrite is older than the checkpoint interval times the full-rewrite multiplier. The check is
  gated on the checkpoint-interval boundary so racing commits just past a boundary do not each
  re-schedule, and it retries at each interval boundary past the span so a full is not skipped when
  the exact boundary version happens to be a small commit.

## How was this patch tested?

Extended the adaptive-metadata checkpoint-policy suite with tests asserting that a large commit does
not write inline until a full tree exists, and that a follow-up full rewrite is scheduled once inline
writes cross the full-rewrite span (with each full at least a span apart). The snapshot-discovery
suite also now covers provider install / log-segment trim for an inline emission.

## Does this PR introduce _any_ user-facing change?

No.
