### PR TITLE
Fix adaptive metadata full-rewrite starvation off the interval grid

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -2907,7 +2907,13 @@ trait OptimisticTransactionImpl extends TransactionHelper
       // The AMT was written inline with this commit (always incremental). A full rewrite is never
       // inlined, so schedule a follow-up full OPTIMIZE CHECKPOINT commit when the full-rewrite
       // cadence is due -- otherwise a table whose commits consistently inline would never get a
-      // full tree.
+      // full tree. When the inline write itself lands on the full-rewrite cadence, the tree is
+      // materialized twice (incrementally inline at this version, then fully at the follow-up
+      // version). We deliberately do not suppress the inline write in that case: the inline write
+      // exists to pack a large writer's file actions into the manifest tree instead of
+      // the commit JSON, and skipping it would push those actions back inline and bloat the commit
+      // JSON -- exactly what the inline path avoids. The rare double materialization is the
+      // accepted cost of never writing a very large commit JSON.
       amtWriterManager.planMaintenanceAfterInlineWrite(attemptVersion, postCommitSnapshot)
     }
     val commitStatsComputer = new CommitStatsComputer()

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriterManager.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriterManager.scala
@@ -214,15 +214,7 @@ class AMTWriterManager(
       return MaintenanceOperation()
     }
     val checkpointInterval = deltaLog.checkpointInterval(postCommitSnapshot.metadata)
-    val fullRewriteSpan = checkpointInterval.toLong * fullRewriteCheckpointIntervalMultiplier
-    val scheduleFull = AMTWriteHelper.previousAMTContentRoot(postCommitSnapshot)
-      .flatMap(_.lastManifestCommitWithFullRewrite)
-      .exists { lastFull =>
-        val versionsSinceFull = commitVersion - lastFull
-        versionsSinceFull > 0 && versionsSinceFull % checkpointInterval == 0 &&
-          versionsSinceFull >= fullRewriteSpan
-      }
-    if (scheduleFull) {
+    if (isFullCheckpointOverdue(commitVersion, postCommitSnapshot, checkpointInterval)) {
       MaintenanceOperation(
         shouldCheckpoint = true,
         amtTriggerModeOpt = Some(AMTTriggerMode.CheckpointIntervalFull))
@@ -262,8 +254,43 @@ class AMTWriterManager(
         })
     }
 
+    // -- case-1b --
+    // Backstop for an overdue full rewrite off the interval boundary. case-1 only fires at an
+    // interval boundary relative to the last AMT, and interval-boundary commits can be inlined.
+    // The inline path i.e. [[planMaintenanceAfterInlineWrite]] only schedules a full when it lands
+    // exactly on the full-rewrite cadence i.e. if checkpoint interval=10 and multiplier = 5 and
+    // last full is at 14 and then we say always have inline AMTs except 64/114/164/214 etc.). Such
+    // a table would never take case-1 and never get a follow-up full rewrite. Anchor this check to
+    // the last full rewrite (not the last AMT) and gate it on fullRewriteSpan: it fires the first
+    // version a full span has elapsed, and a racing follow-up that has not landed yet does not
+    // re-trigger on the very next commit (only once per interval), matching case-1's racing
+    // behavior.
+    if (isFullCheckpointOverdue(commitVersion, postCommitSnapshot, checkpointInterval)) {
+      return Some(AMTTriggerMode.CheckpointIntervalFull)
+    }
+
 
     None
