### PR TITLE
[Sharing] Add DataSource V2 batch-read connector for Delta Sharing

### DIFF
--- a/sharing/src/main/java/io/delta/sharing/spark/DeltaSharingScanBuilder.java
+++ b/sharing/src/main/java/io/delta/sharing/spark/DeltaSharingScanBuilder.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.sharing.spark;
+
+import io.delta.sharing.client.util.ConfUtils;
+import java.util.Optional;
+import java.util.OptionalLong;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.connector.read.Scan;
+import org.apache.spark.sql.connector.read.ScanBuilder;
+import org.apache.spark.sql.connector.read.Statistics;
+import org.apache.spark.sql.connector.read.SupportsPushDownFilters;
+import org.apache.spark.sql.connector.read.SupportsPushDownLimit;
+import org.apache.spark.sql.connector.read.SupportsPushDownRequiredColumns;
+import org.apache.spark.sql.sources.Filter;
+import org.apache.spark.sql.types.StructType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import io.delta.kernel.engine.Engine;
+
+/**
+ * ScanBuilder for the Delta Sharing DSv2 connector.
+ *
+ * <p>Supports column pruning ({@link SupportsPushDownRequiredColumns}), filter pushdown ({@link
+ * SupportsPushDownFilters}), and limit pushdown ({@link SupportsPushDownLimit}). Spark applies
+ * these in the order the {@link ScanBuilder} contract defines (filter, then limit, then column
+ * pruning), all before {@link #build()} -- so by the time {@link #build()} runs it has everything
+ * the {@code getFiles} RPC needs. {@code build()} then calls {@link
+ * DeltaSharingDSV2Utils#buildScan}, which issues that RPC with the pushdown hints, builds the
+ * synthetic Delta log, opens it as a Delta Kernel snapshot, and returns the Kernel V2 connector's
+ * Delta V2 scan over it.
+ *
+ * <p>Filter and limit pushdown are <b>advisory</b>: the sharing server uses the hints for file
+ * skipping but is not required to honor them, so Spark must still apply every filter and re-apply
+ * LIMIT after the scan. This builder therefore reports all filters as residual ({@link
+ * #pushFilters} returns them unchanged) and leaves {@link SupportsPushDownLimit#isPartiallyPushed}
+ * at its default {@code true}. Spark itself only invokes {@link #pushLimit} when no post-scan
+ * filter remains (its limit-pushdown rule matches a scan with no residual filter), so a limit hint
+ * is never sent alongside a filter hint -- matching the V1 path.
+ */
+public class DeltaSharingScanBuilder
+    implements ScanBuilder,
+        SupportsPushDownRequiredColumns,
+        SupportsPushDownFilters,
+        SupportsPushDownLimit {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DeltaSharingScanBuilder.class);
+
+  private final SparkSession spark;
+  private final DeltaSharingV2TableContext ctx;
+  // The Delta Kernel engine (a DefaultEngine over the session hadoopConf), built once by the table
+  // and reused across scans -- mirroring DeltaV2Table's kernelEngine, not rebuilt per build().
+  private final Engine engine;
+  // The table's catalog statistics (DeltaSharingV2Table.computeCatalogStats), handed to the scan
+  // so estimateStatistics can blend catalog column stats with post-prune file-level estimates.
+  // Present only when the shared table's CatalogTable carries stats -- i.e. the mounted share's UC
+  // properties include spark.sql.statistics.* (populated when the provider ran ANALYZE and the
+  // sharing server propagated it). Empty otherwise (no ANALYZE, freshly mounted share), in which
+  // case the scan falls back to file-level estimates alone.
+  private final Optional<Statistics> catalogStats;
+  // Defaults to the full table schema; narrowed by pruneColumns.
+  private StructType requiredSchema;
+  // Filters offered by Spark via pushFilters; converted to the server-side json predicate hint in
+  // build(). Empty until pushFilters is called.
+  private Filter[] pushedFilters = new Filter[0];
+  // Limit offered by Spark via pushLimit; forwarded as the getFiles limit hint in build(). Empty
+  // unless pushLimit accepted a limit (which requires the limit-pushdown conf on).
+  private OptionalLong pushedLimit = OptionalLong.empty();
+
+  public DeltaSharingScanBuilder(
+      SparkSession spark,
+      DeltaSharingV2TableContext ctx,
+      Engine engine,
+      Optional<Statistics> catalogStats) {
+    this.spark = spark;
+    this.ctx = ctx;
+    this.engine = engine;
+    this.catalogStats = catalogStats;
+    this.requiredSchema = ctx.dsMeta().metadata().schema();
+  }
+
+  @Override
+  public void pruneColumns(StructType requiredSchema) {
+    LOG.info("DSV2-Sharing: pruneColumns -> {}", requiredSchema.catalogString());
+    this.requiredSchema = requiredSchema;
+  }
+
+  @Override
+  public Filter[] pushFilters(Filter[] filters) {
+    this.pushedFilters = filters;
+    LOG.info("DSV2-Sharing: pushFilters received {} filter(s)", filters.length);
+    // The json predicate sent to the server is advisory (the server may not apply all of it), so
+    // Spark must still evaluate every filter after the scan. Report them all as residual.
+    return filters;
+  }
+
+  @Override
+  public Filter[] pushedFilters() {
+    return pushedFilters;
+  }
+
+  @Override
+  public boolean pushLimit(int limit) {
+    if (!ConfUtils.limitPushdownEnabled(spark.sessionState().conf())) {
+      LOG.info("DSV2-Sharing: pushLimit({}) declined, limit pushdown disabled", limit);
+      return false;
+    }
+    this.pushedLimit = OptionalLong.of(limit);
+    LOG.info("DSV2-Sharing: pushLimit({})", limit);
+    // Keep the default isPartiallyPushed() == true: the hint is best-effort, so Spark re-applies
+    // LIMIT after the scan.
+    return true;
+  }
+
+  /**
+   * Issues the getFiles RPC (with the pushed-down filter and limit hints) and returns the Delta
+   * Kernel V2 connector's Delta V2 scan over the resulting synthetic-log snapshot.
+   */
+  @Override
+  public Scan build() {
+    LOG.info("DSV2-Sharing: build() -> DeltaV2Scan, requiredSchema={}, pushedFilters={}, "
+            + "pushedLimit={}",
+        requiredSchema.catalogString(), pushedFilters.length, pushedLimit);
+    return DeltaSharingDSV2Utils.buildScan(
+        spark, ctx, engine, requiredSchema, pushedFilters, pushedLimit, catalogStats);
+  }
+}

