### PR TITLE
[Flink] Fix Unity Catalog SQL metadata handling

### DIFF
--- a/flink/src/main/java/io/delta/flink/sink/sql/DeltaDynamicTableSink.java
+++ b/flink/src/main/java/io/delta/flink/sink/sql/DeltaDynamicTableSink.java
@@ -129,6 +129,8 @@ public class DeltaDynamicTableSink implements DynamicTableSink, SupportsPartitio
                       "unitycatalog.table_name", tableId.asSummaryString()))
               .withEndpoint(options.get(FlinkUnityCatalogFactory.ENDPOINT.key()))
               .withToken(options.get(FlinkUnityCatalogFactory.TOKEN.key()))
+              .withPartitionColNames(
+                  Arrays.asList(options.getOrDefault(PARTITIONS.key(), "").split(",")))
               .withWriteMode(writeMode)
               .withPrimaryKey(primaryKeyOrdinals)
               .build();

--- a/flink/src/main/java/io/delta/flink/sink/sql/FlinkUnityCatalog.java
+++ b/flink/src/main/java/io/delta/flink/sink/sql/FlinkUnityCatalog.java
@@ -284,15 +284,13 @@ public class FlinkUnityCatalog extends AbstractCatalog {
   @Override
   public CatalogTableStatistics getTableStatistics(ObjectPath tablePath)
       throws TableNotExistException, CatalogException {
-    notSupported("GET TABLE STATISTICS");
-    return null;
+    return CatalogTableStatistics.UNKNOWN;
   }
 
   @Override
   public CatalogColumnStatistics getTableColumnStatistics(ObjectPath tablePath)
       throws TableNotExistException, CatalogException {
-    notSupported("GET TABLE COLUMN STATISTICS");
-    return null;
+    return CatalogColumnStatistics.UNKNOWN;
   }
 
   @Override

--- a/flink/src/main/java/io/delta/flink/sink/sql/FlinkUnityCatalogTable.java
+++ b/flink/src/main/java/io/delta/flink/sink/sql/FlinkUnityCatalogTable.java
@@ -23,11 +23,13 @@ import io.unitycatalog.client.model.DataSourceFormat;
 import io.unitycatalog.client.model.TableInfo;
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import org.apache.flink.table.api.Schema;
 import org.apache.flink.table.catalog.CatalogBaseTable;
 import org.apache.flink.table.catalog.CatalogTable;
@@ -48,6 +50,7 @@ public class FlinkUnityCatalogTable implements CatalogTable {
   private final Map<String, String> properties;
   private final Schema schema;
   private final String dataFormat;
+  private final List<String> partitionKeys;
 
   private final URI endpoint;
   private final String token;
@@ -61,12 +64,26 @@ public class FlinkUnityCatalogTable implements CatalogTable {
       Map<String, String> properties,
       URI endpoint,
       String token) {
+    this(name, schema, dataFormat, comment, description, properties, List.of(), endpoint, token);
+  }
+
+  private FlinkUnityCatalogTable(
+      String name,
+      Schema schema,
+      String dataFormat,
+      String comment,
+      String description,
+      Map<String, String> properties,
+      List<String> partitionKeys,
+      URI endpoint,
+      String token) {
     this.name = name;
     this.dataFormat = dataFormat;
     this.comment = comment;
     this.description = description;
     this.properties = properties;
     this.schema = schema;
+    this.partitionKeys = List.copyOf(partitionKeys);
 
     this.endpoint = endpoint;
     this.token = token;
@@ -82,8 +99,17 @@ public class FlinkUnityCatalogTable implements CatalogTable {
         tableInfo.getComment(),
         "",
         tableInfo.getProperties(),
+        buildPartitionKeys(tableInfo.getColumns()),
         endpoint,
         token);
+  }
+
+  static List<String> buildPartitionKeys(List<ColumnInfo> columnInfos) {
+    return columnInfos.stream()
+        .filter(column -> column.getPartitionIndex() != null)
+        .sorted(Comparator.comparing(ColumnInfo::getPartitionIndex))
+        .map(ColumnInfo::getName)
+        .collect(Collectors.toList());
   }
 
   public static Schema buildSchema(List<ColumnInfo> columnInfos) {
@@ -168,7 +194,7 @@ public class FlinkUnityCatalogTable implements CatalogTable {
         case "boolean":
           return new AtomicDataType(new BooleanType(nullable));
         case "binary":
-          return new AtomicDataType(new BinaryType(nullable, BinaryType.MAX_LENGTH));
+          return new AtomicDataType(new VarBinaryType(nullable, VarBinaryType.MAX_LENGTH));
         case "date":
           return new AtomicDataType(new DateType(nullable));
         case "double":
@@ -200,18 +226,18 @@ public class FlinkUnityCatalogTable implements CatalogTable {
 
   @Override
   public boolean isPartitioned() {
-    return false;
+    return !partitionKeys.isEmpty();
   }
 
   @Override
   public List<String> getPartitionKeys() {
-    return List.of();
+    return partitionKeys;
   }
 
   @Override
   public CatalogTable copy(Map<String, String> options) {
     return new FlinkUnityCatalogTable(
-        name, schema, dataFormat, comment, description, options, endpoint, token);
+        name, schema, dataFormat, comment, description, options, partitionKeys, endpoint, token);
   }
 
   // TODO: token is visible in Flink EXPLAIN and serialized job graph; consider a secure approach
@@ -224,7 +250,9 @@ public class FlinkUnityCatalogTable implements CatalogTable {
           FlinkUnityCatalogFactory.ENDPOINT.key(),
           endpoint.toString(),
           FlinkUnityCatalogFactory.TOKEN.key(),
-          token);
+          token,
+          DeltaDynamicTableSinkFactory.PARTITIONS.key(),
+          String.join(",", partitionKeys));
     }
     return Map.of();
   }
@@ -237,7 +265,7 @@ public class FlinkUnityCatalogTable implements CatalogTable {
   @Override
   public CatalogBaseTable copy() {
     return new FlinkUnityCatalogTable(
-        name, schema, dataFormat, comment, description, properties, endpoint, token);
+        name, schema, dataFormat, comment, description, properties, partitionKeys, endpoint, token);
   }
 
   @Override

--- a/flink/src/test/java/io/delta/flink/sink/sql/FlinkUnityCatalogTableTest.java
+++ b/flink/src/test/java/io/delta/flink/sink/sql/FlinkUnityCatalogTableTest.java
@@ -19,13 +19,18 @@ package io.delta.flink.sink.sql;
 import static org.junit.jupiter.api.Assertions.*;
 
 import io.unitycatalog.client.model.ColumnInfo;
+import io.unitycatalog.client.model.DataSourceFormat;
+import io.unitycatalog.client.model.TableInfo;
+import java.net.URI;
 import java.util.List;
+import java.util.Map;
 import org.apache.flink.table.api.Schema;
 import org.apache.flink.table.api.Schema.UnresolvedPhysicalColumn;
+import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.types.AtomicDataType;
 import org.apache.flink.table.types.KeyValueDataType;
-import org.apache.flink.table.types.logical.BinaryType;
 import org.apache.flink.table.types.logical.MapType;
+import org.apache.flink.table.types.logical.VarBinaryType;
 import org.junit.jupiter.api.Test;
 
 /** Test suite for {@link FlinkUnityCatalogTable}. */
@@ -99,7 +104,7 @@ class FlinkUnityCatalogTableTest {
     assertTrue(
         ((AtomicDataType) ((UnresolvedPhysicalColumn) schema.getColumns().get(2)).getDataType())
                 .getLogicalType()
-            instanceof BinaryType);
+            instanceof VarBinaryType);
     assertTrue(
         ((UnresolvedPhysicalColumn) schema.getColumns().get(8)).getDataType()
             instanceof KeyValueDataType);
@@ -107,5 +112,36 @@ class FlinkUnityCatalogTableTest {
         ((KeyValueDataType) ((UnresolvedPhysicalColumn) schema.getColumns().get(8)).getDataType())
                 .getLogicalType()
             instanceof MapType);
+  }
+
+  @Test
+  void testPartitionMetadata() {
+    List<ColumnInfo> columns =
+        List.of(column("id"), column("day").partitionIndex(1), column("region").partitionIndex(0));
+    TableInfo tableInfo =
+        new TableInfo()
+            .name("events")
+            .columns(columns)
+            .dataSourceFormat(DataSourceFormat.DELTA)
+            .properties(Map.of());
+
+    FlinkUnityCatalogTable table =
+        new FlinkUnityCatalogTable(tableInfo, URI.create("https://example.com"), "token");
+
+    assertTrue(table.isPartitioned());
+    assertEquals(List.of("region", "day"), table.getPartitionKeys());
+    assertEquals("region,day", table.getOptions().get("partitions"));
+
+    CatalogTable copiedTable = (CatalogTable) table.copy();
+    assertEquals(table.getPartitionKeys(), copiedTable.getPartitionKeys());
+    assertEquals(table.getPartitionKeys(), table.copy(Map.of()).getPartitionKeys());
+  }
+
+  private static ColumnInfo column(String name) {
+    return new ColumnInfo()
+        .name(name)
+        .typeJson(
+            String.format(
+                "{\"name\":\"%s\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}}", name));
   }
 }

