### PR TITLE
Apply AMT manifest DVs without Spark broadcast

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTCheckpointProvider.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTCheckpointProvider.scala
@@ -145,45 +145,43 @@ final class AMTCheckpointProvider(
 
     val files = rootStatus +: leafStatuses
     val fmt = DeltaLogFileIndex.CHECKPOINT_FILE_FORMAT_PARQUET
-    // Read every leaf row, then drop the MDV-marked (leaf, rowIndex) entries with a filter on
-    // top, using a broadcast of each leaf's manifest DV bitmap bytes keyed by its `_metadata`
-    // file path.
+    // Read every leaf row, then drop MDV-masked (leaf, rowIndex) entries while reconstructing
+    // AddFiles. Each leaf's inline manifest DV bytes are keyed by the leaf's `_metadata.file_path`
+    // (the same URL-encoded path Spark uses in [[AMTDataEntryWithLocation.leafPath]]). This avoids
+    // a Spark broadcast by capturing the per-leaf map in the `mapPartitions` closure instead.
     val index = DeltaLogFileIndex(fmt, files.toArray)
-    val mdvByLeaf: Map[String, Array[Byte]] = leaves.flatMap { leaf =>
+    val mdvByLeafPath: Map[String, Array[Byte]] = leaves.flatMap { leaf =>
       leaf.manifestDV.map { case (dvBytes, _) =>
         SparkPath.fromPath(leaf.getAbsolutePath(localTableRoot)).urlEncoded -> dvBytes
       }
     }.toMap
-    val mdvBroadcast = spark.sparkContext.broadcast(mdvByLeaf)
-    val dataEntries = AMTCheckpointProvider.loadEntriesWithLocation(spark, deltaLog, index)
+    AMTCheckpointProvider.loadEntriesWithLocation(spark, deltaLog, index)
       .where(col("entry.content_type") === lit(AMTSingleAction.ContentType.Type.Data))
       .where(col("entry.tracking.status").isin(
         AMTCheckpointProvider.liveTrackingStatuses.toSeq: _*))
-      .filter { entryWithLoc =>
-        mdvBroadcast.value.get(entryWithLoc.leafPath)
-          .forall(bytes => !RoaringBitmapArray.readFrom(bytes).contains(entryWithLoc.pos))
-      }
-
-    dataEntries
       .mapPartitions { entries =>
         val fs = localTableRoot.getFileSystem(serializableConf.value)
-        entries.map { entryWithLoc =>
-          entryWithLoc.entry.unwrap match {
-            case data: DataEntry =>
-              val backReference = if (entryWithLoc.leafPath == encodedRootPath) {
-                None
-              } else {
-                val absLeaf = SparkPath.fromUrlString(entryWithLoc.leafPath).toPath
-                val relManifest =
-                  AMTUtils.relativizeManifestPathToTableRoot(fs, localTableRoot, absLeaf)
-                Some(BackReference(relManifest, entryWithLoc.pos))
-              }
-              val add = data.toAddFile(localTableRoot).copy(backReference = backReference)
-              SingleAction(add = add)
-            case other => throw new IllegalStateException(
-              s"Expected a DATA entry after filtering, got ${other.getClass.getSimpleName}.")
+        entries
+          .filter(entryWithLoc =>
+            !AMTCheckpointProvider.isEntryMaskedByManifestDv(
+              mdvByLeafPath, entryWithLoc.leafPath, entryWithLoc.pos))
+          .map { entryWithLoc =>
+            entryWithLoc.entry.unwrap match {
+              case data: DataEntry =>
+                val backReference = if (entryWithLoc.leafPath == encodedRootPath) {
+                  None
+                } else {
+                  val absLeaf = SparkPath.fromUrlString(entryWithLoc.leafPath).toPath
+                  val relManifest =
+                    AMTUtils.relativizeManifestPathToTableRoot(fs, localTableRoot, absLeaf)
+                  Some(BackReference(relManifest, entryWithLoc.pos))
+                }
+                val add = data.toAddFile(localTableRoot).copy(backReference = backReference)
+                SingleAction(add = add)
+              case other => throw new IllegalStateException(
+                s"Expected a DATA entry after filtering, got ${other.getClass.getSimpleName}.")
+            }
           }
-        }
       }
   }
 
@@ -282,6 +280,20 @@ object AMTCheckpointProvider {
       .map(_.unwrap.asInstanceOf[DataEntry])
       .filter(e => liveTrackingStatuses.contains(e.tracking.status))
       .map(_.toAddFile(tableRoot))
+  }
+
+  /**
+   * Returns true when `pos` in the manifest file at `leafPath` is masked by that leaf's inline
+   * manifest deletion vector (`manifest_info.dv`).
+   *
+   * The lookup map is keyed by URL-encoded absolute leaf paths, matching
+   * [[AMTDataEntryWithLocation.leafPath]] from Spark's `_metadata.file_path`.
+   */
+  private[amt] def isEntryMaskedByManifestDv(
+      mdvByLeafPath: Map[String, Array[Byte]],
+      leafPath: String,
+      pos: Long): Boolean = {
+    mdvByLeafPath.get(leafPath).exists(RoaringBitmapArray.readFrom(_).contains(pos))
   }
 
   /**

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotSuite.scala
@@ -258,6 +258,17 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
     }
   }
 
+  test("isEntryMaskedByManifestDv respects per-leaf inline manifest DV bytes") {
+    val leafPath = "file:/table/leaf0.parquet"
+    val mdv = Map(leafPath -> mdvBytesFor(1L, 3L))
+    assert(AMTCheckpointProvider.isEntryMaskedByManifestDv(mdv, leafPath, pos = 1L))
+    assert(AMTCheckpointProvider.isEntryMaskedByManifestDv(mdv, leafPath, pos = 3L))
+    assert(!AMTCheckpointProvider.isEntryMaskedByManifestDv(mdv, leafPath, pos = 0L))
+    assert(!AMTCheckpointProvider.isEntryMaskedByManifestDv(mdv, leafPath, pos = 2L))
+    assert(!AMTCheckpointProvider.isEntryMaskedByManifestDv(mdv, "file:/other.parquet", pos = 1L))
+    assert(!AMTCheckpointProvider.isEntryMaskedByManifestDv(Map.empty, leafPath, pos = 1L))
+  }
+
   test("manifest deletion vector drops superseded leaf entries during reconstruction") {
     withTable("amt_mdv_drop") {
       val name = "amt_mdv_drop"


### PR DESCRIPTION
## Summary

Follow-up to #7332: remove `spark.sparkContext.broadcast` for per-leaf inline manifest DV bytes. MDV masking now runs inside `mapPartitions` with a closure-captured `mdvByLeafPath` map keyed by `_metadata.file_path`.

This is a semantics-preserving optimization within the #7332 scope — no change to how MDV bytes are sourced or which entries are dropped.

## Test plan

- [x] `isEntryMaskedByManifestDv respects per-leaf inline manifest DV bytes`
- [x] `manifest deletion vector drops superseded leaf entries during reconstruction`
- [x] `manifest deletion vectors apply per leaf across a multi-leaf tree`