### PR TITLE
[Branch-4.0][Delta Sharing] Ensure deletion vector fileId-URL entries are preserved during cache refresh

### DIFF
--- a/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingLogFileSystem.scala
+++ b/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingLogFileSystem.scala
@@ -295,13 +295,6 @@ private[sharing] object DeltaSharingLogFileSystem extends Logging {
     }
   }
 
-  // Only absolute path (which is pre-signed url) need to be put in IdToUrl mapping.
-  // inline DV should be processed in place, and UUID should throw error.
-  private def requiresIdToUrlForDV(deletionVectorOpt: Option[DeletionVectorDescriptor]): Boolean = {
-    deletionVectorOpt.isDefined &&
-    deletionVectorOpt.get.storageType == DeletionVectorDescriptor.PATH_DV_MARKER
-  }
-
   /**
    * Convert DeltaSharingFileAction with delta sharing file path and serialize as json to store in
    * the delta log.
@@ -663,7 +656,7 @@ private[sharing] object DeltaSharingLogFileSystem extends Logging {
 
           // 1. build it to url mapping
           idToUrl(fileAction.id) = fileAction.path
-          if (requiresIdToUrlForDV(fileAction.getDeletionVectorOpt)) {
+          if (DeltaSharingUtils.requiresIdToUrlForDV(fileAction.getDeletionVectorOpt)) {
             idToUrl(fileAction.deletionVectorFileId) =
               fileAction.getDeletionVectorOpt.get.pathOrInlineDv
           }
@@ -799,7 +792,7 @@ private[sharing] object DeltaSharingLogFileSystem extends Logging {
 
       // 1. build id to url mapping
       idToUrl(fileAction.id) = fileAction.path
-      if (requiresIdToUrlForDV(fileAction.getDeletionVectorOpt)) {
+      if (DeltaSharingUtils.requiresIdToUrlForDV(fileAction.getDeletionVectorOpt)) {
         idToUrl(fileAction.deletionVectorFileId) =
           fileAction.getDeletionVectorOpt.get.pathOrInlineDv
       }

--- a/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingUtils.scala
+++ b/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingUtils.scala
@@ -32,6 +32,7 @@ import io.delta.sharing.client.util.JsonUtils
 import org.apache.spark.SparkEnv
 import org.apache.spark.delta.sharing.TableRefreshResult
 import org.apache.spark.internal.Logging
+import org.apache.spark.sql.delta.actions.DeletionVectorDescriptor
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.execution.datasources.FileFormat
 import org.apache.spark.storage.{BlockId, StorageLevel}
@@ -134,21 +135,37 @@ object DeltaSharingUtils extends Logging {
     )
   }
 
+  // Only absolute path (which is pre-signed url) need to be put in IdToUrl mapping.
+  // inline DV should be processed in place, and UUID should throw error.
+  def requiresIdToUrlForDV(deletionVectorOpt: Option[DeletionVectorDescriptor]): Boolean = {
+    deletionVectorOpt.isDefined &&
+      deletionVectorOpt.get.storageType == DeletionVectorDescriptor.PATH_DV_MARKER
+  }
+
   private def getTableRefreshResult(tableFiles: DeltaTableFiles): TableRefreshResult = {
     var minUrlExpiration: Option[Long] = None
+    // Collect the id to url mapping from the table files, which includes the file actions
+    // and deletion vectors.
     val idToUrl = tableFiles.lines
-      .map(
-        JsonUtils.fromJson[model.DeltaSharingSingleAction](_).unwrap
-      )
+      .map(JsonUtils.fromJson[model.DeltaSharingSingleAction](_).unwrap)
       .collect {
         case fileAction: model.DeltaSharingFileAction =>
+          val baseEntries = Seq(fileAction.id -> fileAction.path)
+          val dvEntries = if (requiresIdToUrlForDV(fileAction.getDeletionVectorOpt)) {
+            Seq(
+              fileAction.deletionVectorFileId -> fileAction.getDeletionVectorOpt.get.pathOrInlineDv
+            )
+          } else {
+            Seq.empty
+          }
           if (fileAction.expirationTimestamp != null) {
             minUrlExpiration = minUrlExpiration
               .filter(_ < fileAction.expirationTimestamp)
               .orElse(Some(fileAction.expirationTimestamp))
           }
-          fileAction.id -> fileAction.path
+          baseEntries ++ dvEntries
       }
+      .flatten
       .toMap
 
     TableRefreshResult(idToUrl, minUrlExpiration, tableFiles.refreshToken)

--- a/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingUtilsSuite.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingUtilsSuite.scala
@@ -20,9 +20,158 @@ import scala.reflect.ClassTag
 
 import org.apache.spark.{SharedSparkContext, SparkEnv, SparkFunSuite}
 import org.apache.spark.storage.BlockId
+import org.apache.spark.delta.sharing.TableRefreshResult
+
+import io.delta.sharing.client.model.Table
+import DeltaSharingUtils._
+import io.delta.sharing.client.DeltaSharingClient
+import io.delta.sharing.client.model.{DeltaTableFiles, DeltaTableMetadata}
+import io.delta.sharing.client.DeltaSharingRestClient
 
 class DeltaSharingUtilsSuite extends SparkFunSuite with SharedSparkContext {
-  import DeltaSharingUtils._
+
+  type RefresherFunction = Option[String] => TableRefreshResult
+  class SimpleTestDeltaSharingClient extends DeltaSharingClient {
+    def getStatsStr(): String = {
+      """{
+        |  "numRecords": 20,
+        |  "minValues": { "col-a": 0 },
+        |  "maxValues": { "col-a": 19 },
+        |  "nullCount": { "col-a": 0 }
+        |}""".stripMargin
+        .replace("\n", "")
+        .replace(" ", "")
+        .replace("\"", "\\\"")
+    }
+
+    def getAddFileStr(): String = {
+      val stats = getStatsStr()
+      s"""{
+         |  "file": {
+         |    "id": "add_file_id1",
+         |    "expirationTimestamp": 1721350999999,
+         |    "deltaSingleAction": {
+         |      "add": {
+         |        "path": "c000.snappy.parquet",
+         |        "partitionValues": {
+         |          "col-partition": "3"
+         |        },
+         |        "size": 1213,
+         |        "modificationTime": 1721350059000,
+         |        "dataChange": true,
+         |        "stats": "$stats",
+         |        "tags": {
+         |          "INSERTION_TIME": "1721350059000000"
+         |        }
+         |      }
+         |    }
+         |  }
+         |}""".stripMargin
+    }
+
+    def getDeletionVectorStr(): String = {
+      val stats = getStatsStr()
+      s"""{
+         |  "file": {
+         |    "id": "add_file_id2",
+         |    "expirationTimestamp": 1721350999999,
+         |    "deletionVectorFileId": "dv_file_id",
+         |    "deltaSingleAction": {
+         |      "add": {
+         |        "path": "c001.snappy.parquet",
+         |        "partitionValues": {
+         |          "col-partition": "3"
+         |        },
+         |        "size": 1213,
+         |        "modificationTime": 1721350059000,
+         |        "dataChange": true,
+         |        "stats": "$stats",
+         |        "tags": {
+         |          "INSERTION_TIME": "1721350059000000"
+         |        },
+         |        "deletionVector": {
+         |          "storageType": "p",
+         |          "pathOrInlineDv": "fakeurl",
+         |          "offset": 1,
+         |          "sizeInBytes": 34,
+         |          "cardinality": 1
+         |        }
+         |      }
+         |    }
+         |  }
+         |}""".stripMargin
+    }
+
+    def getCdcStr(): String = {
+      s"""{"file":{
+         |  "id":"cdc_file_id",
+         |  "expirationTimestamp":1721350999999,
+         |  "deltaSingleAction":{
+         |    "cdc":{
+         |      "path":"_change_data/cdc.c000.snappy.parquet",
+         |      "partitionValues":{},
+         |      "size":1213,
+         |      "modificationTime":1721350059000,
+         |      "dataChange":false
+         |    }
+         |  }
+         |}}""".stripMargin
+    }
+    override def listAllTables(): Seq[Table] = Seq.empty
+
+    override def getTableVersion(table: Table, startingTimestamp: Option[String] = None): Long = 0
+
+    override def getMetadata(
+      table: Table,
+      versionAsOf: Option[Long] = None,
+      timestampAsOf: Option[String] = None
+    ): DeltaTableMetadata =
+      throw new UnsupportedOperationException
+
+    override def getFiles(
+      table: Table,
+      predicates: Seq[String],
+      limit: Option[Long],
+      versionAsOf: Option[Long],
+      timestampAsOf: Option[String],
+      jsonPredicateHints: Option[String],
+      refreshToken: Option[String]
+    ): DeltaTableFiles = {
+      val file = getAddFileStr()
+      val dv = getDeletionVectorStr()
+      DeltaTableFiles(
+        version = 0L,
+        respondedFormat = DeltaSharingRestClient.RESPONSE_FORMAT_DELTA,
+        lines = Seq(file, dv)
+      )
+    }
+
+    override def getFiles(table: Table, startingVersion: Long, endingVersion: Option[Long])
+    : DeltaTableFiles = {
+      val file = getAddFileStr()
+      val dv = getDeletionVectorStr()
+      DeltaTableFiles(
+        version = 0L,
+        respondedFormat = DeltaSharingRestClient.RESPONSE_FORMAT_DELTA,
+        lines = Seq(file, dv)
+      )
+    }
+
+    override def getCDFFiles(
+      table: Table,
+      cdfOptions: Map[String, String],
+      includeHistoricalMetadata: Boolean): DeltaTableFiles = {
+      val file = getAddFileStr()
+      val dv = getDeletionVectorStr()
+      val cdc = getCdcStr()
+      DeltaTableFiles(
+        version = 0L,
+        respondedFormat = DeltaSharingRestClient.RESPONSE_FORMAT_DELTA,
+        lines = Seq(file, dv, cdc)
+      )
+    }
+  }
+
 
   test("override single block in blockmanager works") {
     val blockId = BlockId(s"${DeltaSharingUtils.DELTA_SHARING_BLOCK_ID_PREFIX}_1")
@@ -54,5 +203,66 @@ class DeltaSharingUtilsSuite extends SparkFunSuite with SharedSparkContext {
     assert(getSeqFromBlockManager[Int](blockId) == Seq(1, 2))
     overrideIteratorBlock[String](blockId, values = Seq("3", "4").toIterator)
     assert(getSeqFromBlockManager[String](blockId) == Seq("3", "4"))
+  }
+
+  test("getRefresherForGetFiles with deletion vector") {
+    val client = new SimpleTestDeltaSharingClient()
+    val table = Table(name = "table", schema = "schema", share = "share")
+    val func: RefresherFunction = getRefresherForGetFiles(
+      client,
+      table,
+      Seq.empty,
+      None,
+      None,
+      None,
+      None
+    )
+    val idToUrls = func(None).idToUrl
+    assert(idToUrls.size == 3)
+    assert(idToUrls.contains("add_file_id1"))
+    assert(idToUrls.get("add_file_id1") == Some("c000.snappy.parquet"))
+    assert(idToUrls.contains("add_file_id2"))
+    assert(idToUrls.get("add_file_id2") == Some("c001.snappy.parquet"))
+    assert(idToUrls.contains("dv_file_id"))
+    assert(idToUrls.get("dv_file_id") == Some("fakeurl"))
+  }
+
+  test("getRefresherForGetFilesWithStartingVersion with deletion vector") {
+    val client = new SimpleTestDeltaSharingClient()
+    val table = Table(name = "table", schema = "schema", share = "share")
+    val func: RefresherFunction = getRefresherForGetFilesWithStartingVersion(
+      client,
+      table,
+      0L,
+      None
+    )
+    val idToUrls = func(None).idToUrl
+    assert(idToUrls.size == 3)
+    assert(idToUrls.contains("add_file_id1"))
+    assert(idToUrls.get("add_file_id1") == Some("c000.snappy.parquet"))
+    assert(idToUrls.contains("add_file_id2"))
+    assert(idToUrls.get("add_file_id2") == Some("c001.snappy.parquet"))
+    assert(idToUrls.contains("dv_file_id"))
+    assert(idToUrls.get("dv_file_id") == Some("fakeurl"))
+  }
+
+  test("getRefresherForGetCDFFiles with deletion vector") {
+    val client = new SimpleTestDeltaSharingClient()
+    val table = Table(name = "table", schema = "schema", share = "share")
+    val func: RefresherFunction = getRefresherForGetCDFFiles(
+      client,
+      table,
+      Map[String, String]("startingVersion" -> "0")
+    )
+    val idToUrls = func(None).idToUrl
+    assert(idToUrls.size == 4)
+    assert(idToUrls.contains("add_file_id1"))
+    assert(idToUrls.get("add_file_id1") == Some("c000.snappy.parquet"))
+    assert(idToUrls.contains("add_file_id2"))
+    assert(idToUrls.get("add_file_id2") == Some("c001.snappy.parquet"))
+    assert(idToUrls.contains("dv_file_id"))
+    assert(idToUrls.get("dv_file_id") == Some("fakeurl"))
+    assert(idToUrls.contains("cdc_file_id"))
+    assert(idToUrls.get("cdc_file_id") == Some("_change_data/cdc.c000.snappy.parquet"))
   }
 }


### PR DESCRIPTION
## Summary
- Backport of https://github.com/delta-io/delta/commit/27218857d30123f35dedc9bd6d6627b787c4de61 (#4689) to `branch-4.0`.
- Preserves deletion vector fileId-URL entries during Delta Sharing cache refresh so long-running queries do not hit file id not found errors.

## Test plan
- [x] Cherry-pick applied cleanly onto `branch-4.0`
- [ ] Existing `DeltaSharingUtilsSuite` refresh tests (including new DV-related cases) pass