### PR TITLE
[Spark] Isolate feature enablement test table paths

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/FeatureEnablementConcurrencySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/FeatureEnablementConcurrencySuite.scala
@@ -16,6 +16,8 @@
 
 package org.apache.spark.sql.delta
 
+import java.util.concurrent.atomic.AtomicLong
+
 import org.apache.spark.sql.delta.DeltaTestUtils.BOOLEAN_DOMAIN
 import org.apache.spark.sql.delta.actions.{AddFile, Format, Metadata, Protocol}
 import org.apache.spark.sql.delta.fuzzer.{OptimisticTransactionPhases, PhaseLockingTransactionExecutionObserver => TransactionObserver}
@@ -40,7 +42,8 @@ class FeatureEnablementConcurrencySuite
     with DeltaSQLCommandTest
     with ConflictResolutionTestUtils {
 
-  val testTableName = "test_feature_enablement_table"
+  private val nextTestTableId = new AtomicLong()
+  private var testTableName = ""
 
   /** Represents a transaction that alters a table property. */
   case class AlterTableProperty(
@@ -65,7 +68,11 @@ class FeatureEnablementConcurrencySuite
   private def createTestTable(
       properties: Seq[String] = Seq.empty,
       numPartitions: Int = 2): (DeltaLog, CatalogTable) = {
-    sql(s"DROP TABLE IF EXISTS $testTableName")
+    if (testTableName.nonEmpty) {
+      sql(s"DROP TABLE IF EXISTS $testTableName")
+    }
+    // Delta log cleanup can outlive a test, so each setup needs a distinct managed-table path.
+    testTableName = s"test_feature_enablement_table_${nextTestTableId.getAndIncrement()}"
     val propertiesString = if (properties.nonEmpty) properties.mkString(",") + "," else ""
     sql(
       s"""CREATE TABLE $testTableName (idCol bigint)


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Give each `FeatureEnablementConcurrencySuite` setup a distinct managed-table path. Delta log cleanup can continue asynchronously after a test returns, so reusing the table name can let cleanup from one checkpoint test race a later test setup.

## How was this patch tested?

The corresponding shared suite checkpoint-format invariant tests passed in five repeated runs. `git diff --check` also passed.

## Does this PR introduce _any_ user-facing changes?

No.