### PR TITLE
Make the adaptive metadata tree incremental checkpoint path truly incremental

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/InMemoryLogReplay.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/InMemoryLogReplay.scala
@@ -110,6 +110,17 @@ class InMemoryLogReplay(
 
   private[delta] def getDomainMetadatas: Iterable[DomainMetadata] = domainMetadatas.values
 
+  /**
+   * Returns the most recent [[Protocol]] seen during replay, or None if no Protocol action was
+   * seen during the replay.
+   */
+  private[delta] def getProtocol: Option[Protocol] = Option(currentProtocolVersion)
+  /**
+   * Returns the most recent [[Metadata]] seen during replay, or None if no Metadata action was
+   * seen during the replay.
+   */
+  private[delta] def getMetadata: Option[Metadata] = Option(currentMetaData)
+
   /** Returns the current state of the Table as an iterator of actions. */
   override def checkpoint: Iterator[Action] = {
     val fileActions = (activeFiles.values ++ getTombstones).toSeq.sortBy(_.path)
@@ -128,4 +139,14 @@ class InMemoryLogReplay(
 object InMemoryLogReplay{
   /** The unit of path uniqueness in delta log actions is the tuple `(parquet file, dv)`. */
   final case class UniqueFileActionTuple(fileURI: URI, deletionVectorURI: Option[String])
+
+  implicit class UniqueAddFileTuple(a: AddFile) {
+    def toUniqueFileActionTuple: UniqueFileActionTuple =
+      UniqueFileActionTuple(a.pathAsUri, a.getDeletionVectorUniqueId)
+  }
+
+  implicit class UniqueRemoveFileTuple(r: RemoveFile) {
+    def toUniqueFileActionTuple: UniqueFileActionTuple =
+      UniqueFileActionTuple(r.pathAsUri, r.getDeletionVectorUniqueId)
+  }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTCheckpointProvider.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTCheckpointProvider.scala
@@ -157,6 +157,8 @@ final class AMTCheckpointProvider(
     val mdvBroadcast = spark.sparkContext.broadcast(mdvByLeaf)
     val dataEntries = AMTCheckpointProvider.loadEntriesWithLocation(spark, deltaLog, index)
       .where(col("entry.content_type") === lit(AMTSingleAction.ContentType.Type.Data))
+      .where(col("entry.tracking.status").isin(
+        AMTCheckpointProvider.liveTrackingStatuses.toSeq: _*))
       .filter { entryWithLoc =>
         mdvBroadcast.value.get(entryWithLoc.leafPath)
           .forall(bytes => !RoaringBitmapArray.readFrom(bytes).contains(entryWithLoc.pos))
@@ -260,6 +262,26 @@ object AMTCheckpointProvider {
       .filter(_.content_type == AMTSingleAction.ContentType.Type.DataManifest)
       .map(_.unwrap.asInstanceOf[DataManifestEntry])
     new AMTCheckpointProvider(checkpointAction = checkpoint, leaves = leaves, tableRoot = tableRoot)
+  }
+
+  /** Tracking Status representing the live [[DataEntry]] in an AMT. */
+  private[amt] val liveTrackingStatuses: Set[Int] =
+    Set(Tracking.Status.Existing, Tracking.Status.Added)
+
+  /** Reads the AMT root and returns the live [[DataEntry]]s tracked by root. */
+  private[amt] def readLiveRootDataEntries(
+      spark: SparkSession,
+      deltaLog: DeltaLog,
+      checkpoint: Checkpoint): Seq[AddFile] = {
+    val tableRoot = deltaLog.dataPath
+    val rootStatus = checkpoint.contentRoot.toFileStatus(tableRoot)
+    val index =
+      DeltaLogFileIndex(DeltaLogFileIndex.CHECKPOINT_FILE_FORMAT_PARQUET, Array(rootStatus))
+    loadEntries(spark, deltaLog, index).collect().toSeq
+      .filter(_.content_type == AMTSingleAction.ContentType.Type.Data)
+      .map(_.unwrap.asInstanceOf[DataEntry])
+      .filter(e => liveTrackingStatuses.contains(e.tracking.status))
+      .map(_.toAddFile(tableRoot))
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTUtils.scala
@@ -16,6 +16,7 @@
 
 package org.apache.spark.sql.delta.amt
 
+import org.apache.spark.sql.delta.deletionvectors.{RoaringBitmapArray, RoaringBitmapArrayFormat}
 import org.apache.spark.sql.delta.util.DeltaFileOperations
 import org.apache.hadoop.fs.{FileSystem, Path}
 
@@ -48,4 +49,12 @@ object AMTUtils {
     if (child.toUri.getScheme != null || child.isAbsolute) child
     else new Path(tableRoot, child)
   }
+
+  // Serializes a Manifest Deletion Vector to the on-disk byte form carried in `manifest_info.dv`.
+  private[amt] def serializeMdv(mdv: RoaringBitmapArray): Array[Byte] =
+    mdv.serializeAsByteArray(RoaringBitmapArrayFormat.Portable)
+
+  // Deserializes a Manifest Deletion Vector previously written by [[serializeMdv]].
+  private[amt] def deserializeMdv(bytes: Array[Byte]): RoaringBitmapArray =
+    RoaringBitmapArray.readFrom(bytes)
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriteHelper.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriteHelper.scala
@@ -20,7 +20,8 @@ import java.util.concurrent.TimeUnit.NANOSECONDS
 
 // scalastyle:off import.ordering.noEmptyLine
 import org.apache.spark.sql.delta.{Checkpoints, DeltaLog, DeltaParquetWriteSupport, Snapshot}
-import org.apache.spark.sql.delta.actions.{Action, AddFile, Checkpoint, ContentRoot, DomainMetadata, InMemoryLogReplay, Metadata, Protocol, SetTransaction}
+import org.apache.spark.sql.delta.actions.{Action, AddFile, Checkpoint, ContentRoot, DomainMetadata, Metadata, Protocol, SetTransaction}
+import org.apache.spark.sql.delta.deletionvectors.RoaringBitmapArray
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.FileNames
@@ -39,49 +40,6 @@ import org.apache.spark.util.SerializableConfiguration
 
 /** Helpers for emitting an inline AMT checkpoint during a commit. */
 object AMTWriteHelper extends DeltaLogging {
-
-  /**
-   * Incremental materialization (interval / size triggers): the post-commit live files are packed
-   * into leaves in input order on the driver. `actionsToCommit` are replayed onto the read snapshot
-   * via [[computePostCommitState]] to derive both the live file set and the non-file state. Returns
-   * the write result plus its metrics.
-   */
-  def writeIncrementalMaterialization(
-      spark: SparkSession,
-      readSnapshot: Snapshot,
-      commitVersion: Long,
-      actionsToCommit: Seq[Action],
-      postCommitProtocol: Protocol,
-      postCommitMetadata: Metadata,
-      trigger: String,
-      incremental: Boolean): (AMTWriteResult, SingleAMTWriteMetrics) = {
-    val deltaLog = readSnapshot.deltaLog
-    val startNanos = System.nanoTime()
-    val hadoopConf = deltaLog.newDeltaHadoopConf()
-    val entriesPerLeaf = spark.sessionState.conf.getConf(DeltaSQLConf.AMT_ENTRIES_PER_LEAF)
-
-    val postCommitState = computePostCommitState(readSnapshot, actionsToCommit)
-    val (contentRootBase, leaves) = writeManifestTree(
-      spark = spark,
-      hadoopConf = hadoopConf,
-      tableRoot = deltaLog.dataPath,
-      liveAddFiles = postCommitState.allFiles,
-      entriesPerLeaf = entriesPerLeaf)
-    val contentStateVersion =
-      if (actionsToCommit.isEmpty) readSnapshot.version else commitVersion
-    val contentRoot = policyTaggedContentRoot(
-      readSnapshot, contentRootBase, incremental, contentStateVersion)
-    buildResult(
-      contentStateVersion = contentStateVersion,
-      contentRoot = contentRoot,
-      leaves = leaves,
-      postCommitProtocol = postCommitProtocol,
-      postCommitMetadata = postCommitMetadata,
-      domainMetadata = postCommitState.getDomainMetadatas.toSeq,
-      txns = postCommitState.getTransactions.toSeq,
-      trigger = trigger,
-      startNanos = startNanos)
-  }
 
   /**
    * Writes a new AMT from scratch representing the readSnapshot content metadata. Unlike the
@@ -191,58 +149,6 @@ object AMTWriteHelper extends DeltaLogging {
       case _ => None
     }
 
-  // Post-commit table state = the read snapshot's state with this commit's actions applied,
-  // computed via InMemoryLogReplay (the same machinery snapshot state reconstruction uses).
-  private def computePostCommitState(
-      readSnapshot: Snapshot, commitActions: Seq[Action]): InMemoryLogReplay = {
-    val logReplay = new InMemoryLogReplay(
-      minFileRetentionTimestamp = None,
-      minSetTransactionRetentionTimestamp = None)
-    val baseline = readSnapshot.allFiles.collect().iterator ++
-      readSnapshot.domainMetadata.iterator ++
-      readSnapshot.setTransactions.iterator
-    logReplay.append(readSnapshot.version, baseline)
-    logReplay.append(readSnapshot.version + 1, commitActions.iterator)
-    logReplay
-  }
-
-  /**
-   * Writes a two-level AMT (Adaptive Metadata Tree) manifest tree under `<tableRoot>/metadata/`:
-   * `liveAddFiles` is packed into leaf parquet files (up to `entriesPerLeaf` entries each, in input
-   * order), and a single root parquet file lists one pointer per leaf. Returns the [[ContentRoot]]
-   * pointing at the written root file, for embedding in the inline `Checkpoint` action.
-   */
-  private def writeManifestTree(
-      spark: SparkSession,
-      hadoopConf: Configuration,
-      tableRoot: Path,
-      liveAddFiles: Seq[AddFile],
-      entriesPerLeaf: Int): (ContentRoot, Seq[DataManifestEntry]) = {
-    require(entriesPerLeaf > 0, "entriesPerLeaf must be positive.")
-
-    val fs = tableRoot.getFileSystem(hadoopConf)
-    val metadataDir = FileNames.amtMetadataDirPath(tableRoot)
-    if (!fs.exists(metadataDir)) {
-      // mkdirs is idempotent and safe under concurrent writers.
-      fs.mkdirs(metadataDir)
-    }
-
-    val leafBatches = if (liveAddFiles.isEmpty) {
-      // A checkpoint with no live files still gets a single empty leaf so the root always
-      // points at something. Keeps readers from special-casing zero-leaf trees.
-      Seq(Seq.empty[AddFile])
-    } else {
-      liveAddFiles.grouped(entriesPerLeaf).toSeq
-    }
-
-    val leafEntries = leafBatches.map { batch =>
-      writeLeaf(spark, fs, hadoopConf, tableRoot, metadataDir, batch)
-    }
-
-    val contentRoot = writeRoot(spark, fs, hadoopConf, tableRoot, metadataDir, leafEntries)
-    (contentRoot, leafEntries)
-  }
-
   /**
    * Writes a clustered AMT manifest tree for a full checkpoint of `readSnapshot`'s live files.
    * All files are clustered and flushed into leaf manifests -- one leaf per Spark partition,
@@ -273,7 +179,8 @@ object AMTWriteHelper extends DeltaLogging {
       metadataDir = metadataDir,
       addFilesDf = addFilesDf,
       desiredNumLeaves = desiredNumLeaves)
-    val contentRoot = writeRoot(spark, fs, hadoopConf, tableRoot, metadataDir, leafEntries)
+    val contentRoot =
+      writeRoot(spark, fs, hadoopConf, tableRoot, metadataDir, leafEntries.map(_.wrap))
     (contentRoot, leafEntries)
   }
 
@@ -345,8 +252,7 @@ object AMTWriteHelper extends DeltaLogging {
     }
   }
 
-  // Tracking envelope for a freshly written entry with the given status, no lineage/sequence
-  // numbers yet.
+  // Tracking envelope for a freshly written entry with the given status.
   private def trackingWithStatus(status: Int): Tracking = Tracking(
     status = status,
     snapshot_id = None,
@@ -357,11 +263,20 @@ object AMTWriteHelper extends DeltaLogging {
     deleted_positions = None,
     replaced_positions = None)
 
+  // Tracking envelope for a freshly written entry: ADDED.
+  private[amt] def addedTracking: Tracking = trackingWithStatus(Tracking.Status.Added)
+
+  // Tracking envelope for a root-resident tombstone: REMOVED.
+  // `deletedPositions`, when present, is the within-file bitmap of rows this commit deleted
+  // (carried for CDF); it is left None for a whole-file removal.
+  private[amt] def removedTracking(deletedPositions: Option[Array[Byte]] = None): Tracking =
+    trackingWithStatus(Tracking.Status.Deleted).copy(deleted_positions = deletedPositions)
+
   /**
    * Writes a single leaf parquet file (DATA entries) and returns the DataManifestEntry
    * corresponding to it.
    */
-  private def writeLeaf(
+  private[amt] def writeLeaf(
       spark: SparkSession,
       fs: FileSystem,
       hadoopConf: Configuration,
@@ -393,23 +308,35 @@ object AMTWriteHelper extends DeltaLogging {
   }
 
   /**
-   * Writes the root parquet file (DATA_MANIFEST pointers only) and returns the ContentRoot. The
-   * root pointer follows the same table-root-relative (raw) convention as the leaf pointers.
+   * Writes the root parquet file from a pre-built row set and returns the ContentRoot. The rows may
+   * be `DATA_MANIFEST` leaf pointers, root-resident `DATA` entries, or both.
    */
-  private def writeRoot(
+  private[amt] def writeRoot(
       spark: SparkSession,
       fs: FileSystem,
       hadoopConf: Configuration,
       tableRoot: Path,
       metadataDir: Path,
-      leafEntries: Seq[DataManifestEntry]): ContentRoot = {
+      rows: Seq[AMTSingleAction]): ContentRoot = {
     val rootFile = FileNames.newAMTRootManifestFile(metadataDir)
-    val rows: Seq[AMTSingleAction] = leafEntries.map(_.wrap)
     writeAMTParquet(spark, hadoopConf, rootFile, rows)
     val status = fs.getFileStatus(rootFile)
     ContentRoot(
       path = AMTUtils.relativizeManifestPathToTableRoot(fs, tableRoot, rootFile),
       sizeInBytes = status.getLen)
+  }
+
+  // Returns a copy of a carried-forward leaf's ManifestInfo with `mdv` recorded as its Manifest
+  // Deletion Vector.
+  private[amt] def withUpdatedMdv(base: ManifestInfo, mdv: RoaringBitmapArray): ManifestInfo = {
+    if (mdv.isEmpty) {
+      base.copy(dv = None, dv_cardinality = None, deleted_files_count = 0)
+    } else {
+      base.copy(
+        dv = Some(AMTUtils.serializeMdv(mdv)),
+        dv_cardinality = Some(mdv.cardinality),
+        deleted_files_count = mdv.cardinality.toInt)
+    }
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriterManager.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriterManager.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.delta.amt
 import org.apache.spark.sql.delta.{AdaptiveMetadataTableFeature, CurrentTransactionInfo, DeltaErrors, DeltaLog, DeltaOperations, LogSegment, MaintenanceOperation, Snapshot}
 import org.apache.spark.sql.delta.actions.{Action, Checkpoint}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.util.FileNames
 
 import org.apache.spark.sql.SparkSession
 
@@ -60,7 +61,18 @@ case class AMTWriteMetrics(
 case class SingleAMTWriteMetrics(
     trigger: String,
     incremental: String,
-    materializeDurationMs: Long)
+    materializeDurationMs: Long,
+    // Detailed shape breakdown of an incremental write; None for a full rewrite.
+    incrementalWriteMetrics: Option[IncrementalAMTWriteMetrics] = None)
+
+case class IncrementalAMTWriteMetrics(
+    numIntermediateCommits: Int,
+    numExistingLeavesUpdated: Int,
+    numExistingLeavesUntouched: Int,
+    numNewLeaves: Int,
+    numRootLiveAdds: Int,
+    numRootTombstones: Int,
+    numLeafMdvBitsAdded: Int)
 
 /**
  * The outcome of an AMT write for a single commit attempt.
@@ -116,13 +128,13 @@ class AMTWriterManager(
         val incremental =
           optimize.incremental && AMTWriteHelper.previousAMTContentRoot(readSnapshot).isDefined
         Some(materialize(
-          commitVersion, currentTransactionInfo,
+          commitVersion, currentTransactionInfo, preCommitLogSegment,
           incremental = incremental, trigger = optimize.triggerName))
       case _ if shouldDoInlineIncrementalCheckpoint(actionsToCommit) =>
         // A large business commit rebuilds its manifest tree inline (incrementally).
         val mode = AMTTriggerMode.InlineWithLargeCommitIncremental
         Some(materialize(
-          commitVersion, currentTransactionInfo,
+          commitVersion, currentTransactionInfo, preCommitLogSegment,
           incremental = mode.isIncremental, trigger = mode.name))
       case _ =>
         None
@@ -147,21 +159,27 @@ class AMTWriterManager(
   private def materialize(
       commitVersion: Long,
       currentTransactionInfo: CurrentTransactionInfo,
+      preCommitLogSegment: LogSegment,
       incremental: Boolean,
       trigger: String): AMTWriteResult = {
+    val amtProviderOpt = readSnapshot.checkpointProvider match {
+      case amt: AMTCheckpointProvider => Some(amt)
+      case _ => None
+    }
     val (result, singleMetric) =
-      if (incremental) {
-        AMTWriteHelper.writeIncrementalMaterialization(
-          spark = spark,
-          readSnapshot = readSnapshot,
-          commitVersion = commitVersion,
+      if (incremental && amtProviderOpt.isDefined) {
+        val oldAMTVersion = amtProviderOpt.get.checkpointAction.version
+        // The commits written after the old AMT, up to the last committed version.
+        val intermediateLogCommits = preCommitLogSegment.deltas
+          .filter(f => FileNames.getFileVersion(f) > oldAMTVersion)
+        new IncrementalAMTWriter(spark, deltaLog).writeIncremental(
+          oldAMTVersion = oldAMTVersion,
+          oldAMTCheckpointProvider = amtProviderOpt.get,
+          intermediateLogCommits = intermediateLogCommits,
+          attemptVersion = commitVersion,
           actionsToCommit = currentTransactionInfo.actions,
-          postCommitProtocol = currentTransactionInfo.protocol,
-          postCommitMetadata = currentTransactionInfo.metadata,
-          trigger = trigger,
-          incremental = incremental)
+          trigger = trigger)
       } else {
-        // A full rewrite re-materializes the whole live file set; the commit carries no actions.
         assert(currentTransactionInfo.actions.isEmpty,
           "A full AMT rewrite must carry no actions, got " +
             s"${currentTransactionInfo.actions.size}.")

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/IncrementalAMTWriter.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/IncrementalAMTWriter.scala
@@ -1,0 +1,349 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.amt
+
+import java.util.concurrent.TimeUnit.NANOSECONDS
+
+import scala.collection.mutable.ArrayBuffer
+
+import org.apache.spark.sql.delta.{DeltaFileProviderUtils, DeltaLog, SingleCommit}
+import org.apache.spark.sql.delta.actions.{Action, AddFile, Checkpoint, ContentRoot, InMemoryLogReplay, RemoveFile}
+import org.apache.spark.sql.delta.actions.InMemoryLogReplay.UniqueFileActionTuple
+import org.apache.spark.sql.delta.deletionvectors.RoaringBitmapArray
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.util.FileNames
+import org.apache.hadoop.fs.FileStatus
+
+import org.apache.spark.sql.SparkSession
+
+/**
+ * Writes an *incremental* AMT on top of an existing AMT without rewriting a single existing leaf.
+ *
+ * The new root is built from three parts:
+ *   [        Part-1        ][             Part-2              ][      Part-3      ]
+ *   [       old AMT        ][ -- log commits / minor          ][ this commit's    ]
+ *   [       root           ][    compactions after it --      ][ actions          ]
+ *
+ * Algorithm:
+ * - Take [[DataEntry]] from old root (part-1) + logCommits since then until attemptVersion
+ *   (part-2) + commitActions that we want to commit (part-3) -- the logReplay of above becomes
+ *   [[DataEntry]]s for the new AMT root.
+ * - The previous tree's leaves ([[DataManifestEntry]]s) are carried forward by pointer.
+ * - The [[RemoveFile]] actions from part-2 / part-3 that have backreferences contribute towards
+ *   MDVs for existing leafs.
+ * - Tombstones:
+ *   - The RemoveFile from the current proposed commit (part-3) contributes for CDF.
+ *   - The one with backreferences contributes to deleted_positions on the [[DataManifestEntry]]
+ *     corresponding to existing leafs.
+ *   - The one without backreferences contributes to a tombstone [[DataEntry]] in the new root.
+ * - If the root crosses the maxEntriesPerLeaf threshold, live [[DataEntry]]s are spilled to a new
+ *   leaf.
+ */
+class IncrementalAMTWriter(spark: SparkSession, deltaLog: DeltaLog) {
+
+  private def entriesPerLeaf: Int =
+    spark.sessionState.conf.getConf(DeltaSQLConf.AMT_ENTRIES_PER_LEAF)
+
+  private val hadoopConf = deltaLog.newDeltaHadoopConf()
+  private val tableRoot = deltaLog.dataPath
+  private val fs = tableRoot.getFileSystem(hadoopConf)
+  private val metadataDir = FileNames.amtMetadataDirPath(tableRoot)
+
+  /**
+   * Materializes the incremental manifest for `attemptVersion` and returns the inline
+   * [[Checkpoint]] write result plus its metrics.
+   *
+   * @param oldAMTVersion             version the previous AMT checkpoint describes.
+   * @param oldAMTCheckpointProvider  provider for the previous AMT (root, leaves, inline state).
+   * @param intermediateLogCommits    the commit log files written after the old AMT and up to the
+   *                                  last committed version (the window between the old AMT and
+   *                                  this commit), in commit order.
+   * @param attemptVersion            the version this commit targets.
+   * @param actionsToCommit           this commit's actions (empty for a deferred OPTIMIZE
+   *                                  CHECKPOINT).
+   * @param trigger                   trigger name recorded in metrics.
+   */
+  def writeIncremental(
+      oldAMTVersion: Long,
+      oldAMTCheckpointProvider: AMTCheckpointProvider,
+      intermediateLogCommits: Seq[FileStatus],
+      attemptVersion: Long,
+      actionsToCommit: Seq[Action],
+      trigger: String): (AMTWriteResult, SingleAMTWriteMetrics) = {
+    val startNanos = System.nanoTime()
+    val oldCheckpoint = oldAMTCheckpointProvider.checkpointAction
+
+    // ---- Step 0: validate the window is contiguous and lines up with our assumptions. ----
+    // The intermediate commits after the old AMT must contiguously cover
+    // [oldAMTVersion + 1, attemptVersion) with no holes.
+    assertWindowCoversRange(intermediateLogCommits, oldAMTVersion, attemptVersion)
+
+    // ---- Step 1: gather the actions of all three parts. ----
+    // 1.a: old AMT root -- its live root-resident files, plus its inline non-content state
+    // (protocol, metadata, setTxns, domainMetadata). Leaf-resident files are NOT read here.
+    val fileActionsFromOldRoot = AMTCheckpointProvider.readLiveRootDataEntries(
+      spark, deltaLog, oldCheckpoint)
+    val nonContentFromOldRoot: Iterator[Action] =
+      Iterator(oldCheckpoint.protocol, oldCheckpoint.metaData) ++
+        oldCheckpoint.txns.iterator ++ oldCheckpoint.domainMetadata.iterator
+    // 1.b: the log commits / minor compactions committed after the old AMT, read in parallel (the
+    // MinorCompactionHook primitive). Each segment delta file becomes a SingleCommit keyed by its
+    // version (a compacted delta's version is its endVersion, via getFileVersion).
+    val windowCommits =
+      intermediateLogCommits.map(f => SingleCommit(deltaLog, FileNames.getFileVersion(f), f))
+    val actionsFromDeltas =
+      DeltaFileProviderUtils.parallelReadAndParseDeltaFilesAsSeq(spark, deltaLog, windowCommits)
+    // 1.c: this commit attempt's own actions (actionsToCommit).
+
+    // ---- Step 2: log-replay all three parts, keyed by their real commit versions. ----
+    // The version handed to `append` feeds InMemoryLogReplay's monotonic-progress assert: the old
+    // AMT root describes oldAMTVersion, each window delta carries its own commit version
+    // (FileNames.getFileVersion; for a minor compaction that is a good proxy), and this commit
+    // lands at attemptVersion. Because 1.a seeds the old inline non-content state and 1.b/1.c
+    // override it (last-writer-wins), the replay's protocol/metadata/setTxns/domainMetadata equal
+    // the post-commit values.
+    val replay = new InMemoryLogReplay(
+      minFileRetentionTimestamp = None, minSetTransactionRetentionTimestamp = None)
+    replay.append(
+      oldAMTVersion,
+      fileActionsFromOldRoot.iterator ++ nonContentFromOldRoot)
+    windowCommits.zip(actionsFromDeltas).foreach { case (commit, actions) =>
+      replay.append(commit.version, actions.iterator)
+    }
+    replay.append(attemptVersion, actionsToCommit.iterator)
+
+    // ---- Step 3: gather the removes that drive MDV masking and CDF, from different scopes. ----
+    val windowActions = actionsFromDeltas.flatten
+    // 3.a: MDV masking -- ALL leaf-resident removes since the old AMT (window + commit). The MDV
+    // must hide every entry deleted since the last full tree, so it accumulates the window's
+    // removes too, regardless of which commit deleted them.
+    // NOTE: this can NOT come from `replay.getActiveRemoveFiles`. Leaf files are not seeded into
+    // the replay, and a leaf file removed then re-added within the window (e.g. RESTORE) has its
+    // remove cancelled by the re-add there, so getActiveRemoveFiles would omit it -- yet its old
+    // leaf entry still needs masking (the re-added copy lives in the root). We must mask by every
+    // backref position deleted since the old AMT, which is exactly this scan.
+    val mdvBackrefRemoves = (windowActions ++ actionsToCommit)
+      .collect { case r: RemoveFile if r.backReference.isDefined => r }
+    // 3.b: CDF -- ONLY this commit's removes. A window remove already emitted its CDF (deleted DV /
+    // root tombstone) in its own commit; re-emitting here would double-count. So this commit's
+    // with-backref removes drive tracking.deleted_positions on the touched leaf pointers, and its
+    // without-backref removes drive the root tombstones.
+    val commitRemoves = actionsToCommit.collect { case r: RemoveFile => r }
+    val (cdfBackrefRemoves, cdfNoBackrefRemoves) =
+      commitRemoves.partition(_.backReference.isDefined)
+
+    // ---- Step 4: carry the old leaf pointers forward, patching MDV + deleted_positions. ----
+    // Also returns the MDV positions this write added per leaf (keyed by relative location), reused
+    // for the shape metrics below rather than recomputed.
+    val (carriedLeafPointers, mdvPositionsByLeaf) =
+      carryForwardLeaves(oldAMTCheckpointProvider, mdvBackrefRemoves, cdfBackrefRemoves)
+
+    // ---- Step 5: build the root DATA entries. ----
+    // 5.a: live files (added/existing) -- the net-new files, held directly in the root.
+    val liveAdds = replay.allFiles
+    // 5.b: removed tombstones (for CDF) -- net-removed no-backref files removed by THIS commit,
+    // built from the matching AddFile (root + window) so CDF gets full stats, never from the sparse
+    // RemoveFile.
+    val rootAndWindowAdds = fileActionsFromOldRoot ++ windowActions.collect { case a: AddFile => a }
+    val tombstoneEntries = buildTombstones(cdfNoBackrefRemoves, liveAdds, rootAndWindowAdds)
+
+    // ---- Step 6: spill live adds into new leaves if the root would exceed the per-leaf cap. ----
+    val fixedRootCount = carriedLeafPointers.size + tombstoneEntries.size
+    val (rootAdds, spilledLeafPointers) =
+      spillIfNeeded(liveAdds, fixedRootCount)
+
+    // ---- Step 7: write the new root. ----
+    val addedTracking = AMTWriteHelper.addedTracking
+    val rootRows =
+      (carriedLeafPointers ++ spilledLeafPointers).map(_.wrap) ++
+        rootAdds.map(add => DataEntry.fromAddFile(add, addedTracking, tableRoot).wrap) ++
+        tombstoneEntries.map(_.wrap)
+    val contentRootBase =
+      AMTWriteHelper.writeRoot(spark, fs, hadoopConf, tableRoot, metadataDir, rootRows)
+
+    // ---- Step 8: generate the Checkpoint action. ----
+    // The version the tree describes: an inline commit describes itself; a deferred OPTIMIZE
+    // CHECKPOINT (no user actions) describes the last committed version (attemptVersion - 1).
+    val contentStateVersion =
+      if (actionsToCommit.isEmpty) attemptVersion - 1 else attemptVersion
+    // An incremental rewrite carries forward the previous tree's last-full-rewrite marker.
+    val lastFullRewriteVersion = oldCheckpoint.contentRoot
+      .lastManifestCommitWithFullRewrite.getOrElse(contentStateVersion)
+    val contentRoot = ContentRoot(
+      path = contentRootBase.path,
+      sizeInBytes = contentRootBase.sizeInBytes,
+      isIncremental = true,
+      lastManifestCommitWithFullRewrite = lastFullRewriteVersion)
+    val postCommitProtocol = replay.getProtocol.getOrElse(
+      throw new IllegalStateException("Replay produced no protocol for the incremental AMT."))
+    val postCommitMetadata = replay.getMetadata.getOrElse(
+      throw new IllegalStateException("Replay produced no metadata for the incremental AMT."))
+    val checkpoint = Checkpoint(
+      version = contentStateVersion,
+      contentRoot = contentRoot,
+      protocol = postCommitProtocol,
+      metaData = postCommitMetadata,
+      domainMetadata = replay.getDomainMetadatas.toSeq,
+      txns = replay.getTransactions.toSeq,
+      sidecars = Seq.empty)
+    val allLeafPointers = carriedLeafPointers ++ spilledLeafPointers
+    val result = AMTWriteResult(
+      contentRootVersion = contentStateVersion,
+      checkpoint = checkpoint,
+      leaves = allLeafPointers,
+      includeActionsInCommitJson = true)
+    val numExistingLeavesUpdated = carriedLeafPointers.count(p =>
+      mdvPositionsByLeaf.getOrElse(p.location, Seq.empty).nonEmpty)
+    val incrementalWriteMetrics = IncrementalAMTWriteMetrics(
+      numIntermediateCommits = intermediateLogCommits.size,
+      numExistingLeavesUpdated = numExistingLeavesUpdated,
+      numExistingLeavesUntouched = carriedLeafPointers.size - numExistingLeavesUpdated,
+      numNewLeaves = spilledLeafPointers.size,
+      numRootLiveAdds = rootAdds.size,
+      numRootTombstones = tombstoneEntries.size,
+      numLeafMdvBitsAdded = mdvPositionsByLeaf.valuesIterator.map(_.size).sum)
+    val metric = SingleAMTWriteMetrics(
+      trigger = trigger,
+      // This writer only ever produces an incremental tree.
+      incremental = "true",
+      materializeDurationMs = NANOSECONDS.toMillis(System.nanoTime() - startNanos),
+      incrementalWriteMetrics = Some(incrementalWriteMetrics))
+    (result, metric)
+  }
+
+  /**
+   * Carries the previous tree's leaf pointers forward. Two independent, differently-scoped updates
+   * are applied to each carried pointer:
+   *   - `manifest_info.dv` (MDV, masking) accumulates ALL leaf positions removed since the old AMT
+   *     (`mdvRemoves` = window + commit), so the reader hides every entry deleted since the last
+   *     full tree; and
+   *   - `tracking.deleted_positions` (CDF) is RESET to just THIS commit's removed positions
+   *     (`cdfRemoves`) -- a window remove already emitted its CDF in its own commit, and the old
+   *     pointer's stale positions must not carry forward, so this is cleared on every pointer and
+   *     re-set only for leaves this commit touched.
+   * Leaf parquet files are never re-read or rewritten.
+   *
+   * Returns the carried-forward pointers and the MDV positions this write added per leaf (keyed by
+   * relative location), so the caller can derive the shape metrics without recomputing it.
+   */
+  private def carryForwardLeaves(
+      provider: AMTCheckpointProvider,
+      mdvRemoves: Seq[RemoveFile],
+      cdfRemoves: Seq[RemoveFile]): (Seq[DataManifestEntry], Map[String, Seq[Long]]) = {
+    def positionsByLeaf(removes: Seq[RemoveFile]): Map[String, Seq[Long]] =
+      removes.flatMap(r => r.backReference.map(br => br.manifest -> br.pos))
+        .groupBy(_._1).map { case (leaf, pairs) => leaf -> pairs.map(_._2) }
+    val mdvPositionsByLeaf = positionsByLeaf(mdvRemoves)
+    val cdfPositionsByLeaf = positionsByLeaf(cdfRemoves)
+    val pointers = provider.leaves
+      .map { pointer =>
+        val leafKey = pointer.location
+        val newMdvPositions = mdvPositionsByLeaf.getOrElse(leafKey, Seq.empty)
+        val cdfPositions = cdfPositionsByLeaf.getOrElse(leafKey, Seq.empty)
+        // Cumulative MDV = old dv + every position removed from this leaf since the old AMT.
+        val manifestInfo =
+          if (newMdvPositions.isEmpty) {
+            pointer.manifest_info
+          } else {
+            val cumulativeDV = pointer.manifest_info.dv
+              .map(AMTUtils.deserializeMdv).getOrElse(new RoaringBitmapArray)
+            newMdvPositions.foreach(cumulativeDV.add)
+            AMTWriteHelper.withUpdatedMdv(pointer.manifest_info, cumulativeDV)
+          }
+        // A carried leaf pointer stays live (ADDED); only deleted_positions conveys CDF. It is
+        // per-commit: reset to THIS commit's removed positions (empty when this commit did not
+        // delete from this leaf), never the old pointer's stale value.
+        val deletedPositions =
+          if (cdfPositions.isEmpty) None
+          else Some(AMTUtils.serializeMdv(RoaringBitmapArray(cdfPositions: _*)))
+        val tracking = AMTWriteHelper.addedTracking.copy(deleted_positions = deletedPositions)
+        pointer.copy(manifest_info = manifestInfo, tracking = tracking)
+      }
+    (pointers, mdvPositionsByLeaf)
+  }
+
+  /**
+   * Builds root-resident `tracking=removed` tombstones for THIS commit's net-removed no-backref
+   * files, so Change Data Feed can recover them. (Window removes already emitted their CDF in their
+   * own commits, so they are not passed here.) Each tombstone is built from the removed file's
+   * `AddFile` (found among root + window adds, matched by the `(path, dvId)` key) -- NOT from
+   * the sparse `RemoveFile` -- so it carries full stats/DV. A remove is a tombstone only when its
+   * file is net-removed (not present in the replay's live set) and its `AddFile` is found.
+   */
+  private def buildTombstones(
+      withoutBackrefRemoves: Seq[RemoveFile],
+      liveAdds: Seq[AddFile],
+      rootAndWindowAdds: Seq[AddFile]): Seq[DataEntry] = {
+    if (withoutBackrefRemoves.isEmpty) return Seq.empty
+    // Implicit `toUniqueFileActionTuple` on AddFile / RemoveFile.
+    import InMemoryLogReplay.{UniqueAddFileTuple, UniqueRemoveFileTuple}
+    val liveKeys: Set[UniqueFileActionTuple] =
+      liveAdds.iterator.map(_.toUniqueFileActionTuple).toSet
+    // AddFile lookup from root + window (NOT this commit -- Delta disallows add+remove in one
+    // commit, so a removed file's add always predates the commit).
+    val addByKey: Map[UniqueFileActionTuple, AddFile] =
+      rootAndWindowAdds.map(a => a.toUniqueFileActionTuple -> a).toMap
+    withoutBackrefRemoves.flatMap { r =>
+      val removeKey = r.toUniqueFileActionTuple
+      // Only tombstone a genuinely removed file whose originating add we can find.
+      if (liveKeys.contains(removeKey)) None
+      else addByKey.get(removeKey).map(add =>
+        DataEntry.fromAddFile(add, AMTWriteHelper.removedTracking(), tableRoot))
+    }
+  }
+
+  /**
+   * If the root would exceed `entriesPerLeaf` (carried pointers + tombstones + live adds), moves
+   * whole `entriesPerLeaf`-sized batches of live adds into new leaves until the root's row count
+   * fits. Returns the live adds that remain root-resident and the pointers for any new leaves.
+   */
+  private def spillIfNeeded(
+      liveAdds: Seq[AddFile],
+      fixedRootCount: Int): (Seq[AddFile], Seq[DataManifestEntry]) = {
+    var remaining = liveAdds
+    val spilled = ArrayBuffer.empty[DataManifestEntry]
+    // Each spill adds one leaf pointer to the fixed root count; keep spilling while the root would
+    // still overflow.
+    while (fixedRootCount + spilled.size + remaining.size > entriesPerLeaf && remaining.nonEmpty) {
+      val (batch, rest) = remaining.splitAt(entriesPerLeaf)
+      spilled += AMTWriteHelper.writeLeaf(
+        spark, fs, hadoopConf, tableRoot, metadataDir, batch)
+      remaining = rest
+    }
+    (remaining, spilled.toSeq)
+  }
+
+  // Asserts the intermediate commit files cover EXACTLY [oldAMTVersion+1, attemptVersion) -- no
+  // holes and no versions outside the window (a minor-compacted delta covers its whole
+  // [startV, endV] range).
+  private def assertWindowCoversRange(
+      intermediateLogCommits: Seq[FileStatus],
+      oldAMTVersion: Long,
+      attemptVersion: Long): Unit = {
+    val covered = intermediateLogCommits.flatMap { f =>
+      f.getPath match {
+        case FileNames.CompactedDeltaFile(_, startV, endV) => startV to endV
+        case _ => Seq(FileNames.deltaVersion(f))
+      }
+    }.toSet
+    val expected = ((oldAMTVersion + 1) until attemptVersion).toSet
+    assert(covered == expected,
+      s"intermediateLogCommits must cover exactly [${oldAMTVersion + 1}, $attemptVersion); " +
+        s"missing ${(expected -- covered).toList.sorted}, " +
+        s"unexpected ${(covered -- expected).toList.sorted}.")
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTBackReferenceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTBackReferenceSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.delta.amt
 import org.apache.spark.sql.delta.{DeletionVectorsTestUtils, DeltaLog, DeltaOperations, Snapshot}
 import org.apache.spark.sql.delta.actions.{Action, AddFile, BackReference, RemoveFile}
 import org.apache.spark.sql.delta.deletionvectors.RoaringBitmapArray
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.sql.functions.col
@@ -448,11 +449,15 @@ class AMTBackReferenceSuite extends AMTCheckpointTestBase with DeletionVectorsTe
       val restoreTarget = deltaLog.update().version
 
       // The overwrite drops A, B and writes C; a second insert then adds D and lands on a
-      // checkpoint boundary, so the current live files C, D get stamped with this table's own
-      // back references. (Exact commit versions are not asserted: an AMT checkpoint commits as a
+      // checkpoint boundary. entriesPerLeaf=1 forces the incremental write to spill every net-new
+      // file into its own leaf (rather than holding it root-resident, which would leave it
+      // unstamped), so the current live files C, D get stamped with this table's own back
+      // references. (Exact commit versions are not asserted: an AMT checkpoint commits as a
       // separate follow-up commit, so it shifts version numbers; the checks scan via actionsAfter.)
-      sql(s"INSERT OVERWRITE $name VALUES (99)")
-      sql(s"INSERT INTO $name VALUES (100)") // Lands on a checkpoint boundary -> C, D stamped.
+      withSQLConf(DeltaSQLConf.AMT_ENTRIES_PER_LEAF.key -> "1") {
+        sql(s"INSERT OVERWRITE $name VALUES (99)")
+        sql(s"INSERT INTO $name VALUES (100)") // Lands on a checkpoint boundary -> C, D stamped.
+      }
 
       val currentByPath =
         liveAddFiles(deltaLog.update()).map(a => a.path -> a.backReference).toMap

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointTestBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointTestBase.scala
@@ -85,32 +85,18 @@ trait AMTCheckpointTestBase
   }
 
   /**
-   * Appends `n` rows to `tableName` as `n` separate data files in a single commit.
+   * Appends `numRows` rows (ids `startId` until `startId + numRows`) to `tableName` as `numRows`
+   * separate data files in a single commit. `startId` lets successive calls append disjoint id
+   * ranges.
    */
-  protected def appendRowsAsSeparateFiles(tableName: String, n: Int): Unit = {
+  protected def appendRowsAsSeparateFiles(
+      tableName: String, numRows: Int, startId: Int = 0): Unit = {
     withSQLConf(
         "spark.sql.files.maxRecordsPerFile" -> "1",
         DeltaSQLConf.DELTA_OPTIMIZE_WRITE_ENABLED.key -> "false") {
-      sql(s"INSERT INTO $tableName SELECT CAST(id AS INT) FROM range($n)")
+      sql(
+        s"INSERT INTO $tableName SELECT CAST(id AS INT) FROM range($startId, ${startId + numRows})")
     }
-  }
-
-  /**
-   * Emits an AMT by driving the incremental materialization directly, so the live files
-   * pack into leaves deterministically in input order, `AMT_ENTRIES_PER_LEAF` entries per leaf.
-   */
-  protected def emitIncrementalAMT(tableName: String): AMTCheckpointProvider = {
-    val snapshot = deltaLogForName(tableName).update()
-    val (result, _) = AMTWriteHelper.writeIncrementalMaterialization(
-      spark = spark,
-      readSnapshot = snapshot,
-      commitVersion = snapshot.version + 1,
-      actionsToCommit = Seq.empty,
-      postCommitProtocol = snapshot.protocol,
-      postCommitMetadata = snapshot.metadata,
-      trigger = AMTTriggerMode.CheckpointIntervalIncremental.name,
-      incremental = true)
-    new AMTCheckpointProvider(result.checkpoint, result.leaves, snapshot.deltaLog.dataPath)
   }
 
   /**
@@ -179,6 +165,12 @@ trait AMTCheckpointTestBase
    * Total DATA (content_type=0) entry rows across the leaves reachable from the CURRENT snapshot's
    * manifest tree. Reads only the provider's leaves (not every file under `metadata/`, which
    * accumulates superseded leaves from earlier checkpoints).
+   *
+   * Note: this counts *physical* leaf entries and does NOT subtract Manifest Deletion Vectors, nor
+   * does it count live files stored directly in the root. On an incremental tree a deleted file's
+   * entry stays physically present in its carried-forward leaf (tombstoned via the leaf MDV), so
+   * this can exceed the live file count. Use [[currentLiveDataEntries]] to compare against
+   * `snapshot.allFiles`.
    */
   protected def currentLeafDataEntries(snapshot: Snapshot): Long = {
     val provider = amtProvider(snapshot)
@@ -188,5 +180,22 @@ trait AMTCheckpointTestBase
           .where(col("content_type") === AMTSingleAction.ContentType.Type.Data)
           .count()
       }.sum
+  }
+
+  /**
+   * The number of live files the CURRENT snapshot's AMT reconstructs across the WHOLE tree -- root
+   * and leaves. Goes through the provider's own reconstruction, which drops MDV-masked leaf entries
+   * and `tracking=removed` root tombstones, so it equals `snapshot.allFiles.count()` on both full
+   * and incremental trees. This is the count to assert the tree captures exactly the live file set;
+   * unlike [[currentLeafDataEntries]], it counts live files stored directly in the root too (as an
+   * incremental commit does below the spill threshold).
+   */
+  protected def currentLiveDataEntries(snapshot: Snapshot): Long = {
+    val provider = amtProvider(snapshot)
+      .getOrElse(fail("Snapshot has no AMTCheckpointProvider."))
+    provider.loadActionsForStateReconstruction(spark, snapshot.deltaLog)
+      .getOrElse(fail("AMT provider must contribute leaf-derived file actions."))
+      .where("add is not null")
+      .count()
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotSuite.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.delta.amt
 
 import org.apache.spark.sql.delta.{Checkpoints, DeletionVectorsTestUtils, DeltaLog, DeltaOperations}
 import org.apache.spark.sql.delta.actions.{AddFile, Checkpoint, ContentRoot, DeletionVectorDescriptor}
-import org.apache.spark.sql.delta.deletionvectors.{RoaringBitmapArray, RoaringBitmapArrayFormat}
+import org.apache.spark.sql.delta.deletionvectors.RoaringBitmapArray
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.FileNames
 import org.apache.hadoop.fs.Path
@@ -55,10 +55,12 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
         "The post-DELETE snapshot must be AMT-backed.")
       // allFiles must reflect the DELETE: the removed file is gone from the post-commit live set.
       checkAnswer(spark.read.table(name), Seq(Row(2), Row(3)))
-      // The manifest tree written at the checkpoint captures exactly the post-DELETE live files
-      // (computePostCommitState applied the RemoveFile), i.e. it matches snapshot.allFiles.
-      assert(currentLeafDataEntries(snapshot) == snapshot.allFiles.count(),
-        "Leaf DATA entries must equal the post-commit live file count.")
+      // The manifest tree captures exactly the post-DELETE live files: a full rewrite drops the
+      // removed entry outright, while an incremental rewrite masks it (MDV on a carried leaf, or a
+      // root tombstone). Either way, the tree's live entry count -- across root and leaves -- must
+      // match snapshot.allFiles.
+      assert(currentLiveDataEntries(snapshot) == snapshot.allFiles.count(),
+        "Live tree DATA entries must equal the post-commit live file count.")
     }
   }
 
@@ -77,8 +79,8 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
       assert(amtProvider(snapshot).isDefined)
       checkAnswer(spark.read.table(name), Seq(Row(20)))
       assert(snapshot.allFiles.count() == 1, "Only the surviving overwrite file should be live.")
-      assert(currentLeafDataEntries(snapshot) == 1,
-        "Leaves must capture exactly the surviving live file after overwrite + delete.")
+      assert(currentLiveDataEntries(snapshot) == 1,
+        "The tree must capture exactly the surviving live file after overwrite + delete.")
     }
   }
 
@@ -181,18 +183,19 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
   test("distributed reconstruction reads across multiple leaves via a file scan") {
     withTable("amt_dist_multileaf") {
       val name = "amt_dist_multileaf"
-      createAMTTable(name, checkpointInterval = 100)
-      appendRowsAsSeparateFiles(name, 5)
-      // 5 files with entriesPerLeaf=2 yield 3 leaves.
-      val provider = withSQLConf(DeltaSQLConf.AMT_ENTRIES_PER_LEAF.key -> "2") {
-        emitIncrementalAMT(name)
+      val provider = withSQLConf(DeltaSQLConf.AMT_ENTRIES_PER_LEAF.key -> "10") {
+        createAMTTable(name, checkpointInterval = 2)
+        appendRowsAsSeparateFiles(name, 30) // v1: ids 0..29.
+        appendRowsAsSeparateFiles(name, 30, startId = 30) // v2: ids 30..59; emits full tree at v3.
+        amtProvider(deltaLogForName(name).update())
+          .getOrElse(fail("The interval-boundary append must trigger an AMT-backed snapshot."))
       }
-      assert(provider.leaves.size == 3,
-        "entriesPerLeaf=2 with 5 files must pack into exactly 3 leaves.")
+      assert(provider.leaves.size == 6,
+        s"entriesPerLeaf=10 with 60 files must pack into 6 leaves; got ${provider.leaves.size}.")
       val snapshot = deltaLogForName(name).update()
-      checkAnswer(spark.read.table(name), (0 until 5).map(Row(_)))
+      checkAnswer(spark.read.table(name), (0 until 60).map(Row(_)))
       val committedPaths = snapshot.allFiles.select("path").as[String].collect().toSet
-      assert(committedPaths.size == 5)
+      assert(committedPaths.size == 60)
       val df = provider.loadActionsForStateReconstruction(spark, snapshot.deltaLog)
         .getOrElse(fail("AMT provider must contribute leaf-derived actions."))
 
@@ -297,42 +300,60 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
   test("manifest deletion vectors apply per leaf across a multi-leaf tree") {
     withTable("amt_mdv_multi") {
       val name = "amt_mdv_multi"
-      createAMTTable(name, checkpointInterval = 100)
-      // 35 files with entriesPerLeaf=5 deterministically pack into exactly 7 leaves of 5 entries.
-      appendRowsAsSeparateFiles(name, 35)
-      val base = withSQLConf(DeltaSQLConf.AMT_ENTRIES_PER_LEAF.key -> "5") {
-        emitIncrementalAMT(name)
+      val base = withSQLConf(DeltaSQLConf.AMT_ENTRIES_PER_LEAF.key -> "10") {
+        createAMTTable(name, checkpointInterval = 2)
+        appendRowsAsSeparateFiles(name, 30) // v1: ids 0..29.
+        appendRowsAsSeparateFiles(name, 30, startId = 30) // v2: ids 30..59; emits full tree at v3.
+        amtProvider(deltaLogForName(name).update())
+          .getOrElse(fail("The interval-boundary append must trigger an AMT-backed snapshot."))
       }
-      assert(base.leaves.size == 7,
-        "35 files with entriesPerLeaf=5 must pack into exactly 7 leaves.")
+      assert(base.leaves.size == 6,
+        s"60 files with entriesPerLeaf=10 must pack into 6 leaves; got ${base.leaves.size}.")
       val deltaLog = deltaLogForName(name)
       val full = reconstructedPaths(base, deltaLog)
-      assert(full.size == 35)
+      assert(full.size == 60)
 
-      // Exercise every MDV shape in one tree (positions are leaf-local row indices):
-      //   leaf 0: drop pos 0             leaf 3: drop pos 1 and pos 3
-      //   leaf 1: drop all 5 positions   leaf 4: empty MDV (no-op)
-      //   leaves 2, 5, 6: no MDV
+      // The leaf-local row-index -> entry-location map for each observed leaf.
       val locs = base.leaves.map(leafPosToLoc(_, base.tableRoot))
       def withMdv(idx: Int, positions: Seq[Long]): DataManifestEntry = {
         val leaf = base.leaves(idx)
         leaf.copy(manifest_info = leaf.manifest_info.copy(
           dv = Some(mdvBytesFor(positions: _*)), dv_cardinality = Some(positions.size.toLong)))
       }
+      // Exercise every MDV shape in one tree (positions are leaf-local row indices):
+      //   - one leaf: drop a single position (pos 0),
+      //   - one leaf: drop all its positions (whole leaf),
+      //   - one leaf: drop two positions (its 2nd and 4th, i.e. sorted indices 1 and 3),
+      //   - one leaf: an empty MDV (no-op),
+      //   - the remaining leaves: no MDV.
+      // The clustered rewrite does not guarantee a fixed leaf order/size, so the shapes are bound
+      // to leaves chosen by observed size (largest first); the two-position shape needs >= 4
+      // entries.
+      val bySizeDesc = locs.indices.sortBy(i => -locs(i).size)
+      val twoLeaf = bySizeDesc(0)
+      val wholeLeaf = bySizeDesc(1)
+      val singleLeaf = bySizeDesc(2)
+      val emptyLeaf = bySizeDesc(3)
+      def sortedPos(idx: Int): Seq[Long] = locs(idx).keys.toSeq.sorted
+      assert(sortedPos(twoLeaf).size >= 4,
+        s"the largest leaf must hold >= 4 entries for the two-position MDV; " +
+          s"got ${sortedPos(twoLeaf).size}.")
+      val twoPositions = Seq(sortedPos(twoLeaf)(1), sortedPos(twoLeaf)(3))
       val patched = base.leaves.zipWithIndex.map { case (leaf, idx) =>
         idx match {
-          case 0 => withMdv(0, Seq(0L))
-          case 1 => withMdv(1, locs(1).keys.toSeq) // whole leaf
-          case 3 => withMdv(3, Seq(1L, 3L))
-          case 4 => withMdv(4, Seq.empty)          // empty MDV
-          case _ => leaf                           // leaves 2, 5, 6 untouched
+          case `twoLeaf` => withMdv(idx, twoPositions)
+          case `wholeLeaf` => withMdv(idx, sortedPos(idx))
+          case `singleLeaf` => withMdv(idx, Seq(sortedPos(idx).head))
+          case `emptyLeaf` => withMdv(idx, Seq.empty)
+          case _ => leaf
         }
       }
       val provider = new AMTCheckpointProvider(base.checkpointAction, patched, base.tableRoot)
 
       val dropped =
-        Set(locs(0)(0L)) ++ locs(1).values.toSet ++ Set(locs(3)(1L), locs(3)(3L))
-      assert(dropped.size == 1 + 5 + 2)
+        twoPositions.map(locs(twoLeaf)).toSet ++
+          locs(wholeLeaf).values.toSet +
+          locs(singleLeaf)(sortedPos(singleLeaf).head)
       val reconstructed = reconstructedPaths(provider, deltaLog)
       assert(reconstructed == full -- dropped,
         "Each MDV must drop exactly its marked positions from its own leaf, and nothing else.")
@@ -447,7 +468,7 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
 
   /** Serializes a manifest DV bitmap over the given leaf entry positions. */
   private def mdvBytesFor(positions: Long*): Array[Byte] =
-    RoaringBitmapArray(positions: _*).serializeAsByteArray(RoaringBitmapArrayFormat.Portable)
+    AMTUtils.serializeMdv(RoaringBitmapArray(positions: _*))
 
   /** An ADDED tracking envelope with no lineage/sequence numbers, matching the AMT writer. */
   private def addedTracking: Tracking = Tracking(


### PR DESCRIPTION
## Description

The incremental adaptive-metadata-tree (AMT) checkpoint path previously re-materialized the entire live file set on every write, so an "incremental" checkpoint was effectively a full rewrite. This change makes it genuinely incremental:

- the previous tree's leaves are carried forward by pointer and never re-read or rewritten;
- this commit's net-new files are held as root-resident DATA entries, spilling into a new leaf only once the root exceeds the per-leaf cap;
- a removed file that lives in a carried-forward leaf is masked via a cumulative manifest deletion vector on that leaf's pointer (plus per-commit `deleted_positions` for change data feed);
- a removed root-resident file is recorded as a `tracking=removed` root tombstone, which the reader drops from the reconstructed live set.

The work is driven by a new `IncrementalAMTWriter`, which seeds a single `InMemoryLogReplay` with the old root's live files and inline non-content state, the commits written since that checkpoint, and this commit's actions, then emits the new root from that replay. The reader now honors `tracking.status` so masked entries are not surfaced as live.

## How was this patch tested?

Unit tests in `AMTSnapshotSuite`, `AMTCheckpointPolicySuite`, `AMTCheckpointWriteSuite`, `AMTWriterManagerSuite`, and `AMTBackReferenceSuite` covering leaf carry-forward, manifest deletion vector masking across a multi-leaf tree, root tombstones, and multi-leaf distributed reconstruction.

## Does this PR introduce _any_ user-facing changes?

No.
