### PR TITLE
Add fast idempotency check during conflict checking

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
@@ -71,6 +71,7 @@ private[delta] case class CurrentTransactionInfo(
     val op: DeltaOperations.Operation,
     val preCommitLatestAMTCheckpointOpt: Option[Checkpoint] = None
     , val convertedIcebergMetadata: Option[UniformMetadata] = None
+    , idempotentCommitAlreadyLandedAt: Option[Long] = None
  ) {
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -37,7 +37,7 @@ import org.apache.spark.sql.delta.DeltaGeoSpatial
 import org.apache.spark.sql.delta.DeltaOperations.{ChangeColumn, ChangeColumns, CreateTable, Operation, ReplaceColumns, ReplaceTable, UpdateSchema}
 import org.apache.spark.sql.delta.RowId.RowTrackingMetadataDomain
 import org.apache.spark.sql.delta.actions._
-import org.apache.spark.sql.delta.amt.{AMTCheckpointProvider, AMTWriteMetrics, AMTWriterManager}
+import org.apache.spark.sql.delta.amt.{AMTCheckpointProvider, AMTWriteMetrics, AMTWriteResult, AMTWriterManager}
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.commands.DeletionVectorUtils
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
@@ -135,6 +135,7 @@ case class CommitStats(
   fileSizeHistogram: Option[FileSizeHistogram] = None,
   addFilesHistogram: Option[FileSizeHistogram] = None,
   removeFilesHistogram: Option[FileSizeHistogram] = None,
+  isIdempotentRetry: Boolean = false,
   numOfDomainMetadatas: Long = 0,
   txnId: Option[String] = None,
   /** Metrics for the inline AMT (Adaptive Metadata Tree) write, if this commit emitted one. */
@@ -2443,7 +2444,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
 
     val currentSnapshot = deltaLog.updateAfterCommit(
       attemptVersion,
-      commit,
+      Some(commit),
       newChecksumOpt = None,
       preCommitLogSegment = preCommitLogSegment,
       catalogTable)
@@ -2784,6 +2785,39 @@ trait OptimisticTransactionImpl extends TransactionHelper
             // that we want to commit.
             val (newCommitVersion, newCurrentTransactionInfo) = checkForConflicts(
               commitVersion, updatedCurrentTransactionInfo, attemptNumber, isolationLevel)
+            // Check if we may have already committed this version but retried due to
+            // a transient error. If that's the case, just return success.
+            newCurrentTransactionInfo.idempotentCommitAlreadyLandedAt match {
+              case Some(committedVersion) =>
+                // The idempotent self-commit is expected to land at exactly the version we were
+                // attempting. If it landed at a different version, surface it.
+                if (committedVersion != commitVersion) {
+                  throw new IllegalStateException(
+                    s"Idempotent self-commit landed at version $committedVersion but the " +
+                      s"transaction was attempting version $commitVersion.")
+                }
+                // newCurrentTransactionInfo carries the actions read back from the commit file
+                // that actually landed (adopted in resolveConflicts on the idempotent path), so
+                // post-commit stats and the resulting CommittedTransaction reflect exactly what
+                // was committed rather than the pre-doCommit action set
+                val actions = newCurrentTransactionInfo.finalActionsToCommit
+                val jsonActions = actions.map(_.json)
+                val (postCommitSnapshot, txnInfo) = performPostCommitActions(
+                  committedVersion,
+                  actions,
+                  jsonActions,
+                  newCurrentTransactionInfo,
+                  isolationLevel,
+                  fsWriteStartNanoOpt = None,
+                  amtWriterManager = amtWriterManager,
+                  newChecksumOpt = None,
+                  amtWriteResultOpt = None,
+                  commitOpt = None,
+                  isIdempotentRetry = true
+                )
+                return (committedVersion, postCommitSnapshot, txnInfo)
+              case None => // fall through to the normal retry commit below
+            }
             commitVersion = newCommitVersion
             updatedCurrentTransactionInfo = newCurrentTransactionInfo
             doCommit(
@@ -2904,6 +2938,33 @@ trait OptimisticTransactionImpl extends TransactionHelper
     val (newChecksumOpt, commit, committedTransactionInfo) =
       writeCommitFile(attemptVersion, jsonActions.toIterator, updatedCurrentTransactionInfo)
 
+    performPostCommitActions(
+      attemptVersion,
+      actions,
+      jsonActions,
+      committedTransactionInfo,
+      isolationLevel,
+      Some(fsWriteStartNano),
+      amtWriterManager,
+      newChecksumOpt,
+      amtWriteResultOpt,
+      commitOpt = Some(commit)
+    )
+  }
+
+  // scalastyle:off argcount
+  private def performPostCommitActions(
+      attemptVersion: Long,
+      actions: Seq[Action],
+      jsonActions: Seq[String],
+      committedTransactionInfo: CurrentTransactionInfo,
+      isolationLevel: IsolationLevel,
+      fsWriteStartNanoOpt: Option[Long],
+      amtWriterManager: AMTWriterManager,
+      newChecksumOpt: Option[VersionChecksum],
+      amtWriteResultOpt: Option[AMTWriteResult],
+      commitOpt: Option[Commit],
+      isIdempotentRetry: Boolean = false): (Snapshot, CurrentTransactionInfo) = {
     spark.sessionState.conf.setConf(
       DeltaSQLConf.DELTA_LAST_COMMIT_VERSION_IN_SESSION,
       Some(attemptVersion))
@@ -2914,11 +2975,12 @@ trait OptimisticTransactionImpl extends TransactionHelper
     val catalogTableForPostCommitSnapshot = catalogTable
     val postCommitSnapshot = deltaLog.updateAfterCommit(
       attemptVersion,
-      commit,
+      commitOpt,
       newChecksumOpt,
       preCommitLogSegment,
       catalogTableForPostCommitSnapshot,
-      amtCheckpointOpt = amtWriteResultOpt.map(_.checkpoint))
+      amtCheckpointOpt = amtWriteResultOpt.map(_.checkpoint),
+      isIdempotentRetry = isIdempotentRetry)
     val postCommitReconstructionTime = System.nanoTime()
     maintenanceOperation = if (
         !postCommitSnapshot.protocol.isFeatureSupported(AdaptiveMetadataTableFeature)) {
@@ -2953,7 +3015,8 @@ trait OptimisticTransactionImpl extends TransactionHelper
       attemptVersion,
       startVersion = snapshot.version,
       commitDurationMs = NANOSECONDS.toMillis(commitEndNano - commitStartNano),
-      fsWriteDurationMs = NANOSECONDS.toMillis(commitEndNano - fsWriteStartNano),
+      fsWriteDurationMs = fsWriteStartNanoOpt.map { fsWriteStartNano =>
+        NANOSECONDS.toMillis(commitEndNano - fsWriteStartNano)}.getOrElse(-1),
       txnExecutionTimeMs = NANOSECONDS.toMillis(commitEndNano - txnStartNano),
       stateReconstructionDurationMs =
         NANOSECONDS.toMillis(postCommitReconstructionTime - commitEndNano),
@@ -2963,14 +3026,16 @@ trait OptimisticTransactionImpl extends TransactionHelper
       // We don't use postCommitSnapshot.fileSizeHistogram here
       // because it can trigger full state reconstruction.
       fileSizeHistogramOpt = postCommitSnapshot.checksumOpt.flatMap(_.fileSizeHistogram),
-      commitInfoOpt = currentTransactionInfo.commitInfo,
+      commitInfoOpt = committedTransactionInfo.commitInfo,
       commitSizeBytes = commitSizeBytes,
       amtWriteMetricsOpt = Option.when(amtWriterManager.metrics.attempts.nonEmpty)(
-        amtWriterManager.metrics)
+        amtWriterManager.metrics),
+      isIdempotentRetry = isIdempotentRetry
     )
 
     (postCommitSnapshot, committedTransactionInfo)
   }
