### PR TITLE
[Spark] Validate type widening on the V2 connector's reader

### DIFF
--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/ProtocolMetadataAdapterV2Suite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/ProtocolMetadataAdapterV2Suite.scala
@@ -41,8 +41,6 @@ class ProtocolMetadataAdapterV2Suite extends ProtocolMetadataAdapterSuiteBase {
    * These tests can be ignored because V2 has different behavior or limitations.
    */
   protected def ignoredTests: Set[String] = Set(
-    // TODO(delta-io/delta#5649): add type widening validation
-    "assertTableReadable with table with unsupported type widening",
     // V1 IcebergCompat is not supported in Kernel (only V2/V3)
     "isIcebergCompatAnyEnabled when v1 enabled",
     "isIcebergCompatGeqEnabled when v1 enabled"

--- a/spark/src/main/scala/org/apache/spark/sql/delta/TypeWidening.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TypeWidening.scala
@@ -151,7 +151,10 @@ object TypeWidening {
    * happen unless a non-compliant writer applied a type change that is not part of the feature
    * specification.
    */
-  def assertTableReadable(conf: SQLConf, protocol: Protocol, metadata: Metadata): Unit = {
+  def assertTableReadable(
+      conf: SQLConf,
+      protocol: AbstractProtocol,
+      metadata: AbstractMetadata): Unit = {
     if (conf.getConf(DeltaSQLConf.DELTA_TYPE_WIDENING_BYPASS_UNSUPPORTED_TYPE_CHANGE_CHECK) ||
       !isSupported(protocol) ||
       !TypeWideningMetadata.containsTypeWideningMetadata(metadata.schema)) {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/ProtocolMetadataAdapterSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/ProtocolMetadataAdapterSuite.scala
@@ -17,6 +17,7 @@
 package org.apache.spark.sql.delta
 
 import org.apache.spark.sql.delta.actions.{Metadata, Protocol}
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.test.SharedSparkSession
@@ -159,6 +160,23 @@ abstract class ProtocolMetadataAdapterSuiteBase
     }
   }
 
+  /** Field metadata recording one type change, as a writer applying it would leave behind. */
+  private def recordedTypeChange(
+      fromType: String,
+      toType: String): org.apache.spark.sql.types.Metadata =
+    new MetadataBuilder()
+      .putMetadataArray("delta.typeChanges", Array(
+        new MetadataBuilder()
+          .putLong("tableVersion", 1L)
+          .putString("fromType", fromType)
+          .putString("toType", toType)
+          .build()
+      ))
+      .build()
+
+  private val typeWideningEnabled = Map(DeltaConfigs.ENABLE_TYPE_WIDENING.key -> "true")
+  private val typeWideningSupported = Some(Set(TypeWideningTableFeature.name))
+
   Seq[(String, Option[org.apache.spark.sql.types.Metadata], Boolean, Map[String, String],
     Option[Set[String]], Option[Set[String]])](
     // Table with no special features should be readable
@@ -166,19 +184,23 @@ abstract class ProtocolMetadataAdapterSuiteBase
      None, None),
     // Table with unsupported type widening (string -> integer), should not be readable
     ("table with unsupported type widening",
-      Some(new MetadataBuilder()
-        .putMetadataArray("delta.typeChanges", Array(
-          new MetadataBuilder()
-            .putLong("tableVersion", 1L)
-            .putString("fromType", "string")
-            .putString("toType", "integer")
-            .build()
-        ))
-        .build()),
+      Some(recordedTypeChange("string", "integer")),
      false,
-      Map(DeltaConfigs.ENABLE_TYPE_WIDENING.key -> "true"),
-      Some(Set(TypeWideningTableFeature.name)),
-      Some(Set(TypeWideningTableFeature.name)))
+      typeWideningEnabled, typeWideningSupported, typeWideningSupported),
+    // The readable case above has no type change to inspect, so this is the only case asserting
+    // that a supported one is accepted.
+    ("table with supported type widening",
+      Some(recordedTypeChange("integer", "long")),
+     true,
+      typeWideningEnabled, typeWideningSupported, typeWideningSupported),
+    ("table with type widening enabled and no type change",
+      None, true,
+      typeWideningEnabled, typeWideningSupported, typeWideningSupported),
+    // Type change metadata left behind after the feature was dropped.
+    ("table with type change metadata but the feature not supported",
+      Some(recordedTypeChange("string", "integer")),
+     true,
+      Map.empty, None, None)
   ).foreach { case (testCaseName, typeChangeMetadata, tableReadable, config,
     readerFeatures, writerFeatures) =>
     test(s"assertTableReadable with $testCaseName") {
@@ -206,6 +228,28 @@ abstract class ProtocolMetadataAdapterSuiteBase
           wrapper.assertTableReadable(spark)
         }
       }
+    }
+  }
+
+  test("assertTableReadable with unsupported type widening and the check bypassed") {
+    // Separate from the cases above because those cannot express a conf override.
+    val wrapper = createWrapper(
+      minReaderVersion = 3,
+      minWriterVersion = 7,
+      readerFeatures = typeWideningSupported,
+      writerFeatures = typeWideningSupported,
+      schema = new StructType()
+        .add("col1", IntegerType, nullable = true,
+          metadata = recordedTypeChange("string", "integer")),
+      configuration = typeWideningEnabled)
+
+    intercept[Exception] {
+      wrapper.assertTableReadable(spark)
+    }
+
+    withSQLConf(
+        DeltaSQLConf.DELTA_TYPE_WIDENING_BYPASS_UNSUPPORTED_TYPE_CHANGE_CHECK.key -> "true") {
+      wrapper.assertTableReadable(spark)
     }
   }
 

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/ProtocolMetadataAdapterV2.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/ProtocolMetadataAdapterV2.java
@@ -21,6 +21,8 @@ import io.delta.kernel.internal.actions.Protocol;
 import io.delta.kernel.internal.rowtracking.RowTracking;
 import io.delta.kernel.internal.tablefeatures.TableFeatures;
 import io.delta.kernel.internal.util.ColumnMapping;
