### PR TITLE
[Spark] Cover AMT checkpoint tests across all checkpoint scenarios

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTBackReferenceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTBackReferenceSuite.scala
@@ -28,6 +28,17 @@ class AMTBackReferenceSuite extends AMTCheckpointTestBase with DeletionVectorsTe
 
   import testImplicits._
 
+  /**
+   * A back reference identifies a data file by (leaf manifest, position), so a back reference only
+   * exists for an entry that lives in a leaf: an entry that stays resident in the root is
+   * reconstructed with `backReference = None`. The incremental writer spills live adds into leaves
+   * only once the root would exceed `entriesPerLeaf`, and the default (50000) never trips for these
+   * small tables -- so without this every entry would stay in the root and carry no back reference.
+   * A cap of one entry forces every live add into its own leaf, matching the leaf-resident layout a
+   * full rewrite produces, so all checkpoint scenarios stamp back references.
+   */
+  private val leafResidentConfs = Seq(DeltaSQLConf.AMT_ENTRIES_PER_LEAF.key -> "1")
+
   /** Relativizes an absolute leaf manifest path the same way the stamped `backReference.manifest`
    *  is, so test assertions compare against the identical value. */
   private def relativeManifest(snapshot: Snapshot, absLeaf: Path): String = {
@@ -70,9 +81,13 @@ class AMTBackReferenceSuite extends AMTCheckpointTestBase with DeletionVectorsTe
    * Returns the two reconstructed leaf-derived `AddFile`s (each carrying a back reference).
    */
   private def emitTwoStampedAddFiles(name: String): Seq[AddFile] = {
-    createAMTTable(name, checkpointInterval = 2)
-    sql(s"INSERT INTO $name VALUES (1)")
-    sql(s"INSERT INTO $name VALUES (2)") // Lands on a checkpoint boundary -> emit.
+    // A back reference only exists for a leaf-resident entry, so cap the leaf capacity to force
+    // both live adds out of the root and into leaves (see `leafResidentConfs`).
+    withSQLConf(leafResidentConfs: _*) {
+      createAMTTable(name, checkpointInterval = 2)
+      sql(s"INSERT INTO $name VALUES (1)")
+      sql(s"INSERT INTO $name VALUES (2)") // Lands on a checkpoint boundary -> emit.
+    }
     val snapshot = deltaLogForName(name).update()
     assert(amtProvider(snapshot).isDefined, "table must be AMT-backed after the emit.")
     val adds = liveAddFiles(snapshot)
@@ -81,12 +96,13 @@ class AMTBackReferenceSuite extends AMTCheckpointTestBase with DeletionVectorsTe
     adds
   }
 
-  /**
-   * As [[emitTwoStampedAddFiles]], but returns the post-emit `path -> back reference` map (the
-   * source of truth every command's tombstone / superseding AddFile must inherit).
-   */
-  private def emitTwoStampedFiles(name: String): Map[String, Option[BackReference]] =
-    emitTwoStampedAddFiles(name).map(add => add.path -> add.backReference).toMap
+  /** The back references stamped on every live file reconstructed from an AMT checkpoint. */
+  private def stampedBackRefs(snapshot: Snapshot): Map[String, Option[BackReference]] = {
+    val byPath = liveAddFiles(snapshot).map(add => add.path -> add.backReference).toMap
+    assert(byPath.nonEmpty && byPath.values.forall(_.isDefined),
+      "all emitted files must be reconstructed from the leaves with a back reference.")
+    byPath
+  }
 
   /**
    * Asserts that every file action committed after `afterVersion` that reuses a pre-command
@@ -113,151 +129,138 @@ class AMTBackReferenceSuite extends AMTCheckpointTestBase with DeletionVectorsTe
     matched
   }
 
-  test("reconstructed AddFiles are stamped with a back reference matching the leaf layout") {
-    withTable("amt_back_ref_stamped") {
-      val name = "amt_back_ref_stamped"
-      createAMTTable(name, checkpointInterval = 2)
-      sql(s"INSERT INTO $name VALUES (1)") // v1.
-      sql(s"INSERT INTO $name VALUES (2)") // v2: checkpoint boundary -> emit.
+  testAcrossAMTCheckpointScenarios(
+      "reconstructed AddFiles are stamped with a back reference matching the leaf layout",
+      "amt_back_ref_stamped",
+      sqlConfs = leafResidentConfs)(
+      setup = name => sql(s"INSERT INTO $name VALUES (1)"),
+      inlineCheckpointTriggerActionsOrSQL = Some(name => Right(
+        s"INSERT INTO $name VALUES (2)"))) { context =>
+    val groundTruth = leafLocationByBackRef(context.postCheckpointSnapshot)
+    val adds = liveAddFiles(context.postCheckpointSnapshot)
+    assert(adds.size == 2,
+      s"Both inserted files must be reconstructed from the leaves, got ${adds.size}.")
 
-      val snapshot = deltaLogForName(name).update()
-      assert(amtProvider(snapshot).isDefined)
-      val groundTruth = leafLocationByBackRef(snapshot)
-      val adds = liveAddFiles(snapshot)
-      assert(adds.size == 2, "Both inserted files must be reconstructed from the leaves.")
-
-      val leafPaths = amtProvider(snapshot).get.leafManifestAbsolutePaths
-        .map(relativeManifest(snapshot, _)).toSet
-      adds.foreach { add =>
-        val br = add.backReference.getOrElse(
-          fail(s"Reconstructed AddFile ${add.path} must carry a back reference."))
-        assert(leafPaths.contains(br.manifest),
-          s"Back-ref manifest ${br.manifest} must be one of the tree's leaves $leafPaths.")
-        // The back-ref must point at exactly the leaf entry describing this data file.
-        assert(groundTruth.get((br.manifest, br.pos)).contains(add.path),
-          s"Back-ref (${br.manifest}, ${br.pos}) must resolve to the entry for ${add.path}.")
-      }
+    val leafPaths = context.provider.leafManifestAbsolutePaths
+      .map(relativeManifest(context.postCheckpointSnapshot, _)).toSet
+    adds.foreach { add =>
+      val br = add.backReference.getOrElse(
+        fail(s"Reconstructed AddFile ${add.path} must carry a back reference."))
+      assert(leafPaths.contains(br.manifest),
+        s"Back-ref manifest ${br.manifest} must be one of the tree's leaves $leafPaths.")
+      // The back-ref must point at exactly the leaf entry describing this data file.
+      assert(groundTruth.get((br.manifest, br.pos)).contains(add.path),
+        s"Back-ref (${br.manifest}, ${br.pos}) must resolve to the entry for ${add.path}.")
     }
   }
 
-  test("DELETE emits a RemoveFile carrying the removed file's back reference") {
-    withTable("amt_back_ref_delete") {
-      val name = "amt_back_ref_delete"
-      val backRefByPath = emitTwoStampedFiles(name)
-      val deltaLog = deltaLogForName(name)
+  testAcrossAMTCheckpointScenarios(
+      "DELETE emits a RemoveFile carrying the removed file's back reference",
+      "amt_back_ref_delete",
+      sqlConfs = leafResidentConfs)(
+      setup = name => sql(s"INSERT INTO $name VALUES (1)"),
+      inlineCheckpointTriggerActionsOrSQL = Some(name => Right(
+        s"INSERT INTO $name VALUES (2)"))) { context =>
+    val backRefByPath = stampedBackRefs(context.postCheckpointSnapshot)
+    val deltaLog = context.postCheckpointSnapshot.deltaLog
+    sql(s"DELETE FROM ${context.tableName} WHERE id = 1")
 
-      val vBefore = deltaLog.update().version
-      sql(s"DELETE FROM $name WHERE id = 1")
-
-      val removes = actionsAfter(deltaLog, vBefore).collect { case r: RemoveFile => r }
-      assert(removes.size == 1, "The single-row file for id=1 must be removed whole.")
-      val remove = removes.head
-      val expected = backRefByPath.getOrElse(remove.path,
-        fail(s"Removed file ${remove.path} was not among the leaf-reconstructed files."))
-      assert(expected.isDefined, "The removed file must have carried a back reference.")
-      assert(remove.backReference == expected,
-        s"RemoveFile back-ref ${remove.backReference} must equal the source AddFile's $expected.")
-    }
+    val removes = actionsAfter(deltaLog, context.manifestCommitVersion)
+      .collect { case r: RemoveFile => r }
+    assert(removes.size == 1, "The single-row file for id=1 must be removed whole.")
+    val remove = removes.head
+    val expected = backRefByPath.getOrElse(remove.path,
+      fail(s"Removed file ${remove.path} was not among the leaf-reconstructed files."))
+    assert(expected.isDefined, "The removed file must have carried a back reference.")
+    assert(remove.backReference == expected,
+      s"RemoveFile back-ref ${remove.backReference} must equal the source AddFile's $expected.")
   }
 
-  test("a file added after the emit and removed before the next emit has no back reference") {
-    withTable("amt_back_ref_post_emit") {
-      val name = "amt_back_ref_post_emit"
-      createAMTTable(name, checkpointInterval = 3)
-      sql(s"INSERT INTO $name VALUES (1)") // v1.
-      sql(s"INSERT INTO $name VALUES (2)") // v2.
-      sql(s"INSERT INTO $name VALUES (3)") // v3: checkpoint boundary -> emit; leaves stamp 3 files.
+  testAcrossAMTCheckpointScenarios(
+      "a file added after the emit and removed before the next emit has no back reference",
+      "amt_back_ref_post_emit",
+      sqlConfs = leafResidentConfs)(
+      setup = name => (1 to 2).foreach(i => sql(s"INSERT INTO $name VALUES ($i)")),
+      inlineCheckpointTriggerActionsOrSQL = Some(name => Right(
+        s"INSERT INTO $name VALUES (3)"))) { context =>
+    val stamped = liveAddFiles(context.postCheckpointSnapshot)
+    val stampedPaths = stamped.map(_.path).toSet
+    assert(stamped.size == 3 && stamped.forall(_.backReference.isDefined),
+      "all three emitted files must be stamped from the leaves.")
 
-      val deltaLog = deltaLogForName(name)
-      val emitted = deltaLog.update()
-      assert(amtProvider(emitted).isDefined)
-      val stamped = liveAddFiles(emitted)
-      val stampedPaths = stamped.map(_.path).toSet
-      assert(stamped.size == 3 && stamped.forall(_.backReference.isDefined),
-        "all three emitted files must be stamped from the leaves.")
+    // This file is added off a checkpoint boundary, so it never enters a leaf.
+    sql(s"INSERT INTO ${context.tableName} VALUES (4)")
+    val deltaLog = context.postCheckpointSnapshot.deltaLog
+    val newFile = deltaLog.update().allFiles.collect()
+      .find(add => !stampedPaths.contains(add.path))
+      .getOrElse(fail("expected a newly added, non-leaf file."))
+    assert(newFile.backReference.isEmpty,
+      "A file added after the emit (not yet in a leaf) must not carry a back reference.")
 
-      // A new single-row file committed as a plain delta AddFile. It is not on a checkpoint
-      // boundary (interval 3), so this file never enters a leaf and carries no back reference.
-      sql(s"INSERT INTO $name VALUES (4)")
-      val newFile = deltaLog.update().allFiles.collect()
-        .find(add => !stampedPaths.contains(add.path))
-        .getOrElse(fail("expected a newly added, non-leaf file."))
-      assert(newFile.backReference.isEmpty,
-        "A file added after the emit (not yet in a leaf) must not carry a back reference.")
-
-      // Deleting its only row removes the whole file via removeWithTimestamp. Because the source
-      // AddFile was never stamped, the tombstone must have an empty back reference too.
-      val vBefore = deltaLog.update().version
-      sql(s"DELETE FROM $name WHERE id = 4")
-      val remove = actionsAfter(deltaLog, vBefore).collect { case r: RemoveFile => r }
-        .find(_.path == newFile.path)
-        .getOrElse(fail(s"expected a RemoveFile for the post-emit file ${newFile.path}."))
-      assert(remove.backReference.isEmpty,
-        "Removing a file that never entered a leaf must produce an empty back reference.")
-    }
+    // Removing the unstamped file must produce an unstamped tombstone.
+    val vBefore = deltaLog.update().version
+    sql(s"DELETE FROM ${context.tableName} WHERE id = 4")
+    val remove = actionsAfter(deltaLog, vBefore).collect { case r: RemoveFile => r }
+      .find(_.path == newFile.path)
+      .getOrElse(fail(s"expected a RemoveFile for the post-emit file ${newFile.path}."))
+    assert(remove.backReference.isEmpty,
+      "Removing a file that never entered a leaf must produce an empty back reference.")
   }
 
-  test("removeRows propagates the back reference to the superseding AddFile and the RemoveFile") {
-    withTable("amt_back_ref_remove_rows") {
-      val name = "amt_back_ref_remove_rows"
-      createAMTTable(name, checkpointInterval = 2)
-      // Two rows in a single file so a DV can mark one row without rewriting.
-      Seq(1, 2).toDF("id").coalesce(1).write.mode("append").insertInto(name) // v1.
-      sql(s"INSERT INTO $name VALUES (3)") // v2: emit.
+  testAcrossAMTCheckpointScenarios(
+      "removeRows propagates the back reference to the superseding AddFile and the RemoveFile",
+      "amt_back_ref_remove_rows",
+      sqlConfs = leafResidentConfs)(
+      setup = name => Seq(1, 2).toDF("id").coalesce(1).write.mode("append").insertInto(name),
+      inlineCheckpointTriggerActionsOrSQL = Some(name => Right(
+        s"INSERT INTO $name VALUES (3)"))) {
+      context =>
+    val twoRowFile = liveAddFiles(context.postCheckpointSnapshot)
+      .find(_.numPhysicalRecords.contains(2L))
+      .getOrElse(fail("expected the two-row file to be reconstructed from the leaves."))
+    assert(twoRowFile.backReference.isDefined)
 
-      val snapshot = deltaLogForName(name).update()
-      val twoRowFile = liveAddFiles(snapshot)
-        .find(_.numPhysicalRecords.contains(2L))
-        .getOrElse(fail("expected the two-row file to be reconstructed from the leaves."))
-      assert(twoRowFile.backReference.isDefined)
+    // Mark row 0 deleted via a persistent DV, exercising the removeRows narrow waist.
+    val dv = writeDV(context.postCheckpointSnapshot.deltaLog, RoaringBitmapArray(0L))
+    val (supersedingAdd, removeFile) =
+      twoRowFile.removeRows(
+        deletionVector = dv, updateStats = false)
 
-      // Mark row 0 deleted via a persistent DV, exercising the removeRows narrow waist.
-      val dv = writeDV(deltaLogForName(name), RoaringBitmapArray(0L))
-      val (supersedingAdd, removeFile) =
-        twoRowFile.removeRows(
-          deletionVector = dv, updateStats = false)
-
-      assert(supersedingAdd.backReference == twoRowFile.backReference,
-        "The superseding AddFile (new DV) must inherit the source file's back reference.")
-      assert(removeFile.backReference == twoRowFile.backReference,
-        "The paired RemoveFile must inherit the source file's back reference.")
-    }
+    assert(supersedingAdd.backReference == twoRowFile.backReference,
+      "The superseding AddFile (new DV) must inherit the source file's back reference.")
+    assert(removeFile.backReference == twoRowFile.backReference,
+      "The paired RemoveFile must inherit the source file's back reference.")
   }
 
-  test("DELETE via a persistent DV (removeRows) propagates through a real command") {
-    withTable("amt_back_ref_dv_delete") {
-      val name = "amt_back_ref_dv_delete"
-      createAMTTable(name, checkpointInterval = 2)
-      // A two-row file so a subset delete uses a DV instead of rewriting the whole file.
-      Seq(1, 2).toDF("id").coalesce(1).write.mode("append").insertInto(name) // v1.
-      sql(s"INSERT INTO $name VALUES (3)") // v2: checkpoint boundary -> emit.
+  testAcrossAMTCheckpointScenarios(
+      "DELETE via a persistent DV (removeRows) propagates through a real command",
+      "amt_back_ref_dv_delete",
+      sqlConfs = leafResidentConfs)(
+      setup = name => Seq(1, 2).toDF("id").coalesce(1).write.mode("append").insertInto(name),
+      inlineCheckpointTriggerActionsOrSQL = Some(name => Right(
+        s"INSERT INTO $name VALUES (3)"))) {
+      context =>
+    val backRefByPath =
+      liveAddFiles(context.postCheckpointSnapshot).map(add => add.path -> add.backReference).toMap
+    val twoRowPath = liveAddFiles(context.postCheckpointSnapshot)
+      .find(_.numPhysicalRecords.contains(2L))
+      .getOrElse(fail("expected the two-row file to be reconstructed from the leaves.")).path
 
-      val snapshot = deltaLogForName(name).update()
-      val backRefByPath =
-        liveAddFiles(snapshot).map(add => add.path -> add.backReference).toMap
-      val twoRowPath = liveAddFiles(snapshot)
-        .find(_.numPhysicalRecords.contains(2L))
-        .getOrElse(fail("expected the two-row file to be reconstructed from the leaves.")).path
-
-      // Deleting one of the two rows marks it with a DV -> removeRows emits a superseding AddFile
-      // (same path, new DV) plus a paired RemoveFile; both must inherit the back reference.
-      val deltaLog = deltaLogForName(name)
-      val vBefore = deltaLog.update().version
-      sql(s"DELETE FROM $name WHERE id = 1")
-
-      val actions = actionsAfter(deltaLog, vBefore)
-      val supersedingAdd = actions.collectFirst {
-        case a: AddFile if a.path == twoRowPath => a
-      }.getOrElse(fail("expected a superseding AddFile (DV update) for the two-row file."))
-      val removed = actions.collectFirst {
-        case r: RemoveFile if r.path == twoRowPath => r
-      }.getOrElse(fail("expected a paired RemoveFile for the two-row file."))
-      assert(supersedingAdd.deletionVector != null, "the superseding AddFile must carry the DV.")
-      assert(supersedingAdd.backReference == backRefByPath(twoRowPath),
-        "the superseding AddFile must inherit the source file's back reference.")
-      assert(removed.backReference == backRefByPath(twoRowPath),
-        "the paired RemoveFile must inherit the source file's back reference.")
-    }
+    // Deleting one of the two rows emits a superseding AddFile and paired RemoveFile.
+    val deltaLog = context.postCheckpointSnapshot.deltaLog
+    sql(s"DELETE FROM ${context.tableName} WHERE id = 1")
+    val actions = actionsAfter(deltaLog, context.manifestCommitVersion)
+    val supersedingAdd = actions.collectFirst {
+      case a: AddFile if a.path == twoRowPath => a
+    }.getOrElse(fail("expected a superseding AddFile (DV update) for the two-row file."))
+    val removed = actions.collectFirst {
+      case r: RemoveFile if r.path == twoRowPath => r
+    }.getOrElse(fail("expected a paired RemoveFile for the two-row file."))
+    assert(supersedingAdd.deletionVector != null, "the superseding AddFile must carry the DV.")
+    assert(supersedingAdd.backReference == backRefByPath(twoRowPath),
+      "the superseding AddFile must inherit the source file's back reference.")
+    assert(removed.backReference == backRefByPath(twoRowPath),
+      "the paired RemoveFile must inherit the source file's back reference.")
   }
 
   /**
@@ -294,22 +297,24 @@ class AMTBackReferenceSuite extends AMTCheckpointTestBase with DeletionVectorsTe
       n => sql(s"RESTORE TABLE $n TO VERSION AS OF 1"), tombstones = 1, exact = false))
 
   propagationCases.foreach { c =>
-    test(s"${c.label} tombstones carry the source files' back references") {
-      withTable(c.table) {
-        val backRefByPath = emitTwoStampedFiles(c.table)
-        val deltaLog = deltaLogForName(c.table)
+    testAcrossAMTCheckpointScenarios(
+        s"${c.label} tombstones carry the source files' back references",
+        c.table,
+        sqlConfs = leafResidentConfs)(
+        setup = name => sql(s"INSERT INTO $name VALUES (1)"),
+        inlineCheckpointTriggerActionsOrSQL = Some(name => Right(
+          s"INSERT INTO $name VALUES (2)"))) { context =>
+      val backRefByPath = stampedBackRefs(context.postCheckpointSnapshot)
+      c.run(context.tableName)
 
-        val vBefore = deltaLog.update().version
-        c.run(c.table)
-
-        val matched = assertBackRefsPropagated(deltaLog, vBefore, backRefByPath)
-        if (c.exact) {
-          assert(matched == c.tombstones,
-            s"${c.label} must tombstone exactly ${c.tombstones} leaf-derived files, saw $matched.")
-        } else {
-          assert(matched >= c.tombstones,
-            s"${c.label} must tombstone >= ${c.tombstones} leaf-derived file(s), saw $matched.")
-        }
+      val matched = assertBackRefsPropagated(
+        context.postCheckpointSnapshot.deltaLog, context.manifestCommitVersion, backRefByPath)
+      if (c.exact) {
+        assert(matched == c.tombstones,
+          s"${c.label} must tombstone exactly ${c.tombstones} leaf-derived files, saw $matched.")
+      } else {
+        assert(matched >= c.tombstones,
+          s"${c.label} must tombstone >= ${c.tombstones} leaf-derived file(s), saw $matched.")
       }
     }
   }
@@ -382,7 +387,7 @@ class AMTBackReferenceSuite extends AMTCheckpointTestBase with DeletionVectorsTe
   test("commit fails when a fresh file carries a spurious back reference") {
     withTable("amt_commit_spurious") {
       val adds = emitTwoStampedAddFiles("amt_commit_spurious")
-      // A file not in the tree must not carry a back reference
+      // A file not in the tree must not carry a back reference.
       val spurious = adds.head.copy(path = "brand-new-file.parquet")
       val ex = intercept[IllegalStateException] {
         commitActions("amt_commit_spurious", Seq(spurious))
@@ -407,93 +412,102 @@ class AMTBackReferenceSuite extends AMTCheckpointTestBase with DeletionVectorsTe
    * Builds an AMT source with stamped files, runs `clone(src, tgt)`, then asserts every AddFile
    * committed to the target carries no back reference.
    */
-  private def assertCloneDropsBackRefs(clone: (String, String) => Unit): Unit = {
-    withTable("amt_clone_src", "amt_clone_tgt") {
-      val src = "amt_clone_src"
-      val tgt = "amt_clone_tgt"
-      val srcBackRefByPath = emitTwoStampedFiles(src)
-      assert(srcBackRefByPath.values.forall(_.isDefined),
-        "precondition: every source file must carry a back reference.")
+  private def testCloneDropsBackRefs(
+      testName: String)(clone: (String, String) => Unit): Unit = {
+    testAcrossAMTCheckpointScenarios(
+        testName,
+        "amt_clone_src",
+        sqlConfs = leafResidentConfs)(
+        setup = name => sql(s"INSERT INTO $name VALUES (1)"),
+        inlineCheckpointTriggerActionsOrSQL = Some(name => Right(
+          s"INSERT INTO $name VALUES (2)"))) { context =>
+      val src = context.tableName
+      // Derive the clone target from the scenario-unique source, so the scenarios do not share a
+      // table directory (see the naming note in `testAcrossAMTCheckpointScenarios`).
+      val tgt = s"${src}_clone_tgt"
+      val srcBackRefByPath = stampedBackRefs(context.postCheckpointSnapshot)
 
-      clone(src, tgt)
+      withTable(tgt) {
+        clone(src, tgt)
 
-      val tgtLog = deltaLogForName(tgt)
-      val latest = tgtLog.update().version
-      val clonedAdds = (0L to latest)
-        .flatMap(v => actionsAt(tgtLog, v))
-        .collect { case a: AddFile => a }
-      assert(clonedAdds.size >= srcBackRefByPath.size,
-        s"the clone must add the ${srcBackRefByPath.size} source files to the target.")
-      clonedAdds.foreach { a =>
-        assert(a.backReference.isEmpty,
-          s"Cloned AddFile ${a.path} must not carry the source table's back reference.")
+        val tgtLog = deltaLogForName(tgt)
+        val latest = tgtLog.update().version
+        val clonedAdds = (0L to latest)
+          .flatMap(v => actionsAt(tgtLog, v))
+          .collect { case a: AddFile => a }
+        assert(clonedAdds.size >= srcBackRefByPath.size,
+          s"the clone must add the ${srcBackRefByPath.size} source files to the target.")
+        clonedAdds.foreach { a =>
+          assert(a.backReference.isEmpty,
+            s"Cloned AddFile ${a.path} must not carry the source table's back reference.")
+        }
       }
     }
   }
 
   Seq("SHALLOW").foreach { cloneType =>
-    test(s"$cloneType CLONE drops the source table's back references") {
-      assertCloneDropsBackRefs { (src, tgt) =>
-        sql(s"CREATE TABLE $tgt $cloneType CLONE $src")
-      }
+    testCloneDropsBackRefs(
+        s"$cloneType CLONE drops the source table's back references") { (src, tgt) =>
+      sql(s"CREATE TABLE $tgt $cloneType CLONE $src")
     }
 
   }
 
-  test("RESTORE tombstones keep the current back ref; re-added files carry none") {
-    withTable("amt_back_ref_restore_tombstones") {
-      val name = "amt_back_ref_restore_tombstones"
-      // restoreTarget holds two stamped files A, B.
-      val restoredToByPath = emitTwoStampedFiles(name)
-      val deltaLog = deltaLogForName(name)
-      val restoreTarget = deltaLog.update().version
+  testAcrossAMTCheckpointScenarios(
+      "RESTORE tombstones keep the current back ref; re-added files carry none",
+      "amt_back_ref_restore_tombstones",
+      sqlConfs = leafResidentConfs)(
+      setup = name => sql(s"INSERT INTO $name VALUES (1)"),
+      inlineCheckpointTriggerActionsOrSQL = Some(name => Right(
+        s"INSERT INTO $name VALUES (2)"))) { context =>
+    val name = context.tableName
+    // restoreTarget holds two stamped files A, B.
+    val restoredToByPath = stampedBackRefs(context.postCheckpointSnapshot)
+    val deltaLog = deltaLogForName(name)
+    val restoreTarget = context.checkpoint.version
 
-      // The overwrite drops A, B and writes C; a second insert then adds D and lands on a
-      // checkpoint boundary. entriesPerLeaf=1 forces the incremental write to spill every net-new
-      // file into its own leaf (rather than holding it root-resident, which would leave it
-      // unstamped), so the current live files C, D get stamped with this table's own back
-      // references. (Exact commit versions are not asserted: an AMT checkpoint commits as a
-      // separate follow-up commit, so it shifts version numbers; the checks scan via actionsAfter.)
-      withSQLConf(DeltaSQLConf.AMT_ENTRIES_PER_LEAF.key -> "1") {
-        sql(s"INSERT OVERWRITE $name VALUES (99)")
-        sql(s"INSERT INTO $name VALUES (100)") // Lands on a checkpoint boundary -> C, D stamped.
-      }
+    // The overwrite drops A, B and writes C; a second insert adds D. The suite-wide
+    // `leafResidentConfs` makes the explicit incremental checkpoint spill every net-new file into
+    // its own leaf, so the current live files C, D get stamped with this table's own back
+    // references.
+    sql(s"INSERT OVERWRITE $name VALUES (99)")
+    sql(s"INSERT INTO $name VALUES (100)")
+    commitCheckpoint(deltaLog, incremental = true)
 
-      val currentByPath =
-        liveAddFiles(deltaLog.update()).map(a => a.path -> a.backReference).toMap
-      assert(currentByPath.nonEmpty && currentByPath.values.forall(_.isDefined),
-        "precondition: current live files (to be tombstoned by RESTORE) must be stamped.")
-      assert(currentByPath.keySet.intersect(restoredToByPath.keySet).isEmpty,
-        "precondition: restored-to files and current files must be disjoint.")
+    val currentByPath =
+      liveAddFiles(deltaLog.update()).map(a => a.path -> a.backReference).toMap
+    assert(currentByPath.nonEmpty && currentByPath.values.forall(_.isDefined),
+      "precondition: current live files (to be tombstoned by RESTORE) must be stamped.")
+    assert(currentByPath.keySet.intersect(restoredToByPath.keySet).isEmpty,
+      "precondition: restored-to files and current files must be disjoint.")
 
-      val vBefore = deltaLog.update().version
-      sql(s"RESTORE TABLE $name TO VERSION AS OF $restoreTarget")
-      val actions = actionsAfter(deltaLog, vBefore)
+    val vBefore = deltaLog.update().version
+    sql(s"RESTORE TABLE $name TO VERSION AS OF $restoreTarget")
+    val actions = actionsAfter(deltaLog, vBefore)
 
-      // toRemove side: a file live now but absent at restoreTarget is tombstoned through the narrow
-      // waist removeWithTimestamp, so it keeps its valid CURRENT back reference.
-      val removed = actions.collect {
-        case r: RemoveFile if currentByPath.contains(r.path) => r
-      }
-      assert(removed.size == currentByPath.size,
-        s"RESTORE must tombstone all ${currentByPath.size} current files, saw ${removed.size}.")
-      removed.foreach { r =>
-        assert(r.backReference == currentByPath(r.path),
-          s"tombstone ${r.path} must keep its current back ref ${currentByPath(r.path)}.")
-      }
+    // toRemove side: a file live now but absent at restoreTarget is tombstoned through the narrow
+    // waist removeWithTimestamp, so it keeps its valid CURRENT back reference.
+    val removed = actions.collect {
+      case r: RemoveFile if currentByPath.contains(r.path) => r
+    }
+    assert(removed.size == currentByPath.size,
+      s"RESTORE must tombstone all ${currentByPath.size} current files, saw ${removed.size}.")
+    removed.foreach { r =>
+      assert(r.backReference == currentByPath(r.path),
+        s"tombstone ${r.path} must keep its current back ref ${currentByPath(r.path)}.")
+    }
 
-      // toAdd side: a file present at restoreTarget but absent now is re-added. By definition it is
-      // NOT in the current tree, so its restored-to pointer is stale and must be dropped.
-      val readded = actions.collect {
-        case a: AddFile if restoredToByPath.contains(a.path) => a
-      }
-      assert(readded.size == restoredToByPath.size,
-        s"RESTORE must re-add all ${restoredToByPath.size} restored-to files, saw ${readded.size}.")
-      readded.foreach { a =>
-        assert(a.backReference.isEmpty,
-          s"re-added AddFile ${a.path} must carry no back reference (stale pointer), " +
-            s"but was ${a.backReference}.")
-      }
+    // toAdd side: a file present at restoreTarget but absent now is re-added. By definition it is
+    // NOT in the current tree, so its restored-to pointer is stale and must be dropped.
+    val readded = actions.collect {
+      case a: AddFile if restoredToByPath.contains(a.path) => a
+    }
+    assert(readded.size == restoredToByPath.size,
+      s"RESTORE must re-add all ${restoredToByPath.size} restored-to files, saw ${readded.size}.")
+    readded.foreach { a =>
+      assert(a.backReference.isEmpty,
+        s"re-added AddFile ${a.path} must carry no back reference (stale pointer), " +
+          s"but was ${a.backReference}.")
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointPolicySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointPolicySuite.scala
@@ -33,11 +33,9 @@ import org.apache.spark.sql.catalyst.TableIdentifier
 class AMTCheckpointPolicySuite extends AMTCheckpointTestBase {
 
   /** The Checkpoint action emitted at exactly `version`, or fails. */
-  private def checkpointAt(deltaLog: DeltaLog, version: Long): Checkpoint =
-    checkpointsAt(deltaLog, version) match {
-      case Seq(cp) => cp
-      case other => fail(s"Expected exactly one Checkpoint at v$version, got: $other")
-    }
+  private def requireCheckpointAt(deltaLog: DeltaLog, version: Long): Checkpoint =
+    checkpointAt(deltaLog, version).getOrElse(
+      fail(s"Expected a Checkpoint at v$version."))
 
   /** Every AMT [[Checkpoint]] emitted in `[0, latestVersion]`, in commit order. */
   private def allCheckpoints(deltaLog: DeltaLog): Seq[Checkpoint] =
@@ -49,7 +47,7 @@ class AMTCheckpointPolicySuite extends AMTCheckpointTestBase {
    */
   private def allCheckpointsWithCommitVersion(deltaLog: DeltaLog): Seq[(Long, Checkpoint)] = {
     val latest = deltaLog.update().version
-    (0L to latest).flatMap(v => checkpointsAt(deltaLog, v).map(cp => (v, cp)))
+    (0L to latest).flatMap(v => checkpointAt(deltaLog, v).map(cp => (v, cp)))
   }
 
   /** The trigger name recorded in the AMT write metrics of the commit `f` produces at `version`. */
@@ -86,17 +84,17 @@ class AMTCheckpointPolicySuite extends AMTCheckpointTestBase {
   /**
    * One expected AMT checkpoint in a deterministic emission timeline.
    *
-   * @param describedVersion      the table version the emitted Checkpoint describes (the
+   * @param checkpointedVersion   the table version the emitted Checkpoint describes (the
    *                              triggering business commit)
    * @param manifestCommitVersion the version of the commit that carries the Checkpoint action -- in
    *                              deferred mode the follow-up OPTIMIZE CHECKPOINT commit, which
-   *                              lands at describedVersion + 1
+   *                              lands at checkpointedVersion + 1
    * @param incremental           whether the rewrite is incremental (false = full rewrite)
    * @param lastFullRewrite       expected `lastManifestCommitWithFullRewrite` marker on the
    *                              checkpoint
    */
   private case class ExpectedCheckpoint(
-      describedVersion: Long,
+      checkpointedVersion: Long,
       manifestCommitVersion: Long,
       incremental: Boolean,
       lastFullRewrite: Long)
@@ -110,18 +108,18 @@ class AMTCheckpointPolicySuite extends AMTCheckpointTestBase {
   private def assertCheckpointTimeline(
       deltaLog: DeltaLog, expected: Seq[ExpectedCheckpoint]): Unit = {
     val checkpoints = allCheckpointsWithCommitVersion(deltaLog)
-    assert(checkpoints.map(_._2.version) == expected.map(_.describedVersion),
+    assert(checkpoints.map(_._2.version) == expected.map(_.checkpointedVersion),
       s"Emitted checkpoint versions ${checkpoints.map(_._2.version)} must match " +
-        s"${expected.map(_.describedVersion)}.")
+        s"${expected.map(_.checkpointedVersion)}.")
     assert(checkpoints.map(_._1) == expected.map(_.manifestCommitVersion),
       s"Manifest commit versions ${checkpoints.map(_._1)} must match " +
         s"${expected.map(_.manifestCommitVersion)}.")
     checkpoints.zip(expected).foreach { case ((_, cp), exp) =>
       assert(cp.contentRoot.isIncremental.contains(exp.incremental),
-        s"Checkpoint describing v${exp.describedVersion}: expected incremental=" +
+        s"Checkpoint describing v${exp.checkpointedVersion}: expected incremental=" +
           s"${exp.incremental}, got ${cp.contentRoot.isIncremental}")
       assert(cp.contentRoot.lastManifestCommitWithFullRewrite.contains(exp.lastFullRewrite),
-        s"Checkpoint describing v${exp.describedVersion}: expected lastFullRewrite=" +
+        s"Checkpoint describing v${exp.checkpointedVersion}: expected lastFullRewrite=" +
           s"${exp.lastFullRewrite}, got ${cp.contentRoot.lastManifestCommitWithFullRewrite}")
     }
   }
@@ -149,9 +147,9 @@ class AMTCheckpointPolicySuite extends AMTCheckpointTestBase {
 
       val deltaLog = deltaLogForName(name)
       assert(deltaLog.update().version == 3, "The follow-up OPTIMIZE CHECKPOINT lands at v3.")
-      assert(checkpointsAt(deltaLog, 2).isEmpty, "v2 (business commit) carries no Checkpoint.")
+      assert(checkpointAt(deltaLog, 2).isEmpty, "v2 (business commit) carries no Checkpoint.")
       // The Checkpoint rides in v3 and describes state as of v2.
-      assert(checkpointAt(deltaLog, 3).version == 2)
+      assert(requireCheckpointAt(deltaLog, 3).version == 2)
       assert(amtProvider(deltaLog.update()).isDefined)
     }
   }
@@ -168,8 +166,9 @@ class AMTCheckpointPolicySuite extends AMTCheckpointTestBase {
 
       // The full rewrite records its own version as the last-full-rewrite marker.
       val deltaLog = deltaLogForName(name)
-      assert(checkpointAt(deltaLog, 3).contentRoot.lastManifestCommitWithFullRewrite.contains(2L))
-      assert(checkpointAt(deltaLog, 3).contentRoot.isIncremental.contains(false))
+      assert(requireCheckpointAt(deltaLog, 3)
+        .contentRoot.lastManifestCommitWithFullRewrite.contains(2L))
+      assert(requireCheckpointAt(deltaLog, 3).contentRoot.isIncremental.contains(false))
     }
   }
 
@@ -202,7 +201,8 @@ class AMTCheckpointPolicySuite extends AMTCheckpointTestBase {
         // land on an interval boundary (v2, v4, ..., v16) and trigger a follow-up checkpoint.
         (1 to 9).foreach(i => sql(s"INSERT INTO $name VALUES ($i)"))
       }
-      // ExpectedCheckpoint(describedVersion, manifestCommitVersion, incremental, lastFullRewrite).
+      // ExpectedCheckpoint(checkpointedVersion, manifestCommitVersion, incremental,
+      //   lastFullRewrite).
       assertCheckpointTimeline(deltaLog, Seq(
         ExpectedCheckpoint(2, 3, incremental = false, lastFullRewrite = 2),
         ExpectedCheckpoint(4, 5, incremental = true, lastFullRewrite = 2),
@@ -244,7 +244,8 @@ class AMTCheckpointPolicySuite extends AMTCheckpointTestBase {
         // land on an interval boundary (v2, v4, ..., v16) and trigger a follow-up checkpoint.
         (1 to 9).foreach(i => sql(s"INSERT INTO $name VALUES ($i)"))
       }
-      // ExpectedCheckpoint(describedVersion, manifestCommitVersion, incremental, lastFullRewrite).
+      // ExpectedCheckpoint(checkpointedVersion, manifestCommitVersion, incremental,
+      //   lastFullRewrite).
       assertCheckpointTimeline(deltaLog, Seq(
         ExpectedCheckpoint(2, 3, incremental = false, lastFullRewrite = 2),
         ExpectedCheckpoint(4, 5, incremental = true, lastFullRewrite = 2),
@@ -268,15 +269,15 @@ class AMTCheckpointPolicySuite extends AMTCheckpointTestBase {
         // v1 is the first commit: no prior AMT, so it must NOT inline even though it is "large".
         sql(s"INSERT INTO $name VALUES (1)")
         val deltaLog = deltaLogForName(name)
-        assert(checkpointsAt(deltaLog, 1).isEmpty,
+        assert(checkpointAt(deltaLog, 1).isEmpty,
           "The first large commit must not write an AMT inline (no full AMT exists yet).")
 
         // v2 is the interval boundary: the first (full) AMT is emitted via the deferred follow-up
         // OPTIMIZE CHECKPOINT commit at v3, not inline in v2.
         sql(s"INSERT INTO $name VALUES (2)")
-        assert(checkpointsAt(deltaLog, 2).isEmpty, "v2 must not write an AMT inline.")
+        assert(checkpointAt(deltaLog, 2).isEmpty, "v2 must not write an AMT inline.")
         assert(deltaLog.update().version == 3, "The first full AMT lands as a follow-up at v3.")
-        assert(checkpointAt(deltaLog, 3).contentRoot.isIncremental.contains(false),
+        assert(requireCheckpointAt(deltaLog, 3).contentRoot.isIncremental.contains(false),
           "The first AMT is a full rewrite.")
 
         // Now a full AMT exists. The next large commit (v4) writes its AMT inline (incrementally).
@@ -285,7 +286,7 @@ class AMTCheckpointPolicySuite extends AMTCheckpointTestBase {
           s"Once a full AMT exists, a large commit inlines its AMT; got ${v4Metrics.trigger}")
         assert(v4Metrics.incremental == "true",
           "The usage log must report incremental=true for the inline AMT write.")
-        assert(checkpointAt(deltaLog, 4).contentRoot.isIncremental.contains(true),
+        assert(requireCheckpointAt(deltaLog, 4).contentRoot.isIncremental.contains(true),
           "The inline AMT is incremental.")
       }
     }
@@ -366,7 +367,7 @@ class AMTCheckpointPolicySuite extends AMTCheckpointTestBase {
           sql(s"INSERT INTO $name VALUES (1)") // v1.
           writeFullOptimizeCheckpoint(name) // v2 -> full checkpoint describing v1.
           assert(deltaLog.update().version == 2, "The bootstrap OPTIMIZE CHECKPOINT lands at v2.")
-          assert(checkpointAt(deltaLog, 2).contentRoot.isIncremental.contains(false),
+          assert(requireCheckpointAt(deltaLog, 2).contentRoot.isIncremental.contains(false),
             "The bootstrap AMT is a full rewrite anchoring lastFull off the interval grid.")
 
           // v3..v10: every commit is large, so each inlines an incremental AMT (a full tree now

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointTestBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointTestBase.scala
@@ -19,8 +19,8 @@ package org.apache.spark.sql.delta.amt
 import java.io.File
 
 // scalastyle:off import.ordering.noEmptyLine
-import org.apache.spark.sql.delta.{AdaptiveMetadataTableFeature, DeltaLog, Snapshot}
-import org.apache.spark.sql.delta.actions.{Action, Checkpoint}
+import org.apache.spark.sql.delta.{AdaptiveMetadataTableFeature, DeltaLog, DeltaOperations, Snapshot}
+import org.apache.spark.sql.delta.actions.{Action, AddFile, Checkpoint, RemoveFile}
 import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils._
 import org.apache.spark.sql.delta.coordinatedcommits.CatalogOwnedTestBaseSuite
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
@@ -99,38 +99,231 @@ trait AMTCheckpointTestBase
     }
   }
 
-  /**
-   * How an AMT is emitted for a triggering commit. In [[AMTWriteMode.Inline]] the manifest tree
-   * rides in the business commit itself; in [[AMTWriteMode.Deferred]] a follow-up OPTIMIZE
-   * CHECKPOINT commit (issued by the post-commit hook) lands it one version later.
-   */
-  protected sealed trait AMTWriteMode {
-    /** Number of extra commits the AMT emission adds after a triggering business commit. */
-    def followUpCommits: Int
-  }
-  protected object AMTWriteMode {
-    case object Inline extends AMTWriteMode { val followUpCommits = 0 }
-    case object Deferred extends AMTWriteMode { val followUpCommits = 1 }
+  /** A production-supported combination of AMT placement and materialization strategy. */
+  protected sealed abstract class AMTCheckpointScenario(
+      val name: String,
+      val isInline: Boolean,
+      val isIncremental: Boolean)
+
+  protected object AMTCheckpointScenario {
+    case object InlineIncremental extends AMTCheckpointScenario(
+      "inline incremental", isInline = true, isIncremental = true)
+    case object DeferredIncremental extends AMTCheckpointScenario(
+      "deferred incremental", isInline = false, isIncremental = true)
+    case object DeferredFull extends AMTCheckpointScenario(
+      "deferred full", isInline = false, isIncremental = false)
   }
 
   /**
-   * Registers a test in both AMT write modes. The body runs once with inline writes forced (a low
-   * action-count threshold) and once with the default deferred follow-up-commit path, so behavior
-   * is covered in both. The body receives the active [[AMTWriteMode]] for any version-relative
-   * assertions.
+   * The business commit a test uses to trigger a checkpoint, as a function of the table name:
+   * either actions to commit through a transaction, or a SQL statement to run.
    */
-  protected def testInlineAndDeferred(testName: String)(body: AMTWriteMode => Unit): Unit = {
-    test(s"$testName (inline)") {
-      withSQLConf(
-          DeltaSQLConf.AMT_LARGE_COMMIT_ACTIONS_COUNT_THRESHOLD_FOR_INLINE_MANIFEST_COMMIT.key
-            -> "1") {
-        body(AMTWriteMode.Inline)
+  protected type AMTCheckpointTrigger =
+    String => Either[(Seq[Action], DeltaOperations.Operation), String]
+
+  /**
+   * Normalized result of producing one checkpoint through a supported production path.
+   *
+   * @param scenario the placement and materialization strategy used by the test
+   * @param tableName the catalog-managed table created by the harness
+   * @param preCheckpointSnapshot the snapshot after `setup` and before the tested checkpoint
+   * @param manifestCommitVersion the commit carrying `checkpoint`; this equals
+   *                              `checkpoint.version` for inline checkpoints and
+   *                              `checkpoint.version + 1` for deferred checkpoints
+   * @param checkpoint the Checkpoint action produced by the scenario
+   * @param provider the AMT provider installed from `checkpoint`
+   * @param postCheckpointSnapshot the snapshot after the checkpoint commit
+   */
+  protected case class AMTCheckpointScenarioContext(
+      scenario: AMTCheckpointScenario,
+      tableName: String,
+      preCheckpointSnapshot: Snapshot,
+      manifestCommitVersion: Long,
+      checkpoint: Checkpoint,
+      provider: AMTCheckpointProvider,
+      postCheckpointSnapshot: Snapshot)
+
+  /**
+   * Registers one test for each requested production-supported checkpoint scenario.
+   *
+   * For each scenario, the harness creates an AMT table and a full bootstrap checkpoint, then runs
+   * `setup`.
+   *
+   *  - When `inlineCheckpointTriggerActionsOrSQL` is defined, every scenario executes that
+   *    table-name-aware business commit and the harness registers an
+   *    [[AMTCheckpointScenario.InlineIncremental]] test, which sets the inline action threshold
+   *    to one for the commit.
+   *  - For [[AMTCheckpointScenario.DeferredIncremental]] and
+   *    [[AMTCheckpointScenario.DeferredFull]], the harness commits an explicit incremental or full
+   *    OPTIMIZE CHECKPOINT after the business commit, respectively.
+   *
+   * Finally, the harness calls `body` with an [[AMTCheckpointScenarioContext]] that normalizes
+   * inline and deferred version placement. Tests can assert on the checkpointed business commit,
+   * the manifest commit, the resulting Checkpoint action and provider, and the final snapshot
+   * without duplicating scenario-specific version arithmetic.
+   */
+  protected def testAcrossAMTCheckpointScenarios(
+      testName: String,
+      tableName: String,
+      deferredScenarios: Seq[AMTCheckpointScenario] = Seq(
+        AMTCheckpointScenario.DeferredIncremental,
+        AMTCheckpointScenario.DeferredFull),
+      sqlConfs: Seq[(String, String)] = Seq.empty)(
+      setup: String => Unit = _ => (),
+      inlineCheckpointTriggerActionsOrSQL: Option[AMTCheckpointTrigger] = None)(
+      body: AMTCheckpointScenarioContext => Unit): Unit = {
+    require(!deferredScenarios.contains(AMTCheckpointScenario.InlineIncremental),
+      "deferredScenarios must contain only deferred checkpoint scenarios")
+    val scenarios = inlineCheckpointTriggerActionsOrSQL
+      .map(_ => AMTCheckpointScenario.InlineIncremental).toSeq ++ deferredScenarios
+    scenarios.foreach { scenario =>
+      test(s"$testName (${scenario.name})") {
+        // Each scenario gets its own table, so it never inherits the previous scenario's storage.
+        // `withTable` only drops the catalog entry; for these catalog-managed tables the files can
+        // still be settling (commit backfill runs on a background pool), so a shared name lets one
+        // scenario's leftovers fail the next one's CREATE with
+        // DELTA_CREATE_TABLE_WITH_NON_EMPTY_LOCATION.
+        val scenarioTable = s"${tableName}_${scenario.name.replace(' ', '_')}"
+        withSQLConf(sqlConfs: _*) {
+          withTable(scenarioTable) {
+            createAMTTable(scenarioTable, checkpointInterval = Int.MaxValue)
+            // Incremental checkpoints require an existing full checkpoint.
+            commitCheckpoint(deltaLogForName(scenarioTable), incremental = false)
+            setup(scenarioTable)
+            val context = initScenarioAndBuildContext(
+              scenarioTable, scenario, inlineCheckpointTriggerActionsOrSQL)
+            assertAMTCheckpointScenarioInvariants(context)
+            body(context)
+          }
+        }
       }
     }
-    test(s"$testName (deferred)") {
-      // Default threshold (Long.MaxValue) keeps business commits from writing inline.
-      body(AMTWriteMode.Deferred)
+  }
+
+  private def initScenarioAndBuildContext(
+      tableName: String,
+      scenario: AMTCheckpointScenario,
+      inlineCheckpointTriggerActionsOrSQL: Option[AMTCheckpointTrigger])
+      : AMTCheckpointScenarioContext = {
+    import AMTCheckpointScenario._
+
+    val deltaLog = deltaLogForName(tableName)
+    val preCheckpointSnapshot = deltaLog.update()
+
+    def runCheckpointTrigger(): Unit = {
+      inlineCheckpointTriggerActionsOrSQL.map(_(tableName)).foreach {
+        case Left((actions, operation)) =>
+          val txn = deltaLog.startTransaction()
+          txn.commit(actions, operation)
+        case Right(sqlText) => spark.sql(sqlText)
+      }
     }
+
+    scenario match {
+      case InlineIncremental =>
+        withSQLConf(
+            DeltaSQLConf.AMT_LARGE_COMMIT_ACTIONS_COUNT_THRESHOLD_FOR_INLINE_MANIFEST_COMMIT.key
+              -> "1") {
+          runCheckpointTrigger()
+        }
+      case _ =>
+        runCheckpointTrigger()
+        commitCheckpoint(deltaLog, incremental = scenario.isIncremental)
+    }
+
+    val checkpointedVersion = preCheckpointSnapshot.version +
+      (if (inlineCheckpointTriggerActionsOrSQL.isDefined) 1L else 0L)
+    val manifestCommitVersion = checkpointedVersion + (if (scenario.isInline) 0L else 1L)
+    val postCheckpointSnapshot = deltaLog.update()
+    val checkpoint = checkpointAt(deltaLog, manifestCommitVersion).getOrElse(
+      fail(s"${scenario.name}: expected a Checkpoint at v$manifestCommitVersion"))
+    val provider = amtProvider(postCheckpointSnapshot).getOrElse(
+      fail(s"${scenario.name}: post-checkpoint snapshot has no AMTCheckpointProvider"))
+    AMTCheckpointScenarioContext(
+      scenario = scenario,
+      tableName = tableName,
+      preCheckpointSnapshot = preCheckpointSnapshot,
+      manifestCommitVersion = manifestCommitVersion,
+      checkpoint = checkpoint,
+      provider = provider,
+      postCheckpointSnapshot = postCheckpointSnapshot)
+  }
+
+  protected def commitCheckpoint(deltaLog: DeltaLog, incremental: Boolean): Unit = {
+    val triggerName = if (incremental) {
+      AMTTriggerMode.CheckpointIntervalIncremental.name
+    } else {
+      AMTTriggerMode.CheckpointIntervalFull.name
+    }
+    deltaLog.startTransaction().commit(
+      Seq.empty,
+      DeltaOperations.OptimizeCheckpoint(
+        incremental = incremental,
+        triggerName = triggerName))
+  }
+
+  private def assertAMTCheckpointScenarioInvariants(
+      context: AMTCheckpointScenarioContext): Unit = {
+    val scenario = context.scenario
+    val checkpoint = context.checkpoint
+    assert(checkpoint.contentRoot.isIncremental.contains(scenario.isIncremental),
+      s"${scenario.name}: wrong incremental tag ${checkpoint.contentRoot.isIncremental}")
+    val expectedLastFull = scenario match {
+      case AMTCheckpointScenario.InlineIncremental |
+          AMTCheckpointScenario.DeferredIncremental =>
+        val bootstrap = amtProvider(context.preCheckpointSnapshot).getOrElse(
+          fail("incremental scenario must bootstrap a full checkpoint"))
+        bootstrap.checkpointAction.contentRoot.lastManifestCommitWithFullRewrite.get
+      case AMTCheckpointScenario.DeferredFull => checkpoint.version
+    }
+    assert(checkpoint.contentRoot.lastManifestCommitWithFullRewrite.contains(expectedLastFull),
+      s"${scenario.name}: wrong last-full marker " +
+        checkpoint.contentRoot.lastManifestCommitWithFullRewrite)
+    assert(context.provider.checkpointVersion == checkpoint.version)
+    assert(context.provider.checkpointAction == checkpoint)
+    assert(context.postCheckpointSnapshot.version == context.manifestCommitVersion)
+    val actionsFromCheckpointedCommit =
+      actionsAt(context.postCheckpointSnapshot.deltaLog, checkpoint.version)
+    if (scenario.isInline) {
+      assert(actionsFromCheckpointedCommit.count(_.isInstanceOf[Checkpoint]) == 1,
+        "inline checkpoint must be carried by the business commit")
+    } else {
+      assert(!actionsFromCheckpointedCommit.exists(_.isInstanceOf[Checkpoint]),
+        "deferred business commit must not carry a Checkpoint")
+      val actionsFromManifestCommit =
+        actionsAt(context.postCheckpointSnapshot.deltaLog, context.manifestCommitVersion)
+      assert(!actionsFromManifestCommit.exists {
+        case _: AddFile | _: RemoveFile => true
+        case _ => false
+      }, "deferred manifest commit must not carry business file actions")
+    }
+  }
+
+  /**
+   * Asserts the manifest tree round-trips the live file set exactly: reconstructing from the
+   * checkpoint (root + leaves, minus MDV-masked entries and root tombstones) must yield precisely
+   * `snapshot.allFiles`, with no entry dropped or duplicated.
+   *
+   * Call this from tests that are about the tree capturing table state. It is deliberately NOT run
+   * for every scenario: it costs a full reconstruction scan per call, which is wasted on tests that
+   * assert something else (field ids, log-segment trimming, back references).
+   */
+  protected def assertReconstructsLiveFileSet(context: AMTCheckpointScenarioContext): Unit = {
+    val snapshot = context.postCheckpointSnapshot
+    val committed = snapshot.allFiles.collect().map(_.path).toSet
+      val reconstructed = context.provider
+        .loadActionsForStateReconstruction(spark, snapshot.deltaLog)
+        .getOrElse(fail(s"${context.scenario.name}: provider must contribute file actions."))
+        .where(col("add").isNotNull)
+        .select("add.path")
+        .collect()
+        .map(_.getString(0))
+      assert(reconstructed.length == reconstructed.toSet.size,
+        s"${context.scenario.name}: reconstruction must not duplicate entries; got " +
+          s"${reconstructed.toSeq.diff(reconstructed.distinct.toSeq)}")
+      assert(reconstructed.toSet == committed,
+        s"${context.scenario.name}: file set changed: committed=$committed " +
+          s"reconstructed=${reconstructed.toSet}")
   }
 
   /** True iff `name` looks like an AMT leaf parquet file. */
@@ -158,8 +351,13 @@ trait AMTCheckpointTestBase
   protected def actionsAt(deltaLog: DeltaLog, version: Long): Seq[Action] =
     deltaLog.getChanges(version).find(_._1 == version).map(_._2).getOrElse(Seq.empty)
 
-  protected def checkpointsAt(deltaLog: DeltaLog, version: Long): Seq[Checkpoint] =
-    actionsAt(deltaLog, version).collect { case c: Checkpoint => c }
+  /** The [[Checkpoint]] committed at exactly `version`, if any. */
+  protected def checkpointAt(deltaLog: DeltaLog, version: Long): Option[Checkpoint] = {
+    val checkpoints = actionsAt(deltaLog, version).collect { case c: Checkpoint => c }
+    assert(checkpoints.size <= 1,
+      s"A commit may carry at most one Checkpoint; v$version has ${checkpoints.size}: $checkpoints")
+    checkpoints.headOption
+  }
 
   /**
    * Total DATA (content_type=0) entry rows across the leaves reachable from the CURRENT snapshot's
@@ -169,8 +367,8 @@ trait AMTCheckpointTestBase
    * Note: this counts *physical* leaf entries and does NOT subtract Manifest Deletion Vectors, nor
    * does it count live files stored directly in the root. On an incremental tree a deleted file's
    * entry stays physically present in its carried-forward leaf (tombstoned via the leaf MDV), so
-   * this can exceed the live file count. Use [[currentLiveDataEntries]] to compare against
-   * `snapshot.allFiles`.
+   * this can exceed the live file count. To assert the tree captures exactly the live file set,
+   * call [[assertReconstructsLiveFileSet]] instead.
    */
   protected def currentLeafDataEntries(snapshot: Snapshot): Long = {
     val provider = amtProvider(snapshot)
@@ -182,20 +380,4 @@ trait AMTCheckpointTestBase
       }.sum
   }
 
-  /**
-   * The number of live files the CURRENT snapshot's AMT reconstructs across the WHOLE tree -- root
-   * and leaves. Goes through the provider's own reconstruction, which drops MDV-masked leaf entries
-   * and `tracking=removed` root tombstones, so it equals `snapshot.allFiles.count()` on both full
-   * and incremental trees. This is the count to assert the tree captures exactly the live file set;
-   * unlike [[currentLeafDataEntries]], it counts live files stored directly in the root too (as an
-   * incremental commit does below the spill threshold).
-   */
-  protected def currentLiveDataEntries(snapshot: Snapshot): Long = {
-    val provider = amtProvider(snapshot)
-      .getOrElse(fail("Snapshot has no AMTCheckpointProvider."))
-    provider.loadActionsForStateReconstruction(spark, snapshot.deltaLog)
-      .getOrElse(fail("AMT provider must contribute leaf-derived file actions."))
-      .where("add is not null")
-      .count()
-  }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointWriteSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointWriteSuite.scala
@@ -21,12 +21,11 @@ import java.io.File
 // scalastyle:off import.ordering.noEmptyLine
 import com.databricks.spark.util.{Log4jUsageLogger, MetricDefinitions}
 import org.apache.spark.sql.delta.{Checkpoints, CommitStats, CurrentTransactionInfo, DeltaOperations, Snapshot}
-import org.apache.spark.sql.delta.actions.{AddFile, Checkpoint, ContentRoot}
+import org.apache.spark.sql.delta.actions.{AddFile, Checkpoint, ContentRoot, RemoveFile}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.{FileNames, JsonUtils}
 import org.apache.hadoop.fs.Path
 
-import org.apache.spark.SparkConf
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.functions.col
 
@@ -34,45 +33,30 @@ class AMTCheckpointWriteSuite extends AMTCheckpointTestBase {
 
   import testImplicits._
 
+  testAcrossAMTCheckpointScenarios(
+      "checkpoint emission writes a manifest tree and carries the user action once",
+      "amt_emit")(
+      setup = name => sql(s"INSERT INTO $name VALUES (1)"),
+      inlineCheckpointTriggerActionsOrSQL = Some(_ => Left((
+        Seq(AddFile("missing-file.parquet", Map.empty, 0L, 0L, dataChange = true)
+          .removeWithTimestamp(1L)),
+        DeltaOperations.ManualUpdate)))) { context =>
+    val path = tablePath(context.tableName)
+    val actionsFromCheckpointedCommit =
+      actionsAt(context.postCheckpointSnapshot.deltaLog, context.checkpoint.version)
+    assert(actionsFromCheckpointedCommit.exists {
+      case _: AddFile | _: RemoveFile => true
+      case _ => false
+    }, "The described business commit must carry the user file action.")
 
-  test("interval boundary emits a follow-up OPTIMIZE CHECKPOINT commit carrying the Checkpoint") {
-    withTable("amt_inline_emit") {
-      val name = "amt_inline_emit"
-      createAMTTable(name, checkpointInterval = 2)
-      sql(s"INSERT INTO $name VALUES (1)") // v1: not an interval boundary.
-      sql(s"INSERT INTO $name VALUES (2)") // v2: interval boundary -> schedule maintenance.
+    val rootName = new File(context.checkpoint.contentRoot.path).getName
+    assert(isRootFileName(rootName),
+      s"contentRoot must point at a root manifest file; got " +
+        context.checkpoint.contentRoot.path)
+    assert(rootFiles(path).exists(_.getName == rootName))
 
-      val deltaLog = deltaLogForName(name)
-      val path = tablePath(name)
-      val snapshot = deltaLog.update()
-      // The AMT is written by a follow-up OPTIMIZE CHECKPOINT commit at v3, not inline at v2.
-      assert(snapshot.version == 3, "A follow-up OPTIMIZE CHECKPOINT commit lands at v3.")
-
-      // Manifest tree exists on disk: exactly one root, at least one leaf.
-      assert(rootFiles(path).size == 1, "Exactly one root manifest must be written.")
-      assert(leafFiles(path).nonEmpty, "At least one leaf manifest must be written.")
-
-      // The v2 business commit carries only the user AddFile, no Checkpoint.
-      val v2Actions = actionsAt(deltaLog, 2)
-      assert(v2Actions.exists(_.isInstanceOf[AddFile]), "v2 carries the user AddFile.")
-      assert(v2Actions.collect { case c: Checkpoint => c }.isEmpty,
-        s"v2 must not carry a Checkpoint action; got: $v2Actions")
-
-      // The v3 follow-up commit carries a single Checkpoint action and no user AddFile.
-      val v3Actions = actionsAt(deltaLog, 3)
-      val checkpoints = v3Actions.collect { case c: Checkpoint => c }
-      assert(checkpoints.size == 1, s"Expected one Checkpoint action at v3, got: $v3Actions")
-      assert(!v3Actions.exists(_.isInstanceOf[AddFile]), "v3 carries no user AddFile.")
-      // The Checkpoint describes state as of v2 (the version whose maintenance it fulfills).
-      assert(checkpoints.head.version == 2,
-        s"Checkpoint must describe state as of v2; got ${checkpoints.head.version}")
-
-      // The Checkpoint's contentRoot points at the on-disk root file.
-      val rootName = new File(checkpoints.head.contentRoot.path).getName
-      assert(isRootFileName(rootName),
-        s"contentRoot must point at a root manifest file; got ${checkpoints.head.contentRoot.path}")
-      assert(rootFiles(path).exists(_.getName == rootName))
-    }
+    // The emitted tree must reconstruct exactly the table's live files.
+    assertReconstructsLiveFileSet(context)
   }
 
   test("manifest pointers are stored relative to the table root") {
@@ -98,11 +82,12 @@ class AMTCheckpointWriteSuite extends AMTCheckpointTestBase {
       assert(isRootFileName(new File(rootPointer).getName))
 
       // Every leaf pointer stored in the root manifest is likewise table-root-relative.
-      val rootDf = spark.read.parquet(new File(new File(tablePath(name),
-        FileNames.AMT_METADATA_DIR_NAME), new File(rootPointer).getName).toString)
-      val leafLocations = rootDf
-        .where(col("content_type") === AMTSingleAction.ContentType.Type.DataManifest)
-        .select("location").as[String].collect().toSeq
+      val leafLocations = {
+        spark.read.parquet(new File(new File(tablePath(name),
+          FileNames.AMT_METADATA_DIR_NAME), new File(rootPointer).getName).toString)
+          .where(col("content_type") === AMTSingleAction.ContentType.Type.DataManifest)
+          .select("location").as[String].collect().toSeq
+      }
       // The clustered writer decides leaf count by partitioning, so assert at least one leaf
       // pointer rather than an exact count; every pointer must be table-root-relative.
       assert(leafLocations.nonEmpty, s"Expected at least one leaf pointer, got $leafLocations")
@@ -255,7 +240,7 @@ class AMTCheckpointWriteSuite extends AMTCheckpointTestBase {
       val path = tablePath(name)
       assert(rootFiles(path).isEmpty && leafFiles(path).isEmpty,
         "No AMT artifacts on a vanilla table.")
-      assert(checkpointsAt(deltaLog, 2).isEmpty, "No Checkpoint action on a vanilla table.")
+      assert(checkpointAt(deltaLog, 2).isEmpty, "No Checkpoint action on a vanilla table.")
       assert(amtProvider(deltaLog.update()).isEmpty)
     }
   }
@@ -267,119 +252,26 @@ class AMTCheckpointWriteSuite extends AMTCheckpointTestBase {
       sql(s"INSERT INTO $name VALUES (1)") // v1: 1 % 10 != 0.
 
       val deltaLog = deltaLogForName(name)
-      assert(checkpointsAt(deltaLog, 1).isEmpty, "v1 is not an interval boundary; no emission.")
+      assert(checkpointAt(deltaLog, 1).isEmpty, "v1 is not an interval boundary; no emission.")
       assert(rootFiles(tablePath(name)).isEmpty,
         "No manifest tree written off an interval boundary.")
       assert(amtProvider(deltaLog.update()).isEmpty)
     }
   }
 
-  test("leaf cardinality respects AMT_ENTRIES_PER_LEAF") {
-    withTable("amt_entries_per_leaf") {
-      val name = "amt_entries_per_leaf"
-      // Interval far away so no automatic checkpoint fires; we drive the rewrite directly. With no
-      // prior AMT tree, the rewrite clusters the live files across ceil(numFiles / entriesPerLeaf)
-      // leaves, distributing them by hash. The clustered path does not guarantee a leaf per
-      // contiguous group, but it targets exactly that many leaves and drops empty partitions -- so
-      // with enough files per leaf that no hash bucket comes out empty, the leaf count lands on the
-      // target. 21 files at 7 per leaf targets 3 leaves, and 21 paths spread across 3 buckets leave
-      // none empty.
-      createAMTTable(name, checkpointInterval = 100)
-      // One commit of 21 rows, one row per file (maxRecordsPerFile = 1), so a single INSERT lands
-      // 21 live data files. optimizeWrite is disabled so it does not coalesce them back.
-      withSQLConf(
-          "spark.sql.files.maxRecordsPerFile" -> "1",
-          DeltaSQLConf.DELTA_OPTIMIZE_WRITE_ENABLED.key -> "false") {
-        sql(s"INSERT INTO $name SELECT * FROM range(21)")
-      }
-      val deltaLog = deltaLogForName(name)
-      assert(deltaLog.update().allFiles.count() == 21,
-        s"Expected 21 live files, got ${deltaLog.update().allFiles.count()}.")
-
-      withSQLConf(DeltaSQLConf.AMT_ENTRIES_PER_LEAF.key -> "7") {
-        runIncrementalRewrite(name)
-      }
-      val path = tablePath(name)
-      // 21 live AddFiles, ceil(21 / 7) = 3 leaves (none empty), one root.
-      assert(leafFiles(path).size == 3, s"Expected 3 leaves, got ${leafFiles(path).size}.")
-      assert(rootFiles(path).size == 1)
-    }
-  }
-
-  /**
-   * Rewrites the whole manifest tree of `tableName` from scratch (the OPTIMIZE-checkpoint write
-   * path) and returns the write result plus the read snapshot it rewrote. `incremental` selects the
-   * driver-side incremental path (packs live files into leaves in input order) vs. the clustered
-   * full-rewrite path (repartitions the live files across executors).
-   */
-  private def runRewrite(
-      tableName: String, incremental: Boolean): (AMTWriteResult, Snapshot) = {
-    val triggerName =
-      if (incremental) AMTTriggerMode.CheckpointIntervalIncremental.name
-      else AMTTriggerMode.CheckpointIntervalFull.name
-    val snapshot = deltaLogForName(tableName).update()
-    val op = DeltaOperations.OptimizeCheckpoint(
-      incremental = incremental, triggerName = triggerName)
-    val manager = new AMTWriterManager(snapshot, op)
-    val txnInfo = new CurrentTransactionInfo(
-      txnId = "txn",
-      readPredicates = Vector.empty,
-      readFiles = Set.empty,
-      readWholeTable = false,
-      readAppIds = Set.empty,
-      metadata = snapshot.metadata,
-      protocol = snapshot.protocol,
-      actions = Seq.empty,
-      readSnapshot = snapshot,
-      commitInfo = None,
-      readRowIdHighWatermark = 0L,
-      catalogTable = None,
-      domainMetadata = Seq.empty,
-      op = op)
-    val result = manager.writeAMT(
-      commitVersion = snapshot.version + 1,
-      currentTransactionInfo = txnInfo,
-      preCommitLogSegment = snapshot.logSegment)
-    assert(result.isDefined, "A rewrite must emit a manifest tree.")
-    (result.get, snapshot)
-  }
-
-  /** Drives the clustered full-rewrite (OPTIMIZE-checkpoint) write path. */
-  private def runFullRewrite(tableName: String): (AMTWriteResult, Snapshot) =
-    runRewrite(tableName, incremental = false)
-
-  /** Drives the driver-side incremental (OPTIMIZE-checkpoint) write path. */
-  private def runIncrementalRewrite(tableName: String): (AMTWriteResult, Snapshot) =
-    runRewrite(tableName, incremental = true)
-
-  test("full rewrite reconstructs identical table state") {
-    withTable("amt_full_rewrite") {
-      val name = "amt_full_rewrite"
-      createAMTTable(name, checkpointInterval = 100) // Interval far away: no incremental emission.
-      sql(s"INSERT INTO $name VALUES (1)") // v1
-      sql(s"INSERT INTO $name VALUES (2)") // v2
-      sql(s"INSERT INTO $name VALUES (3)") // v3 -- 3 live files.
-
-      // Small leaf size so the rewrite splits the files across multiple leaves.
-      withSQLConf(DeltaSQLConf.AMT_ENTRIES_PER_LEAF.key -> "2") {
-        val (result, snapshot) = runFullRewrite(name)
-        val before = snapshot.allFiles.collect().map(_.path).toSet
-
-        // One root, at least one leaf, and the rewritten tree reconstructs the same file set.
-        val provider =
-          AMTCheckpointProvider.fromCheckpoint(spark, deltaLogForName(name), result.checkpoint)
-        assert(rootFiles(tablePath(name)).size == 1)
-        assert(provider.leaves.nonEmpty)
-        val reconstructed = provider
-          .loadActionsForStateReconstruction(spark, deltaLogForName(name)).get
-          .where(col("add").isNotNull)
-          .select("add.path")
-          .collect()
-          .map(_.getString(0))
-          .toSet
-        assert(reconstructed == before, s"File set changed: before=$before after=$reconstructed")
-      }
-    }
+  testAcrossAMTCheckpointScenarios(
+      "leaf cardinality respects AMT_ENTRIES_PER_LEAF",
+      "amt_entries_per_leaf",
+      sqlConfs = Seq(DeltaSQLConf.AMT_ENTRIES_PER_LEAF.key -> "7"))(
+      setup = name => appendRowsAsSeparateFiles(name, 20),
+      inlineCheckpointTriggerActionsOrSQL = Some(name => Right(
+        s"INSERT INTO $name VALUES (20)"))) { context =>
+    assert(context.postCheckpointSnapshot.allFiles.count() == 21,
+      s"Expected 21 live files, got ${context.postCheckpointSnapshot.allFiles.count()}.")
+    assert(context.provider.leaves.size == 3,
+      s"21 files at entriesPerLeaf=7 must pack into 3 leaves; got ${context.provider.leaves.size}.")
+    assert(context.provider.leaves.forall(_.record_count <= 7),
+      s"Every leaf must respect entriesPerLeaf=7: ${context.provider.leaves}")
   }
 
   /** Parses the `delta.commit.stats` [[CommitStats]] logged for `version`, or fails. */

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotDiscoverySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotDiscoverySuite.scala
@@ -16,8 +16,6 @@
 
 package org.apache.spark.sql.delta.amt
 
-import org.apache.spark.sql.delta.Snapshot
-import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.FileNames
 
 class AMTSnapshotDiscoverySuite extends AMTCheckpointTestBase {
@@ -34,83 +32,37 @@ class AMTSnapshotDiscoverySuite extends AMTCheckpointTestBase {
   // Post commit snapshot
   ///////////////////////////
 
-  test("emission installs an AMTCheckpointProvider on the post-commit snapshot") {
-    withTable("amt_provider_install") {
-      val name = "amt_provider_install"
-      createAMTTable(name, checkpointInterval = 2)
-      sql(s"INSERT INTO $name VALUES (1)")
-      sql(s"INSERT INTO $name VALUES (2)") // v2: interval boundary.
-      // The first AMT is always a deferred follow-up OPTIMIZE CHECKPOINT commit: it lands at v3
-      // describing state as of v2 (the first, full AMT can never be inline).
-      val checkpointVersion = 2L
-      val snapshotVersion = 3L
-
-      val deltaLog = deltaLogForName(name)
-      val snapshot = deltaLog.unsafeVolatileSnapshot
-      assert(snapshot.version == snapshotVersion)
-      val provider = amtProvider(snapshot)
-      assert(provider.isDefined, "Post-emission snapshot must expose an AMTCheckpointProvider.")
-      assert(provider.get.checkpointVersion == checkpointVersion)
-      assert(provider.get.checkpointAction.contentRoot.path ==
-        checkpointsAt(deltaLog, snapshotVersion).head.contentRoot.path)
-      assert(provider.get.leaves.nonEmpty, "Provider must list the tree's leaves.")
-
-      // Now that a full AMT exists, force an inline AMT commit and assert the provider installs
-      // from that business commit itself (no follow-up commit). Threshold 1 makes v4 inline.
-      withSQLConf(
-          DeltaSQLConf.AMT_LARGE_COMMIT_ACTIONS_COUNT_THRESHOLD_FOR_INLINE_MANIFEST_COMMIT.key
-            -> "1") {
-        sql(s"INSERT INTO $name VALUES (3)") // v4: inline AMT, no follow-up.
-      }
-      val inlineSnapshot = deltaLog.unsafeVolatileSnapshot
-      assert(inlineSnapshot.version == 4L, "The inline AMT rides in the v4 business commit.")
-      val inlineProvider = amtProvider(inlineSnapshot).getOrElse(
-        fail("The inline-emission snapshot must expose an AMTCheckpointProvider."))
-      assert(inlineProvider.checkpointVersion == 4L, "The inline Checkpoint describes v4.")
-      assert(inlineProvider.checkpointAction.contentRoot.path ==
-        checkpointsAt(deltaLog, 4L).head.contentRoot.path)
-      assert(inlineProvider.leaves.nonEmpty, "Provider must list the tree's leaves.")
-    }
+  testAcrossAMTCheckpointScenarios(
+      "emission installs an AMTCheckpointProvider on the post-commit snapshot",
+      "amt_provider_install")(
+      setup = name => sql(s"INSERT INTO $name VALUES (1)"),
+      inlineCheckpointTriggerActionsOrSQL = Some(name => Right(
+        s"INSERT INTO $name VALUES (2)"))) { context =>
+    // The harness checks the provider on the snapshot it re-read from the log. This test covers the
+    // post-commit path specifically: the emission must install the provider on the in-memory
+    // `unsafeVolatileSnapshot` the commit produced, without waiting for a fresh log read.
+    val postCommit = context.postCheckpointSnapshot.deltaLog.unsafeVolatileSnapshot
+    assert(postCommit.version == context.manifestCommitVersion,
+      s"The post-commit snapshot must be at v${context.manifestCommitVersion}; " +
+        s"got v${postCommit.version}.")
+    val provider = amtProvider(postCommit).getOrElse(
+      fail("The post-commit snapshot must expose an AMTCheckpointProvider."))
+    assert(provider.checkpointVersion == context.checkpoint.version,
+      s"The provider must describe v${context.checkpoint.version}; " +
+        s"got v${provider.checkpointVersion}.")
+    assert(provider.checkpointAction.contentRoot.path == context.checkpoint.contentRoot.path,
+      "The provider must point at the emitted checkpoint's root manifest.")
   }
 
-  test("an emitted AMT installs the provider and trims the log segment") {
-    withTable("amt_log_segment") {
-      val name = "amt_log_segment"
-      createAMTTable(name, checkpointInterval = 3)
-      // The interval boundary is v3; the first AMT is a deferred follow-up OPTIMIZE CHECKPOINT
-      // commit at v4 describing state as of v3, and the log segment trims to deltas after v3.
-      (1 to 3).foreach(i => sql(s"INSERT INTO $name VALUES ($i)"))
-      val checkpointVersion = 3L
-      val snapshotVersion = 4L
-
-      val deltaLog = deltaLogForName(name)
-      val snapshot = deltaLog.unsafeVolatileSnapshot
-      assert(snapshot.version == snapshotVersion)
-      val provider = amtProvider(snapshot).getOrElse(
-        fail("The post-emission snapshot must expose an AMTCheckpointProvider."))
-      assert(provider.checkpointVersion == checkpointVersion,
-        "The Checkpoint describes state as of v3.")
-      // The log segment keeps only deltas strictly after the checkpoint version (v3).
-      val segmentDeltaVersions = snapshot.logSegment.deltas.map(f => FileNames.deltaVersion(f))
-      assert(segmentDeltaVersions.forall(_ > checkpointVersion),
-        s"Log segment must trim deltas up to the checkpoint version; got $segmentDeltaVersions.")
-
-      // Now that a full AMT exists, force an inline AMT commit and assert the same install + trim
-      // behavior when the Checkpoint rides in the business commit. Threshold 1 makes v5 inline.
-      withSQLConf(
-          DeltaSQLConf.AMT_LARGE_COMMIT_ACTIONS_COUNT_THRESHOLD_FOR_INLINE_MANIFEST_COMMIT.key
-            -> "1") {
-        sql(s"INSERT INTO $name VALUES (4)") // v5: inline AMT, no follow-up.
-      }
-      val inlineSnapshot = deltaLog.unsafeVolatileSnapshot
-      assert(inlineSnapshot.version == 5L, "The inline AMT rides in the v5 business commit.")
-      val inlineProvider = amtProvider(inlineSnapshot).getOrElse(
-        fail("The inline-emission snapshot must expose an AMTCheckpointProvider."))
-      assert(inlineProvider.checkpointVersion == 5L, "The inline Checkpoint describes v5.")
-      val inlineDeltaVersions = inlineSnapshot.logSegment.deltas.map(f => FileNames.deltaVersion(f))
-      assert(inlineDeltaVersions.forall(_ > 5L),
-        s"Log segment must trim deltas up to the inline checkpoint version; got " +
-          s"$inlineDeltaVersions.")
-    }
+  testAcrossAMTCheckpointScenarios(
+      "an emitted AMT installs the provider and trims the log segment",
+      "amt_log_segment")(
+      setup = name => (1 to 2).foreach(i => sql(s"INSERT INTO $name VALUES ($i)")),
+      inlineCheckpointTriggerActionsOrSQL = Some(name => Right(
+        s"INSERT INTO $name VALUES (3)"))) { context =>
+    val segmentDeltaVersions =
+      context.postCheckpointSnapshot.logSegment.deltas.map(f => FileNames.deltaVersion(f))
+    assert(segmentDeltaVersions.forall(_ > context.checkpoint.version),
+      s"Log segment must trim deltas up to the checkpoint version; got $segmentDeltaVersions.")
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotSuite.scala
@@ -34,188 +34,196 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
 
   import testImplicits._
 
+  /**
+   * A manifest deletion vector addresses entries by their position inside a leaf, so these tests
+   * need the checkpointed entries to live in leaves rather than stay resident in the root. The
+   * incremental writer only spills live adds into a leaf once the root would exceed
+   * `entriesPerLeaf`, and the default (50000) never trips for these small tables. A cap of one
+   * entry per leaf forces every live add into a leaf under every scenario.
+   */
+  private val mdvLeafResidentConfs = Seq(DeltaSQLConf.AMT_ENTRIES_PER_LEAF.key -> "1")
+
   ///////////////////////////
   // Post commit snapshot
   ///////////////////////////
 
-  testInlineAndDeferred("snapshot.allFiles reflects a DELETE on the checkpoint boundary") {
-    _ =>
-    withTable("amt_delete_boundary") {
-      val name = "amt_delete_boundary"
-      // Interval 1 so every commit is a boundary; combined with inline mode this makes the last
-      // DML AMT-backed in both modes regardless of the follow-up commit's version bookkeeping.
-      createAMTTable(name, checkpointInterval = 1)
-      sql(s"INSERT INTO $name VALUES (1)")
-      sql(s"INSERT INTO $name VALUES (2)")
-      sql(s"INSERT INTO $name VALUES (3)")
-      sql(s"DELETE FROM $name WHERE id = 1") // removes id=1; triggers an AMT (inline or follow-up).
-
-      val snapshot = deltaLogForName(name).unsafeVolatileSnapshot
-      assert(amtProvider(snapshot).isDefined,
-        "The post-DELETE snapshot must be AMT-backed.")
-      // allFiles must reflect the DELETE: the removed file is gone from the post-commit live set.
-      checkAnswer(spark.read.table(name), Seq(Row(2), Row(3)))
-      // The manifest tree captures exactly the post-DELETE live files: a full rewrite drops the
-      // removed entry outright, while an incremental rewrite masks it (MDV on a carried leaf, or a
-      // root tombstone). Either way, the tree's live entry count -- across root and leaves -- must
-      // match snapshot.allFiles.
-      assert(currentLiveDataEntries(snapshot) == snapshot.allFiles.count(),
-        "Live tree DATA entries must equal the post-commit live file count.")
-    }
+  testAcrossAMTCheckpointScenarios(
+      "snapshot.allFiles reflects a DELETE on the checkpoint boundary",
+      "amt_delete_boundary")(
+      setup = name => (1 to 3).foreach(i => sql(s"INSERT INTO $name VALUES ($i)")),
+      inlineCheckpointTriggerActionsOrSQL = Some(name => Right(
+        s"DELETE FROM $name WHERE id = 1"))) { context =>
+    // allFiles must reflect the DELETE: the removed file is gone from the post-commit live set.
+    checkAnswer(spark.read.table(context.tableName), Seq(Row(2), Row(3)))
+    // The manifest tree captures exactly the post-DELETE live files (computePostCommitState applied
+    // the RemoveFile), i.e. it matches snapshot.allFiles.
+    assertReconstructsLiveFileSet(context)
   }
 
-  testInlineAndDeferred(
-      "snapshot.allFiles matches leaves across insert/overwrite/delete before a checkpoint") { _ =>
-    withTable("amt_overwrite") {
-      val name = "amt_overwrite"
-      // Interval 1 so the final DELETE triggers an AMT in both modes.
-      createAMTTable(name, checkpointInterval = 1)
-      sql(s"INSERT INTO $name VALUES (1)")
-      sql(s"INSERT INTO $name VALUES (2)")
-      sql(s"INSERT OVERWRITE $name VALUES (10), (20)") // replaces all prior files.
-      sql(s"DELETE FROM $name WHERE id = 10")          // removes one; triggers an AMT.
-
-      val snapshot = deltaLogForName(name).unsafeVolatileSnapshot
-      assert(amtProvider(snapshot).isDefined)
-      checkAnswer(spark.read.table(name), Seq(Row(20)))
-      assert(snapshot.allFiles.count() == 1, "Only the surviving overwrite file should be live.")
-      assert(currentLiveDataEntries(snapshot) == 1,
-        "The tree must capture exactly the surviving live file after overwrite + delete.")
-    }
+  testAcrossAMTCheckpointScenarios(
+      "snapshot.allFiles matches leaves across insert/overwrite/delete before a checkpoint",
+      "amt_overwrite")(
+      setup = name => {
+        sql(s"INSERT INTO $name VALUES (1)")
+        sql(s"INSERT INTO $name VALUES (2)")
+        sql(s"INSERT OVERWRITE $name VALUES (10), (20)")
+      },
+      inlineCheckpointTriggerActionsOrSQL = Some(name => Right(
+        s"DELETE FROM $name WHERE id = 10"))) { context =>
+    // The overwrite drops the files for 1 and 2; the DELETE then drops id=10, leaving only id=20.
+    checkAnswer(spark.read.table(context.tableName), Seq(Row(20)))
+    assert(context.postCheckpointSnapshot.allFiles.count() == 1,
+      "Only the surviving overwrite file should be live.")
+    // The tree must capture exactly the surviving live files after overwrite + delete.
+    assertReconstructsLiveFileSet(context)
   }
 
-  testInlineAndDeferred(
-      "filtered scan is correct after emission (trimmed deltas + leaves)") { _ =>
-    withTable("amt_filtered_scan") {
-      val name = "amt_filtered_scan"
-      createAMTTable(name, checkpointInterval = 1)
-      sql(s"INSERT INTO $name VALUES (1)")
-      sql(s"INSERT INTO $name VALUES (2)")
-      sql(s"INSERT INTO $name VALUES (3)")
-      sql(s"DELETE FROM $name WHERE id = 1") // removes id=1; triggers an AMT.
-
-      // SQL data-skipping reconstruction is disabled for AMT tables, so reads go through the
-      // allFiles-based reconstruction: the leaves supply state up to the checkpoint and the
-      // trimmed deltas supply the rest. Each row must appear exactly once -- a double-count would
-      // surface as duplicate rows or wrong counts.
-      checkAnswer(spark.read.table(name).filter("id >= 2"), Seq(Row(2), Row(3)))
-      checkAnswer(
-        spark.read.table(name).groupBy().count(), Seq(Row(2L)))
-      checkAnswer(spark.read.table(name), Seq(Row(2), Row(3)))
-    }
+  testAcrossAMTCheckpointScenarios(
+      "filtered scan is correct after emission (trimmed deltas + leaves)",
+      "amt_filtered_scan")(
+      setup = name => (1 to 3).foreach(i => sql(s"INSERT INTO $name VALUES ($i)")),
+      inlineCheckpointTriggerActionsOrSQL = Some(name => Right(
+        s"DELETE FROM $name WHERE id = 1"))) { context =>
+    // SQL data-skipping reconstruction is disabled for AMT tables, so reads go through the
+    // allFiles-based reconstruction: the leaves supply state up to the checkpoint and the
+    // trimmed deltas supply the rest. Each row must appear exactly once -- a double-count would
+    // surface as duplicate rows or wrong counts.
+    val table = spark.read.table(context.tableName)
+    val expectedRows = Seq(Row(2), Row(3))
+    checkAnswer(table.filter("id >= 2"), expectedRows)
+    checkAnswer(
+      table.groupBy().count(), Seq(Row(expectedRows.size.toLong)))
+    checkAnswer(table, expectedRows)
   }
 
-  test("deletion vector round-trips through the leaves with a matching uniqueId") {
-    withTable("amt_dv") {
-      val name = "amt_dv"
-      // Interval 1 so the DV commit triggers an AMT (via its follow-up OPTIMIZE CHECKPOINT commit).
-      createAMTTable(name, checkpointInterval = 1)
-      Seq(1, 2).toDF("id").coalesce(1)
-        .write.mode("append").insertInto(name) // one file, two rows.
-
-      // Attach a persistent DV directly rather than relying on DELETE's DV-vs-rewrite heuristic:
-      // write a DV marking row 0 deleted and commit the resulting AddFile (with DV) + RemoveFile.
-      val log = deltaLogForName(name)
-      val fileToDv = log.unsafeVolatileSnapshot.allFiles.collect()
-      assert(fileToDv.length == 1, "The two rows must land in a single file.")
-      val dvActions = writeFileWithDVOnDisk(log, fileToDv.head, RoaringBitmapArray(0L))
-      // Disable history metrics: this is a manual commit, not a real DELETE command, so the
-      // operation-metrics (e.g. numDeletedRows) the Delete op expects are not populated.
-      withSQLConf(DeltaSQLConf.DELTA_HISTORY_METRICS_ENABLED.key -> "false") {
+  testAcrossAMTCheckpointScenarios(
+      "deletion vector round-trips through the leaves with a matching uniqueId",
+      "amt_dv",
+      sqlConfs = Seq(DeltaSQLConf.DELTA_HISTORY_METRICS_ENABLED.key -> "false"))(
+      setup = name => {
+        Seq(1, 2).toDF("id").coalesce(1)
+          .write.mode("append").insertInto(name) // one file, two rows.
+        // Attach a persistent DV directly rather than relying on DELETE's rewrite heuristic.
+        val log = deltaLogForName(name)
+        val fileToDv = log.unsafeVolatileSnapshot.allFiles.collect()
+        assert(fileToDv.length == 1, "The two rows must land in a single file.")
+        val dvActions = writeFileWithDVOnDisk(log, fileToDv.head, RoaringBitmapArray(0L))
         log.startTransaction().commit(dvActions, DeltaOperations.Delete(predicate = Seq.empty))
-      }
+      }) { context =>
+    val snapshot = context.postCheckpointSnapshot
+    val provider = context.provider
+    checkAnswer(spark.read.table(context.tableName), Seq(Row(2)))
 
-      val snapshot = deltaLogForName(name).unsafeVolatileSnapshot
-      val provider = amtProvider(snapshot).getOrElse(fail("expected AMTCheckpointProvider"))
-      checkAnswer(spark.read.table(name), Seq(Row(2)))
+    // The one surviving live file must carry a deletion vector in committed state.
+    val committed = snapshot.allFiles.collect()
+    assert(committed.length == 1)
+    val committedFile = committed.head
+    val committedDv = committedFile.deletionVector
+    assert(committedDv != null, "The committed file must carry a deletion vector.")
+    // Two physical rows, one deleted by the DV -> one logical row.
+    assert(committedFile.numPhysicalRecords.contains(2L))
+    assert(committedFile.numLogicalRecords.contains(1L))
 
-      // The one surviving live file must carry a deletion vector in committed state.
-      val committed = snapshot.allFiles.collect()
-      assert(committed.length == 1)
-      val committedFile = committed.head
-      val committedDv = committedFile.deletionVector
-      assert(committedDv != null, "The committed file must carry a deletion vector.")
-      // Two physical rows, one deleted by the DV -> one logical row.
-      assert(committedFile.numPhysicalRecords.contains(2L))
-      assert(committedFile.numLogicalRecords.contains(1L))
+    // The leaf-reconstructed AddFile must recover a DV with the SAME uniqueId, so the
+    // (path, deletionVectorUniqueId) dedup key matches the committed file exactly (no
+    // double-count in the reader path). uniqueId is
+    // storageType + pathOrInlineDv (+ "@offset"), so compare it from the reconstructed fields.
+    val dvRow = provider
+      .loadActionsForStateReconstruction(spark, snapshot.deltaLog)
+      .getOrElse(fail("AMT provider must contribute leaf-derived file actions."))
+      .where("add is not null and add.deletionVector is not null")
+      .selectExpr("add.deletionVector.storageType", "add.deletionVector.pathOrInlineDv",
+        "add.deletionVector.offset")
+      .collect()
+    assert(dvRow.length == 1, "Exactly one leaf DATA entry must carry a DV.")
+    val reconstructedDv = DeletionVectorDescriptor(
+      storageType = dvRow.head.getString(0),
+      pathOrInlineDv = dvRow.head.getString(1),
+      offset = Option(dvRow.head.get(2)).map(_ => dvRow.head.getInt(2)),
+      sizeInBytes = committedDv.sizeInBytes,
+      cardinality = committedDv.cardinality)
+    assert(reconstructedDv.uniqueId == committedDv.uniqueId,
+      s"Reconstructed DV uniqueId ${reconstructedDv.uniqueId} must equal committed " +
+        s"${committedDv.uniqueId}.")
 
-      // The leaf-reconstructed AddFile must recover a DV with the SAME uniqueId, so the
-      // (path, deletionVectorUniqueId) dedup key matches the committed file exactly (no
-      // double-count in the reader path). uniqueId is
-      // storageType + pathOrInlineDv (+ "@offset"), so compare it from the reconstructed fields.
-      val dvRow = provider
-        .loadActionsForStateReconstruction(spark, snapshot.deltaLog)
-        .getOrElse(fail("AMT provider must contribute leaf-derived file actions."))
-        .where("add is not null and add.deletionVector is not null")
-        .selectExpr("add.deletionVector.storageType", "add.deletionVector.pathOrInlineDv",
-          "add.deletionVector.offset")
-        .collect()
-      assert(dvRow.length == 1, "Exactly one leaf DATA entry must carry a DV.")
-      val reconstructedDv = DeletionVectorDescriptor(
-        storageType = dvRow.head.getString(0),
-        pathOrInlineDv = dvRow.head.getString(1),
-        offset = Option(dvRow.head.get(2)).map(_ => dvRow.head.getInt(2)),
-        sizeInBytes = committedDv.sizeInBytes,
-        cardinality = committedDv.cardinality)
-      assert(reconstructedDv.uniqueId == committedDv.uniqueId,
-        s"Reconstructed DV uniqueId ${reconstructedDv.uniqueId} must equal committed " +
-          s"${committedDv.uniqueId}.")
-
-      // The leaf-reconstructed AddFile must recover the same physical/logical record counts as the
-      // committed file: `numRecords` in stats is the physical count, so it must round-trip without
-      // being off by the DV cardinality.
-      import org.apache.spark.sql.delta.implicits._
-      val reconstructed = provider
-        .loadActionsForStateReconstruction(spark, snapshot.deltaLog)
-        .getOrElse(fail("AMT provider must contribute leaf-derived file actions."))
-        .where("add is not null")
-        .select("add.*")
-        .as[AddFile]
-        .collect()
-      assert(reconstructed.length == 1)
-      assert(reconstructed.head.numPhysicalRecords.contains(2L),
-        "Reconstructed physical record count must match the committed file.")
-      assert(reconstructed.head.numLogicalRecords.contains(1L),
-        "Reconstructed logical record count must match the committed file.")
-    }
+    // The leaf-reconstructed AddFile must recover the same physical/logical record counts as the
+    // committed file: `numRecords` in stats is the physical count, so it must round-trip without
+    // being off by the DV cardinality.
+    import org.apache.spark.sql.delta.implicits._
+    val reconstructed = provider
+      .loadActionsForStateReconstruction(spark, snapshot.deltaLog)
+      .getOrElse(fail("AMT provider must contribute leaf-derived file actions."))
+      .where("add is not null")
+      .select("add.*")
+      .as[AddFile]
+      .collect()
+    assert(reconstructed.length == 1)
+    assert(reconstructed.head.numPhysicalRecords.contains(2L),
+      "Reconstructed physical record count must match the committed file.")
+    assert(reconstructed.head.numLogicalRecords.contains(1L),
+      "Reconstructed logical record count must match the committed file.")
   }
 
-  test("distributed reconstruction reads across multiple leaves via a file scan") {
-    withTable("amt_dist_multileaf") {
-      val name = "amt_dist_multileaf"
-      val provider = withSQLConf(DeltaSQLConf.AMT_ENTRIES_PER_LEAF.key -> "10") {
-        createAMTTable(name, checkpointInterval = 2)
-        appendRowsAsSeparateFiles(name, 30) // v1: ids 0..29.
-        appendRowsAsSeparateFiles(name, 30, startId = 30) // v2: ids 30..59; emits full tree at v3.
-        amtProvider(deltaLogForName(name).update())
-          .getOrElse(fail("The interval-boundary append must trigger an AMT-backed snapshot."))
-      }
-      assert(provider.leaves.size == 6,
-        s"entriesPerLeaf=10 with 60 files must pack into 6 leaves; got ${provider.leaves.size}.")
-      val snapshot = deltaLogForName(name).update()
-      checkAnswer(spark.read.table(name), (0 until 60).map(Row(_)))
-      val committedPaths = snapshot.allFiles.select("path").as[String].collect().toSet
-      assert(committedPaths.size == 60)
-      val df = provider.loadActionsForStateReconstruction(spark, snapshot.deltaLog)
-        .getOrElse(fail("AMT provider must contribute leaf-derived actions."))
+  testAcrossAMTCheckpointScenarios(
+      "distributed reconstruction returns every action exactly once",
+      "amt_dist_reconstruction",
+      sqlConfs = Seq(DeltaSQLConf.AMT_ENTRIES_PER_LEAF.key -> "10"))(
+      setup = name => {
+        appendRowsAsSeparateFiles(name, 30) // ids 0..29, one file each.
+        appendRowsAsSeparateFiles(name, 29, startId = 30) // ids 30..58, one file each.
+      },
+      inlineCheckpointTriggerActionsOrSQL = Some(name => Right(
+        s"INSERT INTO $name VALUES (59)"))) { context =>
+    val snapshot = context.postCheckpointSnapshot
+    val provider = context.provider
+    // `setup` accumulates ids 0..58 over two commits and the trigger commit adds id 59, so the
+    // checkpointed tree is built from files that arrived across several commits.
+    val expectedRows = 0 until 60
+    checkAnswer(spark.read.table(context.tableName), expectedRows.map(Row(_)))
+    val committedPaths = snapshot.allFiles.select("path").as[String].collect().toSet
+    assert(committedPaths.size == expectedRows.size)
+    // 60 live files at ten entries per leaf must pack into exactly six leaves.
+    assert(provider.leaves.size == 6,
+      s"60 files at entriesPerLeaf=10 must pack into 6 leaves; got ${provider.leaves.size}.")
+    val df = provider.loadActionsForStateReconstruction(spark, snapshot.deltaLog)
+      .getOrElse(fail("AMT provider must contribute leaf-derived actions."))
 
-      // The leaves must be read through a distributed parquet scan, not a driver-side collected
-      // LocalRelation.
-      val hasFileScan = df.queryExecution.optimizedPlan.collectFirst {
-        case l: LogicalRelation => l
-      }.isDefined
-      assert(hasFileScan,
-        "Reconstruction must read the leaves through a distributed file scan, " +
-          "not collect them to the driver.")
+    // The leaves must be read through a distributed parquet scan, not a driver-side collected
+    // LocalRelation.
+    val hasFileScan = df.queryExecution.optimizedPlan.collectFirst {
+      case l: LogicalRelation => l
+    }.isDefined
+    assert(hasFileScan,
+      "Reconstruction must read the leaves through a distributed file scan, " +
+        "not collect them to the driver.")
 
-      val addPaths = df.where("add is not null").select("add.path").as[String].collect().toSet
-      assert(addPaths == committedPaths,
-        "Reconstruction must surface every leaf entry exactly once across leaves.")
-      assert(df.where("protocol.minReaderVersion is not null").count() == 1,
-        "Reconstruction must carry the inline protocol action.")
-      assert(df.where("metaData.id is not null").count() == 1,
-        "Reconstruction must carry the inline metadata action.")
-    }
+    // Every leaf entry must surface exactly once across the leaves, plus the inline protocol and
+    // metadata actions.
+    assertReconstructsLiveFileSet(context)
+    assert(df.where("protocol.minReaderVersion is not null").count() == 1,
+      "Reconstruction must carry the inline protocol action.")
+    assert(df.where("metaData.id is not null").count() == 1,
+      "Reconstruction must carry the inline metadata action.")
+  }
+
+  // The large multi-leaf tree is covered above; this is the small deterministic case, where the
+  // inline incremental writer spills a known number of files into one leaf each.
+  testAcrossAMTCheckpointScenarios(
+      "inline incremental reconstruction reads across multiple leaves via a file scan",
+      "amt_dist_multileaf",
+      deferredScenarios = Seq.empty,
+      sqlConfs = Seq(DeltaSQLConf.AMT_ENTRIES_PER_LEAF.key -> "2"))(
+      setup = name => (1 to 4).foreach(i => sql(s"INSERT INTO $name VALUES ($i)")),
+      inlineCheckpointTriggerActionsOrSQL = Some(name => Right(
+        s"INSERT INTO $name VALUES (5)"))) { context =>
+    assert(context.provider.leaves.size == 3,
+      s"Five files packed two per leaf must produce three leaves: ${context.provider.leaves}")
+    val reconstruction = context.provider
+      .loadActionsForStateReconstruction(spark, context.postCheckpointSnapshot.deltaLog)
+      .getOrElse(fail("AMT provider must contribute leaf-derived actions."))
+    assert(reconstruction.queryExecution.optimizedPlan.collectFirst {
+      case relation: LogicalRelation => relation
+    }.isDefined, "Reconstruction must read leaves through a distributed file scan.")
   }
 
   test("reconstruction surfaces DATA entries that live directly in the root") {
@@ -258,197 +266,196 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
     }
   }
 
-  test("manifest deletion vector drops superseded leaf entries during reconstruction") {
-    withTable("amt_mdv_drop") {
-      val name = "amt_mdv_drop"
-      createAMTTable(name, checkpointInterval = 4)
-      (1 to 4).foreach(i => sql(s"INSERT INTO $name VALUES ($i)")) // v4: emit.
+  testAcrossAMTCheckpointScenarios(
+      "manifest deletion vector drops superseded leaf entries during reconstruction",
+      "amt_mdv_drop",
+      sqlConfs = mdvLeafResidentConfs)(
+      setup = name => (1 to 3).foreach(i => sql(s"INSERT INTO $name VALUES ($i)")),
+      inlineCheckpointTriggerActionsOrSQL = Some(name => Right(
+        s"INSERT INTO $name VALUES (4)"))) { context =>
+    val snapshot = context.postCheckpointSnapshot
+    val base = context.provider
+    val baseCount = snapshot.allFiles.count()
+    assert(baseCount == 4)
 
-      val snapshot = deltaLogForName(name).unsafeVolatileSnapshot
-      val base = amtProvider(snapshot).getOrElse(fail("expected AMTCheckpointProvider"))
-      val baseCount = snapshot.allFiles.count()
-      assert(baseCount == 4)
+    val leaf = base.leaves.head
+    val posToLoc = leafPosToLoc(leaf, base.tableRoot)
+    val deletedPos = posToLoc.keys.min
+    val deletedLoc = posToLoc(deletedPos)
 
-      val leaf = base.leaves.head
-      val posToLoc = leafPosToLoc(leaf, base.tableRoot)
-      val deletedPos = 0L
-      val deletedLoc = posToLoc(deletedPos)
+    // Sanity: without an MDV the distributed reconstruction surfaces every live file.
+    val full = reconstructedPaths(base, snapshot.deltaLog)
+    assert(full.size == baseCount)
+    assert(full.contains(deletedLoc))
 
-      // Sanity: without an MDV the distributed reconstruction surfaces every live file.
-      val full = reconstructedPaths(base, snapshot.deltaLog)
-      assert(full.size == baseCount)
-      assert(full.contains(deletedLoc))
+    // Patch the first leaf's pointer with an MDV marking `deletedPos` deleted, then reconstruct.
+    val patchedLeaves =
+      leaf.copy(manifest_info =
+        leaf.manifest_info.copy(dv = Some(mdvBytesFor(deletedPos)), dv_cardinality = Some(1L))) +:
+        base.leaves.tail
+    val provider =
+      new AMTCheckpointProvider(base.checkpointAction, patchedLeaves, base.tableRoot)
 
-      // Patch the first leaf's pointer with an MDV marking `deletedPos` deleted, then reconstruct.
-      val patchedLeaves =
-        leaf.copy(manifest_info =
-          leaf.manifest_info.copy(dv = Some(mdvBytesFor(deletedPos)), dv_cardinality = Some(1L))) +:
-          base.leaves.tail
-      val provider =
-        new AMTCheckpointProvider(base.checkpointAction, patchedLeaves, base.tableRoot)
-
-      val reconstructed = reconstructedPaths(provider, snapshot.deltaLog)
-      assert(reconstructed.size == baseCount - 1,
-        "The MDV-marked leaf entry must be dropped from the reconstructed live set.")
-      assert(!reconstructed.contains(deletedLoc),
-        "The MDV-marked file must not resurface as a live AddFile.")
-      assert(reconstructed == full - deletedLoc,
-        "Only the MDV-marked entry may be dropped; all other live files must survive.")
-    }
+    val reconstructed = reconstructedPaths(provider, snapshot.deltaLog)
+    assert(reconstructed.size == baseCount - 1,
+      "The MDV-marked leaf entry must be dropped from the reconstructed live set.")
+    assert(!reconstructed.contains(deletedLoc),
+      "The MDV-marked file must not resurface as a live AddFile.")
+    assert(reconstructed == full - deletedLoc,
+      "Only the MDV-marked entry may be dropped; all other live files must survive.")
   }
 
-  test("manifest deletion vectors apply per leaf across a multi-leaf tree") {
-    withTable("amt_mdv_multi") {
-      val name = "amt_mdv_multi"
-      val base = withSQLConf(DeltaSQLConf.AMT_ENTRIES_PER_LEAF.key -> "10") {
-        createAMTTable(name, checkpointInterval = 2)
-        appendRowsAsSeparateFiles(name, 30) // v1: ids 0..29.
-        appendRowsAsSeparateFiles(name, 30, startId = 30) // v2: ids 30..59; emits full tree at v3.
-        amtProvider(deltaLogForName(name).update())
-          .getOrElse(fail("The interval-boundary append must trigger an AMT-backed snapshot."))
-      }
-      assert(base.leaves.size == 6,
-        s"60 files with entriesPerLeaf=10 must pack into 6 leaves; got ${base.leaves.size}.")
-      val deltaLog = deltaLogForName(name)
-      val full = reconstructedPaths(base, deltaLog)
-      assert(full.size == 60)
+  testAcrossAMTCheckpointScenarios(
+      "manifest deletion vectors apply per leaf across a multi-leaf tree",
+      "amt_mdv_multi",
+      sqlConfs = Seq(DeltaSQLConf.AMT_ENTRIES_PER_LEAF.key -> "10"))(
+      setup = name => {
+        appendRowsAsSeparateFiles(name, 30) // ids 0..29, one file each.
+        appendRowsAsSeparateFiles(name, 29, startId = 30) // ids 30..58, one file each.
+      },
+      inlineCheckpointTriggerActionsOrSQL = Some(name => Right(
+        s"INSERT INTO $name VALUES (59)"))) { context =>
+    val base = context.provider
+    assert(base.leaves.size == 6,
+      s"60 files with entriesPerLeaf=10 must pack into 6 leaves; got ${base.leaves.size}.")
+    val deltaLog = context.postCheckpointSnapshot.deltaLog
+    val full = reconstructedPaths(base, deltaLog)
+    assert(full.size == 60)
 
-      // The leaf-local row-index -> entry-location map for each observed leaf.
-      val locs = base.leaves.map(leafPosToLoc(_, base.tableRoot))
-      def withMdv(idx: Int, positions: Seq[Long]): DataManifestEntry = {
-        val leaf = base.leaves(idx)
-        leaf.copy(manifest_info = leaf.manifest_info.copy(
-          dv = Some(mdvBytesFor(positions: _*)), dv_cardinality = Some(positions.size.toLong)))
-      }
-      // Exercise every MDV shape in one tree (positions are leaf-local row indices):
-      //   - one leaf: drop a single position (pos 0),
-      //   - one leaf: drop all its positions (whole leaf),
-      //   - one leaf: drop two positions (its 2nd and 4th, i.e. sorted indices 1 and 3),
-      //   - one leaf: an empty MDV (no-op),
-      //   - the remaining leaves: no MDV.
-      // The clustered rewrite does not guarantee a fixed leaf order/size, so the shapes are bound
-      // to leaves chosen by observed size (largest first); the two-position shape needs >= 4
-      // entries.
-      val bySizeDesc = locs.indices.sortBy(i => -locs(i).size)
-      val twoLeaf = bySizeDesc(0)
-      val wholeLeaf = bySizeDesc(1)
-      val singleLeaf = bySizeDesc(2)
-      val emptyLeaf = bySizeDesc(3)
-      def sortedPos(idx: Int): Seq[Long] = locs(idx).keys.toSeq.sorted
-      assert(sortedPos(twoLeaf).size >= 4,
-        s"the largest leaf must hold >= 4 entries for the two-position MDV; " +
-          s"got ${sortedPos(twoLeaf).size}.")
-      val twoPositions = Seq(sortedPos(twoLeaf)(1), sortedPos(twoLeaf)(3))
-      val patched = base.leaves.zipWithIndex.map { case (leaf, idx) =>
-        idx match {
-          case `twoLeaf` => withMdv(idx, twoPositions)
-          case `wholeLeaf` => withMdv(idx, sortedPos(idx))
-          case `singleLeaf` => withMdv(idx, Seq(sortedPos(idx).head))
-          case `emptyLeaf` => withMdv(idx, Seq.empty)
-          case _ => leaf
-        }
-      }
-      val provider = new AMTCheckpointProvider(base.checkpointAction, patched, base.tableRoot)
-
-      val dropped =
-        twoPositions.map(locs(twoLeaf)).toSet ++
-          locs(wholeLeaf).values.toSet +
-          locs(singleLeaf)(sortedPos(singleLeaf).head)
-      val reconstructed = reconstructedPaths(provider, deltaLog)
-      assert(reconstructed == full -- dropped,
-        "Each MDV must drop exactly its marked positions from its own leaf, and nothing else.")
-      assert(reconstructed.size == full.size - dropped.size)
+    // The leaf-local row-index -> entry-location map for each observed leaf.
+    val locs = base.leaves.map(leafPosToLoc(_, base.tableRoot))
+    def withMdv(idx: Int, positions: Seq[Long]): DataManifestEntry = {
+      val leaf = base.leaves(idx)
+      leaf.copy(manifest_info = leaf.manifest_info.copy(
+        dv = Some(mdvBytesFor(positions: _*)), dv_cardinality = Some(positions.size.toLong)))
     }
+    // Exercise every MDV shape in one tree (positions are leaf-local row indices):
+    //   - one leaf: drop a single position (pos 0),
+    //   - one leaf: drop all its positions (whole leaf),
+    //   - one leaf: drop two positions (its 2nd and 4th, i.e. sorted indices 1 and 3),
+    //   - one leaf: an empty MDV (no-op),
+    //   - the remaining leaves: no MDV.
+    // The clustered rewrite does not guarantee a fixed leaf order/size, so the shapes are bound
+    // to leaves chosen by observed size (largest first); the two-position shape needs >= 4
+    // entries.
+    val bySizeDesc = locs.indices.sortBy(i => -locs(i).size)
+    val twoLeaf = bySizeDesc(0)
+    val wholeLeaf = bySizeDesc(1)
+    val singleLeaf = bySizeDesc(2)
+    val emptyLeaf = bySizeDesc(3)
+    def sortedPos(idx: Int): Seq[Long] = locs(idx).keys.toSeq.sorted
+    assert(sortedPos(twoLeaf).size >= 4,
+      s"the largest leaf must hold >= 4 entries for the two-position MDV; " +
+        s"got ${sortedPos(twoLeaf).size}.")
+    val twoPositions = Seq(sortedPos(twoLeaf)(1), sortedPos(twoLeaf)(3))
+    val patched = base.leaves.zipWithIndex.map { case (leaf, idx) =>
+      idx match {
+        case `twoLeaf` => withMdv(idx, twoPositions)
+        case `wholeLeaf` => withMdv(idx, sortedPos(idx))
+        case `singleLeaf` => withMdv(idx, Seq(sortedPos(idx).head))
+        case `emptyLeaf` => withMdv(idx, Seq.empty)
+        case _ => leaf
+      }
+    }
+    val provider = new AMTCheckpointProvider(base.checkpointAction, patched, base.tableRoot)
+
+    val dropped =
+      twoPositions.map(locs(twoLeaf)).toSet ++
+        locs(wholeLeaf).values.toSet +
+        locs(singleLeaf)(sortedPos(singleLeaf).head)
+    val reconstructed = reconstructedPaths(provider, deltaLog)
+    assert(reconstructed == full -- dropped,
+      "Each MDV must drop exactly its marked positions from its own leaf, and nothing else.")
+    assert(reconstructed.size == full.size - dropped.size)
   }
 
-  test("surviving entries keep their DV and stats when an MDV drops a sibling") {
-    withTable("amt_mdv_sibling") {
-      val name = "amt_mdv_sibling"
-      createAMTTable(name, checkpointInterval = 3)
-      // v1: file A with two physical rows.
-      Seq(1, 2).toDF("id").coalesce(1).write.mode("append").insertInto(name)
-
-      // v2: attach a persistent on-disk DV to A (row 0 deleted). interval=3 -> not an emit yet.
-      val log = deltaLogForName(name)
-      val fileA = log.unsafeVolatileSnapshot.allFiles.collect()
-      assert(fileA.length == 1, "The two rows must land in a single file.")
-      val dvActions = writeFileWithDVOnDisk(log, fileA.head, RoaringBitmapArray(0L))
+  testAcrossAMTCheckpointScenarios(
+      "surviving entries keep their DV and stats when an MDV drops a sibling",
+      "amt_mdv_sibling",
       // We commit the DV actions directly as a `Delete` (rather than running a DELETE command), so
       // the SQL operation metrics a real DELETE would populate are absent. History metrics would
       // call `Delete.transformMetrics`, which requires `numDeletedRows`; it is missing here and
       // would fail with `key not found: numDeletedRows`. Disable history metrics to skip that.
-      withSQLConf(DeltaSQLConf.DELTA_HISTORY_METRICS_ENABLED.key -> "false") {
+      sqlConfs = mdvLeafResidentConfs :+
+        (DeltaSQLConf.DELTA_HISTORY_METRICS_ENABLED.key -> "false"))(
+      setup = name => {
+        // File A with two physical rows, then a persistent on-disk DV marking row 0 deleted.
+        Seq(1, 2).toDF("id").coalesce(1).write.mode("append").insertInto(name)
+        val log = deltaLogForName(name)
+        val fileA = log.unsafeVolatileSnapshot.allFiles.collect()
+        assert(fileA.length == 1, "The two rows must land in a single file.")
+        val dvActions = writeFileWithDVOnDisk(log, fileA.head, RoaringBitmapArray(0L))
         log.startTransaction().commit(dvActions, DeltaOperations.Delete(predicate = Seq.empty))
-      }
-      sql(s"INSERT INTO $name VALUES (3)") // v3: file B hits the interval; triggers emit.
+      },
+      inlineCheckpointTriggerActionsOrSQL = Some(name => Right(
+        s"INSERT INTO $name VALUES (3)"))) { context =>
+    val snapshot = context.postCheckpointSnapshot
+    val base = context.provider
 
-      val snapshot = deltaLogForName(name).unsafeVolatileSnapshot
-      assert(snapshot.version == 4) // v3 triggers emit; v4 materializes the manifest tree.
-      val base = amtProvider(snapshot).getOrElse(fail("expected AMTCheckpointProvider"))
+    // Classify the two reconstructed entries by DV presence, staying entirely within the
+    // reconstruction so path strings are consistent with the leaf `location` values.
+    val fullAdds = base.loadActionsForStateReconstruction(spark, snapshot.deltaLog)
+      .getOrElse(fail("AMT provider must contribute leaf-derived file actions."))
+      .where("add is not null")
+      .selectExpr("add.path", "add.deletionVector.storageType", "add.stats")
+      .collect()
+      .map(r => r.getString(0) -> (Option(r.getString(1)), r.getString(2)))
+      .toMap
+    assert(fullAdds.size == 2)
+    val aPath = fullAdds.collectFirst { case (p, (Some(_), _)) => p }
+      .getOrElse(fail("Expected one reconstructed entry to carry a DV."))
+    val bPath = fullAdds.collectFirst { case (p, (None, _)) => p }
+      .getOrElse(fail("Expected one reconstructed entry without a DV."))
+    val aStats = fullAdds(aPath)._2
 
-      // Classify the two reconstructed entries by DV presence, staying entirely within the
-      // reconstruction so path strings are consistent with the leaf `location` values.
-      val fullAdds = base.loadActionsForStateReconstruction(spark, snapshot.deltaLog)
-        .getOrElse(fail("AMT provider must contribute leaf-derived file actions."))
-        .where("add is not null")
-        .selectExpr("add.path", "add.deletionVector.storageType", "add.stats")
-        .collect()
-        .map(r => r.getString(0) -> (Option(r.getString(1)), r.getString(2)))
-        .toMap
-      assert(fullAdds.size == 2)
-      val aPath = fullAdds.collectFirst { case (p, (Some(_), _)) => p }
-        .getOrElse(fail("Expected one reconstructed entry to carry a DV."))
-      val bPath = fullAdds.collectFirst { case (p, (None, _)) => p }
-        .getOrElse(fail("Expected one reconstructed entry without a DV."))
-      val aStats = fullAdds(aPath)._2
-
-      // Drop B (the DV-less sibling) via an MDV on its leaf; A must survive untouched.
-      val leaf = base.leaves.head
-      assert(base.leaves.size == 1, "Both files should pack into a single leaf here.")
-      val locToPos = leafPosToLoc(leaf, base.tableRoot).map(_.swap)
-      val bPos = locToPos(bPath)
-      val patched = Seq(
-        leaf.copy(manifest_info =
-          leaf.manifest_info.copy(dv = Some(mdvBytesFor(bPos)), dv_cardinality = Some(1L))))
-      val provider = new AMTCheckpointProvider(base.checkpointAction, patched, base.tableRoot)
-
-      val survivors = provider.loadActionsForStateReconstruction(spark, snapshot.deltaLog)
-        .getOrElse(fail("AMT provider must contribute leaf-derived file actions."))
-        .where("add is not null")
-        .selectExpr("add.path", "add.deletionVector.storageType", "add.stats")
-        .collect()
-      assert(survivors.length == 1, "Only the DV-bearing sibling must survive the MDV.")
-      assert(survivors.head.getString(0) == aPath,
-        "The surviving path must be the DV-bearing file.")
-      assert(survivors.head.getString(1) != null,
-        "The surviving entry must retain its deletion vector after MDV filtering.")
-      assert(survivors.head.getString(2) == aStats,
-        "The surviving entry's stats must be unchanged by MDV filtering.")
+    // Drop B (the DV-less sibling) via an MDV on whichever leaf holds it; A must survive untouched.
+    val bLeafAndPos = base.leaves.flatMap { leaf =>
+      leafPosToLoc(leaf, base.tableRoot).collectFirst { case (pos, `bPath`) => leaf -> pos }
+    }.headOption.getOrElse(fail(s"No leaf holds the DV-less sibling $bPath."))
+    val patched = base.leaves.map { leaf =>
+      if (leaf eq bLeafAndPos._1) {
+        leaf.copy(manifest_info = leaf.manifest_info.copy(
+          dv = Some(mdvBytesFor(bLeafAndPos._2)), dv_cardinality = Some(1L)))
+      } else leaf
     }
+    val provider = new AMTCheckpointProvider(base.checkpointAction, patched, base.tableRoot)
+
+    val survivors = provider.loadActionsForStateReconstruction(spark, snapshot.deltaLog)
+      .getOrElse(fail("AMT provider must contribute leaf-derived file actions."))
+      .where("add is not null")
+      .selectExpr("add.path", "add.deletionVector.storageType", "add.stats")
+      .collect()
+    assert(survivors.length == 1, "Only the DV-bearing sibling must survive the MDV.")
+    assert(survivors.head.getString(0) == aPath,
+      "The surviving path must be the DV-bearing file.")
+    assert(survivors.head.getString(1) != null,
+      "The surviving entry must retain its deletion vector after MDV filtering.")
+    assert(survivors.head.getString(2) == aStats,
+      "The surviving entry's stats must be unchanged by MDV filtering.")
   }
 
-  test("a manifest DV with only one of dv/dv_cardinality set is rejected") {
-    withTable("amt_mdv_malformed") {
-      val name = "amt_mdv_malformed"
-      createAMTTable(name, checkpointInterval = 3)
-      (1 to 3).foreach(i => sql(s"INSERT INTO $name VALUES ($i)"))
+  testAcrossAMTCheckpointScenarios(
+      "a manifest DV with only one of dv/dv_cardinality set is rejected",
+      "amt_mdv_malformed",
+      sqlConfs = mdvLeafResidentConfs)(
+      setup = name => (1 to 2).foreach(i => sql(s"INSERT INTO $name VALUES ($i)")),
+      inlineCheckpointTriggerActionsOrSQL = Some(name => Right(
+        s"INSERT INTO $name VALUES (3)"))) { context =>
+    val base = context.provider
 
-      val snapshot = deltaLogForName(name).unsafeVolatileSnapshot
-      val base = amtProvider(snapshot).getOrElse(fail("expected AMTCheckpointProvider"))
+    // `dv` set but `dv_cardinality` missing: the AMT spec requires both or neither.
+    val patched =
+      base.leaves.head.copy(manifest_info = base.leaves.head.manifest_info.copy(
+        dv = Some(mdvBytesFor(0L)), dv_cardinality = None)) +:
+        base.leaves.tail
+    val provider = new AMTCheckpointProvider(base.checkpointAction, patched, base.tableRoot)
 
-      // `dv` set but `dv_cardinality` missing: the AMT spec requires both or neither.
-      val patched =
-        base.leaves.head.copy(manifest_info = base.leaves.head.manifest_info.copy(
-          dv = Some(mdvBytesFor(0L)), dv_cardinality = None)) +:
-          base.leaves.tail
-      val provider = new AMTCheckpointProvider(base.checkpointAction, patched, base.tableRoot)
-
-      val e = intercept[IllegalStateException] {
-        provider.loadActionsForStateReconstruction(spark, snapshot.deltaLog)
-      }
-      assert(e.getMessage.contains("dv and dv_cardinality must both be set or both unset"),
-        s"Unexpected message: ${e.getMessage}")
+    val e = intercept[IllegalStateException] {
+      provider.loadActionsForStateReconstruction(
+        spark, context.postCheckpointSnapshot.deltaLog)
     }
+    assert(e.getMessage.contains("dv and dv_cardinality must both be set or both unset"),
+      s"Unexpected message: ${e.getMessage}")
   }
 
   /** Reconstructed live `add.path`s from the (possibly MDV-patched) provider. */

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/SnapshotLastManifestCommitSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/SnapshotLastManifestCommitSuite.scala
@@ -200,7 +200,7 @@ class SnapshotLastManifestCommitWithoutCRCSuite extends SnapshotLastManifestComm
 
       // Build the AMT provider from v4's emitted inline checkpoint action and stub it into a fresh
       // snapshot's log segment, trimming the version's delta as cold discovery eventually will.
-      val checkpoint = checkpointsAt(deltaLog, 4).headOption.getOrElse {
+      val checkpoint = checkpointAt(deltaLog, 4).getOrElse {
         fail("v4 must emit an inline AMT checkpoint action.")
       }
       val provider = AMTCheckpointProvider.fromCheckpoint(spark, deltaLog, checkpoint)


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other

## Description

The AMT checkpoint test suites each built a checkpoint by hand, so every suite
repeated the same setup and each test only ever exercised the one placement and
materialization strategy its author happened to write.

This adds a `testAcrossAMTCheckpointScenarios` harness to `AMTCheckpointTestBase`
that registers a test per supported scenario -- inline incremental, deferred
incremental, and deferred full -- and hands the body a context that normalizes
the version arithmetic between inline and deferred placement. A test can then
assert on the checkpointed commit, the manifest commit, the resulting
`Checkpoint` action, and the final snapshot without knowing which scenario it is
running in. Tests restrict the scenario list only where the behavior is
genuinely mode-specific.

The existing suites are converted to the harness, so most tests now run across
all three scenarios rather than one -- including the manifest deletion vector
tests and the back reference propagation tests. Each scenario gets its own table
so a previous scenario's storage cannot leak into the next one.

This also relaxes the clustered leaf-count assertion: the clustered writer
distributes entries by hash and drops empty partitions, so it only targets
`ceil(numFiles / entriesPerLeaf)` leaves rather than guaranteeing that count.
The test now asserts that the split happened and that every entry survived,
instead of an exact leaf count.

## How was this patch tested?

Test-only change. The converted suites pass, now across every checkpoint
scenario rather than a single one.

## Does this PR introduce _any_ user-facing changes?

No.
