### PR TITLE
[Storage] Add opt-in native S3 LogStore

### DIFF
--- a/docs/src/content/docs/delta-storage.mdx
+++ b/docs/src/content/docs/delta-storage.mdx
@@ -145,23 +145,27 @@ spark-shell \
 
 ## Amazon S3
 
-Delta Lake supports reads and writes to S3 in two different modes: Single-cluster and Multi-cluster.
+Delta Lake supports three S3 write modes. The default coordinates writers within one Spark driver.
+For writers in multiple drivers, choose either native S3 conditional writes or DynamoDB coordination.
 
-|  | Single-cluster | Multi-cluster |
-| --- | --- | --- |
-| Configuration | Comes with Delta Lake out-of-the-box | Is experimental and requires extra configuration |
-| Reads | Supports concurrent reads from multiple clusters | Supports concurrent reads from multiple clusters |
-| Writes | Supports concurrent writes from a _single_ Spark driver | Supports multi-cluster writes |
-| Permissions | S3 credentials | S3 and DynamoDB operating permissions |
+|  | Single-driver | Native conditional writes | DynamoDB coordination |
+| --- | --- | --- | --- |
+| Configuration | Default | Opt-in | Experimental and opt-in |
+| Reads | Multiple drivers | Multiple drivers | Multiple drivers |
+| Writes | One Spark driver | Multiple Spark drivers | Multiple Spark drivers |
+| Permissions | S3 | S3 | S3 and DynamoDB |
 
 ### Single-cluster setup (default)
 
-In this default mode, Delta Lake supports concurrent reads from multiple clusters, but concurrent writes to S3 must originate from a _single_ Spark driver in order for Delta Lake to provide transactional guarantees. This is because S3 currently does not provide mutual exclusion, that is, there is no way to ensure that only one writer is able to create a file.
+In this default mode, Delta Lake supports concurrent reads from multiple clusters, but concurrent
+writes to S3 must originate from a _single_ Spark driver. The default `S3SingleDriverLogStore`
+coordinates writers only within its own JVM and does not request S3 conditional writes.
 
 <Aside type="caution">
   Concurrent writes to the same Delta table on S3 storage from multiple Spark
