### PR TITLE
[Spark] Expose modification time in selected scan file descriptors

### DIFF
--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaScanFile.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaScanFile.java
@@ -27,6 +27,7 @@ public final class DeltaScanFile {
   private final String path;
   private final MapValue partitionValues;
   private final long size;
+  private final long modificationTime;
   private final Optional<Long> baseRowId;
   private final Optional<Long> defaultRowCommitVersion;
   private final Optional<DeletionVectorDescriptor> deletionVector;
@@ -35,6 +36,7 @@ public final class DeltaScanFile {
     this.path = Objects.requireNonNull(addFile, "addFile is null").getPath();
     this.partitionValues = addFile.getPartitionValues();
     this.size = addFile.getSize();
+    this.modificationTime = addFile.getModificationTime();
     this.baseRowId = addFile.getBaseRowId();
     this.defaultRowCommitVersion = addFile.getDefaultRowCommitVersion();
     this.deletionVector = addFile.getDeletionVector();
@@ -50,6 +52,10 @@ public final class DeltaScanFile {
 
   public long getSize() {
     return size;
+  }
+
+  public long getModificationTime() {
+    return modificationTime;
   }
 
   public Optional<Long> getBaseRowId() {


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Include AddFile modification times in DeltaScanFile alongside path and size, so selected-file consumers do not need access to Kernel AddFile for this metadata.


<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

CI. Extending the descriptor which is currently not in use.

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No