### PR TITLE
Bin-pack input partitions for v2 changelog

### DIFF
--- a/spark-unified/src/test/scala-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/CDCPartitionReaderTest.java
+++ b/spark-unified/src/test/scala-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/CDCPartitionReaderTest.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.read.changelog;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import io.delta.spark.internal.v2.read.cdc.CDCSchemaContext;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import org.apache.spark.paths.SparkPath;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
+import org.apache.spark.sql.connector.read.InputPartition;
+import org.apache.spark.sql.connector.read.PartitionReader;
+import org.apache.spark.sql.connector.read.PartitionReaderFactory;
+import org.apache.spark.sql.execution.datasources.FilePartition;
+import org.apache.spark.sql.execution.datasources.PartitionedFile;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.unsafe.types.UTF8String;
+import org.junit.jupiter.api.Test;
+import scala.Tuple2;
+import scala.collection.immutable.Map$;
+
+/**
+ * Unit test for {@link DeltaChangelogBatch.CDCPartitionReader}, the executor-side reader that
+ * iterates every {@link PartitionedFile} bundled into one bin-packed {@link FilePartition}, opens a
+ * delegate reader per file, and joins that file's CDC tail ({@code _change_type},
+ * {@code _commit_version}, {@code _commit_timestamp}) onto each of its rows.
+ *
+ * <p>This test drives the reader with a fake {@link PartitionReaderFactory} that returns canned
+ * rows and counts {@code close()} calls, so it exercises the multi-file path without a Spark
+ * session or an end-to-end read-time-CDF query.
+ */
+public class CDCPartitionReaderTest {
+
+  /** Output schema fed to the reader: one data column plus the three CDC tail columns. */
+  private static final StructType OUTPUT_SCHEMA =
+      new StructType()
+          .add("id", DataTypes.LongType, false)
+          .add("_change_type", DataTypes.StringType, false)
+          .add("_commit_version", DataTypes.LongType, false)
+          .add("_commit_timestamp", DataTypes.TimestampType, false);
+
+  /** A single data row carrying one long column. */
+  private static InternalRow dataRow(long id) {
+    GenericInternalRow row = new GenericInternalRow(1);
+    row.setLong(0, id);
+    return row;
+  }
+
+  /**
+   * Build a {@link PartitionedFile} whose constant-metadata map holds only the CDC tail, mirroring
+   * what {@code DeltaChangelogBatch.buildPartition} packs for the reader to recover per file.
+   */
+  private static PartitionedFile cdcFile(
+      int index, String changeType, long commitVersion, long commitTimestampMicros) {
+    scala.collection.immutable.Map<String, Object> meta =
+        (scala.collection.immutable.Map<String, Object>)
+            (scala.collection.immutable.Map<?, ?>) Map$.MODULE$.empty();
+    meta = meta.$plus(new Tuple2<>(CDCSchemaContext.CDC_TYPE_COLUMN, changeType));
+    meta = meta.$plus(new Tuple2<>(CDCSchemaContext.CDC_COMMIT_VERSION, commitVersion));
+    meta = meta.$plus(new Tuple2<>(CDCSchemaContext.CDC_COMMIT_TIMESTAMP, commitTimestampMicros));
+    return new PartitionedFile(
+        new GenericInternalRow(0),
+        SparkPath.fromUrlString("file:/tmp/changelog-test/f" + index + ".parquet"),
+        /* start */ 0L,
+        /* length */ 1L,
+        /* locations */ new String[0],
+        /* modificationTime */ 0L,
+        /* fileSize */ 1L,
+        meta);
+  }
+
+  /** Fake per-file reader over a fixed row list that records how often it is closed. */
+  private static final class FakeReader implements PartitionReader<InternalRow> {
+    private final Iterator<InternalRow> rows;
+    private InternalRow current;
+    int closeCount = 0;
+
+    FakeReader(List<InternalRow> rows) {
+      this.rows = rows.iterator();
+    }
+
+    @Override
+    public boolean next() {
+      if (rows.hasNext()) {
+        current = rows.next();
+        return true;
+      }
+      return false;
+    }
+
+    @Override
+    public InternalRow get() {
+      return current;
+    }
+
+    @Override
+    public void close() {
+      closeCount++;
+    }
+  }
+
+  /** Fake factory that hands out one {@link FakeReader} per delegate open, in file order. */
+  private static final class FakeFactory implements PartitionReaderFactory {
+    private final List<List<InternalRow>> rowsPerFile;
+    private final List<FakeReader> created = new ArrayList<>();
+    private int nextFile = 0;
+
+    FakeFactory(List<List<InternalRow>> rowsPerFile) {
+      this.rowsPerFile = rowsPerFile;
+    }
+
+    @Override
+    public PartitionReader<InternalRow> createReader(InputPartition partition) {
+      FakeReader reader = new FakeReader(rowsPerFile.get(nextFile++));
+      created.add(reader);
+      return reader;
+    }
+  }
+
+  /** One emitted row, values copied out eagerly (the projection reuses its UnsafeRow buffer). */
+  private static final class EmittedRow {
+    private final long id;
+    private final String changeType;
+    private final long commitVersion;
+    private final long commitTimestamp;
+
+    EmittedRow(long id, String changeType, long commitVersion, long commitTimestamp) {
+      this.id = id;
+      this.changeType = changeType;
+      this.commitVersion = commitVersion;
+      this.commitTimestamp = commitTimestamp;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof EmittedRow)) {
+        return false;
+      }
+      EmittedRow that = (EmittedRow) o;
+      return id == that.id
+          && commitVersion == that.commitVersion
+          && commitTimestamp == that.commitTimestamp
+          && Objects.equals(changeType, that.changeType);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(id, changeType, commitVersion, commitTimestamp);
+    }
+
+    @Override
+    public String toString() {
+      return "EmittedRow{id=" + id + ", changeType=" + changeType + ", commitVersion="
+          + commitVersion + ", commitTimestamp=" + commitTimestamp + "}";
+    }
+  }
+
+  private static List<EmittedRow> drain(DeltaChangelogBatch.CDCPartitionReader reader)
+      throws IOException {
+    List<EmittedRow> out = new ArrayList<>();
+    while (reader.next()) {
+      InternalRow row = reader.get();
+      out.add(
+          new EmittedRow(
+              row.getLong(0),
+              row.getUTF8String(1).toString(),
+              row.getLong(2),
+              row.getLong(3)));
+    }
+    return out;
+  }
+
+  @Test
+  public void multipleFilesEmitAllRowsWithPerFileTail() throws IOException {
+    PartitionedFile insertFile = cdcFile(0, "insert", 7L, 700L);
+    PartitionedFile deleteFile = cdcFile(1, "delete", 8L, 800L);
+    FilePartition partition =
+        new FilePartition(0, new PartitionedFile[] {insertFile, deleteFile});
+
+    List<List<InternalRow>> rowsPerFile =
+        List.of(
+            List.of(dataRow(10L), dataRow(11L)),
+            List.of(dataRow(20L)));
+    FakeFactory factory = new FakeFactory(rowsPerFile);
+
+    DeltaChangelogBatch.CDCPartitionReader reader =
+        new DeltaChangelogBatch.CDCPartitionReader(factory, partition, OUTPUT_SCHEMA);
+    List<EmittedRow> emitted = drain(reader);
+    reader.close();
+
+    // All rows from both files are emitted, each stamped with its own file's tail.
+    assertEquals(
+        List.of(
+            new EmittedRow(10L, "insert", 7L, 700L),
+            new EmittedRow(11L, "insert", 7L, 700L),
+            new EmittedRow(20L, "delete", 8L, 800L)),
+        emitted);
+
+    // Every delegate reader is closed exactly once. A regression that closes the exhausted
+    // reader in next() without clearing it double-closes the last file here.
+    assertEquals(2, factory.created.size());
+    for (FakeReader r : factory.created) {
+      assertEquals(1, r.closeCount, "each delegate reader must be closed exactly once");
+    }
+  }
+
+  @Test
+  public void emptyMiddleFileIsSkipped() throws IOException {
+    FilePartition partition =
+        new FilePartition(
+            0,
+            new PartitionedFile[] {
+              cdcFile(0, "insert", 1L, 100L),
+              cdcFile(1, "insert", 2L, 200L),
+              cdcFile(2, "delete", 3L, 300L)
+            });
+
+    List<List<InternalRow>> rowsPerFile =
+        List.of(List.of(dataRow(1L)), List.of(), List.of(dataRow(3L)));
+    FakeFactory factory = new FakeFactory(rowsPerFile);
+
+    DeltaChangelogBatch.CDCPartitionReader reader =
+        new DeltaChangelogBatch.CDCPartitionReader(factory, partition, OUTPUT_SCHEMA);
+    List<EmittedRow> emitted = drain(reader);
+    reader.close();
+
+    // The empty middle file contributes no rows but is still opened and closed once.
+    assertEquals(
+        List.of(new EmittedRow(1L, "insert", 1L, 100L), new EmittedRow(3L, "delete", 3L, 300L)),
+        emitted);
+    assertEquals(3, factory.created.size());
+    for (FakeReader r : factory.created) {
+      assertEquals(1, r.closeCount);
+    }
+  }
+
+  @Test
+  public void emptyPartitionEmitsNothing() throws IOException {
+    FilePartition partition = new FilePartition(0, new PartitionedFile[0]);
+    FakeFactory factory = new FakeFactory(List.of());
+
+    DeltaChangelogBatch.CDCPartitionReader reader =
+        new DeltaChangelogBatch.CDCPartitionReader(factory, partition, OUTPUT_SCHEMA);
+    assertFalse(reader.next(), "no files means no rows");
+    reader.close();
+    assertEquals(0, factory.created.size());
+  }
+}

