### PR TITLE
[Spark] Enabling partitioned column mapping on batch write path in DSv2

### DIFF
--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/PartitionUtils.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/PartitionUtils.java
@@ -207,8 +207,8 @@ public class PartitionUtils {
    * columns of {@code row}, as required by {@code Transaction.getWriteContext}. Insertion order
    * follows {@code partitionSchema}.
    *
-   * <p>TODO(#7140): key by physical name to support column mapping (safe today as build() rejects
-   * column-mapped tables).
+   * <p>Keys are the logical partition column names. For a column-mapped table they are translated
+   * to the physical names and for a non-column-mapped table they are left unchanged.
    *
    * @param row the full write row Spark hands the writer
    * @param partitionSchema the partition columns (in partition order)

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2WriteBuilder.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2WriteBuilder.java
@@ -19,8 +19,10 @@ import static java.util.Objects.requireNonNull;
 
 import io.delta.kernel.Snapshot;
 import io.delta.kernel.engine.Engine;
-import io.delta.kernel.internal.util.ColumnMapping;
-import io.delta.kernel.internal.util.ColumnMapping.ColumnMappingMode;
+import io.delta.kernel.internal.SnapshotImpl;
+import io.delta.kernel.internal.TableConfig;
+import io.delta.kernel.internal.actions.Metadata;
+import io.delta.kernel.internal.actions.Protocol;
 import io.delta.spark.internal.v2.snapshot.DeltaSnapshotManager;
 import io.delta.spark.internal.v2.utils.SchemaUtils;
 import org.apache.hadoop.conf.Configuration;
@@ -87,17 +89,22 @@ public class DeltaV2WriteBuilder implements WriteBuilder {
   public Write build() {
     validateDataSchema(initialSnapshot, writeInfo.schema());
 
-    // TODO(#7140): support partitioned writes to column-mapped tables. Unpartitioned is supported;
-    // partitioned writes need partition values keyed by physical name, so reject for now.
+    // TODO: support partitioned IcebergCompat / materializePartitionColumns writes.
     if (!partitionSchema.isEmpty()) {
-      ColumnMappingMode cmMode =
-          ColumnMapping.getColumnMappingMode(initialSnapshot.getTableProperties());
-      if (cmMode != ColumnMappingMode.NONE) {
+      SnapshotImpl snapshotImpl = (SnapshotImpl) initialSnapshot;
+      Metadata metadata = snapshotImpl.getMetadata();
+      Protocol protocol = snapshotImpl.getProtocol();
+      boolean icebergCompat =
+          TableConfig.ICEBERG_COMPAT_V2_ENABLED.fromMetadata(metadata)
+              || TableConfig.ICEBERG_COMPAT_V3_ENABLED.fromMetadata(metadata);
+      // Detect the materializePartitionColumns writer feature by its protocol name.
+      boolean materializePartitionColumns =
+          protocol.getWriterFeatures().contains("materializePartitionColumns");
+      if (icebergCompat || materializePartitionColumns) {
         throw new UnsupportedOperationException(
-            "DSv2 partitioned writes are not supported on column-mapped Delta tables "
-                + "(delta.columnMapping.mode = "
-                + cmMode
-                + "). Use the V1 write path (format(\"delta\").write()) instead.");
+            "DSv2 partitioned writes are not supported on tables that materialize partition "
+                + "columns (IcebergCompat or the materializePartitionColumns feature). Use the V1 "
+                + "write path (format(\"delta\").write()) instead.");
       }
     }
 

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/write/V2WriteTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/write/V2WriteTest.java
@@ -15,8 +15,10 @@
  */
 package io.delta.spark.internal.v2.write;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.delta.spark.internal.v2.V2TestBase;
@@ -94,12 +96,174 @@ public class V2WriteTest extends V2TestBase {
         List.of(row(1, "Alice", 100.0), row(2, "Bob", 200.0), row(3, "Carol", 300.0)));
   }
 
+  @ParameterizedTest(name = "columnMappingMode={0}")
+  @ValueSource(strings = {"name", "id"})
+  public void writeToPartitionedColumnMappingTable(String mappingMode, @TempDir File deltaTablePath)
+      throws Exception {
+    String tablePath = deltaTablePath.getAbsolutePath();
+    createPartitionedColumnMappingTable(tablePath, mappingMode);
+
+    spark.sql(
+        str(
+            "INSERT INTO dsv2.delta.`%s` VALUES (1, 'Alice', 100.0), (2, 'Bob', 200.0)",
+            tablePath));
+
+    // Read back through both the V2 and V1 paths, both resolve partition values by physical name,
+    // so a logical-directory regression would surface here as null partition columns.
+    check(
+        str("SELECT * FROM dsv2.delta.`%s` ORDER BY id", tablePath),
+        List.of(row(1, "Alice", 100.0), row(2, "Bob", 200.0)));
+    check(
+        str("SELECT * FROM delta.`%s` ORDER BY id", tablePath),
+        List.of(row(1, "Alice", 100.0), row(2, "Bob", 200.0)));
+
+    assertPhysicalPartitionDirExists(tablePath, "Alice");
+    assertPhysicalPartitionDirExists(tablePath, "Bob");
+    assertAddFilePartitionValuesArePhysical(tablePath, "name");
+    // The Parquet body omits the partition column and uses physical col-* names for the rest.
+    assertPhysicalParquetUsesMappedColumnNames(
+        physicalPartitionDir(tablePath, "Alice").getAbsolutePath(), "id", "value");
+    assertParquetBodyOmitsPartitionColumns(
+        physicalPartitionDir(tablePath, "Alice"), /* expectedDataColumns */ 2);
+  }
+
+  @Test
+  public void writeToMultiColumnPartitionedColumnMappingTable(@TempDir File deltaTablePath)
+      throws Exception {
+    String tablePath = deltaTablePath.getAbsolutePath();
+    spark.sql(
+        str(
+            "CREATE TABLE delta.`%s` (id INT, region STRING, tier INT) USING delta "
+                + "PARTITIONED BY (region, tier) "
+                + "TBLPROPERTIES ('delta.columnMapping.mode' = 'name')",
+            tablePath));
+
+    spark.sql(str("INSERT INTO dsv2.delta.`%s` VALUES (1, 'us', 1), (2, 'eu', 2)", tablePath));
+
+    check(
+        str("SELECT * FROM dsv2.delta.`%s` ORDER BY id", tablePath),
+        List.of(row(1, "us", 1), row(2, "eu", 2)));
+    check(
+        str("SELECT * FROM delta.`%s` ORDER BY id", tablePath),
+        List.of(row(1, "us", 1), row(2, "eu", 2)));
+
+    // Nested physical partition directories: col-<uuid>=us/col-<uuid>=1.
+    File outer = physicalPartitionDir(tablePath, "us");
+    File inner = physicalPartitionChildDir(outer, "1");
+    assertTrue(
+        inner != null, "Expected a nested physical partition directory col-*=1 under " + outer);
+    // Both partition columns are path-encoded.
+    assertParquetBodyOmitsPartitionColumns(inner, /* expectedDataColumns */ 1);
+  }
+
+  @Test
+  public void writeNullPartitionValueColumnMappingTable(@TempDir File deltaTablePath)
+      throws Exception {
+    String tablePath = deltaTablePath.getAbsolutePath();
+    createPartitionedColumnMappingTable(tablePath, "name");
+
+    spark.sql(str("INSERT INTO dsv2.delta.`%s` VALUES (1, NULL, 100.0)", tablePath));
+
+    check(str("SELECT * FROM dsv2.delta.`%s`", tablePath), List.of(row(1, null, 100.0)));
+    check(str("SELECT * FROM delta.`%s`", tablePath), List.of(row(1, null, 100.0)));
+
+    // A null partition value is Hive-encoded under the physical parent directory.
+    assertPhysicalPartitionDirExists(tablePath, "__HIVE_DEFAULT_PARTITION__");
+    assertParquetBodyOmitsPartitionColumns(
+        physicalPartitionDir(tablePath, "__HIVE_DEFAULT_PARTITION__"), /* expectedDataColumns */ 2);
+  }
+
+  @Test
+  public void partitionedIcebergCompatWriteIsRejected(@TempDir File deltaTablePath) {
+    String tablePath = deltaTablePath.getAbsolutePath();
+    spark.sql(
+        str(
+            "CREATE TABLE delta.`%s` (id INT, name STRING, value DOUBLE) USING delta "
+                + "PARTITIONED BY (name) TBLPROPERTIES ("
+                + "'delta.columnMapping.mode' = 'name', 'delta.enableIcebergCompatV2' = 'true')",
+            tablePath));
+
+    // IcebergCompat materializes partition columns into the Parquet body, which this write path
+    // does not do yet.
+    assertThrows(
+        UnsupportedOperationException.class,
+        () -> spark.sql(str("INSERT INTO dsv2.delta.`%s` VALUES (1, 'Alice', 100.0)", tablePath)));
+  }
+
   private void createColumnMappingTable(String tablePath, String mappingMode) {
     spark.sql(
         str(
             "CREATE TABLE delta.`%s` (id INT, user_name STRING, amount DOUBLE) "
                 + "USING delta TBLPROPERTIES ('delta.columnMapping.mode' = '%s')",
             tablePath, mappingMode));
+  }
+
+  private void createPartitionedColumnMappingTable(String tablePath, String mappingMode) {
+    spark.sql(
+        str(
+            "CREATE TABLE delta.`%s` (id INT, name STRING, value DOUBLE) USING delta "
+                + "PARTITIONED BY (name) TBLPROPERTIES ('delta.columnMapping.mode' = '%s')",
+            tablePath, mappingMode));
+  }
+
+  /** Returns the {@code col-<uuid>=<value>} partition directory under {@code tablePath}. */
+  private File physicalPartitionDir(String tablePath, String value) {
+    File[] dirs =
+        new File(tablePath).listFiles((d, n) -> n.startsWith("col-") && n.endsWith("=" + value));
+    assertNotNull(dirs, "Expected partition directories under " + tablePath);
+    assertTrue(
+        dirs.length == 1,
+        "Expected one physical partition directory col-*=" + value + ", got " + dirs.length);
+    return dirs[0];
+  }
+
+  /** Returns the nested {@code col-<uuid>=<value>} directory under {@code parent}, or null. */
+  private File physicalPartitionChildDir(File parent, String value) {
+    File[] dirs = parent.listFiles((d, n) -> n.startsWith("col-") && n.endsWith("=" + value));
+    return (dirs != null && dirs.length == 1) ? dirs[0] : null;
+  }
+
+  /**
+   * Asserts a physical {@code col-<uuid>=<value>} partition directory exists and contains data, and
+   * that no logical {@code <logicalName>=<value>} directory was written instead.
+   */
+  private void assertPhysicalPartitionDirExists(String tablePath, String value) {
+    File dir = physicalPartitionDir(tablePath, value);
+    assertTrue(dir.isDirectory(), "Expected a directory at " + dir);
+    File[] parquet = dir.listFiles((d, n) -> n.endsWith(".parquet"));
+    assertTrue(parquet != null && parquet.length > 0, "Expected a parquet file under " + dir);
+    File[] logical =
+        new File(tablePath).listFiles((d, n) -> !n.startsWith("col-") && n.endsWith("=" + value));
+    assertTrue(
+        logical == null || logical.length == 0,
+        "Did not expect a logical partition directory ending in '=" + value + "'");
+  }
+
+  /**
+   * Asserts the AddFile {@code partitionValues} in the log are keyed by the physical col-* name.
+   * The commit JSON is read with schema inference, so {@code partitionValues} surfaces as a struct
+   * whose field names are the partition keys.
+   */
+  private void assertAddFilePartitionValuesArePhysical(String tablePath, String logicalName) {
+    org.apache.spark.sql.types.StructType addType =
+        (org.apache.spark.sql.types.StructType)
+            spark
+                .read()
+                .json(tablePath + "/_delta_log/*.json")
+                .where("add is not null")
+                .schema()
+                .apply("add")
+                .dataType();
+    org.apache.spark.sql.types.StructType partitionValuesType =
+        (org.apache.spark.sql.types.StructType) addType.apply("partitionValues").dataType();
+    List<String> keys = List.of(partitionValuesType.fieldNames());
+    assertFalse(keys.isEmpty(), "Expected at least one partition-value key");
+    assertTrue(
+        keys.stream().allMatch(k -> k.startsWith("col-")),
+        "Expected physical col-* partition-value keys, got: " + keys);
+    assertFalse(
+        keys.contains(logicalName),
+        "AddFile partitionValues must not use the logical key '" + logicalName + "'");
   }
 
   /**
@@ -139,5 +303,28 @@ public class V2WriteTest extends V2TestBase {
       assertNotNull(
           field.getId(), "Expected a Parquet field id on column '" + field.getName() + "'");
     }
+  }
+
+  /**
+   * Verifies the Parquet body under {@code partitionDir} holds only the data columns. Partition
+   * columns are path-encoded, not materialized into the file.
+   */
+  private void assertParquetBodyOmitsPartitionColumns(File partitionDir, int expectedDataColumns)
+      throws Exception {
+    File[] parquetFiles = partitionDir.listFiles((dir, name) -> name.endsWith(".parquet"));
+    assertNotNull(parquetFiles, "Expected parquet data files under " + partitionDir);
+    assertTrue(parquetFiles.length > 0, "Expected at least one parquet data file");
+    List<String> parquetFieldNames =
+        ParquetFileReader.readFooter(
+                spark.sessionState().newHadoopConf(),
+                new Path(parquetFiles[0].getAbsolutePath()),
+                ParquetMetadataConverter.NO_FILTER)
+            .getFileMetaData().getSchema().getFields().stream()
+            .map(org.apache.parquet.schema.Type::getName)
+            .collect(java.util.stream.Collectors.toList());
+    assertEquals(
+        expectedDataColumns,
+        parquetFieldNames.size(),
+        "Expected only the data columns in the Parquet body, got: " + parquetFieldNames);
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Enables the DSv2 batch write path to write partitioned column-mapped tables. Removes the reject guard, `Transaction.getWriteContext` physicalizes the partition directory and `AddFile` partition-value keys to `col-*` names. Identity transform for non-column-mapped tables. Tables that materialize partition columns into the Parquet body (`IcebergCompat`, `materializePartitionColumns`) are still rejected.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

New `V2WriteTest` cases: E2E `name`/`id`-mode partitioned column-mapped writes and then assert on-disk partition dirs use physical `col-*=value` names as well as round-trips on read.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No