### PR TITLE
Propagate AMT manifest DVs via per-file scan metadata

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLogFileIndex.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLogFileIndex.scala
@@ -23,7 +23,7 @@ import org.apache.hadoop.fs._
 import org.apache.spark.internal.{Logging, MDC}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.execution.datasources.{FileFormat, FileIndex, PartitionDirectory}
+import org.apache.spark.sql.execution.datasources.{FileFormat, FileIndex, FileStatusWithMetadata, PartitionDirectory}
 import org.apache.spark.sql.execution.datasources.json.JsonFileFormat
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
 import org.apache.spark.sql.types.{LongType, StructField, StructType}
@@ -38,7 +38,7 @@ import org.apache.spark.sql.types.{LongType, StructField, StructType}
  */
 class DeltaLogFileIndex private[delta] (
     val format: FileFormat,
-    val files: Array[FileStatus]
+    val files: Array[FileStatusWithMetadata]
     )
   extends FileIndex
   with Logging {
@@ -97,15 +97,19 @@ object DeltaLogFileIndex {
   lazy val CHECKSUM_FILE_FORMAT = new JsonFileFormat
 
   def apply(format: FileFormat, fs: FileSystem, paths: Seq[Path]): DeltaLogFileIndex = {
-    new DeltaLogFileIndex(format, paths.map(fs.getFileStatus).toArray)
+    apply(format, paths.map(p => FileStatusWithMetadata(fs.getFileStatus(p))).toArray)
   }
 
   def apply(format: FileFormat, files: Array[FileStatus]): DeltaLogFileIndex = {
+    apply(format, files.map(FileStatusWithMetadata(_)))
+  }
+
+  def apply(format: FileFormat, files: Array[FileStatusWithMetadata]): DeltaLogFileIndex = {
     new DeltaLogFileIndex(format, files)
   }
 
   def apply(format: FileFormat, files: Seq[FileStatus]): Option[DeltaLogFileIndex] = {
-    if (files.isEmpty) None else Some(new DeltaLogFileIndex(format, files.toArray))
+    if (files.isEmpty) None else Some(apply(format, files.map(FileStatusWithMetadata(_)).toArray))
   }
 
   def apply(format: FileFormat, filesOpt: Option[Seq[FileStatus]]): Option[DeltaLogFileIndex] = {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTCheckpointProvider.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTCheckpointProvider.scala
@@ -25,10 +25,10 @@ import org.apache.hadoop.fs.{FileStatus, Path}
 
 import org.apache.spark.paths.SparkPath
 import org.apache.spark.sql.{DataFrame, Dataset, Encoder, SparkSession}
+import org.apache.spark.sql.execution.datasources.FileStatusWithMetadata
 import org.apache.spark.sql.execution.datasources.FileFormat.{FILE_PATH, METADATA_NAME}
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
 import org.apache.spark.sql.functions.{col, lit, struct}
-import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.SerializableConfiguration
 
 /**
@@ -64,9 +64,6 @@ final class AMTCheckpointProvider(
 
   /** The root manifest as a [[FileStatus]]. */
   private lazy val rootStatus: FileStatus = contentRoot.toFileStatus(tableRoot)
-
-  /** The leaf manifests as [[FileStatus]]es. */
-  private lazy val leafStatuses: Seq[FileStatus] = leaves.map(_.toFileStatus(tableRoot))
 
   override def version: Long = checkpointAction.version
 
@@ -143,18 +140,13 @@ final class AMTCheckpointProvider(
     val encodedRootPath = SparkPath.fromPath(rootManifestAbsolutePath).urlEncoded
     val serializableConf = new SerializableConfiguration(deltaLog.newDeltaHadoopConf())
 
-    val files = rootStatus +: leafStatuses
-    val fmt = DeltaLogFileIndex.CHECKPOINT_FILE_FORMAT_PARQUET
-    // Read every leaf row, then drop MDV-masked (leaf, rowIndex) entries while reconstructing
-    // AddFiles. Each leaf's inline manifest DV bytes are keyed by the leaf's `_metadata.file_path`
-    // (the same URL-encoded path Spark uses in [[AMTDataEntryWithLocation.leafPath]]). This avoids
-    // a Spark broadcast by capturing the per-leaf map in the `mapPartitions` closure instead.
-    val index = DeltaLogFileIndex(fmt, files.toArray)
-    val mdvByLeafPath: Map[String, Array[Byte]] = leaves.flatMap { leaf =>
-      leaf.manifestDV.map { case (dvBytes, _) =>
-        SparkPath.fromPath(leaf.getAbsolutePath(localTableRoot)).urlEncoded -> dvBytes
-      }
-    }.toMap
+    // Attach each leaf's inline manifest DV to its scan file via FileStatusWithMetadata, mirroring
+    // TahoeFileIndex.fileStatusWithMetadataFromAddFile for inline file deletion vectors.
+    val filesWithMetadata = Seq(
+      FileStatusWithMetadata(rootStatus)) ++ leaves.map(
+      AMTCheckpointProvider.fileStatusWithMetadataFromLeaf(_, localTableRoot))
+    val fmt = AMTParquetFileFormat.INSTANCE
+    val index = DeltaLogFileIndex(fmt, filesWithMetadata.toArray)
     AMTCheckpointProvider.loadEntriesWithLocation(spark, deltaLog, index)
       .where(col("entry.content_type") === lit(AMTSingleAction.ContentType.Type.Data))
       .where(col("entry.tracking.status").isin(
@@ -164,7 +156,7 @@ final class AMTCheckpointProvider(
         entries
           .filter(entryWithLoc =>
             !AMTCheckpointProvider.isEntryMaskedByManifestDv(
-              mdvByLeafPath, entryWithLoc.leafPath, entryWithLoc.pos))
+              Option(entryWithLoc.manifestDvBytes), entryWithLoc.pos))
           .map { entryWithLoc =>
             entryWithLoc.entry.unwrap match {
               case data: DataEntry =>
@@ -225,13 +217,19 @@ object AMTCheckpointProvider {
   /**
    * An [[AMTSingleAction]] entry paired with its physical read location in its manifest parquet.
    *
-   * @param entry    The manifest content entry.
-   * @param leafPath The URL-encoded absolute path of the manifest parquet the entry was read from
-   *                 (Spark's `_metadata.file_path`).
-   * @param pos      The 0-based position of the entry inside the manifest (Spark's
-   *                 `_metadata.row_index`).
+   * @param entry           The manifest content entry.
+   * @param leafPath        The URL-encoded absolute path of the manifest parquet the entry was read
+   *                        from (Spark's `_metadata.file_path`).
+   * @param pos             The 0-based position of the entry inside the manifest (Spark's
+   *                        `_metadata.row_index`).
+   * @param manifestDvBytes Inline manifest DV bytes for the leaf file, propagated via per-file scan
+   *                        metadata (`_metadata.manifest_dv_bytes`); null when the leaf has no MDV.
    */
-  case class AMTDataEntryWithLocation(entry: AMTSingleAction, leafPath: String, pos: Long)
+  case class AMTDataEntryWithLocation(
+      entry: AMTSingleAction,
+      leafPath: String,
+      pos: Long,
+      manifestDvBytes: Array[Byte] = null)
 
   private lazy val amtDataEntryWithLocationEncoder: Encoder[AMTDataEntryWithLocation] =
     new DeltaEncoder[AMTDataEntryWithLocation].get
@@ -283,17 +281,29 @@ object AMTCheckpointProvider {
   }
 
   /**
-   * Returns true when `pos` in the manifest file at `leafPath` is masked by that leaf's inline
-   * manifest deletion vector (`manifest_info.dv`).
-   *
-   * The lookup map is keyed by URL-encoded absolute leaf paths, matching
-   * [[AMTDataEntryWithLocation.leafPath]] from Spark's `_metadata.file_path`.
+   * Returns true when `pos` is masked by the inline manifest deletion vector (`manifest_info.dv`)
+   * carried on the scanned leaf file.
    */
   private[amt] def isEntryMaskedByManifestDv(
-      mdvByLeafPath: Map[String, Array[Byte]],
-      leafPath: String,
+      manifestDvBytes: Option[Array[Byte]],
       pos: Long): Boolean = {
-    mdvByLeafPath.get(leafPath).exists(RoaringBitmapArray.readFrom(_).contains(pos))
+    manifestDvBytes.exists(RoaringBitmapArray.readFrom(_).contains(pos))
+  }
+
+  /**
+   * Builds a [[FileStatusWithMetadata]] for a leaf manifest, attaching its inline MDV bytes when
+   * present so they travel with the scan task via [[org.apache.spark.sql.execution.PartitionedFile
+   * .otherConstantMetadataColumnValues]].
+   */
+  private[amt] def fileStatusWithMetadataFromLeaf(
+      leaf: DataManifestEntry,
+      tableRoot: Path): FileStatusWithMetadata = {
+    val metadata = leaf.manifestDV match {
+      case Some((dvBytes, _)) =>
+        Map(AMTParquetFileFormat.MANIFEST_DV_BYTES -> dvBytes)
+      case None => Map.empty[String, Any]
+    }
+    FileStatusWithMetadata(leaf.toFileStatus(tableRoot), metadata)
   }
 
   /**
@@ -323,7 +333,8 @@ object AMTCheckpointProvider {
       .select(
         struct(amtSchema.fieldNames.toIndexedSeq.map(col): _*).as("entry"),
         col(s"$METADATA_NAME.$FILE_PATH").as("leafPath"),
-        col(s"$METADATA_NAME.${ParquetFileFormat.ROW_INDEX}").as("pos"))
+        col(s"$METADATA_NAME.${ParquetFileFormat.ROW_INDEX}").as("pos"),
+        col(s"$METADATA_NAME.${AMTParquetFileFormat.MANIFEST_DV_BYTES}").as("manifestDvBytes"))
       .as[AMTDataEntryWithLocation]
   }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTCheckpointProvider.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTCheckpointProvider.scala
@@ -145,45 +145,43 @@ final class AMTCheckpointProvider(
 
     val files = rootStatus +: leafStatuses
     val fmt = DeltaLogFileIndex.CHECKPOINT_FILE_FORMAT_PARQUET
-    // Read every leaf row, then drop the MDV-marked (leaf, rowIndex) entries with a filter on
-    // top, using a broadcast of each leaf's manifest DV bitmap bytes keyed by its `_metadata`
-    // file path.
+    // Read every leaf row, then drop MDV-masked (leaf, rowIndex) entries while reconstructing
+    // AddFiles. Each leaf's inline manifest DV bytes are keyed by the leaf's `_metadata.file_path`
+    // (the same URL-encoded path Spark uses in [[AMTDataEntryWithLocation.leafPath]]). This avoids
+    // a Spark broadcast by capturing the per-leaf map in the `mapPartitions` closure instead.
     val index = DeltaLogFileIndex(fmt, files.toArray)
-    val mdvByLeaf: Map[String, Array[Byte]] = leaves.flatMap { leaf =>
+    val mdvByLeafPath: Map[String, Array[Byte]] = leaves.flatMap { leaf =>
       leaf.manifestDV.map { case (dvBytes, _) =>
         SparkPath.fromPath(leaf.getAbsolutePath(localTableRoot)).urlEncoded -> dvBytes
       }
     }.toMap
-    val mdvBroadcast = spark.sparkContext.broadcast(mdvByLeaf)
-    val dataEntries = AMTCheckpointProvider.loadEntriesWithLocation(spark, deltaLog, index)
+    AMTCheckpointProvider.loadEntriesWithLocation(spark, deltaLog, index)
       .where(col("entry.content_type") === lit(AMTSingleAction.ContentType.Type.Data))
       .where(col("entry.tracking.status").isin(
         AMTCheckpointProvider.liveTrackingStatuses.toSeq: _*))
-      .filter { entryWithLoc =>
-        mdvBroadcast.value.get(entryWithLoc.leafPath)
-          .forall(bytes => !RoaringBitmapArray.readFrom(bytes).contains(entryWithLoc.pos))
-      }
-
-    dataEntries
       .mapPartitions { entries =>
         val fs = localTableRoot.getFileSystem(serializableConf.value)
-        entries.map { entryWithLoc =>
-          entryWithLoc.entry.unwrap match {
-            case data: DataEntry =>
-              val backReference = if (entryWithLoc.leafPath == encodedRootPath) {
-                None
-              } else {
-                val absLeaf = SparkPath.fromUrlString(entryWithLoc.leafPath).toPath
-                val relManifest =
-                  AMTUtils.relativizeManifestPathToTableRoot(fs, localTableRoot, absLeaf)
-                Some(BackReference(relManifest, entryWithLoc.pos))
-              }
-              val add = data.toAddFile(localTableRoot).copy(backReference = backReference)
-              SingleAction(add = add)
-            case other => throw new IllegalStateException(
-              s"Expected a DATA entry after filtering, got ${other.getClass.getSimpleName}.")
+        entries
+          .filter(entryWithLoc =>
+            !AMTCheckpointProvider.isEntryMaskedByManifestDv(
+              mdvByLeafPath, entryWithLoc.leafPath, entryWithLoc.pos))
+          .map { entryWithLoc =>
+            entryWithLoc.entry.unwrap match {
+              case data: DataEntry =>
+                val backReference = if (entryWithLoc.leafPath == encodedRootPath) {
+                  None
+                } else {
+                  val absLeaf = SparkPath.fromUrlString(entryWithLoc.leafPath).toPath
+                  val relManifest =
+                    AMTUtils.relativizeManifestPathToTableRoot(fs, localTableRoot, absLeaf)
+                  Some(BackReference(relManifest, entryWithLoc.pos))
+                }
+                val add = data.toAddFile(localTableRoot).copy(backReference = backReference)
+                SingleAction(add = add)
+              case other => throw new IllegalStateException(
+                s"Expected a DATA entry after filtering, got ${other.getClass.getSimpleName}.")
+            }
           }
-        }
       }
   }
 
@@ -282,6 +280,20 @@ object AMTCheckpointProvider {
       .map(_.unwrap.asInstanceOf[DataEntry])
       .filter(e => liveTrackingStatuses.contains(e.tracking.status))
       .map(_.toAddFile(tableRoot))
+  }
+
+  /**
+   * Returns true when `pos` in the manifest file at `leafPath` is masked by that leaf's inline
+   * manifest deletion vector (`manifest_info.dv`).
+   *
+   * The lookup map is keyed by URL-encoded absolute leaf paths, matching
+   * [[AMTDataEntryWithLocation.leafPath]] from Spark's `_metadata.file_path`.
+   */
+  private[amt] def isEntryMaskedByManifestDv(
+      mdvByLeafPath: Map[String, Array[Byte]],
+      leafPath: String,
+      pos: Long): Boolean = {
+    mdvByLeafPath.get(leafPath).exists(RoaringBitmapArray.readFrom(_).contains(pos))
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTParquetFileFormat.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTParquetFileFormat.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.amt
+
+import org.apache.spark.sql.catalyst.expressions.FileSourceConstantMetadataStructField
+import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
+import org.apache.spark.sql.types.{BinaryType, MetadataBuilder, StructField}
+
+/**
+ * Parquet format for AMT manifest scans that exposes each leaf's inline manifest deletion
+ * vector (MDV) as a file-constant `_metadata` column, mirroring how
+ * [[org.apache.spark.sql.delta.DeltaParquetFileFormat]] exposes inline file deletion vectors via
+ * per-file metadata.
+ */
+final class AMTParquetFileFormat extends ParquetFileFormat {
+
+  override def metadataSchemaFields: Seq[StructField] =
+    super.metadataSchemaFields ++ Seq(AMTParquetFileFormat.ManifestDvBytesMetadataStructField())
+}
+
+object AMTParquetFileFormat {
+
+  /** Key in each scan task's `PartitionedFile.otherConstantMetadataColumnValues`. */
+  val MANIFEST_DV_BYTES = "manifest_dv_bytes"
+
+  lazy val INSTANCE: AMTParquetFileFormat = new AMTParquetFileFormat
+
+  private object ManifestDvBytesMetadataStructField {
+    private val METADATA_COL_ATTR_KEY = "__manifest_dv_bytes_metadata_col"
+
+    def apply(): StructField =
+      StructField(
+        MANIFEST_DV_BYTES,
+        BinaryType,
+        nullable = true,
+        metadata = new MetadataBuilder()
+          .withMetadata(FileSourceConstantMetadataStructField.metadata(MANIFEST_DV_BYTES))
+          .putBoolean(METADATA_COL_ATTR_KEY, value = true)
+          .build())
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotSuite.scala
@@ -258,6 +258,17 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
     }
   }
 
+  test("isEntryMaskedByManifestDv respects per-leaf inline manifest DV bytes") {
+    val leafPath = "file:/table/leaf0.parquet"
+    val mdv = Map(leafPath -> mdvBytesFor(1L, 3L))
+    assert(AMTCheckpointProvider.isEntryMaskedByManifestDv(mdv, leafPath, pos = 1L))
+    assert(AMTCheckpointProvider.isEntryMaskedByManifestDv(mdv, leafPath, pos = 3L))
+    assert(!AMTCheckpointProvider.isEntryMaskedByManifestDv(mdv, leafPath, pos = 0L))
+    assert(!AMTCheckpointProvider.isEntryMaskedByManifestDv(mdv, leafPath, pos = 2L))
+    assert(!AMTCheckpointProvider.isEntryMaskedByManifestDv(mdv, "file:/other.parquet", pos = 1L))
+    assert(!AMTCheckpointProvider.isEntryMaskedByManifestDv(Map.empty, leafPath, pos = 1L))
+  }
+
   test("manifest deletion vector drops superseded leaf entries during reconstruction") {
     withTable("amt_mdv_drop") {
       val name = "amt_mdv_drop"

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotSuite.scala
@@ -259,14 +259,12 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
   }
 
   test("isEntryMaskedByManifestDv respects per-leaf inline manifest DV bytes") {
-    val leafPath = "file:/table/leaf0.parquet"
-    val mdv = Map(leafPath -> mdvBytesFor(1L, 3L))
-    assert(AMTCheckpointProvider.isEntryMaskedByManifestDv(mdv, leafPath, pos = 1L))
-    assert(AMTCheckpointProvider.isEntryMaskedByManifestDv(mdv, leafPath, pos = 3L))
-    assert(!AMTCheckpointProvider.isEntryMaskedByManifestDv(mdv, leafPath, pos = 0L))
-    assert(!AMTCheckpointProvider.isEntryMaskedByManifestDv(mdv, leafPath, pos = 2L))
-    assert(!AMTCheckpointProvider.isEntryMaskedByManifestDv(mdv, "file:/other.parquet", pos = 1L))
-    assert(!AMTCheckpointProvider.isEntryMaskedByManifestDv(Map.empty, leafPath, pos = 1L))
+    val mdvBytes = mdvBytesFor(1L, 3L)
+    assert(AMTCheckpointProvider.isEntryMaskedByManifestDv(Some(mdvBytes), pos = 1L))
+    assert(AMTCheckpointProvider.isEntryMaskedByManifestDv(Some(mdvBytes), pos = 3L))
+    assert(!AMTCheckpointProvider.isEntryMaskedByManifestDv(Some(mdvBytes), pos = 0L))
+    assert(!AMTCheckpointProvider.isEntryMaskedByManifestDv(Some(mdvBytes), pos = 2L))
+    assert(!AMTCheckpointProvider.isEntryMaskedByManifestDv(None, pos = 1L))
   }
 
   test("manifest deletion vector drops superseded leaf entries during reconstruction") {


### PR DESCRIPTION
## Summary

Aligns AMT manifest DV (MDV) handling with the inline file deletion vector read path:

- Attach each leaf's MDV bytes to `FileStatusWithMetadata` (like `TahoeFileIndex.fileStatusWithMetadataFromAddFile`)
- Expose them as `_metadata.manifest_dv_bytes` via `AMTParquetFileFormat`
- Read MDV per scan row from file metadata instead of a driver-side lookup map

Depends on #7346 — review only the top commit (`Propagate AMT manifest DVs via per-file scan metadata`) for the per-file metadata changes.

## Test plan

- [x] `isEntryMaskedByManifestDv respects per-leaf inline manifest DV bytes`
- [x] `manifest deletion vector drops superseded leaf entries during reconstruction`
- [x] `manifest deletion vectors apply per leaf across a multi-leaf tree`