### PR TITLE
Use per-file scan metadata for the AMT manifest deletion vector read path

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLogFileIndex.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLogFileIndex.scala
@@ -24,6 +24,7 @@ import org.apache.spark.internal.{Logging, MDC}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.execution.datasources.{FileFormat, FileIndex, PartitionDirectory}
+import org.apache.spark.sql.execution.datasources.FileStatusWithMetadata
 import org.apache.spark.sql.execution.datasources.json.JsonFileFormat
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
 import org.apache.spark.sql.types.{LongType, StructField, StructType}
@@ -38,7 +39,8 @@ import org.apache.spark.sql.types.{LongType, StructField, StructType}
  */
 class DeltaLogFileIndex private[delta] (
     val format: FileFormat,
-    val files: Array[FileStatus]
+    val files: Array[FileStatus],
+    val perFileMetadata: Map[String, Map[String, Any]] = Map.empty
     )
   extends FileIndex
   with Logging {
@@ -51,7 +53,12 @@ class DeltaLogFileIndex private[delta] (
     files
       .groupBy(f => FileNames.getFileVersionOpt(f.getPath).getOrElse(-1L))
       .map { case (version, versionFiles) =>
-        PartitionDirectory(InternalRow(version), versionFiles)
+        // Attach each file's manifest DV bytes (if any) as per-file scan metadata so they travel
+        // to the task via `PartitionedFile.otherConstantMetadataColumnValues`.
+        val statuses = versionFiles.map { f =>
+          FileStatusWithMetadata(f, perFileMetadata.getOrElse(f.getPath.toString, Map.empty))
+        }.toIndexedSeq
+        PartitionDirectory(InternalRow(version), statuses)
       }
       .toSeq
   }
@@ -112,4 +119,13 @@ object DeltaLogFileIndex {
     filesOpt.flatMap(DeltaLogFileIndex(format, _))
   }
 
+  /**
+   * Builds an index that carries per-file scan metadata (e.g. inline manifest DV bytes).
+   */
+  def apply(
+      format: FileFormat,
+      files: Array[FileStatus],
+      perFileMetadata: Map[String, Map[String, Any]]): DeltaLogFileIndex = {
+    new DeltaLogFileIndex(format, files, perFileMetadata = perFileMetadata)
+  }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTCheckpointProvider.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTCheckpointProvider.scala
@@ -16,10 +16,11 @@
 
 package org.apache.spark.sql.delta.amt
 
+import org.apache.spark.sql.delta.{RowIndexFilter, RowIndexFilterType}
 import org.apache.spark.sql.delta.{CheckpointPolicy, CheckpointProvider, DeltaLog, DeltaLogFileIndex, Snapshot}
 import org.apache.spark.sql.delta.DeltaLogFileIndex.COMMIT_VERSION_COLUMN
-import org.apache.spark.sql.delta.actions.{Action, AddFile, BackReference, Checkpoint, ContentRoot, RemoveFile, SingleAction}
-import org.apache.spark.sql.delta.deletionvectors.RoaringBitmapArray
+import org.apache.spark.sql.delta.DeltaParquetFileFormat
+import org.apache.spark.sql.delta.actions.{Action, AddFile, BackReference, Checkpoint, ContentRoot, DeletionVectorDescriptor, RemoveFile, SingleAction}
 import org.apache.spark.sql.delta.util.DeltaEncoder
 import org.apache.hadoop.fs.{FileStatus, Path}
 
@@ -143,26 +144,24 @@ final class AMTCheckpointProvider(
     val encodedRootPath = SparkPath.fromPath(rootManifestAbsolutePath).urlEncoded
     val serializableConf = new SerializableConfiguration(deltaLog.newDeltaHadoopConf())
 
-    val files = rootStatus +: leafStatuses
-    val fmt = DeltaLogFileIndex.CHECKPOINT_FILE_FORMAT_PARQUET
-    // Read every leaf row, then drop the MDV-marked (leaf, rowIndex) entries with a filter on
-    // top, using a broadcast of each leaf's manifest DV bitmap bytes keyed by its `_metadata`
-    // file path.
-    val index = DeltaLogFileIndex(fmt, files.toArray)
-    val mdvByLeaf: Map[String, Array[Byte]] = leaves.flatMap { leaf =>
-      leaf.manifestDV.map { case (dvBytes, _) =>
-        SparkPath.fromPath(leaf.getAbsolutePath(localTableRoot)).urlEncoded -> dvBytes
+    val files = (rootStatus +: leafStatuses).toArray
+    // Carry each leaf's inline manifest DV as per-file scan metadata under the same keys
+    // data-file DVs use, so AMTParquetFileFormat materializes the `__delta_internal_is_row_deleted`
+    // marker column that loadEntriesWithLocation filters on.
+    val perFileMetadata: Map[String, Map[String, Any]] = leaves.flatMap { leaf =>
+      leaf.manifestDV.map { case (dvBytes, cardinality) =>
+        val encoded = DeletionVectorDescriptor.inlineInLog(dvBytes, cardinality).serializeToBase64()
+        leaf.getAbsolutePath(localTableRoot).toString -> Map[String, Any](
+          DeltaParquetFileFormat.FILE_ROW_INDEX_FILTER_ID_ENCODED -> encoded,
+          DeltaParquetFileFormat.FILE_ROW_INDEX_FILTER_TYPE -> RowIndexFilterType.IF_CONTAINED)
       }
     }.toMap
-    val mdvBroadcast = spark.sparkContext.broadcast(mdvByLeaf)
+    val index = DeltaLogFileIndex(
+      new AMTParquetFileFormat(localTableRoot.toString), files, perFileMetadata)
     val dataEntries = AMTCheckpointProvider.loadEntriesWithLocation(spark, deltaLog, index)
       .where(col("entry.content_type") === lit(AMTSingleAction.ContentType.Type.Data))
       .where(col("entry.tracking.status").isin(
         AMTCheckpointProvider.liveTrackingStatuses.toSeq: _*))
-      .filter { entryWithLoc =>
-        mdvBroadcast.value.get(entryWithLoc.leafPath)
-          .forall(bytes => !RoaringBitmapArray.readFrom(bytes).contains(entryWithLoc.pos))
-      }
 
     dataEntries
       .mapPartitions { entries =>
@@ -307,7 +306,12 @@ object AMTCheckpointProvider {
     implicit val entryLocEncoder: Encoder[AMTDataEntryWithLocation] =
       amtDataEntryWithLocationEncoder
     val amtSchema = spark.emptyDataset[AMTSingleAction].schema
-    deltaLog.loadIndex(index, amtSchema)
+    // Reads the leaf whole with an extra marker column that AMTParquetFileFormat materializes
+    // from the per-file manifest DV; the masked rows are dropped by the filter below.
+    val readSchema = amtSchema.add(DeltaParquetFileFormat.IS_ROW_DELETED_STRUCT_FIELD)
+    deltaLog.loadIndex(index, readSchema)
+      .where(col(DeltaParquetFileFormat.IS_ROW_DELETED_COLUMN_NAME) ===
+        lit(RowIndexFilter.KEEP_ROW_VALUE))
       .select(
         struct(amtSchema.fieldNames.toIndexedSeq.map(col): _*).as("entry"),
         col(s"$METADATA_NAME.$FILE_PATH").as("leafPath"),

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTParquetFileFormat.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTParquetFileFormat.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.amt
+
+import org.apache.spark.sql.delta.{DeltaColumnMappingMode, DeltaParquetFileFormatBase, NoMapping, ProtocolMetadataAdapter}
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.types.{StructField, StructType}
+
+/**
+ * Parquet format for AMT manifest scans that materializes a manifest-deletion-vector (MDV) skip
+ * column via [[DeltaParquetFileFormatBase]].
+ *
+ * The per-leaf inline MDV is carried as scan metadata under the same
+ * `row_index_filter_id_encoded` / `row_index_filter_type` keys that data-file DVs use, so the base
+ * deserializes it once per file and materializes the `__delta_internal_is_row_deleted` column; the
+ * AMT read then drops masked rows with a filter on top.
+ *
+ * @param tableRootPath Table root. Required by the base for deletion-vector processing; for inline
+ *                      manifest DVs the bytes travel in the descriptor so the path is not read, but
+ *                      the base requires it to be present for non-empty DVs.
+ */
+final class AMTParquetFileFormat(val tableRootPath: String)
+  extends DeltaParquetFileFormatBase(
+    protocolMetadataAdapter = AMTParquetFileFormat.Adapter,
+    optimizationsEnabled = false,
+    tablePath = Some(tableRootPath),
+    useMetadataRowIndexOpt = Some(false)) {
+
+  override def equals(other: Any): Boolean = other match {
+    case that: AMTParquetFileFormat => that.tableRootPath == this.tableRootPath
+    case _ => false
+  }
+
+  override def hashCode(): Int = tableRootPath.hashCode
+
+  override def shortName(): String = "amt-manifest-parquet"
+}
+
+object AMTParquetFileFormat {
+  private object Adapter extends ProtocolMetadataAdapter {
+    override def columnMappingMode: DeltaColumnMappingMode = NoMapping
+
+    override def getReferenceSchema: StructType = new StructType()
+
+    override def isRowIdEnabled: Boolean = false
+
+    override def isDeletionVectorReadable: Boolean = true
+
+    override def isIcebergCompatAnyEnabled: Boolean = false
+
+    override def isIcebergCompatGeqEnabled(version: Int): Boolean = false
+
+    override def assertTableReadable(sparkSession: SparkSession): Unit = ()
+
+    override def createRowTrackingMetadataFields(
+        nullableRowTrackingConstantFields: Boolean,
+        nullableRowTrackingGeneratedFields: Boolean): Iterable[StructField] = Iterable.empty
+
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotSuite.scala
@@ -16,16 +16,20 @@
 
 package org.apache.spark.sql.delta.amt
 
-import org.apache.spark.sql.delta.{Checkpoints, DeletionVectorsTestUtils, DeltaLog, DeltaOperations}
+import org.apache.spark.sql.delta.RowIndexFilterType
+import org.apache.spark.sql.delta.{Checkpoints, DataFrameUtils, DeletionVectorsTestUtils, DeltaLog, DeltaOperations, DeltaParquetFileFormat}
 import org.apache.spark.sql.delta.actions.{AddFile, Checkpoint, ContentRoot, DeletionVectorDescriptor}
 import org.apache.spark.sql.delta.deletionvectors.RoaringBitmapArray
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.FileNames
-import org.apache.hadoop.fs.Path
+import org.apache.hadoop.fs.{FileStatus, Path}
 
 import org.apache.spark.sql.Row
-import org.apache.spark.sql.execution.datasources.LogicalRelation
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.execution.datasources.{FileIndex, FileStatusWithMetadata, HadoopFsRelation, LogicalRelation, PartitionDirectory}
 import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.types.{LongType, StructType}
 
 /**
  * Verifies that [[Snapshot]] APIs correct results on AMT tables.
@@ -33,6 +37,7 @@ import org.apache.spark.sql.functions.col
 class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUtils {
 
   import testImplicits._
+
 
   ///////////////////////////
   // Post commit snapshot
@@ -455,6 +460,88 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
     }
     assert(e.getMessage.contains("dv and dv_cardinality must both be set or both unset"),
       s"Unexpected message: ${e.getMessage}")
+  }
+
+  for (vectorizedReader <- Seq(true, false)) {
+    test("AMTParquetFileFormat materializes an inline manifest DV skip column, " +
+        s"vectorizedReader=$vectorizedReader") {
+      // 6 rows; mark leaf-local positions 1 and 4 deleted.
+      checkManifestDvScan(numRows = 6, deletedPositions = Set(1L, 4L), vectorizedReader)
+    }
+
+    test("AMTParquetFileFormat keeps all rows when no manifest DV is present, " +
+        s"vectorizedReader=$vectorizedReader") {
+      checkManifestDvScan(numRows = 5, deletedPositions = Set.empty, vectorizedReader)
+    }
+
+    test("AMTParquetFileFormat drops the whole leaf when the manifest DV covers it, " +
+        s"vectorizedReader=$vectorizedReader") {
+      checkManifestDvScan(numRows = 4, deletedPositions = Set(0L, 1L, 2L, 3L), vectorizedReader)
+    }
+  }
+
+  /** Inline manifest-DV scan metadata over `positions`, keyed exactly like a data-file DV. */
+  private def manifestDvScanMetadata(positions: Long*): Map[String, Any] = {
+    val descriptor = DeletionVectorDescriptor.inlineInLog(
+      mdvBytesFor(positions: _*), positions.length.toLong)
+    Map(
+      DeltaParquetFileFormat.FILE_ROW_INDEX_FILTER_ID_ENCODED -> descriptor.serializeToBase64(),
+      DeltaParquetFileFormat.FILE_ROW_INDEX_FILTER_TYPE -> RowIndexFilterType.IF_CONTAINED)
+  }
+
+  /** A one-file [[FileIndex]] that attaches inline manifest-DV scan metadata to its single file. */
+  private class SingleFileWithMetadataIndex(file: FileStatus, meta: Map[String, Any])
+    extends FileIndex {
+    override def rootPaths: Seq[Path] = Seq(file.getPath)
+    override def listFiles(
+        partitionFilters: Seq[Expression],
+        dataFilters: Seq[Expression]): Seq[PartitionDirectory] =
+      Seq(PartitionDirectory(InternalRow.empty, Seq(FileStatusWithMetadata(file, meta))))
+    override def inputFiles: Array[String] = Array(file.getPath.toString)
+    override def refresh(): Unit = {}
+    override def sizeInBytes: Long = file.getLen
+    override def partitionSchema: StructType = new StructType()
+  }
+
+  /**
+   * Writes ids `0 until numRows` to a single parquet file, then reads it back through a full
+   * [[AMTParquetFileFormat]] scan carrying an inline manifest DV over `deletedPositions`. Asserts
+   * every row is returned with its id intact and `__delta_internal_is_row_deleted` set to DROP (1)
+   * at exactly the DV positions and KEEP (0) elsewhere.
+   */
+  private def checkManifestDvScan(
+      numRows: Int,
+      deletedPositions: Set[Long],
+      vectorizedReader: Boolean): Unit = withTempDir { dir =>
+    spark.range(0, numRows.toLong, 1, 1).write.mode("overwrite").parquet(dir.toString)
+    val hadoopConf = spark.sessionState.newHadoopConf()
+    val dirPath = new Path(dir.toString)
+    val file = dirPath.getFileSystem(hadoopConf).listStatus(dirPath)
+      .find(_.getPath.getName.endsWith(".parquet"))
+      .getOrElse(fail("Expected a single parquet part file."))
+
+    val scanMetadata =
+      if (deletedPositions.isEmpty) Map.empty[String, Any]
+      else manifestDvScanMetadata(deletedPositions.toSeq.sorted: _*)
+    val readingSchema = new StructType().add("id", LongType)
+      .add(DeltaParquetFileFormat.IS_ROW_DELETED_STRUCT_FIELD)
+    val relation = HadoopFsRelation(
+      location = new SingleFileWithMetadataIndex(file, scanMetadata),
+      partitionSchema = new StructType(),
+      dataSchema = readingSchema,
+      bucketSpec = None,
+      fileFormat = new AMTParquetFileFormat(dir.toString),
+      options = Map.empty)(spark)
+
+    withSQLConf("spark.sql.parquet.enableVectorizedReader" -> vectorizedReader.toString) {
+      val actual = DataFrameUtils.ofRows(spark, LogicalRelation(relation))
+        .select("id", DeltaParquetFileFormat.IS_ROW_DELETED_COLUMN_NAME)
+        .as[(Long, Byte)]
+      val expected = (0L until numRows.toLong).map { id =>
+        (id, if (deletedPositions.contains(id)) 1.toByte else 0.toByte)
+      }
+      checkDatasetUnorderly(actual, expected: _*)
+    }
   }
 
   /** Reconstructed live `add.path`s from the (possibly MDV-patched) provider. */


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other

## Description

Exposes each Adaptive Metadata Tree (AMT) leaf's inline manifest deletion vector (MDV) as a file-constant `_metadata` column via a new `AMTParquetFileFormat`, and uses it to drop MDV-masked rows during state reconstruction.

Previously the manifest DV had to be resolved separately from the scan; carrying it as per-file scan metadata lets the reconstruction filter masked entries directly from the scanned leaf, keyed by the row index of each entry.

## How was this patch tested?

Unit tests in `AMTSnapshotSuite`.

## Does this PR introduce _any_ user-facing changes?

No.