### PR TITLE
Skip staged commits in coordinated-commits filesystem listing

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
@@ -127,7 +127,10 @@ trait SnapshotManagement { self: DeltaLog =>
     val files =
       filesOpt.map {
       _.flatMap {
-        case DeltaFile(f, fileVersion) =>
+        // Use BackfilledDeltaFile, not the permissive DeltaFile: a raw listing must not promote
+        // staged commits (`_staged_commits/N.<uuid>.json`) to commits. They are ratified by the
+        // commit coordinator (getCommits), and enter the log segment separately via the caller.
+        case BackfilledDeltaFile(f, fileVersion) =>
           Some((f, FileType.DELTA, fileVersion))
         case CompactedDeltaFile(f, startVersion, endVersion)
             if includeMinorCompactions && versionToLoad.forall(endVersion <= _) =>

--- a/spark/src/test/scala/org/apache/spark/sql/delta/StagedCommitListingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/StagedCommitListingSuite.scala
@@ -1,0 +1,260 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.spark.sql.delta
+
+import java.io.File
+
+import org.apache.spark.sql.delta.DeltaConfigs.COORDINATED_COMMITS_COORDINATOR_NAME
+import org.apache.spark.sql.delta.DeltaTestUtils.verifyUnbackfilled
+import org.apache.spark.sql.delta.coordinatedcommits.{CommitCoordinatorProvider, InMemoryCommitCoordinator, TrackingCommitCoordinatorClient, TrackingInMemoryCommitCoordinatorBuilder}
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.storage.LocalLogStore
+import org.apache.spark.sql.delta.storage.LogStore.logStoreClassConfKey
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.delta.util.FileNames
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileStatus, Path}
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.test.SharedSparkSession
+
+/**
+ * On a Coordinated-Commits table the fs listing must not promote a staged-commit file
+ * (`_staged_commits/N.<uuid>.json`) to a commit. [[RecursiveListingLocalLogStore]] reproduces a
+ * recursive-listing LogStore hermetically (no real object store).
+ */
+class StagedCommitListingSuite extends QueryTest
+    with SharedSparkSession
+    with DeltaSQLCommandTest {
+
+  private val coordinatorName = "tracking-in-memory"
+
+  // Large batch size so commits stay staged (un-backfilled) for the test.
+  private val backfillBatchSize = 100L
+
+  override protected def sparkConf: SparkConf =
+    super.sparkConf.set(logStoreClassConfKey, classOf[RecursiveListingLocalLogStore].getName)
+
+  override protected def beforeEach(): Unit = {
+    super.beforeEach()
+    CommitCoordinatorProvider.clearNonDefaultBuilders()
+    CommitCoordinatorProvider.registerBuilder(
+      TrackingInMemoryCommitCoordinatorBuilder(
+        backfillBatchSize, defaultCommitCoordinatorName = coordinatorName))
+  }
+
+  /** Runs `f` with the coordinated-commits coordinator enabled by default for new tables. */
+  private def withCoordinatedCommits(f: => Unit): Unit = {
+    withSQLConf(
+        COORDINATED_COMMITS_COORDINATOR_NAME.defaultTablePropertyKey -> coordinatorName,
+        // Keep checkpoints/minor-compactions out of the picture; these tests reason about versions.
+        DeltaSQLConf.DELTALOG_MINOR_COMPACTION_USE_FOR_READS.key -> "false") {
+      f
+    }
+  }
+
+  private def logDir(path: String): File = new File(path, "_delta_log")
+
+  private def stagedCommitsDir(path: String): File =
+    new File(logDir(path), FileNames.COMMIT_SUBDIR)
+
+  private def stagedCommitFiles(path: String): Seq[File] =
+    Option(stagedCommitsDir(path).listFiles()).getOrElse(Array.empty)
+      .filter(_.getName.endsWith(".json"))
+      .sortBy(_.getName)
+      .toSeq
+
+  private def backfilledDeltaFile(path: String, version: Long): File =
+    new File(FileNames.unsafeDeltaFile(new Path(logDir(path).toString), version).toString)
+
+  /** The [[InMemoryCommitCoordinator]] backing the builder, for manipulating its ledger. */
+  private def getInMemoryCoordinator: InMemoryCommitCoordinator = {
+    val client = CommitCoordinatorProvider
+      .getCommitCoordinatorClient(coordinatorName, Map.empty, spark)
+    client match {
+      case tracking: TrackingCommitCoordinatorClient =>
+        tracking.delegatingCommitCoordinatorClient.asInstanceOf[InMemoryCommitCoordinator]
+      case inMemory: InMemoryCommitCoordinator => inMemory
+      case other =>
+        throw new IllegalStateException(
+          s"Unexpected commit coordinator client type: ${other.getClass.getName}")
+    }
+  }
+
+  // Sanity check: the harness actually surfaces staged files, else the tests below pass vacuously.
+  test("test harness: recursive listing surfaces _staged_commits files") {
+    withCoordinatedCommits {
+      withTempDir { tempDir =>
+        val path = tempDir.getCanonicalPath
+        spark.range(0, 10).write.format("delta").save(path)
+        // Append v1; with batch size 100 it stays staged (un-backfilled).
+        spark.range(10, 20).write.format("delta").mode("append").save(path)
+
+        assert(stagedCommitFiles(path).nonEmpty,
+          "expected at least one staged commit file to exist on disk")
+
+        val deltaLog = DeltaLog.forTable(spark, path)
+        val logPath = deltaLog.logPath
+        val listed = deltaLog.store
+          .listFrom(FileNames.listingPrefix(logPath, 0L), deltaLog.newDeltaHadoopConf())
+          .map(_.getPath)
+          .toSeq
+        assert(listed.exists(p => p.getParent.getName == FileNames.COMMIT_SUBDIR),
+          s"recursive listing should surface _staged_commits files, but listed: $listed")
+      }
+    }
+  }
+
+  test("backfilled + staged copy of the same version does not throw NOT_CONTIGUOUS") {
+    withCoordinatedCommits {
+      withTempDir { tempDir =>
+        val path = tempDir.getCanonicalPath
+        spark.range(0, 10).write.format("delta").save(path) // v0
+        spark.range(10, 20).write.format("delta").mode("append").save(path) // v1 (staged)
+
+        // Also materialise the backfilled `00...01.json` so v1 exists both backfilled and staged.
+        val staged = stagedCommitFiles(path)
+        assert(staged.nonEmpty, "expected a staged commit for v1")
+        val stagedV1 = staged.find(f => FileNames.deltaVersion(new Path(f.getName)) == 1L).get
+        val backfilledV1 = backfilledDeltaFile(path, 1L)
+        if (!backfilledV1.exists()) {
+          java.nio.file.Files.copy(stagedV1.toPath, backfilledV1.toPath)
+        }
+        assert(backfilledV1.exists() && stagedV1.exists(),
+          "v1 must exist both backfilled and staged for this scenario")
+
+        DeltaLog.invalidateCache(spark, new Path(path))
+
+        // Before the fix this threw DELTA_VERSIONS_NOT_CONTIGUOUS (versions [0, 1, 1]).
+        val snapshot = DeltaLog.forTable(spark, path).update()
+        assert(snapshot.version == 1L)
+        checkAnswer(
+          spark.read.format("delta").load(path).orderBy("id"),
+          (0 until 20).map(i => org.apache.spark.sql.Row(i.toLong)))
+      }
+    }
+  }
+
+  test("orphaned staged commit (not in getCommits) is not read") {
+    withCoordinatedCommits {
+      withTempDir { tempDir =>
+        val path = tempDir.getCanonicalPath
+        spark.range(0, 10).write.format("delta").save(path) // v0
+        // Write a genuine, well-formed v1 commit. With batch size 100 it stays staged.
+        spark.range(10, 20).write.format("delta").mode("append").save(path) // v1 (staged)
+
+        val deltaLog = DeltaLog.forTable(spark, path)
+        val logPath = deltaLog.logPath
+
+        // Orphan v1: drop it from the coordinator and delete any backfilled copy, leaving only the
+        // well-formed staged file under `_staged_commits/`.
+        val coordinator = getInMemoryCoordinator
+        coordinator.removeCommitTestOnly(logPath, commitVersion = 1L)
+        val backfilledV1 = backfilledDeltaFile(path, 1L)
+        if (backfilledV1.exists()) assert(backfilledV1.delete())
+        assert(stagedCommitFiles(path).exists(f =>
+          FileNames.deltaVersion(new Path(f.getName)) == 1L),
+          "the orphaned staged v1 file must still be present on disk")
+
+        DeltaLog.invalidateCache(spark, new Path(path))
+
+        val snapshot = DeltaLog.forTable(spark, path).update()
+        assert(snapshot.version == 0L,
+          s"orphaned staged commit must not advance the snapshot; got v${snapshot.version}")
+        checkAnswer(
+          spark.read.format("delta").load(path).orderBy("id"),
+          (0 until 10).map(i => org.apache.spark.sql.Row(i.toLong)))
+      }
+    }
+  }
+
+  test("ratified, not-yet-backfilled staged commit is still read via the coordinator") {
+    withCoordinatedCommits {
+      withTempDir { tempDir =>
+        val path = tempDir.getCanonicalPath
+        spark.range(0, 10).write.format("delta").save(path) // v0
+        spark.range(10, 20).write.format("delta").mode("append").save(path) // v1 (ratified, staged)
+
+        // v1 is ratified by the coordinator but, with batch size 100, still only exists staged.
+        val staged = stagedCommitFiles(path)
+        assert(staged.exists(f => FileNames.deltaVersion(new Path(f.getName)) == 1L),
+          "v1 should be present as a staged commit")
+        assert(!backfilledDeltaFile(path, 1L).exists(),
+          "v1 should NOT be backfilled yet (batch size is large)")
+
+        DeltaLog.invalidateCache(spark, new Path(path))
+        val deltaLog = DeltaLog.forTable(spark, path)
+
+        // Channel check: the raw fs listing must NOT surface v1 (else we wouldn't be testing the
+        // coordinator path).
+        val (fsListingOpt, _) = deltaLog.listFromFileSystemInternal(
+          startVersion = 0L,
+          versionToLoad = None,
+          includeMinorCompactions = false)
+        val fsDeltaVersions = fsListingOpt.getOrElse(Array.empty)
+          .collect { case (f, FileNames.FileType.DELTA, v) => v }.toSeq
+        assert(!fsDeltaVersions.contains(1L),
+          s"raw fs listing must not surface staged v1 as a delta; got $fsDeltaVersions")
+
+        val snapshot = deltaLog.update()
+        assert(snapshot.version == 1L,
+          s"ratified staged v1 must be read via the coordinator; got v${snapshot.version}")
+        // The v1 delta is the staged (unbackfilled) file, i.e. it came from the coordinator.
+        val v1Delta = snapshot.logSegment.deltas
+          .find(f => FileNames.deltaVersion(f.getPath) == 1L)
+          .getOrElse(fail("v1 delta missing from the log segment"))
+        verifyUnbackfilled(v1Delta)
+
+        checkAnswer(
+          spark.read.format("delta").load(path).orderBy("id"),
+          (0 until 20).map(i => org.apache.spark.sql.Row(i.toLong)))
+      }
+    }
+  }
+}
+
+/**
+ * A [[LocalLogStore]] whose `listFrom` recurses into subdirectories, reproducing a recursive
+ * LogStore that surfaces `_staged_commits/` files (the default [[LocalLogStore]] lists only
+ * immediate children and masks the bug). Top-level so it can be set via the logStore class conf.
+ */
+class RecursiveListingLocalLogStore(sparkConf: SparkConf, hadoopConf: Configuration)
+    extends LocalLogStore(sparkConf, hadoopConf) {
+
+  override def listFrom(path: Path, hadoopConf: Configuration): Iterator[FileStatus] = {
+    val fs = path.getFileSystem(hadoopConf)
+    val parent = path.getParent
+    if (!fs.exists(parent)) {
+      throw DeltaErrors.fileOrDirectoryNotFoundException(s"$parent")
+    }
+    // Recursively collect leaf files under the parent (mirrors a no-delimiter prefix listing).
+    val collected = scala.collection.mutable.ArrayBuffer.empty[FileStatus]
+    def recurse(dir: Path): Unit = {
+      fs.listStatus(dir).foreach { st =>
+        if (st.isDirectory) recurse(st.getPath) else collected += st
+      }
+    }
+    recurse(parent)
+    // Return files with name >= the start name, sorted by leaf name (as the S3 log store does).
+    collected
+      .filter(_.getPath.getName >= path.getName)
+      .sortBy(_.getPath.getName)
+      .iterator
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/StagedCommitListingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/StagedCommitListingSuite.scala
@@ -14,14 +14,13 @@
  * limitations under the License.
  */
 
-
 package org.apache.spark.sql.delta
 
 import java.io.File
+import java.nio.file.Files
 
-import org.apache.spark.sql.delta.DeltaConfigs.COORDINATED_COMMITS_COORDINATOR_NAME
-import org.apache.spark.sql.delta.DeltaTestUtils.verifyUnbackfilled
-import org.apache.spark.sql.delta.coordinatedcommits.{CommitCoordinatorProvider, InMemoryCommitCoordinator, TrackingCommitCoordinatorClient, TrackingInMemoryCommitCoordinatorBuilder}
+import org.apache.spark.sql.delta.coordinatedcommits.{CommitCoordinatorProvider,
+  CoordinatedCommitsBaseSuite, InMemoryCommitCoordinator, TrackingCommitCoordinatorClient}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.storage.LocalLogStore
 import org.apache.spark.sql.delta.storage.LogStore.logStoreClassConfKey
@@ -31,8 +30,7 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, Path}
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.QueryTest
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.{QueryTest, Row}
 
 /**
  * On a Coordinated-Commits table the fs listing must not promote a staged-commit file
@@ -40,53 +38,52 @@ import org.apache.spark.sql.test.SharedSparkSession
  * recursive-listing LogStore hermetically (no real object store).
  */
 class StagedCommitListingSuite extends QueryTest
-    with SharedSparkSession
-    with DeltaSQLCommandTest {
+    with DeltaSQLCommandTest
+    with CoordinatedCommitsBaseSuite {
 
-  private val coordinatorName = "tracking-in-memory"
-
-  // Large batch size so commits stay staged (un-backfilled) for the test.
-  private val backfillBatchSize = 100L
+  // Large batch size keeps commits staged (un-backfilled) for these tests.
+  override def coordinatedCommitsBackfillBatchSize: Option[Int] = Some(100)
 
   override protected def sparkConf: SparkConf =
-    super.sparkConf.set(logStoreClassConfKey, classOf[RecursiveListingLocalLogStore].getName)
+    super.sparkConf
+      .set(logStoreClassConfKey, classOf[RecursiveListingLocalLogStore].getName)
+      // Keep minor compactions out of the picture; these tests reason about commit versions.
+      .set(DeltaSQLConf.DELTALOG_MINOR_COMPACTION_USE_FOR_READS.key, "false")
 
-  override protected def beforeEach(): Unit = {
-    super.beforeEach()
-    CommitCoordinatorProvider.clearNonDefaultBuilders()
-    CommitCoordinatorProvider.registerBuilder(
-      TrackingInMemoryCommitCoordinatorBuilder(
-        backfillBatchSize, defaultCommitCoordinatorName = coordinatorName))
-  }
-
-  /** Runs `f` with the coordinated-commits coordinator enabled by default for new tables. */
-  private def withCoordinatedCommits(f: => Unit): Unit = {
-    withSQLConf(
-        COORDINATED_COMMITS_COORDINATOR_NAME.defaultTablePropertyKey -> coordinatorName,
-        // Keep checkpoints/minor-compactions out of the picture; these tests reason about versions.
-        DeltaSQLConf.DELTALOG_MINOR_COMPACTION_USE_FOR_READS.key -> "false") {
-      f
-    }
-  }
-
-  private def logDir(path: String): File = new File(path, "_delta_log")
-
-  private def stagedCommitsDir(path: String): File =
-    new File(logDir(path), FileNames.COMMIT_SUBDIR)
-
-  private def stagedCommitFiles(path: String): Seq[File] =
-    Option(stagedCommitsDir(path).listFiles()).getOrElse(Array.empty)
+  private def stagedCommitFiles(deltaLog: DeltaLog): Seq[File] =
+    Option(new File(FileNames.commitDirPath(deltaLog.logPath).toUri).listFiles())
+      .getOrElse(Array.empty[File])
       .filter(_.getName.endsWith(".json"))
       .sortBy(_.getName)
       .toSeq
 
-  private def backfilledDeltaFile(path: String, version: Long): File =
-    new File(FileNames.unsafeDeltaFile(new Path(logDir(path).toString), version).toString)
+  private def stagedCommitFile(deltaLog: DeltaLog, version: Long): File =
+    stagedCommitFiles(deltaLog)
+      .find(f => FileNames.deltaVersion(new Path(f.toURI)) == version)
+      .getOrElse(fail(s"expected staged commit v$version"))
+
+  private def backfilledDeltaFile(deltaLog: DeltaLog, version: Long): File =
+    new File(FileNames.unsafeDeltaFile(deltaLog.logPath, version).toUri)
+
+  /** Creates a table with backfilled v0 and staged, ratified v1. */
+  private def withStagedV1Table(f: DeltaLog => Unit): Unit = withTempDir { tempDir =>
+    val path = tempDir.getCanonicalPath
+    spark.range(0, 10).write.format("delta").save(path)
+    spark.range(10, 20).write.format("delta").mode("append").save(path)
+    DeltaLog.invalidateCache(spark, new Path(path))
+    f(DeltaLog.forTable(spark, path))
+  }
+
+  private def checkIds(deltaLog: DeltaLog, endExclusive: Int): Unit =
+    checkAnswer(
+      spark.read.format("delta").load(deltaLog.dataPath.toString).orderBy("id"),
+      (0 until endExclusive).map(i => Row(i.toLong)))
 
   /** The [[InMemoryCommitCoordinator]] backing the builder, for manipulating its ledger. */
   private def getInMemoryCoordinator: InMemoryCommitCoordinator = {
     val client = CommitCoordinatorProvider
-      .getCommitCoordinatorClient(coordinatorName, Map.empty, spark)
+      .getCommitCoordinatorClient(
+        defaultCommitsCoordinatorName, defaultCommitsCoordinatorConf, spark)
     client match {
       case tracking: TrackingCommitCoordinatorClient =>
         tracking.delegatingCommitCoordinatorClient.asInstanceOf[InMemoryCommitCoordinator]
@@ -99,132 +96,87 @@ class StagedCommitListingSuite extends QueryTest
 
   // Sanity check: the harness actually surfaces staged files, else the tests below pass vacuously.
   test("test harness: recursive listing surfaces _staged_commits files") {
-    withCoordinatedCommits {
-      withTempDir { tempDir =>
-        val path = tempDir.getCanonicalPath
-        spark.range(0, 10).write.format("delta").save(path)
-        // Append v1; with batch size 100 it stays staged (un-backfilled).
-        spark.range(10, 20).write.format("delta").mode("append").save(path)
+    withStagedV1Table { deltaLog =>
+      assert(stagedCommitFiles(deltaLog).nonEmpty,
+        "expected at least one staged commit file to exist on disk")
 
-        assert(stagedCommitFiles(path).nonEmpty,
-          "expected at least one staged commit file to exist on disk")
-
-        val deltaLog = DeltaLog.forTable(spark, path)
-        val logPath = deltaLog.logPath
-        val listed = deltaLog.store
-          .listFrom(FileNames.listingPrefix(logPath, 0L), deltaLog.newDeltaHadoopConf())
-          .map(_.getPath)
-          .toSeq
-        assert(listed.exists(p => p.getParent.getName == FileNames.COMMIT_SUBDIR),
-          s"recursive listing should surface _staged_commits files, but listed: $listed")
-      }
+      val listed = deltaLog.store
+        .listFrom(FileNames.listingPrefix(deltaLog.logPath, 0L), deltaLog.newDeltaHadoopConf())
+        .map(_.getPath)
+        .toSeq
+      assert(listed.exists(p => p.getParent.getName == FileNames.COMMIT_SUBDIR),
+        s"recursive listing should surface _staged_commits files, but listed: $listed")
     }
   }
 
   test("backfilled + staged copy of the same version does not throw NOT_CONTIGUOUS") {
-    withCoordinatedCommits {
-      withTempDir { tempDir =>
-        val path = tempDir.getCanonicalPath
-        spark.range(0, 10).write.format("delta").save(path) // v0
-        spark.range(10, 20).write.format("delta").mode("append").save(path) // v1 (staged)
+    withStagedV1Table { deltaLog =>
+      // Also materialise the backfilled `00...01.json` so v1 exists both backfilled and staged.
+      val stagedV1 = stagedCommitFile(deltaLog, version = 1L)
+      val backfilledV1 = backfilledDeltaFile(deltaLog, version = 1L)
+      assert(!backfilledV1.exists(), "v1 should initially exist only as a staged commit")
+      Files.copy(stagedV1.toPath, backfilledV1.toPath)
+      assert(backfilledV1.exists() && stagedV1.exists(),
+        "v1 must exist both backfilled and staged for this scenario")
 
-        // Also materialise the backfilled `00...01.json` so v1 exists both backfilled and staged.
-        val staged = stagedCommitFiles(path)
-        assert(staged.nonEmpty, "expected a staged commit for v1")
-        val stagedV1 = staged.find(f => FileNames.deltaVersion(new Path(f.getName)) == 1L).get
-        val backfilledV1 = backfilledDeltaFile(path, 1L)
-        if (!backfilledV1.exists()) {
-          java.nio.file.Files.copy(stagedV1.toPath, backfilledV1.toPath)
-        }
-        assert(backfilledV1.exists() && stagedV1.exists(),
-          "v1 must exist both backfilled and staged for this scenario")
+      DeltaLog.invalidateCache(spark, deltaLog.dataPath)
 
-        DeltaLog.invalidateCache(spark, new Path(path))
-
-        // Before the fix this threw DELTA_VERSIONS_NOT_CONTIGUOUS (versions [0, 1, 1]).
-        val snapshot = DeltaLog.forTable(spark, path).update()
-        assert(snapshot.version == 1L)
-        checkAnswer(
-          spark.read.format("delta").load(path).orderBy("id"),
-          (0 until 20).map(i => org.apache.spark.sql.Row(i.toLong)))
-      }
+      // Before the fix this threw DELTA_VERSIONS_NOT_CONTIGUOUS (versions [0, 1, 1]).
+      val reloadedLog = DeltaLog.forTable(spark, deltaLog.dataPath)
+      val snapshot = reloadedLog.update()
+      assert(snapshot.version == 1L)
+      checkIds(reloadedLog, endExclusive = 20)
     }
   }
 
   test("orphaned staged commit (not in getCommits) is not read") {
-    withCoordinatedCommits {
-      withTempDir { tempDir =>
-        val path = tempDir.getCanonicalPath
-        spark.range(0, 10).write.format("delta").save(path) // v0
-        // Write a genuine, well-formed v1 commit. With batch size 100 it stays staged.
-        spark.range(10, 20).write.format("delta").mode("append").save(path) // v1 (staged)
+    withStagedV1Table { deltaLog =>
+      // Orphan v1: drop it from the coordinator, leaving only the well-formed staged file under
+      // `_staged_commits/`.
+      val coordinator = getInMemoryCoordinator
+      coordinator.removeCommitTestOnly(deltaLog.logPath, commitVersion = 1L)
+      assert(!backfilledDeltaFile(deltaLog, version = 1L).exists(),
+        "v1 should not be backfilled")
+      stagedCommitFile(deltaLog, version = 1L)
 
-        val deltaLog = DeltaLog.forTable(spark, path)
-        val logPath = deltaLog.logPath
+      DeltaLog.invalidateCache(spark, deltaLog.dataPath)
 
-        // Orphan v1: drop it from the coordinator and delete any backfilled copy, leaving only the
-        // well-formed staged file under `_staged_commits/`.
-        val coordinator = getInMemoryCoordinator
-        coordinator.removeCommitTestOnly(logPath, commitVersion = 1L)
-        val backfilledV1 = backfilledDeltaFile(path, 1L)
-        if (backfilledV1.exists()) assert(backfilledV1.delete())
-        assert(stagedCommitFiles(path).exists(f =>
-          FileNames.deltaVersion(new Path(f.getName)) == 1L),
-          "the orphaned staged v1 file must still be present on disk")
-
-        DeltaLog.invalidateCache(spark, new Path(path))
-
-        val snapshot = DeltaLog.forTable(spark, path).update()
-        assert(snapshot.version == 0L,
-          s"orphaned staged commit must not advance the snapshot; got v${snapshot.version}")
-        checkAnswer(
-          spark.read.format("delta").load(path).orderBy("id"),
-          (0 until 10).map(i => org.apache.spark.sql.Row(i.toLong)))
-      }
+      val reloadedLog = DeltaLog.forTable(spark, deltaLog.dataPath)
+      val snapshot = reloadedLog.update()
+      assert(snapshot.version == 0L,
+        s"orphaned staged commit must not advance the snapshot; got v${snapshot.version}")
+      checkIds(reloadedLog, endExclusive = 10)
     }
   }
 
   test("ratified, not-yet-backfilled staged commit is still read via the coordinator") {
-    withCoordinatedCommits {
-      withTempDir { tempDir =>
-        val path = tempDir.getCanonicalPath
-        spark.range(0, 10).write.format("delta").save(path) // v0
-        spark.range(10, 20).write.format("delta").mode("append").save(path) // v1 (ratified, staged)
+    withStagedV1Table { deltaLog =>
+      // v1 is ratified by the coordinator but, with batch size 100, still only exists staged.
+      stagedCommitFile(deltaLog, version = 1L)
+      assert(!backfilledDeltaFile(deltaLog, version = 1L).exists(),
+        "v1 should NOT be backfilled yet (batch size is large)")
 
-        // v1 is ratified by the coordinator but, with batch size 100, still only exists staged.
-        val staged = stagedCommitFiles(path)
-        assert(staged.exists(f => FileNames.deltaVersion(new Path(f.getName)) == 1L),
-          "v1 should be present as a staged commit")
-        assert(!backfilledDeltaFile(path, 1L).exists(),
-          "v1 should NOT be backfilled yet (batch size is large)")
+      // Channel check: the raw fs listing must NOT surface v1 (else we wouldn't be testing the
+      // coordinator path).
+      val (fsListingOpt, _) = deltaLog.listFromFileSystemInternal(
+        startVersion = 0L,
+        versionToLoad = None,
+        includeMinorCompactions = false)
+      val fsDeltaVersions = fsListingOpt.getOrElse(Array.empty)
+        .collect { case (f, FileNames.FileType.DELTA, v) => v }.toSeq
+      assert(!fsDeltaVersions.contains(1L),
+        s"raw fs listing must not surface staged v1 as a delta; got $fsDeltaVersions")
 
-        DeltaLog.invalidateCache(spark, new Path(path))
-        val deltaLog = DeltaLog.forTable(spark, path)
+      val snapshot = deltaLog.update()
+      assert(snapshot.version == 1L,
+        s"ratified staged v1 must be read via the coordinator; got v${snapshot.version}")
+      // The v1 delta is the staged (unbackfilled) file, i.e. it came from the coordinator.
+      val v1Delta = snapshot.logSegment.deltas
+        .find(f => FileNames.deltaVersion(f.getPath) == 1L)
+        .getOrElse(fail("v1 delta missing from the log segment"))
+      verifyUnbackfilled(v1Delta)
 
-        // Channel check: the raw fs listing must NOT surface v1 (else we wouldn't be testing the
-        // coordinator path).
-        val (fsListingOpt, _) = deltaLog.listFromFileSystemInternal(
-          startVersion = 0L,
-          versionToLoad = None,
-          includeMinorCompactions = false)
-        val fsDeltaVersions = fsListingOpt.getOrElse(Array.empty)
-          .collect { case (f, FileNames.FileType.DELTA, v) => v }.toSeq
-        assert(!fsDeltaVersions.contains(1L),
-          s"raw fs listing must not surface staged v1 as a delta; got $fsDeltaVersions")
-
-        val snapshot = deltaLog.update()
-        assert(snapshot.version == 1L,
-          s"ratified staged v1 must be read via the coordinator; got v${snapshot.version}")
-        // The v1 delta is the staged (unbackfilled) file, i.e. it came from the coordinator.
-        val v1Delta = snapshot.logSegment.deltas
-          .find(f => FileNames.deltaVersion(f.getPath) == 1L)
-          .getOrElse(fail("v1 delta missing from the log segment"))
-        verifyUnbackfilled(v1Delta)
-
-        checkAnswer(
-          spark.read.format("delta").load(path).orderBy("id"),
-          (0 until 20).map(i => org.apache.spark.sql.Row(i.toLong)))
-      }
+      checkIds(deltaLog, endExclusive = 20)
     }
   }
 }

--- a/storage/src/main/java/io/delta/storage/internal/S3LogStoreUtil.java
+++ b/storage/src/main/java/io/delta/storage/internal/S3LogStoreUtil.java
@@ -27,6 +27,7 @@ import java.util.HashSet;
 import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_MAX_PAGING_KEYS;
 import static org.apache.hadoop.fs.s3a.Constants.MAX_PAGING_KEYS;
 import static org.apache.hadoop.fs.s3a.S3AUtils.iteratorToStatuses;
+import static org.apache.hadoop.fs.s3a.S3AUtils.maybeAddTrailingSlash;
 
 
 /**
@@ -63,15 +64,39 @@ public final class S3LogStoreUtil {
         // List files lexicographically after resolvedPath inclusive within the same directory
         return listing.createFileStatusListingIterator(resolvedPath,
                 S3ListRequest.v2(
-                    ListObjectsV2Request.builder()
-                        .bucket(s3afs.getBucket())
-                        .maxKeys(maxKeys)
-                        .prefix(s3afs.pathToKey(parentPath))
-                        .startAfter(keyBefore(s3afs.pathToKey(resolvedPath)))
-                        .build()
+                    buildListObjectsV2Request(
+                        s3afs.getBucket(),
+                        s3afs.pathToKey(parentPath),
+                        s3afs.pathToKey(resolvedPath),
+                        maxKeys)
                 ), ACCEPT_ALL,
                 new Listing.AcceptAllButSelfAndS3nDirs(parentPath),
                 s3afs.getActiveAuditSpan());
+    }
+
+    /**
+     * Builds the {@link ListObjectsV2Request} for the fast {@code listFrom} path.
+     *
+     * <p>{@code delimiter="/"} keeps the listing to the immediate children of {@code parentPath}
+     * (matching {@code FileSystem.listStatus}); without it ListObjectsV2 recurses and surfaces
+     * {@code _staged_commits/} files as if they were commits. The delimiter only groups
+     * subdirectories when the prefix ends in {@code "/"}, so we re-add the trailing slash that
+     * {@code pathToKey} strips via {@code maybeAddTrailingSlash}.
+     *
+     * <p>Package-private for unit testing.
+     */
+    static ListObjectsV2Request buildListObjectsV2Request(
+            String bucket,
+            String parentKey,
+            String resolvedKey,
+            int maxKeys) {
+        return ListObjectsV2Request.builder()
+            .bucket(bucket)
+            .maxKeys(maxKeys)
+            .prefix(maybeAddTrailingSlash(parentKey))
+            .delimiter("/")
+            .startAfter(keyBefore(resolvedKey))
+            .build();
     }
 
     /**

--- a/storage/src/test/scala/io/delta/storage/internal/S3LogStoreUtilTest.scala
+++ b/storage/src/test/scala/io/delta/storage/internal/S3LogStoreUtilTest.scala
@@ -41,4 +41,22 @@ class S3LogStoreUtilTest extends AnyFunSuite {
         new FilterFileSystem(new FilterFileSystem(raw)), p, p.getParent)
     }
   }
+
+  // The fast listFrom request must be delimited (single-directory), so it never recurses
+  // into `_staged_commits/`. The prefix must end in "/" or the delimiter groups nothing.
+  test("buildListObjectsV2Request is a delimited single-directory listing") {
+    val req = S3LogStoreUtil.buildListObjectsV2Request(
+      "bucket",
+      "tbl/_delta_log", // parentKey as produced by pathToKey: no trailing slash
+      "tbl/_delta_log/00000000000000000003.json",
+      1000)
+
+    assert("/" == req.delimiter())
+    assert("tbl/_delta_log/" == req.prefix())
+    assert(req.prefix().endsWith("/"))
+    assert("bucket" == req.bucket())
+    assert(1000 == req.maxKeys())
+    assert(S3LogStoreUtil.keyBefore("tbl/_delta_log/00000000000000000003.json") ==
+      req.startAfter())
+  }
 }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other

## Description

The filesystem listing in `SnapshotManagement.listFromFileSystemInternal` used the
permissive `DeltaFile` matcher, which also matches staged commits under
`_delta_log/_staged_commits/`. On a coordinated-commits table, a recursive listing
(e.g. the S3A fast-list path) could then promote a staged file to a commit — reading
un-ratified data, or throwing `DELTA_VERSIONS_NOT_CONTIGUOUS` when a version is both
backfilled and staged.

Use `BackfilledDeltaFile` so a raw listing never promotes staged files; ratified
staged commits still enter via the commit coordinator. Also add `.delimiter("/")` to
the S3A fast-path request so it lists a single directory instead of recursing.

## How was this patch tested?

New `StagedCommitListingSuite` (orphaned staged commit not read; backfilled + staged
same version does not throw; ratified staged commit still read via the coordinator)
and a `buildListObjectsV2Request` unit test.

## Does this PR introduce _any_ user-facing changes?

No.