+  }
+
+  /**
+   * Whether a full rewrite is overdue at `commitVersion`: a full span has elapsed since the last
+   * full rewrite AND `commitVersion` sits on an interval boundary relative to that anchor. The
+   * boundary gate keeps this racing-safe -- while a scheduled follow-up is in flight it re-triggers
+   * at most once per interval, not on every commit -- matching `followUpTriggerMode`'s case-1.
+   */
+  private def isFullCheckpointOverdue(
+      commitVersion: Long,
+      postCommitSnapshot: Snapshot,
+      checkpointInterval: Long): Boolean = {
+    val fullRewriteSpan = checkpointInterval * fullRewriteCheckpointIntervalMultiplier
+    AMTWriteHelper.previousAMTContentRoot(postCommitSnapshot)
+      .flatMap(_.lastManifestCommitWithFullRewrite)
+      .exists { lastFull =>
+        val versionsSinceFull = commitVersion - lastFull
+        versionsSinceFull > 0 && versionsSinceFull % checkpointInterval == 0 &&
+          versionsSinceFull >= fullRewriteSpan
+      }
   }
 
   /**

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointPolicySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointPolicySuite.scala
@@ -18,10 +18,13 @@ package org.apache.spark.sql.delta.amt
 
 import com.databricks.spark.util.{Log4jUsageLogger, MetricDefinitions}
 import org.apache.spark.sql.delta.{AdaptiveMetadataTableFeature, CommitStats, DeltaLog}
+import org.apache.spark.sql.delta.DeltaOperations
 import org.apache.spark.sql.delta.actions.Checkpoint
 import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils._
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.JsonUtils
+
+import org.apache.spark.sql.catalyst.TableIdentifier
 
 /**
  * Emission-policy scenarios for AMT (`adaptiveMetadata-preview`): the checkpoint-interval trigger
@@ -63,6 +66,20 @@ class AMTCheckpointPolicySuite extends AMTCheckpointTestBase {
       .flatMap(_.amtWriteMetrics)
       .flatMap(_.attempts.headOption)
       .getOrElse(fail(s"No AMT write metrics logged for version $version."))
+  }
+
+  /**
+   * Writes a full AMT via a direct OPTIMIZE CHECKPOINT commit (the same operation the post-commit
+   * checkpoint hook issues), landing a full rewrite that describes the latest committed version.
+   * Used to bootstrap a full anchor at an arbitrary (off-interval-grid) version.
+   */
+  private def writeFullOptimizeCheckpoint(tableName: String): Unit = {
+    val deltaLog = deltaLogForName(tableName)
+    val catalogTable = spark.sessionState.catalog.getTableMetadata(TableIdentifier(tableName))
+    deltaLog.startTransaction(Some(catalogTable), Some(deltaLog.update())).commit(
+      Seq.empty,
+      DeltaOperations.OptimizeCheckpoint(
+        incremental = false, triggerName = AMTTriggerMode.CheckpointIntervalFull.name))
   }
 
 
@@ -304,6 +321,82 @@ class AMTCheckpointPolicySuite extends AMTCheckpointTestBase {
             s"Full rewrite at v$next is only ${next - prev} versions after v$prev (span " +
               s"$fullRewriteSpan).")
         case _ => ()
