### PR TITLE
[Spark] Add a log-commit-only action reader for SingleCommit and simplify parallel commit reads

### DIFF
--- a/hudi/src/main/scala/org/apache/spark/sql/delta/hudi/HudiConverter.scala
+++ b/hudi/src/main/scala/org/apache/spark/sql/delta/hudi/HudiConverter.scala
@@ -273,7 +273,7 @@ class HudiConverter
         )
 
         val actionIterators =
-          DeltaFileProviderUtils.parallelReadAndParseDeltaFilesAsIterator(spark, log, commits)
+          DeltaFileProviderUtils.parallelReadAndParseDeltaFilesAsIterator(spark, commits)
         actionIterators.foreach { actionsIter =>
           try {
             actionsIter.grouped(actionBatchSize).foreach { actions =>

--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConverter.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConverter.scala
@@ -430,7 +430,7 @@ class IcebergConverter
           )
 
           val actionIterators =
-            DeltaFileProviderUtils.parallelReadAndParseDeltaFilesAsIterator(spark, log, commits)
+            DeltaFileProviderUtils.parallelReadAndParseDeltaFilesAsIterator(spark, commits)
           var deltaVersion = prevSnapshot.version
           val commitInfos = actionIterators.map { actionsIter =>
             try {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaFileProviderUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaFileProviderUtils.scala
@@ -102,9 +102,8 @@ object DeltaFileProviderUtils extends DeltaLogging {
    */
   def parallelReadAndParseDeltaFilesAsIterator(
       spark: SparkSession,
-      deltaLog: DeltaLog,
       commits: Seq[SingleCommit]): Seq[ClosableIterator[Action]] =
-    parallelReadDeltaFiles(spark, deltaLog, commits)(_.getActionsIterator())
+    parallelReadDeltaFiles(spark, commits)(_.getActionsIterator())
 
   /**
    * Parallel-read a set of commits off the driver, materializing each commit's [[Action]]s into a
@@ -112,23 +111,28 @@ object DeltaFileProviderUtils extends DeltaLogging {
    */
   def parallelReadAndParseDeltaFilesAsSeq(
       spark: SparkSession,
-      deltaLog: DeltaLog,
       commits: Seq[SingleCommit]): Seq[Seq[Action]] =
-    parallelReadDeltaFiles(spark, deltaLog, commits) { commit =>
+    parallelReadDeltaFiles(spark, commits) { commit =>
       commit.getActionsIterator().processAndClose(_.toSeq)
+    }
+
+  /**
+   * Like [[parallelReadAndParseDeltaFilesAsSeq]], but asserts each commit is a log commit.
+   */
+  private[delta] def parallelReadAndParseLogCommitsAsSeqUnsafe(
+      spark: SparkSession,
+      commits: Seq[SingleCommit]): Seq[Seq[Action]] =
+    parallelReadDeltaFiles(spark, commits) { commit =>
+      commit.getLogCommitActionsIteratorUnsafe().processAndClose(_.toSeq)
     }
 
   /**
    * Parallel-read a set of commits off the driver, applying `f` to each. The commits are read
    * concurrently on the driver delta-log thread pool; results are returned in the input order.
+   * Only derive `A` from `commits`.
    */
   protected def parallelReadDeltaFiles[A](
       spark: SparkSession,
-      deltaLog: DeltaLog,
-      commits: Seq[SingleCommit])(f: SingleCommit => A): Seq[A] = {
-    val hadoopConf = deltaLog.newDeltaHadoopConf()
-    readThreadPool.parallelMap(spark, commits) { commit =>
-      f(commit)
-    }.toSeq
-  }
+      commits: Seq[SingleCommit])(f: SingleCommit => A): Seq[A] =
+    readThreadPool.parallelMap(spark, commits)(f).toSeq
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/SingleCommit.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/SingleCommit.scala
@@ -16,10 +16,10 @@
 
 package org.apache.spark.sql.delta
 
-import org.apache.spark.sql.delta.actions.Action
+import org.apache.spark.sql.delta.actions.{Action, Checkpoint}
 import org.apache.spark.sql.delta.storage.{ClosableIterator, SupportsRewinding}
 import org.apache.spark.sql.delta.storage.ClosableIterator._
-import org.apache.hadoop.fs.{FileStatus, Path}
+import org.apache.hadoop.fs.FileStatus
 
 /**
  * A handle to a single commit in the Delta log, standing in for the raw commit log file that
@@ -44,19 +44,37 @@ class SingleCommit private (
     SingleCommit.createRewindableActionIterator(deltaLog, fileStatus, maxInMemoryFileSizeBytes)
 
   /**
-   * The modification time of this commit's log file. Delta internal only.
+   * Like [[getActionsIterator]], but asserts this commit is a log commit.
+   *
+   * @param maxInMemoryFileSizeBytes see [[getActionsIterator]].
+   */
+  private[delta] def getLogCommitActionsIteratorUnsafe(
+      maxInMemoryFileSizeBytes: Long = 0)
+      : ClosableIterator[Action] with SupportsRewinding[Action] = {
+    val underlying =
+      SingleCommit.createRewindableActionIterator(deltaLog, fileStatus, maxInMemoryFileSizeBytes)
+    new ClosableIterator[Action] with SupportsRewinding[Action] {
+      override def hasNext: Boolean = underlying.hasNext
+      override def next(): Action = underlying.next() match {
+        case _: Checkpoint =>
+          throw new IllegalStateException(
+            s"commit $version is a manifest commit and cannot be read as a log commit")
+        case action => action
+      }
+      override def close(): Unit = underlying.close()
+      override def rewind(): Unit = underlying.rewind()
+    }
+  }
+
+  /**
+   * The modification time of this commit's log file.
    */
   private[delta] def fileModificationTimestamp: Long = fileStatus.getModificationTime
 
   /**
-   * The size of this commit's log file, in bytes. Delta internal only.
+   * The size of this commit's log file, in bytes.
    */
-  private[delta] def sizeInBytes: Long = fileStatus.getLen
-
-  /**
-   * The commit log file's path. Should used by delta internal only.
-   */
-  private[delta] def path: Path = fileStatus.getPath
+  private[delta] def commitFileSizeInBytes: Long = fileStatus.getLen
 }
 
 object SingleCommit {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/IncrementalAMTWriter.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/IncrementalAMTWriter.scala
@@ -106,7 +106,7 @@ class IncrementalAMTWriter(spark: SparkSession, deltaLog: DeltaLog) {
     val windowCommits =
       intermediateLogCommits.map(f => SingleCommit(deltaLog, FileNames.getFileVersion(f), f))
     val actionsFromDeltas =
-      DeltaFileProviderUtils.parallelReadAndParseDeltaFilesAsSeq(spark, deltaLog, windowCommits)
+      DeltaFileProviderUtils.parallelReadAndParseDeltaFilesAsSeq(spark, windowCommits)
     // 1.c: this commit attempt's own actions (actionsToCommit).
 
     // ---- Step 2: log-replay all three parts, keyed by their real commit versions. ----

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
@@ -808,7 +808,7 @@ class DeltaLogSuite extends QueryTest
       val expected =
         commits.map(c => c.version -> c.getActionsIterator().processAndClose(_.toList))
       val parallelActions =
-        DeltaFileProviderUtils.parallelReadAndParseDeltaFilesAsIterator(spark, log, commits)
+        DeltaFileProviderUtils.parallelReadAndParseDeltaFilesAsIterator(spark, commits)
           .map(_.processAndClose(_.toList))
       val actual = commits.map(_.version).zip(parallelActions)
       assert(actual === expected)
@@ -1010,105 +1010,6 @@ class DeltaLogSuite extends QueryTest
     }
   }
 
-  private def createDeltaTableWithCommits(tableDir: File, numVersions: Int): DeltaLog = {
-    val log = DeltaLog.forTable(spark, tableDir.getCanonicalPath)
-    spark.sql(s"CREATE TABLE delta.`${tableDir.getCanonicalPath}` (id INT) USING delta")
-    (1 to numVersions).foreach { i =>
-      spark.sql(s"INSERT INTO delta.`${tableDir.getCanonicalPath}` VALUES ($i)")
-    }
-    log
-  }
-
-  test("getChangesIterator yields one SingleCommit per commit with the right version") {
-    withTempDir { tableDir =>
-      val log = createDeltaTableWithCommits(tableDir, numVersions = 3)
-      // CREATE is version 0, the three INSERTs are versions 1..3.
-      val commits = log.getChangesIterator(startVersion = 0).toList
-      assert(commits.map(_.version) === (0L to 3L).toList)
-
-      // The handle exposes the commit file's modification time (not the in-commit timestamp), so it
-      // matches what getChangeLogFiles reports for the same commit.
-      val fileModTimes =
-        log.getChangeLogFiles(startVersion = 0).map(_._2.getModificationTime).toList
-      assert(commits.map(_.fileModificationTimestamp) === fileModTimes)
-    }
-  }
-
-  test("getChangesIterator endVersion override bounds the range (both inclusive)") {
-    withTempDir { tableDir =>
-      val log = createDeltaTableWithCommits(tableDir, numVersions = 5)
-      val commits = log.getChangesIterator(
-        startVersion = 1, endVersion = 3, catalogTableOpt = None, failOnDataLoss = true).toList
-      assert(commits.map(_.version) === List(1L, 2L, 3L))
-    }
-  }
-
-  test("SingleCommit.getActionsIterator returns the commit's actions and matches getChanges") {
-    withTempDir { tableDir =>
-      val log = createDeltaTableWithCommits(tableDir, numVersions = 3)
-      val viaHandle = log.getChangesIterator(startVersion = 0).map { commit =>
-        (commit.version, commit.getActionsIterator().processAndClose(_.toList))
-      }.toList
-      val viaGetChanges = log.getChanges(startVersion = 0).map {
-        case (version, actions) => (version, actions.toList)
-      }.toList
-      assert(viaHandle === viaGetChanges)
-    }
-  }
-
-  test("SingleCommit.getActionsIterator is rewindable and replays the same actions") {
-    withTempDir { tableDir =>
-      val log = createDeltaTableWithCommits(tableDir, numVersions = 1)
-      // Version 1 is the single INSERT; open its actions and read twice via rewind().
-      val commit = log.getChangesIterator(startVersion = 1).next()
-      val iter = commit.getActionsIterator()
-      try {
-        val firstPass = iter.toList
-        assert(firstPass.nonEmpty)
-        iter.rewind()
-        val secondPass = iter.toList
-        assert(secondPass === firstPass)
-      } finally {
-        iter.close()
-      }
-    }
-  }
-
-  test("SingleCommit.getActionsIterator returns all actions of a multi-action commit") {
-    withTempDir { dir =>
-      val log = DeltaLog.forTable(spark, new Path(dir.getCanonicalPath))
-      // Commit 0 creates the table and adds "old". Commit 1 packs several data actions -- three new
-      // AddFiles and a RemoveFile of "old" -- into one commit so the commit has more than one
-      // action.
-      log.startTransaction().commitManually(
-        Metadata(configuration = Map(DeltaConfigs.CHECKPOINT_INTERVAL.key -> "10")),
-        createTestAddFile(encodedPath = "old"))
-      val dataActions: Seq[Action] = Seq(
-        createTestAddFile(encodedPath = "a"),
-        createTestAddFile(encodedPath = "b"),
-        createTestAddFile(encodedPath = "c"),
-        RemoveFile("old", Some(System.currentTimeMillis()), dataChange = true))
-      log.startTransaction().commitManually(dataActions: _*)
-
-      // Read commit 1 (the multi-action one) back through the new API.
-      val commit = log.getChangesIterator(startVersion = 1).next()
-      assert(commit.version === 1L)
-      val actions = commit.getActionsIterator().processAndClose(_.toList)
-
-      // It contains more than one action, and every data action we committed is present (order and
-      // exact identity of synthesized CommitInfo/Protocol are not asserted -- commit() adds those).
-      assert(actions.size > 1, s"expected a multi-action commit, got: $actions")
-      val addedPaths = actions.collect { case a: AddFile => a.path }.toSet
-      assert(addedPaths === Set("a", "b", "c"), s"missing AddFiles, got: $addedPaths")
-      val removedPaths = actions.collect { case r: RemoveFile => r.path }.toSet
-      assert(removedPaths === Set("old"), s"missing RemoveFile, got: $removedPaths")
-
-      // The authoritative invariant: getActionsIterator returns exactly what getChanges returns for
-      // this same multi-action commit.
-      val viaGetChanges = log.getChanges(startVersion = 1).next()._2.toList
-      assert(actions === viaGetChanges)
-    }
-  }
 }
 
 class DeltaLogWithCatalogOwnedBatch1Suite extends DeltaLogSuite {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSingleCommitSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSingleCommitSuite.scala
@@ -1,0 +1,229 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.amt
+
+import org.apache.spark.sql.delta.{DeltaFileProviderUtils, DeltaLog, DeltaOperations, SingleCommit}
+import org.apache.spark.sql.delta.DeltaTestUtils.createTestAddFile
+import org.apache.spark.sql.delta.actions.{Action, AddFile, RemoveFile}
+
+/**
+ * Tests for SingleCommit related handling.
+ */
+class AMTSingleCommitSuite extends AMTCheckpointTestBase {
+
+  /**
+   * Create an AMT-featured table with `numVersions` plain INSERT commits that all stay classic log
+   * commits (checkpoint interval far away, huge size threshold so no manifest is emitted); return
+   * its [[DeltaLog]].
+   */
+  private def createLogCommitTable(name: String, numVersions: Int): DeltaLog = {
+    createAMTTable(name, checkpointInterval = 1000)
+    (1 to numVersions).foreach(i => sql(s"INSERT INTO $name VALUES ($i)"))
+    deltaLogForName(name)
+  }
+
+  /** A [[SingleCommit]] handle for exactly `version`. */
+  private def commitAt(deltaLog: DeltaLog, version: Long): SingleCommit =
+    deltaLog.getChangesIterator(startVersion = version)
+      .find(_.version == version)
+      .getOrElse(fail(s"no commit at version $version"))
+
+  test("getActionsIterator returns the commit's actions and matches getChanges") {
+    withTable("amt_getactions") {
+      val deltaLog = createLogCommitTable("amt_getactions", numVersions = 3)
+      val viaHandle = deltaLog.getChangesIterator(startVersion = 0).map { commit =>
+        (commit.version, commit.getActionsIterator().processAndClose(_.toList))
+      }.toList
+      val viaGetChanges = deltaLog.getChanges(startVersion = 0).map {
+        case (version, actions) => (version, actions.toList)
+      }.toList
+      assert(viaHandle === viaGetChanges)
+    }
+  }
+
+  test("getActionsIterator is rewindable and replays the same actions") {
+    withTable("amt_rewind") {
+      val deltaLog = createLogCommitTable("amt_rewind", numVersions = 1)
+      // Version 1 is the single INSERT; open its actions and read twice via rewind().
+      val iter = commitAt(deltaLog, 1L).getActionsIterator()
+      try {
+        val firstPass = iter.toList
+        assert(firstPass.nonEmpty)
+        iter.rewind()
+        assert(iter.toList === firstPass)
+      } finally {
+        iter.close()
+      }
+    }
+  }
+
+  test("getActionsIterator returns all actions of a multi-action commit") {
+    withTable("amt_multi_action") {
+      val name = "amt_multi_action"
+      // v1 adds "old"; v2 packs several data actions -- three new AddFiles and a RemoveFile of
+      // "old" -- into one manual commit so the commit has more than one action.
+      val deltaLog = createLogCommitTable(name, numVersions = 0)
+      val oldFile = createTestAddFile(encodedPath = "old")
+      deltaLog.startTransaction()
+        .commit(Seq(oldFile), DeltaOperations.ManualUpdate)
+      val dataActions: Seq[Action] = Seq(
+        createTestAddFile(encodedPath = "a"),
+        createTestAddFile(encodedPath = "b"),
+        createTestAddFile(encodedPath = "c"),
+        oldFile.remove)
+      deltaLog.startTransaction()
+        .commit(dataActions, DeltaOperations.ManualUpdate)
+
+      // Read commit 2 (the multi-action one) back through the SingleCommit API.
+      val commit = commitAt(deltaLog, 2L)
+      val actions = commit.getActionsIterator().processAndClose(_.toList)
+
+      // It contains more than one action, and every data action we committed is present (order and
+      // exact identity of synthesized CommitInfo/Protocol are not asserted -- commit() adds those).
+      assert(actions.size > 1, s"expected a multi-action commit, got: $actions")
+      val addedPaths = actions.collect { case a: AddFile => a.path }.toSet
+      assert(addedPaths === Set("a", "b", "c"), s"missing AddFiles, got: $addedPaths")
+      val removedPaths = actions.collect { case r: RemoveFile => r.path }.toSet
+      assert(removedPaths === Set("old"), s"missing RemoveFile, got: $removedPaths")
+
+      // The authoritative invariant: getActionsIterator returns exactly what getChanges returns for
+      // this same multi-action commit.
+      val viaGetChanges = deltaLog.getChanges(startVersion = 2).next()._2.toList
+      assert(actions === viaGetChanges)
+    }
+  }
+
+  test("getChangesIterator yields one SingleCommit per commit with the right version") {
+    withTable("amt_versions") {
+      val deltaLog = createLogCommitTable("amt_versions", numVersions = 3)
+      // CREATE is version 0, the three INSERTs are versions 1..3.
+      val commits = deltaLog.getChangesIterator(startVersion = 0).toList
+      assert(commits.map(_.version) === (0L to 3L).toList)
+
+      // The handle exposes the commit file's modification time (not the in-commit timestamp), so it
+      // matches what getChangeLogFiles reports for the same commit.
+      val fileModTimes =
+        deltaLog.getChangeLogFiles(startVersion = 0).map(_._2.getModificationTime).toList
+      assert(commits.map(_.fileModificationTimestamp) === fileModTimes)
+    }
+  }
+
+  test("getChangesIterator endVersion override bounds the range (both inclusive)") {
+    withTable("amt_range") {
+      val deltaLog = createLogCommitTable("amt_range", numVersions = 5)
+      val commits = deltaLog.getChangesIterator(
+        startVersion = 1, endVersion = 3, catalogTableOpt = None, failOnDataLoss = true).toList
+      assert(commits.map(_.version) === List(1L, 2L, 3L))
+    }
+  }
+
+  private val insertTwoRows: String => Unit = { name =>
+    sql(s"INSERT INTO $name VALUES (1)")
+    sql(s"INSERT INTO $name VALUES (2)")
+  }
+
+  private val insertThirdRow: Option[AMTCheckpointTrigger] =
+    Some(name => Right(s"INSERT INTO $name VALUES (3)"))
+
+  testAcrossAMTCheckpointScenarios(
+    "getLogCommitActionsIteratorUnsafe reads a log commit like getActionsIterator",
+    tableName = "amt_log_read")(
+    setup = insertTwoRows,
+    inlineCheckpointTriggerActionsOrSQL = insertThirdRow
+  ) { context =>
+    val deltaLog = deltaLogForName(context.tableName)
+    val logCommits =
+      (0L to context.manifestCommitVersion).filter(checkpointAt(deltaLog, _).isEmpty)
+    assert(logCommits.nonEmpty, "expected at least one log commit before the manifest commit")
+    logCommits.foreach { v =>
+      val commit = commitAt(deltaLog, v)
+      val viaUnsafe = commit.getLogCommitActionsIteratorUnsafe().processAndClose(_.toList)
+      val viaPlain = commit.getActionsIterator().processAndClose(_.toList)
+      assert(viaUnsafe === viaPlain, s"v$v disagreed between the unsafe and plain readers")
+    }
+  }
+
+  testAcrossAMTCheckpointScenarios(
+    "getLogCommitActionsIteratorUnsafe throws on a manifest commit",
+    tableName = "amt_manifest_read")(
+    setup = insertTwoRows,
+    inlineCheckpointTriggerActionsOrSQL = insertThirdRow
+  ) { context =>
+    val manifestVersion = context.manifestCommitVersion
+    val commit = commitAt(deltaLogForName(context.tableName), manifestVersion)
+    val e = intercept[IllegalStateException] {
+      commit.getLogCommitActionsIteratorUnsafe().processAndClose(_.toList)
+    }
+    assert(e.getMessage.contains(s"commit $manifestVersion"))
+    assert(e.getMessage.contains("cannot be read as a log commit"))
+  }
+
+  testAcrossAMTCheckpointScenarios(
+    "parallelReadAndParseLogCommitsAsSeqUnsafe throws if any commit is a manifest commit",
+    tableName = "amt_par_manifest")(
+    setup = insertTwoRows,
+    inlineCheckpointTriggerActionsOrSQL = insertThirdRow
+  ) { context =>
+    val deltaLog = deltaLogForName(context.tableName)
+    val firstLogCommit = context.preCheckpointSnapshot.version
+    assert(checkpointAt(deltaLog, firstLogCommit).isEmpty, s"v$firstLogCommit must be a log commit")
+    val commits = DeltaFileProviderUtils.getCommitsInVersionRange(
+      spark,
+      deltaLog,
+      startVersion = firstLogCommit,
+      endVersion = context.manifestCommitVersion,
+      catalogTableOpt = None)
+    val e = intercept[Exception] {
+      DeltaFileProviderUtils.parallelReadAndParseLogCommitsAsSeqUnsafe(spark, commits)
+    }
+    val causes = Iterator.iterate[Throwable](e)(_.getCause).takeWhile(_ != null).toList
+    assert(
+      causes.exists { c =>
+        c.isInstanceOf[IllegalStateException] &&
+          c.getMessage != null && c.getMessage.contains("cannot be read as a log commit")
+      },
+      s"expected an IllegalStateException about a manifest commit in the cause chain, got: " +
+        causes.map(c => s"${c.getClass.getName}: ${c.getMessage}").mkString(" -> "))
+  }
+
+  testAcrossAMTCheckpointScenarios(
+    "parallelReadAndParseLogCommitsAsSeqUnsafe reads a range after the manifest commit",
+    tableName = "amt_par_after_manifest")(
+    setup = insertTwoRows,
+    inlineCheckpointTriggerActionsOrSQL = insertThirdRow
+  ) { context =>
+    val deltaLog = deltaLogForName(context.tableName)
+    // Three log commits land after the manifest commit, so the table looks like
+    // [.., log, manifest, log, log, log] and the range below starts past the manifest commit.
+    (4 to 6).foreach(i => sql(s"INSERT INTO ${context.tableName} VALUES ($i)"))
+    val firstLogCommit = context.manifestCommitVersion + 1
+    val lastLogCommit = context.manifestCommitVersion + 3
+    assert((firstLogCommit to lastLogCommit).forall(checkpointAt(deltaLog, _).isEmpty),
+      s"v$firstLogCommit..v$lastLogCommit must all be log commits")
+
+    val commits = DeltaFileProviderUtils.getCommitsInVersionRange(
+      spark,
+      deltaLog,
+      startVersion = firstLogCommit,
+      endVersion = lastLogCommit,
+      catalogTableOpt = None)
+    // Does not throw.
+    val viaUnsafe = DeltaFileProviderUtils.parallelReadAndParseLogCommitsAsSeqUnsafe(spark, commits)
+    val viaPlain = commits.map(_.getActionsIterator().processAndClose(_.toSeq))
+    assert(viaUnsafe === viaPlain)
+  }
+}


### PR DESCRIPTION
## Description

This patches a few rough edges of the `SingleCommit` API.

- Adds `SingleCommit.getLogCommitActionsIteratorUnsafe` (and
  `DeltaFileProviderUtils.parallelReadAndParseLogCommitsAsSeqUnsafe`) for
  callers that must only read log commits. The iterator asserts that the commit
  is a log commit and throws an `IllegalStateException` if it encounters a
  manifest (checkpoint) commit.
- Removes the unused `DeltaLog` argument from `DeltaFileProviderUtils`'
  `parallelReadAndParse*` helpers and from `parallelReadDeltaFiles`. The Hadoop
  configuration it built was never used, and the file-system safety check is
  already performed when the `DeltaLog` is initialized, so the argument was
  redundant. Callers in `HudiConverter`, `IcebergConverter`, and
  `IncrementalAMTWriter` are updated accordingly.
- Renames `SingleCommit.sizeInBytes` to `commitFileSizeInBytes` and removes the
  now-unused `SingleCommit.path` accessor.

## How was this patch tested?

Adds `AMTSingleCommitSuite`, which covers the new log-commit readers (including
the assertion failure on a manifest commit and the parallel read path), and
moves the existing `SingleCommit` test cases out of `DeltaLogSuite` into it.

## Does this PR introduce _any_ user-facing changes?

No.