### PR TITLE
Reorganize DataSkipping test suite structure

### DIFF
--- a/spark/delta-suite-generator/src/main/scala/io/delta/suitegenerator/SuiteGeneratorConfig.scala
+++ b/spark/delta-suite-generator/src/main/scala/io/delta/suitegenerator/SuiteGeneratorConfig.scala
@@ -503,7 +503,7 @@ object SuiteGeneratorConfig {
 
     // Column-mapping expansion for the V1 data-skipping suites. The referenced mixins live in
     // DataSkippingDeltaTests.scala.
-    if (base == "DataSkippingDeltaV1Tests") {
+    if (base.contains("DataSkippingDeltaV1Tests")) {
       if (mixins.contains(Dims.COLUMN_MAPPING.traitNames.head)) {
         finalMixins += "DataSkippingDeltaTestV1ColumnMappingMode"
       }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/stats/DataSkippingDeltaTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/stats/DataSkippingDeltaTests.scala
@@ -242,6 +242,11 @@ trait DataSkippingDeltaTestsBase extends QueryTest
       }
     }
   }
+}
+
+trait DataSkippingDeltaTests extends DataSkippingDeltaTestsBase
+{
+  import testImplicits._
 
   testSkipping(
     "top level, single 1",
@@ -2367,7 +2372,6 @@ trait DataSkippingDeltaTestsBase extends QueryTest
 
 }
 
-trait DataSkippingDeltaTests extends DataSkippingDeltaTestsBase
 /** Tests code paths within DataSkippingReader.scala */
 trait DataSkippingDeltaV1Tests
   extends DataSkippingDeltaTests


### PR DESCRIPTION
## Description

Behavior-preserving reorganization of the `DataSkippingDelta` test suite composition.

- Extract a `DataSkippingDeltaTests` trait out of `DataSkippingDeltaTestsBase`, so the shared
  data-skipping test body can be composed independently of the base infrastructure.
- Generalize the suite generator's column-mapping expansion rule to match any base suite whose
  name contains `DataSkippingDeltaV1Tests` rather than requiring an exact match.

No test logic changes; the same cases run under the same configurations.

## How was this patch tested?

Existing `DataSkippingDelta` suites; this is a no-op refactor of test-suite composition.

## Does this PR introduce _any_ user-facing changes?

No.