### PR TITLE
Add kernel factory for constructing Default Engine

### DIFF
--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/v2/interop/KernelSnapshotUtilsSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/v2/interop/KernelSnapshotUtilsSuite.scala
@@ -20,15 +20,16 @@ import org.apache.spark.sql.delta.{DeltaConfigs, DeltaLog}
 import org.apache.spark.sql.delta.actions.AddFile
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import io.delta.spark.internal.v2.kernel.KernelEngineFactory
 import io.delta.kernel.TableManager
-import io.delta.kernel.defaults.engine.DefaultEngine
 import io.delta.kernel.engine.Engine
 import io.delta.kernel.internal.SnapshotImpl
 
 class KernelSnapshotUtilsSuite extends DeltaSQLCommandTest {
 
   // scalastyle:off deltahadoopconfiguration
-  private def engine: Engine = DefaultEngine.create(spark.sessionState.newHadoopConf())
+  private def engine: Engine =
+    KernelEngineFactory.createDefaultEngine(spark.sessionState.newHadoopConf())
   // scalastyle:on deltahadoopconfiguration
 
   private def kernelSnapshotFor(path: String, engine: Engine): SnapshotImpl =

--- a/spark/v2/src/main/java-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaV2ChangelogScanBuilder.java
+++ b/spark/v2/src/main/java-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaV2ChangelogScanBuilder.java
@@ -2,11 +2,11 @@ package io.delta.spark.internal.v2.read.changelog;
 
 import io.delta.kernel.CommitRange;
 import io.delta.kernel.Snapshot;
-import io.delta.kernel.defaults.engine.DefaultEngine;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.internal.rowtracking.RowTracking;
 import io.delta.spark.internal.v2.catalog.DeltaV2Table;
+import io.delta.spark.internal.v2.kernel.KernelEngineFactory;
 import io.delta.spark.internal.v2.snapshot.DeltaSnapshotManager;
 import io.delta.spark.internal.v2.utils.SchemaUtils;
 import java.util.Objects;
@@ -48,7 +48,7 @@ class DeltaV2ChangelogScanBuilder implements ScanBuilder {
     Configuration hadoopConf =
         Objects.requireNonNull(
             SparkSession.active().sparkContext().hadoopConfiguration(), "hadoopConf is null");
-    Engine engine = DefaultEngine.create(hadoopConf);
+    Engine engine = KernelEngineFactory.createDefaultEngine(hadoopConf);
     DeltaSnapshotManager snapshotManager = deltaV2Table.getSnapshotManager();
     CommitRange commitRange =
         snapshotManager.getTableChanges(engine, startVersion, Optional.of(endVersion));

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
@@ -21,7 +21,6 @@ import static io.delta.spark.internal.v2.utils.StatsUtils.toV2Statistics;
 import static java.util.Objects.requireNonNull;
 
 import io.delta.kernel.Snapshot;
-import io.delta.kernel.defaults.engine.DefaultEngine;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.internal.DeltaHistoryManager;
 import io.delta.kernel.internal.SnapshotImpl;
@@ -31,6 +30,7 @@ import io.delta.spark.internal.v2.adapters.KernelProtocolAdapter;
 import io.delta.spark.internal.v2.exception.NoRecreatableHistoryException;
 import io.delta.spark.internal.v2.exception.TableNotFoundException;
 import io.delta.spark.internal.v2.exception.TimestampOutOfRangeException;
+import io.delta.spark.internal.v2.kernel.KernelEngineFactory;
 import io.delta.spark.internal.v2.read.DeltaV2ScanUtils;
 import io.delta.spark.internal.v2.read.MetadataEvolutionHandler;
 import io.delta.spark.internal.v2.read.cdc.CDCSchemaContext;
@@ -246,7 +246,7 @@ public class DeltaV2Table extends DeltaV2TableShims
 
     this.hadoopConf =
         SparkSession.active().sessionState().newHadoopConfWithOptions(toScalaMap(options));
-    this.kernelEngine = DefaultEngine.create(this.hadoopConf);
+    this.kernelEngine = KernelEngineFactory.createDefaultEngine(this.hadoopConf);
     this.snapshotManager = SnapshotManagerFactory.create(tablePath, kernelEngine, catalogTable);
     try {
       this.initialSnapshot =

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/ddl/CreateTableBuilder.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/ddl/CreateTableBuilder.java
@@ -19,11 +19,11 @@ import static java.util.Objects.requireNonNull;
 
 import io.delta.kernel.TableManager;
 import io.delta.kernel.Transaction;
-import io.delta.kernel.defaults.engine.DefaultEngine;
 import io.delta.kernel.transaction.CreateTableTransactionBuilder;
 import io.delta.kernel.transaction.DataLayoutSpec;
 import io.delta.kernel.unitycatalog.UCCatalogManagedClient;
 import io.delta.kernel.unitycatalog.UCTableIdentifier;
+import io.delta.spark.internal.v2.kernel.KernelEngineFactory;
 import io.delta.spark.internal.v2.snapshot.unitycatalog.UCTableInfo;
 import io.delta.spark.internal.v2.utils.SchemaUtils;
 import io.delta.storage.commit.uccommitcoordinator.UCClient;
@@ -89,7 +89,7 @@ public final class CreateTableBuilder {
         DDLUtils.filterProperties(properties),
         comment,
         dataLayoutSpec,
-        DefaultEngine.create(hadoopConf),
+        KernelEngineFactory.createDefaultEngine(hadoopConf),
         ucTableInfo,
         txnBuilder);
   }

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/kernel/KernelEngineFactory.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/kernel/KernelEngineFactory.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.spark.internal.v2.kernel;
+
+import io.delta.kernel.defaults.engine.DefaultEngine;
+import io.delta.kernel.engine.Engine;
+import org.apache.hadoop.conf.Configuration;
+
+/** Factory for creating the default Kernel {@link Engine} used by the DSv2 connector. */
+public final class KernelEngineFactory {
+
+  private KernelEngineFactory() {}
+
+  /** Builds the backend-appropriate default engine. */
+  public static Engine createDefaultEngine(Configuration hadoopConf) {
+    return DefaultEngine.create(hadoopConf);
+  }
+}

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2MicroBatchStream.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2MicroBatchStream.java
@@ -26,7 +26,6 @@ import io.delta.kernel.Scan;
 import io.delta.kernel.Snapshot;
 import io.delta.kernel.data.ColumnarBatch;
 import io.delta.kernel.data.FilteredColumnarBatch;
-import io.delta.kernel.defaults.engine.DefaultEngine;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.exceptions.UnsupportedProtocolVersionException;
 import io.delta.kernel.exceptions.UnsupportedTableFeatureException;
@@ -45,6 +44,7 @@ import io.delta.kernel.internal.util.Utils;
 import io.delta.kernel.internal.util.VectorUtils;
 import io.delta.kernel.utils.CloseableIterator;
 import io.delta.spark.internal.v2.adapters.KernelMetadataAdapter;
+import io.delta.spark.internal.v2.kernel.KernelEngineFactory;
 import io.delta.spark.internal.v2.snapshot.DeltaSnapshotManager;
 import io.delta.spark.internal.v2.utils.PartitionUtils;
 import io.delta.spark.internal.v2.utils.ScalaUtils;
@@ -250,7 +250,7 @@ class DeltaV2MicroBatchStream
     this.snapshotManager = Objects.requireNonNull(snapshotManager, "snapshotManager is null");
     this.hadoopConf = Objects.requireNonNull(hadoopConf, "hadoopConf is null");
     this.spark = Objects.requireNonNull(spark, "spark is null");
-    this.engine = DefaultEngine.create(hadoopConf);
+    this.engine = KernelEngineFactory.createDefaultEngine(hadoopConf);
     this.options = Objects.requireNonNull(options, "options is null");
     this.ignoreFileDeletion = this.options.ignoreFileDeletion();
     // Deprecated. Please use `skipChangeCommits` from now on.

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2Scan.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2Scan.java
@@ -18,9 +18,9 @@ package io.delta.spark.internal.v2.read;
 import static io.delta.spark.internal.v2.utils.ExpressionUtils.dsv2PredicateToCatalystExpression;
 
 import io.delta.kernel.Snapshot;
-import io.delta.kernel.defaults.engine.DefaultEngine;
 import io.delta.kernel.expressions.Predicate;
 import io.delta.kernel.internal.SnapshotImpl;
+import io.delta.spark.internal.v2.kernel.KernelEngineFactory;
 import io.delta.spark.internal.v2.read.cdc.CDCSchemaContext;
 import io.delta.spark.internal.v2.read.deletionvector.DeletionVectorSchemaContext;
 import io.delta.spark.internal.v2.snapshot.DeltaSnapshotManager;
@@ -264,7 +264,7 @@ class DeltaV2Scan implements Scan, SupportsReportStatistics, SupportsRuntimeV2Fi
             (io.delta.kernel.internal.SnapshotImpl) latestSnapshot,
             options,
             snapshotManager,
-            DefaultEngine.create(hadoopConf),
+            KernelEngineFactory.createDefaultEngine(hadoopConf),
             Option.apply(checkpointLocation),
             /* mergeConsecutiveSchemaChanges= */ false);
 

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/ScanFileRDD.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/ScanFileRDD.java
@@ -83,7 +83,7 @@ public class ScanFileRDD extends RDD<Row> {
   @Override
   public scala.collection.Iterator<Row> compute(Partition split, TaskContext context) {
     Engine engine = DefaultEngine.create(serializableSnapshot.getHadoopConf());
-    Scan scan = serializableSnapshot.toScan();
+    Scan scan = serializableSnapshot.toScan(engine);
 
     CloseableIterator<FilteredColumnarBatch> batchIter;
     try {

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/snapshot/PathBasedSnapshotManager.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/snapshot/PathBasedSnapshotManager.java
@@ -21,11 +21,11 @@ import io.delta.kernel.CommitRange;
 import io.delta.kernel.CommitRangeBuilder;
 import io.delta.kernel.Snapshot;
 import io.delta.kernel.TableManager;
-import io.delta.kernel.defaults.engine.DefaultEngine;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.internal.DeltaHistoryManager;
 import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.spark.internal.v2.exception.VersionNotFoundException;
+import io.delta.spark.internal.v2.kernel.KernelEngineFactory;
 import java.util.ArrayList;
 import java.util.Optional;
 import org.apache.hadoop.conf.Configuration;
@@ -39,7 +39,9 @@ public class PathBasedSnapshotManager implements DeltaSnapshotManager {
   private final Engine kernelEngine;
 
   public PathBasedSnapshotManager(String tablePath, Configuration hadoopConf) {
-    this(tablePath, DefaultEngine.create(requireNonNull(hadoopConf, "hadoopConf is null")));
+    this(
+        tablePath,
+        KernelEngineFactory.createDefaultEngine(requireNonNull(hadoopConf, "hadoopConf is null")));
   }
 
   public PathBasedSnapshotManager(String tablePath, Engine kernelEngine) {

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/SerializableReadOnlySnapshot.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/SerializableReadOnlySnapshot.java
@@ -119,7 +119,7 @@ public class SerializableReadOnlySnapshot implements Serializable {
    * returned {@code Scan} only exposes {@code getScanFiles()} — no write-path or commit APIs.
    */
   public Scan toScan(Configuration hadoopConfOverride) {
-    return buildScan(hadoopConfOverride);
+    return buildScan(DefaultEngine.create(hadoopConfOverride));
   }
 
   /**
@@ -127,22 +127,26 @@ public class SerializableReadOnlySnapshot implements Serializable {
    * no conf override is needed.
    */
   public Scan toScan() {
-    return buildScan(hadoopConf.value());
+    return buildScan(DefaultEngine.create(hadoopConf.value()));
+  }
+
+  /** Reconstructs a read-only scan using the caller-owned imperative engine. */
+  public Scan toScan(Engine engine) {
+    return buildScan(engine);
   }
 
   public long getVersion() {
     return version;
   }
 
-  /** Returns the serialized Hadoop configuration for creating an Engine on the executor. */
+  /** Returns the serialized Hadoop configuration for creating an Engine on the Spark executor. */
   public Configuration getHadoopConf() {
     return hadoopConf.value();
   }
 
   // ---- internal reconstruction ----
 
-  private Scan buildScan(Configuration conf) {
-    Engine engine = DefaultEngine.create(conf);
+  private Scan buildScan(Engine engine) {
     io.delta.kernel.internal.fs.Path kernelDataPath =
         new io.delta.kernel.internal.fs.Path(dataPath);
     io.delta.kernel.internal.fs.Path kernelLogPath = new io.delta.kernel.internal.fs.Path(logPath);

--- a/spark/v2/src/main/scala/org/apache/spark/sql/delta/v2/interop/DeltaV2Snapshot.scala
+++ b/spark/v2/src/main/scala/org/apache/spark/sql/delta/v2/interop/DeltaV2Snapshot.scala
@@ -33,8 +33,8 @@ import org.apache.spark.sql.delta.actions.{
 }
 import org.apache.spark.sql.delta.coordinatedcommits.TableCommitCoordinatorClient
 import org.apache.spark.sql.delta.stats.{DeltaStatsColumnSpec, StatisticsCollection}
+import io.delta.spark.internal.v2.kernel.KernelEngineFactory
 import org.apache.hadoop.fs.Path
-import io.delta.kernel.defaults.engine.DefaultEngine
 import io.delta.kernel.engine.Engine
 import io.delta.kernel.internal.{SnapshotImpl => KernelSnapshot}
 
@@ -83,7 +83,7 @@ class DeltaV2Snapshot(
   // No DeltaLog to source a Hadoop conf from, so use the session Hadoop conf for the engine.
   def this(kernelSnapshot: KernelSnapshot, sparkSession: SparkSession) =
     this(kernelSnapshot, sparkSession,
-      DefaultEngine.create(sparkSession.sessionState.newHadoopConf()))
+      KernelEngineFactory.createDefaultEngine(sparkSession.sessionState.newHadoopConf()))
   // scalastyle:on deltahadoopconfiguration
 
   // --- logSegment/deltaLog = null guardrail: construction-path overrides ----------------------

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/SerializableReadOnlySnapshotTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/SerializableReadOnlySnapshotTest.java
@@ -68,10 +68,10 @@ public class SerializableReadOnlySnapshotTest extends DeltaV2TestBase {
 
     assertEquals(original.getVersion(), deserialized.getVersion());
 
-    Scan scan = deserialized.toScan();
+    Engine engine = DefaultEngine.create(deserialized.getHadoopConf());
+    Scan scan = deserialized.toScan(engine);
     assertNotNull(scan);
 
-    Engine engine = DefaultEngine.create(deserialized.getHadoopConf());
     List<FilteredColumnarBatch> batches = new ArrayList<>();
     try (CloseableIterator<FilteredColumnarBatch> iter = scan.getScanFiles(engine)) {
       while (iter.hasNext()) {
@@ -93,7 +93,7 @@ public class SerializableReadOnlySnapshotTest extends DeltaV2TestBase {
     SerializableReadOnlySnapshot serializable =
         SerializableReadOnlySnapshot.fromSnapshot(snapshot, hadoopConf);
 
-    Scan scan = serializable.toScan();
+    Scan scan = serializable.toScan(defaultEngine);
     assertNotNull(scan);
     assertNotNull(scan.getScanState(defaultEngine));
     assertNotNull(scan.getRemainingFilter());


### PR DESCRIPTION
## What changes were proposed in this pull request?

This change centralizes creation of Kernel engines used by the Delta V2 connector. `SerializableReadOnlySnapshot` can reconstruct a scan with a caller-owned engine, allowing scan construction and file iteration to share the same engine.

## How was this patch tested?

Verified with the Delta V2 scan test suite.