--- a/flink/src/test/java/io/delta/flink/sink/sql/FlinkUnityCatalogTest.java
+++ b/flink/src/test/java/io/delta/flink/sink/sql/FlinkUnityCatalogTest.java
@@ -16,12 +16,15 @@
 
 package io.delta.flink.sink.sql;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.delta.flink.MockHttp;
 import java.util.UUID;
 import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.stats.CatalogColumnStatistics;
+import org.apache.flink.table.catalog.stats.CatalogTableStatistics;
 import org.junit.jupiter.api.Test;
 
 /** Test suite for {@link FlinkUnityCatalog}. */
@@ -51,6 +54,18 @@ class FlinkUnityCatalogTest {
     MockHttp.withMock(
         MockHttp.forUnsupportedUCTable(),
         mock -> assertTrue(catalog(mock).tableExists(TABLE_PATH)));
+  }
+
+  @Test
+  void statisticsAreUnknownWhenTheCatalogDoesNotProvideThem() {
+    MockHttp.withMock(
+        MockHttp.forExistingUCTable(UUID.randomUUID().toString(), "s3://bucket/default/tbl"),
+        mock -> {
+          FlinkUnityCatalog catalog = catalog(mock);
+          assertEquals(CatalogTableStatistics.UNKNOWN, catalog.getTableStatistics(TABLE_PATH));
+          assertEquals(
+              CatalogColumnStatistics.UNKNOWN, catalog.getTableColumnStatistics(TABLE_PATH));
+        });
   }
 
   private static FlinkUnityCatalog catalog(MockHttp mock) {


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/7349/files) to review incremental changes.
- [stack/flink-uc-5-browsing](https://github.com/delta-io/delta/pull/7247) [[Files changed](https://github.com/delta-io/delta/pull/7247/files)] [MERGED]
  - [**stack/flink-uc-6-catalog-correctness**](https://github.com/delta-io/delta/pull/7349) [[Files changed](https://github.com/delta-io/delta/pull/7349/files)] ← _this PR_

---------
## Description

Fix three correctness gaps in Flink SQL tables backed by Unity Catalog:

- Map Delta `binary` columns to Flink `VARBINARY` so variable-length binary values can be written.
- Preserve ordered partition keys from catalog column metadata and pass them to the catalog-backed Delta sink.
- Return Flink's `UNKNOWN` statistics objects instead of rejecting statistics requests, allowing explicit target-column inserts to be planned.

## How was this patch tested?

- `build/sbt "flink / javafmt"`
- `build/sbt "flink / Test / javafmt"`
- `build/sbt "flink / test"` — 248 tests, 0 failures
- `build/sbt "flink / Compile / doc"`
- Manual: four cross-engine integration workloads covering binary/null/boundary values, partitioned table creation with skewed and null keys, quoted columns with Unicode values, and schema evolution followed by writes from multiple engines.

## Does this PR introduce any user-facing changes?

Yes. Flink SQL writes now handle variable-length binary data, preserve catalog table partitioning, and support plans that request unavailable catalog statistics.