--- a/spark/v2/src/main/java-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogBatch.java
+++ b/spark/v2/src/main/java-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaChangelogBatch.java
@@ -1,5 +1,8 @@
 package io.delta.spark.internal.v2.read.changelog;
 
+import io.delta.spark.internal.v2.read.cdc.CDCSchemaContext;
+import org.apache.spark.sql.SparkSession;
+import scala.collection.immutable.Map$;
 import io.delta.kernel.CommitActions;
 import io.delta.kernel.CommitRange;
 import io.delta.kernel.Snapshot;
@@ -20,10 +23,8 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
@@ -50,10 +51,10 @@ import scala.Tuple2;
 
 /**
  * Batch implementation for read-time CDF that turns a commit range into CDC input partitions. It
- * iterates the AddFile, RemoveFile and Metadata actions of each commit in the range, emitting one
- * partition per data-changing file (RemoveFiles before AddFiles per commit), and rejects ranges
- * whose schema or row-tracking state is not stable. {@link #createReaderFactory()} wraps the Parquet
- * reader with {@link CDCPartitionReaderFactory} to append the CDC tail columns ({@code _change_type},
+ * iterates the AddFile, RemoveFile and Metadata actions of each commit in the range, emitting
+ * partitions packing multiple files, and rejects ranges whose schema or row-tracking state is not
+ * stable. {@link #createReaderFactory()} wraps the Parquet reader with
+ * {@link CDCPartitionReaderFactory} to append the CDC tail columns ({@code _change_type},
  * {@code _commit_version}, {@code _commit_timestamp}).
  */
 public class DeltaChangelogBatch implements Batch {
@@ -84,9 +85,91 @@ public class DeltaChangelogBatch implements Batch {
     this.hadoopConf = hadoopConf;
   }
 
+
+  /**
+   * All per-file constants are packed into the file's {@code otherConstantMetadataColumnValues}
+   * map so the bin-packing reader can recover them per file: the row-tracking pair
+   * ({@code baseRowId}, {@code defaultRowCommitVersion}), the deletion-vector descriptor,
+   * and the CDC tail ({@code _change_type}, {@code _commit_version}, {@code _commit_timestamp}).
+   */
+  private static PartitionedFile buildPartition(
+      String path,
+      long size,
+      String changeType,
+      long commitVersion,
+      long commitTimestampMillis,
+      Supplier<Optional<Long>> baseRowIdAccessor,
+      Supplier<Optional<Long>> defaultRowCommitVersionAccessor,
+      String actionDescription,
+      String deletionVector,
+      String tablePath) {
+    long baseRowId =
+        baseRowIdAccessor
+            .get()
+            .orElseThrow(
+                () ->
+                    new IllegalStateException(
+                        actionDescription + " " + path + " missing baseRowId"));
+    long defaultRcv =
+        defaultRowCommitVersionAccessor
+            .get()
+            .orElseThrow(
+                () ->
+                    new IllegalStateException(
+                        actionDescription + " " + path + " missing defaultRowCommitVersion"));
+
+    scala.collection.immutable.Map<String, Object> constantMetadata =
+        (scala.collection.immutable.Map<String, Object>)
+          (scala.collection.immutable.Map<?, ?>)
+            Map$.MODULE$.empty();
+    constantMetadata =
+        constantMetadata.$plus(
+            new Tuple2<>(RowId$.MODULE$.BASE_ROW_ID(), baseRowId));
+    constantMetadata =
+        constantMetadata.$plus(
+            new Tuple2<>(
+                DefaultRowCommitVersion$.MODULE$.METADATA_STRUCT_FIELD_NAME(),
+                defaultRcv));
+
+    for (Map.Entry<String, Object> entry :
+        PartitionUtils.buildDvMetadata(deletionVector).entrySet()) {
+      constantMetadata =
+          constantMetadata.$plus(new Tuple2<>(entry.getKey(), entry.getValue()));
+    }
+    constantMetadata = constantMetadata.$plus(new Tuple2<>(
+        CDCSchemaContext.CDC_COMMIT_VERSION, commitVersion));
+    constantMetadata = constantMetadata.$plus(new Tuple2<>(
+        CDCSchemaContext.CDC_COMMIT_TIMESTAMP,
+        TimeUnit.MILLISECONDS.toMicros(commitTimestampMillis)));
+    constantMetadata = constantMetadata.$plus(new Tuple2<>(
+        CDCSchemaContext.CDC_TYPE_COLUMN, changeType));
+
+    PartitionedFile file =
+        new PartitionedFile(
+            new GenericInternalRow(0),
+            sparkPathFromRawPath(tablePath, path),
+            /* start */ 0L,
+            /* length */ size,
+            /* locations */ new String[0],
+            /* modificationTime */ commitTimestampMillis,
+            /* fileSize */ size,
+            constantMetadata);
+    return file;
+  }
+
+  /**
+   * Rejects a schema at {@code version} that the end schema cannot read. Used for both the
+   * start/end pre-check and each in-range Metadata action.
+   */
+  private void requireReadCompatible(StructType schema, long version) {
+    if (!SchemaUtils.isReadCompatible(schema, endDataSchema)) {
+      DeltaErrors.throwChangelogSchemaChangeInRange(version);
+    }
+  }
+
   @Override
   public InputPartition[] planInputPartitions() {
-    List<InputPartition> partitions = new ArrayList<>();
+    List<PartitionedFile> partitions = new ArrayList<>();
 
     // Pre-check catches schema drift between start and end. The per-commit loop below catches
     // in-range Metadata commits.
@@ -98,6 +181,7 @@ public class DeltaChangelogBatch implements Batch {
     //
     // try-with-resources forces a catch (Exception) below because CommitActions.close()
     // declares it. Unchecked exceptions pass through unchanged.
+    long totalBytes = 0L;
     try (CloseableIterator<CommitActions> commitsIter =
         StreamingHelper.getCommitActionsFromRangeUnsafe(
             engine, (CommitRangeImpl) commitRange, snapshot.getPath(), CHANGELOG_ACTION_SET)) {
@@ -105,8 +189,8 @@ public class DeltaChangelogBatch implements Batch {
         // Emit RemoveFiles before AddFiles per commit. The Spark analyzer re-sorts anyway, but
         // direct-batch tests iterate in emission order and rely on the preimage-then-postimage
         // shape.
-        List<InputPartition> commitRemoves = new ArrayList<>();
-        List<InputPartition> commitAdds = new ArrayList<>();
+        List<PartitionedFile> commitRemoves = new ArrayList<>();
+        List<PartitionedFile> commitAdds = new ArrayList<>();
         try (CommitActions commit = commitsIter.next();
             CloseableIterator<ColumnarBatch> actionsIter = commit.getActions()) {
           while (actionsIter.hasNext()) {
@@ -129,7 +213,9 @@ public class DeltaChangelogBatch implements Batch {
                         add::getBaseRowId,
                         add::getDefaultRowCommitVersion,
                         "AddFile",
-                        deletionVectorBase64));
+                        deletionVectorBase64,
+                        snapshot.getPath()));
+                totalBytes += add.getSize();
               }
               Optional<RemoveFile> removeOpt = StreamingHelper.getDataChangeRemove(batch, rowId);
               if (removeOpt.isPresent()) {
@@ -149,7 +235,9 @@ public class DeltaChangelogBatch implements Batch {
                         remove::getBaseRowId,
                         remove::getDefaultRowCommitVersion,
                         "RemoveFile",
-                        deletionVectorBase64));
+                        deletionVectorBase64,
+                        snapshot.getPath()));
+                totalBytes += remove.getSize().orElse(0L);
               }
               // Validate Metadata actions: schema and row-tracking config must match the
               // end-version baseline established by DeltaChangelogScanBuilder. Mid-range