+  // scalastyle:on argcount
 
   class FileSystemBasedCommitCoordinatorClient(val deltaLog: DeltaLog)
     extends CommitCoordinatorClient {
@@ -3245,7 +3310,10 @@ trait OptimisticTransactionImpl extends TransactionHelper
           winningCommitSummary,
           commitIsolationLevel)
 
-        updatedCurrentTransactionInfo = conflictChecker.checkConflictsAndValidateActions()
+        updatedCurrentTransactionInfo = resolveAgainstWinningCommit(
+            winningCommitSummary, firstWinningVersion, updatedCurrentTransactionInfo).getOrElse {
+          conflictChecker.checkConflictsAndValidateActions()
+        }
 
         logInfo(logPrefix +
           log"No conflicts in version ${MDC(DeltaLogKeys.VERSION, otherCommitVersion)}, " +
@@ -3253,6 +3321,53 @@ trait OptimisticTransactionImpl extends TransactionHelper
             clock.getTimeMillis() - commitAttemptStartTimeMillis)} ms since start")
       }
     updatedCurrentTransactionInfo
+  }
+
+  /**
+   * Resolve conflicts against a single winning commit. If a winning commit turns out
+   * to be this txn's own already-landed commit (a lost-response retry, only possible at
+   * firstWinningVersion), we record the landed version instead in the
+   * updatedCurrentTransactionInfo.
+   */
+  protected def resolveAgainstWinningCommit(
+      summary: WinningCommitSummary,
+      firstWinningVersion: Long,
+      currentTransactionInfo: CurrentTransactionInfo): Option[CurrentTransactionInfo] =
+    detectIdempotentSelfCommit(summary, firstWinningVersion).map { version =>
+      // If this is an idempotent retry, reuse the winning commit file's actions
+      // in the current transaction info because these are the ones that were already
+      // committed by this attempt.
+      currentTransactionInfo.copy(
+        commitInfo = summary.commitInfo,
+        actions = summary.actions.filterNot(_.isInstanceOf[CommitInfo]),
+        idempotentCommitAlreadyLandedAt = Some(version))
+    }
+
+  /**
+   * Detects whether the winning transaction is this transaction's own commit
+   * by comparing the transaction IDs of the winning and losing transactions.
+   * The only version for which this can happen is the first conflicting version.
+   */
+  protected def detectIdempotentSelfCommit(
+      winningCommitSummary: WinningCommitSummary,
+      firstWinningVersion: Long): Option[Long] = {
+    if (winningCommitSummary.commitVersion == firstWinningVersion &&
+      spark.conf.get(DeltaSQLConf.DELTA_COMMIT_IDEMPOTENCY_CHECK_ENABLED) &&
+      winningCommitSummary.commitInfo.flatMap(_.txnId).contains(txnId)) {
+      recordDeltaEvent(
+        deltaLog,
+        "delta.commit.idempotentSelfCommitDetected",
+        data = Map(
+          "txnId" -> txnId,
+          "attemptedVersion" -> winningCommitSummary.commitVersion,
+          "winningCommitTimestamp" -> winningCommitSummary.commitFileTimestamp))
+      logInfo(log"Detected idempotent self-commit at version " +
+        log"${MDC(DeltaLogKeys.VERSION, winningCommitSummary.commitVersion)}; " +
+        log"treating as already committed.")
+      Some(winningCommitSummary.commitVersion)
+    } else {
+      None
+    }
   }
 
   /** Returns the version that the first attempt will try to commit at. */