--- a/sharing/src/main/java/io/delta/sharing/spark/DeltaSharingV2Table.java
+++ b/sharing/src/main/java/io/delta/sharing/spark/DeltaSharingV2Table.java
@@ -35,7 +35,6 @@ import org.apache.spark.sql.connector.catalog.SupportsMetadataColumns;
 import org.apache.spark.sql.connector.catalog.SupportsRead;
 import org.apache.spark.sql.connector.catalog.Table;
 import org.apache.spark.sql.connector.catalog.TableCapability;
-import org.apache.spark.sql.connector.catalog.V2TableWithV1Fallback;
 import org.apache.spark.sql.connector.expressions.Expressions;
 import org.apache.spark.sql.connector.expressions.Transform;
 import org.apache.spark.sql.connector.read.ScanBuilder;
@@ -65,10 +64,7 @@ import io.delta.kernel.engine.Engine;
  * the V1 Delta Sharing connector, unchanged.
  */
 public class DeltaSharingV2Table
-    implements Table,
-        SupportsRead,
-        SupportsMetadataColumns,
-        V2TableWithV1Fallback {
+    implements Table, SupportsRead, SupportsMetadataColumns {
 
   private static final Logger LOG = LoggerFactory.getLogger(DeltaSharingV2Table.class);
 
@@ -109,16 +105,6 @@ public class DeltaSharingV2Table
   }
 
   public CatalogTable getCatalogTable() {
-    return catalogTable;
-  }
-
-
-  /**
-   * V1 fallback for read capabilities this V2 table does not implement. Because {@link
-   * #capabilities()} advertises only {@code BATCH_READ}, a streaming read resolves through this.
-   */
-  @Override
-  public CatalogTable v1Table() {
     return catalogTable;
   }
 

--- a/sharing/src/main/java/io/delta/sharing/spark/DeltaSharingV2Table.java
+++ b/sharing/src/main/java/io/delta/sharing/spark/DeltaSharingV2Table.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.sharing.spark;
+
+import static io.delta.spark.internal.v2.utils.ScalaUtils.toJavaOptional;
+import static io.delta.spark.internal.v2.utils.StatsUtils.toV2Statistics;
+
+import org.apache.spark.sql.delta.RowTracking$;
+import io.delta.spark.internal.v2.shims.CatalogV2UtilShims;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.catalog.CatalogTable;
+import org.apache.spark.sql.connector.catalog.Column;
+import org.apache.spark.sql.connector.catalog.MetadataColumn;
+import org.apache.spark.sql.connector.catalog.SupportsMetadataColumns;
+import org.apache.spark.sql.connector.catalog.SupportsRead;
+import org.apache.spark.sql.connector.catalog.Table;
+import org.apache.spark.sql.connector.catalog.TableCapability;
+import org.apache.spark.sql.connector.catalog.V2TableWithV1Fallback;
+import org.apache.spark.sql.connector.expressions.Expressions;
+import org.apache.spark.sql.connector.expressions.Transform;
+import org.apache.spark.sql.connector.read.ScanBuilder;
+import org.apache.spark.sql.connector.read.Statistics;
+import org.apache.spark.sql.execution.datasources.FileFormat$;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import scala.jdk.javaapi.CollectionConverters;
+import io.delta.kernel.defaults.engine.DefaultEngine;
+import io.delta.kernel.engine.Engine;
+
+/**
+ * A DSv2 {@link Table} over a Delta Sharing shared table, returned from {@code
+ * AbstractDeltaCatalog.loadTable} when {@code spark.sql.delta.sharing.dsv2.enabled} is set and the
+ * shared table is a delta format batch snapshot (see {@link
+ * DeltaSharingDSV2Utils#resolveBatchSnapshotContext}).
+ *
+ * <p>The per-table context (sharing client + getMetadata response) is built by the routing gate
+ * ({@link DeltaSharingDSV2Utils#resolveBatchSnapshotContext}) and handed to the constructor, so
+ * the read reuses it without re-fetching metadata.
+ *
+ * <p>Scope: delta format batch snapshot reads only. Reads the DSv2 path does not serve fall back to
+ * the V1 Delta Sharing connector, unchanged.
+ */
+public class DeltaSharingV2Table
+    implements Table,
+        SupportsRead,
+        SupportsMetadataColumns,
+        V2TableWithV1Fallback {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DeltaSharingV2Table.class);
+
+  // Signals to Spark what features the Table supports.
+  // Signals that the table doesn't support streaming, which will trigger fallback to V1.
+  private static final Set<TableCapability> CAPABILITIES =
+      Collections.unmodifiableSet(EnumSet.of(TableCapability.BATCH_READ));
+
+  private static final String METADATA_COLUMN_NAME = FileFormat$.MODULE$.METADATA_NAME();
+
+  private final CatalogTable catalogTable;
+  private final SparkSession spark;
+
+  // The per-table context (sharing client + getMetadata response), resolved by the catalog routing
+  // (resolveBatchSnapshotContext) and reused so the read does not re-fetch getMetadata.
+  private final DeltaSharingV2TableContext context;
+
+  // The Delta Kernel engine (a DefaultEngine over the session hadoopConf), built once here and
+  // reused across scans -- mirroring DeltaV2Table's kernelEngine, rather than rebuilt per scan.
+  private final Engine engine;
+
+  /**
+   * @param context the context resolved by the catalog routing ({@link
+   *     DeltaSharingDSV2Utils#resolveBatchSnapshotContext}), reused so the read does not re-issue
+   *     getMetadata.
+   */
+  public DeltaSharingV2Table(
+      CatalogTable catalogTable, SparkSession spark, DeltaSharingV2TableContext context) {
+    this.catalogTable = catalogTable;
+    this.spark = spark;
+    this.context = context;
+    // Register the `delta-sharing-log://` FS scheme before snapshotting the session hadoopConf into
+    // the engine, so the conf it captures can resolve the synthetic log the scan builds.
+    DeltaSharingDataSource.setupFileSystem(spark.sqlContext());
+    this.engine = DefaultEngine.create(spark.sessionState().newHadoopConf());
+    LOG.info("DSV2-Sharing: DeltaSharingV2Table constructed for {}",
+        catalogTable.identifier().unquotedString());
+  }
+
+  public CatalogTable getCatalogTable() {
+    return catalogTable;
+  }
+
+
+  /**
+   * V1 fallback for read capabilities this V2 table does not implement. Because {@link
+   * #capabilities()} advertises only {@code BATCH_READ}, a streaming read resolves through this.
+   */
+  @Override
+  public CatalogTable v1Table() {
+    return catalogTable;
+  }
+
+  @Override
+  public String name() {
+    return catalogTable.identifier().unquotedString();
+  }
+
+  @Override
+  public StructType schema() {
+    return context.dsMeta().metadata().schema();
+  }
+
+  @Override
+  public Column[] columns() {
+    return CatalogV2UtilShims.structTypeToV2Columns(schema());
+  }
+
+  @Override
+  public Transform[] partitioning() {
+    // Partition column values are injected by the reader (from the synthetic delta log), so this is
+    // not load-bearing for read correctness; it reports identity transforms purely for optimizer
+    // partition awareness (e.g. dynamic file pruning), mirroring DeltaV2Table.
+    return Arrays.stream(context.dsMeta().metadata().partitionSchema().fieldNames())
+        .map(Expressions::identity)
+        .toArray(Transform[]::new);
+  }
+
+  @Override
+  public Map<String, String> properties() {
+    // Display-only (DESCRIBE EXTENDED / SHOW TBLPROPERTIES); no read path consumes this. Mirrors
+    // DeltaV2Table: the shared table's delta.* config plus provider/location/comment.
+    return DeltaSharingDSV2Utils.tableProperties(context);
+  }
+
+  @Override
+  public Set<TableCapability> capabilities() {
+    return CAPABILITIES;
+  }
+
+  /**
+   * Exposes a single {@code _metadata} struct column: the six file-source base metadata fields from
+   * {@code FileFormat.BASE_METADATA_FIELDS} (file_path, file_name, file_size, file_block_start,
+   * file_block_length, file_modification_time), plus the four row-tracking fields (row_id,
+   * base_row_id, default_row_commit_version, row_commit_version) when row tracking is enabled on
+   * the shared table. The same SparkScan read path populates them.
+   *
+   * <p>{@code file_path} is the opaque {@code delta-sharing:///} id from the synthetic log, not the
+   * pre-signed URL (held separately in the CachedTableManager id-to-URL map).
+   */
+  @Override
+  public MetadataColumn[] metadataColumns() {
+    StructType metadataType = new StructType();
+    for (StructField field :
+        CollectionConverters.asJava(FileFormat$.MODULE$.BASE_METADATA_FIELDS())) {
+      metadataType = metadataType.add(field);
+    }
+    for (StructField field :
+        CollectionConverters.asJava(
+            RowTracking$.MODULE$.createMetadataStructFields(
+                context.dsMeta().protocol().deltaProtocol(),
+                context.dsMeta().metadata().deltaMetadata(),
+                /* nullableConstantFields= */ false,
+                /* nullableGeneratedFields= */ false))) {
+      metadataType = metadataType.add(field);
+    }
+    final StructType finalMetadataType = metadataType;
+
+    MetadataColumn[] columns = new MetadataColumn[1];
+    columns[0] =
+        new MetadataColumn() {
+          @Override
+          public String name() {
+            return METADATA_COLUMN_NAME;
+          }
+
+          @Override
+          public DataType dataType() {
+            return finalMetadataType;
+          }
+
+          @Override
+          public boolean isNullable() {
+            return false;
+          }
+        };
+    return columns;
+  }
+
+  // Cached lazily on first call, mirroring DeltaV2Table. Inputs (catalogTable, the context's
+  // schemas) are immutable for a given DeltaSharingV2Table, so concurrent computation by racing
+  // optimizer passes yields the same value -- volatile is enough for visibility, no lock needed.
+  private volatile Optional<Statistics> cachedCatalogStats;
+
+  private Optional<Statistics> computeCatalogStats() {
+    Optional<Statistics> cached = cachedCatalogStats;
+    if (cached != null) {
+      return cached;
+    }
+    Optional<Statistics> computed =
+        toJavaOptional(catalogTable.stats())
+            .map(
+                stats ->
+                    toV2Statistics(
+                        stats,
+                        context.dsMeta().metadata().deltaMetadata().dataSchema(),
+                        context.dsMeta().metadata().partitionSchema()));
+    cachedCatalogStats = computed;
+    return computed;
+  }
+
+
+  @Override
+  public ScanBuilder newScanBuilder(CaseInsensitiveStringMap options) {
+    LOG.info("DSV2-Sharing: newScanBuilder for {}", name());
+    // Time travel is resolved before this point, so no time-travel option reaches here as a scan
+    // option. A CDF (readChangeFeed) read is redirected to the V1 sharing path by DeltaAnalysis
+    // before planning.
+    return new DeltaSharingScanBuilder(spark, context, engine, computeCatalogStats());
+  }
+}

