### PR TITLE
[Kernel] Cherry-pick parquet reading optimizations to ds-11122025

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -937,7 +937,7 @@ lazy val kernelDefaults = (project in file("kernel/kernel-defaults"))
       "org.apache.hadoop" % "hadoop-client-runtime" % hadoopVersion,
       "com.fasterxml.jackson.core" % "jackson-databind" % "2.13.5",
       "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % "2.13.5",
-      "org.apache.parquet" % "parquet-hadoop" % "1.12.3",
+      "org.apache.parquet" % "parquet-hadoop" % "1.16.0",
 
       "org.scalatest" %% "scalatest" % scalaTestVersion % "test",
       "junit" % "junit" % "4.13.2" % "test",

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checkpoints/Checkpointer.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checkpoints/Checkpointer.java
@@ -91,6 +91,11 @@ public class Checkpointer {
       numberOfAddFiles = checkpointDataIter.getNumberOfAddActions();
     } catch (FileAlreadyExistsException faee) {
       throw new CheckpointAlreadyExistsException(version);
+    } catch (IOException io) {
+      if (io.getCause() instanceof FileAlreadyExistsException) {
+        throw new CheckpointAlreadyExistsException(version);
+      }
+      throw io;
     }
 
     final CheckpointMetaData checkpointMetaData =

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/hadoopio/HadoopInputFile.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/hadoopio/HadoopInputFile.java
@@ -18,6 +18,7 @@ package io.delta.kernel.defaults.engine.hadoopio;
 import io.delta.kernel.defaults.engine.fileio.InputFile;
 import io.delta.kernel.defaults.engine.fileio.SeekableInputStream;
 import java.io.IOException;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