@@ -181,58 +269,9 @@ public class DeltaChangelogBatch implements Batch {
     } catch (Exception e) {
       DeltaErrors.throwChangelogReadFailed("PLAN_INPUT_PARTITIONS", e);
     }
-    return partitions.toArray(new InputPartition[0]);
-  }
-
-  /**
-   * Rejects a schema at {@code version} that the end schema cannot read. Used for both the
-   * start/end pre-check and each in-range Metadata action.
-   */
-  private void requireReadCompatible(StructType schema, long version) {
-    if (!SchemaUtils.isReadCompatible(schema, endDataSchema)) {
-      DeltaErrors.throwChangelogSchemaChangeInRange(version);
-    }
-  }
-
-  /**
-   * Build a {@link CDCInputPartition} for a single AddFile or RemoveFile action. Both action types
-   * require non-empty {@code baseRowId} and {@code defaultRowCommitVersion}; the caller (catalog)
-   * has already validated that row tracking is enabled at the start version of the read, so any
-   * missing value here is an invariant violation rather than a user-facing error.
-   */
-  private static CDCInputPartition buildPartition(
-      String path,
-      long size,
-      String changeType,
-      long commitVersion,
-      long commitTimestampMillis,
-      Supplier<Optional<Long>> baseRowIdAccessor,
-      Supplier<Optional<Long>> defaultRowCommitVersionAccessor,
-      String actionDescription,
-      String deletionVector) {
-    long baseRowId =
-        baseRowIdAccessor
-            .get()
-            .orElseThrow(
-                () ->
-                    new IllegalStateException(
-                        actionDescription + " " + path + " missing baseRowId"));
-    long defaultRcv =
-        defaultRowCommitVersionAccessor
-            .get()
-            .orElseThrow(
-                () ->
-                    new IllegalStateException(
-                        actionDescription + " " + path + " missing defaultRowCommitVersion"));
-    return new CDCInputPartition(
-        path,
-        size,
-        commitVersion,
-        commitTimestampMillis,
-        changeType,
-        baseRowId,
-        defaultRcv,
-        deletionVector);
+    SQLConf sqlConf = SQLConf.get();
+    return PartitionUtils.planInputPartitions(
+        SparkSession.active(), partitions, totalBytes, hadoopConf, sqlConf);
   }
 
   /**
@@ -263,7 +302,7 @@ public class DeltaChangelogBatch implements Batch {
         endDataSchema.add(DeltaChangelog.METADATA_COLUMN, DeltaChangelog.METADATA_STRUCT, false);
     Filter[] dataFilters = new Filter[0];
     scala.collection.immutable.Map<String, String> scalaOptions =
-        scala.collection.immutable.Map$.MODULE$.empty();
+        Map$.MODULE$.empty();
     SQLConf sqlConf = SQLConf.get();
 
     // Read-time CDF: tail columns are added by CDCPartitionReaderFactory below, so
@@ -286,165 +325,88 @@ public class DeltaChangelogBatch implements Batch {
             .add("_change_type", DataTypes.StringType, false)
             .add("_commit_version", DataTypes.LongType, false)
             .add("_commit_timestamp", DataTypes.TimestampType, false);
-    return new CDCPartitionReaderFactory(delegate, snapshot.getPath(), outputSchema);
-  }
-
-  /** Serialized to executors; represents one CDC file change unit. */
-  static class CDCInputPartition implements InputPartition, Serializable {
-    private final String filePath;
-    private final long fileSize;
-    private final long commitVersion;
-    private final long commitTimestampMillis;
-    private final String changeType;
-    private final long baseRowId;
-    private final long defaultRowCommitVersion;
-    private final String deletionVectorInfo;
-
-    CDCInputPartition(
-        String filePath,
-        long fileSize,
-        long commitVersion,
-        long commitTimestampMillis,
-        String changeType,
-        long baseRowId,
-        long defaultRowCommitVersion,
-        String deletionVectorInfo) {
-      this.filePath = filePath;
-      this.fileSize = fileSize;
-      this.commitVersion = commitVersion;
-      this.commitTimestampMillis = commitTimestampMillis;
-      this.changeType = changeType;
-      this.baseRowId = baseRowId;
-      this.defaultRowCommitVersion = defaultRowCommitVersion;
-      this.deletionVectorInfo = deletionVectorInfo;
-    }
-
-    public String getFilePath() {
-      return filePath;
-    }
-
-    public long getFileSize() {
-      return fileSize;
-    }
-
-    public long getCommitVersion() {
-      return commitVersion;
-    }
-
-    public long getCommitTimestampMillis() {
-      return commitTimestampMillis;
-    }
-
-    public String getChangeType() {
-      return changeType;
-    }
-
-    public long getBaseRowId() {
-      return baseRowId;
-    }
-
-    public long getDefaultRowCommitVersion() {
-      return defaultRowCommitVersion;
-    }
-
-    public String getDeletionVectorInfo() {
-      return deletionVectorInfo;
-    }
+    return new CDCPartitionReaderFactory(delegate, outputSchema);
   }
 
   /** Executor-side factory for CDC partition readers. */
   static class CDCPartitionReaderFactory implements PartitionReaderFactory, Serializable {
     private final PartitionReaderFactory delegate;
-    private final String tablePath;
     private final StructType outputSchema;
 
     CDCPartitionReaderFactory(
-        PartitionReaderFactory delegate, String tablePath, StructType outputSchema) {
+        PartitionReaderFactory delegate, StructType outputSchema) {
       this.delegate = delegate;
-      this.tablePath = tablePath;
       this.outputSchema = outputSchema;
     }
 
     @Override
     public PartitionReader<InternalRow> createReader(InputPartition partition) {
-      CDCInputPartition cdcPartition = (CDCInputPartition) partition;
-      InternalRow partitionValues = new GenericInternalRow(0);
-      // Join the raw table root and the URL-encoded file path (see sparkPathFromRawPath); the naive
-      // SparkPath.fromUrlString(new Path(tablePath, filePath).toString()) throws on a reserved
-      // character (space, '%') in the table path.
-      SparkPath sparkPath = sparkPathFromRawPath(tablePath, cdcPartition.getFilePath());
-      scala.collection.immutable.Map<String, Object> constantMetadata =
-          (scala.collection.immutable.Map<String, Object>)
-              (scala.collection.immutable.Map<?, ?>)
-                  scala.collection.immutable.Map$.MODULE$.empty();
-      constantMetadata =
-          constantMetadata.$plus(
-              new Tuple2<>(RowId$.MODULE$.BASE_ROW_ID(), cdcPartition.getBaseRowId()));
-      constantMetadata =
-          constantMetadata.$plus(
-              new Tuple2<>(
-                  DefaultRowCommitVersion$.MODULE$.METADATA_STRUCT_FIELD_NAME(),
-                  cdcPartition.getDefaultRowCommitVersion()));
-
-      // When the action carries a DV, set both Parquet reader constants together. Setting only
-      // one triggers IllegalStateException in DeltaParquetFileFormat. IF_CONTAINED makes the
-      // reader drop physical rows whose index is in the DV bitmap (visible-rows semantics).
-      for (java.util.Map.Entry<String, Object> entry :
-          PartitionUtils.buildDvMetadata(cdcPartition.getDeletionVectorInfo()).entrySet()) {
-        constantMetadata =
-            constantMetadata.$plus(new Tuple2<>(entry.getKey(), entry.getValue()));
-      }
-
-      PartitionedFile file =
-          new PartitionedFile(
-              partitionValues,
-              sparkPath,
-              /* start */ 0L,
-              /* length */ cdcPartition.getFileSize(),
-              /* locations */ new String[0],
-              /* modificationTime */ cdcPartition.getCommitTimestampMillis(),
-              /* fileSize */ cdcPartition.getFileSize(),
-              constantMetadata);
-      FilePartition filePartition = new FilePartition(0, new PartitionedFile[] {file});
-      PartitionReader<InternalRow> baseReader = delegate.createReader(filePartition);
-      return new CDCPartitionReader(baseReader, cdcPartition, outputSchema);
+      FilePartition filePartition = (FilePartition) partition;
+      return new CDCPartitionReader(delegate, filePartition, outputSchema);
     }
   }
 