--- a/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingDSV2Utils.scala
+++ b/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingDSV2Utils.scala
@@ -1,0 +1,366 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.sharing.spark
+
+import java.util.Locale
+
+import scala.collection.JavaConverters._
+import scala.util.control.NonFatal
+
+import org.apache.spark.sql.delta.DeltaGeoSpatial
+import org.apache.spark.sql.delta.metering.DeltaLogging
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import io.delta.spark.internal.v2.read.DeltaV2ScanUtils
+import io.delta.spark.internal.v2.snapshot.PathBasedSnapshotManager
+import io.delta.sharing.client.{DeltaSharingClient, DeltaSharingRestClient}
+import io.delta.sharing.client.model.{DeltaTableMetadata, Table => DeltaSharingTable}
+import io.delta.kernel.{Snapshot => KernelSnapshot}
+import io.delta.kernel.engine.Engine
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogUtils}
+import org.apache.spark.sql.connector.catalog.TableCatalog
+import org.apache.spark.sql.connector.read.{Scan, Statistics, SupportsPushDownRequiredColumns}
+import org.apache.spark.sql.sources.Filter
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+/**
+ * Per-table state built once when a shared table is loaded. Held by DeltaSharingV2Table and
+ * threaded into the ScanBuilder/Scan. Top-level (not nested) so the Java connector classes can
+ * name it.
+ *
+ * Holds the sharing client + metadata directly (no DeltaSharingFileIndex): the DSV2 read builds
+ * its own Delta Kernel snapshot from the synthetic log.
+ *
+ * `readOptions` carries the time-travel pin (versionAsOf / timestampAsOf); empty for a latest read.
+ * getMetadata (hence the reported schema) is fetched at the pin when the context is built, and the
+ * scan reuses these same options for getFiles + the query-params hash, so both RPCs resolve the
+ * same point in time.
+ */
+class DeltaSharingV2TableContext(
+    val client: DeltaSharingClient,
+    val dsTable: DeltaSharingTable,
+    val dsMeta: DeltaSharingUtils.DeltaSharingTableMetadata,
+    val tablePath: String,
+    val readOptions: DeltaSharingOptions = new DeltaSharingOptions(Map.empty[String, String]))
+
+
+/**
+ * Scala bridge for the (Java) Delta Sharing DSV2 connector classes.
+ */
+object DeltaSharingDSV2Utils extends DeltaLogging {
+
+  /**
+   * Build the sharing client + table handle from a catalog table's storage fields (no RPC). Used by
+   * [[resolveBatchSnapshotContext]]. Returns (client, table, path).
+   *
+   * `responseFormat` defaults to delta because the DSV2 read path is delta-format only (synthetic
+   * delta log + Kernel snapshot). The read path can't consume a parquet getFiles response, so it
+   * always requests delta -- unlike V1, which advertises "parquet,delta" because it has a parquet
+   * fallback path that the V2 path does not. Only the routing gate
+   * ([[resolveBatchSnapshotContext]]) overrides this, to ask the server which format it would
+   * really serve.
+   */
+  private def buildSharingClient(
+      spark: SparkSession,
+      catalogTable: CatalogTable,
+      responseFormat: String = DeltaSharingOptions.RESPONSE_FORMAT_DELTA)
+      : (DeltaSharingClient, DeltaSharingTable, String) = {
+    val path = CatalogUtils.URIToString(
+      catalogTable.storage.locationUri.getOrElse(
+        throw DeltaSharingErrors.pathNotSpecifiedException))
+    val parsedPath = DeltaSharingRestClient.parsePath(path, Map.empty)
+    val client = DeltaSharingRestClient(
+      profileFile = parsedPath.profileFile,
+      shareCredentialsOptions = Map.empty,
+      forStreaming = false,
+      responseFormat = responseFormat,
+      // Snapshot reader features only -- the DSv2 path does not serve CDF (it falls back to V1),
+      // so it must not advertise the read-time-CDF feature that getAllSupportedReaderFeatures adds.
+      readerFeatures = DeltaSharingUtils.SUPPORTED_READER_FEATURES.mkString(","))
+    val dsTable = DeltaSharingTable(
+      share = parsedPath.share, schema = parsedPath.schema, name = parsedPath.table)
+    (client, dsTable, path)
+  }
+
+  /**
+   * Resolve a shared table to a DSV2 batch-snapshot read context, or None to stay on V1. Called
+   * from the AbstractDeltaCatalog loadTable/loadTables guards; the returned context is handed to
+   * DeltaSharingV2Table, which reuses its getMetadata (no second fetch).
+   *
+   * Only delta-format batch snapshots are eligible; parquet / non-delta stay on V1. `versionAsOf` /
+   * `timestampAsOf` (both None for a latest read) pin the context, so getMetadata resolves at that
+   * point in a single RPC; the raw strings are normalized through [[DeltaSharingOptions]] (the same
+   * V1-parity validation: version+timestamp conflict, version parse, ISO-8601 timestamp). A latest
+   * resolve is best-effort (any error returns None -> V1); a pinned resolve is not (see the catch).
+   *
+   * Format/CDF/streaming are query-time concerns invisible here, so they fall back to V1 downstream
+   * (DeltaAnalysis / TableChanges.toReadQuery / DeltaSharingV2Table's V2TableWithV1Fallback).
+   *
+   * A read inside a multi-statement transaction (MST) also stays on V1.
+   */
+  def resolveBatchSnapshotContext(
+      spark: SparkSession,
+      catalogTable: CatalogTable,
+      versionAsOf: Option[String] = None,
+      timestampAsOf: Option[String] = None): Option[DeltaSharingV2TableContext] = {
+    val conf = spark.sessionState.conf
+    val tableName = catalogTable.identifier.unquotedString
+    val forceDeltaFormat = conf.getConf(DeltaSQLConf.DELTA_SHARING_FORCE_DELTA_FORMAT)
+    val isTimeTravel = versionAsOf.isDefined || timestampAsOf.isDefined
+    try {
+      val pin = new DeltaSharingOptions(
+        versionAsOf.map(DeltaSharingOptions.TIME_TRAVEL_VERSION -> _).toMap ++
+          timestampAsOf.map(DeltaSharingOptions.TIME_TRAVEL_TIMESTAMP -> _).toMap)
+      // The delta read client (responseFormat=delta), held by the returned context for the later
+      // getFiles. No RPC to build it.
+      val (readClient, dsTable, path) = buildSharingClient(spark, catalogTable)
+      if (!conf.getConf(DeltaSQLConf.DELTA_SHARING_ENABLE_DELTA_FORMAT_BATCH)) {
+        logInfo(s"DSV2-Sharing: $tableName stays on V1 (delta-format batch sharing disabled)")
+        None
+      } else if (forceDeltaFormat) {
+        // DELTA_SHARING_FORCE_DELTA_FORMAT forces every shared table onto the delta path: query
+        // getMetadata with the delta read client and use it directly -- no probe, delta by
+        // construction.
+        val deltaTableMetadata = DeltaSharingUtils.queryDeltaTableMetadata(
+          client = readClient,
+          table = dsTable,
+          versionAsOf = pin.versionAsOf,
+          timestampAsOf = pin.timestampAsOf)
+        buildContext(
+          readClient, dsTable, path, deltaTableMetadata, pin, forceDeltaFormat, isTimeTravel)
+      } else {
+        // Auto-resolve: probe getMetadata with a "parquet,delta" client so the server's
+        // respondedFormat is trustworthy. The probe must NOT use a delta-only client: that makes
+        // the server always respond delta, which would wrongly route parquet-format tables to V2.
+        val (probeClient, _, _) = buildSharingClient(
+          spark,
+          catalogTable,
+          responseFormat = s"${DeltaSharingOptions.RESPONSE_FORMAT_PARQUET}," +
+            s"${DeltaSharingOptions.RESPONSE_FORMAT_DELTA}")
+        val deltaTableMetadata = DeltaSharingUtils.queryDeltaTableMetadata(
+          client = probeClient,
+          table = dsTable,
+          versionAsOf = pin.versionAsOf,
+          timestampAsOf = pin.timestampAsOf)
+        if (deltaTableMetadata.respondedFormat == DeltaSharingOptions.RESPONSE_FORMAT_DELTA) {
+          // Delta format: reuse the probe's metadata, but seed the context with the delta read
+          // client so getFiles requests delta.
+          buildContext(
+            readClient, dsTable, path, deltaTableMetadata, pin, forceDeltaFormat, isTimeTravel)
+        } else {
+          logInfo(s"DSV2-Sharing: $tableName stays on V1 " +
+            s"(auto-resolved respondedFormat=${deltaTableMetadata.respondedFormat})")
+          None
+        }
+      }
+    } catch {
+      // Best-effort only for a latest (routing) resolve: any error keeps the table on V1. A pinned
+      // (time-travel) resolve is NOT best-effort -- the table is a known delta share, so a bad
+      // version / out-of-range timestamp must surface, not silently fall back and read latest.
+      case NonFatal(e) if versionAsOf.isEmpty && timestampAsOf.isEmpty =>
+        logWarning(s"DSV2-Sharing: $tableName stays on V1 (error resolving format: $e)")
+        None
+    }
+  }
+
+  /**
+   * Assemble a [[DeltaSharingV2TableContext]] from an already-fetched getMetadata response
+   * (no RPC), for [[resolveBatchSnapshotContext]]. `client` is the delta read client used for the
+   * later getFiles. `readOptions` carries the (already-normalized) time-travel pin, empty for a
+   * latest read.
+   *
+   * None (-> stays on V1) for a geo schema: the Kernel read path cannot convert Geometry/Geography.
+   */
+  private def buildContext(
+      client: DeltaSharingClient,
+      dsTable: DeltaSharingTable,
+      path: String,
+      deltaTableMetadata: DeltaTableMetadata,
+      readOptions: DeltaSharingOptions,
+      forceDeltaFormat: Boolean,
+      isTimeTravel: Boolean): Option[DeltaSharingV2TableContext] = {
+    val dsMeta = DeltaSharingUtils.getDeltaSharingTableMetadata(
+      table = dsTable,
+      deltaTableMetadata = deltaTableMetadata)
+
+    if (DeltaGeoSpatial.containsGeoColumns(dsMeta.metadata.schema)) {
+      logInfo(s"DSV2-Sharing: ${dsTable.name} stays on V1 (schema has a geospatial column, which " +
+        s"the DSV2 Kernel read path does not support)")
+      return None
+    }
+
+    logInfo(s"DSV2-Sharing: built context share=${dsTable.share} schema=${dsTable.schema} " +
+      s"table=${dsTable.name} version=${dsMeta.version} " +
+      s"versionAsOf=${readOptions.versionAsOf.map(_.toString).getOrElse("None")} " +
+      s"timestampAsOf=${readOptions.timestampAsOf.getOrElse("None")} " +
+      s"dataCols=[${dsMeta.metadata.deltaMetadata.dataSchema.fieldNames.mkString(",")}] " +
+      s"partitionCols=[${dsMeta.metadata.partitionSchema.fieldNames.mkString(",")}]")
+
+
+    Some(new DeltaSharingV2TableContext(
+      client = client,
+      dsTable = dsTable,
+      dsMeta = dsMeta,
+      tablePath = path,
+      readOptions = readOptions))
+  }
+
+  /**
+   * Curated table properties for the DSV2 surface, display-only (DESCRIBE EXTENDED / SHOW
+   * TBLPROPERTIES; no read path consumes them). Shaped like DeltaV2Table.properties() /
+   * DeltaTableV2: the shared table's delta.* configuration (from the already-fetched getMetadata
+   * response) plus provider / location / comment.
+   */
+  def tableProperties(ctx: DeltaSharingV2TableContext): java.util.Map[String, String] = {
+    val deltaMetadata = ctx.dsMeta.metadata.deltaMetadata
+    val props = new java.util.HashMap[String, String]()
+    props.putAll(deltaMetadata.configuration.asJava)
+    props.put(TableCatalog.PROP_PROVIDER, "deltasharing")
+    props.put(TableCatalog.PROP_LOCATION, ctx.tablePath)
+    Option(deltaMetadata.description).foreach(props.put(TableCatalog.PROP_COMMENT, _))
+    java.util.Collections.unmodifiableMap(props)
+  }
+
+  /**
+   * The required non-partition columns: the pruned (column-projected) schema minus partition
+   * columns. Passed to DeltaV2Scan as its `readDataSchema` -- the data columns Kernel actually
+   * reads out of the Parquet files. Partition columns are dropped here because their values come
+   * from the file's partition path (reconstructed by the reader), not from the file contents, so
+   * reading them would be wrong; DeltaV2Scan re-appends them to form the full output schema.
+   */
+  private[spark] def prunedNonPartitionColumns(
+      ctx: DeltaSharingV2TableContext, requiredSchema: StructType): StructType = {
+    val partCols =
+      ctx.dsMeta.metadata.partitionSchema.fieldNames.map(_.toLowerCase(Locale.ROOT)).toSet
+    StructType(
+      requiredSchema.fields.filterNot(f => partCols.contains(f.name.toLowerCase(Locale.ROOT))))
+  }
+
+  /**
+   * The heart of the DSV2 read: issue the getFiles RPC + build the synthetic log (shared with the
+   * V1 path via [[DeltaSharingDeltaLogBuilder]]), open it as a Delta Kernel snapshot, and return a
+   * Delta V2 scan over it. The scan owns everything downstream:
+   * file planning, statistics (post-skipping planned bytes, row counts under CBO), runtime V2
+   * filtering, and the SparkBatch.
+   *
+   * The getFiles RPC fires here, inside ScanBuilder.build() -- the DSV2 contract orders
+   * pushFilters / pushLimit / pruneColumns before build(), so `pushedFilters` and `pushedLimit` are
+   * already captured by the time this runs (after pushdown, not during analysis). They become the
+   * server-side hints on getFiles: the json predicate hint (built by
+   * [[DeltaSharingJsonPredicates]], gated as in V1) and the limit hint.
+   *
+   * Both hints are best-effort -- the server may return a superset -- so the pushed filters and
+   * limit are NOT re-applied by the Delta V2 scan: they stay as the residual Filter / LIMIT
+   * operators Spark leaves above the scan (`pushFilters` returns every filter, `isPartiallyPushed`
+   * stays true). The Delta V2 scan builder therefore does no filter pushdown of its own; it must
+   * not assume any filtering happened.
+   */
+  def buildScan(
+      spark: SparkSession,
+      ctx: DeltaSharingV2TableContext,
+      engine: Engine,
+      requiredSchema: StructType,
+      pushedFilters: Array[Filter],
+      pushedLimit: java.util.OptionalLong,
+      catalogStats: java.util.Optional[Statistics]): Scan = {
+    DeltaSharingDataSource.setupFileSystem(spark.sqlContext)
+
+    // 1. Convert the pushed filters to a server-side json predicate hint and unwrap the limit, then
+    // do the getFiles RPC + synthetic delta log + CachedTableManager registration -> encoded path
+    // (shared util). Both hints join the query-params hash, so scans of the same table with
+    // different filters / limits get distinct synthetic log paths and cache entries.
+    // The shared utils read versionAsOf/timestampAsOf off the DeltaSharingOptions; reuse the
+    // context's readOptions (the pin fetched getMetadata at, empty for a latest read) so getFiles
+    // resolves the same point.
+    val jsonPredicateHints = DeltaSharingJsonPredicates.fromPushedFilters(
+      pushedFilters,
+      ctx.dsMeta.metadata.schema,
+      ctx.dsMeta.metadata.partitionSchema.fieldNames.toSet,
+      spark.sessionState.conf)
+    val limit: Option[Long] = if (pushedLimit.isPresent) Some(pushedLimit.getAsLong) else None
+    val queryParamsHashId = DeltaSharingUtils.getQueryParamsHashId(
+      options = ctx.readOptions,
+      partitionFiltersString = "",
+      dataFiltersString = "",
+      jsonPredicateHints = jsonPredicateHints.getOrElse(""),
+      limitHint = limit.map(_.toString).getOrElse(""),
+      version = ctx.dsMeta.version)
+    logInfo(s"DSV2-Sharing: buildScan: getFiles RPC + building synthetic delta log " +
+      s"(jsonPredicateHints=${jsonPredicateHints.isDefined}, limit=$limit)")
+    // Build the synthetic log now, but defer the CachedTableManager registration until the scan's
+    // snapshot manager exists, to anchor the cache entry to it (see registerPreSignedUrls below).
+    val unregisteredDeltaLog = DeltaSharingDeltaLogBuilder.buildSnapshotDeltaLog(
+      client = ctx.client,
+      table = ctx.dsTable,
+      options = ctx.readOptions,
+      tablePath = ctx.tablePath,
+      queryParamsHashId = queryParamsHashId,
+      jsonPredicateHints = jsonPredicateHints,
+      limit = limit,
+      logPrefix = "DSV2-Sharing"
+    )
+    val encodedPath = unregisteredDeltaLog.encodedPath
+
+    // 2. Open the synthetic log as a Delta Kernel snapshot. The caller-provided engine (a
+    // DefaultEngine over the session hadoopConf, built once per table like DeltaV2Table) reads
+    // through the Hadoop FileSystem, so the registered `delta-sharing-log://` FS serves the
+    // fabricated _delta_log exactly as the classic DeltaLog reader does on the V1 path.
+    //
+    // PathBasedSnapshotManager directly, deliberately not SnapshotManagerFactory: the snapshot is
+    // over the per-query synthetic log, not the shared catalog entity, so it must stay path-based
+    // regardless of how the factory's dispatch evolves (a UC-managed snapshot manager would try to
+    // resolve commits through UC).
+    val snapshotManager = new PathBasedSnapshotManager(encodedPath.toString, engine)
+    val snapshot: KernelSnapshot = snapshotManager.loadLatestSnapshot()
+    if (snapshot.getVersion != 0) {
+      throw new IllegalStateException(
+        s"DSV2-Sharing: expected a single version-0 synthetic delta log at $encodedPath, but got " +
+        s"version ${snapshot.getVersion}")
+    }
+    logInfo(s"DSV2-Sharing: built Kernel snapshot over $encodedPath -> DeltaV2Scan (reads via " +
+      s"DeltaParquetFileFormatV2)")
+
+    // 3. Hand the snapshot to Delta's public scan-builder factory. DeltaV2Scan itself is
+    // package-private, so sharing code must depend only on Spark connector interfaces here.
+    val scanBuilder = DeltaV2ScanUtils.newScanBuilder(
+      ctx.dsTable.name,
+      snapshot,
+      engine,
+      java.util.Optional.empty[CatalogTable](),
+      snapshotManager,
+      ctx.dsMeta.metadata.deltaMetadata.dataSchema,
+      ctx.dsMeta.metadata.partitionSchema,
+      ctx.dsMeta.metadata.schema,
+      catalogStats,
+      // Empty options: sharing options must not leak into DeltaOptions parsing.
+      CaseInsensitiveStringMap.empty())
+    scanBuilder.asInstanceOf[SupportsPushDownRequiredColumns].pruneColumns(requiredSchema)
+    val scan = scanBuilder.build()
+
+    // Register the presigned URLs anchored to the per-query `snapshotManager`, not `scan`:
+    // DeltaV2Scan.withPrunedColumns re-plans into a new DeltaV2Scan copy, so `scan` may be
+    // orphaned, but the copy shares this snapshotManager by reference.
+    DeltaSharingDeltaLogBuilder.registerPreSignedUrls(
+      unregisteredDeltaLog, anchor = snapshotManager)
+
+
+    scan
+  }
+
+}

