### PR TITLE
[Build] Make Spark 4.2 the default version

### DIFF
--- a/examples/scala/build.sbt
+++ b/examples/scala/build.sbt
@@ -51,7 +51,7 @@ def getMajorMinor(version: String): (Int, Int) = {
 // Used as a fallback for local dev when SPARK_VERSION env var is not set.
 val lookupSparkVersion: PartialFunction[(Int, Int), String] = {
   // TODO: how to run integration tests for multiple Spark versions
-  case (deltaMajor, deltaMinor) if deltaMajor >= 4 && deltaMinor >= 4 => "4.2.0" // Delta 4.4+
+  case (major, minor) if major >= 4 && minor >= 4 => "4.2.0"
   case (major, minor) if major >= 4 && minor >= 1 => "4.1.0"
   // version 4.0.0
   case (major, minor) if major >= 4 => "4.0.0"

--- a/examples/scala/build.sbt
+++ b/examples/scala/build.sbt
@@ -51,6 +51,7 @@ def getMajorMinor(version: String): (Int, Int) = {
 // Used as a fallback for local dev when SPARK_VERSION env var is not set.
 val lookupSparkVersion: PartialFunction[(Int, Int), String] = {
   // TODO: how to run integration tests for multiple Spark versions
+  case (major, minor) if major >= 4 && minor >= 4 => "4.2.0"
   case (major, minor) if major >= 4 && minor >= 1 => "4.1.0"
   // version 4.0.0
   case (major, minor) if major >= 4 => "4.0.0"

--- a/examples/scala/build.sbt
+++ b/examples/scala/build.sbt
@@ -51,7 +51,7 @@ def getMajorMinor(version: String): (Int, Int) = {
 // Used as a fallback for local dev when SPARK_VERSION env var is not set.
 val lookupSparkVersion: PartialFunction[(Int, Int), String] = {
   // TODO: how to run integration tests for multiple Spark versions
-  case (major, minor) if major >= 4 && minor >= 4 => "4.2.0"
+  case (deltaMajor, deltaMinor) if deltaMajor >= 4 && deltaMinor >= 4 => "4.2.0" // Delta 4.4+
   case (major, minor) if major >= 4 && minor >= 1 => "4.1.0"
   // version 4.0.0
   case (major, minor) if major >= 4 => "4.0.0"

--- a/examples/scala/build.sbt
+++ b/examples/scala/build.sbt
@@ -51,6 +51,7 @@ def getMajorMinor(version: String): (Int, Int) = {
 // Used as a fallback for local dev when SPARK_VERSION env var is not set.
 val lookupSparkVersion: PartialFunction[(Int, Int), String] = {
   // TODO: how to run integration tests for multiple Spark versions
+  // `major` and `minor` refer to the Delta version, not the Spark version.
   case (major, minor) if major >= 4 && minor >= 4 => "4.2.0"
   case (major, minor) if major >= 4 && minor >= 1 => "4.1.0"
   // version 4.0.0

--- a/project/CrossSparkVersions.scala
+++ b/project/CrossSparkVersions.scala
@@ -135,7 +135,8 @@ import Unidoc._
  * Step 2: Publish Spark-dependent modules WITH suffix for each non-master Spark version
  *   build/sbt -DsparkVersion=4.0 "runOnlyForReleasableSparkModules publishSigned"
  *   build/sbt -DsparkVersion=4.1 "runOnlyForReleasableSparkModules publishSigned"
- *   # Publishes: delta-spark_4.0_2.13, delta-spark_4.1_2.13, etc.
+ *   build/sbt -DsparkVersion=4.2 "runOnlyForReleasableSparkModules publishSigned"
+ *   # Publishes: delta-spark_4.0_2.13, delta-spark_4.1_2.13, delta-spark_4.2_2.13, etc.
  *
  * This workflow is automated via crossSparkReleaseSteps() in the release process.
  * See releaseProcess in build.sbt for integration.
@@ -153,6 +154,7 @@ import Unidoc._
  *   build/sbt -DskipSparkSuffix=true publishM2  # Without suffix (backward compat)
  *   build/sbt -DsparkVersion=4.0 "runOnlyForReleasableSparkModules publishM2"
  *   build/sbt -DsparkVersion=4.1 "runOnlyForReleasableSparkModules publishM2"
+ *   build/sbt -DsparkVersion=4.2 "runOnlyForReleasableSparkModules publishM2"
  *   # Verify JARs in ~/.m2/repository/io/delta/
  *
  * ========================================================
@@ -194,7 +196,7 @@ import Unidoc._
  *   Example:
  *     build/sbt exportSparkVersionsJson
  *     # Generates: target/spark-versions.json
- *     # Output: [{"fullVersion": "4.0.1", "shortVersion": "4.0", "isMaster": false, "isDefault": true, "targetJvm": "17", "packageSuffix": "_4.0"}, ...]
+ *     # Output: [{"fullVersion": "4.0.1", ...}, ..., {"fullVersion": "4.2.0", "isDefault": true, ...}]
  *
  *   Use with Python utilities to extract specific fields:
  *     python3 project/scripts/get_spark_version_info.py --all-spark-versions
@@ -318,7 +320,7 @@ object SparkVersionSpec {
   )
 
   /** Default Spark version */
-  val DEFAULT = spark41
+  val DEFAULT = spark42
 
   /** Spark master branch version (optional). Release branches should not build against master */
   val MASTER: Option[SparkVersionSpec] = None
@@ -519,9 +521,10 @@ object CrossSparkVersions extends AutoPlugin {
    * 1. Publishes all modules WITHOUT Spark suffix (backward compatibility)
    * 2. Publishes Spark-dependent modules WITH Spark suffix for each non-master version
    *
-   * For example, with Spark versions 4.0 (default) and 4.1:
+   * For example, with Spark versions 4.0, 4.1, and 4.2 (default):
    * - Step 1 publishes: delta-spark_2.13, delta-storage, delta-kernel-api, etc. (no suffix)
-   * - Step 2 publishes: delta-spark_4.0_2.13, delta-spark_4.1_2.13, etc. (with suffix)
+   * - Step 2 publishes: delta-spark_4.0_2.13, delta-spark_4.1_2.13,
+   *   delta-spark_4.2_2.13, etc. (with suffix)
    *
    * Each step runs as a separate SBT subprocess so the build reloads with
    * the correct sparkVersion/skipSparkSuffix settings (SBT settings like

--- a/project/scripts/setup_unitycatalog_main.sh
+++ b/project/scripts/setup_unitycatalog_main.sh
@@ -75,6 +75,7 @@
 # Release pipeline examples:
 #   UC_REF=v0.5.0 UC_VERSION=0.5.0-rc1 DELTA_RELEASE_MODE=1 SPARK_VERSION=4.0 bash setup_unitycatalog_main.sh
 #   UC_REF=v0.5.0 UC_VERSION=0.5.0-rc1 DELTA_RELEASE_MODE=1 SPARK_VERSION=4.1 bash setup_unitycatalog_main.sh
+#   UC_REF=v0.5.0 UC_VERSION=0.5.0-rc1 DELTA_RELEASE_MODE=1 SPARK_VERSION=4.2 bash setup_unitycatalog_main.sh
 #   UC_VERSION=0.5.0-rc1 bash setup_unitycatalog_main.sh --print-version  # => 0.5.0-rc1
 
 set -euo pipefail
@@ -91,7 +92,7 @@ UC_DIR="${UC_DIR:-/tmp/unitycatalog}"
 UC_REPO="${UC_REPO:-https://github.com/unitycatalog/unitycatalog.git}"
 UC_REF="${UC_REF:-$UC_PIN_SHA}"
 UC_FORCE="${UC_FORCE:-0}"
-SPARK_VERSION="${SPARK_VERSION:-4.1}"
+SPARK_VERSION="${SPARK_VERSION:-4.2}"
 DELTA_RELEASE_MODE="${DELTA_RELEASE_MODE:-0}"
 
 # Compose version coordinate. When UC_VERSION is set from env, use it verbatim (no SHA suffix).

--- a/project/scripts/setup_unitycatalog_main.sh
+++ b/project/scripts/setup_unitycatalog_main.sh
@@ -75,7 +75,6 @@
 # Release pipeline examples:
 #   UC_REF=v0.5.0 UC_VERSION=0.5.0-rc1 DELTA_RELEASE_MODE=1 SPARK_VERSION=4.0 bash setup_unitycatalog_main.sh
 #   UC_REF=v0.5.0 UC_VERSION=0.5.0-rc1 DELTA_RELEASE_MODE=1 SPARK_VERSION=4.1 bash setup_unitycatalog_main.sh
-#   UC_REF=v0.5.0 UC_VERSION=0.5.0-rc1 DELTA_RELEASE_MODE=1 SPARK_VERSION=4.2 bash setup_unitycatalog_main.sh
 #   UC_VERSION=0.5.0-rc1 bash setup_unitycatalog_main.sh --print-version  # => 0.5.0-rc1
 
 set -euo pipefail

--- a/project/tests/test_cross_spark_publish.py
+++ b/project/tests/test_cross_spark_publish.py
@@ -117,7 +117,7 @@ SPARK_VERSIONS: Dict[str, SparkVersionSpec] = {
 
 # The default Spark version
 # This is intentionally hardcoded here to explicitly test the default version.
-DEFAULT_SPARK = "4.1.0"
+DEFAULT_SPARK = "4.2.0"
 
 
 def substitute_xversion(jar_templates: List[str], delta_version: str) -> Set[str]:

--- a/run-integration-tests.py
+++ b/run-integration-tests.py
@@ -129,8 +129,8 @@ def get_spark_variants(spark_specs):
     Builds the list of artifact variants to test from the Spark version specs.
 
     Each variant is a dict with:
-      - suffix: Maven artifact suffix, e.g. "" (unsuffixed), "_4.0", "_4.1"
-      - spark_version: full Spark version, e.g. "4.1.0", "4.0.1"
+      - suffix: Maven artifact suffix, e.g. "" (unsuffixed), "_4.0", "_4.1", "_4.2"
+      - spark_version: full Spark version, e.g. "4.0.1", "4.1.0", "4.2.0"
       - support_iceberg: "true" or "false"
       - support_hudi: "true" or "false"
 
@@ -141,7 +141,7 @@ def get_spark_variants(spark_specs):
       [
         {"suffix": "",     "spark_version": "4.2.0", "support_iceberg": "false", "support_hudi": "false"},
         {"suffix": "_4.0", "spark_version": "4.0.1", "support_iceberg": "true",  "support_hudi": "true"},
-        {"suffix": "_4.1", "spark_version": "4.1.0", "support_iceberg": "false", "support_hudi": "false"},
+        {"suffix": "_4.1", "spark_version": "4.1.0", "support_iceberg": "true",  "support_hudi": "false"},
         {"suffix": "_4.2", "spark_version": "4.2.0", "support_iceberg": "false", "support_hudi": "false"},
       ]
     """

--- a/run-integration-tests.py
+++ b/run-integration-tests.py
@@ -137,11 +137,12 @@ def get_spark_variants(spark_specs):
     The first variant is always unsuffixed (backward compat) using the DEFAULT spec's metadata.
     Remaining variants are suffixed, one per non-master Spark version.
 
-    Example return value (given Spark 4.0 and 4.1 specs, with 4.1 as default):
+    Example return value (given Spark 4.0, 4.1, and 4.2 specs, with 4.2 as default):
       [
-        {"suffix": "",     "spark_version": "4.1.0", "support_iceberg": "false", "support_hudi": "false"},
+        {"suffix": "",     "spark_version": "4.2.0", "support_iceberg": "false", "support_hudi": "false"},
         {"suffix": "_4.0", "spark_version": "4.0.1", "support_iceberg": "true",  "support_hudi": "true"},
         {"suffix": "_4.1", "spark_version": "4.1.0", "support_iceberg": "false", "support_hudi": "false"},
+        {"suffix": "_4.2", "spark_version": "4.2.0", "support_iceberg": "false", "support_hudi": "false"},
       ]
     """
     variants = []


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other

## Description

Make Spark 4.2.0 the default build version now that it is supported. This updates default and unsuffixed artifact publishing, Unity Catalog setup, and Scala example resolution while retaining suffixed builds for Spark 4.0 and 4.1.

## How was this patch tested?

- python3.11 project/tests/test_cross_spark_publish.py
- build/sbt exportSparkVersionsJson
- Scala example dependency resolution
- bash -n project/scripts/setup_unitycatalog_main.sh
- git diff --check

## Does this PR introduce any user-facing changes?

Yes. Unsuffixed Spark-dependent artifacts now target Spark 4.2.0.