-  /** Executor-side reader stub for per-file CDC row materialization. */
   static class CDCPartitionReader implements PartitionReader<InternalRow> {
-    private final PartitionReader<InternalRow> baseReader;
+    private final PartitionReaderFactory delegate;
     private final UnsafeProjection projection;
-    private final GenericInternalRow cdcTail = new GenericInternalRow(3);
+    private final PartitionedFile[] files;
     private final JoinedRow joined = new JoinedRow();
+    private final GenericInternalRow cdcTail = new GenericInternalRow(3);
+    private int currentFileIndex = 0;
+    private PartitionReader<InternalRow> currentBaseReader;
+
 
     CDCPartitionReader(
-        PartitionReader<InternalRow> baseReader,
-        CDCInputPartition cdcPartition,
-        StructType outputSchema) {
-      this.baseReader = baseReader;
+        PartitionReaderFactory delegate, FilePartition partition, StructType outputSchema) {
+      this.delegate = delegate;
       this.projection = UnsafeProjection.create(outputSchema);
-      // Tail values are partition-constants. Set them once at construction so get() does not
-      // redo the same writes on every row.
-      this.cdcTail.update(0, UTF8String.fromString(cdcPartition.getChangeType()));
-      this.cdcTail.setLong(1, cdcPartition.getCommitVersion());
-      // millis to micros: Catalyst stores TimestampType as microseconds since epoch.
-      this.cdcTail.setLong(2, cdcPartition.getCommitTimestampMillis() * 1000L);
+      // Resolve the packed files once here so the loop below is accessor-agnostic.
+      this.files = partition.files();
     }
+
 
     @Override
     public boolean next() throws IOException {
-      return baseReader.next();
+      while (true) {
+        // current file still has rows
+        if (currentBaseReader != null && currentBaseReader.next()) {
+          return true;
+        }
+        // current files has no rows => close current file, open next
+        if (currentBaseReader != null) {
+          currentBaseReader.close();
+          currentBaseReader = null;
+        }
+        // last file has been read
+        if (currentFileIndex >= files.length) {
+          return false;
+        }
+        // open next file
+        PartitionedFile file = files[currentFileIndex++];
+        currentBaseReader =
+            delegate.createReader(new FilePartition(0, new PartitionedFile[] {file}));
+
+        scala.collection.immutable.Map<String, Object> meta =
+            file.otherConstantMetadataColumnValues();
+        this.cdcTail.update(0,
+            UTF8String.fromString((String) meta.apply(CDCSchemaContext.CDC_TYPE_COLUMN)));
+        this.cdcTail.setLong(1,
+            (Long) meta.apply(CDCSchemaContext.CDC_COMMIT_VERSION));
+        this.cdcTail.setLong(2,
+            (Long) meta.apply(CDCSchemaContext.CDC_COMMIT_TIMESTAMP));
+      }
     }
 
     @Override
     public InternalRow get() {
-      return projection.apply(joined.apply(baseReader.get(), cdcTail));
+      return projection.apply(joined.apply(currentBaseReader.get(), cdcTail));
     }
 
     @Override
     public void close() throws IOException {
-      baseReader.close();
+      if (currentBaseReader != null) {
+        currentBaseReader.close();
+      }
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

The V2 changelog read path previously emitted one input partition per data-changing file. On a change range that touches many files this produces one Spark task per file, which inflates scheduling overhead and drives up driver-side memory on file-heavy CDF reads.

This PR reuses Spark's existing file bin-packing (`PartitionUtils.planInputPartitions`, which wraps `FilePartition.getFilePartitions`) so that multiple files are packed into a single `FilePartition`, matching how the regular Parquet scan groups files. Each file's per-file constants (the CDC tail `_change_type` / `_commit_version` / `_commit_timestamp`, the row-tracking `base_row_id` / `default_row_commit_version` pair, and the deletion vector descriptor) are carried in the `PartitionedFile`'s `otherConstantMetadataColumnValues` map, so bundling files together does not lose any per-file information.

The executor-side reader (`CDCPartitionReader`) now iterates every `PartitionedFile` packed into its `FilePartition`, opens a delegate Parquet reader per file, and joins that file's CDC tail onto each of its rows before moving to the next file.

## How was this patch tested?

Added `CDCPartitionReaderTest`, which drives the reader with a fake `PartitionReaderFactory` (canned rows, `close()` accounting) so it exercises the multi-file path without a Spark session. It covers:

- multiple files in one partition each emit their rows stamped with their own CDC tail, and every delegate reader is closed exactly once;
- an empty file in the middle of the partition is skipped without affecting the surrounding files;
- an empty partition emits no rows and opens no delegate readers.

End-to-end correctness through the bin-packed reader is covered by the generated `readcdcv2` CDC suites (`Delete`/`Merge`/`Update` x DV-on/off x row-tracking), which exercise the `CHANGES` read path over real DELETE/MERGE/UPDATE operations: 80 tests, all passing.

## Does this PR introduce _any_ user-facing changes?

No. This changes only the internal partitioning of the V2 changelog scan. The rows returned, their schema, and their ordering are unchanged.
