### PR TITLE
Verify AMT back references on every commit

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -57,6 +57,7 @@ import org.apache.spark.sql.delta.sources.{DeltaSourceUtils, DeltaSQLConf}
 import org.apache.spark.sql.delta.stats._
 import org.apache.spark.sql.delta.stats.FileSizeHistogramUtils
 import org.apache.spark.sql.delta.util.{DeltaCommitFileProvider, JsonUtils, PartitionUtils, TransactionHelper}
+import org.apache.spark.sql.delta.util.{Utils => DeltaUtils}
 import org.apache.spark.sql.util.ScalaExtensions._
 import io.delta.storage.commit._
 import io.delta.storage.commit.actions.{AbstractDomainMetadata, AbstractMetadata, AbstractProtocol}
@@ -2667,7 +2668,32 @@ trait OptimisticTransactionImpl extends TransactionHelper
       checkColumnDefaults(op)
     }
 
+    verifyAmtBackReferences(finalActions)
     finalActions
+  }
+
+  /**
+   * Test-only invariant check for AMT back references, run on every commit to an AMT-backed table.
+   */
+  private def verifyAmtBackReferences(finalActions: Seq[Action]): Unit = {
+    if (!DeltaUtils.isTesting) return
+    snapshot.checkpointProvider match {
+      case amt: AMTCheckpointProvider =>
+        amt.verifyCommitBackReferences(spark, deltaLog, finalActions)
+      case _ =>
+        // Not an AMT-backed table: no file action may carry a back reference.
+        finalActions.foreach {
+          case a: AddFile if a.backReference.isDefined =>
+            throw new IllegalStateException(
+              s"AddFile '${a.path}' carries a back reference ${a.backReference} on a " +
+              "non-AMT table, which must not happen.")
+          case r: RemoveFile if r.backReference.isDefined =>
+            throw new IllegalStateException(
+              s"RemoveFile '${r.path}' carries a back reference ${r.backReference} on a " +
+              "non-AMT table, which must not happen.")
+          case _ => // File action without a back reference, or a non-file action: nothing to check.
+        }
+    }
   }
 
   // Returns the isolation level to use for committing the transaction

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTCheckpointProvider.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTCheckpointProvider.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.delta.amt
 
 import org.apache.spark.sql.delta.{CheckpointPolicy, CheckpointProvider, DeltaLog, DeltaLogFileIndex, Snapshot}
 import org.apache.spark.sql.delta.DeltaLogFileIndex.COMMIT_VERSION_COLUMN
-import org.apache.spark.sql.delta.actions.{BackReference, Checkpoint, ContentRoot, SingleAction}
+import org.apache.spark.sql.delta.actions.{Action, AddFile, BackReference, Checkpoint, ContentRoot, RemoveFile, SingleAction}
 import org.apache.spark.sql.delta.deletionvectors.RoaringBitmapArray
 import org.apache.spark.sql.delta.util.DeltaEncoder
 import org.apache.hadoop.fs.{FileStatus, Path}
@@ -183,6 +183,40 @@ final class AMTCheckpointProvider(
           }
         }
       }
+  }
+
+  /**
+   * Test-only invariant check for AMT back references.
+   */
+  private[delta] def verifyCommitBackReferences(
+      spark: SparkSession,
+      deltaLog: DeltaLog,
+      committedActions: Seq[Action]): Unit = {
+    val committedFiles: Seq[(String, Option[BackReference])] = committedActions.collect {
+      case a: AddFile => a.path -> a.backReference
+      case r: RemoveFile => r.path -> r.backReference
+    }
+    if (committedFiles.isEmpty) return
+
+    val expectedPathToBackreferenceMap: Map[String, Option[BackReference]] =
+      liveAddSingleActions(spark, deltaLog)
+        .collect()
+        .map(sa => sa.add.path -> sa.add.backReference)
+        .toMap
+
+    committedFiles.foreach { case (path, actual) =>
+      expectedPathToBackreferenceMap.get(path) match {
+        case Some(expected) if actual != expected =>
+          throw new IllegalStateException(
+            s"AMT back reference for file '$path' does not match the AMT. " +
+            s"Expected $expected but the committed action carried $actual.")
+        case None if actual.isDefined =>
+          throw new IllegalStateException(
+            s"File '$path' carries a back reference $actual but is not present in the AMT " +
+            "tree, so it must not carry one.")
+        case _ => // Present and matching, or absent and empty: as expected.
+      }
+    }
   }
 }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTBackReferenceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTBackReferenceSuite.scala
@@ -16,7 +16,7 @@
 
 package org.apache.spark.sql.delta.amt
 
-import org.apache.spark.sql.delta.{DeletionVectorsTestUtils, DeltaLog, Snapshot}
+import org.apache.spark.sql.delta.{DeletionVectorsTestUtils, DeltaLog, DeltaOperations, Snapshot}
 import org.apache.spark.sql.delta.actions.{Action, AddFile, BackReference, RemoveFile}
 import org.apache.spark.sql.delta.deletionvectors.RoaringBitmapArray
 import org.apache.hadoop.fs.Path
@@ -66,20 +66,26 @@ class AMTBackReferenceSuite extends AMTCheckpointTestBase with DeletionVectorsTe
   /**
    * Creates an AMT table and inserts two single-row files, the second insert landing on a
    * checkpoint boundary so both files are captured in the leaves and stamped with back references.
-   * Returns the post-emit `path -> back reference` map (the source of truth every command's
-   * tombstone / superseding AddFile must inherit).
+   * Returns the two reconstructed leaf-derived `AddFile`s (each carrying a back reference).
    */