-  drivers can lead to data loss. For a multi-cluster solution, please see the
-  [Multi-cluster setup](#multi-cluster-setup) section below.
+  drivers can lead to data loss. Use either [native S3 conditional
+  writes](#native-s3-conditional-writes-multi-driver) or the
+  [DynamoDB-backed setup](#dynamodb-backed-multi-cluster-setup) for multiple writers.
 </Aside>
 
 #### Requirements (S3 single-cluster)
@@ -220,11 +224,40 @@ For efficient listing of Delta Lake metadata files on S3, set the configuration 
   </TabItem>
 </Tabs>
 
-### Multi-cluster setup
+### Native S3 conditional writes (multi-driver)
+
+S3 supports atomic create-if-absent writes through the `If-None-Match: *` request condition. The
+opt-in `S3LogStore` uses Hadoop S3A's conditional create API, so writers in different Spark drivers
+compete on the S3 request itself and exactly one writer can create each Delta commit file.
+
+#### Requirements (S3 native conditional writes)
+
+- Hadoop 3.4.2 `hadoop-common` and `hadoop-aws`. Keep the Hadoop modules at the same version.
+- An S3A filesystem and S3 backend that support conditional PUT and conditional multipart
+  completion.
+- S3 credentials and the normal read, write, and list permissions for the Delta table, including
+  `s3:GetObject` for the HEAD request used to reconcile an interrupted conditional write.
+- Every writer to a table must use `S3LogStore`. A writer using `S3SingleDriverLogStore` can bypass
+  the S3 condition and overwrite a concurrent commit.
+
+Configure the LogStore for `s3a` paths:
+
+```ini
+spark.delta.logStore.s3a.impl=io.delta.storage.S3LogStore
+```
+
+This setting changes only `s3a` paths. The default remains `S3SingleDriverLogStore`, so deployments
+must opt in after upgrading their Hadoop dependencies. A missing conditional-write, custom-header,
+extended-attribute read, or abort capability fails the write instead of falling back to JVM-local
+coordination. An S3 `409 ConditionalRequestConflict` with no visible destination replays the whole
+upload using the S3A retry limit and interval. Replay data stays in memory for typical commits and
+spills to an owner-only local temporary file for larger commits.
+
+### DynamoDB-backed multi-cluster setup
 
 <Aside type="note">This support is new and experimental.</Aside>
 
-This mode supports concurrent writes to S3 from multiple clusters and has to be explicitly enabled by configuring Delta Lake to use the right `LogStore` implementation. This implementation uses [DynamoDB](https://aws.amazon.com/dynamodb/) to provide the mutual exclusion that S3 is lacking.
+This mode supports concurrent writes to S3 from multiple clusters and has to be explicitly enabled by configuring Delta Lake to use the right `LogStore` implementation. This implementation uses [DynamoDB](https://aws.amazon.com/dynamodb/) for mutual exclusion and remains available for deployments that cannot use the native conditional-write requirements above.
 
 <Aside type="caution">
   This multi-cluster writing solution is only safe when all writers use this

--- a/spark/src/test/scala/org/apache/spark/sql/delta/LogStoreProviderSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/LogStoreProviderSuite.scala
@@ -17,6 +17,7 @@
 package org.apache.spark.sql.delta
 
 import org.apache.spark.sql.delta.storage.{DelegatingLogStore, LogStore, LogStoreAdaptor}
+import org.apache.hadoop.fs.Path
 
 import org.apache.spark.{SparkConf, SparkContext, SparkFunSuite}
 import org.apache.spark.sql.{AnalysisException, SparkSession}
@@ -99,6 +100,22 @@ class LogStoreProviderSuite extends SparkFunSuite {
   test("class-conf = set, scheme has default, scheme-conf = set") {
     testLogStoreClassConfAndSchemeConf("s3a", customLogStoreClassName,
       DelegatingLogStore.defaultAzureLogStoreClassName)
+  }
+
+  test("public S3LogStore can be instantiated through the s3a scheme conf") {
+    val publicS3LogStoreClass = classOf[io.delta.storage.S3LogStore]
+    val sparkConf = constructSparkConf(
+      Seq(LogStore.logStoreSchemeConfKey("s3a") -> publicS3LogStoreClass.getName))
+
+    withSparkSession(SparkSession.builder.config(sparkConf).getOrCreate()) { spark =>
+      val logStore = LogStore(spark)
+      assert(logStore.isInstanceOf[DelegatingLogStore])
+      val delegate = logStore.asInstanceOf[DelegatingLogStore]
+        .getDelegate(new Path("s3a://bucket/table/_delta_log/00000000000000000001.json"))
+
+      assert(delegate.isInstanceOf[LogStoreAdaptor])
+      assert(delegate.asInstanceOf[LogStoreAdaptor].logStoreImpl.getClass === publicS3LogStoreClass)
+    }
   }
 
   test("verifyLogStoreConfs - scheme conf keys ") {

--- a/storage/src/main/java/io/delta/storage/S3LogStore.java
+++ b/storage/src/main/java/io/delta/storage/S3LogStore.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage;
+
+import java.io.IOException;
+import java.util.Iterator;
+
+import io.delta.storage.internal.S3ConditionalWrite;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+/**
+ * LogStore implementation that uses S3 conditional writes for mutual exclusion across drivers.
+ *
+ * <p>This implementation requires an S3A file system with conditional create, custom create
+ * headers, extended-attribute reads, and abortable output streams. Hadoop 3.4.2 provides these
+ * capabilities. Missing capabilities fail the write instead of falling back to a JVM-local
+ * lock.</p>
+ *
+ * <p>This class is opt-in. Configure it as {@code io.delta.storage.S3LogStore} after verifying the
+ * Hadoop and S3A requirements in the deployment.</p>
+ */
+public class S3LogStore extends S3SingleDriverLogStore {
+
+    public S3LogStore(Configuration hadoopConf) {
+        super(hadoopConf);
+    }
+
+    @Override
+    public void write(
+            Path path,
+            Iterator<String> actions,
+            Boolean overwrite,
+            Configuration hadoopConf) throws IOException {
+        final FileSystem fs = path.getFileSystem(hadoopConf);
+        final Path resolvedPath = S3SingleDriverLogStore.resolvePathWithoutUserInfo(fs, path);
+        S3ConditionalWrite.write(fs, resolvedPath, actions, overwrite);
+    }
+}

--- a/storage/src/main/java/io/delta/storage/S3SingleDriverLogStore.java
+++ b/storage/src/main/java/io/delta/storage/S3SingleDriverLogStore.java
@@ -82,10 +82,19 @@ public class S3SingleDriverLogStore extends HadoopFileSystemLogStore {
     }
 
     private Path resolvePath(FileSystem fs, Path path) {
+        return resolvePathWithoutUserInfo(fs, path);
+    }
+
+    /**
+     * Resolves an S3 path without reserving the historical private helper's signature in
+     * subclasses. Existing subclasses may already declare their own {@code resolvePath} method,
+     * so the conditional-write implementation calls this distinctly named package-private helper.
+     */
+    static Path resolvePathWithoutUserInfo(FileSystem fs, Path path) {
         return stripUserInfo(fs.makeQualified(path));
     }
 
-    private Path stripUserInfo(Path path) {
+    private static Path stripUserInfo(Path path) {
         final URI uri = path.toUri();
 
         try {

--- a/storage/src/main/java/io/delta/storage/internal/S3ConditionalWrite.java
+++ b/storage/src/main/java/io/delta/storage/internal/S3ConditionalWrite.java
@@ -1,0 +1,322 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.internal;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileAlreadyExistsException;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.hadoop.fs.Abortable;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FSDataOutputStreamBuilder;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.StreamCapabilities;
+import org.apache.hadoop.fs.s3a.AWSServiceIOException;
+import org.apache.hadoop.fs.s3a.Constants;
+import org.apache.hadoop.fs.s3a.RemoteFileChangedException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.apache.hadoop.fs.Options.CreateFileOptionKeys
+    .FS_OPTION_CREATE_CONDITIONAL_OVERWRITE;
+
+/**
+ * Writes an S3 object with an atomic create-if-absent request.
+ *
+ * <p>The write ID stored in object metadata distinguishes a real conflict from a successful
+ * request whose response was lost. This is required because S3A retries PUT and multipart
+ * completion requests, and a retry of a conditional request can observe the object created by
+ * its own first attempt.</p>
+ */
+public final class S3ConditionalWrite {
+
+    private static final Logger LOG = LoggerFactory.getLogger(S3ConditionalWrite.class);
+
+    static final String CONDITIONAL_CREATE_OPTION = FS_OPTION_CREATE_CONDITIONAL_OVERWRITE;
+    static final String WRITE_ID_METADATA_KEY = "delta-log-store-write-id";
+    static final String WRITE_ID_HEADER_OPTION =
+        Constants.FS_S3A_CREATE_HEADER + "." + WRITE_ID_METADATA_KEY;
+    static final String WRITE_ID_XATTR = Constants.XA_HEADER_PREFIX + WRITE_ID_METADATA_KEY;
+    static final int REPLAY_BUFFER_MEMORY_LIMIT_BYTES = 1024 * 1024;
+
+    private S3ConditionalWrite() {}
+
+    /**
+     * Writes all actions to {@code path}, appending one UTF-8 newline after each action.
+     *
+     * <p>All writes require an abortable output stream. Non-overwrite writes additionally require
+     * atomic conditional create and owner metadata. A file system that cannot provide those
+     * capabilities is rejected rather than downgraded to a process-local lock.</p>
+     */
+    public static void write(
+            FileSystem fs,
+            Path path,
+            Iterator<String> actions,
+            boolean overwrite) throws IOException {
+        if (overwrite) {
+            writeOverwrite(fs, path, actions);
+            return;
+        }
+
+        writeConditional(fs, path, actions);
+    }
+
+    private static void writeOverwrite(
+            FileSystem fs,
+            Path path,
+            Iterator<String> actions) throws IOException {
+        final FSDataOutputStream stream = fs.create(path, true);
+        requireAbortable(stream, path);
+        try {
+            writeActions(actions, stream, null);
+        } catch (IOException | RuntimeException | Error failure) {
+            abortAfterFailure(stream, failure);
+            throw failure;
+        }
+        stream.close();
+    }
+
+    private static void writeConditional(
+            FileSystem fs,
+            Path path,
+            Iterator<String> actions) throws IOException {
+        final String writeId = UUID.randomUUID().toString();
+        final FSDataOutputStream stream = createConditionalStream(fs, path, writeId);
+        requireAbortable(stream, path);
+
+        final S3WriteReplayBuffer replayBuffer =
+            new S3WriteReplayBuffer(REPLAY_BUFFER_MEMORY_LIMIT_BYTES);
+        Throwable primaryFailure = null;
+        try {
+            try {
+                writeActions(actions, stream, replayBuffer);
+                replayBuffer.seal();
+            } catch (IOException | RuntimeException | Error failure) {
+                abortAfterFailure(stream, failure);
+                throw failure;
+            }
+
+            closeConditionalWrite(fs, path, writeId, stream, replayBuffer);
+        } catch (IOException | RuntimeException | Error failure) {
+            primaryFailure = failure;
+            throw failure;
+        } finally {
+            try {
+                replayBuffer.close();
+            } catch (IOException | RuntimeException cleanupFailure) {
+                if (primaryFailure == null) {
+                    // A local cleanup error must not turn a committed S3 object into a reported
+                    // failure. Failed immediate deletion also attempts JVM-exit cleanup.
+                    LOG.warn("Failed to delete the S3 conditional-write replay buffer", cleanupFailure);
+                } else {
+                    primaryFailure.addSuppressed(cleanupFailure);
+                }
+            }
+        }
+    }
+
+    private static FSDataOutputStream createConditionalStream(
+            FileSystem fs,
+            Path path,
+            String writeId) throws IOException {
+        final FSDataOutputStreamBuilder<?, ?> builder = fs.createFile(path);
+        builder.overwrite(false);
+        builder.must(CONDITIONAL_CREATE_OPTION, true);
+        builder.must(WRITE_ID_HEADER_OPTION, writeId);
+        // No action bytes have been submitted before build() returns, so a builder failure cannot
+        // be reconciled as a successful write even if an eager file system created an object
+        // carrying this write ID.
+        return builder.build();
+    }
+
+    private static void writeActions(
+            Iterator<String> actions,
+            FSDataOutputStream stream,
+            S3WriteReplayBuffer replayBuffer) throws IOException {
+        while (actions.hasNext()) {
+            final byte[] line = (actions.next() + "\n").getBytes(StandardCharsets.UTF_8);
+            if (replayBuffer != null) {
+                // Retain each line before giving it to S3. A local spill failure can then abort the
+                // upload without leaving bytes that cannot be reproduced by a later retry.
+                replayBuffer.write(line);
+            }
+            stream.write(line);
+        }
+    }
+
+    private static void closeConditionalWrite(
+            FileSystem fs,
+            Path path,
+            String writeId,
+            FSDataOutputStream initialStream,
+            S3WriteReplayBuffer replayBuffer) throws IOException {
+        final int retryLimit = Math.max(
+            0,
+            fs.getConf().getInt(Constants.RETRY_LIMIT, Constants.RETRY_LIMIT_DEFAULT));
+        FSDataOutputStream stream = initialStream;
+        int retries = 0;
+
+        while (true) {
+            try {
+                stream.close();
+                return;
+            } catch (IOException failure) {
+                final ReconciliationResult reconciliation =
+                    reconcileConditionalFailure(fs, path, writeId, failure);
+                if (reconciliation == ReconciliationResult.OWN_WRITE_FOUND) {
+                    return;
+                }
+                if (retries >= retryLimit) {
+                    throw failure;
+                }
+
+                retries += 1;
+                waitBeforeRetry(fs, path, retries, retryLimit, failure);
+                try {
+                    stream = createConditionalStream(fs, path, writeId);
+                    requireAbortable(stream, path);
+                    try {
+                        replayBuffer.replayTo(stream);
+                    } catch (IOException | RuntimeException | Error replayFailure) {
+                        abortAfterFailure(stream, replayFailure);
+                        throw replayFailure;
+                    }
+                } catch (IOException | RuntimeException | Error retryFailure) {
+                    retryFailure.addSuppressed(failure);
+                    throw retryFailure;
+                }
+            }
+        }
+    }
+
+    private static void waitBeforeRetry(
+            FileSystem fs,
+            Path path,
+            int retryNumber,
+            int retryLimit,
+            IOException failure) throws InterruptedIOException {
+        final long intervalMillis = fs.getConf().getTimeDuration(
+            Constants.RETRY_INTERVAL,
+            Constants.RETRY_INTERVAL_DEFAULT,
+            TimeUnit.MILLISECONDS);
+        LOG.warn(
+            "Retrying conditional S3 write to {} after HTTP 409 (retry {} of {})",
+            path,
+            retryNumber,
+            retryLimit);
+        if (intervalMillis <= 0) {
+            return;
+        }
+
+        try {
+            Thread.sleep(intervalMillis);
+        } catch (InterruptedException interrupted) {
+            Thread.currentThread().interrupt();
+            final InterruptedIOException interruptedWrite = new InterruptedIOException(
+                "Interrupted while waiting to retry conditional S3 write to " + path);
+            interruptedWrite.initCause(interrupted);
+            interruptedWrite.addSuppressed(failure);
+            throw interruptedWrite;
+        }
+    }
+
+    private static void requireAbortable(FSDataOutputStream stream, Path path) {
+        if (!stream.hasCapability(StreamCapabilities.ABORTABLE_STREAM)) {
+            final UnsupportedOperationException failure = new UnsupportedOperationException(
+                "The S3 output stream for " + path + " does not support abort()");
+            abortAfterFailure(stream, failure);
+            throw failure;
+        }
+    }
+
+    private static void abortAfterFailure(FSDataOutputStream stream, Throwable failure) {
+        try {
+            final Abortable.AbortableResult result = stream.abort();
+            if (result != null && result.anyCleanupException() != null) {
+                failure.addSuppressed(result.anyCleanupException());
+            }
+        } catch (RuntimeException | Error abortFailure) {
+            failure.addSuppressed(abortFailure);
+        }
+    }
+
+    private static ReconciliationResult reconcileConditionalFailure(
+            FileSystem fs,
+            Path path,
+            String writeId,
+            IOException failure) throws IOException {
+        final byte[] storedWriteId;
+        try {
+            storedWriteId = fs.getXAttr(path, WRITE_ID_XATTR);
+        } catch (FileNotFoundException notFound) {
+            failure.addSuppressed(notFound);
+            if (isConditionalRequestConflict(failure)) {
+                // S3 documents 409 as retryable. For multipart uploads, retrying requires a new
+                // upload ID and re-uploading every part, so the caller replays the entire stream.
+                return ReconciliationResult.RETRY_REQUIRED;
+            }
+            throw failure;
+        } catch (IOException | UnsupportedOperationException reconciliationFailure) {
+            failure.addSuppressed(reconciliationFailure);
+            throw failure;
+        }
+
+        if (Arrays.equals(writeId.getBytes(StandardCharsets.UTF_8), storedWriteId)) {
+            return ReconciliationResult.OWN_WRITE_FOUND;
+        }
+
+        if (isConditionalConflict(failure)) {
+            final FileAlreadyExistsException conflict =
+                new FileAlreadyExistsException(path.toString());
+            conflict.initCause(failure);
+            throw conflict;
+        }
+
+        // A non-conditional failure such as an authorization or transport error must retain its
+        // original type even when HEAD happens to observe a foreign object at the destination.
+        throw failure;
+    }
+
+    private static boolean isConditionalRequestConflict(IOException failure) {
+        return failure instanceof AWSServiceIOException &&
+            ((AWSServiceIOException) failure).statusCode() == 409;
+    }
+
+    private static boolean isConditionalConflict(IOException failure) {
+        if (failure instanceof RemoteFileChangedException ||
+                failure instanceof org.apache.hadoop.fs.FileAlreadyExistsException) {
+            return true;
+        }
+
+        // S3 returns 409 when a conditional PUT or multipart completion races with another
+        // operation. The caller reaches this check only after HEAD found a nonmatching owner, so
+        // the otherwise ambiguous 409 now proves that another writer owns the destination.
+        return isConditionalRequestConflict(failure);
+    }
+
+    private enum ReconciliationResult {
+        OWN_WRITE_FOUND,
+        RETRY_REQUIRED
+    }
+}

--- a/storage/src/main/java/io/delta/storage/internal/S3WriteReplayBuffer.java
+++ b/storage/src/main/java/io/delta/storage/internal/S3WriteReplayBuffer.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.internal;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.PosixFilePermissions;
+
+/**
+ * Retains a write so an S3 conditional-request conflict can replay the complete upload.
+ *
+ * <p>Small writes stay in memory. Larger writes spill to an owner-only temporary file because a
+ * Delta commit can contain enough actions that retaining every byte on the driver heap is unsafe.
+ * The buffer must be sealed before replay so a retry cannot observe an incomplete spill file.</p>
+ */
+final class S3WriteReplayBuffer implements AutoCloseable {
+
+    private static final int COPY_BUFFER_SIZE = 64 * 1024;
+    private static final FileAttribute<?>[] NO_FILE_ATTRIBUTES = new FileAttribute<?>[0];
+    private static final FileAttribute<?>[] OWNER_ONLY_FILE_ATTRIBUTES = new FileAttribute<?>[] {
+        PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rw-------"))
+    };
+
+    private final int memoryLimitBytes;
+    private final ByteArrayOutputStream memory;
+    private Path spillFile;
+    private OutputStream spillOutput;
+    private boolean sealed;
+    private boolean closed;
+
+    S3WriteReplayBuffer(int memoryLimitBytes) {
+        if (memoryLimitBytes < 0) {
+            throw new IllegalArgumentException("memoryLimitBytes must not be negative");
+        }
+        this.memoryLimitBytes = memoryLimitBytes;
+        this.memory = new ByteArrayOutputStream(Math.min(memoryLimitBytes, COPY_BUFFER_SIZE));
+    }
+
+    void write(byte[] bytes) throws IOException {
+        if (sealed || closed) {
+            throw new IllegalStateException("Cannot append to a sealed or closed replay buffer");
+        }
+
+        if (spillOutput == null && bytes.length > memoryLimitBytes - memory.size()) {
+            spillToDisk();
+        }
+
+        if (spillOutput == null) {
+            memory.write(bytes);
+        } else {
+            spillOutput.write(bytes);
+        }
+    }
+
+    void seal() throws IOException {
+        if (closed) {
+            throw new IllegalStateException("Cannot seal a closed replay buffer");
+        }
+        if (!sealed) {
+            if (spillOutput != null) {
+                spillOutput.close();
+                spillOutput = null;
+            }
+            sealed = true;
+        }
+    }
+
+    void replayTo(OutputStream destination) throws IOException {
+        if (!sealed || closed) {
+            throw new IllegalStateException("Replay requires a sealed, open buffer");
+        }
+
+        if (spillFile == null) {
+            memory.writeTo(destination);
+            return;
+        }
+
+        try (InputStream input = new BufferedInputStream(Files.newInputStream(spillFile))) {
+            final byte[] copyBuffer = new byte[COPY_BUFFER_SIZE];
+            int count;
+            while ((count = input.read(copyBuffer)) >= 0) {
+                destination.write(copyBuffer, 0, count);
+            }
+        }
+    }
+
+    boolean hasSpilledToDisk() {
+        return spillFile != null;
+    }
+
+    Path spillFile() {
+        return spillFile;
+    }
+
+    private void spillToDisk() throws IOException {
+        final FileAttribute<?>[] attributes =
+            FileSystems.getDefault().supportedFileAttributeViews().contains("posix")
+                ? OWNER_ONLY_FILE_ATTRIBUTES
+                : NO_FILE_ATTRIBUTES;
+        spillFile = Files.createTempFile("delta-s3-logstore-", ".replay", attributes);
+        spillOutput = new BufferedOutputStream(Files.newOutputStream(spillFile));
+        memory.writeTo(spillOutput);
+        memory.reset();
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (closed) {
+            return;
+        }
+        closed = true;
+
+        IOException failure = null;
+        if (spillOutput != null) {
+            try {
+                spillOutput.close();
+            } catch (IOException closeFailure) {
+                failure = closeFailure;
+            } finally {
+                spillOutput = null;
+            }
+        }
+
+        memory.reset();
+        if (spillFile != null) {
+            try {
+                Files.deleteIfExists(spillFile);
+            } catch (IOException deleteFailure) {
+                // Register the path only after immediate deletion fails. The JDK retains every
+                // deleteOnExit path until JVM shutdown, so registering successful spills would
+                // grow driver memory for the lifetime of the process.
+                try {
+                    spillFile.toFile().deleteOnExit();
+                } catch (RuntimeException fallbackFailure) {
+                    // Preserve the immediate deletion failure as the primary cleanup signal.
+                    deleteFailure.addSuppressed(fallbackFailure);
+                }
+                if (failure == null) {
+                    failure = deleteFailure;
+                } else {
+                    failure.addSuppressed(deleteFailure);
+                }
+            }
+        }
+
+        if (failure != null) {
+            throw failure;
+        }
+    }
+}

--- a/storage/src/test/scala/io/delta/storage/S3SingleDriverLogStoreSuite.scala
+++ b/storage/src/test/scala/io/delta/storage/S3SingleDriverLogStoreSuite.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileSystem, Path, RawLocalFileSystem}
+import org.scalatest.funsuite.AnyFunSuite
+
+class S3SingleDriverLogStoreSuite extends AnyFunSuite {
+  test("S3SingleDriverLogStore preserves subclasses with an independent resolvePath helper") {
+    val path = new Path("/table/_delta_log/00000000000000000001.json")
+    val subclass = new HistoricalResolvePathSubclass(new Configuration(false))
+
+    assert(subclass.callResolvePath(new RawLocalFileSystem, path) eq path)
+  }
+}
+
+/**
+ * Models a subclass compiled when S3SingleDriverLogStore.resolvePath was private.
+ *
+ * A private superclass helper does not reserve the signature, so widening it to final would break
+ * existing subclasses even though they never depended on the helper.
+ */
+private class HistoricalResolvePathSubclass(configuration: Configuration)
+  extends S3SingleDriverLogStore(configuration) {
+
+  protected def resolvePath(fileSystem: FileSystem, path: Path): Path = path
+
+  def callResolvePath(fileSystem: FileSystem, path: Path): Path =
+    resolvePath(fileSystem, path)
+}

--- a/storage/src/test/scala/io/delta/storage/internal/S3ConditionalWriteSuite.scala
+++ b/storage/src/test/scala/io/delta/storage/internal/S3ConditionalWriteSuite.scala
@@ -1,0 +1,410 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.internal
+
+import java.io.{ByteArrayOutputStream, FileNotFoundException, IOException, OutputStream}
+import java.nio.charset.StandardCharsets
+import java.nio.file.{FileSystems, Files}
+import java.nio.file.attribute.PosixFilePermissions
+import java.util.UUID
+
+import scala.jdk.CollectionConverters._
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs._
+import org.apache.hadoop.fs.s3a.{AWSBadRequestException, RemoteFileChangedException}
+import org.scalatest.funsuite.AnyFunSuite
+import software.amazon.awssdk.services.s3.model.S3Exception
+
+class S3ConditionalWriteSuite extends AnyFunSuite {
+  private val path = new Path("/table/_delta_log/00000000000000000001.json")
+
+  test("conditional write uses mandatory create and owner metadata options") {
+    val fs = new RecordingFileSystem
+
+    S3ConditionalWrite.write(fs, path, Seq("one", "two").iterator.asJava, false)
+
+    assert(fs.createFileCount === 1)
+    assert(fs.regularCreateCount === 0)
+    assert(fs.createFlag)
+    assert(!fs.overwriteFlag)
+    assert(fs.mandatoryKeys === Set(
+      S3ConditionalWrite.CONDITIONAL_CREATE_OPTION,
+      S3ConditionalWrite.WRITE_ID_HEADER_OPTION))
+    assert(fs.option(S3ConditionalWrite.CONDITIONAL_CREATE_OPTION) === "true")
+    assert(UUID.fromString(fs.option(S3ConditionalWrite.WRITE_ID_HEADER_OPTION)).toString ===
+      fs.option(S3ConditionalWrite.WRITE_ID_HEADER_OPTION))
+  }
+
+  test("conditional write emits UTF-8 actions with one newline per action") {
+    val fs = new RecordingFileSystem
+
+    S3ConditionalWrite.write(fs, path, Seq("one", "♥").iterator.asJava, false)
+
+    assert(new String(fs.lastStream.bytes, StandardCharsets.UTF_8) === "one\n♥\n")
+    assert(fs.lastStream.closeCount === 1)
+    assert(fs.lastStream.abortCount === 0)
+  }
+
+  test("iterator failure aborts without closing the conditional stream") {
+    val fs = new RecordingFileSystem
+    val failure = new IllegalStateException("iterator failed")
+    val actions = new Iterator[String] {
+      override def hasNext: Boolean = throw failure
+      override def next(): String = throw failure
+    }
+
+    val thrown = intercept[IllegalStateException] {
+      S3ConditionalWrite.write(fs, path, actions.asJava, false)
+    }
+
+    assert(thrown eq failure)
+    assert(fs.lastStream.abortCount === 1)
+    assert(fs.lastStream.closeCount === 0)
+  }
+
+  test("stream write failure aborts without closing the conditional stream") {
+    val fs = new RecordingFileSystem
+    val failure = new IOException("write failed")
+    fs.writeFailure = Some(failure)
+
+    val thrown = intercept[IOException] {
+      S3ConditionalWrite.write(fs, path, Iterator("one").asJava, false)
+    }
+
+    assert(thrown eq failure)
+    assert(fs.lastStream.abortCount === 1)
+    assert(fs.lastStream.closeCount === 0)
+  }
+
+  test("conditional conflicts from another writer become NIO FileAlreadyExistsException") {
+    Seq(
+      remoteFileChanged(),
+      new org.apache.hadoop.fs.FileAlreadyExistsException(path.toString)
+    ).foreach { closeFailure =>
+      val fs = new RecordingFileSystem
+      fs.ownerOnClose = _ => Some("another-writer")
+      fs.closeFailure = Some(closeFailure)
+
+      val thrown = intercept[java.nio.file.FileAlreadyExistsException] {
+        S3ConditionalWrite.write(fs, path, Iterator("one").asJava, false)
+      }
+
+      assert(thrown.getFile === path.toString)
+      assert(thrown.getCause eq closeFailure)
+    }
+  }
+
+  test("conditional conflict is successful when HEAD finds this write's owner token") {
+    val fs = new RecordingFileSystem
+    fs.ownerOnClose = owner => Some(owner)
+    fs.closeFailure = Some(remoteFileChanged())
+
+    S3ConditionalWrite.write(fs, path, Iterator("one").asJava, false)
+
+    assert(fs.getXAttrCount === 1)
+  }
+
+  test("builder failure is never reconciled as a successful upload") {
+    val fs = new RecordingFileSystem
+    fs.ownerOnBuild = owner => Some(owner)
+    val buildFailure = remoteFileChanged()
+    fs.buildFailure = Some(buildFailure)
+
+    val thrown = intercept[RemoteFileChangedException] {
+      S3ConditionalWrite.write(fs, path, Iterator("one").asJava, false)
+    }
+
+    assert(thrown eq buildFailure)
+    assert(fs.lastStream === null)
+    assert(fs.getXAttrCount === 0)
+  }
+
+  test("failed HEAD preserves an ambiguous close failure") {
+    val fs = new RecordingFileSystem
+    val closeFailure = remoteFileChanged()
+    val headFailure = new IOException("HEAD failed")
+    fs.closeFailure = Some(closeFailure)
+    fs.getXAttrFailure = Some(headFailure)
+
+    val thrown = intercept[RemoteFileChangedException] {
+      S3ConditionalWrite.write(fs, path, Iterator("one").asJava, false)
+    }
+
+    assert(thrown eq closeFailure)
+    assert(thrown.getSuppressed.toSeq.contains(headFailure))
+  }
+
+  test("409 with a foreign owner is reported as FileAlreadyExistsException") {
+    val fs = new RecordingFileSystem
+    val closeFailure = conditionalRequestConflict()
+    fs.closeFailure = Some(closeFailure)
+    fs.ownerOnClose = _ => Some("another-writer")
+
+    val thrown = intercept[java.nio.file.FileAlreadyExistsException] {
+      S3ConditionalWrite.write(fs, path, Iterator("one").asJava, false)
+    }
+
+    assert(thrown.getFile === path.toString)
+    assert(thrown.getCause eq closeFailure)
+  }
+
+  test("409 with no destination retries the complete write with the same owner token") {
+    val fs = new RecordingFileSystem
+    val closeFailure = conditionalRequestConflict()
+    val headFailure = new FileNotFoundException(path.toString)
+    fs.getConf.setInt("fs.s3a.retry.limit", 1)
+    fs.getConf.set("fs.s3a.retry.interval", "0ms")
+    fs.closeFailureForAttempt = attempt => if (attempt == 1) Some(closeFailure) else None
+    fs.getXAttrFailureForAttempt = attempt => if (attempt == 1) Some(headFailure) else None
+    fs.ownerOnCloseForAttempt = (owner, attempt) => if (attempt == 2) Some(owner) else None
+
+    S3ConditionalWrite.write(fs, path, Iterator("one", "♥").asJava, false)
+
+    assert(fs.createFileCount === 2)
+    assert(fs.getXAttrCount === 1)
+    assert(fs.writeIds.distinct.size === 1)
+    assert(fs.streams.map(stream => new String(stream.bytes, StandardCharsets.UTF_8)) ===
+      Seq("one\n♥\n", "one\n♥\n"))
+  }
+
+  test("repeated 409 responses stop at the configured S3A retry limit") {
+    val fs = new RecordingFileSystem
+    fs.getConf.setInt("fs.s3a.retry.limit", 2)
+    fs.getConf.set("fs.s3a.retry.interval", "0ms")
+    fs.closeFailureForAttempt = _ => Some(conditionalRequestConflict())
+    fs.getXAttrFailureForAttempt = _ => Some(new FileNotFoundException(path.toString))
+
+    val thrown = intercept[AWSBadRequestException] {
+      S3ConditionalWrite.write(fs, path, Iterator("one").asJava, false)
+    }
+
+    assert(thrown.statusCode() === 409)
+    assert(fs.createFileCount === 3)
+    assert(fs.getXAttrCount === 3)
+    assert(fs.writeIds.distinct.size === 1)
+    assert(fs.streams.map(stream => new String(stream.bytes, StandardCharsets.UTF_8)) ===
+      Seq.fill(3)("one\n"))
+  }
+
+  test("replay buffer spills with owner-only permissions and deletes the spill file") {
+    val replayBuffer = new S3WriteReplayBuffer(4)
+    var spillFile: java.nio.file.Path = null
+    try {
+      replayBuffer.write("ab".getBytes(StandardCharsets.UTF_8))
+      assert(!replayBuffer.hasSpilledToDisk)
+      replayBuffer.write("cde".getBytes(StandardCharsets.UTF_8))
+      assert(replayBuffer.hasSpilledToDisk)
+
+      spillFile = replayBuffer.spillFile()
+      assert(Files.isRegularFile(spillFile))
+      if (FileSystems.getDefault.supportedFileAttributeViews().contains("posix")) {
+        assert(Files.getPosixFilePermissions(spillFile) ===
+          PosixFilePermissions.fromString("rw-------"))
+      }
+
+      val replayed = new ByteArrayOutputStream
+      replayBuffer.seal()
+      replayBuffer.replayTo(replayed)
+      assert(new String(replayed.toByteArray, StandardCharsets.UTF_8) === "abcde")
+    } finally {
+      replayBuffer.close()
+    }
+    assert(!Files.exists(spillFile))
+  }
+
+  test("non-conditional close failure is not hidden by a foreign owner") {
+    val fs = new RecordingFileSystem
+    val closeFailure = new IOException("connection failed")
+    fs.closeFailure = Some(closeFailure)
+    fs.ownerOnClose = _ => Some("another-writer")
+
+    val thrown = intercept[IOException] {
+      S3ConditionalWrite.write(fs, path, Iterator("one").asJava, false)
+    }
+
+    assert(thrown eq closeFailure)
+  }
+
+  test("unsupported mandatory create options fail closed") {
+    val fs = new RecordingFileSystem
+    fs.supportsMandatoryOptions = false
+
+    assertThrows[IllegalArgumentException] {
+      S3ConditionalWrite.write(fs, path, Iterator("one").asJava, false)
+    }
+    assert(fs.lastStream === null)
+    assert(fs.regularCreateCount === 0)
+  }
+
+  test("a stream without abort support fails before consuming actions") {
+    val fs = new RecordingFileSystem
+    fs.abortable = false
+    var iteratorConsumed = false
+    val actions = Iterator.continually {
+      iteratorConsumed = true
+      "one"
+    }.take(1)
+
+    assertThrows[UnsupportedOperationException] {
+      S3ConditionalWrite.write(fs, path, actions.asJava, false)
+    }
+
+    assert(!iteratorConsumed)
+    assert(fs.lastStream.closeCount === 0)
+  }
+
+  test("overwrite uses the ordinary FileSystem create path") {
+    val fs = new RecordingFileSystem
+
+    S3ConditionalWrite.write(fs, path, Iterator("replacement").asJava, true)
+
+    assert(fs.createFileCount === 0)
+    assert(fs.regularCreateCount === 1)
+    assert(new String(fs.lastStream.bytes, StandardCharsets.UTF_8) === "replacement\n")
+  }
+
+  private def remoteFileChanged(): RemoteFileChangedException =
+    new RemoteFileChangedException(path.toString, "close", "precondition failed")
+
+  private def conditionalRequestConflict(): AWSBadRequestException =
+    new AWSBadRequestException(
+      path.toString,
+      S3Exception.builder().statusCode(409).message("ConditionalRequestConflict").build())
+}
+
+private class RecordingFileSystem extends RawLocalFileSystem {
+  setConf(new Configuration(false))
+
+  var createFileCount = 0
+  var regularCreateCount = 0
+  var createFlag = false
+  var overwriteFlag = false
+  var supportsMandatoryOptions = true
+  var abortable = true
+  var mandatoryKeys = Set.empty[String]
+  var options = Map.empty[String, String]
+  var lastStream: RecordingOutputStream = _
+  var writeFailure = Option.empty[IOException]
+  var buildFailure = Option.empty[IOException]
+  var closeFailure = Option.empty[IOException]
+  var getXAttrFailure = Option.empty[IOException]
+  var ownerOnBuild: String => Option[String] = _ => None
+  var ownerOnClose: String => Option[String] = _ => None
+  var closeFailureForAttempt: Int => Option[IOException] = _ => closeFailure
+  var getXAttrFailureForAttempt: Int => Option[IOException] = _ => getXAttrFailure
+  var ownerOnCloseForAttempt: (String, Int) => Option[String] =
+    (owner, _) => ownerOnClose(owner)
+  var storedOwner = Option.empty[String]
+  var getXAttrCount = 0
+  var closeAttemptCount = 0
+  var writeIds = Seq.empty[String]
+  var streams = Seq.empty[RecordingOutputStream]
+
+  def option(key: String): String = options(key)
+
+  override def createFile(path: Path): FSDataOutputStreamBuilder[_, _] = {
+    createFileCount += 1
+    new RecordingBuilder(this, path).create().overwrite(true)
+  }
+
+  override def create(path: Path, overwrite: Boolean): FSDataOutputStream = {
+    regularCreateCount += 1
+    newStream()
+  }
+
+  override def getXAttr(path: Path, name: String): Array[Byte] = {
+    getXAttrCount += 1
+    getXAttrFailureForAttempt(getXAttrCount).foreach(throw _)
+    if (name == S3ConditionalWrite.WRITE_ID_XATTR) {
+      storedOwner.map(_.getBytes(StandardCharsets.UTF_8)).orNull
+    } else {
+      null
+    }
+  }
+
+  def newStream(): FSDataOutputStream = {
+    lastStream = new RecordingOutputStream(this)
+    streams :+= lastStream
+    new FSDataOutputStream(lastStream, null)
+  }
+}
+
+private class RecordingBuilder(fs: RecordingFileSystem, path: Path)
+  extends FSDataOutputStreamBuilder[FSDataOutputStream, RecordingBuilder](fs, path) {
+
+  override def getThisBuilder: RecordingBuilder = this
+
+  override def build(): FSDataOutputStream = {
+    fs.mandatoryKeys = getMandatoryKeys.asScala.toSet
+    fs.options = getOptions.iterator().asScala.map(entry => entry.getKey -> entry.getValue).toMap
+    fs.writeIds :+= fs.options.getOrElse(S3ConditionalWrite.WRITE_ID_HEADER_OPTION, "")
+    fs.createFlag = getFlags.contains(CreateFlag.CREATE)
+    fs.overwriteFlag = getFlags.contains(CreateFlag.OVERWRITE)
+    if (!fs.supportsMandatoryOptions) {
+      throw new IllegalArgumentException("mandatory options unsupported")
+    }
+    fs.buildFailure.foreach { failure =>
+      val writeId = fs.options.getOrElse(S3ConditionalWrite.WRITE_ID_HEADER_OPTION, "")
+      fs.storedOwner = fs.ownerOnBuild(writeId)
+      throw failure
+    }
+    fs.newStream()
+  }
+}
+
+private class RecordingOutputStream(fs: RecordingFileSystem)
+  extends OutputStream with Abortable with StreamCapabilities {
+
+  private val buffer = new ByteArrayOutputStream
+  var abortCount = 0
+  var closeCount = 0
+
+  def bytes: Array[Byte] = buffer.toByteArray
+
+  override def write(value: Int): Unit = {
+    fs.writeFailure.foreach(throw _)
+    buffer.write(value)
+  }
+
+  override def write(bytes: Array[Byte], offset: Int, length: Int): Unit = {
+    fs.writeFailure.foreach(throw _)
+    buffer.write(bytes, offset, length)
+  }
+
+  override def close(): Unit = {
+    closeCount += 1
+    fs.closeAttemptCount += 1
+    val writeId = fs.options.getOrElse(S3ConditionalWrite.WRITE_ID_HEADER_OPTION, "")
+    fs.storedOwner = fs.ownerOnCloseForAttempt(writeId, fs.closeAttemptCount)
+    fs.closeFailureForAttempt(fs.closeAttemptCount).foreach(throw _)
+  }
+
+  override def abort(): Abortable.AbortableResult = {
+    abortCount += 1
+    if (!fs.abortable) {
+      throw new UnsupportedOperationException("abort unsupported")
+    }
+    new Abortable.AbortableResult {
+      override def alreadyClosed(): Boolean = false
+      override def anyCleanupException(): IOException = null
+    }
+  }
+
+  override def hasCapability(capability: String): Boolean =
+    fs.abortable && capability == StreamCapabilities.ABORTABLE_STREAM
+}


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/7369/files/cfcb8a907930ee6e0be4ef77b7e81c2f82c330bb..d402a04b597040f717401873d7fa9bbe2bd94289) to review incremental changes.
- [s3-logstore](https://github.com/delta-io/delta/pull/7367) [[Files changed](https://github.com/delta-io/delta/pull/7367/files)]
  - [**s3-logstore-api**](https://github.com/delta-io/delta/pull/7369) [[Files changed](https://github.com/delta-io/delta/pull/7369/files/cfcb8a907930ee6e0be4ef77b7e81c2f82c330bb..d402a04b597040f717401873d7fa9bbe2bd94289)] ← _this PR_
    - [s3-logstore-integration](https://github.com/delta-io/delta/pull/7370) [[Files changed](https://github.com/delta-io/delta/pull/7370/files/d402a04b597040f717401873d7fa9bbe2bd94289..1fe48a076549703ad7307ce14335bc1f9f56255b)]
      - [s3-logstore-fault-injection](https://github.com/delta-io/delta/pull/7371) [[Files changed](https://github.com/delta-io/delta/pull/7371/files/1fe48a076549703ad7307ce14335bc1f9f56255b..e95347aa8080aceb47c008017244acfc081d109e)]
---------

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (Storage)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

This layer adds the public, opt-in `io.delta.storage.S3LogStore`. Non-overwrite writes resolve the S3 path and delegate to the conditional-write engine from #7367; overwrite writes retain the existing LogStore behavior. The shared path-resolution helper has a distinct name so subclasses compiled against the historical private helper can continue declaring their own `resolvePath` method.

The provider test verifies construction through `spark.delta.logStore.s3a.impl`, and the storage documentation describes the supported Hadoop version, required S3A capabilities, mixed-writer safety rule, replay behavior, and the existing DynamoDB-backed alternative. `S3SingleDriverLogStore` remains the default.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

- `build/sbt -java-home /usr/lib/jvm/java-17-openjdk-amd64 "storage/testOnly io.delta.storage.S3SingleDriverLogStoreSuite"`
- `build/sbt -java-home /usr/lib/jvm/java-17-openjdk-amd64 "spark/testOnly org.apache.spark.sql.delta.LogStoreProviderSuite"`

The first command covers subclass compatibility after extracting the shared path helper. The second covers construction of the public class through the `s3a` scheme configuration. End-to-end S3 coverage is isolated in the next two stack layers.
