### PR TITLE
[Spark] Promote a single AMT manifest to the root instead of writing a tree

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriteHelper.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriteHelper.scala
@@ -151,9 +151,11 @@ object AMTWriteHelper extends DeltaLogging {
 
   /**
    * Writes a clustered AMT manifest tree for a full checkpoint of `readSnapshot`'s live files.
-   * All files are clustered and flushed into leaf manifests -- one leaf per Spark partition,
-   * written by executors. The root lists only leaf pointers (no inline data entries). Returns the
-   * [[ContentRoot]] plus the per-leaf [[DataManifestEntry]] pointers.
+   * Live files are clustered and flushed into manifests -- one per Spark partition, written by
+   * executors. A snapshot small enough to produce a single manifest needs no tree: that manifest is
+   * promoted to the root and no leaf pointers are returned. Otherwise a root listing one pointer
+   * per leaf is written. Returns the [[ContentRoot]] plus the per-leaf [[DataManifestEntry]]
+   * pointers, which are empty for a promoted single-manifest checkpoint.
    */
   private def writeClusteredManifestTree(
       spark: SparkSession,
@@ -179,9 +181,17 @@ object AMTWriteHelper extends DeltaLogging {
       metadataDir = metadataDir,
       addFilesDf = addFilesDf,
       desiredNumLeaves = desiredNumLeaves)
-    val contentRoot =
-      writeRoot(spark, fs, hadoopConf, tableRoot, metadataDir, leafEntries.map(_.wrap))
-    (contentRoot, leafEntries)
+    leafEntries match {
+      case Seq(onlyLeaf) =>
+        // If there is only one leaf, promote it to the root.
+        val contentRoot =
+          ContentRoot(path = onlyLeaf.location, sizeInBytes = onlyLeaf.file_size_in_bytes)
+        (contentRoot, Seq.empty)
+      case _ =>
+        val contentRoot =
+          writeRoot(spark, fs, hadoopConf, tableRoot, metadataDir, leafEntries.map(_.wrap))
+        (contentRoot, leafEntries)
+    }
   }
 
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTBackReferenceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTBackReferenceSuite.scala
@@ -28,17 +28,6 @@ class AMTBackReferenceSuite extends AMTCheckpointTestBase with DeletionVectorsTe
 
   import testImplicits._
 
-  /**
-   * A back reference identifies a data file by (leaf manifest, position), so a back reference only
-   * exists for an entry that lives in a leaf: an entry that stays resident in the root is
-   * reconstructed with `backReference = None`. The incremental writer spills live adds into leaves
-   * only once the root would exceed `entriesPerLeaf`, and the default (50000) never trips for these
-   * small tables -- so without this every entry would stay in the root and carry no back reference.
-   * A cap of one entry forces every live add into its own leaf, matching the leaf-resident layout a
-   * full rewrite produces, so all checkpoint scenarios stamp back references.
-   */
-  private val leafResidentConfs = Seq(DeltaSQLConf.AMT_ENTRIES_PER_LEAF.key -> "1")
-
   /** Relativizes an absolute leaf manifest path the same way the stamped `backReference.manifest`
    *  is, so test assertions compare against the identical value. */
   private def relativeManifest(snapshot: Snapshot, absLeaf: Path): String = {
@@ -76,23 +65,23 @@ class AMTBackReferenceSuite extends AMTCheckpointTestBase with DeletionVectorsTe
   }
 
   /**
-   * Creates an AMT table and inserts two single-row files, the second insert landing on a
-   * checkpoint boundary so both files are captured in the leaves and stamped with back references.
-   * Returns the two reconstructed leaf-derived `AddFile`s (each carrying a back reference).
+   * Creates an AMT table, seeds it with single-row files, and checkpoints them into leaves. Returns
+   * the reconstructed leaf-derived `AddFile`s (each carrying a back reference).
    */
-  private def emitTwoStampedAddFiles(name: String): Seq[AddFile] = {
-    // A back reference only exists for a leaf-resident entry, so cap the leaf capacity to force
-    // both live adds out of the root and into leaves (see `leafResidentConfs`).
-    withSQLConf(leafResidentConfs: _*) {
-      createAMTTable(name, checkpointInterval = 2)
-      sql(s"INSERT INTO $name VALUES (1)")
-      sql(s"INSERT INTO $name VALUES (2)") // Lands on a checkpoint boundary -> emit.
+  private def emitStampedAddFiles(name: String): Seq[AddFile] = {
+    // The interval is parked out of reach so the tree comes from the explicit OPTIMIZE CHECKPOINT
+    // below rather than from a commit happening to land on the interval grid.
+    createAMTTable(name, checkpointInterval = 100)
+    val deltaLog = deltaLogForName(name)
+    withSQLConf(leafPackingConfs: _*) {
+      appendRowsAsSeparateFiles(name, numRows = leafPackedFiles)
+      commitCheckpoint(deltaLog, incremental = false)
     }
-    val snapshot = deltaLogForName(name).update()
+    val snapshot = deltaLog.update()
     assert(amtProvider(snapshot).isDefined, "table must be AMT-backed after the emit.")
     val adds = liveAddFiles(snapshot)
-    assert(adds.size == 2 && adds.forall(_.backReference.isDefined),
-      "both emitted files must be reconstructed from the leaves with a back reference.")
+    assert(adds.size == leafPackedFiles && adds.forall(_.backReference.isDefined),
+      "every emitted file must be reconstructed from the leaves with a back reference.")
     adds
   }
 
@@ -132,14 +121,15 @@ class AMTBackReferenceSuite extends AMTCheckpointTestBase with DeletionVectorsTe
   testAcrossAMTCheckpointScenarios(
       "reconstructed AddFiles are stamped with a back reference matching the leaf layout",
       "amt_back_ref_stamped",
-      sqlConfs = leafResidentConfs)(
-      setup = name => sql(s"INSERT INTO $name VALUES (1)"),
+      sqlConfs = leafPackingConfs)(
+      setup = name => appendRowsAsSeparateFiles(name, numRows = leafPackedFiles - 1),
       inlineCheckpointTriggerActionsOrSQL = Some(name => Right(
-        s"INSERT INTO $name VALUES (2)"))) { context =>
+        s"INSERT INTO $name VALUES (${leafPackedFiles - 1})"))) { context =>
     val groundTruth = leafLocationByBackRef(context.postCheckpointSnapshot)
     val adds = liveAddFiles(context.postCheckpointSnapshot)
-    assert(adds.size == 2,
-      s"Both inserted files must be reconstructed from the leaves, got ${adds.size}.")
+    assert(adds.size == leafPackedFiles,
+      s"All $leafPackedFiles inserted files must be reconstructed from the leaves, " +
+        s"got ${adds.size}.")
 
     val leafPaths = context.provider.leafManifestAbsolutePaths
       .map(relativeManifest(context.postCheckpointSnapshot, _)).toSet
@@ -155,12 +145,42 @@ class AMTBackReferenceSuite extends AMTCheckpointTestBase with DeletionVectorsTe
   }
 
   testAcrossAMTCheckpointScenarios(
+      "no back references are generated for a root without leaves",
+      "amt_back_ref_root_only")(
+      setup = name => {
+        sql(s"INSERT INTO $name VALUES (1)")
+        sql(s"INSERT INTO $name VALUES (2)")
+      },
+      inlineCheckpointTriggerActionsOrSQL = Some(name => Right(
+        s"INSERT INTO $name VALUES (3)"))) { context =>
+    assert(context.provider.leaves.isEmpty,
+      "precondition: the tree must hold no leaves for entries to stay root-resident.")
+    val adds = liveAddFiles(context.postCheckpointSnapshot)
+    assert(adds.size == 3,
+      s"All three live files must be reconstructed from the root; got ${adds.size}.")
+    adds.foreach { add =>
+      assert(add.backReference.isEmpty,
+        s"Root-resident ${add.path} must carry no back reference, but was ${add.backReference}.")
+    }
+
+    // A DELETE of a root-resident file likewise has no back reference to propagate.
+    val deltaLog = context.postCheckpointSnapshot.deltaLog
+    val vBefore = deltaLog.update().version
+    sql(s"DELETE FROM ${context.tableName} WHERE id = 1")
+    val removes = actionsAfter(deltaLog, vBefore).collect { case r: RemoveFile => r }
+    assert(removes.size == 1, s"The file holding id=1 must be removed whole; got ${removes.size}.")
+    assert(removes.head.backReference.isEmpty,
+      s"Removing a root-resident file must emit an empty back reference, " +
+        s"but was ${removes.head.backReference}.")
+  }
+
+  testAcrossAMTCheckpointScenarios(
       "DELETE emits a RemoveFile carrying the removed file's back reference",
       "amt_back_ref_delete",
-      sqlConfs = leafResidentConfs)(
-      setup = name => sql(s"INSERT INTO $name VALUES (1)"),
+      sqlConfs = leafPackingConfs)(
+      setup = name => appendRowsAsSeparateFiles(name, numRows = leafPackedFiles - 1),
       inlineCheckpointTriggerActionsOrSQL = Some(name => Right(
-        s"INSERT INTO $name VALUES (2)"))) { context =>
+        s"INSERT INTO $name VALUES (${leafPackedFiles - 1})"))) { context =>
     val backRefByPath = stampedBackRefs(context.postCheckpointSnapshot)
     val deltaLog = context.postCheckpointSnapshot.deltaLog
     sql(s"DELETE FROM ${context.tableName} WHERE id = 1")
@@ -179,17 +199,17 @@ class AMTBackReferenceSuite extends AMTCheckpointTestBase with DeletionVectorsTe
   testAcrossAMTCheckpointScenarios(
       "a file added after the emit and removed before the next emit has no back reference",
       "amt_back_ref_post_emit",
-      sqlConfs = leafResidentConfs)(
-      setup = name => (1 to 2).foreach(i => sql(s"INSERT INTO $name VALUES ($i)")),
+      sqlConfs = leafPackingConfs)(
+      setup = name => appendRowsAsSeparateFiles(name, numRows = leafPackedFiles - 1),
       inlineCheckpointTriggerActionsOrSQL = Some(name => Right(
-        s"INSERT INTO $name VALUES (3)"))) { context =>
+        s"INSERT INTO $name VALUES (${leafPackedFiles - 1})"))) { context =>
     val stamped = liveAddFiles(context.postCheckpointSnapshot)
     val stampedPaths = stamped.map(_.path).toSet
-    assert(stamped.size == 3 && stamped.forall(_.backReference.isDefined),
-      "all three emitted files must be stamped from the leaves.")
+    assert(stamped.size == leafPackedFiles && stamped.forall(_.backReference.isDefined),
+      s"all $leafPackedFiles emitted files must be stamped from the leaves.")
 
     // This file is added off a checkpoint boundary, so it never enters a leaf.
-    sql(s"INSERT INTO ${context.tableName} VALUES (4)")
+    sql(s"INSERT INTO ${context.tableName} VALUES ($leafPackedFiles)")
     val deltaLog = context.postCheckpointSnapshot.deltaLog
     val newFile = deltaLog.update().allFiles.collect()
       .find(add => !stampedPaths.contains(add.path))
@@ -199,7 +219,7 @@ class AMTBackReferenceSuite extends AMTCheckpointTestBase with DeletionVectorsTe
 
     // Removing the unstamped file must produce an unstamped tombstone.
     val vBefore = deltaLog.update().version
-    sql(s"DELETE FROM ${context.tableName} WHERE id = 4")
+    sql(s"DELETE FROM ${context.tableName} WHERE id = $leafPackedFiles")
     val remove = actionsAfter(deltaLog, vBefore).collect { case r: RemoveFile => r }
       .find(_.path == newFile.path)
       .getOrElse(fail(s"expected a RemoveFile for the post-emit file ${newFile.path}."))
@@ -210,10 +230,14 @@ class AMTBackReferenceSuite extends AMTCheckpointTestBase with DeletionVectorsTe
   testAcrossAMTCheckpointScenarios(
       "removeRows propagates the back reference to the superseding AddFile and the RemoveFile",
       "amt_back_ref_remove_rows",
-      sqlConfs = leafResidentConfs)(
-      setup = name => Seq(1, 2).toDF("id").coalesce(1).write.mode("append").insertInto(name),
+      sqlConfs = leafPackingConfs)(
+      setup = name => {
+        // A single file holding two rows.
+        Seq(1, 2).toDF("id").coalesce(1).write.mode("append").insertInto(name)
+        appendRowsAsSeparateFiles(name, numRows = leafPackedFiles - 2, startId = 100)
+      },
       inlineCheckpointTriggerActionsOrSQL = Some(name => Right(
-        s"INSERT INTO $name VALUES (3)"))) {
+        s"INSERT INTO $name VALUES (${leafPackedFiles - 1})"))) {
       context =>
     val twoRowFile = liveAddFiles(context.postCheckpointSnapshot)
       .find(_.numPhysicalRecords.contains(2L))
@@ -235,10 +259,14 @@ class AMTBackReferenceSuite extends AMTCheckpointTestBase with DeletionVectorsTe
   testAcrossAMTCheckpointScenarios(
       "DELETE via a persistent DV (removeRows) propagates through a real command",
       "amt_back_ref_dv_delete",
-      sqlConfs = leafResidentConfs)(
-      setup = name => Seq(1, 2).toDF("id").coalesce(1).write.mode("append").insertInto(name),
+      sqlConfs = leafPackingConfs)(
+      setup = name => {
+        // A single file holding two rows.
+        Seq(1, 2).toDF("id").coalesce(1).write.mode("append").insertInto(name)
+        appendRowsAsSeparateFiles(name, numRows = leafPackedFiles - 2, startId = 100)
+      },
       inlineCheckpointTriggerActionsOrSQL = Some(name => Right(
-        s"INSERT INTO $name VALUES (3)"))) {
+        s"INSERT INTO $name VALUES (${leafPackedFiles - 1})"))) {
       context =>
     val backRefByPath =
       liveAddFiles(context.postCheckpointSnapshot).map(add => add.path -> add.backReference).toMap
@@ -292,7 +320,8 @@ class AMTBackReferenceSuite extends AMTCheckpointTestBase with DeletionVectorsTe
            |WHEN MATCHED THEN UPDATE SET id = 200""".stripMargin),
       tombstones = 1, exact = false),
     PropagationCase("INSERT OVERWRITE", "amt_back_ref_insert_overwrite",
-      n => sql(s"INSERT OVERWRITE $n VALUES (99)"), tombstones = 2, exact = true),
+      n => sql(s"INSERT OVERWRITE $n VALUES (99)"),
+      tombstones = leafPackedFiles, exact = true),
     PropagationCase("RESTORE", "amt_back_ref_restore",
       n => sql(s"RESTORE TABLE $n TO VERSION AS OF 1"), tombstones = 1, exact = false))
 
@@ -300,10 +329,10 @@ class AMTBackReferenceSuite extends AMTCheckpointTestBase with DeletionVectorsTe
     testAcrossAMTCheckpointScenarios(
         s"${c.label} tombstones carry the source files' back references",
         c.table,
-        sqlConfs = leafResidentConfs)(
-        setup = name => sql(s"INSERT INTO $name VALUES (1)"),
+        sqlConfs = leafPackingConfs)(
+        setup = name => appendRowsAsSeparateFiles(name, numRows = leafPackedFiles - 1),
         inlineCheckpointTriggerActionsOrSQL = Some(name => Right(
-          s"INSERT INTO $name VALUES (2)"))) { context =>
+          s"INSERT INTO $name VALUES (${leafPackedFiles - 1})"))) { context =>
       val backRefByPath = stampedBackRefs(context.postCheckpointSnapshot)
       c.run(context.tableName)
 
@@ -356,7 +385,7 @@ class AMTBackReferenceSuite extends AMTCheckpointTestBase with DeletionVectorsTe
 
   test("commit accepts a RemoveFile carrying the correct back reference") {
     withTable("amt_commit_ok") {
-      val adds = emitTwoStampedAddFiles("amt_commit_ok")
+      val adds = emitStampedAddFiles("amt_commit_ok")
       // Tombstoning a leaf-derived file keeps its (correct) back reference: the commit must pass.
       commitActions("amt_commit_ok", Seq(adds.head.removeWithTimestamp()))
     }
@@ -364,7 +393,7 @@ class AMTBackReferenceSuite extends AMTCheckpointTestBase with DeletionVectorsTe
 
   test("commit accepts a fresh file that carries no back reference") {
     withTable("amt_commit_fresh") {
-      val adds = emitTwoStampedAddFiles("amt_commit_fresh")
+      val adds = emitStampedAddFiles("amt_commit_fresh")
       // A brand-new file not present in the tree legitimately carries no back reference.
       val fresh = adds.head.copy(path = "brand-new-file.parquet", backReference = None)
       commitActions("amt_commit_fresh", Seq(fresh))
@@ -373,7 +402,7 @@ class AMTBackReferenceSuite extends AMTCheckpointTestBase with DeletionVectorsTe
 
   test("commit fails when a leaf-derived file's tombstone is missing its back reference") {
     withTable("amt_commit_missing") {
-      val adds = emitTwoStampedAddFiles("amt_commit_missing")
+      val adds = emitStampedAddFiles("amt_commit_missing")
       // Strip the back reference off a tombstone for a file the tree says should carry one.
       val stripped = adds.head.removeWithTimestamp().copy(backReference = None)
       val ex = intercept[IllegalStateException] {
@@ -386,7 +415,7 @@ class AMTBackReferenceSuite extends AMTCheckpointTestBase with DeletionVectorsTe
 
   test("commit fails when a fresh file carries a spurious back reference") {
     withTable("amt_commit_spurious") {
-      val adds = emitTwoStampedAddFiles("amt_commit_spurious")
+      val adds = emitStampedAddFiles("amt_commit_spurious")
       // A file not in the tree must not carry a back reference.
       val spurious = adds.head.copy(path = "brand-new-file.parquet")
       val ex = intercept[IllegalStateException] {
@@ -398,7 +427,7 @@ class AMTBackReferenceSuite extends AMTCheckpointTestBase with DeletionVectorsTe
 
   test("commit fails when a present file's tombstone carries the wrong back reference") {
     withTable("amt_commit_wrong") {
-      val adds = emitTwoStampedAddFiles("amt_commit_wrong")
+      val adds = emitStampedAddFiles("amt_commit_wrong")
       val wrongBr = adds.head.backReference.get.copy(pos = adds.head.backReference.get.pos + 1000L)
       val wrong = adds.head.removeWithTimestamp().copy(backReference = Some(wrongBr))
       val ex = intercept[IllegalStateException] {
@@ -417,10 +446,10 @@ class AMTBackReferenceSuite extends AMTCheckpointTestBase with DeletionVectorsTe
     testAcrossAMTCheckpointScenarios(
         testName,
         "amt_clone_src",
-        sqlConfs = leafResidentConfs)(
-        setup = name => sql(s"INSERT INTO $name VALUES (1)"),
+        sqlConfs = leafPackingConfs)(
+        setup = name => appendRowsAsSeparateFiles(name, numRows = leafPackedFiles - 1),
         inlineCheckpointTriggerActionsOrSQL = Some(name => Right(
-          s"INSERT INTO $name VALUES (2)"))) { context =>
+          s"INSERT INTO $name VALUES (${leafPackedFiles - 1})"))) { context =>
       val src = context.tableName
       // Derive the clone target from the scenario-unique source, so the scenarios do not share a
       // table directory (see the naming note in `testAcrossAMTCheckpointScenarios`).
@@ -456,20 +485,19 @@ class AMTBackReferenceSuite extends AMTCheckpointTestBase with DeletionVectorsTe
   testAcrossAMTCheckpointScenarios(
       "RESTORE tombstones keep the current back ref; re-added files carry none",
       "amt_back_ref_restore_tombstones",
-      sqlConfs = leafResidentConfs)(
-      setup = name => sql(s"INSERT INTO $name VALUES (1)"),
+      sqlConfs = Seq(DeltaSQLConf.AMT_ENTRIES_PER_LEAF.key -> "1"))(
+      setup = name => appendRowsAsSeparateFiles(name, numRows = leafPackedFiles - 1),
       inlineCheckpointTriggerActionsOrSQL = Some(name => Right(
-        s"INSERT INTO $name VALUES (2)"))) { context =>
+        s"INSERT INTO $name VALUES (${leafPackedFiles - 1})"))) { context =>
     val name = context.tableName
-    // restoreTarget holds two stamped files A, B.
+    // The version RESTORE returns to, where every seeded file is stamped from a leaf.
     val restoredToByPath = stampedBackRefs(context.postCheckpointSnapshot)
     val deltaLog = deltaLogForName(name)
     val restoreTarget = context.checkpoint.version
 
-    // The overwrite drops A, B and writes C; a second insert adds D. The suite-wide
-    // `leafResidentConfs` makes the explicit incremental checkpoint spill every net-new file into
-    // its own leaf, so the current live files C, D get stamped with this table's own back
-    // references.
+    // The overwrite replaces every seeded file with one new file, and a second insert adds another.
+    // One entry per leaf makes the explicit incremental checkpoint spill each net-new file into its
+    // own leaf, so both current live files get stamped with this table's own back references.
     sql(s"INSERT OVERWRITE $name VALUES (99)")
     sql(s"INSERT INTO $name VALUES (100)")
     commitCheckpoint(deltaLog, incremental = true)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointTestBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointTestBase.scala
@@ -99,6 +99,43 @@ trait AMTCheckpointTestBase
     }
   }
 
+  /**
+   * The per-leaf cap tests use to get a deterministic, multi-entry leaf layout.
+   *
+   * A test that needs a leaf-resident entry cannot just write a file or two. For example, a back
+   * reference or a manifest deletion vector both need an entry that actually lives in a leaf. But a
+   * full rewrite spreads the live files over cap-sized partitions by hash of path and skips the
+   * empty ones, and if there is only a single leaf produced, that leaf is promoted to be a root, so
+   * a small table can end up with no leaf at all.
+   */
+  protected val entriesPerLeaf: Int = 10
+
+  /**
+   * File count that packs into whole [[entriesPerLeaf]]-sized leaves.
+   */
+  protected val leafPackedFiles: Int = 3 * entriesPerLeaf
+
+  /** Session conf that puts [[entriesPerLeaf]] entries in each leaf. */
+  protected def leafPackingConfs: Seq[(String, String)] =
+    Seq(DeltaSQLConf.AMT_ENTRIES_PER_LEAF.key -> entriesPerLeaf.toString)
+
+  /** Leaves that `numFiles` live files pack into at [[entriesPerLeaf]] entries per leaf. */
+  protected def expectedLeafCount(numFiles: Int): Int =
+    math.ceil(numFiles.toDouble / entriesPerLeaf).toInt
+
+  /**
+   * Asserts `leaves` holds exactly the leaves `numFiles` live files pack into. Fails with the
+   * arithmetic spelled out, so a count mismatch reads as a packing problem rather than a bare
+   * number comparison.
+   */
+  protected def assertLeafCount(
+      leaves: Seq[DataManifestEntry], numFiles: Int = leafPackedFiles): Unit = {
+    val expected = expectedLeafCount(numFiles)
+    assert(leaves.size == expected,
+      s"$numFiles files at $entriesPerLeaf per leaf must pack into $expected leaves; " +
+        s"got ${leaves.size}.")
+  }
+
   /** A production-supported combination of AMT placement and materialization strategy. */
   protected sealed abstract class AMTCheckpointScenario(
       val name: String,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointWriteSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointWriteSuite.scala
@@ -35,13 +35,13 @@ class AMTCheckpointWriteSuite extends AMTCheckpointTestBase {
 
   testAcrossAMTCheckpointScenarios(
       "checkpoint emission writes a manifest tree and carries the user action once",
-      "amt_emit")(
-      setup = name => sql(s"INSERT INTO $name VALUES (1)"),
+      "amt_emit",
+      sqlConfs = leafPackingConfs)(
+      setup = name => appendRowsAsSeparateFiles(name, numRows = leafPackedFiles),
       inlineCheckpointTriggerActionsOrSQL = Some(_ => Left((
         Seq(AddFile("missing-file.parquet", Map.empty, 0L, 0L, dataChange = true)
           .removeWithTimestamp(1L)),
         DeltaOperations.ManualUpdate)))) { context =>
-    val path = tablePath(context.tableName)
     val actionsFromCheckpointedCommit =
       actionsAt(context.postCheckpointSnapshot.deltaLog, context.checkpoint.version)
     assert(actionsFromCheckpointedCommit.exists {
@@ -49,69 +49,89 @@ class AMTCheckpointWriteSuite extends AMTCheckpointTestBase {
       case _ => false
     }, "The described business commit must carry the user file action.")
 
+    val path = tablePath(context.tableName)
     val rootName = new File(context.checkpoint.contentRoot.path).getName
     assert(isRootFileName(rootName),
-      s"contentRoot must point at a root manifest file; got " +
-        context.checkpoint.contentRoot.path)
+      s"a written tree's root must carry a root manifest name; got $rootName")
     assert(rootFiles(path).exists(_.getName == rootName))
+    assertLeafCount(context.provider.leaves)
 
     // The emitted tree must reconstruct exactly the table's live files.
     assertReconstructsLiveFileSet(context)
   }
 
-  test("manifest pointers are stored relative to the table root") {
-    withTable("amt_relative_pointers") {
-      val name = "amt_relative_pointers"
-      createAMTTable(name, checkpointInterval = 2)
-      withSQLConf(DeltaSQLConf.AMT_ENTRIES_PER_LEAF.key -> "1") {
-        sql(s"INSERT INTO $name VALUES (1)") // v1: one data file.
-        sql(s"INSERT INTO $name VALUES (2)") // v2: interval boundary -> triggers AMT emission.
-      }
-
-      val deltaLog = deltaLogForName(name)
-      val snapshot = deltaLog.update()
-      val provider = amtProvider(snapshot).getOrElse(fail("expected AMTCheckpointProvider"))
-
-      // The Checkpoint's contentRoot pointer is stored relative to the table root, i.e.
-      // `metadata/root-<uuid>.parquet`, not an absolute URI.
-      val rootPointer = provider.checkpointAction.contentRoot.path
-      assert(rootPointer == s"${FileNames.AMT_METADATA_DIR_NAME}/${new File(rootPointer).getName}",
-        s"contentRoot.path must be table-root-relative; got $rootPointer")
-      assert(!new Path(rootPointer).isAbsolute,
-        s"contentRoot.path must not be absolute; got $rootPointer")
-      assert(isRootFileName(new File(rootPointer).getName))
-
-      // Every leaf pointer stored in the root manifest is likewise table-root-relative.
-      val leafLocations = {
-        spark.read.parquet(new File(new File(tablePath(name),
-          FileNames.AMT_METADATA_DIR_NAME), new File(rootPointer).getName).toString)
-          .where(col("content_type") === AMTSingleAction.ContentType.Type.DataManifest)
-          .select("location").as[String].collect().toSeq
-      }
-      // The clustered writer decides leaf count by partitioning, so assert at least one leaf
-      // pointer rather than an exact count; every pointer must be table-root-relative.
-      assert(leafLocations.nonEmpty, s"Expected at least one leaf pointer, got $leafLocations")
-      leafLocations.foreach { loc =>
-        assert(loc == s"${FileNames.AMT_METADATA_DIR_NAME}/${new File(loc).getName}",
-          s"leaf pointer must be table-root-relative; got $loc")
-        assert(isLeafFileName(new File(loc).getName))
-      }
-
-      // The pointers are stored relative on disk; the provider re-absolutizes them via
-      // `leafManifestAbsolutePaths`, and reconstruction driven off the manifest tree (root +
-      // leaves, both stored relative) surfaces exactly the two committed data files.
-      val leafLocs = provider.leaves.map(_.location)
-      assert(leafLocs.forall(loc =>
-        loc == s"${FileNames.AMT_METADATA_DIR_NAME}/${new File(loc).getName}"),
-        s"leaf pointer locations must be table-root-relative; got $leafLocs")
-      assert(provider.leafManifestAbsolutePaths.forall(_.isAbsolute),
-        s"resolved leaf manifest paths must be absolute; got ${provider.leafManifestAbsolutePaths}")
-      val reconstructed = provider.loadActionsForStateReconstruction(spark, deltaLog)
-        .getOrElse(fail("AMT provider must contribute reconstructed actions."))
-      assert(reconstructed.where("add is not null").count() == 2,
-        "Reconstruction from the relative-pointer manifest tree must surface both committed files.")
-      checkAnswer(spark.table(name), Seq(Row(1), Row(2)))
+  testAcrossAMTCheckpointScenarios(
+      "small full checkpoint promotes its single distributed manifest to the root",
+      "amt_root_only",
+      deferredScenarios = Seq(AMTCheckpointScenario.DeferredFull))(
+      setup = name => {
+        sql(s"INSERT INTO $name VALUES (1)")
+        sql(s"INSERT INTO $name VALUES (2)")
+      }) { context =>
+    val rootDataEntries = {
+      spark.read
+        .parquet(context.checkpoint.contentRoot.getAbsolutePath(context.provider.tableRoot)
+          .toString)
+        .where(col("content_type") === AMTSingleAction.ContentType.Type.Data)
+        .count()
     }
+
+    assert(context.provider.leaves.isEmpty, "The root must contain no leaf pointers.")
+    assert(rootDataEntries == 2L, "Both live files must be reachable as DATA entries in the root.")
+
+    // The promoted root alone must reconstruct exactly the table's live files.
+    assertReconstructsLiveFileSet(context)
+  }
+
+  testAcrossAMTCheckpointScenarios(
+      "manifest pointers are stored relative to the table root",
+      "amt_relative_pointers",
+      // The leaf packing keeps several leaf pointers in the root to check, rather than the single
+      // manifest a small table would promote.
+      sqlConfs = leafPackingConfs)(
+      setup = name => appendRowsAsSeparateFiles(name, numRows = leafPackedFiles - 1),
+      inlineCheckpointTriggerActionsOrSQL = Some(name => Right(
+        s"INSERT INTO $name VALUES (${leafPackedFiles - 1})"))) { context =>
+    val name = context.tableName
+    val provider = context.provider
+
+    // The Checkpoint's contentRoot pointer is stored relative to the table root, i.e.
+    // `metadata/root-<uuid>.parquet`, not an absolute URI.
+    val rootPointer = provider.checkpointAction.contentRoot.path
+    assert(rootPointer == s"${FileNames.AMT_METADATA_DIR_NAME}/${new File(rootPointer).getName}",
+      s"contentRoot.path must be table-root-relative; got $rootPointer")
+    assert(!new Path(rootPointer).isAbsolute,
+      s"contentRoot.path must not be absolute; got $rootPointer")
+    assert(isRootFileName(new File(rootPointer).getName))
+
+    // Every leaf pointer stored in the root manifest is likewise table-root-relative.
+    val leafLocations = {
+      spark.read.parquet(new File(new File(tablePath(name),
+        FileNames.AMT_METADATA_DIR_NAME), new File(rootPointer).getName).toString)
+        .where(col("content_type") === AMTSingleAction.ContentType.Type.DataManifest)
+        .select("location").as[String].collect().toSeq
+    }
+    assert(leafLocations.size == expectedLeafCount(leafPackedFiles),
+      s"$leafPackedFiles files at $entriesPerLeaf per leaf must yield "  +
+        s"${expectedLeafCount(leafPackedFiles)} leaf pointers; got $leafLocations")
+    leafLocations.foreach { loc =>
+      assert(loc == s"${FileNames.AMT_METADATA_DIR_NAME}/${new File(loc).getName}",
+        s"leaf pointer must be table-root-relative; got $loc")
+      assert(isLeafFileName(new File(loc).getName))
+    }
+
+    // The pointers are stored relative on disk; the provider re-absolutizes them via
+    // `leafManifestAbsolutePaths`, and reconstruction driven off the manifest tree (root +
+    // leaves, both stored relative) surfaces exactly the committed data files.
+    val leafLocs = provider.leaves.map(_.location)
+    assert(leafLocs.forall(loc =>
+      loc == s"${FileNames.AMT_METADATA_DIR_NAME}/${new File(loc).getName}"),
+      s"leaf pointer locations must be table-root-relative; got $leafLocs")
+    assert(provider.leafManifestAbsolutePaths.forall(_.isAbsolute),
+      s"resolved leaf manifest paths must be absolute; got ${provider.leafManifestAbsolutePaths}")
+    assertReconstructsLiveFileSet(context)
+    // `setup` writes one file per id, and the trigger adds the last one.
+    checkAnswer(spark.table(name), (0 until leafPackedFiles).map(Row(_)))
   }
 
   test("manifest tree round-trips when the table root contains spaces") {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotSuite.scala
@@ -34,15 +34,6 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
 
   import testImplicits._
 
-  /**
-   * A manifest deletion vector addresses entries by their position inside a leaf, so these tests
-   * need the checkpointed entries to live in leaves rather than stay resident in the root. The
-   * incremental writer only spills live adds into a leaf once the root would exceed
-   * `entriesPerLeaf`, and the default (50000) never trips for these small tables. A cap of one
-   * entry per leaf forces every live add into a leaf under every scenario.
-   */
-  private val mdvLeafResidentConfs = Seq(DeltaSQLConf.AMT_ENTRIES_PER_LEAF.key -> "1")
-
   ///////////////////////////
   // Post commit snapshot
   ///////////////////////////
@@ -167,24 +158,20 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
   testAcrossAMTCheckpointScenarios(
       "distributed reconstruction returns every action exactly once",
       "amt_dist_reconstruction",
-      sqlConfs = Seq(DeltaSQLConf.AMT_ENTRIES_PER_LEAF.key -> "10"))(
+      sqlConfs = leafPackingConfs)(
       setup = name => {
-        appendRowsAsSeparateFiles(name, 30) // ids 0..29, one file each.
-        appendRowsAsSeparateFiles(name, 29, startId = 30) // ids 30..58, one file each.
+        appendRowsAsSeparateFiles(name, leafPackedFiles)
+        appendRowsAsSeparateFiles(name, leafPackedFiles - 1, startId = leafPackedFiles)
       },
       inlineCheckpointTriggerActionsOrSQL = Some(name => Right(
-        s"INSERT INTO $name VALUES (59)"))) { context =>
+        s"INSERT INTO $name VALUES (${2 * leafPackedFiles - 1})"))) { context =>
     val snapshot = context.postCheckpointSnapshot
     val provider = context.provider
-    // `setup` accumulates ids 0..58 over two commits and the trigger commit adds id 59, so the
-    // checkpointed tree is built from files that arrived across several commits.
-    val expectedRows = 0 until 60
+    val expectedRows = 0 until 2 * leafPackedFiles
     checkAnswer(spark.read.table(context.tableName), expectedRows.map(Row(_)))
     val committedPaths = snapshot.allFiles.select("path").as[String].collect().toSet
     assert(committedPaths.size == expectedRows.size)
-    // 60 live files at ten entries per leaf must pack into exactly six leaves.
-    assert(provider.leaves.size == 6,
-      s"60 files at entriesPerLeaf=10 must pack into 6 leaves; got ${provider.leaves.size}.")
+    assertLeafCount(provider.leaves, numFiles = 2 * leafPackedFiles)
     val df = provider.loadActionsForStateReconstruction(spark, snapshot.deltaLog)
       .getOrElse(fail("AMT provider must contribute leaf-derived actions."))
 
@@ -269,14 +256,14 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
   testAcrossAMTCheckpointScenarios(
       "manifest deletion vector drops superseded leaf entries during reconstruction",
       "amt_mdv_drop",
-      sqlConfs = mdvLeafResidentConfs)(
-      setup = name => (1 to 3).foreach(i => sql(s"INSERT INTO $name VALUES ($i)")),
+      sqlConfs = leafPackingConfs)(
+      setup = name => appendRowsAsSeparateFiles(name, numRows = leafPackedFiles - 1),
       inlineCheckpointTriggerActionsOrSQL = Some(name => Right(
-        s"INSERT INTO $name VALUES (4)"))) { context =>
+        s"INSERT INTO $name VALUES (${leafPackedFiles - 1})"))) { context =>
     val snapshot = context.postCheckpointSnapshot
     val base = context.provider
     val baseCount = snapshot.allFiles.count()
-    assert(baseCount == 4)
+    assert(baseCount == leafPackedFiles, "The seeded files plus the trigger's.")
 
     val leaf = base.leaves.head
     val posToLoc = leafPosToLoc(leaf, base.tableRoot)
@@ -308,19 +295,18 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
   testAcrossAMTCheckpointScenarios(
       "manifest deletion vectors apply per leaf across a multi-leaf tree",
       "amt_mdv_multi",
-      sqlConfs = Seq(DeltaSQLConf.AMT_ENTRIES_PER_LEAF.key -> "10"))(
+      sqlConfs = leafPackingConfs)(
       setup = name => {
-        appendRowsAsSeparateFiles(name, 30) // ids 0..29, one file each.
-        appendRowsAsSeparateFiles(name, 29, startId = 30) // ids 30..58, one file each.
+        appendRowsAsSeparateFiles(name, leafPackedFiles)
+        appendRowsAsSeparateFiles(name, leafPackedFiles - 1, startId = leafPackedFiles)
       },
       inlineCheckpointTriggerActionsOrSQL = Some(name => Right(
-        s"INSERT INTO $name VALUES (59)"))) { context =>
+        s"INSERT INTO $name VALUES (${2 * leafPackedFiles - 1})"))) { context =>
     val base = context.provider
-    assert(base.leaves.size == 6,
-      s"60 files with entriesPerLeaf=10 must pack into 6 leaves; got ${base.leaves.size}.")
+    assertLeafCount(base.leaves, numFiles = 2 * leafPackedFiles)
     val deltaLog = context.postCheckpointSnapshot.deltaLog
     val full = reconstructedPaths(base, deltaLog)
-    assert(full.size == 60)
+    assert(full.size == 2 * leafPackedFiles)
 
     // The leaf-local row-index -> entry-location map for each observed leaf.
     val locs = base.leaves.map(leafPosToLoc(_, base.tableRoot))
@@ -376,8 +362,9 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
       // the SQL operation metrics a real DELETE would populate are absent. History metrics would
       // call `Delete.transformMetrics`, which requires `numDeletedRows`; it is missing here and
       // would fail with `key not found: numDeletedRows`. Disable history metrics to skip that.
-      sqlConfs = mdvLeafResidentConfs :+
-        (DeltaSQLConf.DELTA_HISTORY_METRICS_ENABLED.key -> "false"))(
+      sqlConfs = Seq(
+        DeltaSQLConf.AMT_ENTRIES_PER_LEAF.key -> entriesPerLeaf.toString,
+        DeltaSQLConf.DELTA_HISTORY_METRICS_ENABLED.key -> "false"))(
       setup = name => {
         // File A with two physical rows, then a persistent on-disk DV marking row 0 deleted.
         Seq(1, 2).toDF("id").coalesce(1).write.mode("append").insertInto(name)
@@ -386,14 +373,18 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
         assert(fileA.length == 1, "The two rows must land in a single file.")
         val dvActions = writeFileWithDVOnDisk(log, fileA.head, RoaringBitmapArray(0L))
         log.startTransaction().commit(dvActions, DeltaOperations.Delete(predicate = Seq.empty))
+        // DV-less siblings, so the tree packs multi-entry leaves around file A. File A and the
+        // trigger's file make up the rest of the packed count.
+        appendRowsAsSeparateFiles(name, numRows = leafPackedFiles - 2, startId = 10)
       },
       inlineCheckpointTriggerActionsOrSQL = Some(name => Right(
         s"INSERT INTO $name VALUES (3)"))) { context =>
     val snapshot = context.postCheckpointSnapshot
     val base = context.provider
 
-    // Classify the two reconstructed entries by DV presence, staying entirely within the
-    // reconstruction so path strings are consistent with the leaf `location` values.
+    // Classify the reconstructed entries by DV presence, staying entirely within the reconstruction
+    // so path strings are consistent with the leaf `location` values. Exactly one entry carries a
+    // DV (file A); the rest are the DV-less siblings the setup seeded.
     val fullAdds = base.loadActionsForStateReconstruction(spark, snapshot.deltaLog)
       .getOrElse(fail("AMT provider must contribute leaf-derived file actions."))
       .where("add is not null")
@@ -401,17 +392,20 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
       .collect()
       .map(r => r.getString(0) -> (Option(r.getString(1)), r.getString(2)))
       .toMap
-    assert(fullAdds.size == 2)
-    val aPath = fullAdds.collectFirst { case (p, (Some(_), _)) => p }
-      .getOrElse(fail("Expected one reconstructed entry to carry a DV."))
-    val bPath = fullAdds.collectFirst { case (p, (None, _)) => p }
-      .getOrElse(fail("Expected one reconstructed entry without a DV."))
+    assert(fullAdds.size == leafPackedFiles,
+      "One DV-bearing file plus the DV-less siblings.")
+    val withDv = fullAdds.filter(_._2._1.isDefined)
+    assert(withDv.size == 1, s"Exactly one reconstructed entry must carry a DV; got $withDv")
+    val aPath = withDv.head._1
     val aStats = fullAdds(aPath)._2
 
-    // Drop B (the DV-less sibling) via an MDV on whichever leaf holds it; A must survive untouched.
-    val bLeafAndPos = base.leaves.flatMap { leaf =>
-      leafPosToLoc(leaf, base.tableRoot).collectFirst { case (pos, `bPath`) => leaf -> pos }
-    }.headOption.getOrElse(fail(s"No leaf holds the DV-less sibling $bPath."))
+    // Drop one DV-less entry that shares file A's own leaf, so the MDV removes a true sibling from
+    // a multi-entry leaf while A sits beside it.
+    val aLeaf = base.leaves.find(leafPosToLoc(_, base.tableRoot).values.exists(_ == aPath))
+      .getOrElse(fail(s"No leaf holds the DV-bearing file $aPath."))
+    val aLeafEntries = leafPosToLoc(aLeaf, base.tableRoot)
+    val (bPos, bPath) = aLeafEntries.filter { case (_, loc) => loc != aPath }.head
+    val bLeafAndPos = (aLeaf, bPos)
     val patched = base.leaves.map { leaf =>
       if (leaf eq bLeafAndPos._1) {
         leaf.copy(manifest_info = leaf.manifest_info.copy(
@@ -425,22 +419,27 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
       .where("add is not null")
       .selectExpr("add.path", "add.deletionVector.storageType", "add.stats")
       .collect()
-    assert(survivors.length == 1, "Only the DV-bearing sibling must survive the MDV.")
-    assert(survivors.head.getString(0) == aPath,
-      "The surviving path must be the DV-bearing file.")
-    assert(survivors.head.getString(1) != null,
+    // Only the MDV-marked sibling is dropped; every other entry -- including file A, which shares
+    // its leaf -- survives with its deletion vector and stats intact.
+    assert(survivors.length == fullAdds.size - 1,
+      s"The MDV must drop exactly one entry; kept ${survivors.length} of ${fullAdds.size}.")
+    assert(!survivors.exists(_.getString(0) == bPath),
+      s"The MDV-marked sibling $bPath must not survive.")
+    val a = survivors.find(_.getString(0) == aPath)
+      .getOrElse(fail(s"The DV-bearing file $aPath must survive the MDV."))
+    assert(a.getString(1) != null,
       "The surviving entry must retain its deletion vector after MDV filtering.")
-    assert(survivors.head.getString(2) == aStats,
+    assert(a.getString(2) == aStats,
       "The surviving entry's stats must be unchanged by MDV filtering.")
   }
 
   testAcrossAMTCheckpointScenarios(
       "a manifest DV with only one of dv/dv_cardinality set is rejected",
       "amt_mdv_malformed",
-      sqlConfs = mdvLeafResidentConfs)(
-      setup = name => (1 to 2).foreach(i => sql(s"INSERT INTO $name VALUES ($i)")),
+      sqlConfs = leafPackingConfs)(
+      setup = name => appendRowsAsSeparateFiles(name, numRows = leafPackedFiles - 1),
       inlineCheckpointTriggerActionsOrSQL = Some(name => Right(
-        s"INSERT INTO $name VALUES (3)"))) { context =>
+        s"INSERT INTO $name VALUES (${leafPackedFiles - 1})"))) { context =>
     val base = context.provider
 
     // `dv` set but `dv_cardinality` missing: the AMT spec requires both or neither.

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTWriterManagerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTWriterManagerSuite.scala
@@ -17,6 +17,7 @@
 package org.apache.spark.sql.delta.amt
 
 import org.apache.spark.sql.delta.{CurrentTransactionInfo, DeltaOperations, Snapshot}
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import io.delta.exceptions.ConcurrentWriteException
 
 /**
@@ -57,22 +58,22 @@ class AMTWriterManagerSuite extends AMTCheckpointTestBase {
     withTable("amt_optimize_ckpt") {
       val name = "amt_optimize_ckpt"
       createAMTTable(name, checkpointInterval = 2)
-      sql(s"INSERT INTO $name VALUES (1)")
+      withSQLConf(leafPackingConfs: _*) {
+        appendRowsAsSeparateFiles(name, numRows = leafPackedFiles)
 
-      val (manager, snapshot) = managerFor(name, DeltaOperations.OptimizeCheckpoint(
-        incremental = false, triggerName = AMTTriggerMode.CheckpointIntervalFull.name))
-      val result = manager.writeAMT(
-        commitVersion = snapshot.version + 1,
-        currentTransactionInfo = txnInfoFor(snapshot, actions = Seq.empty),
-        preCommitLogSegment = snapshot.logSegment).getOrElse(
-          fail("OPTIMIZE checkpoint must materialize an AMT."))
-      // A full rewrite flushes the live files into freshly clustered leaves via the distributed
-      // write path, so at least one leaf must be written.
-      assert(result.leaves.nonEmpty, "The clustered rewrite must write at least one leaf.")
-      // The commit carries no user actions, so the tree describes state as of the read version.
-      assert(result.contentRootVersion == snapshot.version)
-      // The metric records the trigger name carried on the operation.
-      assert(manager.metrics.attempts.head.trigger == AMTTriggerMode.CheckpointIntervalFull.name)
+        val (manager, snapshot) = managerFor(name, DeltaOperations.OptimizeCheckpoint(
+          incremental = false, triggerName = AMTTriggerMode.CheckpointIntervalFull.name))
+        val result = manager.writeAMT(
+          commitVersion = snapshot.version + 1,
+          currentTransactionInfo = txnInfoFor(snapshot, actions = Seq.empty),
+          preCommitLogSegment = snapshot.logSegment).getOrElse(
+            fail("OPTIMIZE checkpoint must materialize an AMT."))
+        assertLeafCount(result.leaves)
+        // The commit carries no user actions, so the tree describes state as of the read version.
+        assert(result.contentRootVersion == snapshot.version)
+        // The metric records the trigger name carried on the operation.
+        assert(manager.metrics.attempts.head.trigger == AMTTriggerMode.CheckpointIntervalFull.name)
+      }
     }
   }
 


### PR DESCRIPTION
## Description

A full checkpoint rewrite clusters the live files into one manifest per Spark
partition and then writes a root listing one pointer per manifest. When a snapshot
is small enough that the distribution yields a single manifest, that extra root adds
a level of indirection describing nothing: readers follow a pointer to reach the only
manifest there is.

This promotes the lone manifest to the root in place instead. The `ContentRoot` points
straight at what the executor already wrote, so no rename or extra I/O is needed, and
no leaf pointers are returned. Trees with more than one manifest are unaffected. The
promoted file keeps the name the executor gave it, which readers must already tolerate
since manifest names are informational.

## How was this patch tested?

Existing checkpoint suites, plus:

- A test that a small full checkpoint promotes its single manifest to the root, and
  that the promoted root alone reconstructs exactly the live file set.
- A test that a tree with no leaves stamps no back references, covering every
  checkpoint scenario: a full rewrite promotes its lone manifest, and an incremental
  keeps small entries root-resident.

Reaching a leaf-resident entry needs enough files that the writer really packs leaves,
so the per-leaf cap, the file count, and the expected leaf count now come from shared
helpers on the test base rather than being restated in each suite.

## Does this PR introduce _any_ user-facing changes?

No.
