### PR TITLE
[Spark] Add usage logging for @-syntax path-based time travel

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTimeTravelSpec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTimeTravelSpec.scala
@@ -83,7 +83,7 @@ case class DeltaTimeTravelSpec(
   }
 }
 
-object DeltaTimeTravelSpec {
+object DeltaTimeTravelSpec extends DeltaLogging {
   /** A regex which looks for the pattern ...@v(some numbers) for extracting the version number */
   private val VERSION_URI_FOR_TIME_TRAVEL = ".*@[vV](\\d+)$".r
 
@@ -116,11 +116,14 @@ object DeltaTimeTravelSpec {
         val timestamp = parseTimestamp(ts, conf.sessionLocalTimeZone)
         // Drop the 18 characters in the right, which is the timestamp format and the @ character.
         val realIdentifier = identifier.dropRight(TIMESTAMP_FORMAT_LENGTH + 1)
-
+        recordDeltaEvent(null, "delta.timeTravel.atSyntaxUsage",
+          data = Map("source" -> "atSyntax.path", "atTimestamp" -> ts))
         DeltaTimeTravelSpec(Some(timestamp), None, Some("atSyntax.path")) -> realIdentifier
       case VERSION_URI_FOR_TIME_TRAVEL(v) =>
         // Drop the version, and `@v` characters from the identifier
         val realIdentifier = identifier.dropRight(v.length + 2)
+        recordDeltaEvent(null, "delta.timeTravel.atSyntaxUsage",
+          data = Map("source" -> "atSyntax.path", "atVersion" -> v))
         DeltaTimeTravelSpec(None, Some(v.toLong), Some("atSyntax.path")) -> realIdentifier
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Adds a usage log event (`delta.timeTravel.atSyntaxUsage`) when the `@`-suffix time travel syntax is parsed for a path, recording whether a version (`@vN`) or timestamp (`@<yyyyMMddHHmmssSSS>`) was used, and its value.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No