### PR TITLE
[Flink] Support narrow integer types in Unity Catalog tables

### DIFF
--- a/flink/src/main/java/io/delta/flink/sink/sql/FlinkUnityCatalogTable.java
+++ b/flink/src/main/java/io/delta/flink/sink/sql/FlinkUnityCatalogTable.java
@@ -195,6 +195,8 @@ public class FlinkUnityCatalogTable implements CatalogTable {
           return new AtomicDataType(new BooleanType(nullable));
         case "binary":
           return new AtomicDataType(new VarBinaryType(nullable, VarBinaryType.MAX_LENGTH));
+        case "byte":
+          return new AtomicDataType(new TinyIntType(nullable));
         case "date":
           return new AtomicDataType(new DateType(nullable));
         case "double":
@@ -205,6 +207,8 @@ public class FlinkUnityCatalogTable implements CatalogTable {
           return new AtomicDataType(new IntType(nullable));
         case "long":
           return new AtomicDataType(new BigIntType(nullable));
+        case "short":
+          return new AtomicDataType(new SmallIntType(nullable));
         case "string":
           return new AtomicDataType(new VarCharType(nullable, VarCharType.MAX_LENGTH));
         case "timestamp":

--- a/flink/src/test/java/io/delta/flink/sink/sql/FlinkUnityCatalogTableTest.java
+++ b/flink/src/test/java/io/delta/flink/sink/sql/FlinkUnityCatalogTableTest.java
@@ -30,6 +30,8 @@ import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.types.AtomicDataType;
 import org.apache.flink.table.types.KeyValueDataType;
 import org.apache.flink.table.types.logical.MapType;
+import org.apache.flink.table.types.logical.SmallIntType;
+import org.apache.flink.table.types.logical.TinyIntType;
 import org.apache.flink.table.types.logical.VarBinaryType;
 import org.junit.jupiter.api.Test;
 
@@ -112,6 +114,17 @@ class FlinkUnityCatalogTableTest {
         ((KeyValueDataType) ((UnresolvedPhysicalColumn) schema.getColumns().get(8)).getDataType())
                 .getLogicalType()
             instanceof MapType);
+  }
+
+  @Test
+  void testNarrowIntegerTypes() {
+    assertEquals(
+        new TinyIntType(true),
+        FlinkUnityCatalogTable.fromJson("{\"type\":\"byte\",\"nullable\":true}").getLogicalType());
+    assertEquals(
+        new SmallIntType(false),
+        FlinkUnityCatalogTable.fromJson("{\"type\":\"short\",\"nullable\":false}")
+            .getLogicalType());
   }
 
   @Test


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/7389/files) to review incremental changes.
- [stack/flink-uc-narrow-integer-types](https://github.com/delta-io/delta/pull/7389) [[Files changed](https://github.com/delta-io/delta/pull/7389/files)]

---------
## Description

Unity Catalog table metadata represents TINYINT and SMALLINT as byte and short in type JSON. Map those values to Flink TinyIntType and SmallIntType while preserving column nullability.

## Testing

- build/sbt "flink / javafmt"
- build/sbt "flink / Test / javafmt"
- build/sbt "flink / testOnly io.delta.flink.sink.sql.FlinkUnityCatalogTableTest" (3 passed)
- build/sbt "flink / test" (249 total, 245 passed, 4 skipped)
- Cross-engine integration matrix for TINYINT and SMALLINT values, schema discovery, and reader parity (36 passed)