@@ -40,6 +41,11 @@ public class HadoopInputFile implements InputFile {
   @Override
   public String path() {
     return path.toString();
+  }
+
+  /** Returns the Hadoop {@link Configuration} this file is read with. */
+  public Configuration configuration() {
+    return fs.getConf();
   }
 
   @Override

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/hadoopio/HadoopInputFile.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/hadoopio/HadoopInputFile.java
@@ -18,6 +18,7 @@ package io.delta.kernel.defaults.engine.hadoopio;
 import io.delta.kernel.defaults.engine.fileio.InputFile;
 import io.delta.kernel.defaults.engine.fileio.SeekableInputStream;
 import java.io.IOException;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
@@ -40,6 +41,11 @@ public class HadoopInputFile implements InputFile {
   @Override
   public String path() {
     return path.toString();
+  }
+
+  /** Returns the Hadoop {@link Configuration} this file is read with. */
+  public Configuration getConfiguration() {
+    return fs.getConf();
   }
 
   @Override

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetBatchRowReader.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetBatchRowReader.java
@@ -1,0 +1,264 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.defaults.internal.parquet;
+
+import static java.util.Objects.requireNonNull;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.PrimitiveIterator;
+import java.util.Set;
+import java.util.stream.LongStream;
+import org.apache.parquet.ParquetReadOptions;
+import org.apache.parquet.column.page.PageReadStore;
+import org.apache.parquet.conf.ParquetConfiguration;
+import org.apache.parquet.filter2.compat.FilterCompat;
+import org.apache.parquet.hadoop.ParquetFileReader;
+import org.apache.parquet.hadoop.api.InitContext;
+import org.apache.parquet.hadoop.api.ReadSupport;
+import org.apache.parquet.hadoop.metadata.FileMetaData;
+import org.apache.parquet.io.ColumnIOFactory;
+import org.apache.parquet.io.MessageColumnIO;
+import org.apache.parquet.io.ParquetDecodingException;
+import org.apache.parquet.io.RecordReader;
+import org.apache.parquet.io.api.RecordMaterializer;
+import org.apache.parquet.schema.MessageType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Iterates rows from an already-opened {@link ParquetFileReader}, using public parquet-mr APIs
+ * ({@code readNextFilteredRowGroup} + {@link ColumnIOFactory}) instead of package-private {@code
+ * InternalParquetRecordReader}.
+ *
+ * <p>Callers own footer reuse by opening the file reader with {@link
+ * ParquetFileReader#open(org.apache.parquet.io.InputFile,
+ * org.apache.parquet.hadoop.metadata.ParquetMetadata, ParquetReadOptions,
+ * org.apache.parquet.io.SeekableInputStream)} before calling {@link #open}.
+ *
+ * <p>Ownership of {@code fileReader} transfers to this class; {@link #close()} closes it.
+ */
+final class ParquetBatchRowReader implements Closeable {
+  private static final Logger logger = LoggerFactory.getLogger(ParquetBatchRowReader.class);
+  private static final String STRICT_TYPE_CHECKING = "parquet.strict.typing";
+  private final ParquetFileReader fileReader;
+  private final ColumnIOFactory columnIOFactory;
+  private final MessageType fileSchema;
+  private final MessageType requestedSchema;
+  private final RecordMaterializer<Object> materializer;
+  private final boolean strictTypeChecking;
+  private final boolean filterRecords;
+  private final FilterCompat.Filter recordFilter;
+  private final long totalRows;
+  private long rowsConsumed = 0;
+  private long rowsLoadedFromGroups = 0;
+  private PageReadStore currentRowGroup;
+  private RecordReader<Object> recordReader;
+  private long currentRowIndex = -1;
+  private PrimitiveIterator.OfLong rowIndexInFile;
+
+  private ParquetBatchRowReader(
+      ParquetFileReader fileReader,
+      ColumnIOFactory columnIOFactory,
+      MessageType fileSchema,
+      MessageType requestedSchema,
+      RecordMaterializer<Object> materializer,
+      boolean strictTypeChecking,
+      boolean filterRecords,
+      FilterCompat.Filter recordFilter,
+      long totalRows) {
+    this.fileReader = fileReader;
+    this.columnIOFactory = columnIOFactory;
+    this.fileSchema = fileSchema;
+    this.requestedSchema = requestedSchema;
+    this.materializer = materializer;
+    this.strictTypeChecking = strictTypeChecking;
+    this.filterRecords = filterRecords;
+    this.recordFilter = recordFilter;
+    this.totalRows = totalRows;
+  }
+
+  /**
+   * Takes ownership of {@code fileReader}. Projects columns via {@code readSupport}, applies the
+   * row-group filter already configured on {@code fileReader}'s options, and prepares to iterate
+   * rows.
+   */
+  static ParquetBatchRowReader open(
+      ParquetFileReader fileReader, ParquetReadOptions options, ReadSupport<Object> readSupport) {
+    requireNonNull(fileReader, "fileReader");
+    requireNonNull(options, "options");
+    requireNonNull(readSupport, "readSupport");
+    // Mirror InternalParquetRecordReader: copy option properties onto the conf used by ReadSupport.
+    ParquetConfiguration conf = requireNonNull(options.getConfiguration(), "options.configuration");
+    for (String property : options.getPropertyNames()) {
+      conf.set(property, options.getProperty(property));
+    }
+    FileMetaData parquetFileMetadata = fileReader.getFooter().getFileMetaData();
+    MessageType fileSchema = parquetFileMetadata.getSchema();
+    Map<String, String> fileMetadata = parquetFileMetadata.getKeyValueMetaData();
+    ReadSupport.ReadContext readContext =
+        readSupport.init(new InitContext(conf, toSetMultiMap(fileMetadata), fileSchema));
+    ColumnIOFactory columnIOFactory = new ColumnIOFactory(parquetFileMetadata.getCreatedBy());
+    MessageType requestedSchema = readContext.getRequestedSchema();
+    // Setting the projection schema before running any filtering (e.g. getting filtered record
+    // count) because projection impacts filtering
+    fileReader.setRequestedSchema(requestedSchema);
+    RecordMaterializer<Object> materializer =
+        readSupport.prepareForRead(conf, fileMetadata, fileSchema, readContext);
+    return new ParquetBatchRowReader(
+        fileReader,
+        columnIOFactory,
+        fileSchema,
+        requestedSchema,
+        materializer,
+        options.isEnabled(STRICT_TYPE_CHECKING, true),
+        options.useRecordFilter(),
+        options.getRecordFilter() == null ? FilterCompat.NOOP : options.getRecordFilter(),
+        fileReader.getFilteredRecordCount());
+  }
+
+  /**
+   * Advances to the next row. Returns {@code true} if a row is available; {@link
+   * #currentRowIndex()} is then valid until the next call.
+   *
+   * <p>Materialized values are written into the {@link ReadSupport}'s {@link RecordMaterializer}
+   * (Kernel's {@code BatchReadSupport} / {@code RowRecordCollector}). The returned boolean is the
+   * only signal the iterator needs — there is no {@code getCurrentValue()}.
+   */
+  boolean next() throws IOException {
+    while (rowsConsumed < totalRows) {
+      loadNextRowGroupIfNeeded();
+      rowsConsumed++;
+      try {
+        Object value = recordReader.read();
+        advanceRowIndex();
+        if (recordReader.shouldSkipCurrentRecord()) {
+          // this record is being filtered via the filter2 package
+          continue;
+        }
+        if (value == null) {
+          // only happens with FilteredRecordReader at end of block
+          rowsConsumed = rowsLoadedFromGroups;
+          continue;
+        }
+        return true;
+      } catch (RuntimeException e) {
+        throw new ParquetDecodingException(
+            String.format(
+                "Can not read value at %d in file %s", rowsConsumed, fileReader.getFile()),
+            e);
+      }
+    }
+    return false;
+  }
+
+  /** File-level row index of the row made current by the last successful {@link #next()}. */
+  long currentRowIndex() {
+    return currentRowIndex;
+  }
+
+  @Override
+  public void close() throws IOException {
+    try {
+      if (currentRowGroup != null) {
+        currentRowGroup.close();
+        currentRowGroup = null;
+      }
+    } finally {
+      fileReader.close();
+    }
+  }
+
+  private void loadNextRowGroupIfNeeded() throws IOException {
+    if (rowsConsumed != rowsLoadedFromGroups) {
+      return;
+    }
+    if (currentRowGroup != null) {
+      currentRowGroup.close();
+      currentRowGroup = null;
+    }
+    logger.info("at row " + rowsConsumed + ". reading next block");
+    // Applies stats / dictionary / bloom / column-index filters from ParquetReadOptions.
+    // (Plain readNextRowGroup() would ignore those.)
+    currentRowGroup = fileReader.readNextFilteredRowGroup();
+    if (currentRowGroup == null) {
+      throw new IOException(
+          "expecting more rows but reached last block. Read "
+              + rowsConsumed
+              + " out of "
+              + totalRows);
+    }
+    resetRowIndexIterator(currentRowGroup);
+    MessageColumnIO columnIO =
+        columnIOFactory.getColumnIO(requestedSchema, fileSchema, strictTypeChecking);
+    recordReader =
+        columnIO.getRecordReader(
+            currentRowGroup, materializer, filterRecords ? recordFilter : FilterCompat.NOOP);
+    rowsLoadedFromGroups += currentRowGroup.getRowCount();
+  }
+
+  /** Resets the row index based on the current processed row group. */
+  private void resetRowIndexIterator(PageReadStore pages) {
+    Optional<Long> rowGroupOffset = pages.getRowIndexOffset();
+    if (!rowGroupOffset.isPresent()) {
+      rowIndexInFile = null;
+      currentRowIndex = -1;
+      return;
+    }
+    currentRowIndex = -1;
+    final PrimitiveIterator.OfLong rowIdxInRowGroup;
+    if (pages.getRowIndexes().isPresent()) {
+      rowIdxInRowGroup = pages.getRowIndexes().get();
+    } else {
+      rowIdxInRowGroup = LongStream.range(0, pages.getRowCount()).iterator();
+    }
+    final long offset = rowGroupOffset.get();
+    rowIndexInFile =
+        new PrimitiveIterator.OfLong() {
+          @Override
+          public long nextLong() {
+            return offset + rowIdxInRowGroup.nextLong();
+          }
+
+          @Override
+          public boolean hasNext() {
+            return rowIdxInRowGroup.hasNext();
+          }
+        };
+  }
+
+  private void advanceRowIndex() {
+    if (rowIndexInFile != null && rowIndexInFile.hasNext()) {
+      currentRowIndex = rowIndexInFile.nextLong();
+    } else {
+      currentRowIndex = -1;
+    }
+  }
+
+  private static <K, V> Map<K, Set<V>> toSetMultiMap(Map<K, V> map) {
+    Map<K, Set<V>> out = new HashMap<>();
+    for (Map.Entry<K, V> e : map.entrySet()) {
+      Set<V> set = new HashSet<>();
+      set.add(e.getValue());
+      out.put(e.getKey(), set);
+    }
+    return out;
+  }
+}

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetFileReader.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetFileReader.java
@@ -33,10 +33,10 @@ import io.delta.kernel.utils.FileStatus;
 import java.io.IOException;
 import java.util.*;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.ParquetReadOptions;
 import org.apache.parquet.conf.ParquetConfiguration;
 import org.apache.parquet.filter2.compat.FilterCompat;
 import org.apache.parquet.filter2.predicate.FilterPredicate;
-import org.apache.parquet.hadoop.ParquetReader;
 import org.apache.parquet.hadoop.api.InitContext;
 import org.apache.parquet.hadoop.api.ReadSupport;
 import org.apache.parquet.hadoop.metadata.ParquetMetadata;
@@ -71,7 +71,7 @@ public class ParquetFileReader {
 
     return new CloseableIterator<ColumnarBatch>() {
       private final BatchReadSupport readSupport = new BatchReadSupport(maxBatchSize, schema);
-      private ParquetReader<Object> reader;
+      private ParquetRecordReaderWrapper<Object> reader;
       private boolean hasNotConsumedNextElement;
 
       @Override
@@ -87,8 +87,7 @@ public class ParquetFileReader {
             return true;
           }
 
-          Object next = reader.read();
-          hasNotConsumedNextElement = next != null;
+          hasNotConsumedNextElement = reader.nextKeyValue() && reader.getCurrentValue() != null;
           return hasNotConsumedNextElement;
         } catch (IOException ex) {
           throw new KernelEngineException(
@@ -126,7 +125,7 @@ public class ParquetFileReader {
             org.apache.parquet.io.InputFile parquetInputFile =
                 ParquetIOUtils.createParquetInputFile(inputFile);
 
-            // Pass the configuration explicitly at both `parquet-mr` entry points below, so
+            // Seed both the footer read and the read options below with this configuration, so
             // neither constructs a fresh Hadoop Configuration per file. See
             // ParquetIOUtils#parquetConfiguration.
             ParquetConfiguration parquetConf = ParquetIOUtils.parquetConfiguration(inputFile);
@@ -137,16 +136,8 @@ public class ParquetFileReader {
             Optional<FilterPredicate> parquetPredicate =
                 predicate.flatMap(predicate -> toParquetFilter(parquetSchema, predicate));
 
-            // TODO: We can avoid reading the footer again if we can pass the footer, but there is
-            // no API to do that in the current version of parquet-mr which takes InputFile
-            // as input.
-            reader =
-                new ParquetReader.Builder<Object>(parquetInputFile, parquetConf) {
-                  @Override
-                  protected ReadSupport<Object> getReadSupport() {
-                    return readSupport;
-                  }
-                }.withFilter(parquetPredicate.map(FilterCompat::get).orElse(FilterCompat.NOOP))
+            ParquetReadOptions readOptions =
+                ParquetReadOptions.builder(parquetConf)
                     // Disable the record level filtering as the `parquet-mr` evaluates
                     // the filter once the entire record has been materialized. Instead,
                     // we use the predicate to prune the row groups which is more efficient.
@@ -157,8 +148,16 @@ public class ParquetFileReader {
                     .useBloomFilter(false)
                     .useDictionaryFilter(false)
                     .useColumnIndexFilter(false)
+                    .withRecordFilter(
+                        parquetPredicate.map(FilterCompat::get).orElse(FilterCompat.NOOP))
                     .build();
 
+            // Pass the already read footer to the reader to avoid reading it again.
+            fileReader =
+                org.apache.parquet.hadoop.ParquetFileReader.open(
+                    parquetInputFile, footer, readOptions, parquetInputFile.newStream());
+            reader = new ParquetRecordReaderWrapper<>(readSupport);
+            reader.initialize(fileReader, readOptions);
           } catch (IOException e) {
             Utils.closeCloseablesSilently(fileReader, reader);
             throw new KernelEngineException(

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetFileReader.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetFileReader.java
@@ -33,9 +33,9 @@ import io.delta.kernel.utils.FileStatus;
 import java.io.IOException;
 import java.util.*;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.conf.ParquetConfiguration;
 import org.apache.parquet.filter2.compat.FilterCompat;
 import org.apache.parquet.filter2.predicate.FilterPredicate;
-import org.apache.parquet.format.converter.ParquetMetadataConverter;
 import org.apache.parquet.hadoop.ParquetReader;
 import org.apache.parquet.hadoop.api.InitContext;
 import org.apache.parquet.hadoop.api.ReadSupport;
@@ -126,9 +126,12 @@ public class ParquetFileReader {
             org.apache.parquet.io.InputFile parquetInputFile =
                 ParquetIOUtils.createParquetInputFile(inputFile);
 
-            ParquetMetadata footer =
-                org.apache.parquet.hadoop.ParquetFileReader.readFooter(
-                    parquetInputFile, ParquetMetadataConverter.NO_FILTER);
+            // Pass the configuration explicitly at both `parquet-mr` entry points below, so
+            // neither constructs a fresh Hadoop Configuration per file. See
+            // ParquetIOUtils#parquetConfiguration.
+            ParquetConfiguration parquetConf = ParquetIOUtils.parquetConfiguration(inputFile);
+
+            ParquetMetadata footer = ParquetIOUtils.readFooter(parquetInputFile, parquetConf);
 
             MessageType parquetSchema = footer.getFileMetaData().getSchema();
             Optional<FilterPredicate> parquetPredicate =
@@ -138,7 +141,7 @@ public class ParquetFileReader {
             // no API to do that in the current version of parquet-mr which takes InputFile
             // as input.
             reader =
-                new ParquetReader.Builder<Object>(parquetInputFile) {
+                new ParquetReader.Builder<Object>(parquetInputFile, parquetConf) {
                   @Override
                   protected ReadSupport<Object> getReadSupport() {
                     return readSupport;

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetFileReader.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetFileReader.java
@@ -33,9 +33,9 @@ import io.delta.kernel.utils.FileStatus;
 import java.io.IOException;
 import java.util.*;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.conf.ParquetConfiguration;
 import org.apache.parquet.filter2.compat.FilterCompat;
 import org.apache.parquet.filter2.predicate.FilterPredicate;
-import org.apache.parquet.format.converter.ParquetMetadataConverter;
 import org.apache.parquet.hadoop.ParquetReader;
 import org.apache.parquet.hadoop.api.InitContext;
 import org.apache.parquet.hadoop.api.ReadSupport;
@@ -126,9 +126,15 @@ public class ParquetFileReader {
             org.apache.parquet.io.InputFile parquetInputFile =
                 ParquetIOUtils.createParquetInputFile(inputFile);
 
-            ParquetMetadata footer =
-                org.apache.parquet.hadoop.ParquetFileReader.readFooter(
-                    parquetInputFile, ParquetMetadataConverter.NO_FILTER);
+            // Pass the configuration explicitly at both `parquet-mr` entry points below, so
+            // neither constructs a fresh Hadoop Configuration per file. See
+            // ParquetIOUtils#parquetConfiguration.
+            //
+            // This also means that the reader now inherits any parquet-mr options set on the
+            // file's Hadoop Configuration, rather than always using the defaults.
+            ParquetConfiguration parquetConf = ParquetIOUtils.parquetConfiguration(inputFile);
+
+            ParquetMetadata footer = ParquetIOUtils.readFooter(parquetInputFile, parquetConf);
 
             MessageType parquetSchema = footer.getFileMetaData().getSchema();
             Optional<FilterPredicate> parquetPredicate =
@@ -138,7 +144,7 @@ public class ParquetFileReader {
             // no API to do that in the current version of parquet-mr which takes InputFile
             // as input.
             reader =
-                new ParquetReader.Builder<Object>(parquetInputFile) {
+                new ParquetReader.Builder<Object>(parquetInputFile, parquetConf) {
                   @Override
                   protected ReadSupport<Object> getReadSupport() {
                     return readSupport;

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetFileReader.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetFileReader.java
@@ -33,10 +33,10 @@ import io.delta.kernel.utils.FileStatus;
 import java.io.IOException;
 import java.util.*;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.ParquetReadOptions;
 import org.apache.parquet.conf.ParquetConfiguration;
 import org.apache.parquet.filter2.compat.FilterCompat;
 import org.apache.parquet.filter2.predicate.FilterPredicate;
-import org.apache.parquet.hadoop.ParquetReader;
 import org.apache.parquet.hadoop.api.InitContext;
 import org.apache.parquet.hadoop.api.ReadSupport;
 import org.apache.parquet.hadoop.metadata.ParquetMetadata;
@@ -71,7 +71,7 @@ public class ParquetFileReader {
 
     return new CloseableIterator<ColumnarBatch>() {
       private final BatchReadSupport readSupport = new BatchReadSupport(maxBatchSize, schema);
-      private ParquetReader<Object> reader;
+      private ParquetBatchRowReader reader;
       private boolean hasNotConsumedNextElement;
 
       @Override
@@ -87,8 +87,7 @@ public class ParquetFileReader {
             return true;
           }
 
-          Object next = reader.read();
-          hasNotConsumedNextElement = next != null;
+          hasNotConsumedNextElement = reader.next();
           return hasNotConsumedNextElement;
         } catch (IOException ex) {
           throw new KernelEngineException(
@@ -106,7 +105,7 @@ public class ParquetFileReader {
           hasNotConsumedNextElement = false;
           // hasNext reads to row to confirm there is a next element.
           // get the row index only if required by the read schema
-          long rowIndex = hasRowIndexCol ? reader.getCurrentRowIndex() : -1;
+          long rowIndex = hasRowIndexCol ? reader.currentRowIndex() : -1;
           readSupport.finalizeCurrentRow(rowIndex);
           batchSize++;
         } while (batchSize < maxBatchSize && hasNext());
@@ -126,7 +125,7 @@ public class ParquetFileReader {
             org.apache.parquet.io.InputFile parquetInputFile =
                 ParquetIOUtils.createParquetInputFile(inputFile);
 
-            // Pass the configuration explicitly at both `parquet-mr` entry points below, so
+            // Seed both the footer read and the read options below with this configuration, so
             // neither constructs a fresh Hadoop Configuration per file. See
             // ParquetIOUtils#parquetConfiguration.
             //
@@ -140,16 +139,8 @@ public class ParquetFileReader {
             Optional<FilterPredicate> parquetPredicate =
                 predicate.flatMap(predicate -> toParquetFilter(parquetSchema, predicate));
 
-            // TODO: We can avoid reading the footer again if we can pass the footer, but there is
-            // no API to do that in the current version of parquet-mr which takes InputFile
-            // as input.
-            reader =
-                new ParquetReader.Builder<Object>(parquetInputFile, parquetConf) {
-                  @Override
-                  protected ReadSupport<Object> getReadSupport() {
-                    return readSupport;
-                  }
-                }.withFilter(parquetPredicate.map(FilterCompat::get).orElse(FilterCompat.NOOP))
+            ParquetReadOptions readOptions =
+                ParquetReadOptions.builder(parquetConf)
                     // Disable the record level filtering as the `parquet-mr` evaluates
                     // the filter once the entire record has been materialized. Instead,
                     // we use the predicate to prune the row groups which is more efficient.
@@ -160,8 +151,16 @@ public class ParquetFileReader {
                     .useBloomFilter(false)
                     .useDictionaryFilter(false)
                     .useColumnIndexFilter(false)
+                    .withRecordFilter(
+                        parquetPredicate.map(FilterCompat::get).orElse(FilterCompat.NOOP))
                     .build();
 
+            // Pass the already read footer to the reader to avoid reading it again.
+            fileReader =
+                org.apache.parquet.hadoop.ParquetFileReader.open(
+                    parquetInputFile, footer, readOptions, parquetInputFile.newStream());
+            // Ownership of fileReader transfers to the row reader, which closes it on close().
+            reader = ParquetBatchRowReader.open(fileReader, readOptions, readSupport);
           } catch (IOException e) {
             Utils.closeCloseablesSilently(fileReader, reader);
             throw new KernelEngineException(

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetIOUtils.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetIOUtils.java
@@ -19,7 +19,14 @@ import io.delta.kernel.defaults.engine.fileio.InputFile;
 import io.delta.kernel.defaults.engine.fileio.OutputFile;
 import io.delta.kernel.defaults.engine.fileio.PositionOutputStream;
 import io.delta.kernel.defaults.engine.fileio.SeekableInputStream;
+import io.delta.kernel.defaults.engine.hadoopio.HadoopInputFile;
 import java.io.IOException;
+import org.apache.parquet.ParquetReadOptions;
+import org.apache.parquet.conf.HadoopParquetConfiguration;
+import org.apache.parquet.conf.ParquetConfiguration;
+import org.apache.parquet.format.converter.ParquetMetadataConverter;
+import org.apache.parquet.hadoop.ParquetFileReader;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
 import org.apache.parquet.io.DelegatingPositionOutputStream;
 import org.apache.parquet.io.DelegatingSeekableInputStream;
 
@@ -29,6 +36,44 @@ import org.apache.parquet.io.DelegatingSeekableInputStream;
  */
 public class ParquetIOUtils {
   private ParquetIOUtils() {}
+
+  /**
+   * Returns the {@link ParquetConfiguration} to read {@code inputFile} with.
+   *
+   * <p>This matters for concurrency, not just for honoring settings. `parquet-mr` entry points
+   * taking an {@link org.apache.parquet.io.InputFile} that isn't {@code
+   * org.apache.parquet.hadoop.util.HadoopInputFile} fall back to {@code new
+   * HadoopParquetConfiguration()}, which wraps a fresh {@code Configuration(loadDefaults=true)}.
+   * Hadoop loads such a configuration's properties lazily, so the first property read -- which
+   * `parquet-mr` issues immediately while building the read options -- scans the classpath for
+   * `core-default.xml` and friends under a JVM-global lock. This would make concurrent readers
+   * serialize on the lock.
+   *
+   * <p>Reusing the configuration the file is already being read with avoids the scan entirely: its
+   * properties are loaded once and memoized on the instance. A non-{@code HadoopInputFile} input
+   * carries no Hadoop configuration to reuse, so it falls back to a fresh {@code
+   * HadoopParquetConfiguration}.
+   */
+  static ParquetConfiguration parquetConfiguration(InputFile inputFile) {
+    return inputFile instanceof HadoopInputFile
+        ? new HadoopParquetConfiguration(((HadoopInputFile) inputFile).configuration())
+        : new HadoopParquetConfiguration();
+  }
+
+  /**
+   * Reads the footer of {@code parquetFile} using {@code conf}, so that `parquet-mr` doesn't
+   * construct a fresh Hadoop Configuration for the read. See {@link #parquetConfiguration}.
+   */
+  static ParquetMetadata readFooter(
+      org.apache.parquet.io.InputFile parquetFile, ParquetConfiguration conf) throws IOException {
+    ParquetReadOptions readOptions =
+        ParquetReadOptions.builder(conf)
+            .withMetadataFilter(ParquetMetadataConverter.NO_FILTER)
+            .build();
+    try (org.apache.parquet.io.SeekableInputStream stream = parquetFile.newStream()) {
+      return ParquetFileReader.readFooter(parquetFile, readOptions, stream);
+    }
+  }
 
   /** Create a Parquet {@link org.apache.parquet.io.InputFile} from a Kernel's {@link InputFile}. */
   static org.apache.parquet.io.InputFile createParquetInputFile(InputFile inputFile) {

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetIOUtils.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetIOUtils.java
@@ -19,7 +19,14 @@ import io.delta.kernel.defaults.engine.fileio.InputFile;
 import io.delta.kernel.defaults.engine.fileio.OutputFile;
 import io.delta.kernel.defaults.engine.fileio.PositionOutputStream;
 import io.delta.kernel.defaults.engine.fileio.SeekableInputStream;
+import io.delta.kernel.defaults.engine.hadoopio.HadoopInputFile;
 import java.io.IOException;
+import org.apache.parquet.ParquetReadOptions;
+import org.apache.parquet.conf.HadoopParquetConfiguration;
+import org.apache.parquet.conf.ParquetConfiguration;
+import org.apache.parquet.format.converter.ParquetMetadataConverter;
+import org.apache.parquet.hadoop.ParquetFileReader;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
 import org.apache.parquet.io.DelegatingPositionOutputStream;
 import org.apache.parquet.io.DelegatingSeekableInputStream;
 
@@ -29,6 +36,42 @@ import org.apache.parquet.io.DelegatingSeekableInputStream;
  */
 public class ParquetIOUtils {
   private ParquetIOUtils() {}
+
+  /**
+   * Returns the {@link ParquetConfiguration} to read {@code inputFile} with.
+   *
+   * <p>This matters for concurrency, not just for honoring settings. `parquet-mr` entry points
+   * taking an {@link org.apache.parquet.io.InputFile} that isn't {@code
+   * org.apache.parquet.hadoop.util.HadoopInputFile} fall back to {@code new
+   * HadoopParquetConfiguration()}, which wraps a fresh {@code Configuration(loadDefaults=true)}.
+   * Hadoop loads such a configuration's properties lazily, so the first property read -- which
+   * `parquet-mr` issues immediately while building the read options -- scans the classpath for
+   * `core-default.xml` and friends under a JVM-global lock. This would make concurrent readers
+   * serialize on the lock.
+   *
+   * <p>Reusing the configuration the file is already being read with avoids the scan entirely: its
+   * properties are loaded once and memoized on the instance.
+   */
+  static ParquetConfiguration parquetConfiguration(InputFile inputFile) {
+    return inputFile instanceof HadoopInputFile
+        ? new HadoopParquetConfiguration(((HadoopInputFile) inputFile).getConfiguration())
+        : new HadoopParquetConfiguration();
+  }
+
+  /**
+   * Reads the footer of {@code parquetFile} using {@code conf}, so that `parquet-mr` doesn't
+   * construct a fresh Hadoop Configuration for the read. See {@link #parquetConfiguration}.
+   */
+  static ParquetMetadata readFooter(
+      org.apache.parquet.io.InputFile parquetFile, ParquetConfiguration conf) throws IOException {
+    ParquetReadOptions readOptions =
+        ParquetReadOptions.builder(conf)
+            .withMetadataFilter(ParquetMetadataConverter.NO_FILTER)
+            .build();
+    try (org.apache.parquet.io.SeekableInputStream stream = parquetFile.newStream()) {
+      return ParquetFileReader.readFooter(parquetFile, readOptions, stream);
+    }
+  }
 
   /** Create a Parquet {@link org.apache.parquet.io.InputFile} from a Kernel's {@link InputFile}. */
   static org.apache.parquet.io.InputFile createParquetInputFile(InputFile inputFile) {

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetRecordReaderWrapper.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetRecordReaderWrapper.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.defaults.internal.parquet;
+
+import static java.util.Objects.requireNonNull;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import org.apache.parquet.ParquetReadOptions;
+import org.apache.parquet.hadoop.ParquetFileReader;
+import org.apache.parquet.hadoop.api.ReadSupport;
+
+/**
+ * Thin wrapper that exposes {@code parquet-mr}'s package-private {@code
+ * InternalParquetRecordReader} to Kernel, delegating each call to the underlying reader via
+ * reflection.
+ *
+ * <p>Kernel drives the low-level {@link ParquetFileReader} directly (rather than the high-level
+ * {@link org.apache.parquet.hadoop.ParquetReader}) so that it can reuse the {@link
+ * org.apache.parquet.hadoop.metadata.ParquetMetadata footer} it already read to build the row-group
+ * filter, instead of having the reader read (and parse) the footer a second time. The class that
+ * materializes rows from such a reader — {@code InternalParquetRecordReader} — is package-private,
+ * so this wrapper reaches it reflectively.
+ *
+ * <p>An earlier version of this wrapper (delta-io/delta#4429) instead <em>subclassed</em> {@code
+ * InternalParquetRecordReader} from a source file declared in package {@code
+ * org.apache.parquet.hadoop}. That was removed because it caused {@link IllegalAccessError}s when
+ * {@code parquet-mr} and Kernel are loaded by different class loaders: the JVM's package-private
+ * access check requires the same runtime package (same package name <em>and</em> same class
+ * loader), which does not hold across class loaders. Reflection with {@link
+ * java.lang.reflect.AccessibleObject#setAccessible(boolean) setAccessible(true)} disables that
+ * access check, so it works regardless of the class-loader topology.
+ *
+ * <p>Every member accessed here is {@code public} on {@code InternalParquetRecordReader}; only the
+ * class itself is package-private.
+ */
+class ParquetRecordReaderWrapper<T> implements Closeable {
+
+  private static final String INTERNAL_READER_CLASS =
+      "org.apache.parquet.hadoop.InternalParquetRecordReader";
+
+  // Reflection handles for InternalParquetRecordReader, resolved once and made accessible. They are
+  // stateless and safe to share; the reader instances they operate on are not.
+  private static final Constructor<?> CONSTRUCTOR;
+  private static final Method INITIALIZE;
+  private static final Method NEXT_KEY_VALUE;
+  private static final Method GET_CURRENT_VALUE;
+  private static final Method GET_CURRENT_ROW_INDEX;
+  private static final Method CLOSE;
+
+  static {
+    try {
+      Class<?> cls = Class.forName(INTERNAL_READER_CLASS);
+      CONSTRUCTOR = cls.getConstructor(ReadSupport.class);
+      INITIALIZE = cls.getMethod("initialize", ParquetFileReader.class, ParquetReadOptions.class);
+      NEXT_KEY_VALUE = cls.getMethod("nextKeyValue");
+      GET_CURRENT_VALUE = cls.getMethod("getCurrentValue");
+      GET_CURRENT_ROW_INDEX = cls.getMethod("getCurrentRowIndex");
+      CLOSE = cls.getMethod("close");
+      // The class is package-private, so its public members are only reachable after this.
+      CONSTRUCTOR.setAccessible(true);
+      INITIALIZE.setAccessible(true);
+      NEXT_KEY_VALUE.setAccessible(true);
+      GET_CURRENT_VALUE.setAccessible(true);
+      GET_CURRENT_ROW_INDEX.setAccessible(true);
+      CLOSE.setAccessible(true);
+    } catch (ReflectiveOperationException e) {
+      // The JVM wraps this in an ExceptionInInitializerError, which is what callers observe.
+      // Thrown as a RuntimeException rather than constructing the Error directly, so as not to
+      // trip checkstyle's ban on throwing Errors from application code.
+      throw new IllegalStateException(
+          "Failed to set up "
+              + INTERNAL_READER_CLASS
+              + ". This is likely due to an incompatible version of parquet-hadoop on the"
+              + " classpath.",
+          e);
+    }
+  }
+
+  // Thrown for an IllegalAccessException at a call site: it is effectively impossible after the
+  // static block's setAccessible(true) calls succeeded, so it signals a broken JVM/parquet
+  // environment rather than a recoverable I/O error.
+  private static final String ACCESS_BUG_MESSAGE =
+      "Unexpected reflective access failure on " + INTERNAL_READER_CLASS + " after setAccessible";
+
+  private final Object internalReader;
+
+  ParquetRecordReaderWrapper(ReadSupport<T> readSupport) throws IOException {
+    requireNonNull(readSupport, "readSupport is null");
+    try {
+      this.internalReader = CONSTRUCTOR.newInstance(readSupport);
+    } catch (InvocationTargetException e) {
+      throw rethrow(e);
+    } catch (InstantiationException | IllegalAccessException e) {
+      throw new IllegalStateException(ACCESS_BUG_MESSAGE, e);
+    }
+  }
+
+  /**
+   * Delegates to {@code InternalParquetRecordReader.initialize(ParquetFileReader,
+   * ParquetReadOptions)}.
+   */
+  void initialize(ParquetFileReader fileReader, ParquetReadOptions options) {
+    try {
+      INITIALIZE.invoke(internalReader, fileReader, options);
+    } catch (InvocationTargetException e) {
+      throw rethrowUnchecked(e);
+    } catch (IllegalAccessException e) {
+      throw new IllegalStateException(ACCESS_BUG_MESSAGE, e);
+    }
+  }
+
+  /** Delegates to {@code InternalParquetRecordReader.nextKeyValue()}. */
+  boolean nextKeyValue() throws IOException {
+    try {
+      return (Boolean) NEXT_KEY_VALUE.invoke(internalReader);
+    } catch (InvocationTargetException e) {
+      throw rethrow(e);
+    } catch (IllegalAccessException e) {
+      throw new IllegalStateException(ACCESS_BUG_MESSAGE, e);
+    }
+  }
+
+  /** Delegates to {@code InternalParquetRecordReader.getCurrentValue()}. */
+  @SuppressWarnings("unchecked")
+  T getCurrentValue() throws IOException {
+    try {
+      return (T) GET_CURRENT_VALUE.invoke(internalReader);
+    } catch (InvocationTargetException e) {
+      throw rethrow(e);
+    } catch (IllegalAccessException e) {
+      throw new IllegalStateException(ACCESS_BUG_MESSAGE, e);
+    }
+  }
+
+  /** Delegates to {@code InternalParquetRecordReader.getCurrentRowIndex()}. */
+  long getCurrentRowIndex() {
+    // Unlike the other methods, the underlying getCurrentRowIndex() declares no checked exception,
+    // so this wrapper does not declare `throws IOException` either.
+    try {
+      return (Long) GET_CURRENT_ROW_INDEX.invoke(internalReader);
+    } catch (InvocationTargetException e) {
+      throw rethrowUnchecked(e);
+    } catch (IllegalAccessException e) {
+      throw new IllegalStateException(ACCESS_BUG_MESSAGE, e);
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    try {
+      CLOSE.invoke(internalReader);
+    } catch (InvocationTargetException e) {
+      throw rethrow(e);
+    } catch (IllegalAccessException e) {
+      throw new IllegalStateException(ACCESS_BUG_MESSAGE, e);
+    }
+  }
+
+  /**
+   * Rethrows the real cause of a reflective call, preserving its type. {@link Error}s and {@link
+   * RuntimeException}s (e.g. {@code ParquetDecodingException}) are rethrown as-is so callers see
+   * the same exceptions they would from a direct call. An {@link IOException} cause is returned for
+   * the caller to throw. Any other (checked) cause is wrapped in an {@link IOException}, which
+   * mirrors {@link org.apache.parquet.hadoop.ParquetReader} that Kernel used previously.
+   */
+  private static IOException rethrow(InvocationTargetException e) {
+    Throwable cause = e.getCause();
+    if (cause instanceof Error) {
+      throw (Error) cause;
+    }
+    if (cause instanceof RuntimeException) {
+      throw (RuntimeException) cause;
+    }
+    if (cause instanceof IOException) {
+      return (IOException) cause;
+    }
+    return new IOException(cause);
+  }
+
+  /**
+   * Variant of {@link #rethrow} for methods that do not declare {@code throws IOException}. The
+   * underlying method declares no checked exception, so a checked cause would itself be a bug; wrap
+   * it in an unchecked exception.
+   */
+  private static RuntimeException rethrowUnchecked(InvocationTargetException e) {
+    Throwable cause = e.getCause();
+    if (cause instanceof Error) {
+      throw (Error) cause;
+    }
+    if (cause instanceof RuntimeException) {
+      throw (RuntimeException) cause;
+    }
+    return new RuntimeException(cause);
+  }
+}

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetStatsReader.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetStatsReader.java
@@ -33,8 +33,6 @@ import java.util.*;
 import org.apache.hadoop.shaded.com.google.common.collect.ImmutableMultimap;
 import org.apache.hadoop.shaded.com.google.common.collect.Multimap;
 import org.apache.parquet.column.statistics.*;
-import org.apache.parquet.format.converter.ParquetMetadataConverter;
-import org.apache.parquet.hadoop.ParquetFileReader;
 import org.apache.parquet.hadoop.metadata.BlockMetaData;
 import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
 import org.apache.parquet.hadoop.metadata.ParquetMetadata;
@@ -54,11 +52,14 @@ public class ParquetStatsReader {
   public static DataFileStatistics readDataFileStatistics(
       InputFile kernelInputFile, StructType dataSchema, List<Column> statsColumns)
       throws IOException {
-    // Read the Parquet footer to compute the statistics
+    // Read the Parquet footer to compute the statistics. Pass the configuration explicitly so
+    // `parquet-mr` doesn't construct a fresh Hadoop Configuration here; see
+    // ParquetIOUtils#parquetConfiguration.
     org.apache.parquet.io.InputFile parquetFile =
         ParquetIOUtils.createParquetInputFile(kernelInputFile);
     ParquetMetadata footer =
-        ParquetFileReader.readFooter(parquetFile, ParquetMetadataConverter.NO_FILTER);
+        ParquetIOUtils.readFooter(
+            parquetFile, ParquetIOUtils.parquetConfiguration(kernelInputFile));
     ImmutableMultimap.Builder<Column, ColumnChunkMetaData> metadataForColumn =
         ImmutableMultimap.builder();
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/engine/DefaultParquetHandlerSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/engine/DefaultParquetHandlerSuite.scala
@@ -15,6 +15,7 @@
  */
 package io.delta.kernel.defaults.engine
 
+import java.io.IOException
 import java.nio.file.FileAlreadyExistsException
 
 import scala.collection.JavaConverters._
@@ -63,11 +64,12 @@ class DefaultParquetHandlerSuite extends AnyFunSuite with ParquetSuiteBase {
       writeAndVerify()
 
       // Try to write as same file and expect an error
-      intercept[FileAlreadyExistsException] {
+      val e = intercept[IOException] {
         parquetHandler.writeParquetFileAtomically(
           filePath,
           toCloseableIterator(dataToWrite.asJava.iterator()))
       }
+      assert(e.getCause.isInstanceOf[FileAlreadyExistsException])
     }
   }
 }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/parquet/ParquetFileReaderSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/parquet/ParquetFileReaderSuite.scala
@@ -16,13 +16,21 @@
 package io.delta.kernel.defaults.internal.parquet
 
 import java.math.BigDecimal
-import java.util.TimeZone
+import java.nio.file.{Files, Paths}
+import java.util.{Optional, TimeZone}
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
 
 import io.delta.golden.GoldenTableUtils.{goldenTableFile, goldenTablePath}
+import io.delta.kernel.defaults.engine.fileio.{FileIO, InputFile, OutputFile, SeekableInputStream}
+import io.delta.kernel.defaults.engine.hadoopio.HadoopFileIO
 import io.delta.kernel.defaults.utils.{ExpressionTestUtils, TestRow}
+import io.delta.kernel.expressions.Literal.ofLong
+import io.delta.kernel.expressions.Predicate
 import io.delta.kernel.test.VectorTestUtils
 import io.delta.kernel.types._
-import io.delta.kernel.utils.MetadataColumnTestUtils
+import io.delta.kernel.utils.{CloseableIterator, MetadataColumnTestUtils}
+import io.delta.kernel.utils.{FileStatus => KernelFileStatus}
 
 import org.apache.spark.sql.internal.SQLConf
 import org.scalatest.funsuite.AnyFunSuite
@@ -330,6 +338,41 @@ class ParquetFileReaderSuite extends AnyFunSuite
   }
 
   /////////////////////////////////////////////////////////////////////////////////////////////////
+  // Tests for footer reuse: the footer read up-front to build the filter is reused by the reader //
+  // instead of being read (and parsed) a second time.                                            //
+  /////////////////////////////////////////////////////////////////////////////////////////////////
+
+  test("footer is read only once when reading a Parquet file") {
+    // Multiple row groups + a predicate that prunes some of them exercises the full record-read
+    // loop (row-group iteration, stats filtering and row-index tracking) while still needing only
+    // a single footer read.
+    val filePath = getTestResourceFilePath("parquet/row_index_multiple_row_groups.parquet")
+    val readSchema = new StructType()
+      .add("id", LongType.LONG)
+      .add(ROW_INDEX)
+    val fileStatus = KernelFileStatus.of(
+      filePath,
+      Files.size(Paths.get(filePath)),
+      /* modificationTime = */ 0L)
+
+    // Read once with no predicate and once with a predicate that prunes row groups; the footer
+    // should be read exactly once in both cases.
+    Seq[Optional[Predicate]](
+      Optional.empty(),
+      Optional.of(gt(col("id"), ofLong(5000L)))).foreach { predicate =>
+      val fileIO = new FooterReadCountingFileIO(new HadoopFileIO(configuration))
+      val reader = new ParquetFileReader(fileIO)
+      // Drain the iterator (the implicit `forEach` closes it) so all row groups are read.
+      reader.read(fileStatus, readSchema, predicate).forEach(_ => ())
+
+      assert(
+        fileIO.footerReadCount(filePath) === 1,
+        s"Expected the footer to be read exactly once for predicate=$predicate, " +
+          s"but it was read ${fileIO.footerReadCount(filePath)} times")
+    }
+  }
+
+  /////////////////////////////////////////////////////////////////////////////////////////////////
   // Test compatibility with Parquet legacy format files                                         //
   /////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -385,4 +428,69 @@ class ParquetFileReaderSuite extends AnyFunSuite
       readParquetFilesUsingKernel(parquetFilePath, readSchema), /* actual */
       readParquetFilesUsingSpark(parquetFilePath, readSchema) /* expected */ )
   }
+}
+
+/**
+ * A [[FileIO]] that delegates to an underlying [[FileIO]] but counts how many times the Parquet
+ * footer is read for each file. A footer read is detected by a seek to the footer-length index
+ * (`fileLength - 8`), which is where `parquet-mr` starts reading the footer trailer.
+ */
+class FooterReadCountingFileIO(delegate: FileIO) extends FileIO {
+  private val footerReadCounts = new ConcurrentHashMap[String, AtomicInteger]()
+
+  def footerReadCount(path: String): Int =
+    Option(footerReadCounts.get(path)).map(_.get()).getOrElse(0)
+
+  private def recordFooterRead(path: String): Unit = {
+    footerReadCounts.putIfAbsent(path, new AtomicInteger(0))
+    footerReadCounts.get(path).incrementAndGet()
+  }
+
+  override def newInputFile(path: String, fileSize: Long): InputFile = {
+    val delegateInputFile = delegate.newInputFile(path, fileSize)
+    new InputFile {
+      override def length(): Long = delegateInputFile.length()
+
+      override def path(): String = delegateInputFile.path()
+
+      override def newStream(): SeekableInputStream = {
+        val delegateStream = delegateInputFile.newStream()
+        // `fileLength - 8` == fileLength - MAGIC(4) - FOOTER_LENGTH_SIZE(4), the position
+        // parquet-mr seeks to when it reads the footer.
+        val footerIndex = delegateInputFile.length() - 8
+        new SeekableInputStream {
+          override def getPos(): Long = delegateStream.getPos()
+
+          override def seek(newPos: Long): Unit = {
+            if (newPos == footerIndex) {
+              recordFooterRead(path)
+            }
+            delegateStream.seek(newPos)
+          }
+
+          override def readFully(b: Array[Byte], off: Int, len: Int): Unit =
+            delegateStream.readFully(b, off, len)
+
+          override def read(): Int = delegateStream.read()
+
+          override def read(b: Array[Byte], off: Int, len: Int): Int =
+            delegateStream.read(b, off, len)
+
+          override def close(): Unit = delegateStream.close()
+        }
+      }
+    }
+  }
+
+  // All other operations simply delegate.
+  override def listFrom(filePath: String): CloseableIterator[KernelFileStatus] =
+    delegate.listFrom(filePath)
+  override def getFileStatus(path: String): KernelFileStatus = delegate.getFileStatus(path)
+  override def resolvePath(path: String): String = delegate.resolvePath(path)
+  override def mkdirs(path: String): Boolean = delegate.mkdirs(path)
+  override def newOutputFile(path: String): OutputFile = delegate.newOutputFile(path)
+  override def delete(path: String): Boolean = delegate.delete(path)
+  override def getConf(confKey: String): Optional[String] = delegate.getConf(confKey)
+  override def copyFileAtomically(srcPath: String, destPath: String, overwrite: Boolean): Unit =
+    delegate.copyFileAtomically(srcPath, destPath, overwrite)
 }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/parquet/ParquetFileReaderSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/parquet/ParquetFileReaderSuite.scala
@@ -19,11 +19,13 @@ import java.math.BigDecimal
 import java.util.TimeZone
 
 import io.delta.golden.GoldenTableUtils.{goldenTableFile, goldenTablePath}
+import io.delta.kernel.defaults.engine.hadoopio.HadoopFileIO
 import io.delta.kernel.defaults.utils.{ExpressionTestUtils, TestRow}
 import io.delta.kernel.test.VectorTestUtils
 import io.delta.kernel.types._
 import io.delta.kernel.utils.MetadataColumnTestUtils
 
+import org.apache.hadoop.conf.Configuration
 import org.apache.spark.sql.internal.SQLConf
 import org.scalatest.funsuite.AnyFunSuite
 import org.slf4j.LoggerFactory
@@ -32,6 +34,18 @@ class ParquetFileReaderSuite extends AnyFunSuite
     with ParquetSuiteBase with VectorTestUtils with ExpressionTestUtils
     with MetadataColumnTestUtils {
   private val logger = LoggerFactory.getLogger(classOf[ParquetFileReaderSuite])
+
+  test("parquetConfiguration reuses the HadoopInputFile's configuration") {
+    // Disable the FileSystem cache for this scheme so newInputFile initializes a fresh
+    // FileSystem carrying this exact Configuration, rather than a cached one whose conf
+    // (the cache keys on scheme+authority+UGI, not conf) would lack the sentinel key.
+    val conf = new Configuration(false)
+    conf.setBoolean("fs.file.impl.disable.cache", true)
+    conf.set("my.sentinel.key", "sentinel-value")
+    val input = new HadoopFileIO(conf).newInputFile("file:/tmp/does-not-need-to-exist", 0)
+    val parquetConf = ParquetIOUtils.parquetConfiguration(input)
+    assertResult("sentinel-value")(parquetConf.get("my.sentinel.key"))
+  }
 
   test("decimals encoded using dictionary encoding ") {
     // Below golden tables contains three decimal columns

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/parquet/ParquetFileReaderSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/parquet/ParquetFileReaderSuite.scala
@@ -16,14 +16,21 @@
 package io.delta.kernel.defaults.internal.parquet
 
 import java.math.BigDecimal
-import java.util.TimeZone
+import java.nio.file.{Files, Paths}
+import java.util.{Optional, TimeZone}
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
 
 import io.delta.golden.GoldenTableUtils.{goldenTableFile, goldenTablePath}
+import io.delta.kernel.defaults.engine.fileio.{FileIO, InputFile, OutputFile, SeekableInputStream}
 import io.delta.kernel.defaults.engine.hadoopio.HadoopFileIO
 import io.delta.kernel.defaults.utils.{ExpressionTestUtils, TestRow}
+import io.delta.kernel.expressions.Literal.ofLong
+import io.delta.kernel.expressions.Predicate
 import io.delta.kernel.test.VectorTestUtils
 import io.delta.kernel.types._
-import io.delta.kernel.utils.MetadataColumnTestUtils
+import io.delta.kernel.utils.{CloseableIterator, MetadataColumnTestUtils}
+import io.delta.kernel.utils.{FileStatus => KernelFileStatus}
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.spark.sql.internal.SQLConf
@@ -344,6 +351,41 @@ class ParquetFileReaderSuite extends AnyFunSuite
   }
 
   /////////////////////////////////////////////////////////////////////////////////////////////////
+  // Tests for footer reuse: the footer read up-front to build the filter is reused by the reader //
+  // instead of being read (and parsed) a second time.                                            //
+  /////////////////////////////////////////////////////////////////////////////////////////////////
+
+  test("footer is read only once when reading a Parquet file") {
+    // Multiple row groups + a predicate that prunes some of them exercises the full record-read
+    // loop (row-group iteration, stats filtering and row-index tracking) while still needing only
+    // a single footer read.
+    val filePath = getTestResourceFilePath("parquet/row_index_multiple_row_groups.parquet")
+    val readSchema = new StructType()
+      .add("id", LongType.LONG)
+      .add(ROW_INDEX)
+    val fileStatus = KernelFileStatus.of(
+      filePath,
+      Files.size(Paths.get(filePath)),
+      /* modificationTime = */ 0L)
+
+    // Read once with no predicate and once with a predicate that prunes row groups; the footer
+    // should be read exactly once in both cases.
+    Seq[Optional[Predicate]](
+      Optional.empty(),
+      Optional.of(gt(col("id"), ofLong(5000L)))).foreach { predicate =>
+      val fileIO = new FooterReadCountingFileIO(new HadoopFileIO(configuration))
+      val reader = new ParquetFileReader(fileIO)
+      // Drain the iterator (the implicit `forEach` closes it) so all row groups are read.
+      reader.read(fileStatus, readSchema, predicate).forEach(_ => ())
+
+      assert(
+        fileIO.footerReadCount(filePath) === 1,
+        s"Expected the footer to be read exactly once for predicate=$predicate, " +
+          s"but it was read ${fileIO.footerReadCount(filePath)} times")
+    }
+  }
+
+  /////////////////////////////////////////////////////////////////////////////////////////////////
   // Test compatibility with Parquet legacy format files                                         //
   /////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -399,4 +441,69 @@ class ParquetFileReaderSuite extends AnyFunSuite
       readParquetFilesUsingKernel(parquetFilePath, readSchema), /* actual */
       readParquetFilesUsingSpark(parquetFilePath, readSchema) /* expected */ )
   }
+}
+
+/**
+ * A [[FileIO]] that delegates to an underlying [[FileIO]] but counts how many times the Parquet
+ * footer is read for each file. A footer read is detected by a seek to the footer-length index
+ * (`fileLength - 8`), which is where `parquet-mr` starts reading the footer trailer.
+ */
+class FooterReadCountingFileIO(delegate: FileIO) extends FileIO {
+  private val footerReadCounts = new ConcurrentHashMap[String, AtomicInteger]()
+
+  def footerReadCount(path: String): Int =
+    Option(footerReadCounts.get(path)).map(_.get()).getOrElse(0)
+
+  private def recordFooterRead(path: String): Unit = {
+    footerReadCounts.putIfAbsent(path, new AtomicInteger(0))
+    footerReadCounts.get(path).incrementAndGet()
+  }
+
+  override def newInputFile(path: String, fileSize: Long): InputFile = {
+    val delegateInputFile = delegate.newInputFile(path, fileSize)
+    new InputFile {
+      override def length(): Long = delegateInputFile.length()
+
+      override def path(): String = delegateInputFile.path()
+
+      override def newStream(): SeekableInputStream = {
+        val delegateStream = delegateInputFile.newStream()
+        // `fileLength - 8` == fileLength - MAGIC(4) - FOOTER_LENGTH_SIZE(4), the position
+        // parquet-mr seeks to when it reads the footer.
+        val footerIndex = delegateInputFile.length() - 8
+        new SeekableInputStream {
+          override def getPos(): Long = delegateStream.getPos()
+
+          override def seek(newPos: Long): Unit = {
+            if (newPos == footerIndex) {
+              recordFooterRead(path)
+            }
+            delegateStream.seek(newPos)
+          }
+
+          override def readFully(b: Array[Byte], off: Int, len: Int): Unit =
+            delegateStream.readFully(b, off, len)
+
+          override def read(): Int = delegateStream.read()
+
+          override def read(b: Array[Byte], off: Int, len: Int): Int =
+            delegateStream.read(b, off, len)
+
+          override def close(): Unit = delegateStream.close()
+        }
+      }
+    }
+  }
+
+  // All other operations simply delegate.
+  override def listFrom(filePath: String): CloseableIterator[KernelFileStatus] =
+    delegate.listFrom(filePath)
+  override def getFileStatus(path: String): KernelFileStatus = delegate.getFileStatus(path)
+  override def resolvePath(path: String): String = delegate.resolvePath(path)
+  override def mkdirs(path: String): Boolean = delegate.mkdirs(path)
+  override def newOutputFile(path: String): OutputFile = delegate.newOutputFile(path)
+  override def delete(path: String): Boolean = delegate.delete(path)
+  override def getConf(confKey: String): Optional[String] = delegate.getConf(confKey)
+  override def copyFileAtomically(srcPath: String, destPath: String, overwrite: Boolean): Unit =
+    delegate.copyFileAtomically(srcPath, destPath, overwrite)
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

Cherry-pick below `master` branch parquet reading optimizations to `ds-11122025`:
1. Partial change in https://github.com/delta-io/delta/commit/5252e329bf644e766b936056e63ae3fcfa64ec6d (#6471): Update `parquet-mr` version from `1.12.3` to `1.16.0`, this is required for backporting 2 and 3
2. https://github.com/delta-io/delta/pull/7378
3. https://github.com/delta-io/delta/pull/7388
4. Partial change in https://github.com/delta-io/delta/commit/db826cf883e24eb8bb643232a29860338a80e98f (#5616): adapt to parquet-mr 1.16.0 wrapping `FileAlreadyExistsException` in an `IOException`. `Checkpointer` now catches the wrapped exception and re-throws `CheckpointAlreadyExistsException`, and `DefaultParquetHandlerSuite` expects the wrapped exception. Required by the 1.16.0 upgrade in 1; only the two relevant hunks of that commit are applied (the rest is unrelated Spark 3.5 removal).

## How was this patch tested?

Unit tests

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
