### PR TITLE
[Spark] Add frame profiling to DeltaV2ScanBuilder

### DIFF
--- a/spark/v2/src/main/scala/io/delta/spark/internal/v2/read/DeltaV2ScanBuilder.scala
+++ b/spark/v2/src/main/scala/io/delta/spark/internal/v2/read/DeltaV2ScanBuilder.scala
@@ -19,6 +19,7 @@ package io.delta.spark.internal.v2.read
 import java.util.{Locale, Objects, Optional, OptionalInt}
 import java.util.function.Supplier
 
+import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.stats.DeltaScan
 import org.apache.spark.sql.delta.v2.interop.DeltaV2Snapshot
 import io.delta.spark.internal.v2.read.cdc.CDCSchemaContext
@@ -74,7 +75,8 @@ private[read] class DeltaV2ScanBuilder(
   extends ScanBuilder
   with SupportsPushDownRequiredColumns
   with SupportsPushDownCatalystFilters
-  with SupportsPushDownLimit {
+  with SupportsPushDownLimit
+  with DeltaLogging {
 
   // Use Objects.requireNonNull (throws NullPointerException) rather than Scala's require (throws
   // IllegalArgumentException) to preserve the exact null-check behavior of the original Java class.
@@ -102,17 +104,18 @@ private[read] class DeltaV2ScanBuilder(
   private var hasPostScanResidualFilters: Boolean = false
   private var pushedLimit: OptionalInt = OptionalInt.empty()
 
-  override def pushFilters(filters: Seq[Expression]): Seq[Expression] = {
-    val (partitionFilters, dataFilters) =
-      DataSourceUtils.getPartitionFiltersAndDataFilters(partitionSchema, filters)
-    partitionCatalystFilters = partitionFilters.toArray
-    dataCatalystFilters = dataFilters.toArray
-    // Data filters need post-scan evaluation (min/max skipping is not row-exact); partition
-    // filters are exact and need no re-evaluation. ScanBuilder mutations can be cumulative, so a
-    // later pushFilters call must not make an earlier residual safe to ignore.
-    hasPostScanResidualFilters |= dataFilters.nonEmpty
-    dataFilters
-  }
+  override def pushFilters(filters: Seq[Expression]): Seq[Expression] =
+    recordFrameProfile("Delta", "DeltaV2.pushFilters") {
+      val (partitionFilters, dataFilters) =
+        DataSourceUtils.getPartitionFiltersAndDataFilters(partitionSchema, filters)
+      partitionCatalystFilters = partitionFilters.toArray
+      dataCatalystFilters = dataFilters.toArray
+      // Data filters need post-scan evaluation (min/max skipping is not row-exact); partition
+      // filters are exact and need no re-evaluation. ScanBuilder mutations can be cumulative, so a
+      // later pushFilters call must not make an earlier residual safe to ignore.
+      hasPostScanResidualFilters |= dataFilters.nonEmpty
+      dataFilters
+    }
 
   // Filters are kept as Catalyst expressions and are not translated to data source predicates.
   override def pushedFilters: Array[Predicate] = Array.empty


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Wraps the `DeltaV2ScanBuilder` planning method `pushFilters` in `recordFrameProfile`.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No