-  private def emitTwoStampedFiles(name: String): Map[String, Option[BackReference]] = {
+  private def emitTwoStampedAddFiles(name: String): Seq[AddFile] = {
     createAMTTable(name, checkpointInterval = 2)
     sql(s"INSERT INTO $name VALUES (1)")
     sql(s"INSERT INTO $name VALUES (2)") // Lands on a checkpoint boundary -> emit.
     val snapshot = deltaLogForName(name).update()
     assert(amtProvider(snapshot).isDefined, "table must be AMT-backed after the emit.")
-    val byPath = liveAddFiles(snapshot).map(add => add.path -> add.backReference).toMap
-    assert(byPath.size == 2 && byPath.values.forall(_.isDefined),
+    val adds = liveAddFiles(snapshot)
+    assert(adds.size == 2 && adds.forall(_.backReference.isDefined),
       "both emitted files must be reconstructed from the leaves with a back reference.")
-    byPath
+    adds
   }
+
+  /**
+   * As [[emitTwoStampedAddFiles]], but returns the post-emit `path -> back reference` map (the
+   * source of truth every command's tombstone / superseding AddFile must inherit).
+   */
+  private def emitTwoStampedFiles(name: String): Map[String, Option[BackReference]] =
+    emitTwoStampedAddFiles(name).map(add => add.path -> add.backReference).toMap
 
   /**
    * Asserts that every file action committed after `afterVersion` that reuses a pre-command
@@ -332,6 +338,67 @@ class AMTBackReferenceSuite extends AMTCheckpointTestBase with DeletionVectorsTe
         assert(r.backReference.isEmpty,
           s"Non-AMT RemoveFile ${r.path} must not carry a back reference.")
       }
+    }
+  }
+
+  /** Commits `actions` through a real transaction so the OptimisticTransaction back-reference
+   *  check runs. */
+  private def commitActions(name: String, actions: Seq[Action]): Unit = {
+    val log = deltaLogForName(name)
+    log.startTransaction().commit(actions, DeltaOperations.ManualUpdate)
+  }
+
+  test("commit accepts a RemoveFile carrying the correct back reference") {
+    withTable("amt_commit_ok") {
+      val adds = emitTwoStampedAddFiles("amt_commit_ok")
+      // Tombstoning a leaf-derived file keeps its (correct) back reference: the commit must pass.
+      commitActions("amt_commit_ok", Seq(adds.head.removeWithTimestamp()))
+    }
+  }
+
+  test("commit accepts a fresh file that carries no back reference") {
+    withTable("amt_commit_fresh") {
+      val adds = emitTwoStampedAddFiles("amt_commit_fresh")
+      // A brand-new file not present in the tree legitimately carries no back reference.
+      val fresh = adds.head.copy(path = "brand-new-file.parquet", backReference = None)
+      commitActions("amt_commit_fresh", Seq(fresh))
+    }
+  }
+
+  test("commit fails when a leaf-derived file's tombstone is missing its back reference") {
+    withTable("amt_commit_missing") {
+      val adds = emitTwoStampedAddFiles("amt_commit_missing")
+      // Strip the back reference off a tombstone for a file the tree says should carry one.
+      val stripped = adds.head.removeWithTimestamp().copy(backReference = None)
+      val ex = intercept[IllegalStateException] {
+        commitActions("amt_commit_missing", Seq(stripped))
+      }
+      assert(ex.getMessage.contains("does not match the AMT"))
+      assert(ex.getMessage.contains(stripped.path))
+    }
+  }
+
+  test("commit fails when a fresh file carries a spurious back reference") {
+    withTable("amt_commit_spurious") {
+      val adds = emitTwoStampedAddFiles("amt_commit_spurious")
+      // A file not in the tree must not carry a back reference
+      val spurious = adds.head.copy(path = "brand-new-file.parquet")
+      val ex = intercept[IllegalStateException] {
+        commitActions("amt_commit_spurious", Seq(spurious))
+      }
+      assert(ex.getMessage.contains("not present in the AMT"))
+    }
+  }
+
+  test("commit fails when a present file's tombstone carries the wrong back reference") {
+    withTable("amt_commit_wrong") {
+      val adds = emitTwoStampedAddFiles("amt_commit_wrong")
+      val wrongBr = adds.head.backReference.get.copy(pos = adds.head.backReference.get.pos + 1000L)
+      val wrong = adds.head.removeWithTimestamp().copy(backReference = Some(wrongBr))
+      val ex = intercept[IllegalStateException] {
+        commitActions("amt_commit_wrong", Seq(wrong))
+      }
+      assert(ex.getMessage.contains("does not match the AMT"))
     }
   }
 


### PR DESCRIPTION
## Description

Adds a test-only invariant check that validates AMT (Adaptive Metadata Tree) back references on every commit.

On each commit to an AMT-backed table, the transaction now verifies that every committed `AddFile`/`RemoveFile` carries a back reference consistent with the live AMT state:

- A file present in the AMT must carry exactly the back reference the tree expects.
- A file not present in the AMT must not carry a back reference.
- On non-AMT tables, no file action may carry a back reference at all.

Any mismatch throws an `IllegalStateException`. The check is gated on the testing flag, so it adds no overhead in production.

## How was this patch tested?

Added `AMTBackReferenceSuite` cases covering:
- A tombstone that keeps its correct back reference (accepted).
- A fresh file with no back reference (accepted).
- A leaf-derived tombstone missing its back reference (rejected).
- A fresh file carrying a spurious back reference (rejected).
- A tombstone carrying a wrong back reference (rejected).

## Does this PR introduce _any_ user-facing changes?

No.