+      }
+    }
+  }
+
+  // A table whose full anchor sits off the interval grid (here the first full AMT is written by a
+  // direct OPTIMIZE CHECKPOINT at v2, describing v1) and whose commits otherwise all write their
+  // AMT inline must still get a periodic full rewrite. The span commit at v11 (11 - anchor 1 = 10 =
+  // 2 * interval) is where the full is due; whether it inlines or not, a full checkpoint must land
+  // describing v11.
+  //   - interval boundary inline = false: v11 is a small commit -> deferred follow-up path, where
+  //     case-1 cannot fire (11 - lastAMT 10 = 1) and case-1b emits the full instead.
+  //   - interval boundary inline = true:  v11 is a large commit -> inlines an incremental AMT and
+  //     planMaintenanceAfterInlineWrite schedules the full follow-up (the tree is materialized
+  //     twice at v11 and v12, the accepted cost of never inlining a large commit's actions).
+  Seq(true, false).foreach { boundaryInline =>
+    test("[full checkpoint off boundary] table which only gets inline commits except at interval " +
+        s"boundary is not starved of full checkpoint [interval boundary inline = $boundaryInline]"
+        ) {
+      withTable("amt_offgrid_full") {
+        val name = "amt_offgrid_full"
+        // interval 5, multiplier 2 -> fullRewriteSpan = 10.
+        //   commit 0             CREATE TABLE
+        //   commit 1  INSERT     (data commit; no full tree yet, so it does not write an AMT)
+        //   commit 2  OPTIMIZE CHECKPOINT full        (describes v1,  lastFull=1; off-grid anchor)
+        //   commit 3..10 INSERT range(8)  (large -> inline incremental each)
+        //   commit 11 INSERT     (interval boundary: large inline OR small deferred, per parameter)
+        //   commit 12 full checkpoint                (describes v11, lastFull=11)
+        createAMTTable(name, checkpointInterval = 5)
+        val deltaLog = deltaLogForName(name)
+        withSQLConf(
+            DeltaSQLConf.AMT_FULL_REWRITE_CHECKPOINT_INTERVAL_MULTIPLIER.key -> "2",
+            // A large commit (>= 4 actions) inlines its AMT once a full tree exists; a small one
+            // does not. maxRecordsPerFile 1 with optimized writes off makes an N-row insert commit
+            // N AddFile actions, so row count controls the action count directly.
+            DeltaSQLConf.AMT_LARGE_COMMIT_ACTIONS_COUNT_THRESHOLD_FOR_INLINE_MANIFEST_COMMIT.key
+              -> "4",
+            DeltaSQLConf.DELTA_OPTIMIZE_WRITE_ENABLED.key -> "false",
+            "spark.sql.files.maxRecordsPerFile" -> "1") {
+          // v1: a data commit off the interval boundary. No full tree exists yet, so it writes no
+          // AMT inline. v2: write the first (full) AMT via a direct OPTIMIZE CHECKPOINT commit, the
+          // same operation the checkpoint hook issues; it describes v1 and anchors lastFull off the
+          // interval grid.
+          sql(s"INSERT INTO $name VALUES (1)") // v1.
+          writeFullOptimizeCheckpoint(name) // v2 -> full checkpoint describing v1.
+          assert(deltaLog.update().version == 2, "The bootstrap OPTIMIZE CHECKPOINT lands at v2.")
+          assert(checkpointAt(deltaLog, 2).contentRoot.isIncremental.contains(false),
+            "The bootstrap AMT is a full rewrite anchoring lastFull off the interval grid.")
+
+          // v3..v10: every commit is large, so each inlines an incremental AMT (a full tree now
+          // exists). The inline checkpoints ride on v3..v10; none crosses the span yet.
+          (1 to 8).foreach(_ => sql(s"INSERT INTO $name SELECT * FROM range(8)"))
+          assert(deltaLog.update().version == 10, "Eight inline commits land at v3..v10.")
+
+          // v11 is a full span past the anchor (11 - 1 = 10). Per the parameter it either inlines
+          // (large) or takes the deferred path (small); either way a full must follow at v12.
+          if (boundaryInline) {
+            sql(s"INSERT INTO $name SELECT * FROM range(8)") // v11 large -> inline incr + full v12.
+          } else {
+            sql(s"INSERT INTO $name VALUES (0)") // v11 small -> deferred; case-1b full v12.
+          }
+        }
+        // ExpectedCheckpoint(describedVersion, manifestCommitVersion, incremental, lastFullRewrite)
+        // The inline incremental describing v11 is present only when v11 itself inlines.
+        val v11Inline =
+          if (boundaryInline) {
+            Seq(ExpectedCheckpoint(11, 11, incremental = true, lastFullRewrite = 1))
+          } else {
+            Seq.empty
+          }
+        val inlineIncrementals =
+          (3L to 10L).map(v => ExpectedCheckpoint(v, v, incremental = true, lastFullRewrite = 1))
+        assertCheckpointTimeline(deltaLog,
+          Seq(ExpectedCheckpoint(1, 2, incremental = false, lastFullRewrite = 1)) ++
+            inlineIncrementals ++
+            v11Inline ++
+            Seq(ExpectedCheckpoint(11, 12, incremental = false, lastFullRewrite = 11)))
       }
     }
   }


### PR DESCRIPTION
## Description

The adaptive metadata tree schedules a full manifest rewrite once a full span (`checkpointInterval * fullRewriteCheckpointIntervalMultiplier`) has elapsed since the last full rewrite; between fulls it emits incremental trees. The follow-up checkpoint path decided full-vs-incremental only at an interval boundary measured relative to the last adaptive metadata tree.

That check can starve the full rewrite once a table's interval-boundary commits are consistently written inline. An inline write advances the last-tree version onto the interval grid but leaves the last-full-rewrite anchor where it was, and that anchor can itself sit off the grid. Because the inline path only schedules a full when the inline commit lands exactly on the full-rewrite cadence, a table whose boundaries keep inlining never takes the boundary path and never re-triggers a full, so the full rewrite is deferred indefinitely past the span.

This PR adds a backstop that anchors the boundary check to the last full rewrite rather than the last tree: it schedules a full rewrite on the first version that is both an exact interval multiple and at least a full span past the anchor. It is racing-safe in the same way the existing boundary check is -- a scheduled follow-up that has not landed yet does not re-trigger on the very next commit, and once the follow-up lands it advances the anchor. It also documents why an inline write that lands on the full-rewrite cadence is deliberately not suppressed even though the tree is then materialized twice (inline incrementally, then fully at the follow-up).

## How was this patch tested?

Added a regression test that bootstraps an off-interval-grid full anchor via a direct `OPTIMIZE CHECKPOINT` commit, writes inline incremental trees on the interval grid, then asserts a full rewrite fires once a full span has elapsed. The test is parameterized over whether the span-boundary commit itself is written inline (deferred vs inline path), and both variants assert the full checkpoint lands.

## Does this PR introduce _any_ user-facing changes?

No.