--- a/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
@@ -1460,14 +1460,17 @@ trait SnapshotManagement { self: DeltaLog =>
    *                      tables. When present, it is installed in the underlying post-commit
    *                      snapshot as it must be the latest checkpoint in the commit range
    *                      [0, committedVersion]. None otherwise.
+   * @param isIdempotentRetry when true, this is an idempotent retry of a commit that already
+   *                          landed
    */
   def updateAfterCommit(
       committedVersion: Long,
-      commit: Commit,
+      commitOpt: Option[Commit],
       newChecksumOpt: Option[VersionChecksum],
       preCommitLogSegment: LogSegment,
       catalogTableOpt: Option[CatalogTable],
-      amtCheckpointOpt: Option[Checkpoint] = None): Snapshot = {
+      amtCheckpointOpt: Option[Checkpoint] = None,
+      isIdempotentRetry: Boolean = false): Snapshot = {
     var previousSnapshot: Snapshot = null
     recordDeltaOperation(this, "delta.log.updateAfterCommit") {
       val updatedSnapshot = withSnapshotLockInterruptibly {
@@ -1480,15 +1483,26 @@ trait SnapshotManagement { self: DeltaLog =>
         )
         val amtCheckpointProviderOpt =
           amtCheckpointOpt.map(cp => AMTCheckpointProvider.fromCheckpoint(spark, this, cp))
-        val segment = getLogSegmentAfterCommit(
-          committedVersion,
-          newChecksumOpt,
-          preCommitLogSegment,
-          commit,
-          commitCoordinatorOpt,
-          catalogTableOpt,
-          previousSnapshot.checkpointProvider,
-          amtCheckpointProviderOpt = amtCheckpointProviderOpt)
+        val segment = if (isIdempotentRetry) {
+          // The commit already landed and the preCommitLogSegment has been advanced to a
+          // segment at  >= committedVersion by conflict checking, so it is already the
+          // post-commit segment.
+          preCommitLogSegment
+        } else {
+          val commit = commitOpt.getOrElse {
+            throw new IllegalStateException(
+              "A Commit is required to build the post-commit log segment.")
+          }
+          getLogSegmentAfterCommit(
+            committedVersion,
+            newChecksumOpt,
+            preCommitLogSegment,
+            commit,
+            commitCoordinatorOpt,
+            catalogTableOpt,
+            previousSnapshot.checkpointProvider,
+            amtCheckpointProviderOpt = amtCheckpointProviderOpt)
+        }
 
         // This likely implies a list-after-write inconsistency
         if (segment.version < committedVersion) {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -529,6 +529,16 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .booleanConf
       .createWithDefault(false)
 
+  val DELTA_COMMIT_IDEMPOTENCY_CHECK_ENABLED =
+    buildConf("commit.idempotencyCheck.enabled")
+      .internal()
+      .doc("When enabled, during commit conflict retries, if the winning commit at the exact " +
+        "version this transaction attempted to commit has the same txnId as this transaction, " +
+        "treat the commit as already succeeded (the write landed but the response was lost). " +
+        "Prevents duplicating data on retry after a transient commit-response loss.")
+      .booleanConf
+      .createWithDefault(false)
+
   val FEATURE_ENABLEMENT_CONFLICT_RESOLUTION_ENABLED =
     buildConf("featureEnablement.conflictResolution.enabled")
       .internal()

--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/TransactionHelper.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/TransactionHelper.scala
@@ -378,7 +378,8 @@ trait TransactionHelper extends DeltaLogging {
         fileSizeHistogramOpt: Option[FileSizeHistogram],
         commitInfoOpt: Option[CommitInfo],
         commitSizeBytes: Long,
-        amtWriteMetricsOpt: Option[AMTWriteMetrics] = None): Unit = {
+        amtWriteMetricsOpt: Option[AMTWriteMetrics] = None,
+        isIdempotentRetry: Boolean = false): Unit = {
       assertStateBeforeFinalization()
 
       val doCollectCommitStats =

--- a/spark/src/test/scala/org/apache/spark/sql/delta/IdempotentCommitRetrySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/IdempotentCommitRetrySuite.scala
@@ -1,0 +1,160 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import java.nio.file.FileAlreadyExistsException
+
+import org.apache.spark.sql.delta.DeltaOperations.ManualUpdate
+import org.apache.spark.sql.delta.DeltaTestUtils.createTestAddFile
+import org.apache.spark.sql.delta.actions.Metadata
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.storage.LocalLogStore
+import org.apache.spark.sql.delta.storage.LogStore.logStoreClassConfKey
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.test.SharedSparkSession
+
+class IdempotentCommitRetrySuite
+  extends QueryTest
+  with DeltaSQLCommandTest
+  with SharedSparkSession {
+
+  protected override def sparkConf: SparkConf = {
+    super.sparkConf
+      .set(logStoreClassConfKey, classOf[FailAfterWriteLogStore].getName)
+      .set(DeltaSQLConf.DELTA_COMMIT_IDEMPOTENCY_CHECK_ENABLED.key, "true")
+  }
+
+  test("idempotent self-commit is detected and returns success") {
+    withTempDir { tempDir =>
+      val log = DeltaLog.forTable(spark, new Path(tempDir.getCanonicalPath))
+      // Commit the metadata at version 0 (this write is allowed to succeed).
+      log.startTransaction(catalogTableOpt = None).commit(Seq(Metadata()), ManualUpdate)
+
+      // The next commit's write lands at version 1 but the response is "lost": the log store
+      // throws FileAlreadyExistsException after writing, so the retry loop runs conflict checking
+      // and finds this transaction's own commit at version 1.
+      FailAfterWriteLogStore.failAtVersion = 1
+      // The self-commit fires the detection exactly once and does not rebase to a second version.
+      log.startTransaction(catalogTableOpt = None).commit(
+        Seq(createTestAddFile(encodedPath = "file-1")), ManualUpdate)
+
+      val snapshot = log.update()
+      assert(snapshot.version == 1)
+      assert(snapshot.allFiles.collect().map(_.path).toSeq == Seq("file-1"),
+        "The AddFile must appear exactly once. No duplication on the idempotent retry")
+    }
+  }
+
+  test("idempotency check disabled (default): self-commit is not detected") {
+    withSQLConf(DeltaSQLConf.DELTA_COMMIT_IDEMPOTENCY_CHECK_ENABLED.key -> "false") {
+      withTempDir { tempDir =>
+        val log = DeltaLog.forTable(spark, new Path(tempDir.getCanonicalPath))
+        log.startTransaction(catalogTableOpt = None).commit(Seq(Metadata()), ManualUpdate)
+
+        FailAfterWriteLogStore.failAtVersion = 1
+        // With the flag off, the idempotency short-circuit must not run.
+        log.startTransaction(catalogTableOpt = None).commit(
+          Seq(createTestAddFile(encodedPath = "file-1")), ManualUpdate)
+
+        // The retry committed again and so the table is now at version 2.
+        assert(log.update().version == 2)
+      }
+    }
+  }
+
+  test("post-commit hooks run on the idempotent path (checkpoint is written)") {
+    withTempDir { tempDir =>
+      val log = DeltaLog.forTable(spark, new Path(tempDir.getCanonicalPath))
+      // Set the checkpoint interval to 1 so the idempotent commit at version 1
+      // triggers a checkpoint.
+      log.startTransaction(catalogTableOpt = None).commit(
+        Seq(Metadata(configuration = Map(DeltaConfigs.CHECKPOINT_INTERVAL.key -> "1"))),
+        ManualUpdate)
+
+      FailAfterWriteLogStore.failAtVersion = 1
+      // The self-commit fires the detection exactly once.
+      log.startTransaction(catalogTableOpt = None).commit(
+        Seq(createTestAddFile(encodedPath = "file-1")), ManualUpdate)
+
+      // The commit landed at version 1 and, because needsCheckpoint was set on the idempotent
+      // path, CheckpointHook wrote a checkpoint at version 1.
+      assert(log.update().version == 1)
+      assert(log.readLastCheckpointFile().exists(_.version == 1),
+        "a checkpoint should be written at version 1 on the idempotent path")
+      // ChecksumHook also runs on the idempotent path and writes the .crc for the committed
+      // version (synchronously, since the checksum threadpool is set to size 0 in this suite).
+      assert(log.readChecksum(version = 1).isDefined,
+        "a checksum (.crc) should be written at version 1 on the idempotent path")
+    }
+  }
+}
+
+object FailAfterWriteLogStore {
+
+  var failAtVersion: Long = -1
+
+  var blockAfterWrite: Boolean = false
+
+  @volatile var blockedAtWrite: Boolean = false
+
+  @volatile private var block = new java.util.concurrent.CountDownLatch(1)
+
+  def resetBlock(): Unit = block = new java.util.concurrent.CountDownLatch(1)
+
+  def releaseBlock(): Unit = block.countDown()
+
+  def awaitRelease(): Unit = block.await()
+}
+
+/**
+ * A log store that, for the configured delta version, performs the real write and then throws
+ * [[FileAlreadyExistsException]] exactly once, modelling a commit that landed but whose response
+ * was lost. When [[FailAfterWriteLogStore.blockAfterWrite]] is set, it blocks after writing (before
+ * throwing) until released, so a concurrent writer can advance the table first. All other writes
+ * behave normally.
+ */
+class FailAfterWriteLogStore(sparkConf: SparkConf, defaultHadoopConf: Configuration)
+  extends LocalLogStore(sparkConf, defaultHadoopConf) {
+
+  override def write(
+      path: Path,
+      actions: Iterator[String],
+      overwrite: Boolean,
+      hadoopConf: Configuration): Unit = {
+    val failVersion = FailAfterWriteLogStore.failAtVersion
+    val shouldFail =
+      failVersion >= 0 && path.getName == f"$failVersion%020d.json"
+    // Perform the write so the commit fully lands before we simulate the lost response.
+    super.write(path, actions, overwrite, hadoopConf)
+    if (shouldFail) {
+      // Only fail the first write of this version; the retry (after conflict resolution) must
+      // not throw again.
+      FailAfterWriteLogStore.failAtVersion = -1
+      if (FailAfterWriteLogStore.blockAfterWrite) {
+        FailAfterWriteLogStore.blockAfterWrite = false
+        FailAfterWriteLogStore.blockedAtWrite = true
+        FailAfterWriteLogStore.awaitRelease()
+      }
+      throw new FileAlreadyExistsException(path.toString)
+    }
+  }
+}

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/CommitCompletionUnknownException.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/CommitCompletionUnknownException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.commit.uccommitcoordinator;
+
+import io.delta.storage.commit.CommitFailedException;
+
+/**
+ * Raised when UC cannot determine whether the commit at the requested version already landed: the
+ * version is at or below the latest commit, but UC retains no row at it (the row was backfilled and
+ * cleaned up), so UC cannot tell whether the version holds this caller's own commit or a different
+ * writer's.
+ *
+ * <p>The client must verify its staged commit against the backfilled {@code <version>.json} on the
+ * filesystem before rebasing; a content match means the commit already landed and must not be
+ * re-committed (otherwise a lost-ACK retry double-commits the data at version+1).
+ *
+ * <p>Extends {@link CommitFailedException} (retryable + conflict) on purpose: it must be caught by
+ * the commit-coordinator retry loop, where the filesystem verification lives.
+ */
+public class CommitCompletionUnknownException extends CommitFailedException {
+  public CommitCompletionUnknownException(String message) {
+    super(true /* retryable */, true /* conflict */, message);
+  }
+}

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCCommitCoordinatorClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCCommitCoordinatorClient.java
@@ -470,6 +470,19 @@ public class UCCommitCoordinatorClient implements CommitCoordinatorClient {
           newProtocol
         );
         break;
+      } catch (CommitCompletionUnknownException ccue) {
+        if (hasSameContent(
+            logStore,
+            hadoopConf,
+            logPath,
+            CoordinatedCommitsUtils.getBackfilledDeltaFilePath(logPath, commitVersion),
+            commitFile.getPath())) {
+          eventData.put("alreadyBackfilledCommitCausedConflict", true);
+          break;
+        } else {
+          recordUsageLog.accept(Optional.of(ccue), UCCoordinatedCommitsUsageLogs.UC_COMMIT_STATS);
+          throw ccue;
+        }
       } catch (CommitFailedException cfe) {
         if (transientErrorRetryCount > 0 && cfe.getConflict() && cfe.getRetryable() &&
           hasSameContent(


### PR DESCRIPTION
## Description

When a transaction commit hits a commit-completion-unknown outcome — the commit path
cannot confirm whether the commit actually succeeded — the transaction retries. On retry,
if the write had in fact landed but the response was lost, a naive retry can duplicate
data.

This change adds a fast idempotency check during conflict resolution: if the winning
commit at the exact version this transaction attempted to commit carries the same
`txnId` as this transaction, the commit is recognized as already succeeded and the
transaction short-circuits instead of duplicating the write.

Changes:
- `ConflictChecker` / `OptimisticTransaction`: detect, during conflict checking, that the
  winning commit at the attempted version is this transaction's own previously-landed
  commit (matched by `txnId`).
- `SnapshotManagement` / `TransactionHelper`: supporting plumbing for the check.
- `DeltaSQLConf`: add `commit.idempotencyCheck.enabled` to gate the behavior.

## How was this patch tested?

Added `IdempotentCommitRetrySuite` covering the idempotency-detection paths on retry.

## Does this PR introduce _any_ user-facing change?

No.