--- a/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingDSV2UtilsSuite.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingDSV2UtilsSuite.scala
@@ -1,0 +1,161 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.sharing.spark
+
+import org.apache.spark.sql.delta.actions.{Metadata, Protocol}
+import io.delta.sharing.client.model.{Table => DeltaSharingTable}
+import io.delta.sharing.spark.model.{DeltaSharingMetadata, DeltaSharingProtocol}
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.connector.catalog.TableCatalog
+import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
+
+/**
+ * Pure-function unit tests for [[DeltaSharingDSV2Utils]].
+ */
+class DeltaSharingDSV2UtilsSuite extends SparkFunSuite {
+
+  private val tablePath = "uc-deltasharing://main.default.t#main.default.t"
+
+  /**
+   * Build a [[DeltaSharingV2TableContext]] whose delta metadata carries the given schema,
+   * partition columns, configuration and description. `partitionSchema` is derived by Metadata from
+   * `schemaString` + `partitionColumns`, so a partition column must also appear in `schema`. The
+   * client is null: none of the functions under test touch it.
+   */
+  private def contextWith(
+      schema: StructType = new StructType(),
+      partitionColumns: Seq[String] = Nil,
+      configuration: Map[String, String] = Map.empty,
+      description: String = null): DeltaSharingV2TableContext = {
+    val deltaMetadata = Metadata(
+      schemaString = schema.json,
+      partitionColumns = partitionColumns,
+      configuration = configuration,
+      description = description)
+    val dsMeta = DeltaSharingUtils.DeltaSharingTableMetadata(
+      version = 1L,
+      protocol = DeltaSharingProtocol(Protocol()),
+      metadata = DeltaSharingMetadata(deltaMetadata = deltaMetadata))
+    new DeltaSharingV2TableContext(
+      client = null,
+      dsTable = DeltaSharingTable(share = "share", schema = "schema", name = "t"),
+      dsMeta = dsMeta,
+      tablePath = tablePath)
+  }
+
+  test("tableProperties: passes through delta.* configuration and adds provider + location") {
+    val props = DeltaSharingDSV2Utils.tableProperties(
+      contextWith(configuration = Map(
+        "delta.enableDeletionVectors" -> "true",
+        "delta.columnMapping.mode" -> "name")))
+
+    // Provider is always "deltasharing"; location is the shared table path.
+    assert(props.get(TableCatalog.PROP_PROVIDER) == "deltasharing")
+    assert(props.get(TableCatalog.PROP_LOCATION) == tablePath)
+    // The shared table's delta.* configuration is surfaced verbatim.
+    assert(props.get("delta.enableDeletionVectors") == "true")
+    assert(props.get("delta.columnMapping.mode") == "name")
+  }
+
+  test("tableProperties: empty configuration yields just provider + location, no comment") {
+    val props = DeltaSharingDSV2Utils.tableProperties(contextWith(configuration = Map.empty))
+
+    assert(props.keySet().size() == 2)
+    assert(props.get(TableCatalog.PROP_PROVIDER) == "deltasharing")
+    assert(props.get(TableCatalog.PROP_LOCATION) == tablePath)
+    assert(!props.containsKey(TableCatalog.PROP_COMMENT))
+  }
+
+  test("tableProperties: a non-null description surfaces as the comment property") {
+    val props = DeltaSharingDSV2Utils.tableProperties(
+      contextWith(configuration = Map.empty, description = "a shared table"))
+
+    assert(props.get(TableCatalog.PROP_COMMENT) == "a shared table")
+  }
+
+  test("tableProperties: a null description omits the comment property (no null value)") {
+    val props = DeltaSharingDSV2Utils.tableProperties(
+      contextWith(configuration = Map.empty, description = null))
+
+    assert(!props.containsKey(TableCatalog.PROP_COMMENT))
+  }
+
+  test("tableProperties: the returned map is unmodifiable") {
+    val props = DeltaSharingDSV2Utils.tableProperties(contextWith(configuration = Map.empty))
+
+    intercept[UnsupportedOperationException] {
+      props.put("delta.foo", "bar")
+    }
+  }
+
+  // prunedNonPartitionColumns: the required (column-projected) schema minus the table's partition
+  // columns -- the data columns Kernel reads out of the Parquet files. Partition columns are
+  // dropped because their values come from the file path, not the file contents. SparkScan
+  // re-appends them, so a bug here surfaces as reading a partition column out of the file (wrong).
+
+  private val fullSchema = new StructType()
+    .add(StructField("id", IntegerType))
+    .add(StructField("value", StringType))
+    .add(StructField("part", StringType))
+
+  test("prunedNonPartitionColumns: drops the partition column and preserves data field order") {
+    val ctx = contextWith(schema = fullSchema, partitionColumns = Seq("part"))
+    val pruned = DeltaSharingDSV2Utils.prunedNonPartitionColumns(
+      ctx, requiredSchema = fullSchema)
+
+    // Field order of the required schema is preserved; only the partition column is removed.
+    assert(pruned.fieldNames.toSeq == Seq("id", "value"))
+  }
+
+  test("prunedNonPartitionColumns: partition matching is case-insensitive") {
+    // The table's partition column is "part"; the required schema references it as "PART" (e.g.
+    // after case-insensitive analysis). It must still be recognized as a partition column and
+    // dropped -- the method lower-cases both sides.
+    val ctx = contextWith(schema = fullSchema, partitionColumns = Seq("part"))
+    val requiredSchema = new StructType()
+      .add(StructField("id", IntegerType))
+      .add(StructField("PART", StringType))
+    val pruned = DeltaSharingDSV2Utils.prunedNonPartitionColumns(ctx, requiredSchema)
+
+    assert(pruned.fieldNames.toSeq == Seq("id"))
+  }
+
+  test("prunedNonPartitionColumns: drops every partition column when there are multiple") {
+    val schema = fullSchema.add(StructField("part2", StringType))
+    val ctx = contextWith(schema = schema, partitionColumns = Seq("part", "part2"))
+    val pruned = DeltaSharingDSV2Utils.prunedNonPartitionColumns(ctx, requiredSchema = schema)
+
+    assert(pruned.fieldNames.toSeq == Seq("id", "value"))
+  }
+
+  test("prunedNonPartitionColumns: an unpartitioned table returns the required schema unchanged") {
+    val ctx = contextWith(schema = fullSchema, partitionColumns = Nil)
+    val pruned = DeltaSharingDSV2Utils.prunedNonPartitionColumns(
+      ctx, requiredSchema = fullSchema)
+
+    assert(pruned == fullSchema)
+  }
+
+  test("prunedNonPartitionColumns: projecting only the partition column yields an empty schema") {
+    val ctx = contextWith(schema = fullSchema, partitionColumns = Seq("part"))
+    val requiredSchema = new StructType().add(StructField("part", StringType))
+    val pruned = DeltaSharingDSV2Utils.prunedNonPartitionColumns(ctx, requiredSchema)
+
+    assert(pruned.isEmpty)
+  }
+}


