### PR TITLE
[Docs] Note that the S3A quickstart also works with S3-compatible endpoints

### DIFF
--- a/docs/src/content/docs/delta-storage.mdx
+++ b/docs/src/content/docs/delta-storage.mdx
@@ -206,6 +206,16 @@ This section explains how to quickly start reading and writing Delta tables on S
 
 For other languages and more examples of Delta table operations, see the [Quickstart](/quick-start/) page.
 
+<Aside type="note" title="Using an S3-compatible endpoint">
+  The `s3a` connector works with Amazon S3 as well as any S3-compatible object
+  store (for example, Backblaze B2, Cloudflare R2, or MinIO). To target a
+  compatible store, keep the configuration above and set
+  `spark.hadoop.fs.s3a.endpoint` to your provider's endpoint URL (for example,
+  `<your-s3-compatible-endpoint>`). Some providers also require path-style
+  access, which you can enable with
+  `spark.hadoop.fs.s3a.path.style.access=true`.
+</Aside>
+
 For efficient listing of Delta Lake metadata files on S3, set the configuration `delta.enableFastS3AListFrom=true`. This performance optimization is in experimental support mode. It will only work on `S3A` filesystems and will not work on [Amazon's EMR](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-plan-file-systems.html) default filesystem `S3`.
 
 <Tabs>


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (Docs)

## Description

Adds a short note to the S3 single-cluster quickstart on the storage configuration page (`docs/src/content/docs/delta-storage.mdx`) explaining that the same setup works against S3-compatible object stores, not only Amazon S3.

The note states that:
- The `s3a` connector works with Amazon S3 as well as any S3-compatible object store (Backblaze B2, Cloudflare R2, and MinIO are listed as examples).
- To target a compatible store, the configuration shown just above stays the same and `spark.hadoop.fs.s3a.endpoint` is set to the provider's endpoint URL.
- Some providers also require path-style access, enabled with `spark.hadoop.fs.s3a.path.style.access=true`.

Motivation: the page documents `s3a://` end to end but only in terms of Amazon S3, so it is not obvious that the same connector and configuration apply to other S3-compatible endpoints. Users hitting this today have to infer the two extra `fs.s3a` settings from Hadoop's documentation.

No new behavior or configuration is introduced; both settings are existing Hadoop `hadoop-aws` options.

## How was this patch tested?

Documentation-only change, 10 added lines in a single `.mdx` file and no code paths touched. The note uses the same `<Aside type="note">` component already used elsewhere on this page, and the endpoint value is a placeholder in the same style as the surrounding `<your-s3-...>` placeholders.

## Does this PR introduce _any_ user-facing changes?

No functional changes. The only user-facing difference is on the docs site: the S3 single-cluster quickstart now carries a note that the `s3a` configuration also applies to S3-compatible endpoints, and which two settings to adjust.
