### PR TITLE
[RLC] Case 2 — same-file deletion-vector merge (concurrent DML ⟂ DML)

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
@@ -17,24 +17,28 @@
 package org.apache.spark.sql.delta
 
 // scalastyle:off import.ordering.noEmptyLine
+import java.util.UUID
 import java.util.concurrent.TimeUnit
 
 import scala.collection.mutable
 
-import org.apache.spark.sql.delta.DeltaOperations.{OP_SET_TBLPROPERTIES, ROW_TRACKING_BACKFILL_OPERATION_NAME, ROW_TRACKING_UNBACKFILL_OPERATION_NAME}
+import org.apache.spark.sql.delta.DeltaOperations.{OP_DELETE, OP_SET_TBLPROPERTIES, OP_UPDATE, ROW_TRACKING_BACKFILL_OPERATION_NAME, ROW_TRACKING_UNBACKFILL_OPERATION_NAME}
 import org.apache.spark.sql.delta.RowId.RowTrackingMetadataDomain
 import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
+import org.apache.spark.sql.delta.commands.DeletionVectorUtils
+import org.apache.spark.sql.delta.deletionvectors.{RoaringBitmapArray, RoaringBitmapArrayFormat}
 import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.sources.DeltaSourceUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.storage.dv.DeletionVectorStore
 import org.apache.spark.sql.delta.util.DeltaSparkPlanUtils.CheckDeterministicOptions
 import org.apache.spark.sql.delta.util.FileNames
 import io.delta.storage.commit.UpdatedActions
 import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorClient
 import io.delta.storage.commit.uniform.UniformMetadata
-import org.apache.hadoop.fs.FileStatus
+import org.apache.hadoop.fs.{FileStatus, Path}
 
 import org.apache.spark.internal.{MDC, MessageWithContext}
 import org.apache.spark.sql.{DataFrame, SparkSession}