### PR DESCRIPTION
## Description

This PR adds a DataSource V2 batch-read connector for Delta Sharing tables, alongside
the existing V1 sharing path.

The connector consists of:

- `DeltaSharingV2Table` / `DeltaSharingScanBuilder` (Java) — the V2 `Table` and
  `ScanBuilder` implementations, mirroring the shape of the Kernel-backed V2 Delta
  connector.
- `DeltaSharingDSV2Utils` (Scala) — the glue that builds the scan over a
  `PathBasedSnapshotManager` via `DeltaV2ScanUtils.newScanBuilder`, and translates
  sharing options (latest-snapshot reads, time travel) and pushed-down
  filters/limits.

Reads go through the Kernel V2 scan path and support latest-snapshot reads, time
travel, and filter / limit pushdown. The new code is inert by default: it is gated
behind the `spark.sql.delta.sharing.dsv2.enabled` config (default `false`), so the
existing V1 read path is unchanged.

`DeltaSharingDSV2Utils.columns()` builds column metadata via `structTypeToV2Columns`,
using `CatalogV2UtilShims` so it works across the supported Spark versions.

## How was this patch tested?

Added `DeltaSharingDSV2UtilsSuite`, covering the utility methods that translate table
properties and prune non-partition columns.

## Does this PR introduce _any_ user-facing change?

No. The new connector is behind the default-off `spark.sql.delta.sharing.dsv2.enabled`
config; default behavior is unchanged.
