### PR TITLE
[Kernel][Defaults] Reuse the file's Hadoop Configuration in the Parquet reader

### DIFF
--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/hadoopio/HadoopInputFile.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/hadoopio/HadoopInputFile.java
@@ -20,6 +20,7 @@ import io.delta.kernel.defaults.engine.fileio.SeekableInputStream;
 import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.util.concurrent.ExecutionException;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.FutureDataInputStreamBuilder;
@@ -45,6 +46,11 @@ public class HadoopInputFile implements InputFile {
   @Override
   public String path() {
     return path.toString();
+  }
+
+  /** Returns the Hadoop {@link Configuration} this file is read with. */
+  public Configuration getConfiguration() {
+    return fs.getConf();
   }
 
   @Override

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetFileReader.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetFileReader.java
@@ -33,9 +33,9 @@ import io.delta.kernel.utils.FileStatus;
 import java.io.IOException;
 import java.util.*;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.conf.ParquetConfiguration;
 import org.apache.parquet.filter2.compat.FilterCompat;
 import org.apache.parquet.filter2.predicate.FilterPredicate;
-import org.apache.parquet.format.converter.ParquetMetadataConverter;
 import org.apache.parquet.hadoop.ParquetReader;
 import org.apache.parquet.hadoop.api.InitContext;
 import org.apache.parquet.hadoop.api.ReadSupport;
@@ -126,9 +126,12 @@ public class ParquetFileReader {
             org.apache.parquet.io.InputFile parquetInputFile =
                 ParquetIOUtils.createParquetInputFile(inputFile);
 
-            ParquetMetadata footer =
-                org.apache.parquet.hadoop.ParquetFileReader.readFooter(
-                    parquetInputFile, ParquetMetadataConverter.NO_FILTER);
+            // Pass the configuration explicitly at both `parquet-mr` entry points below, so
+            // neither constructs a fresh Hadoop Configuration per file. See
+            // ParquetIOUtils#parquetConfiguration.
+            ParquetConfiguration parquetConf = ParquetIOUtils.parquetConfiguration(inputFile);
+
+            ParquetMetadata footer = ParquetIOUtils.readFooter(parquetInputFile, parquetConf);
 
             MessageType parquetSchema = footer.getFileMetaData().getSchema();
             Optional<FilterPredicate> parquetPredicate =
@@ -138,7 +141,7 @@ public class ParquetFileReader {
             // no API to do that in the current version of parquet-mr which takes InputFile
             // as input.
             reader =
-                new ParquetReader.Builder<Object>(parquetInputFile) {
+                new ParquetReader.Builder<Object>(parquetInputFile, parquetConf) {
                   @Override
                   protected ReadSupport<Object> getReadSupport() {
                     return readSupport;

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetIOUtils.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetIOUtils.java
@@ -19,7 +19,14 @@ import io.delta.kernel.defaults.engine.fileio.InputFile;
 import io.delta.kernel.defaults.engine.fileio.OutputFile;
 import io.delta.kernel.defaults.engine.fileio.PositionOutputStream;
 import io.delta.kernel.defaults.engine.fileio.SeekableInputStream;
+import io.delta.kernel.defaults.engine.hadoopio.HadoopInputFile;
 import java.io.IOException;
+import org.apache.parquet.ParquetReadOptions;
+import org.apache.parquet.conf.HadoopParquetConfiguration;
+import org.apache.parquet.conf.ParquetConfiguration;
+import org.apache.parquet.format.converter.ParquetMetadataConverter;
+import org.apache.parquet.hadoop.ParquetFileReader;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
 import org.apache.parquet.io.DelegatingPositionOutputStream;
 import org.apache.parquet.io.DelegatingSeekableInputStream;
 
@@ -29,6 +36,42 @@ import org.apache.parquet.io.DelegatingSeekableInputStream;
  */
 public class ParquetIOUtils {
   private ParquetIOUtils() {}
+
+  /**
+   * Returns the {@link ParquetConfiguration} to read {@code inputFile} with.
+   *
+   * <p>This matters for concurrency, not just for honoring settings. `parquet-mr` entry points
+   * taking an {@link org.apache.parquet.io.InputFile} that isn't {@code
+   * org.apache.parquet.hadoop.util.HadoopInputFile} fall back to {@code new
+   * HadoopParquetConfiguration()}, which wraps a fresh {@code Configuration(loadDefaults=true)}.
+   * Hadoop loads such a configuration's properties lazily, so the first property read -- which
+   * `parquet-mr` issues immediately while building the read options -- scans the classpath for
+   * `core-default.xml` and friends under a JVM-global lock. This would make concurrent readers
+   * serialize on the lock.
+   *
+   * <p>Reusing the configuration the file is already being read with avoids the scan entirely: its
+   * properties are loaded once and memoized on the instance.
+   */
+  static ParquetConfiguration parquetConfiguration(InputFile inputFile) {
+    return inputFile instanceof HadoopInputFile
+        ? new HadoopParquetConfiguration(((HadoopInputFile) inputFile).getConfiguration())
+        : new HadoopParquetConfiguration();
+  }
+
+  /**
+   * Reads the footer of {@code parquetFile} using {@code conf}, so that `parquet-mr` doesn't
+   * construct a fresh Hadoop Configuration for the read. See {@link #parquetConfiguration}.
+   */
+  static ParquetMetadata readFooter(
+      org.apache.parquet.io.InputFile parquetFile, ParquetConfiguration conf) throws IOException {
+    ParquetReadOptions readOptions =
+        ParquetReadOptions.builder(conf)
+            .withMetadataFilter(ParquetMetadataConverter.NO_FILTER)
+            .build();
+    try (org.apache.parquet.io.SeekableInputStream stream = parquetFile.newStream()) {
+      return ParquetFileReader.readFooter(parquetFile, readOptions, stream);
+    }
+  }
 
   /** Create a Parquet {@link org.apache.parquet.io.InputFile} from a Kernel's {@link InputFile}. */
   static org.apache.parquet.io.InputFile createParquetInputFile(InputFile inputFile) {

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetStatsReader.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetStatsReader.java
@@ -36,8 +36,6 @@ import org.apache.hadoop.shaded.com.google.common.collect.Multimap;
 import org.apache.parquet.column.statistics.*;
 import org.apache.parquet.column.statistics.geospatial.BoundingBox;
 import org.apache.parquet.column.statistics.geospatial.GeospatialStatistics;
-import org.apache.parquet.format.converter.ParquetMetadataConverter;
-import org.apache.parquet.hadoop.ParquetFileReader;
 import org.apache.parquet.hadoop.metadata.BlockMetaData;
 import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
 import org.apache.parquet.hadoop.metadata.ParquetMetadata;
@@ -57,11 +55,14 @@ public class ParquetStatsReader {
   public static DataFileStatistics readDataFileStatistics(
       InputFile kernelInputFile, StructType dataSchema, List<Column> statsColumns)
       throws IOException {
-    // Read the Parquet footer to compute the statistics
+    // Read the Parquet footer to compute the statistics. Pass the configuration explicitly so
+    // `parquet-mr` doesn't construct a fresh Hadoop Configuration here; see
+    // ParquetIOUtils#parquetConfiguration.
     org.apache.parquet.io.InputFile parquetFile =
         ParquetIOUtils.createParquetInputFile(kernelInputFile);
     ParquetMetadata footer =
-        ParquetFileReader.readFooter(parquetFile, ParquetMetadataConverter.NO_FILTER);
+        ParquetIOUtils.readFooter(
+            parquetFile, ParquetIOUtils.parquetConfiguration(kernelInputFile));
     ImmutableMultimap.Builder<Column, ColumnChunkMetaData> metadataForColumn =
         ImmutableMultimap.builder();
 


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/7387/files) to review incremental changes.
- [**stack/master-hadoop-io-fix**](https://github.com/delta-io/delta/pull/7387) [[Files changed](https://github.com/delta-io/delta/pull/7387/files)] ← _this PR_
  - [stack/reuse-parquet-footer](https://github.com/delta-io/delta/pull/7388) [[Files changed](https://github.com/delta-io/delta/pull/7388/files/c86736930cff96907b18b0381d3f29ad00036ca3..231357df64fec1e387c4855367fb22d707975b97)]

---------
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

Kernel wraps its own `InputFile` before handing it to `parquet-mr`, so the wrapper is never a `parquet-mr` `HadoopInputFile`. Every entry point that takes an `InputFile` without a configuration therefore falls back to `new HadoopParquetConfiguration()`, which wraps a fresh `Configuration(loadDefaults=true)`. Hadoop loads such a configuration's properties lazily, so the first property read -- which `parquet-mr` issues immediately while building the read options -- scans the classpath for `core-default.xml` and friends under a JVM-global lock. With one of these per Parquet file, concurrent readers serialize on that lock.

Pass the configuration the file is already being read with instead. Its properties are loaded once and memoized on the instance, so the scan disappears. This affects all three call sites that were constructing a fresh configuration: the footer read and the reader build in ParquetFileReader (both per Parquet file), and the footer read in ParquetStatsReader.

## How was this patch tested?

Covered by existing tests

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
