### PR TITLE
[Spark] Replace deprecated input_file_name() with _metadata.file_path

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
@@ -484,9 +484,19 @@ object DeltaTableUtils extends PredicateHelper
    * test failure rather than as a user visible one: the batch runs once outside tests and the plan
    * it produces is correct. Disabling nested pruning here avoids depending on an optimizer result
    * that Spark itself reports as invalid, at the cost of not pruning nested fields for this one
-   * query. It is limited to conditions that reference a variant column, and should be removed once
-   * Spark makes nested schema pruning idempotent for this plan shape, tracked in
-   * https://github.com/apache/spark/issues/57659.
+   * query. It is limited to conditions that reference a variant column.
+   *
+   * Spark fixed this in SPARK-59171 by running `SchemaPruning` after `PushVariantIntoScan` in
+   * `SparkOptimizer.earlyScanPushDownRules`. That fix is only on Spark master: every Spark version
+   * this repo builds against (see `CrossSparkVersions.ALL_SPECS`) still orders `SchemaPruning`
+   * before `PushVariantIntoScan` and therefore still needs this workaround.
+   *
+   * When a Spark version containing SPARK-59171 is added, make this a no-op for that version
+   * rather than deleting it, since the older versions remain supported. Follow the shim pattern
+   * used elsewhere for cross-version differences (e.g. `VariantShreddingShims`): add a
+   * `needsVariantPruningWorkaround` shim returning `false` under the new version's
+   * `scala-shims/spark-X.Y` directory and `true` for the existing ones, then short-circuit here.
+   * This helper can be dropped entirely once no supported version predates the fix.
    */
   def withNestedSchemaPruningDisabledForVariant[T](
       spark: SparkSession,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
@@ -469,7 +469,7 @@ object DeltaTableUtils extends PredicateHelper
   }
 
   /**
-   * Runs `thunk` with nested schema pruning disabled when `schema` contains a variant column.
+   * Runs `thunk` with nested schema pruning disabled when `condition` references a variant column.
    *
    * Spark's "Early Filter and Projection Push-Down" batch is not idempotent when a scan requests
    * the file source metadata column while a shredded variant column is only referenced by a
@@ -484,14 +484,17 @@ object DeltaTableUtils extends PredicateHelper
    * test failure rather than as a user visible one: the batch runs once outside tests and the plan
    * it produces is correct. Disabling nested pruning here avoids depending on an optimizer result
    * that Spark itself reports as invalid, at the cost of not pruning nested fields for this one
-   * query. It is limited to variant tables, and should be removed once Spark makes nested schema
-   * pruning idempotent for this plan shape, tracked in
+   * query. It is limited to conditions that reference a variant column, and should be removed once
+   * Spark makes nested schema pruning idempotent for this plan shape, tracked in
    * https://github.com/apache/spark/issues/57659.
    */
   def withNestedSchemaPruningDisabledForVariant[T](
       spark: SparkSession,
-      schema: StructType)(thunk: => T): T = {
-    if (!SchemaUtils.checkForVariantTypeColumnsRecursively(schema)) {
+      condition: Expression)(thunk: => T): T = {
+    val referencesVariant = condition.references.exists { attr =>
+      SchemaUtils.typeExistsRecursively(attr.dataType)(_.isInstanceOf[VariantType])
+    }
+    if (!referencesVariant) {
       thunk
     } else {
       val newConf = spark.sessionState.conf.copy(SQLConf.NESTED_SCHEMA_PRUNING_ENABLED -> false)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
@@ -23,6 +23,7 @@ import scala.util.control.NonFatal
 import org.apache.spark.sql.delta.files.{TahoeFileIndex, TahoeLogFileIndex}
 import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.metering.{DeltaLogging, LogThrottler}
+import org.apache.spark.sql.delta.schema.SchemaUtils
 import org.apache.spark.sql.delta.skipping.clustering.temp.{ClusterByTransform => TempClusterByTransform}
 import org.apache.spark.sql.delta.sources.{DeltaSourceUtils, DeltaSQLConf}
 import org.apache.hadoop.fs.{FileSystem, Path}
@@ -465,6 +466,37 @@ object DeltaTableUtils extends PredicateHelper
         "Could not find a file source relation to add the file metadata column to.")
     }
     (newTarget, fileMetadataCol)
+  }
+
+  /**
+   * Runs `thunk` with nested schema pruning disabled when `schema` contains a variant column.
+   *
+   * Spark's "Early Filter and Projection Push-Down" batch is not idempotent when a scan requests
+   * the file source metadata column while a shredded variant column is only referenced by a
+   * filter that gets pushed below the variant reconstruction projection. That leaves the
+   * projection unused, and nested schema pruning only removes it on a second application of the
+   * batch.
+   *
+   * Finding the files to rewrite is exactly that shape: it reads `_metadata.file_path` and
+   * outputs nothing else.
+   *
+   * Note that `RuleExecutor` only checks idempotence when `Utils.isTesting`, so this surfaces as a
+   * test failure rather than as a user visible one: the batch runs once outside tests and the plan
+   * it produces is correct. Disabling nested pruning here avoids depending on an optimizer result
+   * that Spark itself reports as invalid, at the cost of not pruning nested fields for this one
+   * query. It is limited to variant tables, and should be removed once Spark makes nested schema
+   * pruning idempotent for this plan shape, tracked in
+   * https://github.com/apache/spark/issues/57659.
+   */
+  def withNestedSchemaPruningDisabledForVariant[T](
+      spark: SparkSession,
+      schema: StructType)(thunk: => T): T = {
+    if (!SchemaUtils.checkForVariantTypeColumnsRecursively(schema)) {
+      thunk
+    } else {
+      val newConf = spark.sessionState.conf.copy(SQLConf.NESTED_SCHEMA_PRUNING_ENABLED -> false)
+      SQLConf.withExistingConf(newConf)(thunk)
+    }
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
@@ -421,6 +421,53 @@ object DeltaTableUtils extends PredicateHelper
   }
 
   /**
+   * Add the file source metadata column to the output of `target`, and return the updated plan
+   * together with the attribute referencing the added column.
+   *
+   * Commands such as UPDATE/DELETE/MERGE read `_metadata.file_path` to identify the files that
+   * need to be rewritten. That column cannot be looked up by name on the resulting DataFrame:
+   * views don't expose metadata columns, so resolving `_metadata` fails whenever the command
+   * targets a view. Instead we add the column to the scan and thread it through the projections
+   * above it, so it can be referenced directly by its attribute.
+   *
+   * This follows the same approach that `DMLWithDeletionVectorsHelper.replaceFileIndex` already
+   * uses to request the metadata column for the deletion vector code paths, which is why those
+   * paths work on views today. The difference is that this only adds the column, leaving the file
+   * index untouched, and that it renames the column on conflict.
+   *
+   * @param target the logical plan to add the file source metadata column to
+   */
+  def addFileMetadataColumn(target: LogicalPlan): (LogicalPlan, AttributeReference) = {
+    var fileMetadataCol: AttributeReference = null
+
+    val newTarget = target transformUp {
+      case l @ LogicalRelationWithTable(hfsr: HadoopFsRelation, _) =>
+        val metadataCol = hfsr.fileFormat.createFileMetadataCol()
+        // Rename the added column when the table has a data column with the same name, so that
+        // references to that data column stay unambiguous. Renaming is safe because we reference
+        // the added column by its attribute rather than by name, and because the logical name
+        // that identifies it as the file source metadata column is kept in its metadata.
+        var name = metadataCol.name
+        while (l.output.exists(_.name.equalsIgnoreCase(name))) {
+          name = s"_$name"
+        }
+        fileMetadataCol = metadataCol.withName(name)
+        l.copy(output = l.output :+ fileMetadataCol)
+      case p @ Project(projectList, _) =>
+        if (fileMetadataCol == null) {
+          throw new IllegalStateException("File metadata column is not yet created.")
+        }
+        p.copy(projectList = projectList :+ fileMetadataCol)
+    }
+
+    if (fileMetadataCol == null) {
+      throw new IllegalStateException(
+        "Could not find a file source relation to add the file metadata column to.")
+    }
+    (newTarget, fileMetadataCol)
+  }
+
+  /**
    * Transform the file format in a logical plan and return the updated plan.
    *
    * @param target the logical plan in which the file format is replaced.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/ConvertToDeltaCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/ConvertToDeltaCommand.scala
@@ -498,6 +498,9 @@ object ConvertToDeltaCommand extends DeltaLogging {
       addFiles: Seq[AddFile]): Iterator[AddFile] = {
     import org.apache.spark.sql.functions._
     val filesDF = deltaLog.createDataFrame(snapshot, addFiles)
+    // Unlike UPDATE/DELETE/MERGE, which run against the resolved target and therefore have to add
+    // the metadata column to the plan, this DataFrame is built directly from the transaction log.
+    // It can never be a view, so the metadata column is always resolvable by name here.
     val filesWithStats = filesDF
       .groupBy(DeltaTableUtils.getFileMetadataColumn(filesDF).getField(FILE_PATH))
       .agg(to_json(snapshot.statsCollector))

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/ConvertToDeltaCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/ConvertToDeltaCommand.scala
@@ -43,7 +43,7 @@ import org.apache.spark.sql.catalyst.analysis.{Analyzer, NoSuchTableException}
 import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogTableType, SessionCatalog}
 import org.apache.spark.sql.connector.catalog.{Identifier, TableCatalog, V1Table}
 import org.apache.spark.sql.execution.command.LeafRunnableCommand
-import org.apache.spark.sql.execution.datasources.FileFormat.{FILE_PATH, METADATA_NAME}
+import org.apache.spark.sql.execution.datasources.FileFormat.FILE_PATH
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.types.StructType
 
@@ -492,8 +492,10 @@ object ConvertToDeltaCommand extends DeltaLogging {
       snapshot: Snapshot,
       addFiles: Seq[AddFile]): Iterator[AddFile] = {
     import org.apache.spark.sql.functions._
-    val filesWithStats = deltaLog.createDataFrame(snapshot, addFiles)
-      .groupBy(col(s"${METADATA_NAME}.${FILE_PATH}")).agg(to_json(snapshot.statsCollector))
+    val filesDF = deltaLog.createDataFrame(snapshot, addFiles)
+    val filesWithStats = filesDF
+      .groupBy(DeltaTableUtils.getFileMetadataColumn(filesDF).getField(FILE_PATH))
+      .agg(to_json(snapshot.statsCollector))
 
     val pathToAddFileMap = generateCandidateFileMap(deltaLog.dataPath, addFiles)
     filesWithStats.collect().iterator.map { row =>

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/ConvertToDeltaCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/ConvertToDeltaCommand.scala
@@ -493,6 +493,9 @@ object ConvertToDeltaCommand extends DeltaLogging {
       addFiles: Seq[AddFile]): Iterator[AddFile] = {
     import org.apache.spark.sql.functions._
     val filesDF = deltaLog.createDataFrame(snapshot, addFiles)
+    // Unlike UPDATE/DELETE/MERGE, which run against the resolved target and therefore have to add
+    // the metadata column to the plan, this DataFrame is built directly from the transaction log.
+    // It can never be a view, so the metadata column is always resolvable by name here.
     val filesWithStats = filesDF
       .groupBy(DeltaTableUtils.getFileMetadataColumn(filesDF).getField(FILE_PATH))
       .agg(to_json(snapshot.statsCollector))

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/ConvertToDeltaCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/ConvertToDeltaCommand.scala
@@ -43,6 +43,7 @@ import org.apache.spark.sql.catalyst.analysis.{Analyzer, NoSuchTableException}
 import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogTableType, SessionCatalog}
 import org.apache.spark.sql.connector.catalog.{Identifier, TableCatalog, V1Table}
 import org.apache.spark.sql.execution.command.LeafRunnableCommand
+import org.apache.spark.sql.execution.datasources.FileFormat.{FILE_PATH, METADATA_NAME}
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.types.StructType
 
@@ -497,7 +498,7 @@ object ConvertToDeltaCommand extends DeltaLogging {
       addFiles: Seq[AddFile]): Iterator[AddFile] = {
     import org.apache.spark.sql.functions._
     val filesWithStats = deltaLog.createDataFrame(snapshot, addFiles)
-      .groupBy(input_file_name()).agg(to_json(snapshot.statsCollector))
+      .groupBy(col(s"${METADATA_NAME}.${FILE_PATH}")).agg(to_json(snapshot.statsCollector))
 
     val pathToAddFileMap = generateCandidateFileMap(deltaLog.dataPath, addFiles)
     filesWithStats.collect().iterator.map { row =>

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/ConvertToDeltaCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/ConvertToDeltaCommand.scala
@@ -43,6 +43,7 @@ import org.apache.spark.sql.catalyst.analysis.{Analyzer, NoSuchTableException}
 import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogTableType, SessionCatalog}
 import org.apache.spark.sql.connector.catalog.{Identifier, TableCatalog, V1Table}
 import org.apache.spark.sql.execution.command.LeafRunnableCommand
+import org.apache.spark.sql.execution.datasources.FileFormat.{FILE_PATH, METADATA_NAME}
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.types.StructType
 
@@ -492,7 +493,7 @@ object ConvertToDeltaCommand extends DeltaLogging {
       addFiles: Seq[AddFile]): Iterator[AddFile] = {
     import org.apache.spark.sql.functions._
     val filesWithStats = deltaLog.createDataFrame(snapshot, addFiles)
-      .groupBy(input_file_name()).agg(to_json(snapshot.statsCollector))
+      .groupBy(col(s"${METADATA_NAME}.${FILE_PATH}")).agg(to_json(snapshot.statsCollector))
 
     val pathToAddFileMap = generateCandidateFileMap(deltaLog.dataPath, addFiles)
     filesWithStats.collect().iterator.map { row =>

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/ConvertToDeltaCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/ConvertToDeltaCommand.scala
@@ -43,7 +43,7 @@ import org.apache.spark.sql.catalyst.analysis.{Analyzer, NoSuchTableException}
 import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogTableType, SessionCatalog}
 import org.apache.spark.sql.connector.catalog.{Identifier, TableCatalog, V1Table}
 import org.apache.spark.sql.execution.command.LeafRunnableCommand
-import org.apache.spark.sql.execution.datasources.FileFormat.{FILE_PATH, METADATA_NAME}
+import org.apache.spark.sql.execution.datasources.FileFormat.FILE_PATH
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.types.StructType
 
@@ -497,8 +497,10 @@ object ConvertToDeltaCommand extends DeltaLogging {
       snapshot: Snapshot,
       addFiles: Seq[AddFile]): Iterator[AddFile] = {
     import org.apache.spark.sql.functions._
-    val filesWithStats = deltaLog.createDataFrame(snapshot, addFiles)
-      .groupBy(col(s"${METADATA_NAME}.${FILE_PATH}")).agg(to_json(snapshot.statsCollector))
+    val filesDF = deltaLog.createDataFrame(snapshot, addFiles)
+    val filesWithStats = filesDF
+      .groupBy(DeltaTableUtils.getFileMetadataColumn(filesDF).getField(FILE_PATH))
+      .agg(to_json(snapshot.statsCollector))
 
     val pathToAddFileMap = generateCandidateFileMap(deltaLog.dataPath, addFiles)
     filesWithStats.collect().iterator.map { row =>

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
@@ -315,7 +315,9 @@ case class DeleteCommand(
             // Keep everything from the resolved target except a new TahoeFileIndex
             // that only involves the affected files instead of all files.
             val newTarget = DeltaTableUtils.replaceFileIndex(target, fileIndex)
-            val data = DataFrameUtils.ofRows(sparkSession, newTarget)
+            val (newTargetWithFileMetadata, fileMetadataCol) =
+              DeltaTableUtils.addFileMetadataColumn(newTarget)
+            val data = DataFrameUtils.ofRows(sparkSession, newTargetWithFileMetadata)
             val incrDeletedCountExpr = IncrementMetric(TrueLiteral, metrics("numDeletedRows"))
             val filesToRewrite =
               withStatusCode("DELTA", FINDING_TOUCHED_FILES_MSG) {
@@ -323,7 +325,7 @@ case class DeleteCommand(
                   Array.empty[String]
                 } else {
                   data.filter(Column(cond))
-                    .select(DeltaTableUtils.getFileMetadataColumn(data).getField(FILE_PATH))
+                    .select(Column(fileMetadataCol).getField(FILE_PATH))
                     .filter(Column(incrDeletedCountExpr))
                     .distinct()
                     .as[String]

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
@@ -325,7 +325,7 @@ case class DeleteCommand(
                   Array.empty[String]
                 } else {
                   DeltaTableUtils.withNestedSchemaPruningDisabledForVariant(
-                      sparkSession, txn.metadata.schema) {
+                      sparkSession, cond) {
                     data.filter(Column(cond))
                       .select(Column(fileMetadataCol).getField(FILE_PATH))
                       .filter(Column(incrDeletedCountExpr))

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
@@ -314,7 +314,9 @@ case class DeleteCommand(
             // Keep everything from the resolved target except a new TahoeFileIndex
             // that only involves the affected files instead of all files.
             val newTarget = DeltaTableUtils.replaceFileIndex(target, fileIndex)
-            val data = DataFrameUtils.ofRows(sparkSession, newTarget)
+            val (newTargetWithFileMetadata, fileMetadataCol) =
+              DeltaTableUtils.addFileMetadataColumn(newTarget)
+            val data = DataFrameUtils.ofRows(sparkSession, newTargetWithFileMetadata)
             val incrDeletedCountExpr = IncrementMetric(TrueLiteral, metrics("numDeletedRows"))
             val filesToRewrite =
               withStatusCode("DELTA", FINDING_TOUCHED_FILES_MSG) {
@@ -322,7 +324,7 @@ case class DeleteCommand(
                   Array.empty[String]
                 } else {
                   data.filter(Column(cond))
-                    .select(DeltaTableUtils.getFileMetadataColumn(data).getField(FILE_PATH))
+                    .select(Column(fileMetadataCol).getField(FILE_PATH))
                     .filter(Column(incrDeletedCountExpr))
                     .distinct()
                     .as[String]

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
@@ -42,10 +42,9 @@ import org.apache.spark.sql.catalyst.plans.logical.{DeltaDelete, LogicalPlan}
 import org.apache.spark.sql.delta.DeltaOperations.Operation
 import org.apache.spark.sql.catalyst.plans.logical.SupportsSubquery
 import org.apache.spark.sql.execution.command.LeafRunnableCommand
-import org.apache.spark.sql.execution.datasources.FileFormat.{FILE_PATH, METADATA_NAME}
+import org.apache.spark.sql.execution.datasources.FileFormat.FILE_PATH
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.execution.metric.SQLMetrics.{createMetric, createTimingMetric}
-import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.types.LongType
 
 trait DeleteCommandMetrics { self: LeafRunnableCommand =>
@@ -324,7 +323,7 @@ case class DeleteCommand(
                   Array.empty[String]
                 } else {
                   data.filter(Column(cond))
-                    .select(col(s"${METADATA_NAME}.${FILE_PATH}"))
+                    .select(DeltaTableUtils.getFileMetadataColumn(data).getField(FILE_PATH))
                     .filter(Column(incrDeletedCountExpr))
                     .distinct()
                     .as[String]

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
@@ -42,9 +42,10 @@ import org.apache.spark.sql.catalyst.plans.logical.{DeltaDelete, LogicalPlan}
 import org.apache.spark.sql.delta.DeltaOperations.Operation
 import org.apache.spark.sql.catalyst.plans.logical.SupportsSubquery
 import org.apache.spark.sql.execution.command.LeafRunnableCommand
+import org.apache.spark.sql.execution.datasources.FileFormat.{FILE_PATH, METADATA_NAME}
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.execution.metric.SQLMetrics.{createMetric, createTimingMetric}
-import org.apache.spark.sql.functions.input_file_name
+import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.types.LongType
 
 trait DeleteCommandMetrics { self: LeafRunnableCommand =>
@@ -322,7 +323,7 @@ case class DeleteCommand(
                   Array.empty[String]
                 } else {
                   data.filter(Column(cond))
-                    .select(input_file_name())
+                    .select(col(s"${METADATA_NAME}.${FILE_PATH}"))
                     .filter(Column(incrDeletedCountExpr))
                     .distinct()
                     .as[String]

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
@@ -42,9 +42,10 @@ import org.apache.spark.sql.catalyst.plans.logical.{DeltaDelete, LogicalPlan}
 import org.apache.spark.sql.delta.DeltaOperations.Operation
 import org.apache.spark.sql.catalyst.plans.logical.SupportsSubquery
 import org.apache.spark.sql.execution.command.LeafRunnableCommand
+import org.apache.spark.sql.execution.datasources.FileFormat.{FILE_PATH, METADATA_NAME}
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.execution.metric.SQLMetrics.{createMetric, createTimingMetric}
-import org.apache.spark.sql.functions.input_file_name
+import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.types.LongType
 
 trait DeleteCommandMetrics { self: LeafRunnableCommand =>
@@ -323,7 +324,7 @@ case class DeleteCommand(
                   Array.empty[String]
                 } else {
                   data.filter(Column(cond))
-                    .select(input_file_name())
+                    .select(col(s"${METADATA_NAME}.${FILE_PATH}"))
                     .filter(Column(incrDeletedCountExpr))
                     .distinct()
                     .as[String]

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
@@ -323,12 +323,15 @@ case class DeleteCommand(
                 if (candidateFiles.isEmpty) {
                   Array.empty[String]
                 } else {
-                  data.filter(Column(cond))
-                    .select(Column(fileMetadataCol).getField(FILE_PATH))
-                    .filter(Column(incrDeletedCountExpr))
-                    .distinct()
-                    .as[String]
-                    .collect()
+                  DeltaTableUtils.withNestedSchemaPruningDisabledForVariant(
+                      sparkSession, txn.metadata.schema) {
+                    data.filter(Column(cond))
+                      .select(Column(fileMetadataCol).getField(FILE_PATH))
+                      .filter(Column(incrDeletedCountExpr))
+                      .distinct()
+                      .as[String]
+                      .collect()
+                  }
                 }
               }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
@@ -42,10 +42,9 @@ import org.apache.spark.sql.catalyst.plans.logical.{DeltaDelete, LogicalPlan}
 import org.apache.spark.sql.delta.DeltaOperations.Operation
 import org.apache.spark.sql.catalyst.plans.logical.SupportsSubquery
 import org.apache.spark.sql.execution.command.LeafRunnableCommand
-import org.apache.spark.sql.execution.datasources.FileFormat.{FILE_PATH, METADATA_NAME}
+import org.apache.spark.sql.execution.datasources.FileFormat.FILE_PATH
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.execution.metric.SQLMetrics.{createMetric, createTimingMetric}
-import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.types.LongType
 
 trait DeleteCommandMetrics { self: LeafRunnableCommand =>
@@ -323,7 +322,7 @@ case class DeleteCommand(
                   Array.empty[String]
                 } else {
                   data.filter(Column(cond))
-                    .select(col(s"${METADATA_NAME}.${FILE_PATH}"))
+                    .select(DeltaTableUtils.getFileMetadataColumn(data).getField(FILE_PATH))
                     .filter(Column(incrDeletedCountExpr))
                     .distinct()
                     .as[String]

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
@@ -324,12 +324,15 @@ case class DeleteCommand(
                 if (candidateFiles.isEmpty) {
                   Array.empty[String]
                 } else {
-                  data.filter(Column(cond))
-                    .select(Column(fileMetadataCol).getField(FILE_PATH))
-                    .filter(Column(incrDeletedCountExpr))
-                    .distinct()
-                    .as[String]
-                    .collect()
+                  DeltaTableUtils.withNestedSchemaPruningDisabledForVariant(
+                      sparkSession, txn.metadata.schema) {
+                    data.filter(Column(cond))
+                      .select(Column(fileMetadataCol).getField(FILE_PATH))
+                      .filter(Column(incrDeletedCountExpr))
+                      .distinct()
+                      .as[String]
+                      .collect()
+                  }
                 }
               }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
@@ -324,7 +324,7 @@ case class DeleteCommand(
                   Array.empty[String]
                 } else {
                   DeltaTableUtils.withNestedSchemaPruningDisabledForVariant(
-                      sparkSession, txn.metadata.schema) {
+                      sparkSession, cond) {
                     data.filter(Column(cond))
                       .select(Column(fileMetadataCol).getField(FILE_PATH))
                       .filter(Column(incrDeletedCountExpr))

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeltaCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeltaCommand.scala
@@ -118,8 +118,8 @@ trait DeltaCommand extends DeltaLogging with DeltaCommandInvariants {
    * @param deltaLog The DeltaLog of the table that is being operated on
    * @param nameToAddFileMap A map generated using `generateCandidateFileMap`.
    * @param filesToRewrite Absolute paths of the files that were touched. We will search for these
-   *                       in `candidateFiles`. Obtained as the output of the `input_file_name`
-   *                       function.
+   *                       in `candidateFiles`. Obtained as the output of the `_metadata.file_path`
+   *                       column.
    * @param operationTimestamp The timestamp of the operation
    */
   protected def removeFilesFromPaths(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/UpdateCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/UpdateCommand.scala
@@ -192,7 +192,7 @@ case class UpdateCommand(
         val pathsToRewrite =
           withStatusCode("DELTA", UpdateCommand.FINDING_TOUCHED_FILES_MSG) {
             DeltaTableUtils.withNestedSchemaPruningDisabledForVariant(
-                sparkSession, txn.metadata.schema) {
+                sparkSession, updateCondition) {
               data.filter(Column(updateCondition))
                 .select(Column(fileMetadataCol).getField(FILE_PATH))
                 .filter(Column(incrUpdatedCountExpr))

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/UpdateCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/UpdateCommand.scala
@@ -42,9 +42,10 @@ import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.delta.DeltaOperations.Operation
 import org.apache.spark.sql.execution.command.LeafRunnableCommand
+import org.apache.spark.sql.execution.datasources.FileFormat.{FILE_PATH, METADATA_NAME}
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.execution.metric.SQLMetrics.{createMetric, createTimingMetric}
-import org.apache.spark.sql.functions.{array, col, explode, input_file_name, lit, struct}
+import org.apache.spark.sql.functions.{array, col, explode, lit, struct}
 import org.apache.spark.sql.types.LongType
 
 /**
@@ -189,7 +190,7 @@ case class UpdateCommand(
         val pathsToRewrite =
           withStatusCode("DELTA", UpdateCommand.FINDING_TOUCHED_FILES_MSG) {
             data.filter(Column(updateCondition))
-              .select(input_file_name())
+              .select(col(s"${METADATA_NAME}.${FILE_PATH}"))
               .filter(Column(incrUpdatedCountExpr))
               .distinct()
               .as[String]

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/UpdateCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/UpdateCommand.scala
@@ -42,7 +42,7 @@ import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.delta.DeltaOperations.Operation
 import org.apache.spark.sql.execution.command.LeafRunnableCommand
-import org.apache.spark.sql.execution.datasources.FileFormat.{FILE_PATH, METADATA_NAME}
+import org.apache.spark.sql.execution.datasources.FileFormat.FILE_PATH
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.execution.metric.SQLMetrics.{createMetric, createTimingMetric}
 import org.apache.spark.sql.functions.{array, col, explode, lit, struct}
@@ -190,7 +190,7 @@ case class UpdateCommand(
         val pathsToRewrite =
           withStatusCode("DELTA", UpdateCommand.FINDING_TOUCHED_FILES_MSG) {
             data.filter(Column(updateCondition))
-              .select(col(s"${METADATA_NAME}.${FILE_PATH}"))
+              .select(DeltaTableUtils.getFileMetadataColumn(data).getField(FILE_PATH))
               .filter(Column(incrUpdatedCountExpr))
               .distinct()
               .as[String]

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/UpdateCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/UpdateCommand.scala
@@ -185,12 +185,14 @@ case class UpdateCommand(
         // Keep everything from the resolved target except a new TahoeFileIndex
         // that only involves the affected files instead of all files.
         val newTarget = DeltaTableUtils.replaceFileIndex(target, fileIndex)
-        val data = DataFrameUtils.ofRows(sparkSession, newTarget)
+        val (newTargetWithFileMetadata, fileMetadataCol) =
+          DeltaTableUtils.addFileMetadataColumn(newTarget)
+        val data = DataFrameUtils.ofRows(sparkSession, newTargetWithFileMetadata)
         val incrUpdatedCountExpr = IncrementMetric(TrueLiteral, metrics("numUpdatedRows"))
         val pathsToRewrite =
           withStatusCode("DELTA", UpdateCommand.FINDING_TOUCHED_FILES_MSG) {
             data.filter(Column(updateCondition))
-              .select(DeltaTableUtils.getFileMetadataColumn(data).getField(FILE_PATH))
+              .select(Column(fileMetadataCol).getField(FILE_PATH))
               .filter(Column(incrUpdatedCountExpr))
               .distinct()
               .as[String]

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/UpdateCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/UpdateCommand.scala
@@ -191,12 +191,15 @@ case class UpdateCommand(
         val incrUpdatedCountExpr = IncrementMetric(TrueLiteral, metrics("numUpdatedRows"))
         val pathsToRewrite =
           withStatusCode("DELTA", UpdateCommand.FINDING_TOUCHED_FILES_MSG) {
-            data.filter(Column(updateCondition))
-              .select(Column(fileMetadataCol).getField(FILE_PATH))
-              .filter(Column(incrUpdatedCountExpr))
-              .distinct()
-              .as[String]
-              .collect()
+            DeltaTableUtils.withNestedSchemaPruningDisabledForVariant(
+                sparkSession, txn.metadata.schema) {
+              data.filter(Column(updateCondition))
+                .select(Column(fileMetadataCol).getField(FILE_PATH))
+                .filter(Column(incrUpdatedCountExpr))
+                .distinct()
+                .as[String]
+                .collect()
+            }
           }
 
         // Wrap AddFile into TouchedFileWithDV that has empty DV.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/ClassicMergeExecutor.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/ClassicMergeExecutor.scala
@@ -31,7 +31,8 @@ import org.apache.spark.sql.delta.util.SetAccumulator
 import org.apache.spark.sql.{Column, Dataset, SparkSession}
 import org.apache.spark.sql.catalyst.expressions.{And, Expression, Literal, Or}
 import org.apache.spark.sql.catalyst.plans.logical.DeltaMergeIntoClause
-import org.apache.spark.sql.functions.{coalesce, col, count, input_file_name, lit, monotonically_increasing_id, sum}
+import org.apache.spark.sql.execution.datasources.FileFormat.{FILE_PATH, METADATA_NAME}
+import org.apache.spark.sql.functions.{coalesce, col, count, lit, monotonically_increasing_id, sum}
 
 /**
  * Trait with merge execution in two phases:
@@ -135,7 +136,7 @@ trait ClassicMergeExecutor extends MergeOutputGeneration {
         columnsToDrop)
     val targetDF = DataFrameUtils.ofRows(spark, targetPlan)
       .withColumn(ROW_ID_COL, monotonically_increasing_id())
-      .withColumn(FILE_NAME_COL, input_file_name())
+      .withColumn(FILE_NAME_COL, col(s"${METADATA_NAME}.${FILE_PATH}"))
 
     val joinToFindTouchedFiles =
       sourceDF.join(targetDF, Column(condition), joinType)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/ClassicMergeExecutor.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/ClassicMergeExecutor.scala
@@ -134,11 +134,11 @@ trait ClassicMergeExecutor extends MergeOutputGeneration {
         deltaTxn,
         dataSkippedFiles,
         columnsToDrop)
-    val targetPlanDF = DataFrameUtils.ofRows(spark, targetPlan)
-    val targetDF = targetPlanDF
+    val (targetPlanWithFileMetadata, fileMetadataCol) =
+      DeltaTableUtils.addFileMetadataColumn(targetPlan)
+    val targetDF = DataFrameUtils.ofRows(spark, targetPlanWithFileMetadata)
       .withColumn(ROW_ID_COL, monotonically_increasing_id())
-      .withColumn(
-        FILE_NAME_COL, DeltaTableUtils.getFileMetadataColumn(targetPlanDF).getField(FILE_PATH))
+      .withColumn(FILE_NAME_COL, Column(fileMetadataCol).getField(FILE_PATH))
 
     val joinToFindTouchedFiles =
       sourceDF.join(targetDF, Column(condition), joinType)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/ClassicMergeExecutor.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/ClassicMergeExecutor.scala
@@ -31,7 +31,7 @@ import org.apache.spark.sql.delta.util.SetAccumulator
 import org.apache.spark.sql.{Column, Dataset, SparkSession}
 import org.apache.spark.sql.catalyst.expressions.{And, Expression, Literal, Or}
 import org.apache.spark.sql.catalyst.plans.logical.DeltaMergeIntoClause
-import org.apache.spark.sql.execution.datasources.FileFormat.{FILE_PATH, METADATA_NAME}
+import org.apache.spark.sql.execution.datasources.FileFormat.FILE_PATH
 import org.apache.spark.sql.functions.{coalesce, col, count, lit, monotonically_increasing_id, sum}
 
 /**
@@ -134,9 +134,11 @@ trait ClassicMergeExecutor extends MergeOutputGeneration {
         deltaTxn,
         dataSkippedFiles,
         columnsToDrop)
-    val targetDF = DataFrameUtils.ofRows(spark, targetPlan)
+    val targetPlanDF = DataFrameUtils.ofRows(spark, targetPlan)
+    val targetDF = targetPlanDF
       .withColumn(ROW_ID_COL, monotonically_increasing_id())
-      .withColumn(FILE_NAME_COL, col(s"${METADATA_NAME}.${FILE_PATH}"))
+      .withColumn(
+        FILE_NAME_COL, DeltaTableUtils.getFileMetadataColumn(targetPlanDF).getField(FILE_PATH))
 
     val joinToFindTouchedFiles =
       sourceDF.join(targetDF, Column(condition), joinType)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DMLWithConflictingMetadataColumnSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DMLWithConflictingMetadataColumnSuite.scala
@@ -1,0 +1,129 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+
+import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.test.SharedSparkSession
+
+/**
+ * Tests that DML commands work on tables that have a data column whose name conflicts with the
+ * file source metadata column (`_metadata`).
+ *
+ * Delta supports such tables (see RowIdSuite "Base Row IDs can be read with conflicting metadata
+ * column name"). When a data column named `_metadata` exists, Spark renames the file source
+ * metadata column, and a plain `col("_metadata.file_path")` lookup resolves to the *user* column
+ * instead. Commands must therefore look the metadata column up by its logical name.
+ */
+class DMLWithConflictingMetadataColumnSuite
+  extends QueryTest
+  with SharedSparkSession
+  with DeltaSQLCommandTest {
+
+  /** Writes 2 files so that the commands have to identify which file(s) to rewrite. */
+  private def writeTableWithMetadataColumn(path: String): Unit = {
+    spark.range(start = 0, end = 5).toDF("_metadata")
+      .withColumn("value", col("_metadata") * 10)
+      .repartition(1)
+      .write.format("delta").save(path)
+    spark.range(start = 5, end = 10).toDF("_metadata")
+      .withColumn("value", col("_metadata") * 10)
+      .repartition(1)
+      .write.format("delta").mode("append").save(path)
+  }
+
+  // Deletion vectors take a different code path, so cover the classic path explicitly.
+  private def withoutDeletionVectors(thunk: => Unit): Unit =
+    withSQLConf(DeltaSQLConf.DELETE_USE_PERSISTENT_DELETION_VECTORS.key -> "false",
+      DeltaSQLConf.UPDATE_USE_PERSISTENT_DELETION_VECTORS.key -> "false") {
+      thunk
+    }
+
+  test("UPDATE on a table with a conflicting _metadata column") {
+    withoutDeletionVectors {
+      withTempDir { dir =>
+        val path = dir.getAbsolutePath
+        writeTableWithMetadataColumn(path)
+
+        sql(s"UPDATE delta.`$path` SET value = -1 WHERE _metadata = 3")
+
+        checkAnswer(
+          spark.read.format("delta").load(path).select("_metadata", "value"),
+          (0 until 10).map(i => Row(i, if (i == 3) -1 else i * 10)))
+      }
+    }
+  }
+
+  test("DELETE on a table with a conflicting _metadata column") {
+    withoutDeletionVectors {
+      withTempDir { dir =>
+        val path = dir.getAbsolutePath
+        writeTableWithMetadataColumn(path)
+
+        sql(s"DELETE FROM delta.`$path` WHERE _metadata = 3")
+
+        checkAnswer(
+          spark.read.format("delta").load(path).select("_metadata", "value"),
+          (0 until 10).filter(_ != 3).map(i => Row(i, i * 10)))
+      }
+    }
+  }
+
+  test("MERGE on a table with a conflicting _metadata column") {
+    import testImplicits._
+    withoutDeletionVectors {
+      withTempDir { dir =>
+        val path = dir.getAbsolutePath
+        writeTableWithMetadataColumn(path)
+
+        withTempView("source") {
+          Seq((3L, -1L), (100L, 1000L)).toDF("_metadata", "value")
+            .createOrReplaceTempView("source")
+
+          sql(
+            s"""MERGE INTO delta.`$path` t
+               |USING source s ON t._metadata = s._metadata
+               |WHEN MATCHED THEN UPDATE SET t.value = s.value
+               |WHEN NOT MATCHED THEN INSERT *""".stripMargin)
+        }
+
+        checkAnswer(
+          spark.read.format("delta").load(path).select("_metadata", "value"),
+          (0 until 10).map(i => Row(i, if (i == 3) -1 else i * 10)) :+ Row(100, 1000))
+      }
+    }
+  }
+
+  test("CONVERT TO DELTA with stats on a table with a conflicting _metadata column") {
+    withTempDir { dir =>
+      val path = new java.io.File(dir, "parquet_table").getAbsolutePath
+      spark.range(start = 0, end = 10).toDF("_metadata")
+        .withColumn("value", col("_metadata") * 10)
+        .repartition(2)
+        .write.format("parquet").save(path)
+
+      sql(s"CONVERT TO DELTA parquet.`$path`")
+
+      checkAnswer(
+        spark.read.format("delta").load(path).select("_metadata", "value"),
+        (0 until 10).map(i => Row(i, i * 10)))
+    }
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeleteSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeleteSuiteBase.scala
@@ -532,7 +532,8 @@ trait DeleteBaseTests extends DeleteBaseMixin {
       case f: FileSourceScanLike => f
     })
 
-    assert(scans.head.schema == StructType.fromDDL("nested STRUCT<key: int>"))
+    assert(DeltaTestUtils.dataSchemaOf(scans.head) ==
+      StructType.fromDDL("nested STRUCT<key: int>"))
   }
 
   /**

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTestUtils.scala
@@ -48,7 +48,7 @@ import org.apache.spark.{SparkConf, SparkContext, SparkFunSuite, SparkThrowable}
 import org.apache.spark.scheduler.{JobFailed, SparkListener, SparkListenerJobEnd, SparkListenerJobStart}
 import org.apache.spark.sql.{AnalysisException, DataFrame, DataFrameWriter, SparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier
-import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.expressions.{Expression, FileSourceMetadataAttribute}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.util.{quietly, FailFastMode}
 import org.apache.spark.sql.execution.{FileSourceScanLike, QueryExecution, RDDScanExec, SparkPlan, WholeStageCodegenExec}
@@ -222,6 +222,17 @@ trait DeltaTestUtilsBase {
       spark.listenerManager.unregister(planCapturingListener)
     }
   }
+
+  /**
+   * Returns the schema of `scan` with the file source metadata columns (e.g.
+   * `_metadata.file_path`, which DML commands use to identify the files to rewrite) removed.
+   *
+   * These columns are file-constant: they are derived from the file being scanned rather than
+   * read from it, so they don't affect data column pruning and should be ignored when asserting
+   * on which columns a scan reads.
+   */
+  def dataSchemaOf(scan: FileSourceScanLike): StructType =
+    StructType(scan.schema.filterNot(f => FileSourceMetadataAttribute.isValid(f.metadata)))
 
   /**
    * Run a thunk with logical and physical plans for all queries captured and passed

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaVariantSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaVariantSuite.scala
@@ -31,6 +31,8 @@ import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.delta.DeltaAnalysisException
 import org.apache.spark.sql.delta.schema.DeltaInvariantViolationException
+import org.apache.spark.sql.execution.FileSourceScanLike
+import org.apache.spark.sql.execution.datasources.FileFormat.FILE_PATH
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.StructType
@@ -464,6 +466,30 @@ class DeltaVariantSuite
                where _change_type = 'update_postimage'"""),
         Seq(Row("update_postimage", -2))
       )
+    }
+  }
+
+  test("nested schema pruning stays enabled when the condition does not reference variant") {
+    withTable("tbl") {
+      sql(
+        """CREATE TABLE tbl USING DELTA AS
+          |SELECT parse_json(cast(id AS string)) v,
+          |       named_struct('a', cast(id AS int), 'b', cast(id * 2 AS int)) s
+          |FROM range(10)""".stripMargin)
+
+      val plans = withSQLConf(
+          DeltaSQLConf.UPDATE_USE_PERSISTENT_DELETION_VECTORS.key -> "false") {
+        DeltaTestUtils.withPhysicalPlansCaptured(spark) {
+          sql("UPDATE tbl SET s.b = -1 WHERE s.a = 3")
+        }
+      }
+
+      val touchedFilesScan = plans
+        .flatMap(_.collect { case scan: FileSourceScanLike => scan })
+        .find(_.schema.fieldNames.contains(FILE_PATH))
+        .getOrElse(fail("Expected the scan that finds the files to update."))
+      assert(DeltaTestUtils.dataSchemaOf(touchedFilesScan) ==
+        StructType.fromDDL("s STRUCT<a: INT>"))
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/UpdateSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/UpdateSuiteBase.scala
@@ -878,8 +878,10 @@ trait UpdateBaseMiscTests extends UpdateBaseMixin {
       case f: FileSourceScanLike => f
     })
     // The first scan is for finding files to update. We only are matching against the key
-    // so that should be the only field in the schema.
-    assert(scans.head.schema == StructType(
+    // so that should be the only field in the schema. The scan additionally exposes the
+    // `_metadata.file_path` column used to identify the files to rewrite, which is file-constant
+    // and therefore not read from the data files.
+    assert(DeltaTestUtils.dataSchemaOf(scans.head) == StructType(
       Seq(
         StructField("key", IntegerType)
       )
@@ -903,7 +905,8 @@ trait UpdateBaseMiscTests extends UpdateBaseMixin {
       case f: FileSourceScanLike => f
     })
 
-    assert(scans.head.schema == StructType.fromDDL("nested STRUCT<key: int>"))
+    assert(DeltaTestUtils.dataSchemaOf(scans.head) ==
+      StructType.fromDDL("nested STRUCT<key: int>"))
   }
 
   /**

--- a/spark/src/test/scala/org/apache/spark/sql/delta/serverSidePlanning/ServerSidePlannedTableSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/serverSidePlanning/ServerSidePlannedTableSuite.scala
@@ -134,6 +134,19 @@ class ServerSidePlannedTableSuite extends QueryTest with DeltaSQLCommandTest {
     }
   }
 
+  test("planning client handles a data column named _metadata") {
+    withTable("test_db.metadata_conflict") {
+      sql(
+        """CREATE TABLE test_db.metadata_conflict (_metadata BIGINT, value STRING)
+          |USING delta""".stripMargin)
+      sql("INSERT INTO test_db.metadata_conflict VALUES (1, 'a')")
+
+      val plan = new TestServerSidePlanningClient(spark)
+        .planScan("test_db", "metadata_conflict")
+      assert(plan.files.nonEmpty)
+    }
+  }
+
   test("verify normal path unchanged when feature disabled") {
     // Explicitly disable server-side planning
     spark.conf.set(DeltaSQLConf.ENABLE_SERVER_SIDE_PLANNING.key, "false")

--- a/spark/src/test/scala/org/apache/spark/sql/delta/serverSidePlanning/TestServerSidePlanningClient.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/serverSidePlanning/TestServerSidePlanningClient.scala
@@ -19,12 +19,12 @@ package org.apache.spark.sql.delta.serverSidePlanning
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
-import org.apache.spark.sql.functions.input_file_name
+import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.sources.Filter
 
 /**
- * Implementation of ServerSidePlanningClient that uses Spark SQL with input_file_name()
- * to discover the list of files in a table. This allows end-to-end testing without
+ * Implementation of ServerSidePlanningClient that uses Spark SQL with the `_metadata.file_path`
+ * column to discover the list of files in a table. This allows end-to-end testing without
  * a real server that can do server-side planning.
  *
  * Also captures filter/projection parameters for test verification via companion object.
@@ -49,10 +49,10 @@ class TestServerSidePlanningClient(spark: SparkSession) extends ServerSidePlanni
     spark.conf.set(DeltaSQLConf.ENABLE_SERVER_SIDE_PLANNING.key, "false")
 
     try {
-      // Use input_file_name() to get the list of files
-      // Query: SELECT DISTINCT input_file_name() FROM table
+      // Use the `_metadata.file_path` column to get the list of files
+      // Query: SELECT DISTINCT _metadata.file_path FROM table
       val filesDF = spark.table(fullTableName)
-        .select(input_file_name().as("file_path"))
+        .select(col("_metadata.file_path").as("file_path"))
         .distinct()
 
       // Collect file paths
@@ -65,7 +65,7 @@ class TestServerSidePlanningClient(spark: SparkSession) extends ServerSidePlanni
       val hadoopConf = spark.sessionState.newHadoopConf()
       // scalastyle:on deltahadoopconfiguration
       val files = filePaths.map { filePath =>
-        // input_file_name() returns URL-encoded paths, decode them
+        // _metadata.file_path returns URL-encoded paths, decode them
         val decodedPath = java.net.URLDecoder.decode(filePath, "UTF-8")
         val path = new Path(decodedPath)
         val fs = path.getFileSystem(hadoopConf)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/serverSidePlanning/TestServerSidePlanningClient.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/serverSidePlanning/TestServerSidePlanningClient.scala
@@ -18,8 +18,9 @@ package org.apache.spark.sql.delta.serverSidePlanning
 
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.delta.DeltaTableUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
-import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.execution.datasources.FileFormat.FILE_PATH
 import org.apache.spark.sql.sources.Filter
 
 /**
@@ -51,8 +52,9 @@ class TestServerSidePlanningClient(spark: SparkSession) extends ServerSidePlanni
     try {
       // Use the `_metadata.file_path` column to get the list of files
       // Query: SELECT DISTINCT _metadata.file_path FROM table
-      val filesDF = spark.table(fullTableName)
-        .select(col("_metadata.file_path").as("file_path"))
+      val tableDF = spark.table(fullTableName)
+      val filesDF = tableDF
+        .select(DeltaTableUtils.getFileMetadataColumn(tableDF).getField(FILE_PATH).as("file_path"))
         .distinct()
 
       // Collect file paths


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

`input_file_name()` is [deprecated](https://docs.databricks.com/en/sql/language-manual/functions/input_file_name.html). This PR replaces its remaining usages in `delta-spark` with the `_metadata.file_path` file source metadata column.

Resolves #2263

**Why this is safe:** both expressions return URL-encoded URI paths, so the collected values stay compatible with `getTouchedFile` / `generateCandidateFileMap`, which resolve paths via `new Path(new URI(path))`:

| | Value produced |
|---|---|
| `input_file_name()` | `currentFile.urlEncodedPath` (`FileScanRDD`) |
| `_metadata.file_path` | `new Path(pf.filePath.toPath.toString).toUri.toString` (`FileFormat`) |

`StatisticsCollection.computeNewAddFiles` already used `_metadata.file_path` with the same `getTouchedFile` consumer, and the deletion vector code paths already read the file path from `_metadata`.

### Main changes

- `UpdateCommand`, `DeleteCommand`: finding the files touched by the operation
- `ClassicMergeExecutor`: `FILE_NAME_COL` in `findTouchedFiles`
- `ConvertToDeltaCommand`: `computeStats` aggregation key
- `DeltaCommand`: update a stale doc comment referring to `input_file_name`

#### Getting the metadata column when the target is a view

`input_file_name()` is a leaf expression, so it needs no name resolution. `_metadata` does, and views do not expose metadata columns, so resolving it by name fails with `UNRESOLVED_COLUMN` whenever the command targets a view.

`UPDATE`/`DELETE`/`MERGE` therefore add the column to the plan with the new `DeltaTableUtils.addFileMetadataColumn` and reference the returned attribute directly. This is the same approach `DMLWithDeletionVectorsHelper.replaceFileIndex` already uses to request the metadata column, which is why the deletion vector code paths work on views today.

The added column is renamed when the table has a data column called `_metadata`, so references to that data column stay unambiguous. That is safe because the column is referenced by attribute rather than by name, and the logical name identifying it as the file source metadata column is kept in its metadata. Delta supports such tables — see `RowIdSuite`, "Base Row IDs can be read with conflicting metadata column name" — but the existing coverage is read-only, so `DMLWithConflictingMetadataColumnSuite` is added for the DML commands.

`ConvertToDeltaCommand` keeps resolving the column by name: it builds its DataFrame directly from the transaction log, so it can never be a view.

#### Nested schema pruning on variant tables

On variant tables the file-finding query hits a Spark optimizer bug: the `Early Filter and Projection Push-Down` batch is not idempotent when a query reads only `_metadata.file_path` while a variant column is referenced by a filter below a nondeterministic filter, which is exactly the shape of this query. Reported as https://github.com/apache/spark/issues/57659, with a reproduction that needs no Delta.

`RuleExecutor` only checks idempotence under `Utils.isTesting`, so this is a test failure rather than a user visible one, but it fails `DeltaVariantSuite` on Spark 4.1 and 4.2. Nested schema pruning is disabled for that one query only when the UPDATE/DELETE condition references a variant-typed column; an unrelated variant column no longer disables pruning for predicates on other nested columns.

Spark has since fixed this in [SPARK-59171](https://issues.apache.org/jira/browse/SPARK-59171) ([`a5a9e7b`](https://github.com/apache/spark/commit/a5a9e7baddbe8109190fa3bac38bd9a8abcb2330)) by running `SchemaPruning` after `PushVariantIntoScan`. That fix is only on Spark master: `v4.1.0` and `v4.2.0` both still order `SchemaPruning` before `PushVariantIntoScan`, so every version this repo builds against still needs the workaround. Its scaladoc records how to make it a no-op via the existing `scala-shims/spark-X.Y` mechanism when a Spark version containing the fix is added, and it can be deleted once no supported version predates the fix.

### Test changes

- Add `DMLWithConflictingMetadataColumnSuite`, covering UPDATE/DELETE/MERGE/CONVERT on a table with a `_metadata` data column.
- `TestServerSidePlanningClient`: use the conflict-safe metadata API for file discovery (it still URL-decodes the returned paths), with coverage for a user data column named `_metadata`.
- Add `DeltaTestUtils.dataSchemaOf` and use it in the three schema pruning tests. `DeltaVariantSuite` also verifies that an unrelated variant column does not disable pruning for a predicate on a regular nested struct.

  Selecting the metadata column adds `file_path` to the scan output, so assertions comparing `FileSourceScanLike.schema` against an exact `StructType` needed updating. `file_path` is a *file-constant* metadata column (`FileSourceConstantMetadataStructField`): it is derived from the `PartitionedFile` rather than read from the data file. In `FileSourceStrategy` only data and *generated* metadata columns go into `outputDataSchema` (the scan's `requiredSchema`), while constant metadata columns are appended to the output attributes. So data column pruning is unaffected and no additional data is read from the Parquet files.

One usage is intentionally left unchanged: `DeltaSinkSuite` uses `input_file_name()` on a non-Delta JSON stream purely to reproduce a bug ("Not sure why needs this to reproduce"), so it is not worth perturbing.

## How was this patch tested?

New `DMLWithConflictingMetadataColumnSuite`, plus existing unit tests, on Spark 4.0, 4.1, and 4.2.

The behavior most sensitive to this change is path encoding, which is covered by the existing special-character tests (partition values such as `part%one`, which get URL-encoded in the file path):

- all of `org.apache.spark.sql.delta.generatedsuites.update.*` and `...generatedsuites.delete.*`, which include the temp view and special character tests
- `MergeIntoSuiteBaseMiscScalaSuite`, `MergeIntoTempViewsSQLNameBasedSuite`, `MergeIntoTempViewsSQLPathBasedCDCOnDVsPredPushOnSuite`, `MergeIntoSQLSuite`
- `ConvertToDeltaScalaSuite`, `ConvertToDeltaSQLSuite`, `StatsCollectionSuite`, `ServerSidePlannedTableSuite`
- `DeltaVariantSuite` on Spark 4.2
- `org.apache.spark.sql.delta.rowid.*` and `org.apache.spark.sql.delta.rowtracking.*`

## Does this PR introduce _any_ user-facing changes?

No. This is an internal refactor; the file paths used to identify files to rewrite are encoded identically before and after.