+import io.delta.spark.internal.v2.adapters.KernelMetadataAdapter;
+import io.delta.spark.internal.v2.adapters.KernelProtocolAdapter;
 import io.delta.spark.internal.v2.utils.RowTrackingUtils;
 import io.delta.spark.internal.v2.utils.SchemaUtils;
 import java.io.Serializable;
@@ -30,6 +32,7 @@ import org.apache.spark.sql.delta.IdMapping$;
 import org.apache.spark.sql.delta.NameMapping$;
 import org.apache.spark.sql.delta.NoMapping$;
 import org.apache.spark.sql.delta.ProtocolMetadataAdapter;
+import org.apache.spark.sql.delta.TypeWidening;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import scala.jdk.javaapi.CollectionConverters;
@@ -119,7 +122,10 @@ public class ProtocolMetadataAdapterV2 implements ProtocolMetadataAdapter, Seria
 
   @Override
   public void assertTableReadable(SparkSession sparkSession) {
-    // TODO(delta-io/delta#5649): Add type widening validation.
+    TypeWidening.assertTableReadable(
+        sparkSession.sessionState().conf(),
+        new KernelProtocolAdapter(protocol),
+        new KernelMetadataAdapter(metadata));
   }
 
   @Override


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

ProtocolMetadataAdapterV2.assertTableReadable was empty, so a V2 read accepted a schema recording a type change outside the type widening feature specification while the V1 reader rejected it. Only a non-compliant writer can produce such a schema, but the two readers should not disagree about it.

Widen TypeWidening.assertTableReadable to the AbstractProtocol / AbstractMetadata interop traits, matching TypeWidening.isEnabled, and call it from V2 through KernelProtocolAdapter / KernelMetadataAdapter. This closes only the type widening gap; V2 still does not run V1's geospatial check.

Re-enables the shared ProtocolMetadataAdapterSuiteBase case that was ignored for V2 pending this change, and adds the paths that case left untested for both adapters: a supported change is accepted, the check is skipped when the feature is not supported and when nothing has been widened, and the bypass conf still works.

Resolves #5649.

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

Reenabled and added new tests and CI.

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No