@@ -229,6 +233,13 @@ private[delta] class ConflictChecker(
 
   protected var currentTransactionInfo: CurrentTransactionInfo = initialCurrentTransactionInfo
 
+  /**
+   * Paths of files whose "same physical file" conflict with the winning transaction was resolved at
+   * the row level by [[resolveRowLevelConflicts]] (deletion vectors merged). The file-level delete
+   * and append checks skip these paths, since they have already been reconciled.
+   */
+  private val rowLevelResolvedPaths = mutable.Set.empty[String]
+
   protected def recordSkippedPhase(phase: String): Unit = timingStats += phase -> 0
 
   /**
@@ -299,6 +310,12 @@ private[delta] class ConflictChecker(
 
     // Update the table version in newly added type widening metadata.
     updateTypeWideningMetadata()
+
+    // Row-level concurrency: try to resolve "same physical file" conflicts by merging deletion
+    // vectors before the file-level checks run, so that concurrent DML touching disjoint rows of
+    // the same file no longer aborts. Runs after row-ID reassignment so merged files keep stable
+    // base row IDs.
+    resolveRowLevelConflicts()
 
     // Data file checks.
     checkForAddedFilesThatShouldHaveBeenReadByCurrentTxn()
@@ -1117,6 +1134,204 @@ private[delta] class ConflictChecker(
     false
   }
 
+  /** Whether row-level concurrency resolution is enabled and applicable to this table. */
+  private lazy val rowLevelConcurrencyEnabled: Boolean =
+    spark.conf.get(DeltaSQLConf.DELTA_ROW_LEVEL_CONCURRENCY_ENABLED) &&
+      DeletionVectorUtils.deletionVectorsWritable(
+        currentTransactionInfo.protocol, currentTransactionInfo.metadata)
+
+  /** The operation name of the winning commit, if available. */
+  private lazy val winningOperationName: Option[String] =
+    winningCommitSummary.commitInfo.map(_.operation)
+
+  /**
+   * Whether the winning commit is a row-level DML that only rewrites or removes existing rows
+   * (DELETE or UPDATE), i.e. it introduces no net-new logical rows. Files added by such a commit
+   * are rewrites of rows that the current transaction already observed in its read snapshot (or
+   * re-adds of files masked by a deletion vector), so they cannot introduce phantom rows for the
+   * current transaction. MERGE is intentionally excluded because it may insert net-new rows.
+   */
+  private lazy val winningCommitIsRewriteOnlyRowLevelDml: Boolean = {
+    val usesDeletionVectors = winningCommitSummary.addedFiles.exists(_.deletionVector != null)
+    usesDeletionVectors && winningOperationName.exists {
+      case OP_DELETE | OP_UPDATE => true
+      case _ => false
+    }
+  }
+
+  /**
+   * Whether a file added by the winning transaction can be skipped in the added-files (append)
+   * conflict check thanks to row-level concurrency resolution. This is true when:
+   *   1. the file's "same physical file" conflict was already reconciled by merging deletion
+   *      vectors ([[rowLevelResolvedPaths]]), or
+   *   2. the winning commit is a rewrite-only row-level DML (DELETE/UPDATE) whose added files
+   *      cannot introduce phantom rows (see [[winningCommitIsRewriteOnlyRowLevelDml]]).
+   */
+  private def canSkipAddedFileForRowLevelConcurrency(addFile: AddFile): Boolean = {
+    if (!rowLevelConcurrencyEnabled) return false
+    rowLevelResolvedPaths.contains(addFile.path) || winningCommitIsRewriteOnlyRowLevelDml
+  }
+
+  /**
+   * Resolves "same physical file" conflicts with the winning transaction at the row level.
+   *
+   * A DV-based DELETE/UPDATE emits, for each touched file `P`, a `RemoveFile(P)` (tombstone of the
+   * pre-image) and an `AddFile(P)` carrying a larger deletion vector. When both the winning and the
+   * current transaction touch the same file `P` this way, the two operations are logically
+   * independent as long as they mark *different* rows deleted. For every such shared file we:
+   *   1. decode the winning DV, the current DV and their common base DV (from the pre-image
+   *      `RemoveFile`) as [[RoaringBitmapArray]]s;
+   *   2. check whether the newly-deleted rows are disjoint, i.e. `(dv_win INTERSECT dv_cur) MINUS
+   *      dv_base` is empty. If they overlap, this is a genuine row-level conflict and we leave the
+   *      file for the standard checks to abort;
+   *   3. on disjoint sets, merge the DVs (`dv_win UNION dv_cur`), persist a new DV file,
+   *      and rebase the current transaction onto the winner's post-image: the current `AddFile(P)`
+   *      now carries the merged DV and the current `RemoveFile(P)` now tombstones the winner's
+   *      `AddFile(P)`.
+   *
+   * Resolved paths are recorded in [[rowLevelResolvedPaths]] and skipped by the file-level delete
+   * and append checks. Row identity is preserved for free: the merged file is the same physical
+   * file, so its base row ID is unchanged and [[reassignOverlappingRowIds]] (already run) leaves it
+   * alone. Deletion vectors index physical row positions within one immutable Parquet file, so the
+   * merge needs no row tracking.
+   */
+  private def resolveRowLevelConflicts(): Unit = {
+    if (!rowLevelConcurrencyEnabled) return
+
+    // Winning transaction's DV updates: path present in both an AddFile (with a DV) and a
+    // RemoveFile of the winning commit.
+    val winningRemovedPaths = winningCommitSummary.removedFiles.map(_.path).toSet
+    val winningDvUpdates: Map[String, AddFile] = winningCommitSummary.addedFiles.iterator
+      .filter(a => a.deletionVector != null && winningRemovedPaths.contains(a.path))
+      .map(a => a.path -> a)
+      .toMap
+    if (winningDvUpdates.isEmpty) return
+
+    // Current transaction's DV updates, indexed by path.
+    val currentAddByPath = currentTransactionInfo.actions.collect {
+      case a: AddFile if a.deletionVector != null => a.path -> a
+    }.toMap
+    val currentRemoveByPath = currentTransactionInfo.actions.collect {
+      case r: RemoveFile => r.path -> r
+    }.toMap
+
+    val sharedPaths = winningDvUpdates.keySet
+      .intersect(currentAddByPath.keySet)
+      .intersect(currentRemoveByPath.keySet)
+    if (sharedPaths.isEmpty) return
+
+    recordTime("resolved-row-level-conflicts") {
+      val dvStore = DeletionVectorStore.createInstance(deltaLog.newDeltaHadoopConf())
+      val tablePath = deltaLog.dataPath
+
+      // path -> (rebased AddFile, rebased RemoveFile)
+      val replacements = mutable.Map.empty[String, (AddFile, RemoveFile)]
+      for (path <- sharedPaths) {
+        val winningAdd = winningDvUpdates(path)
+        val currentAdd = currentAddByPath(path)
+        val currentRemove = currentRemoveByPath(path)
+
+        def bitmapOf(dv: DeletionVectorDescriptor): RoaringBitmapArray =
+          readDeletionVectorOrEmpty(dvStore, dv, tablePath)
+        val baseBitmap = bitmapOf(currentRemove.deletionVector)
+        val winningBitmap = bitmapOf(winningAdd.deletionVector)
+        val currentBitmap = bitmapOf(currentAdd.deletionVector)
+
+        // `baseBitmap` is the DV of `P` at the current txn's read time (carried on its RemoveFile);
+        // for a 2-way conflict it equals the winner's pre-image too. Both `dv_win` and `dv_cur` are
+        // supersets of it (a DV only grows), so the newly-deleted rows are `dv \ base` on each side
+        // and their overlap is `(dv_win INTERSECT dv_cur) MINUS base`. If empty, the two txns
+        // touched disjoint rows and the schedule `current ; winner` is a valid serialization under
+        // both WriteSerializable and Serializable (the winner's rewrites/deletes are of rows the
+        // current txn did not touch), so merging is safe. If non-empty, the same row was touched by
+        // both -> genuine conflict, left for the standard checks. (For 3+ way chains `base` becomes
+        // previous winner's DV rather than the original pre-image; the merge stays correct and the
+        // overlap test stays conservative.)
+        val newlyDeletedOverlap = winningBitmap.copy()
+        newlyDeletedOverlap.and(currentBitmap)
+        newlyDeletedOverlap.andNot(baseBitmap)
+
+        if (newlyDeletedOverlap.isEmpty) {
+          // Disjoint: merge the deletion vectors and rebase onto the winner's post-image.
+          val mergedBitmap = winningBitmap.copy()
+          mergedBitmap.merge(currentBitmap)
+          val mergedDescriptor = writeMergedDeletionVector(dvStore, tablePath, mergedBitmap)
+          // Keep the current AddFile's identity (base row ID / default row commit version already
+          // reconciled by the row-ID phases) but point it at the merged DV.
+          val rebasedAdd = currentAdd
+            .copy(deletionVector = mergedDescriptor, dataChange = true)
+            .withoutTightBoundStats
+          // Tombstone the winner's now-live AddFile (carries the winning DV) instead of the stale
+          // pre-image.
+          val rebasedRemove = winningAdd.removeWithTimestamp()
+          replacements(path) = (rebasedAdd, rebasedRemove)
+          rowLevelResolvedPaths += path
+        }
+        // else: overlapping row-level modification -> genuine conflict, leave for standard checks.
+      }
+
+      if (replacements.nonEmpty) {
+        val newActions = currentTransactionInfo.actions.map {
+          case a: AddFile if replacements.contains(a.path) => replacements(a.path)._1
+          case r: RemoveFile if replacements.contains(r.path) => replacements(r.path)._2
+          case other => other
+        }
+        // Resolved files are no longer "read" for the purposes of the delete-read check.
+        val newReadFiles = currentTransactionInfo.readFiles
+          .filterNot(f => rowLevelResolvedPaths.contains(f.path))
+        currentTransactionInfo =
+          currentTransactionInfo.copy(actions = newActions, readFiles = newReadFiles)
+
+        recordDeltaEvent(
+          deltaLog,
+          opType = "delta.rowLevelConcurrency.deletionVectorsMerged",
+          data = Map(
+            "winningCommitVersion" -> winningCommitVersion,
+            "resolvedPaths" -> rowLevelResolvedPaths.size,
+            "winningOperation" -> winningOperationName.getOrElse("UNKNOWN")))
+      }
+    }
+  }
+
+  /** Reads a deletion vector into a [[RoaringBitmapArray]], returning an empty bitmap for none. */
+  private def readDeletionVectorOrEmpty(
+      dvStore: DeletionVectorStore,
+      dv: DeletionVectorDescriptor,
+      tablePath: Path): RoaringBitmapArray = {
+    if (dv == null || dv.isEmpty) new RoaringBitmapArray() else dvStore.read(dv, tablePath)
+  }
+
+  /**
+   * Persists a merged bitmap to a new deletion vector file and returns its descriptor.
+   *
+   * NOTE: this writes a DV file as a side effect of conflict resolution. If the commit ultimately
+   * fails or is retried against another winning version, the file is orphaned and later reclaimed
+   * by VACUUM (same lifecycle as any DV written by DML). This mirrors how the DML write path
+   * persists DVs (see `DeletionVectorWriter.storeSerializedBitmap`).
+   */
+  private def writeMergedDeletionVector(
+      dvStore: DeletionVectorStore,
+      tablePath: Path,
+      bitmap: RoaringBitmapArray): DeletionVectorDescriptor = {
+    // An empty DV has no on-disk representation (matches DeletionVectorWriter).
+    if (bitmap.isEmpty) return DeletionVectorDescriptor.EMPTY
+    val tablePathWithFs = dvStore.pathWithFileSystem(tablePath)
+    val fileId = UUID.randomUUID()
+    val writer = dvStore.createWriter(dvStore.generateFileNameInTable(tablePathWithFs, fileId))
+    try {
+      val serialized = DeletionVectorUtils.serialize(
+        bitmap, RoaringBitmapArrayFormat.Portable, Some(tablePath))
+      val range = writer.write(serialized)
+      DeletionVectorDescriptor.onDiskWithRelativePath(
+        id = fileId,
+        sizeInBytes = serialized.length,
+        cardinality = bitmap.cardinality,
+        offset = Some(range.offset))
+    } finally {
+      writer.close()
+    }
+  }
+
   /**
    * Check if the new files added by the already committed transactions should have been read by
    * the current transaction.
@@ -1137,8 +1352,11 @@ private[delta] class ConflictChecker(
           Seq.empty
       }
 
+      val addedFilesAfterRowLevelResolution =
+        addedFilesToCheckForConflicts.filterNot(canSkipAddedFileForRowLevelConcurrency)
+
       val fileMatchingPartitionReadPredicates =
-        getFirstFileMatchingPartitionPredicates(addedFilesToCheckForConflicts)
+        getFirstFileMatchingPartitionPredicates(addedFilesAfterRowLevelResolution)
 
       if (fileMatchingPartitionReadPredicates.nonEmpty) {
         throw DeltaErrors.concurrentAppendException(
@@ -1160,7 +1378,7 @@ private[delta] class ConflictChecker(
       val readFilePaths = currentTransactionInfo.readFiles.map(
         f => f.path -> f.partitionValues).toMap
       val deleteReadOverlap = winningCommitSummary.removedFiles
-        .find(r => readFilePaths.contains(r.path))
+        .find(r => readFilePaths.contains(r.path) && !rowLevelResolvedPaths.contains(r.path))
       if (deleteReadOverlap.nonEmpty) {
         val partitionOpt = getPrettyPartitionMessage(readFilePaths(deleteReadOverlap.get.path))
         throw DeltaErrors.concurrentDeleteReadException(
@@ -1169,7 +1387,11 @@ private[delta] class ConflictChecker(
           winningCommitVersion,
           partitionOpt)
       }
-      if (winningCommitSummary.removedFiles.nonEmpty && currentTransactionInfo.readWholeTable) {
+      // Row-level concurrency: a removed file that was reconciled at the row level must not
+      // re-trigger the whole-table conflict either.
+      val unresolvedRemovedFiles =
+        winningCommitSummary.removedFiles.exists(r => !rowLevelResolvedPaths.contains(r.path))
+      if (unresolvedRemovedFiles && currentTransactionInfo.readWholeTable) {
         throw DeltaErrors.concurrentDeleteReadException(
           winningCommitSummary.commitInfo,
           getTableNameOrPath,
@@ -1190,7 +1412,7 @@ private[delta] class ConflictChecker(
         .collect { case r: RemoveFile => r.path -> r.partitionValues }
         .toMap
       val deleteOverlap = winningCommitSummary.removedFiles
-        .find(r => deletedFilePaths.contains(r.path))
+        .find(r => deletedFilePaths.contains(r.path) && !rowLevelResolvedPaths.contains(r.path))
       if (deleteOverlap.nonEmpty) {
         val partitionOpt = getPrettyPartitionMessage(deletedFilePaths(deleteOverlap.get.path))
         throw DeltaErrors.concurrentDeleteDeleteException(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
@@ -218,7 +218,11 @@ object WinningCommitSummary {
 private[delta] class ConflictChecker(
     protected val spark: SparkSession,
     initialCurrentTransactionInfo: CurrentTransactionInfo,
-    protected val winningCommitSummary: WinningCommitSummary,
+    // A `var` (reassigned once by [[resolveRowLevelConflicts]]) to drop files that were reconciled
+    // at the row level, mirroring how `currentTransactionInfo` is rebased. After that the
+    // file-level checks run against a summary that never mentions the reconciled files, so they
+    // need no changes.
+    protected var winningCommitSummary: WinningCommitSummary,
     isolationLevel: IsolationLevel)
   extends DeltaLogging with ConflictCheckerPredicateElimination
   with RowLevelConcurrencyResolution {
@@ -1144,15 +1148,8 @@ private[delta] class ConflictChecker(
           Seq.empty
       }
 
-      // Only re-scan the added files when row-level resolution actually reconciled something: a
-      // file is skippable only if its path is in `rowLevelResolvedPaths`, so an empty set means the
-      // filter is a no-op. Skips the traversal (and its allocation) on the common no-conflict path.
-      val addedFilesAfterRowLevelResolution =
-        if (rowLevelResolvedPaths.isEmpty) addedFilesToCheckForConflicts
-        else addedFilesToCheckForConflicts.filterNot(canSkipAddedFileForRowLevelConcurrency)
-
       val fileMatchingPartitionReadPredicates =
-        getFirstFileMatchingPartitionPredicates(addedFilesAfterRowLevelResolution)
+        getFirstFileMatchingPartitionPredicates(addedFilesToCheckForConflicts)
 
       if (fileMatchingPartitionReadPredicates.nonEmpty) {
         throw DeltaErrors.concurrentAppendException(
@@ -1174,7 +1171,7 @@ private[delta] class ConflictChecker(
       val readFilePaths = currentTransactionInfo.readFiles.map(
         f => f.path -> f.partitionValues).toMap
       val deleteReadOverlap = winningCommitSummary.removedFiles
-        .find(r => readFilePaths.contains(r.path) && !rowLevelResolvedPaths.contains(r.path))
+        .find(r => readFilePaths.contains(r.path))
       if (deleteReadOverlap.nonEmpty) {
         val partitionOpt = getPrettyPartitionMessage(readFilePaths(deleteReadOverlap.get.path))
         throw DeltaErrors.concurrentDeleteReadException(
@@ -1183,11 +1180,7 @@ private[delta] class ConflictChecker(
           winningCommitVersion,
           partitionOpt)
       }
-      // Row-level concurrency: a removed file that was reconciled at the row level must not
-      // re-trigger the whole-table conflict either.
-      val unresolvedRemovedFiles =
-        winningCommitSummary.removedFiles.exists(r => !rowLevelResolvedPaths.contains(r.path))
-      if (unresolvedRemovedFiles && currentTransactionInfo.readWholeTable) {
+      if (winningCommitSummary.removedFiles.nonEmpty && currentTransactionInfo.readWholeTable) {
         throw DeltaErrors.concurrentDeleteReadException(
           winningCommitSummary.commitInfo,
           getTableNameOrPath,
@@ -1208,7 +1201,7 @@ private[delta] class ConflictChecker(
         .collect { case r: RemoveFile => r.path -> r.partitionValues }
         .toMap
       val deleteOverlap = winningCommitSummary.removedFiles
-        .find(r => deletedFilePaths.contains(r.path) && !rowLevelResolvedPaths.contains(r.path))
+        .find(r => deletedFilePaths.contains(r.path))
       if (deleteOverlap.nonEmpty) {
         val partitionOpt = getPrettyPartitionMessage(deletedFilePaths(deleteOverlap.get.path))
         throw DeltaErrors.concurrentDeleteDeleteException(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
@@ -1144,8 +1144,12 @@ private[delta] class ConflictChecker(
           Seq.empty
       }
 
+      // Only re-scan the added files when row-level resolution actually reconciled something: a
+      // file is skippable only if its path is in `rowLevelResolvedPaths`, so an empty set means the
+      // filter is a no-op. Skips the traversal (and its allocation) on the common no-conflict path.
       val addedFilesAfterRowLevelResolution =
-        addedFilesToCheckForConflicts.filterNot(canSkipAddedFileForRowLevelConcurrency)
+        if (rowLevelResolvedPaths.isEmpty) addedFilesToCheckForConflicts
+        else addedFilesToCheckForConflicts.filterNot(canSkipAddedFileForRowLevelConcurrency)
 
       val fileMatchingPartitionReadPredicates =
         getFirstFileMatchingPartitionPredicates(addedFilesAfterRowLevelResolution)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
@@ -17,7 +17,6 @@
 package org.apache.spark.sql.delta
 
 // scalastyle:off import.ordering.noEmptyLine
-import java.util.UUID
 import java.util.concurrent.TimeUnit
 
 import scala.collection.mutable
@@ -26,19 +25,16 @@ import org.apache.spark.sql.delta.DeltaOperations.{OP_SET_TBLPROPERTIES, ROW_TRA
 import org.apache.spark.sql.delta.RowId.RowTrackingMetadataDomain
 import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
-import org.apache.spark.sql.delta.commands.DeletionVectorUtils
-import org.apache.spark.sql.delta.deletionvectors.{RoaringBitmapArray, RoaringBitmapArrayFormat}
 import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.sources.DeltaSourceUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
-import org.apache.spark.sql.delta.storage.dv.DeletionVectorStore
 import org.apache.spark.sql.delta.util.DeltaSparkPlanUtils.CheckDeterministicOptions
 import org.apache.spark.sql.delta.util.FileNames
 import io.delta.storage.commit.UpdatedActions
 import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorClient
 import io.delta.storage.commit.uniform.UniformMetadata
-import org.apache.hadoop.fs.{FileStatus, Path}
+import org.apache.hadoop.fs.FileStatus
 
 import org.apache.spark.internal.{MDC, MessageWithContext}
 import org.apache.spark.sql.{DataFrame, SparkSession}
@@ -220,11 +216,12 @@ object WinningCommitSummary {
 }
 
 private[delta] class ConflictChecker(
-    spark: SparkSession,
+    protected val spark: SparkSession,
     initialCurrentTransactionInfo: CurrentTransactionInfo,
-    winningCommitSummary: WinningCommitSummary,
+    protected val winningCommitSummary: WinningCommitSummary,
     isolationLevel: IsolationLevel)
-  extends DeltaLogging with ConflictCheckerPredicateElimination {
+  extends DeltaLogging with ConflictCheckerPredicateElimination
+  with RowLevelConcurrencyResolution {
 
   protected val winningCommitVersion = winningCommitSummary.commitVersion
   protected val startTimeMs = System.currentTimeMillis()
@@ -232,13 +229,6 @@ private[delta] class ConflictChecker(
   protected val deltaLog = initialCurrentTransactionInfo.readSnapshot.deltaLog
 
   protected var currentTransactionInfo: CurrentTransactionInfo = initialCurrentTransactionInfo
-
-  /**
-   * Paths of files whose "same physical file" conflict with the winning transaction was resolved at
-   * the row level by [[resolveRowLevelConflicts]] (deletion vectors merged). The file-level delete
-   * and append checks skip these paths, since they have already been reconciled.
-   */
-  private val rowLevelResolvedPaths = mutable.Set.empty[String]
 
   protected def recordSkippedPhase(phase: String): Unit = timingStats += phase -> 0
 
@@ -1132,198 +1122,6 @@ private[delta] class ConflictChecker(
       return true
     }
     false
-  }
-
-  /** Whether row-level concurrency resolution is enabled and applicable to this table. */
-  private lazy val rowLevelConcurrencyEnabled: Boolean =
-    spark.conf.get(DeltaSQLConf.DELTA_ROW_LEVEL_CONCURRENCY_ENABLED) &&
-      DeletionVectorUtils.deletionVectorsWritable(
-        currentTransactionInfo.protocol, currentTransactionInfo.metadata)
-
-  /** The operation name of the winning commit, if available. */
-  private lazy val winningOperationName: Option[String] =
-    winningCommitSummary.commitInfo.map(_.operation)
-
-  /**
-   * Whether a file added by the winning transaction can be skipped in the added-files (append)
-   * conflict check thanks to row-level concurrency resolution.
-   *
-   * This is true only when the file's "same physical file" conflict was already reconciled by
-   * merging deletion vectors ([[resolveRowLevelConflicts]] recorded the path in
-   * [[rowLevelResolvedPaths]]). In that case the winner's re-added `AddFile(P)` carries the winning
-   * DV that we already folded into the current transaction's merged DV, so re-checking it would be
-   * a false conflict.
-   *
-   * We deliberately do NOT skip a rewrite-only DML winner's *new image* files here (an UPDATE
-   * writes updated row values to a fresh path). Those are ordinary non-blind changed-data files
-   * and can legitimately conflict: e.g. an UPDATE can move a row *into* the loser's predicate
-   * (winner `SET x = 15`, loser `DELETE WHERE x > 10`, row was `x = 5`), a genuine write-skew that
-   * the DV union cannot detect. They are arbitrated by the standard added-files check (and, when
-   * enabled, by conflict-time data skipping over their stats).
-   */
-  private def canSkipAddedFileForRowLevelConcurrency(addFile: AddFile): Boolean = {
-    if (!rowLevelConcurrencyEnabled) return false
-    rowLevelResolvedPaths.contains(addFile.path)
-  }
-
-  /**
-   * Resolves "same physical file" conflicts with the winning transaction at the row level.
-   *
-   * A DV-based DELETE/UPDATE emits, for each touched file `P`, a `RemoveFile(P)` (tombstone of the
-   * pre-image) and an `AddFile(P)` carrying a larger deletion vector. When both the winning and the
-   * current transaction touch the same file `P` this way, the two operations are logically
-   * independent as long as they mark *different* rows deleted. For every such shared file we:
-   *   1. decode the winning DV, the current DV and their common base DV (from the pre-image
-   *      `RemoveFile`) as [[RoaringBitmapArray]]s;
-   *   2. check whether the newly-deleted rows are disjoint, i.e. `(dv_win INTERSECT dv_cur) MINUS
-   *      dv_base` is empty. If they overlap, this is a genuine row-level conflict and we leave the
-   *      file for the standard checks to abort;
-   *   3. on disjoint sets, merge the DVs (`dv_win UNION dv_cur`), persist a new DV file,
-   *      and rebase the current transaction onto the winner's post-image: the current `AddFile(P)`
-   *      now carries the merged DV and the current `RemoveFile(P)` now tombstones the winner's
-   *      `AddFile(P)`.
-   *
-   * Resolved paths are recorded in [[rowLevelResolvedPaths]] and skipped by the file-level delete
-   * and append checks. Row identity is preserved for free: the merged file is the same physical
-   * file, so its base row ID is unchanged and [[reassignOverlappingRowIds]] (already run) leaves it
-   * alone. Deletion vectors index physical row positions within one immutable Parquet file, so the
-   * merge needs no row tracking.
-   */
-  private def resolveRowLevelConflicts(): Unit = {
-    if (!rowLevelConcurrencyEnabled) return
-
-    // Winning transaction's DV updates: path present in both an AddFile (with a DV) and a
-    // RemoveFile of the winning commit.
-    val winningRemovedPaths = winningCommitSummary.removedFiles.map(_.path).toSet
-    val winningDvUpdates: Map[String, AddFile] = winningCommitSummary.addedFiles.iterator
-      .filter(a => a.deletionVector != null && winningRemovedPaths.contains(a.path))
-      .map(a => a.path -> a)
-      .toMap
-    if (winningDvUpdates.isEmpty) return
-
-    // Current transaction's DV updates, indexed by path.
-    val currentAddByPath = currentTransactionInfo.actions.collect {
-      case a: AddFile if a.deletionVector != null => a.path -> a
-    }.toMap
-    val currentRemoveByPath = currentTransactionInfo.actions.collect {
-      case r: RemoveFile => r.path -> r
-    }.toMap
-
-    val sharedPaths = winningDvUpdates.keySet
-      .intersect(currentAddByPath.keySet)
-      .intersect(currentRemoveByPath.keySet)
-    if (sharedPaths.isEmpty) return
-
-    recordTime("resolved-row-level-conflicts") {
-      val dvStore = DeletionVectorStore.createInstance(deltaLog.newDeltaHadoopConf())
-      val tablePath = deltaLog.dataPath
-
-      // path -> (rebased AddFile, rebased RemoveFile)
-      val replacements = mutable.Map.empty[String, (AddFile, RemoveFile)]
-      for (path <- sharedPaths) {
-        val winningAdd = winningDvUpdates(path)
-        val currentAdd = currentAddByPath(path)
-        val currentRemove = currentRemoveByPath(path)
-
-        def bitmapOf(dv: DeletionVectorDescriptor): RoaringBitmapArray =
-          readDeletionVectorOrEmpty(dvStore, dv, tablePath)
-        val baseBitmap = bitmapOf(currentRemove.deletionVector)
-        val winningBitmap = bitmapOf(winningAdd.deletionVector)
-        val currentBitmap = bitmapOf(currentAdd.deletionVector)
-
-        // `baseBitmap` is the DV of `P` at the current txn's read time (carried on its RemoveFile);
-        // for a 2-way conflict it equals the winner's pre-image too. Both `dv_win` and `dv_cur` are
-        // supersets of it (a DV only grows), so the newly-deleted rows are `dv \ base` on each side
-        // and their overlap is `(dv_win INTERSECT dv_cur) MINUS base`. If empty, the two txns
-        // touched disjoint rows and the schedule `current ; winner` is a valid serialization under
-        // both WriteSerializable and Serializable (the winner's rewrites/deletes are of rows the
-        // current txn did not touch), so merging is safe. If non-empty, the same row was touched by
-        // both -> genuine conflict, left for the standard checks. (For 3+ way chains `base` becomes
-        // previous winner's DV rather than the original pre-image; the merge stays correct and the
-        // overlap test stays conservative.)
-        val newlyDeletedOverlap = winningBitmap.copy()
-        newlyDeletedOverlap.and(currentBitmap)
-        newlyDeletedOverlap.andNot(baseBitmap)
-
-        if (newlyDeletedOverlap.isEmpty) {
-          // Disjoint: merge the deletion vectors and rebase onto the winner's post-image.
-          val mergedBitmap = winningBitmap.copy()
-          mergedBitmap.merge(currentBitmap)
-          val mergedDescriptor = writeMergedDeletionVector(dvStore, tablePath, mergedBitmap)
-          // Keep the current AddFile's identity (base row ID / default row commit version already
-          // reconciled by the row-ID phases) but point it at the merged DV.
-          val rebasedAdd = currentAdd
-            .copy(deletionVector = mergedDescriptor, dataChange = true)
-            .withoutTightBoundStats
-          // Tombstone the winner's now-live AddFile (carries the winning DV) instead of the stale
-          // pre-image.
-          val rebasedRemove = winningAdd.removeWithTimestamp()
-          replacements(path) = (rebasedAdd, rebasedRemove)
-          rowLevelResolvedPaths += path
-        }
-        // else: overlapping row-level modification -> genuine conflict, leave for standard checks.
-      }
-
-      if (replacements.nonEmpty) {
-        val newActions = currentTransactionInfo.actions.map {
-          case a: AddFile if replacements.contains(a.path) => replacements(a.path)._1
-          case r: RemoveFile if replacements.contains(r.path) => replacements(r.path)._2
-          case other => other
-        }
-        // Resolved files are no longer "read" for the purposes of the delete-read check.
-        val newReadFiles = currentTransactionInfo.readFiles
-          .filterNot(f => rowLevelResolvedPaths.contains(f.path))
-        currentTransactionInfo =
-          currentTransactionInfo.copy(actions = newActions, readFiles = newReadFiles)
-
-        recordDeltaEvent(
-          deltaLog,
-          opType = "delta.rowLevelConcurrency.deletionVectorsMerged",
-          data = Map(
-            "winningCommitVersion" -> winningCommitVersion,
-            "resolvedPaths" -> rowLevelResolvedPaths.size,
-            "winningOperation" -> winningOperationName.getOrElse("UNKNOWN")))
-      }
-    }
-  }
-
-  /** Reads a deletion vector into a [[RoaringBitmapArray]], returning an empty bitmap for none. */
-  private def readDeletionVectorOrEmpty(
-      dvStore: DeletionVectorStore,
-      dv: DeletionVectorDescriptor,
-      tablePath: Path): RoaringBitmapArray = {
-    if (dv == null || dv.isEmpty) new RoaringBitmapArray() else dvStore.read(dv, tablePath)
-  }
-
-  /**
-   * Persists a merged bitmap to a new deletion vector file and returns its descriptor.
-   *
-   * NOTE: this writes a DV file as a side effect of conflict resolution. If the commit ultimately
-   * fails or is retried against another winning version, the file is orphaned and later reclaimed
-   * by VACUUM (same lifecycle as any DV written by DML). This mirrors how the DML write path
-   * persists DVs (see `DeletionVectorWriter.storeSerializedBitmap`).
-   */
-  private def writeMergedDeletionVector(
-      dvStore: DeletionVectorStore,
-      tablePath: Path,
-      bitmap: RoaringBitmapArray): DeletionVectorDescriptor = {
-    // An empty DV has no on-disk representation (matches DeletionVectorWriter).
-    if (bitmap.isEmpty) return DeletionVectorDescriptor.EMPTY
-    val tablePathWithFs = dvStore.pathWithFileSystem(tablePath)
-    val fileId = UUID.randomUUID()
-    val writer = dvStore.createWriter(dvStore.generateFileNameInTable(tablePathWithFs, fileId))
-    try {
-      val serialized = DeletionVectorUtils.serialize(
-        bitmap, RoaringBitmapArrayFormat.Portable, Some(tablePath))
-      val range = writer.write(serialized)
-      DeletionVectorDescriptor.onDiskWithRelativePath(
-        id = fileId,
-        sizeInBytes = serialized.length,
-        cardinality = bitmap.cardinality,
-        offset = Some(range.offset))
-    } finally {
-      writer.close()
-    }
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
@@ -22,7 +22,7 @@ import java.util.concurrent.TimeUnit
 
 import scala.collection.mutable
 
-import org.apache.spark.sql.delta.DeltaOperations.{OP_DELETE, OP_SET_TBLPROPERTIES, OP_UPDATE, ROW_TRACKING_BACKFILL_OPERATION_NAME, ROW_TRACKING_UNBACKFILL_OPERATION_NAME}
+import org.apache.spark.sql.delta.DeltaOperations.{OP_SET_TBLPROPERTIES, ROW_TRACKING_BACKFILL_OPERATION_NAME, ROW_TRACKING_UNBACKFILL_OPERATION_NAME}
 import org.apache.spark.sql.delta.RowId.RowTrackingMetadataDomain
 import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
@@ -1145,31 +1145,25 @@ private[delta] class ConflictChecker(
     winningCommitSummary.commitInfo.map(_.operation)
 
   /**
-   * Whether the winning commit is a row-level DML that only rewrites or removes existing rows
-   * (DELETE or UPDATE), i.e. it introduces no net-new logical rows. Files added by such a commit
-   * are rewrites of rows that the current transaction already observed in its read snapshot (or
-   * re-adds of files masked by a deletion vector), so they cannot introduce phantom rows for the
-   * current transaction. MERGE is intentionally excluded because it may insert net-new rows.
-   */
-  private lazy val winningCommitIsRewriteOnlyRowLevelDml: Boolean = {
-    val usesDeletionVectors = winningCommitSummary.addedFiles.exists(_.deletionVector != null)
-    usesDeletionVectors && winningOperationName.exists {
-      case OP_DELETE | OP_UPDATE => true
-      case _ => false
-    }
-  }
-
-  /**
    * Whether a file added by the winning transaction can be skipped in the added-files (append)
-   * conflict check thanks to row-level concurrency resolution. This is true when:
-   *   1. the file's "same physical file" conflict was already reconciled by merging deletion
-   *      vectors ([[rowLevelResolvedPaths]]), or
-   *   2. the winning commit is a rewrite-only row-level DML (DELETE/UPDATE) whose added files
-   *      cannot introduce phantom rows (see [[winningCommitIsRewriteOnlyRowLevelDml]]).
+   * conflict check thanks to row-level concurrency resolution.
+   *
+   * This is true only when the file's "same physical file" conflict was already reconciled by
+   * merging deletion vectors ([[resolveRowLevelConflicts]] recorded the path in
+   * [[rowLevelResolvedPaths]]). In that case the winner's re-added `AddFile(P)` carries the winning
+   * DV that we already folded into the current transaction's merged DV, so re-checking it would be
+   * a false conflict.
+   *
+   * We deliberately do NOT skip a rewrite-only DML winner's *new image* files here (an UPDATE
+   * writes updated row values to a fresh path). Those are ordinary non-blind changed-data files
+   * and can legitimately conflict: e.g. an UPDATE can move a row *into* the loser's predicate
+   * (winner `SET x = 15`, loser `DELETE WHERE x > 10`, row was `x = 5`), a genuine write-skew that
+   * the DV union cannot detect. They are arbitrated by the standard added-files check (and, when
+   * enabled, by conflict-time data skipping over their stats).
    */
   private def canSkipAddedFileForRowLevelConcurrency(addFile: AddFile): Boolean = {
     if (!rowLevelConcurrencyEnabled) return false
-    rowLevelResolvedPaths.contains(addFile.path) || winningCommitIsRewriteOnlyRowLevelDml
+    rowLevelResolvedPaths.contains(addFile.path)
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/RowLevelConcurrencyResolution.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/RowLevelConcurrencyResolution.scala
@@ -31,6 +31,7 @@ import org.apache.spark.sql.delta.storage.dv.DeletionVectorStore
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.internal.MDC
+import org.apache.spark.util.ThreadUtils
 
 /**
  * Row-level concurrency resolution for the [[ConflictChecker]]: instead of aborting a concurrent
@@ -148,17 +149,15 @@ trait RowLevelConcurrencyResolution extends DeltaLogging { self: ConflictChecker
       val dvStore = DeletionVectorStore.createInstance(deltaLog.newDeltaHadoopConf())
       val tablePath = deltaLog.dataPath
 
-      // path -> (rebased AddFile, rebased RemoveFile)
-      val replacements = mutable.Map.empty[String, (AddFile, RemoveFile)]
-      for (path <- sharedPaths) {
+      // Reconcile each shared file's DVs independently; the work is driver-side object-store DV
+      // I/O (read + merge + write). When many files conflict, parallelize across a bounded pool
+      // to shorten the conflict window; a single file stays on the caller thread.
+      def reconcileOnePath(path: String): Option[(String, (AddFile, RemoveFile))] =
         try {
           reconcileFileDeletionVectors(
               dvStore, tablePath,
               winningDvUpdates(path), currentAddByPath(path), currentRemoveByPath(path))
-            .foreach { rebased =>
-              replacements(path) = rebased
-              rowLevelResolvedPaths += path
-            }
+            .map(path -> _)
         } catch {
           case NonFatal(e) =>
             // Fail safe: DV decode/merge/write is a pure optimization over the conservative
@@ -168,7 +167,22 @@ trait RowLevelConcurrencyResolution extends DeltaLogging { self: ConflictChecker
             // conflict detection. Other shared files are still resolved independently.
             logWarning(log"Row-level concurrency resolution failed for file " +
               log"${MDC(DeltaLogKeys.PATH, path)}; leaving it for the standard conflict checks", e)
+            None
         }
+
+      // Bounded driver parallelism (cf. DeltaFileOperations footer reads, which use 8).
+      val pathList = sharedPaths.toSeq
+      val parallelism = math.min(pathList.size, 8)
+      val reconciled =
+        if (parallelism <= 1) pathList.flatMap(reconcileOnePath)
+        else ThreadUtils.parmap(pathList, "rowLevelConflictResolution", parallelism)(
+          reconcileOnePath).flatten
+
+      // Apply per-file results on the caller thread (no shared-state races across the pool).
+      val replacements = mutable.Map.empty[String, (AddFile, RemoveFile)]
+      for ((path, rebased) <- reconciled) {
+        replacements(path) = rebased
+        rowLevelResolvedPaths += path
       }
 
       if (replacements.nonEmpty) {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/RowLevelConcurrencyResolution.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/RowLevelConcurrencyResolution.scala
@@ -1,0 +1,252 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import java.util.UUID
+
+import scala.collection.mutable
+
+import org.apache.spark.sql.delta.actions.{AddFile, DeletionVectorDescriptor, RemoveFile}
+import org.apache.spark.sql.delta.commands.DeletionVectorUtils
+import org.apache.spark.sql.delta.deletionvectors.{RoaringBitmapArray, RoaringBitmapArrayFormat}
+import org.apache.spark.sql.delta.metering.DeltaLogging
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.storage.dv.DeletionVectorStore
+import org.apache.hadoop.fs.Path
+
+/**
+ * Row-level concurrency resolution for the [[ConflictChecker]]: instead of aborting a concurrent
+ * DV-based DELETE/UPDATE that touches the same physical files as the winning transaction, MERGE the
+ * two transactions' deletion vectors when they deleted disjoint rows.
+ *
+ * Mixed into [[ConflictChecker]] as a self-typed trait: it reads and rewrites the checker's
+ * transaction state (`currentTransactionInfo`, `winningCommitSummary`, `deltaLog`, `spark`)
+ * directly, and lives in its own file so ConflictChecker stays focused on file-level conflict
+ * detection. The two deletion-vector helpers are `protected` so the OPTIMIZE-vs-DML reconciliation
+ * (which mixes into the same checker) can reuse them.
+ */
+trait RowLevelConcurrencyResolution extends DeltaLogging { self: ConflictChecker =>
+
+  /**
+   * Paths of files whose "same physical file" conflict with the winning transaction was resolved at
+   * the row level by [[resolveRowLevelConflicts]] (deletion vectors merged). The file-level delete
+   * and append checks skip these paths, since they have already been reconciled.
+   */
+  protected val rowLevelResolvedPaths = mutable.Set.empty[String]
+
+  /** Whether row-level concurrency resolution is enabled and applicable to this table. */
+  protected lazy val rowLevelConcurrencyEnabled: Boolean =
+    spark.conf.get(DeltaSQLConf.DELTA_ROW_LEVEL_CONCURRENCY_ENABLED) &&
+      DeletionVectorUtils.deletionVectorsWritable(
+        currentTransactionInfo.protocol, currentTransactionInfo.metadata)
+
+  /** The operation name of the winning commit, if available. */
+  protected lazy val winningOperationName: Option[String] =
+    winningCommitSummary.commitInfo.map(_.operation)
+
+  /**
+   * Whether a file added by the winning transaction can be skipped in the added-files (append)
+   * conflict check thanks to row-level concurrency resolution.
+   *
+   * This is true only when the file's "same physical file" conflict was already reconciled by
+   * merging deletion vectors ([[resolveRowLevelConflicts]] recorded the path in
+   * [[rowLevelResolvedPaths]]). In that case the winner's re-added `AddFile(P)` carries the winning
+   * DV that we already folded into the current transaction's merged DV, so re-checking it would be
+   * a false conflict.
+   *
+   * We deliberately do NOT skip a rewrite-only DML winner's *new image* files here (an UPDATE
+   * writes updated row values to a fresh path). Those are ordinary non-blind changed-data files
+   * and can legitimately conflict: e.g. an UPDATE can move a row *into* the loser's predicate
+   * (winner `SET x = 15`, loser `DELETE WHERE x > 10`, row was `x = 5`), a genuine write-skew that
+   * the DV union cannot detect. They are arbitrated by the standard added-files check (and, when
+   * enabled, by conflict-time data skipping over their stats).
+   */
+  protected def canSkipAddedFileForRowLevelConcurrency(addFile: AddFile): Boolean = {
+    if (!rowLevelConcurrencyEnabled) return false
+    rowLevelResolvedPaths.contains(addFile.path)
+  }
+
+  /**
+   * Resolves "same physical file" conflicts with the winning transaction at the row level.
+   *
+   * A DV-based DELETE/UPDATE emits, for each touched file `P`, a `RemoveFile(P)` (tombstone of the
+   * pre-image) and an `AddFile(P)` carrying a larger deletion vector. When both the winning and the
+   * current transaction touch the same file `P` this way, the two operations are logically
+   * independent as long as they mark *different* rows deleted. For every such shared file we:
+   *   1. decode the winning DV, the current DV and their common base DV (from the pre-image
+   *      `RemoveFile`) as [[RoaringBitmapArray]]s;
+   *   2. check whether the newly-deleted rows are disjoint, i.e. `(dv_win INTERSECT dv_cur) MINUS
+   *      dv_base` is empty. If they overlap, this is a genuine row-level conflict and we leave the
+   *      file for the standard checks to abort;
+   *   3. on disjoint sets, merge the DVs (`dv_win UNION dv_cur`), persist a new DV file,
+   *      and rebase the current transaction onto the winner's post-image: the current `AddFile(P)`
+   *      now carries the merged DV and the current `RemoveFile(P)` now tombstones the winner's
+   *      `AddFile(P)`.
+   *
+   * Worked example: file `P` holds rows 0..99, undeleted at the current txn's read time
+   * (`dv_base = {}`). The winner commits `DELETE WHERE id IN (5, 10)` so `dv_win = {5, 10}`; the
+   * current txn holds `DELETE WHERE id IN (20, 21)` so `dv_cur = {20, 21}`. The overlap is
+   * `({5,10} INTERSECT {20,21}) MINUS {} = {}` -> disjoint, so we merge to `dv = {5, 10, 20, 21}`,
+   * point the current `AddFile(P)` at it, and tombstone the winner's `AddFile(P)`; both deletes
+   * survive. Had the current txn instead deleted row 5 (`dv_cur = {5, 21}`), the overlap would be
+   * `{5}` -> the same row was deleted twice concurrently, a genuine conflict left for the standard
+   * checks to abort. (For a 3+ way chain `dv_base` is the previous winner's DV rather than the
+   * original pre-image, which keeps the overlap test conservative and the merge correct.)
+   *
+   * Resolved paths are recorded in [[rowLevelResolvedPaths]] and skipped by the file-level delete
+   * and append checks. Row identity is preserved for free: the merged file is the same physical
+   * file, so its base row ID is unchanged and [[reassignOverlappingRowIds]] (already run) leaves it
+   * alone. Deletion vectors index physical row positions within one immutable Parquet file, so the
+   * merge needs no row tracking.
+   */
+  protected def resolveRowLevelConflicts(): Unit = {
+    if (!rowLevelConcurrencyEnabled) return
+
+    // Winning transaction's DV updates: path present in both an AddFile (with a DV) and a
+    // RemoveFile of the winning commit.
+    val winningRemovedPaths = winningCommitSummary.removedFiles.map(_.path).toSet
+    val winningDvUpdates: Map[String, AddFile] = winningCommitSummary.addedFiles.iterator
+      .filter(a => a.deletionVector != null && winningRemovedPaths.contains(a.path))
+      .map(a => a.path -> a)
+      .toMap
+    if (winningDvUpdates.isEmpty) return
+
+    // Current transaction's DV updates, indexed by path.
+    val currentAddByPath = currentTransactionInfo.actions.collect {
+      case a: AddFile if a.deletionVector != null => a.path -> a
+    }.toMap
+    val currentRemoveByPath = currentTransactionInfo.actions.collect {
+      case r: RemoveFile => r.path -> r
+    }.toMap
+
+    val sharedPaths = winningDvUpdates.keySet
+      .intersect(currentAddByPath.keySet)
+      .intersect(currentRemoveByPath.keySet)
+    if (sharedPaths.isEmpty) return
+
+    recordTime("resolved-row-level-conflicts") {
+      val dvStore = DeletionVectorStore.createInstance(deltaLog.newDeltaHadoopConf())
+      val tablePath = deltaLog.dataPath
+
+      // path -> (rebased AddFile, rebased RemoveFile)
+      val replacements = mutable.Map.empty[String, (AddFile, RemoveFile)]
+      for (path <- sharedPaths) {
+        val winningAdd = winningDvUpdates(path)
+        val currentAdd = currentAddByPath(path)
+        val currentRemove = currentRemoveByPath(path)
+
+        def bitmapOf(dv: DeletionVectorDescriptor): RoaringBitmapArray =
+          readDeletionVectorOrEmpty(dvStore, dv, tablePath)
+        val baseBitmap = bitmapOf(currentRemove.deletionVector)
+        val winningBitmap = bitmapOf(winningAdd.deletionVector)
+        val currentBitmap = bitmapOf(currentAdd.deletionVector)
+
+        // `baseBitmap` is the DV of `P` at the current txn's read time (carried on its RemoveFile);
+        // for a 2-way conflict it equals the winner's pre-image too. Both `dv_win` and `dv_cur` are
+        // supersets of it (a DV only grows), so the newly-deleted rows are `dv \ base` on each side
+        // and their overlap is `(dv_win INTERSECT dv_cur) MINUS base`. If empty, the two txns
+        // touched disjoint rows and the schedule `current ; winner` is a valid serialization under
+        // both WriteSerializable and Serializable (the winner's rewrites/deletes are of rows the
+        // current txn did not touch), so merging is safe. If non-empty, the same row was touched by
+        // both -> genuine conflict, left for the standard checks. (For 3+ way chains `base` becomes
+        // previous winner's DV rather than the original pre-image; the merge stays correct and the
+        // overlap test stays conservative.)
+        val newlyDeletedOverlap = winningBitmap.copy()
+        newlyDeletedOverlap.and(currentBitmap)
+        newlyDeletedOverlap.andNot(baseBitmap)
+
+        if (newlyDeletedOverlap.isEmpty) {
+          // Disjoint: merge the deletion vectors and rebase onto the winner's post-image.
+          val mergedBitmap = winningBitmap.copy()
+          mergedBitmap.merge(currentBitmap)
+          val mergedDescriptor = writeMergedDeletionVector(dvStore, tablePath, mergedBitmap)
+          // Keep the current AddFile's identity (base row ID / default row commit version already
+          // reconciled by the row-ID phases) but point it at the merged DV.
+          val rebasedAdd = currentAdd
+            .copy(deletionVector = mergedDescriptor, dataChange = true)
+            .withoutTightBoundStats
+          // Tombstone the winner's now-live AddFile (carries the winning DV) instead of the stale
+          // pre-image.
+          val rebasedRemove = winningAdd.removeWithTimestamp()
+          replacements(path) = (rebasedAdd, rebasedRemove)
+          rowLevelResolvedPaths += path
+        }
+        // else: overlapping row-level modification -> genuine conflict, leave for standard checks.
+      }
+
+      if (replacements.nonEmpty) {
+        val newActions = currentTransactionInfo.actions.map {
+          case a: AddFile if replacements.contains(a.path) => replacements(a.path)._1
+          case r: RemoveFile if replacements.contains(r.path) => replacements(r.path)._2
+          case other => other
+        }
+        // Resolved files are no longer "read" for the purposes of the delete-read check.
+        val newReadFiles = currentTransactionInfo.readFiles
+          .filterNot(f => rowLevelResolvedPaths.contains(f.path))
+        currentTransactionInfo =
+          currentTransactionInfo.copy(actions = newActions, readFiles = newReadFiles)
+
+        recordDeltaEvent(
+          deltaLog,
+          opType = "delta.rowLevelConcurrency.deletionVectorsMerged",
+          data = Map(
+            "winningCommitVersion" -> winningCommitVersion,
+            "resolvedPaths" -> rowLevelResolvedPaths.size,
+            "winningOperation" -> winningOperationName.getOrElse("UNKNOWN")))
+      }
+    }
+  }
+
+  /** Reads a deletion vector into a [[RoaringBitmapArray]], returning an empty bitmap for none. */
+  protected def readDeletionVectorOrEmpty(
+      dvStore: DeletionVectorStore,
+      dv: DeletionVectorDescriptor,
+      tablePath: Path): RoaringBitmapArray = {
+    if (dv == null || dv.isEmpty) new RoaringBitmapArray() else dvStore.read(dv, tablePath)
+  }
+
+  /**
+   * Persists a merged bitmap to a new deletion vector file and returns its descriptor.
+   *
+   * NOTE: this writes a DV file as a side effect of conflict resolution. If the commit ultimately
+   * fails or is retried against another winning version, the file is orphaned and later reclaimed
+   * by VACUUM (same lifecycle as any DV written by DML). This mirrors how the DML write path
+   * persists DVs (see `DeletionVectorWriter.storeSerializedBitmap`).
+   */
+  protected def writeMergedDeletionVector(
+      dvStore: DeletionVectorStore,
+      tablePath: Path,
+      bitmap: RoaringBitmapArray): DeletionVectorDescriptor = {
+    // An empty DV has no on-disk representation (matches DeletionVectorWriter).
+    if (bitmap.isEmpty) return DeletionVectorDescriptor.EMPTY
+    val tablePathWithFs = dvStore.pathWithFileSystem(tablePath)
+    val fileId = UUID.randomUUID()
+    val writer = dvStore.createWriter(dvStore.generateFileNameInTable(tablePathWithFs, fileId))
+    try {
+      val serialized = DeletionVectorUtils.serialize(
+        bitmap, RoaringBitmapArrayFormat.Portable, Some(tablePath))
+      val range = writer.write(serialized)
+      DeletionVectorDescriptor.onDiskWithRelativePath(
+        id = fileId,
+        sizeInBytes = serialized.length,
+        cardinality = bitmap.cardinality,
+        offset = Some(range.offset))
+    } finally {
+      writer.close()
+    }
+  }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/RowLevelConcurrencyResolution.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/RowLevelConcurrencyResolution.scala
@@ -227,16 +227,25 @@ trait RowLevelConcurrencyResolution extends DeltaLogging { self: ConflictChecker
     val winningBitmap = bitmapOf(winningAdd.deletionVector)
     val currentBitmap = bitmapOf(currentAdd.deletionVector)
 
-    // `baseBitmap` is the DV of `P` at the current txn's read time (carried on its RemoveFile);
-    // for a 2-way conflict it equals the winner's pre-image too. Both `dv_win` and `dv_cur` are
-    // supersets of it (a DV only grows), so the newly-deleted rows are `dv \ base` on each side
-    // and their overlap is `(dv_win INTERSECT dv_cur) MINUS base`. If empty, the two txns
-    // touched disjoint rows and the schedule `current ; winner` is a valid serialization under
-    // both WriteSerializable and Serializable (the winner's rewrites/deletes are of rows the
-    // current txn did not touch), so merging is safe. If non-empty, the same row was touched by
-    // both -> genuine conflict, left for the standard checks. (For 3+ way chains `base` becomes
-    // previous winner's DV rather than the original pre-image; the merge stays correct and the
-    // overlap test stays conservative.)
+    // `baseBitmap` is the DV of `P` at the current txn's read time (carried on its RemoveFile).
+    // Both `dv_win` and `dv_cur` are supersets of it (a DV only grows), so each side's *newly*
+    // deleted rows are `dv \ base`, and their overlap is `(dv_win INTERSECT dv_cur) MINUS base`.
+    // Empty overlap => the two txns deleted disjoint rows, and `current ; winner` is a valid
+    // serialization under both WriteSerializable and Serializable (each deleted only rows the
+    // other did not touch), so the DV union is safe. Non-empty => the same row was deleted
+    // concurrently: a genuine conflict, left for the standard checks to abort.
+    //
+    // N-way: the current txn reconciles against a chain of winners, once per winning commit.
+    // Induction on the number of prior winners `k` already merged into the current txn:
+    //   k = 0 (first winner): `base` is P's read-time DV, so `dv_cur \ base` and `dv_win \ base`
+    //     are exactly the two txns' own new deletes -- the test is precise.
+    //   k -> k+1: merging winner k rebased the current RemoveFile onto winner k's AddFile (so now
+    //     `base = dv_win_k`) and the current AddFile onto the merged DV. Winner k+1 committed on
+    //     top of winner k, so `dv_win_k` is a subset of `dv_win_{k+1}`. The test
+    //     `(dv_win_{k+1} INTERSECT dv_cur) MINUS dv_win_k` then reduces to winner k+1's *own* new
+    //     deletes intersected with the current txn's own new deletes -- prior winners cancel out.
+    // Every step compares only the two operations' genuinely new rows, and the merged DV is a
+    // union of disjoint contributions, so the result is independent of winner order.
     val newlyDeletedOverlap = winningBitmap.copy()
     newlyDeletedOverlap.and(currentBitmap)
     newlyDeletedOverlap.andNot(baseBitmap)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/RowLevelConcurrencyResolution.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/RowLevelConcurrencyResolution.scala
@@ -46,13 +46,6 @@ import org.apache.spark.util.ThreadUtils
  */
 trait RowLevelConcurrencyResolution extends DeltaLogging { self: ConflictChecker =>
 
-  /**
-   * Paths of files whose "same physical file" conflict with the winning transaction was resolved at
-   * the row level by [[resolveRowLevelConflicts]] (deletion vectors merged). The file-level delete
-   * and append checks skip these paths, since they have already been reconciled.
-   */
-  protected val rowLevelResolvedPaths = mutable.Set.empty[String]
-
   /** Whether row-level concurrency resolution is enabled and applicable to this table. */
   protected lazy val rowLevelConcurrencyEnabled: Boolean =
     spark.conf.get(DeltaSQLConf.DELTA_ROW_LEVEL_CONCURRENCY_ENABLED) &&
@@ -62,28 +55,6 @@ trait RowLevelConcurrencyResolution extends DeltaLogging { self: ConflictChecker
   /** The operation name of the winning commit, if available. */
   protected lazy val winningOperationName: Option[String] =
     winningCommitSummary.commitInfo.map(_.operation)
-
-  /**
-   * Whether a file added by the winning transaction can be skipped in the added-files (append)
-   * conflict check thanks to row-level concurrency resolution.
-   *
-   * This is true only when the file's "same physical file" conflict was already reconciled by
-   * merging deletion vectors ([[resolveRowLevelConflicts]] recorded the path in
-   * [[rowLevelResolvedPaths]]). In that case the winner's re-added `AddFile(P)` carries the winning
-   * DV that we already folded into the current transaction's merged DV, so re-checking it would be
-   * a false conflict.
-   *
-   * We deliberately do NOT skip a rewrite-only DML winner's *new image* files here (an UPDATE
-   * writes updated row values to a fresh path). Those are ordinary non-blind changed-data files
-   * and can legitimately conflict: e.g. an UPDATE can move a row *into* the loser's predicate
-   * (winner `SET x = 15`, loser `DELETE WHERE x > 10`, row was `x = 5`), a genuine write-skew that
-   * the DV union cannot detect. They are arbitrated by the standard added-files check (and, when
-   * enabled, by conflict-time data skipping over their stats).
-   */
-  protected def canSkipAddedFileForRowLevelConcurrency(addFile: AddFile): Boolean = {
-    if (!rowLevelConcurrencyEnabled) return false
-    rowLevelResolvedPaths.contains(addFile.path)
-  }
 
   /**
    * Resolves "same physical file" conflicts with the winning transaction at the row level.
@@ -179,33 +150,61 @@ trait RowLevelConcurrencyResolution extends DeltaLogging { self: ConflictChecker
           reconcileOnePath).flatten
 
       // Apply per-file results on the caller thread (no shared-state races across the pool).
-      val replacements = mutable.Map.empty[String, (AddFile, RemoveFile)]
-      for ((path, rebased) <- reconciled) {
-        replacements(path) = rebased
-        rowLevelResolvedPaths += path
-      }
-
+      val replacements = reconciled.toMap
       if (replacements.nonEmpty) {
+        val resolvedPaths = replacements.keySet
+
+        // Rewrite BOTH sides of the conflict so the residual is a plain no-conflict state that the
+        // file-level checks (unchanged from upstream) handle. Current txn: rebase each AddFile(P)
+        // onto the merged DV and each RemoveFile(P) onto the winner's post-image, and drop P from
+        // readFiles (it is no longer "read" for the delete-read check).
         val newActions = currentTransactionInfo.actions.map {
           case a: AddFile if replacements.contains(a.path) => replacements(a.path)._1
           case r: RemoveFile if replacements.contains(r.path) => replacements(r.path)._2
           case other => other
         }
-        // Resolved files are no longer "read" for the purposes of the delete-read check.
-        val newReadFiles = currentTransactionInfo.readFiles
-          .filterNot(f => rowLevelResolvedPaths.contains(f.path))
+        val newReadFiles =
+          currentTransactionInfo.readFiles.filterNot(f => resolvedPaths.contains(f.path))
         currentTransactionInfo =
           currentTransactionInfo.copy(actions = newActions, readFiles = newReadFiles)
+        // Winning side: drop the reconciled AddFile(P)/RemoveFile(P) pair from the summary, so no
+        // check sees P as a winner-side add or remove.
+        winningCommitSummary = pruneReconciledFiles(winningCommitSummary, resolvedPaths)
 
         recordDeltaEvent(
           deltaLog,
           opType = "delta.rowLevelConcurrency.deletionVectorsMerged",
           data = Map(
             "winningCommitVersion" -> winningCommitVersion,
-            "resolvedPaths" -> rowLevelResolvedPaths.size,
+            "resolvedPaths" -> resolvedPaths.size,
             "winningOperation" -> winningOperationName.getOrElse("UNKNOWN")))
       }
     }
+  }
+
+  /**
+   * Returns a copy of `summary` with the reconciled files removed: for each resolved path we drop
+   * the winner's `AddFile(P)` (its deletion vector was folded into the current transaction's merged
+   * DV) and its `RemoveFile(P)` (tombstone of the shared pre-image). Rebuilding from the filtered
+   * action list recomputes the derived views (`addedFiles`, `removedFiles`,
+   * `changedDataAddedFiles`, ...), so the file-level conflict checks see a winner that never
+   * touched these files.
+   *
+   * Only the same-path reconciled pair is pruned. A rewrite-only DML winner's *new image* files (an
+   * UPDATE writes updated row values to a fresh path) are left in the summary and arbitrated by the
+   * standard added-files check: an UPDATE can move a row *into* the loser's predicate (winner
+   * `SET x = 15`, loser `DELETE WHERE x > 10`, row was `x = 5`), a genuine write-skew the DV union
+   * cannot detect. All non-file actions (protocol, metadata, domain metadata) are preserved.
+   */
+  private def pruneReconciledFiles(
+      summary: WinningCommitSummary,
+      resolvedPaths: Set[String]): WinningCommitSummary = {
+    val prunedActions = summary.actions.filterNot {
+      case a: AddFile => resolvedPaths.contains(a.path)
+      case r: RemoveFile => resolvedPaths.contains(r.path)
+      case _ => false
+    }
+    new WinningCommitSummary(prunedActions, summary.fileStatus, summary.readTimeMs)
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/RowLevelConcurrencyResolution.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/RowLevelConcurrencyResolution.scala
@@ -19,14 +19,18 @@ package org.apache.spark.sql.delta
 import java.util.UUID
 
 import scala.collection.mutable
+import scala.util.control.NonFatal
 
 import org.apache.spark.sql.delta.actions.{AddFile, DeletionVectorDescriptor, RemoveFile}
 import org.apache.spark.sql.delta.commands.DeletionVectorUtils
 import org.apache.spark.sql.delta.deletionvectors.{RoaringBitmapArray, RoaringBitmapArrayFormat}
+import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.storage.dv.DeletionVectorStore
 import org.apache.hadoop.fs.Path
+
+import org.apache.spark.internal.MDC
 
 /**
  * Row-level concurrency resolution for the [[ConflictChecker]]: instead of aborting a concurrent
@@ -125,13 +129,15 @@ trait RowLevelConcurrencyResolution extends DeltaLogging { self: ConflictChecker
       .toMap
     if (winningDvUpdates.isEmpty) return
 
-    // Current transaction's DV updates, indexed by path.
-    val currentAddByPath = currentTransactionInfo.actions.collect {
-      case a: AddFile if a.deletionVector != null => a.path -> a
-    }.toMap
-    val currentRemoveByPath = currentTransactionInfo.actions.collect {
-      case r: RemoveFile => r.path -> r
-    }.toMap
+    // Current transaction's DV updates and file removes, indexed by path. Built in a single pass
+    // over the actions (last-writer-wins per path, matching the prior `.collect{}.toMap`).
+    val currentAddByPath = mutable.Map.empty[String, AddFile]
+    val currentRemoveByPath = mutable.Map.empty[String, RemoveFile]
+    currentTransactionInfo.actions.foreach {
+      case a: AddFile if a.deletionVector != null => currentAddByPath(a.path) = a
+      case r: RemoveFile => currentRemoveByPath(r.path) = r
+      case _ =>
+    }
 
     val sharedPaths = winningDvUpdates.keySet
       .intersect(currentAddByPath.keySet)
@@ -145,47 +151,24 @@ trait RowLevelConcurrencyResolution extends DeltaLogging { self: ConflictChecker
       // path -> (rebased AddFile, rebased RemoveFile)
       val replacements = mutable.Map.empty[String, (AddFile, RemoveFile)]
       for (path <- sharedPaths) {
-        val winningAdd = winningDvUpdates(path)
-        val currentAdd = currentAddByPath(path)
-        val currentRemove = currentRemoveByPath(path)
-
-        def bitmapOf(dv: DeletionVectorDescriptor): RoaringBitmapArray =
-          readDeletionVectorOrEmpty(dvStore, dv, tablePath)
-        val baseBitmap = bitmapOf(currentRemove.deletionVector)
-        val winningBitmap = bitmapOf(winningAdd.deletionVector)
-        val currentBitmap = bitmapOf(currentAdd.deletionVector)
-
-        // `baseBitmap` is the DV of `P` at the current txn's read time (carried on its RemoveFile);
-        // for a 2-way conflict it equals the winner's pre-image too. Both `dv_win` and `dv_cur` are
-        // supersets of it (a DV only grows), so the newly-deleted rows are `dv \ base` on each side
-        // and their overlap is `(dv_win INTERSECT dv_cur) MINUS base`. If empty, the two txns
-        // touched disjoint rows and the schedule `current ; winner` is a valid serialization under
-        // both WriteSerializable and Serializable (the winner's rewrites/deletes are of rows the
-        // current txn did not touch), so merging is safe. If non-empty, the same row was touched by
-        // both -> genuine conflict, left for the standard checks. (For 3+ way chains `base` becomes
-        // previous winner's DV rather than the original pre-image; the merge stays correct and the
-        // overlap test stays conservative.)
-        val newlyDeletedOverlap = winningBitmap.copy()
-        newlyDeletedOverlap.and(currentBitmap)
-        newlyDeletedOverlap.andNot(baseBitmap)
-
-        if (newlyDeletedOverlap.isEmpty) {
-          // Disjoint: merge the deletion vectors and rebase onto the winner's post-image.
-          val mergedBitmap = winningBitmap.copy()
-          mergedBitmap.merge(currentBitmap)
-          val mergedDescriptor = writeMergedDeletionVector(dvStore, tablePath, mergedBitmap)
-          // Keep the current AddFile's identity (base row ID / default row commit version already
-          // reconciled by the row-ID phases) but point it at the merged DV.
-          val rebasedAdd = currentAdd
-            .copy(deletionVector = mergedDescriptor, dataChange = true)
-            .withoutTightBoundStats
-          // Tombstone the winner's now-live AddFile (carries the winning DV) instead of the stale
-          // pre-image.
-          val rebasedRemove = winningAdd.removeWithTimestamp()
-          replacements(path) = (rebasedAdd, rebasedRemove)
-          rowLevelResolvedPaths += path
+        try {
+          reconcileFileDeletionVectors(
+              dvStore, tablePath,
+              winningDvUpdates(path), currentAddByPath(path), currentRemoveByPath(path))
+            .foreach { rebased =>
+              replacements(path) = rebased
+              rowLevelResolvedPaths += path
+            }
+        } catch {
+          case NonFatal(e) =>
+            // Fail safe: DV decode/merge/write is a pure optimization over the conservative
+            // default. If it fails for this file (unreadable/corrupt DV, transient I/O), skip
+            // row-level resolution for it so the standard file-level checks abort cleanly with a
+            // retryable Concurrent* exception instead of surfacing an unexpected error out of
+            // conflict detection. Other shared files are still resolved independently.
+            logWarning(log"Row-level concurrency resolution failed for file " +
+              log"${MDC(DeltaLogKeys.PATH, path)}; leaving it for the standard conflict checks", e)
         }
-        // else: overlapping row-level modification -> genuine conflict, leave for standard checks.
       }
 
       if (replacements.nonEmpty) {
@@ -208,6 +191,59 @@ trait RowLevelConcurrencyResolution extends DeltaLogging { self: ConflictChecker
             "resolvedPaths" -> rowLevelResolvedPaths.size,
             "winningOperation" -> winningOperationName.getOrElse("UNKNOWN")))
       }
+    }
+  }
+
+  /**
+   * Reconciles the winning and current transactions' deletion vectors for a single shared file `P`.
+   * Returns the rebased `(AddFile, RemoveFile)` to substitute into the current transaction when the
+   * two transactions deleted disjoint rows, or `None` when they overlap (a genuine row-level
+   * conflict, left for the standard checks). All deletion-vector I/O for `P` happens here, so its
+   * caller can wrap it in a fail-safe boundary.
+   */
+  private def reconcileFileDeletionVectors(
+      dvStore: DeletionVectorStore,
+      tablePath: Path,
+      winningAdd: AddFile,
+      currentAdd: AddFile,
+      currentRemove: RemoveFile): Option[(AddFile, RemoveFile)] = {
+    def bitmapOf(dv: DeletionVectorDescriptor): RoaringBitmapArray =
+      readDeletionVectorOrEmpty(dvStore, dv, tablePath)
+    val baseBitmap = bitmapOf(currentRemove.deletionVector)
+    val winningBitmap = bitmapOf(winningAdd.deletionVector)
+    val currentBitmap = bitmapOf(currentAdd.deletionVector)
+
+    // `baseBitmap` is the DV of `P` at the current txn's read time (carried on its RemoveFile);
+    // for a 2-way conflict it equals the winner's pre-image too. Both `dv_win` and `dv_cur` are
+    // supersets of it (a DV only grows), so the newly-deleted rows are `dv \ base` on each side
+    // and their overlap is `(dv_win INTERSECT dv_cur) MINUS base`. If empty, the two txns
+    // touched disjoint rows and the schedule `current ; winner` is a valid serialization under
+    // both WriteSerializable and Serializable (the winner's rewrites/deletes are of rows the
+    // current txn did not touch), so merging is safe. If non-empty, the same row was touched by
+    // both -> genuine conflict, left for the standard checks. (For 3+ way chains `base` becomes
+    // previous winner's DV rather than the original pre-image; the merge stays correct and the
+    // overlap test stays conservative.)
+    val newlyDeletedOverlap = winningBitmap.copy()
+    newlyDeletedOverlap.and(currentBitmap)
+    newlyDeletedOverlap.andNot(baseBitmap)
+
+    if (!newlyDeletedOverlap.isEmpty) {
+      // Overlapping row-level modification -> genuine conflict, leave for the standard checks.
+      None
+    } else {
+      // Disjoint: merge the deletion vectors and rebase onto the winner's post-image.
+      val mergedBitmap = winningBitmap.copy()
+      mergedBitmap.merge(currentBitmap)
+      val mergedDescriptor = writeMergedDeletionVector(dvStore, tablePath, mergedBitmap)
+      // Keep the current AddFile's identity (base row ID / default row commit version already
+      // reconciled by the row-ID phases) but point it at the merged DV.
+      val rebasedAdd = currentAdd
+        .copy(deletionVector = mergedDescriptor, dataChange = true)
+        .withoutTightBoundStats
+      // Tombstone the winner's now-live AddFile (carries the winning DV) instead of the stale
+      // pre-image.
+      val rebasedRemove = winningAdd.removeWithTimestamp()
+      Some((rebasedAdd, rebasedRemove))
     }
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -534,6 +534,19 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .booleanConf
       .createWithDefault(true)
 
+  val DELTA_ROW_LEVEL_CONCURRENCY_ENABLED =
+    buildConf("rowLevelConcurrency.enabled")
+      .internal()
+      .doc(
+        """When enabled, the conflict checker attempts to resolve conflicts between concurrent
+          |DML operations at the row level using deletion vectors, instead of failing the
+          |transaction. For every "same physical file" conflict, it decodes both transactions'
+          |deletion vectors, checks whether the newly-deleted rows are disjoint, and on disjoint
+          |sets merges the deletion vectors and rebases the losing transaction onto the winner's
+          |post-image. Only active when deletion vectors are writable.""".stripMargin)
+      .booleanConf
+      .createWithDefault(false)
+
   val DELTA_PROTOCOL_DEFAULT_WRITER_VERSION =
     buildConf("properties.defaults.minWriterVersion")
       .doc("The default writer protocol version to create new tables with, unless a feature " +

--- a/spark/src/test/scala/org/apache/spark/sql/delta/RowLevelConcurrencySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/RowLevelConcurrencySuite.scala
@@ -1,0 +1,297 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import java.io.File
+
+import scala.concurrent.duration.Duration
+
+import org.apache.spark.sql.delta.concurrency.PhaseLockingTestMixin
+import org.apache.spark.sql.delta.concurrency.TransactionExecutionTestMixin
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+
+import org.apache.spark.{SparkConf, SparkException}
+import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.functions.lit
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.util.ThreadUtils
+
+/**
+ * End-to-end tests for deletion-vector-based row-level concurrency
+ * ([[DeltaSQLConf.DELTA_ROW_LEVEL_CONCURRENCY_ENABLED]]).
+ *
+ * Two concurrent DML operations that touch the same physical file but modify disjoint rows should
+ * commit cleanly by merging their deletion vectors, instead of aborting the losing transaction.
+ */
+class RowLevelConcurrencySuite extends QueryTest
+  with SharedSparkSession
+  with DeltaSQLCommandTest
+  with PhaseLockingTestMixin
+  with TransactionExecutionTestMixin {
+
+  // Enable deletion vectors on every table created by this suite.
+  override protected def sparkConf: SparkConf = super.sparkConf
+    .set(DeltaConfigs.ENABLE_DELETION_VECTORS_CREATION.defaultTablePropertyKey, "true")
+
+  private def tableRef(dir: File): String = s"delta.`${dir.getCanonicalPath}`"
+
+  /** Creates a single-file Delta table with `id` in [0, numRows) and deletion vectors enabled. */
+  private def createSingleFileTableWithDVs(dir: File, numRows: Int = 100): DeltaLog = {
+    spark.range(start = 0, end = numRows, step = 1, numPartitions = 1)
+      .write.format("delta").mode("append").save(dir.getAbsolutePath)
+    val log = DeltaLog.forTable(spark, dir.getCanonicalPath)
+    val snapshot = log.update()
+    assert(
+      snapshot.metadata.configuration
+        .get(DeltaConfigs.ENABLE_DELETION_VECTORS_CREATION.key).contains("true"),
+      "deletion vectors must be enabled on the test table")
+    assert(snapshot.allFiles.collect().length === 1, "test table must have a single data file")
+    log
+  }
+
+  /** A DELETE/UPDATE transaction that runs under the given row-level-concurrency setting. */
+  private def sqlTxn(sqlText: String, rowLevelConcurrency: Boolean): () => Array[Row] =
+    () => {
+      withSQLConf(
+        DeltaSQLConf.DELTA_ROW_LEVEL_CONCURRENCY_ENABLED.key -> rowLevelConcurrency.toString) {
+        sql(sqlText).collect()
+      }
+      Array.empty[Row]
+    }
+
+  private def deletionVectorCardinalities(log: DeltaLog): Seq[Long] =
+    log.update().allFiles.collect()
+      .filter(_.deletionVector != null)
+      .map(_.deletionVector.cardinality)
+      .toSeq
+
+  private def assertConcurrentModificationException(e: SparkException): Unit = {
+    val causeName = e.getCause.getClass.getName
+    assert(
+      Seq("ConcurrentAppend", "ConcurrentDeleteRead", "ConcurrentDeleteDelete")
+        .exists(causeName.contains),
+      s"Expected a concurrency conflict, got: $causeName")
+  }
+
+  private def ids(dir: File): Seq[Long] =
+    spark.read.format("delta").load(dir.getAbsolutePath).select("id")
+      .collect().map(_.getLong(0)).sorted.toSeq
+
+  // ---------------------------------------------------------------------------
+  // DELETE vs DELETE (same file)
+  // ---------------------------------------------------------------------------
+
+  test("disjoint concurrent DELETEs on the same file both commit by merging deletion vectors") {
+    withTempDir { dir =>
+      val log = createSingleFileTableWithDVs(dir)
+      val txnA = sqlTxn(s"DELETE FROM ${tableRef(dir)} WHERE id = 10", rowLevelConcurrency = true)
+      val txnB = sqlTxn(s"DELETE FROM ${tableRef(dir)} WHERE id = 20", rowLevelConcurrency = true)
+
+      val (futureA, futureB) = runTxnsWithOrder__A_Start__B__A_End(txnA, txnB)
+      ThreadUtils.awaitResult(futureA, Duration.Inf)
+      ThreadUtils.awaitResult(futureB, Duration.Inf)
+
+      assert(ids(dir) === (0L to 99L).filterNot(id => id == 10 || id == 20))
+      // One surviving file carrying the merged deletion vector (cardinality 2).
+      assert(deletionVectorCardinalities(log) === Seq(2L))
+    }
+  }
+
+  test("overlapping concurrent DELETEs still conflict") {
+    withTempDir { dir =>
+      val log = createSingleFileTableWithDVs(dir)
+      val txnA = sqlTxn(s"DELETE FROM ${tableRef(dir)} WHERE id = 10", rowLevelConcurrency = true)
+      val txnB = sqlTxn(s"DELETE FROM ${tableRef(dir)} WHERE id = 10", rowLevelConcurrency = true)
+
+      val (futureA, futureB) = runTxnsWithOrder__A_Start__B__A_End(txnA, txnB)
+      ThreadUtils.awaitResult(futureB, Duration.Inf)
+      val e = intercept[SparkException] { ThreadUtils.awaitResult(futureA, Duration.Inf) }
+      assertConcurrentModificationException(e)
+      // Clean abort: only the winner's delete (id=10) is applied; its DV has cardinality 1.
+      assert(ids(dir) === (0L to 99L).filterNot(_ == 10))
+      assert(deletionVectorCardinalities(log) === Seq(1L))
+    }
+  }
+
+  test("feature disabled: disjoint concurrent DELETEs still conflict") {
+    withTempDir { dir =>
+      val log = createSingleFileTableWithDVs(dir)
+      val txnA = sqlTxn(s"DELETE FROM ${tableRef(dir)} WHERE id = 10", rowLevelConcurrency = false)
+      val txnB = sqlTxn(s"DELETE FROM ${tableRef(dir)} WHERE id = 20", rowLevelConcurrency = false)
+
+      val (futureA, futureB) = runTxnsWithOrder__A_Start__B__A_End(txnA, txnB)
+      ThreadUtils.awaitResult(futureB, Duration.Inf)
+      val e = intercept[SparkException] { ThreadUtils.awaitResult(futureA, Duration.Inf) }
+      assertConcurrentModificationException(e)
+      // Only the winner's delete (id=20) is applied; DVs are still used, so its DV has cardinality 1.
+      assert(ids(dir) === (0L to 99L).filterNot(_ == 20))
+      assert(deletionVectorCardinalities(log) === Seq(1L))
+    }
+  }
+
+  test("deletion vectors disabled: row-level concurrency gate is off, disjoint DELETEs conflict") {
+    withTempDir { dir =>
+      createSingleFileTableWithDVs(dir)
+      sql(s"ALTER TABLE ${tableRef(dir)} SET TBLPROPERTIES " +
+        s"('${DeltaConfigs.ENABLE_DELETION_VECTORS_CREATION.key}' = 'false')")
+      val log = DeltaLog.forTable(spark, dir.getCanonicalPath)
+      // Flag ON, but DVs are not writable -> resolveRowLevelConflicts no-ops.
+      val txnA = sqlTxn(s"DELETE FROM ${tableRef(dir)} WHERE id = 10", rowLevelConcurrency = true)
+      val txnB = sqlTxn(s"DELETE FROM ${tableRef(dir)} WHERE id = 20", rowLevelConcurrency = true)
+
+      val (futureA, futureB) = runTxnsWithOrder__A_Start__B__A_End(txnA, txnB)
+      ThreadUtils.awaitResult(futureB, Duration.Inf)
+      val e = intercept[SparkException] { ThreadUtils.awaitResult(futureA, Duration.Inf) }
+      assertConcurrentModificationException(e)
+      // Winner's delete (id=20) applied by rewriting the file (no DVs), so no DV is present.
+      assert(ids(dir) === (0L to 99L).filterNot(_ == 20))
+      assert(deletionVectorCardinalities(log) === Seq.empty[Long])
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Layer 2: UPDATE (rewrite-only DML adds new data files)
+  // ---------------------------------------------------------------------------
+
+  test("disjoint DELETE (loser) vs UPDATE (winner) both commit") {
+    withTempDir { dir =>
+      val log = createSingleFileTableWithDVs(dir)
+      // A (loser) deletes id=10; B (winner) updates id=20 -> 1020 (masks row 20, appends image).
+      val txnA = sqlTxn(s"DELETE FROM ${tableRef(dir)} WHERE id = 10", rowLevelConcurrency = true)
+      val txnB = sqlTxn(s"UPDATE ${tableRef(dir)} SET id = 1020 WHERE id = 20",
+        rowLevelConcurrency = true)
+
+      val (futureA, futureB) = runTxnsWithOrder__A_Start__B__A_End(txnA, txnB)
+      ThreadUtils.awaitResult(futureA, Duration.Inf)
+      ThreadUtils.awaitResult(futureB, Duration.Inf)
+
+      assert(ids(dir) === ((0L to 99L).filterNot(id => id == 10 || id == 20) :+ 1020L).sorted)
+      // The original file's merged DV masks rows 10 and 20; the updated image lives in a new file.
+      assert(deletionVectorCardinalities(log) === Seq(2L))
+    }
+  }
+
+  test("disjoint UPDATE vs UPDATE both commit") {
+    withTempDir { dir =>
+      val log = createSingleFileTableWithDVs(dir)
+      val txnA = sqlTxn(s"UPDATE ${tableRef(dir)} SET id = 1010 WHERE id = 10",
+        rowLevelConcurrency = true)
+      val txnB = sqlTxn(s"UPDATE ${tableRef(dir)} SET id = 1020 WHERE id = 20",
+        rowLevelConcurrency = true)
+
+      val (futureA, futureB) = runTxnsWithOrder__A_Start__B__A_End(txnA, txnB)
+      ThreadUtils.awaitResult(futureA, Duration.Inf)
+      ThreadUtils.awaitResult(futureB, Duration.Inf)
+
+      assert(ids(dir) ===
+        ((0L to 99L).filterNot(id => id == 10 || id == 20) ++ Seq(1010L, 1020L)).sorted)
+      // Original file's merged DV masks rows 10 and 20; updated images live in two new files.
+      assert(deletionVectorCardinalities(log) === Seq(2L))
+    }
+  }
+
+  test("overlapping UPDATE vs UPDATE (same row) still conflict") {
+    withTempDir { dir =>
+      val log = createSingleFileTableWithDVs(dir)
+      val txnA = sqlTxn(s"UPDATE ${tableRef(dir)} SET id = 1010 WHERE id = 20",
+        rowLevelConcurrency = true)
+      val txnB = sqlTxn(s"UPDATE ${tableRef(dir)} SET id = 2020 WHERE id = 20",
+        rowLevelConcurrency = true)
+
+      val (futureA, futureB) = runTxnsWithOrder__A_Start__B__A_End(txnA, txnB)
+      ThreadUtils.awaitResult(futureB, Duration.Inf)
+      val e = intercept[SparkException] { ThreadUtils.awaitResult(futureA, Duration.Inf) }
+      assertConcurrentModificationException(e)
+      // Only the winner's update (20 -> 2020) is applied; original file's DV masks row 20.
+      assert(ids(dir) === ((0L to 99L).filterNot(_ == 20) :+ 2020L).sorted)
+      assert(deletionVectorCardinalities(log) === Seq(1L))
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Winner fully removes the file -> not reconcilable -> conflict
+  // ---------------------------------------------------------------------------
+
+  test("winner that fully removes a file conflicts with a concurrent row-level delete") {
+    withTempDir { dir =>
+      // Two files: [0,50) and [50,100).
+      spark.range(start = 0, end = 100, step = 1, numPartitions = 2)
+        .write.format("delta").mode("append").save(dir.getAbsolutePath)
+      val log = DeltaLog.forTable(spark, dir.getCanonicalPath)
+      // A (loser) DV-deletes one row in the first file; B (winner) deletes the whole first file.
+      val txnA = sqlTxn(s"DELETE FROM ${tableRef(dir)} WHERE id = 10", rowLevelConcurrency = true)
+      val txnB = sqlTxn(s"DELETE FROM ${tableRef(dir)} WHERE id < 50", rowLevelConcurrency = true)
+
+      val (futureA, futureB) = runTxnsWithOrder__A_Start__B__A_End(txnA, txnB)
+      ThreadUtils.awaitResult(futureB, Duration.Inf)
+      val e = intercept[SparkException] { ThreadUtils.awaitResult(futureA, Duration.Inf) }
+      assertConcurrentModificationException(e)
+      // Winner fully removed the first file (no DV); loser aborted cleanly.
+      assert(ids(dir) === (50L to 99L))
+      assert(deletionVectorCardinalities(log) === Seq.empty[Long])
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // N-way: three concurrent transactions on the same file
+  // ---------------------------------------------------------------------------
+
+  test("three concurrent disjoint DELETEs on the same file all commit") {
+    withTempDir { dir =>
+      val log = createSingleFileTableWithDVs(dir)
+      val txnA = sqlTxn(s"DELETE FROM ${tableRef(dir)} WHERE id = 10", rowLevelConcurrency = true)
+      val txnB = sqlTxn(s"DELETE FROM ${tableRef(dir)} WHERE id = 20", rowLevelConcurrency = true)
+      val txnC = sqlTxn(s"DELETE FROM ${tableRef(dir)} WHERE id = 30", rowLevelConcurrency = true)
+
+      // A starts; B commits; C commits; A commits last (reconciles against both B and C).
+      val (futureA, futureB, futureC) =
+        runTxnsWithOrder__A_Start__B__C__A_End(txnA, txnB, txnC)
+      ThreadUtils.awaitResult(futureA, Duration.Inf)
+      ThreadUtils.awaitResult(futureB, Duration.Inf)
+      ThreadUtils.awaitResult(futureC, Duration.Inf)
+
+      assert(ids(dir) === (0L to 99L).filterNot(id => Set(10L, 20L, 30L).contains(id)))
+      assert(deletionVectorCardinalities(log) === Seq(3L))
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Partitioned table (DV merge is partition-agnostic)
+  // ---------------------------------------------------------------------------
+
+  test("disjoint concurrent DELETEs on a partitioned table's file both commit") {
+    withTempDir { dir =>
+      // Single partition p=0 with a single data file.
+      spark.range(start = 0, end = 100, step = 1, numPartitions = 1)
+        .withColumn("p", lit(0))
+        .write.partitionBy("p").format("delta").mode("append").save(dir.getAbsolutePath)
+      val log = DeltaLog.forTable(spark, dir.getCanonicalPath)
+      assert(log.update().allFiles.collect().length === 1)
+
+      val txnA = sqlTxn(s"DELETE FROM ${tableRef(dir)} WHERE id = 10", rowLevelConcurrency = true)
+      val txnB = sqlTxn(s"DELETE FROM ${tableRef(dir)} WHERE id = 20", rowLevelConcurrency = true)
+
+      val (futureA, futureB) = runTxnsWithOrder__A_Start__B__A_End(txnA, txnB)
+      ThreadUtils.awaitResult(futureA, Duration.Inf)
+      ThreadUtils.awaitResult(futureB, Duration.Inf)
+
+      assert(ids(dir) === (0L to 99L).filterNot(id => id == 10 || id == 20))
+      assert(deletionVectorCardinalities(log) === Seq(2L))
+    }
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/RowLevelConcurrencySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/RowLevelConcurrencySuite.scala
@@ -42,7 +42,7 @@ import org.apache.spark.util.ThreadUtils
  * image* files (an UPDATE emits updated row values to a fresh path) is NOT reconciled here. Those
  * image files are ordinary non-blind changed-data files that can carry a genuine conflict (a
  * value-flip write-skew), so they fall back to today's abort. Reconciling them on proven
- * non-overlap is conflict-time data skipping, owned by Case 1 (fork issue #4).
+ * non-overlap is conflict-time reader-side data skipping (a separate change).
  */
 class RowLevelConcurrencySuite extends QueryTest
   with SharedSparkSession
@@ -56,10 +56,17 @@ class RowLevelConcurrencySuite extends QueryTest
 
   private def tableRef(dir: File): String = s"delta.`${dir.getCanonicalPath}`"
 
-  /** Creates a single-file Delta table with `id` in [0, numRows) and deletion vectors enabled. */
-  private def createSingleFileTableWithDVs(dir: File, numRows: Int = 100): DeltaLog = {
+  /**
+   * Creates a single-file Delta table with `id` in [0, numRows) and deletion vectors enabled.
+   * `extraProperties` are applied as `delta.*` table properties at creation (e.g. row tracking or
+   * change data feed).
+   */
+  private def createSingleFileTableWithDVs(
+      dir: File,
+      numRows: Int = 100,
+      extraProperties: Map[String, String] = Map.empty): DeltaLog = {
     spark.range(start = 0, end = numRows, step = 1, numPartitions = 1)
-      .write.format("delta").mode("append").save(dir.getAbsolutePath)
+      .write.format("delta").options(extraProperties).mode("append").save(dir.getAbsolutePath)
     val log = DeltaLog.forTable(spark, dir.getCanonicalPath)
     val snapshot = log.update()
     assert(
@@ -118,6 +125,48 @@ class RowLevelConcurrencySuite extends QueryTest
     }
   }
 
+  test("disjoint concurrent DELETEs reconcile on a file that already carries a base DV") {
+    withTempDir { dir =>
+      val log = createSingleFileTableWithDVs(dir)
+      // Establish a non-empty base DV: delete id=5 and commit (the file now carries a DV of
+      // cardinality 1). Both concurrent txns below read this DV as their common base, so the
+      // overlap test must subtract it (`(dv_win INTERSECT dv_cur) MINUS base`); without that
+      // subtraction the shared row 5 would look like a false conflict and abort the merge.
+      sql(s"DELETE FROM ${tableRef(dir)} WHERE id = 5")
+      assert(deletionVectorCardinalities(log) === Seq(1L))
+
+      val txnA = sqlTxn(s"DELETE FROM ${tableRef(dir)} WHERE id = 10", rowLevelConcurrency = true)
+      val txnB = sqlTxn(s"DELETE FROM ${tableRef(dir)} WHERE id = 20", rowLevelConcurrency = true)
+
+      val (futureA, futureB) = runTxnsWithOrder__A_Start__B__A_End(txnA, txnB)
+      ThreadUtils.awaitResult(futureA, Duration.Inf)
+      ThreadUtils.awaitResult(futureB, Duration.Inf)
+
+      assert(ids(dir) === (0L to 99L).filterNot(id => Set(5L, 10L, 20L).contains(id)))
+      // Base row 5 plus the two disjoint new deletes -> merged deletion vector cardinality 3.
+      assert(deletionVectorCardinalities(log) === Seq(3L))
+    }
+  }
+
+  test("disjoint concurrent DELETEs reconcile under Serializable isolation") {
+    withTempDir { dir =>
+      val log = createSingleFileTableWithDVs(dir)
+      sql(s"ALTER TABLE ${tableRef(dir)} SET TBLPROPERTIES " +
+        s"('${DeltaConfigs.ISOLATION_LEVEL.key}' = 'Serializable')")
+      // The `current ; winner` schedule of two disjoint-row deletes is a valid serialization even
+      // under Serializable (neither read a row the other wrote), so the DV union still commits.
+      val txnA = sqlTxn(s"DELETE FROM ${tableRef(dir)} WHERE id = 10", rowLevelConcurrency = true)
+      val txnB = sqlTxn(s"DELETE FROM ${tableRef(dir)} WHERE id = 20", rowLevelConcurrency = true)
+
+      val (futureA, futureB) = runTxnsWithOrder__A_Start__B__A_End(txnA, txnB)
+      ThreadUtils.awaitResult(futureA, Duration.Inf)
+      ThreadUtils.awaitResult(futureB, Duration.Inf)
+
+      assert(ids(dir) === (0L to 99L).filterNot(id => id == 10 || id == 20))
+      assert(deletionVectorCardinalities(log) === Seq(2L))
+    }
+  }
+
   test("overlapping concurrent DELETEs still conflict") {
     withTempDir { dir =>
       val log = createSingleFileTableWithDVs(dir)
@@ -171,9 +220,9 @@ class RowLevelConcurrencySuite extends QueryTest
   }
 
   // ---------------------------------------------------------------------------
-  // UPDATE image files: rewrite-only DML writes new data files that Layer-1 (DV union) does not
-  // reconcile. They conservatively conflict here; conflict-time data skipping (Case 1 / #4)
-  // reconciles the provably-disjoint case.
+  // UPDATE image files: rewrite-only DML writes new data files that same-file DV union does not
+  // reconcile. They conservatively conflict here; conflict-time reader-side data skipping (a
+  // separate change) reconciles the provably-disjoint case.
   // ---------------------------------------------------------------------------
 
   test("DELETE (loser) vs UPDATE (winner): winner image file conservatively conflicts") {
@@ -188,9 +237,10 @@ class RowLevelConcurrencySuite extends QueryTest
       ThreadUtils.awaitResult(futureB, Duration.Inf)
       // The shared file's DVs are disjoint and would merge, but the winner's UPDATE also writes an
       // *image* file (new path) that the append check cannot prove disjoint from the loser's read
-      // without conflict-time data skipping (Case 1 / #4). It conservatively conflicts, so the
-      // loser aborts. This is one-way safe: it never reconciles a genuine value-flip write-skew
-      // (e.g. winner `SET x = 15`, loser `DELETE WHERE x > 10`), which the DV union cannot detect.
+      // without conflict-time reader-side data skipping (a separate change). It conservatively
+      // conflicts, so the loser aborts. This is one-way safe: it never reconciles a genuine
+      // value-flip write-skew (e.g. winner `SET x = 15`, loser `DELETE WHERE x > 10`), which the
+      // DV union cannot detect.
       val e = intercept[SparkException] { ThreadUtils.awaitResult(futureA, Duration.Inf) }
       assertConcurrentModificationException(e)
       // Loser aborted cleanly: only the winner's update is applied (row 20 masked, 1020 appended).
@@ -264,6 +314,30 @@ class RowLevelConcurrencySuite extends QueryTest
     }
   }
 
+  test("three concurrent DELETEs: two disjoint commit, the overlapping last one aborts") {
+    withTempDir { dir =>
+      val log = createSingleFileTableWithDVs(dir)
+      // B (id=20) and C (id=10) touch disjoint rows and both commit. A also deletes id=10 and,
+      // committing last, reconciles cleanly against B (disjoint) but then discovers its overlap
+      // with C on row 10, so it aborts.
+      val txnA = sqlTxn(s"DELETE FROM ${tableRef(dir)} WHERE id = 10", rowLevelConcurrency = true)
+      val txnB = sqlTxn(s"DELETE FROM ${tableRef(dir)} WHERE id = 20", rowLevelConcurrency = true)
+      val txnC = sqlTxn(s"DELETE FROM ${tableRef(dir)} WHERE id = 10", rowLevelConcurrency = true)
+
+      // A starts; B commits; C commits (reading B's state); A commits last.
+      val (futureA, futureB, futureC) =
+        runTxnsWithOrder__A_Start__B__C__A_End(txnA, txnB, txnC)
+      ThreadUtils.awaitResult(futureB, Duration.Inf)
+      ThreadUtils.awaitResult(futureC, Duration.Inf)
+      val e = intercept[SparkException] { ThreadUtils.awaitResult(futureA, Duration.Inf) }
+      assertConcurrentModificationException(e)
+
+      // Only B (id=20) and C (id=10) applied; A aborted cleanly on the id=10 overlap.
+      assert(ids(dir) === (0L to 99L).filterNot(id => id == 10 || id == 20))
+      assert(deletionVectorCardinalities(log) === Seq(2L))
+    }
+  }
+
   // ---------------------------------------------------------------------------
   // Partitioned table (DV merge is partition-agnostic)
   // ---------------------------------------------------------------------------
@@ -286,6 +360,80 @@ class RowLevelConcurrencySuite extends QueryTest
 
       assert(ids(dir) === (0L to 99L).filterNot(id => id == 10 || id == 20))
       assert(deletionVectorCardinalities(log) === Seq(2L))
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Row tracking: the merge keeps the same physical file, so stable row IDs are preserved
+  // ---------------------------------------------------------------------------
+
+  test("row tracking: reconciled disjoint DELETEs preserve surviving rows' stable row IDs") {
+    withTempDir { dir =>
+      val log = createSingleFileTableWithDVs(dir,
+        extraProperties = Map(DeltaConfigs.ROW_TRACKING_ENABLED.key -> "true"))
+      // Snapshot each row's stable row id before the concurrent deletes.
+      val before = spark.read.format("delta").load(dir.getAbsolutePath)
+        .select("id", "_metadata.row_id")
+        .collect().map(r => r.getLong(0) -> r.getLong(1)).toMap
+
+      val txnA = sqlTxn(s"DELETE FROM ${tableRef(dir)} WHERE id = 10", rowLevelConcurrency = true)
+      val txnB = sqlTxn(s"DELETE FROM ${tableRef(dir)} WHERE id = 20", rowLevelConcurrency = true)
+
+      val (futureA, futureB) = runTxnsWithOrder__A_Start__B__A_End(txnA, txnB)
+      ThreadUtils.awaitResult(futureA, Duration.Inf)
+      ThreadUtils.awaitResult(futureB, Duration.Inf)
+
+      assert(ids(dir) === (0L to 99L).filterNot(id => id == 10 || id == 20))
+      assert(deletionVectorCardinalities(log) === Seq(2L))
+
+      val after = spark.read.format("delta").load(dir.getAbsolutePath)
+        .select("id", "_metadata.row_id")
+        .collect().map(r => r.getLong(0) -> r.getLong(1)).toMap
+      // Merging DVs on the same physical file leaves base row IDs untouched, so every surviving
+      // row keeps the exact stable row id it had before the concurrent deletes.
+      assert(after === (before -- Seq(10L, 20L)))
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Change Data Feed: each deleted row is emitted once, at the version that deleted it
+  // ---------------------------------------------------------------------------
+
+  test("change data feed: reconciled disjoint DELETEs each emit one delete at their own version") {
+    withTempDir { dir =>
+      val log = createSingleFileTableWithDVs(dir,
+        extraProperties = Map(DeltaConfigs.CHANGE_DATA_FEED.key -> "true"))
+      // Table creation is version 0; the winner commits at version 1 and the reconciled current
+      // txn at version 2.
+      val firstDeleteVersion = log.update().version + 1
+
+      // A starts first but commits last, so B (id=20) is the winner at version 1 and A (id=10) is
+      // the reconciled current txn at version 2.
+      val txnA = sqlTxn(s"DELETE FROM ${tableRef(dir)} WHERE id = 10", rowLevelConcurrency = true)
+      val txnB = sqlTxn(s"DELETE FROM ${tableRef(dir)} WHERE id = 20", rowLevelConcurrency = true)
+
+      val (futureA, futureB) = runTxnsWithOrder__A_Start__B__A_End(txnA, txnB)
+      ThreadUtils.awaitResult(futureA, Duration.Inf)
+      ThreadUtils.awaitResult(futureB, Duration.Inf)
+
+      assert(ids(dir) === (0L to 99L).filterNot(id => id == 10 || id == 20))
+      assert(deletionVectorCardinalities(log) === Seq(2L))
+
+      val changes = spark.read.format("delta")
+        .option("readChangeFeed", "true")
+        .option("startingVersion", firstDeleteVersion)
+        .load(dir.getAbsolutePath)
+        .select("id", "_change_type", "_commit_version")
+        .where("_change_type = 'delete'")
+        .collect()
+        .map(r => (r.getLong(0), r.getString(1), r.getLong(2)))
+        .sortBy(_._1)
+        .toSeq
+      // Each deleted row appears exactly once, attributed to the version that deleted it: the
+      // winner's id=20 at version 1 and the reconciled txn's id=10 at version 2.
+      assert(changes === Seq(
+        (10L, "delete", firstDeleteVersion + 1),
+        (20L, "delete", firstDeleteVersion)))
     }
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/RowLevelConcurrencySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/RowLevelConcurrencySuite.scala
@@ -167,6 +167,29 @@ class RowLevelConcurrencySuite extends QueryTest
     }
   }
 
+  test("Serializable: a MERGE matched-delete (read-then-modify) reconciles vs a concurrent DELETE") {
+    withTempDir { dir =>
+      val log = createSingleFileTableWithDVs(dir)
+      sql(s"ALTER TABLE ${tableRef(dir)} SET TBLPROPERTIES " +
+        s"('${DeltaConfigs.ISOLATION_LEVEL.key}' = 'Serializable')")
+      // The disjoint-DELETE Serializable test above already covers a delete-only loser. Here the
+      // loser is a MERGE, which *scans* the file to evaluate its ON condition, so the shared path
+      // enters the current txn's readFiles as a genuine read (not merely as a delete target). The
+      // winner's disjoint DELETE removes that same file, which under Serializable would trip the
+      // delete-read check -- unless row-level resolution drops the reconciled path from readFiles.
+      // This confirms that removal holds for a read-then-modify op under the stricter isolation.
+      val txnA = sqlTxn(mergeMatched(dir, 10, "DELETE"), rowLevelConcurrency = true)
+      val txnB = sqlTxn(s"DELETE FROM ${tableRef(dir)} WHERE id = 20", rowLevelConcurrency = true)
+
+      val (futureA, futureB) = runTxnsWithOrder__A_Start__B__A_End(txnA, txnB)
+      ThreadUtils.awaitResult(futureA, Duration.Inf)
+      ThreadUtils.awaitResult(futureB, Duration.Inf)
+
+      assert(ids(dir) === (0L to 99L).filterNot(id => id == 10 || id == 20))
+      assert(deletionVectorCardinalities(log) === Seq(2L))
+    }
+  }
+
   test("overlapping concurrent DELETEs still conflict") {
     withTempDir { dir =>
       val log = createSingleFileTableWithDVs(dir)
@@ -419,6 +442,35 @@ class RowLevelConcurrencySuite extends QueryTest
       // Only B (id=20) and C (id=10) applied; A aborted cleanly on the id=10 overlap.
       assert(ids(dir) === (0L to 99L).filterNot(id => id == 10 || id == 20))
       assert(deletionVectorCardinalities(log) === Seq(2L))
+    }
+  }
+
+  test("three concurrent disjoint DELETEs reconcile on a file that already carries a base DV") {
+    withTempDir { dir =>
+      val log = createSingleFileTableWithDVs(dir)
+      // Establish a non-empty base DV before any concurrency: delete id=5 (file DV cardinality 1).
+      // All three concurrent txns read this DV as their common base, and the last one (A) then
+      // reconciles against a two-deep winner chain (B, then C) stacked on that base. This is the
+      // deepest chain the ordering helpers reach, and it combines the base-DV subtlety with the
+      // N-way induction: each step must subtract the *prior winner's* DV, not the read-time base,
+      // or the accumulated deletes would look like a false overlap.
+      sql(s"DELETE FROM ${tableRef(dir)} WHERE id = 5")
+      assert(deletionVectorCardinalities(log) === Seq(1L))
+
+      val txnA = sqlTxn(s"DELETE FROM ${tableRef(dir)} WHERE id = 10", rowLevelConcurrency = true)
+      val txnB = sqlTxn(s"DELETE FROM ${tableRef(dir)} WHERE id = 20", rowLevelConcurrency = true)
+      val txnC = sqlTxn(s"DELETE FROM ${tableRef(dir)} WHERE id = 30", rowLevelConcurrency = true)
+
+      // A starts; B commits; C commits (reading B's state); A commits last (reconciles vs B, C).
+      val (futureA, futureB, futureC) =
+        runTxnsWithOrder__A_Start__B__C__A_End(txnA, txnB, txnC)
+      ThreadUtils.awaitResult(futureA, Duration.Inf)
+      ThreadUtils.awaitResult(futureB, Duration.Inf)
+      ThreadUtils.awaitResult(futureC, Duration.Inf)
+
+      assert(ids(dir) === (0L to 99L).filterNot(id => Set(5L, 10L, 20L, 30L).contains(id)))
+      // Base row 5 plus three disjoint concurrent deletes -> merged deletion vector cardinality 4.
+      assert(deletionVectorCardinalities(log) === Seq(4L))
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/RowLevelConcurrencySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/RowLevelConcurrencySuite.scala
@@ -423,6 +423,42 @@ class RowLevelConcurrencySuite extends QueryTest
   }
 
   // ---------------------------------------------------------------------------
+  // Two shared files in one conflict -> bounded-parallel reconcile (ThreadUtils.parmap).
+  // Every test above conflicts on one file (sharedPaths.size == 1 -> caller-thread branch).
+  // A DELETE whose predicate spans two files DV-updates both in ONE commit, so the loser
+  // reconciles two shared paths at once, crossing the `parallelism <= 1` boundary into parmap.
+  // parmap preserves input order, so the reconciled result matches the sequential branch.
+  // ---------------------------------------------------------------------------
+
+  test("disjoint DELETEs spanning two files reconcile via the bounded-parallel path") {
+    withTempDir { dir =>
+      // Two data files: ids [0,100) and [100,200), one file each (separate appends).
+      spark.range(start = 0, end = 100, step = 1, numPartitions = 1)
+        .write.format("delta").mode("append").save(dir.getAbsolutePath)
+      spark.range(start = 100, end = 200, step = 1, numPartitions = 1)
+        .write.format("delta").mode("append").save(dir.getAbsolutePath)
+      val log = DeltaLog.forTable(spark, dir.getCanonicalPath)
+      assert(log.update().allFiles.collect().length === 2, "test table must have two data files")
+
+      // Each DELETE's IN list spans both files (one id < 100, one id >= 100), so each commit
+      // removes and re-adds BOTH files with a per-file DV. The loser therefore has two shared
+      // paths in one resolveRowLevelConflicts call -> parallelism == 2 (the parmap branch).
+      val txnA =
+        sqlTxn(s"DELETE FROM ${tableRef(dir)} WHERE id IN (20, 120)", rowLevelConcurrency = true)
+      val txnB =
+        sqlTxn(s"DELETE FROM ${tableRef(dir)} WHERE id IN (10, 110)", rowLevelConcurrency = true)
+
+      val (futureA, futureB) = runTxnsWithOrder__A_Start__B__A_End(txnA, txnB)
+      ThreadUtils.awaitResult(futureA, Duration.Inf)
+      ThreadUtils.awaitResult(futureB, Duration.Inf)
+
+      assert(ids(dir) === (0L to 199L).filterNot(id => Set(10L, 20L, 110L, 120L).contains(id)))
+      // Both files survive, each carrying its own merged DV (winner + loser delete): cardinality 2.
+      assert(deletionVectorCardinalities(log).sorted === Seq(2L, 2L))
+    }
+  }
+
+  // ---------------------------------------------------------------------------
   // Partitioned table (DV merge is partition-agnostic)
   // ---------------------------------------------------------------------------
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/RowLevelConcurrencySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/RowLevelConcurrencySuite.scala
@@ -268,6 +268,90 @@ class RowLevelConcurrencySuite extends QueryTest
   }
 
   // ---------------------------------------------------------------------------
+  // MERGE (matched clauses only): a matched-DELETE writes an in-place deletion vector, exactly like
+  // a standalone DELETE, so disjoint matched-deletes reconcile through the same DV union. A
+  // matched-UPDATE additionally writes an *image* file (like a standalone UPDATE), so it
+  // conservatively conflicts. MERGE inserts / WHEN NOT MATCHED BY SOURCE are out of scope here
+  // (they need per-file row-tracking classification) and are not exercised.
+  // ---------------------------------------------------------------------------
+
+  /** `MERGE INTO t USING (single-row source) ... ON t.id = s.id` for the given matched action. */
+  private def mergeMatched(dir: File, matchId: Long, action: String): String =
+    s"""MERGE INTO ${tableRef(dir)} t USING (SELECT id FROM range($matchId, ${matchId + 1})) s
+       |ON t.id = s.id WHEN MATCHED THEN $action""".stripMargin
+
+  test("disjoint concurrent MERGE matched-deletes on the same file both commit by merging DVs") {
+    withTempDir { dir =>
+      val log = createSingleFileTableWithDVs(dir)
+      val txnA = sqlTxn(mergeMatched(dir, 10, "DELETE"), rowLevelConcurrency = true)
+      val txnB = sqlTxn(mergeMatched(dir, 20, "DELETE"), rowLevelConcurrency = true)
+
+      val (futureA, futureB) = runTxnsWithOrder__A_Start__B__A_End(txnA, txnB)
+      ThreadUtils.awaitResult(futureA, Duration.Inf)
+      ThreadUtils.awaitResult(futureB, Duration.Inf)
+
+      assert(ids(dir) === (0L to 99L).filterNot(id => id == 10 || id == 20))
+      // A matched-DELETE MERGE writes only a DV (no image file), so the two disjoint deletes merge
+      // into a single surviving file's deletion vector of cardinality 2 -- identical to DELETE.
+      assert(deletionVectorCardinalities(log) === Seq(2L))
+    }
+  }
+
+  test("MERGE matched-delete reconciles against a concurrent DELETE on the same file") {
+    withTempDir { dir =>
+      val log = createSingleFileTableWithDVs(dir)
+      // The DV union is op-agnostic: a MERGE matched-delete and a plain DELETE on disjoint rows
+      // reconcile just like two DELETEs.
+      val txnA = sqlTxn(mergeMatched(dir, 10, "DELETE"), rowLevelConcurrency = true)
+      val txnB = sqlTxn(s"DELETE FROM ${tableRef(dir)} WHERE id = 20", rowLevelConcurrency = true)
+
+      val (futureA, futureB) = runTxnsWithOrder__A_Start__B__A_End(txnA, txnB)
+      ThreadUtils.awaitResult(futureA, Duration.Inf)
+      ThreadUtils.awaitResult(futureB, Duration.Inf)
+
+      assert(ids(dir) === (0L to 99L).filterNot(id => id == 10 || id == 20))
+      assert(deletionVectorCardinalities(log) === Seq(2L))
+    }
+  }
+
+  test("overlapping concurrent MERGE matched-deletes still conflict") {
+    withTempDir { dir =>
+      val log = createSingleFileTableWithDVs(dir)
+      val txnA = sqlTxn(mergeMatched(dir, 10, "DELETE"), rowLevelConcurrency = true)
+      val txnB = sqlTxn(mergeMatched(dir, 10, "DELETE"), rowLevelConcurrency = true)
+
+      val (futureA, futureB) = runTxnsWithOrder__A_Start__B__A_End(txnA, txnB)
+      ThreadUtils.awaitResult(futureB, Duration.Inf)
+      val e = intercept[SparkException] { ThreadUtils.awaitResult(futureA, Duration.Inf) }
+      assertConcurrentModificationException(e)
+      // Clean abort: only the winner's matched-delete (id=10) is applied; its DV has cardinality 1.
+      assert(ids(dir) === (0L to 99L).filterNot(_ == 10))
+      assert(deletionVectorCardinalities(log) === Seq(1L))
+    }
+  }
+
+  test("DELETE (loser) vs MERGE matched-update (winner): winner image file conservatively " +
+      "conflicts") {
+    withTempDir { dir =>
+      val log = createSingleFileTableWithDVs(dir)
+      // A (loser) deletes id=10; B (winner) matched-updates id=20 -> 1020, which masks row 20 with a
+      // DV and appends an image file for 1020. Like the standalone-UPDATE case above, that image
+      // file is a non-blind changed-data add the append check cannot prove disjoint, so the loser
+      // conservatively aborts rather than reconciling.
+      val txnA = sqlTxn(s"DELETE FROM ${tableRef(dir)} WHERE id = 10", rowLevelConcurrency = true)
+      val txnB = sqlTxn(mergeMatched(dir, 20, "UPDATE SET id = 1020"), rowLevelConcurrency = true)
+
+      val (futureA, futureB) = runTxnsWithOrder__A_Start__B__A_End(txnA, txnB)
+      ThreadUtils.awaitResult(futureB, Duration.Inf)
+      val e = intercept[SparkException] { ThreadUtils.awaitResult(futureA, Duration.Inf) }
+      assertConcurrentModificationException(e)
+      // Loser aborted cleanly: only the winner's update is applied (row 20 masked, 1020 appended).
+      assert(ids(dir) === ((0L to 99L).filterNot(_ == 20) :+ 1020L).sorted)
+      assert(deletionVectorCardinalities(log) === Seq(1L))
+    }
+  }
+
+  // ---------------------------------------------------------------------------
   // Winner fully removes the file -> not reconcilable -> conflict
   // ---------------------------------------------------------------------------
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/RowLevelConcurrencySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/RowLevelConcurrencySuite.scala
@@ -37,6 +37,12 @@ import org.apache.spark.util.ThreadUtils
  *
  * Two concurrent DML operations that touch the same physical file but modify disjoint rows should
  * commit cleanly by merging their deletion vectors, instead of aborting the losing transaction.
+ *
+ * Scope note: this is the sound *same-file DV union*. A rewrite-only DML that also writes *new
+ * image* files (an UPDATE emits updated row values to a fresh path) is NOT reconciled here. Those
+ * image files are ordinary non-blind changed-data files that can carry a genuine conflict (a
+ * value-flip write-skew), so they fall back to today's abort. Reconciling them on proven
+ * non-overlap is conflict-time data skipping, owned by Case 1 (fork issue #4).
  */
 class RowLevelConcurrencySuite extends QueryTest
   with SharedSparkSession
@@ -138,7 +144,7 @@ class RowLevelConcurrencySuite extends QueryTest
       ThreadUtils.awaitResult(futureB, Duration.Inf)
       val e = intercept[SparkException] { ThreadUtils.awaitResult(futureA, Duration.Inf) }
       assertConcurrentModificationException(e)
-      // Only the winner's delete (id=20) is applied; DVs are still used, so its DV has cardinality 1.
+      // Only the winner's delete (id=20) is applied; DVs still used, so its DV cardinality is 1.
       assert(ids(dir) === (0L to 99L).filterNot(_ == 20))
       assert(deletionVectorCardinalities(log) === Seq(1L))
     }
@@ -165,10 +171,12 @@ class RowLevelConcurrencySuite extends QueryTest
   }
 
   // ---------------------------------------------------------------------------
-  // Layer 2: UPDATE (rewrite-only DML adds new data files)
+  // UPDATE image files: rewrite-only DML writes new data files that Layer-1 (DV union) does not
+  // reconcile. They conservatively conflict here; conflict-time data skipping (Case 1 / #4)
+  // reconciles the provably-disjoint case.
   // ---------------------------------------------------------------------------
 
-  test("disjoint DELETE (loser) vs UPDATE (winner) both commit") {
+  test("DELETE (loser) vs UPDATE (winner): winner image file conservatively conflicts") {
     withTempDir { dir =>
       val log = createSingleFileTableWithDVs(dir)
       // A (loser) deletes id=10; B (winner) updates id=20 -> 1020 (masks row 20, appends image).
@@ -177,31 +185,17 @@ class RowLevelConcurrencySuite extends QueryTest
         rowLevelConcurrency = true)
 
       val (futureA, futureB) = runTxnsWithOrder__A_Start__B__A_End(txnA, txnB)
-      ThreadUtils.awaitResult(futureA, Duration.Inf)
       ThreadUtils.awaitResult(futureB, Duration.Inf)
-
-      assert(ids(dir) === ((0L to 99L).filterNot(id => id == 10 || id == 20) :+ 1020L).sorted)
-      // The original file's merged DV masks rows 10 and 20; the updated image lives in a new file.
-      assert(deletionVectorCardinalities(log) === Seq(2L))
-    }
-  }
-
-  test("disjoint UPDATE vs UPDATE both commit") {
-    withTempDir { dir =>
-      val log = createSingleFileTableWithDVs(dir)
-      val txnA = sqlTxn(s"UPDATE ${tableRef(dir)} SET id = 1010 WHERE id = 10",
-        rowLevelConcurrency = true)
-      val txnB = sqlTxn(s"UPDATE ${tableRef(dir)} SET id = 1020 WHERE id = 20",
-        rowLevelConcurrency = true)
-
-      val (futureA, futureB) = runTxnsWithOrder__A_Start__B__A_End(txnA, txnB)
-      ThreadUtils.awaitResult(futureA, Duration.Inf)
-      ThreadUtils.awaitResult(futureB, Duration.Inf)
-
-      assert(ids(dir) ===
-        ((0L to 99L).filterNot(id => id == 10 || id == 20) ++ Seq(1010L, 1020L)).sorted)
-      // Original file's merged DV masks rows 10 and 20; updated images live in two new files.
-      assert(deletionVectorCardinalities(log) === Seq(2L))
+      // The shared file's DVs are disjoint and would merge, but the winner's UPDATE also writes an
+      // *image* file (new path) that the append check cannot prove disjoint from the loser's read
+      // without conflict-time data skipping (Case 1 / #4). It conservatively conflicts, so the
+      // loser aborts. This is one-way safe: it never reconciles a genuine value-flip write-skew
+      // (e.g. winner `SET x = 15`, loser `DELETE WHERE x > 10`), which the DV union cannot detect.
+      val e = intercept[SparkException] { ThreadUtils.awaitResult(futureA, Duration.Inf) }
+      assertConcurrentModificationException(e)
+      // Loser aborted cleanly: only the winner's update is applied (row 20 masked, 1020 appended).
+      assert(ids(dir) === ((0L to 99L).filterNot(_ == 20) :+ 1020L).sorted)
+      assert(deletionVectorCardinalities(log) === Seq(1L))
     }
   }
 


### PR DESCRIPTION
Part of the row-level-concurrency umbrella (#7360) — **Case 2**. Full design: #7357. Addresses #7057.

## Summary

POC implementing deletion-vector-based **row-level concurrency** for OSS Delta (Spark). Two concurrent DML operations that modify the **same physical file** but touch **disjoint rows** no longer abort the loser. A new config-gated phase in `ConflictChecker` decodes both transactions' deletion vectors, and when the newly-deleted rows are disjoint, merges them (`dv_win ∪ dv_cur`), writes a new DV file, and rebases the losing transaction onto the winner's post-image.

This is the **sound same-file DV union**. It is deliberately narrow: it reconciles conflicts that are *provable* from DV positions alone, and falls back to today's abort for everything else — including a rewrite-only DML winner's new **image** files, which are handed to conflict-time data skipping (Case 1, #7356 / #7358). It is one-way safe: it never suppresses a winner's added files, so it can only remove aborts, never admit a commit the base checks would reject. See **Safety invariant, and the scope of UPDATE reconciliation** below.

## What it does

- New phase `resolveRowLevelConflicts()` in `ConflictChecker`, run before the file-level checks.
- For a file both transactions modified with a DV, decode `dv_win`, `dv_cur`, and their common base `dv_base` (from the current txn's pre-image `RemoveFile`).
- Disjointness rule: `(dv_win ∩ dv_cur) \ dv_base` empty → merge the DVs, persist a new DV file, and rebase the current `AddFile(P)` onto the winner's post-image (its `RemoveFile(P)` now tombstones the winner's `AddFile(P)`). Non-empty → genuine same-row conflict, aborts as before.
- Reconciliation rewrites **both sides** of the conflict once, so the existing file-level checks run **unchanged from upstream**: the current transaction is rebased onto the winner's post-image (already the case), and the reconciled `AddFile(P)`/`RemoveFile(P)` pair is pruned from a single effective `winningCommitSummary`. The checks then see a winner that never touched the reconciled files, so there is no per-check special-casing.
- **DV-only — row tracking is not required.** Physical DV positions index one immutable Parquet file, so they are version-independent; when row tracking is enabled, the existing `reassignOverlappingRowIds` phase (already run) keeps IDs consistent since the merged file is the same physical file with an unchanged base row ID.
- Gated by `spark.databricks.delta.rowLevelConcurrency.enabled` (internal, default **off**). No protocol / action / reader changes — the output is a standard DV action.

## Safety invariant, and the scope of UPDATE reconciliation

**This change is one-way safe: it never suppresses a winning transaction's added files.** `resolveRowLevelConflicts` prunes only the *same-path* reconciled deletion-vector pair (`AddFile(P)`/`RemoveFile(P)`); every other winning action — including any file added at a fresh path — is left in the summary and arbitrated by the existing added-files check. So the loser aborts in exactly the cases today's Delta aborts. The reconciliation can only *remove* aborts (the disjoint DV pair), never admit a commit the base checks would have rejected.

This is what bounds `UPDATE` reconciliation. An `UPDATE` emits, per touched file `P`, both the same-path DV pair (deleting the pre-update rows — reconciled here) **and** a new *image* file at a fresh path holding the updated values. The DV union soundly reconciles the pair, but it cannot reason about the image file: an `UPDATE` can move a row *into* the loser's read predicate (winner `UPDATE SET x = 15 WHERE id = r`, loser `DELETE WHERE x > 10`, where `r` was `x = 5`), which is invisible at the DV level. So the image file stays an ordinary changed-data file and flows through the added-files check; a blanket "skip a rewrite-only winner's added files" rule would miss that row and is therefore not taken. On an unpartitioned table the added-files check conservatively conflicts, so an `UPDATE`-vs-DML overlap on a shared file still aborts (asserted by the `DELETE (loser) vs UPDATE (winner)` test).

Reconciling the *provably-disjoint* image-file case — the loser's read predicate vs the image file's **stats** — is conflict-time data skipping, owned by **Case 1 (#7356 / #7358)**. Until that lands, Case 2 fully reconciles `DELETE`-vs-`DELETE`; `UPDATE` overlaps on unpartitioned tables continue to abort as they do today.

## Scope

- **In:** `DELETE`-vs-`DELETE` (fully reconciled), and the same-file DV union for `UPDATE`/`DELETE` mixes.
- **Out (follow-ups):**
  - `UPDATE` **image files** → conservative abort here; provably-disjoint reconcile owned by **Case 1 (#7356 / #7358)**.
  - `MERGE` with net-new inserts still conflicts by design; the skippable part is covered by #7356's value-exact tier, and genuine same-new-key phantoms are out of scope (a uniqueness constraint, not row tracking).
  - `OPTIMIZE`-compaction-vs-DML needs a cross-file offset remap → **Case 4** ([design](https://github.com/sezruby/delta/issues/7) · [forward PR](https://github.com/sezruby/delta/pull/9) · [reverse PR](https://github.com/sezruby/delta/pull/11)), prototyped on a fork, which reuses this PR's DV helpers.

## Testing & coverage

`RowLevelConcurrencySuite` (new), driven by the phase-locking concurrency harness. Every test asserts the end-to-end surviving row set plus the merged deletion-vector cardinalities.

| Scenario | Expected | Test |
| --- | --- | --- |
| `DELETE` ⟂ `DELETE`, disjoint rows | both commit, DVs merged | disjoint concurrent DELETEs … both commit |
| `DELETE` ⟂ `DELETE`, same row | loser aborts | overlapping concurrent DELETEs still conflict |
| Non-empty base DV at read time | overlap test subtracts the base | reconcile on a file that already carries a base DV |
| 3 winners stacked on a base DV | reconcile against each prior winner | three concurrent disjoint DELETEs reconcile on a file that already carries a base DV |
| N-way with a late same-row overlap | disjoint ones commit, the overlapping one aborts | three concurrent DELETEs: two disjoint commit, the overlapping last one aborts |
| Two shared files in one commit | bounded-parallel reconcile (`ThreadUtils.parmap`) | disjoint DELETEs spanning two files … bounded-parallel path |
| `MERGE` matched-delete | same DV union as `DELETE` | disjoint concurrent MERGE matched-deletes … / MERGE matched-delete reconciles against a concurrent DELETE |
| `UPDATE` / `MERGE` matched-update image file | conservative abort (deferred to #7358) | DELETE (loser) vs UPDATE (winner) … / DELETE (loser) vs MERGE matched-update (winner) … |
| `UPDATE` ⟂ `UPDATE`, same row | loser aborts | overlapping UPDATE vs UPDATE (same row) still conflict |
| Winner fully removes the file | not reconcilable → abort | winner that fully removes a file conflicts … |
| Serializable, disjoint `DELETE` | reconcile | reconcile under Serializable isolation |
| Serializable, read-then-modify loser (`MERGE`) | reconcile; reconciled path dropped from `readFiles` | Serializable: a MERGE matched-delete … reconciles vs a concurrent DELETE |
| Partitioned table | reconcile (partition-agnostic) | disjoint concurrent DELETEs on a partitioned table's file … |
| Row tracking enabled | surviving rows keep stable row IDs | row tracking: … preserve surviving rows' stable row IDs |
| Change Data Feed enabled | one delete per row at its deleting version | change data feed: … each emit one delete at their own version |
| Feature flag off | default behavior (abort) | feature disabled: … |
| Deletion vectors not writable | gate off → abort | deletion vectors disabled: … |

**N-way correctness.** `reconcileFileDeletionVectors` documents the induction: when the current transaction reconciles against a chain of winners (once per winning commit), the step-`k` overlap test `(dv_win_{k+1} ∩ dv_cur) \ dv_win_k` reduces to *winner k+1's own new deletes ∩ the current txn's own new deletes* — prior winners cancel out. The test is therefore precise for any number of winners, and the merged DV (a union of disjoint contributions) is independent of winner order.

**Not yet covered.**
- The fail-safe fallback — a per-file `NonFatal` guard that, on a DV read/merge/write error, leaves that file to the standard checks to abort — is not exercised by a test; it needs a store-level fault-injection seam.
- The `readWholeTable` + fully-reconciled path is not exercised; no concurrent DML reliably marks the whole table as read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

