### PR TITLE
Introduce AMTPassthrough to AddFile action

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
@@ -1287,6 +1287,8 @@ object Checkpoints
       additionalCols ++= partitionValues
       additionalCols ++= Checkpoints.extractStats(snapshot.statsSchema, "add.stats")
     }
+    // amtResidue and backReference are dropped on purpose here: V1/V2 checkpoints are incompatible
+    // with AMT, so these AMT-era extras do not belong in the checkpoint `add` struct.
     val withAdd = state.withColumn("add",
       when(col("add").isNotNull, struct(Seq(
         col("add.path"),

--- a/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
@@ -635,7 +635,8 @@ class Snapshot(
             col("add.baseRowId"),
             col("add.defaultRowCommitVersion"),
             col("add.clusteringProvider"),
-            col("add.backReference")
+            col("add.backReference"),
+            col("add.amtPassthrough")
           )))
         .withColumn("remove", when(
           col("remove.path").isNotNull,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -30,7 +30,7 @@ import scala.util.control.NonFatal
 import com.databricks.spark.util.TagDefinition
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.ClassicColumnConversions._
-import org.apache.spark.sql.delta.amt.AMTUtils
+import org.apache.spark.sql.delta.amt.{AMTPassthrough, AMTUtils}
 import org.apache.spark.sql.delta.commands.DeletionVectorUtils
 import org.apache.spark.sql.delta.metering.{DeltaLogging, DeltaLoggingProvider}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
@@ -917,7 +917,8 @@ case class AddFile(
     @JsonDeserialize(contentAs = classOf[java.lang.Long])
     defaultRowCommitVersion: Option[Long] = None,
     clusteringProvider: Option[String] = None,
-    backReference: Option[BackReference] = None
+    backReference: Option[BackReference] = None,
+    amtPassthrough: Option[AMTPassthrough] = None
 ) extends FileAction with HasNumRecords {
   require(path.nonEmpty)
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/actions.scala
@@ -21,12 +21,14 @@ import java.util.UUID
 import scala.util.Try
 
 import org.apache.spark.sql.delta.DeltaColumnMapping
-import org.apache.spark.sql.delta.actions.{AddFile, DeletionVectorDescriptor}
+import org.apache.spark.sql.delta.actions.{Action, AddFile, DeletionVectorDescriptor}
 import org.apache.spark.sql.delta.stats.DeltaStatistics
 import org.apache.spark.sql.delta.storage.dv.DeletionVectorStore
 import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import org.apache.hadoop.fs.{FileStatus, Path}
 
+import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.execution.datasources.parquet.ParquetUtils
 import org.apache.spark.sql.types.{MetadataBuilder, StructField, StructType}
 
@@ -469,13 +471,15 @@ case class DataEntry(
       stats = stats,
       deletionVector = dv,
       baseRowId = tracking.first_row_id,
-      defaultRowCommitVersion = tracking.sequence_number)
+      defaultRowCommitVersion = tracking.sequence_number,
+      amtPassthrough = AMTPassthrough.fromDataEntry(this))
   }
 }
 
 object DataEntry {
   /** Creates [[DataEntry]] from AddFile. */
-  def fromAddFile(add: AddFile, tracking: Tracking, tableRoot: Path): DataEntry =
+  def fromAddFile(add: AddFile, tracking: Tracking, tableRoot: Path): DataEntry = {
+    val passthrough = add.amtPassthrough
     DataEntry(
       location = add.path,
       file_format = AMTSingleAction.FileFormatParquet,
@@ -493,7 +497,74 @@ object DataEntry {
       partition = Partition(Option(add.partitionValues).filter(_.nonEmpty)),
       deletion_vector =
         Option(add.deletionVector).map(DeletionVector.fromDescriptor(_, tableRoot)),
+      spec_id = passthrough.flatMap(_.spec_id),
       content_stats = None)
+  }
+}
+
+/**
+ * The AMT-native fields of a [[DataEntry]] that should be carried by [[AddFile]].
+ */
+case class AMTPassthrough(
+    @JsonDeserialize(contentAs = classOf[java.lang.Integer])
+    spec_id: Option[Int] = None)
+
+object AMTPassthrough {
+  /** Name of the `amtPassthrough` field on the AddFile schema. */
+  final val FIELD_NAME: String = "amtPassthrough"
+
+  /** The struct type of the `amtPassthrough` field on the AddFile schema. */
+  final lazy val STRUCT_TYPE: StructType =
+    Action.addFileSchema(FIELD_NAME).dataType.asInstanceOf[StructType]
+
+  /**
+   * Positions of the `amtPassthrough` struct within an [[InternalRow]].
+   */
+  case class RowIndices(structIndex: Int, numFields: Int, specId: Int)
+
+  object RowIndices {
+    /**
+     * Resolve the positions against `schema`, the schema of an `add`-shaped row, or `None` when
+     * `schema` does not project `amtPassthrough` at all.
+     */
+    def resolve(schema: StructType): Option[RowIndices] =
+      schema.getFieldIndex(FIELD_NAME).map { structIndex =>
+        val passthroughSchema = schema(FIELD_NAME).dataType.asInstanceOf[StructType]
+        RowIndices(
+          structIndex = structIndex,
+          numFields = passthroughSchema.fields.length,
+          specId = passthroughSchema.fieldIndex("spec_id"))
+      }
+  }
+
+  /**
+   * Read the [[AMTPassthrough]] out of `row` at the pre-resolved `indices`, or `None` when the row
+   * carries no AMT-native fields.
+   */
+  def fromRow(row: InternalRow, indices: RowIndices): Option[AMTPassthrough] = {
+    if (row.isNullAt(indices.structIndex)) {
+      None
+    } else {
+      val struct = row.getStruct(indices.structIndex, indices.numFields)
+      Some(AMTPassthrough(
+        spec_id =
+          if (struct.isNullAt(indices.specId)) None else Some(struct.getInt(indices.specId))))
+    }
+  }
+
+  /**
+   * Build the [[AMTPassthrough]] carried on a Delta [[AddFile]] from `entry`, or `None` when the
+   * entry has no AMT-native fields to carry.
+   */
+  def fromDataEntry(entry: DataEntry): Option[AMTPassthrough] = {
+    require(
+      entry.file_format == AMTSingleAction.FileFormatParquet &&
+        entry.format_version == AMTSingleAction.FormatVersionV4,
+      s"amtPassthrough only supports parquet/v4. got " +
+        s"${entry.file_format}/${entry.format_version}.")
+    val passthrough = AMTPassthrough(spec_id = entry.spec_id)
+    if (passthrough == AMTPassthrough()) None else Some(passthrough)
+  }
 }
 
 /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableBase.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableBase.scala
@@ -229,9 +229,10 @@ abstract class CloneTableBase(
         addFileIter.map { fileToCopy =>
           val copiedFile = fileToCopy.copy(dataChange = dataChangeInFileAction)
           // CLONE does not preserve Row IDs and Commit Versions, nor the source table's AMT
-          // back reference.
+          // back reference and passthrough.
           copiedFile.copy(
-            baseRowId = None, defaultRowCommitVersion = None, backReference = None)
+            baseRowId = None, defaultRowCommitVersion = None, backReference = None,
+            amtPassthrough = None)
         }
       sourceTable.snapshot.foreach { sourceSnapshot =>
         // Handle DomainMetadata for cloning a table.

--- a/spark/src/test/scala/org/apache/spark/sql/delta/ActionSerializerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/ActionSerializerSuite.scala
@@ -21,6 +21,7 @@ import java.util.UUID
 import org.apache.spark.sql.delta.DeltaOperations.ManualUpdate
 import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils.{TABLE_FEATURES_MIN_READER_VERSION, TABLE_FEATURES_MIN_WRITER_VERSION}
+import org.apache.spark.sql.delta.amt.AMTPassthrough
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
@@ -142,6 +143,40 @@ class ActionSerializerSuite extends QueryTest with SharedSparkSession with Delta
     assert(add.removeWithTimestamp().backReference == backRef)
     // copy (the mechanism the superseding AddFile of removeRows relies on) preserves it.
     assert(add.copy(dataChange = false).backReference == backRef)
+  }
+
+  test("AddFile - amtPassthrough json serialization/deserialization") {
+    val withPassthrough = AddFile(
+      path = "a",
+      partitionValues = Map.empty,
+      size = 1,
+      modificationTime = 2,
+      dataChange = false,
+      amtPassthrough = Some(AMTPassthrough(spec_id = Some(7))))
+    assert(withPassthrough.json.contains("\"amtPassthrough\":{\"spec_id\":7}"))
+    assert(Action.fromJson(withPassthrough.json) === withPassthrough)
+
+    // Absent (default None) -> omitted from the serialized action.
+    val withoutPassthrough = AddFile("a", Map.empty, 1, 2, dataChange = false)
+    assert(!withoutPassthrough.json.contains("amtPassthrough"))
+    assert(Action.fromJson(withoutPassthrough.json).asInstanceOf[AddFile].amtPassthrough.isEmpty)
+
+    // A present-but-empty passthrough keeps the struct, with its own field omitted.
+    val emptyPassthrough = AddFile(
+      "a", Map.empty, 1, 2, dataChange = false, amtPassthrough = Some(AMTPassthrough()))
+    assert(emptyPassthrough.json.contains("\"amtPassthrough\":{}"))
+    assert(Action.fromJson(emptyPassthrough.json) === emptyPassthrough)
+  }
+
+  test("AddFile amtPassthrough propagates to copy but not to removeWithTimestamp") {
+    val passthrough = Some(AMTPassthrough(spec_id = Some(7)))
+    val add = AddFile("a", Map.empty, 1, 2, dataChange = true, amtPassthrough = passthrough)
+    // copy (the mechanism the superseding AddFile of removeRows relies on) preserves it.
+    assert(add.copy(dataChange = false).amtPassthrough == passthrough)
+    // Unlike backReference, RemoveFile has no amtPassthrough field: the tombstone drops it. The
+    // surviving AddFile is what carries the AMT-native state forward.
+    assert(add.removeWithTimestamp().json.contains("\"remove\""))
+    assert(!add.removeWithTimestamp().json.contains("amtPassthrough"))
   }
 
   // This is the same test as "removefile" in OSS, but due to a Jackson library upgrade the behavior

--- a/spark/src/test/scala/org/apache/spark/sql/delta/CheckpointsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CheckpointsSuite.scala
@@ -26,6 +26,7 @@ import scala.concurrent.duration._
 import com.databricks.spark.util.{Log4jUsageLogger, MetricDefinitions, UsageRecord}
 import org.apache.spark.sql.delta.DeltaTestUtils.createTestAddFile
 import org.apache.spark.sql.delta.actions._
+import org.apache.spark.sql.delta.amt.AMTPassthrough
 import org.apache.spark.sql.delta.coordinatedcommits.CatalogOwnedTestBaseSuite
 import org.apache.spark.sql.delta.deletionvectors.DeletionVectorsSuite
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
@@ -723,7 +724,7 @@ class CheckpointsSuite
     }
   }
 
-  test("non-AMT tables do not persist backReference in checkpoint or commit JSON") {
+  test("non-AMT tables do not persist backReference or amtPassthrough in checkpoint or commit") {
     withClassicCheckpointPolicyForCatalogOwned {
       withTempDir { tempDir =>
         val tablePath = tempDir.getAbsolutePath
@@ -734,7 +735,7 @@ class CheckpointsSuite
         deltaLog.checkpoint()
         val version = deltaLog.snapshot.version
 
-        // 1. The classic checkpoint parquet must not carry backReference on add or remove.
+        // 1. The classic checkpoint parquet must carry neither backReference nor amtPassthrough.
         val checkpointFile =
           FileNames.checkpointFileSingular(deltaLog.logPath, version).toString
         val checkpointSchema = spark.read.format("parquet").load(checkpointFile).schema
@@ -746,8 +747,10 @@ class CheckpointsSuite
           s"checkpoint add struct must not contain backReference, got: $addFields")
         assert(!removeFields.contains("backReference"),
           s"checkpoint remove struct must not contain backReference, got: $removeFields")
+        assert(!addFields.contains("amtPassthrough"),
+          s"checkpoint add struct must not contain amtPassthrough, got: $addFields")
 
-        // 2. No commit JSON should mention backReference (null fields are omitted from JSON).
+        // 2. No commit JSON should mention backReference or amtPassthrough.
         val commitProvider = DeltaCommitFileProvider(deltaLog.unsafeVolatileSnapshot)
         val hadoopConf = deltaLog.newDeltaHadoopConf()
         (0L to version).foreach { v =>
@@ -755,6 +758,9 @@ class CheckpointsSuite
           val content = deltaLog.store.read(deltaFile, hadoopConf)
           assert(!content.exists(_.contains("backReference")),
             s"commit JSON for version $v must not contain backReference: ${content.mkString("\n")}")
+          assert(!content.exists(_.contains("amtPassthrough")),
+            s"commit JSON for version $v must not contain amtPassthrough: " +
+              s"${content.mkString("\n")}")
         }
       }
     }
@@ -1086,10 +1092,12 @@ class CheckpointsSuite
 
     val actionsToWrite = Checkpoints
       .buildCheckpoint(actionsDS, snapshot)
-      // buildCheckpoint drops backReference from the on-disk add/remove shape so we need to
-      // re-materialize it as a null column before .as[SingleAction].
+      // buildCheckpoint drops backReference (add/remove) and amtPassthrough (add only) from the
+      // on-disk shape, so we re-materialize them as null columns before .as[SingleAction].
       .withColumn("add", when(col("add.path").isNotNull,
-        col("add").withField("backReference", lit(null).cast(BackReference.STRUCT_TYPE))))
+        col("add")
+          .withField("backReference", lit(null).cast(BackReference.STRUCT_TYPE))
+          .withField("amtPassthrough", lit(null).cast(AMTPassthrough.STRUCT_TYPE))))
       .withColumn("remove", when(col("remove.path").isNotNull,
         col("remove").withField("backReference", lit(null).cast(BackReference.STRUCT_TYPE))))
       .as[SingleAction]

--- a/spark/src/test/scala/org/apache/spark/sql/delta/actions/AddFileSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/actions/AddFileSuite.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql.delta.actions
 
 import org.apache.spark.sql.delta.{DeltaConfigs, DeltaLog, DeltaRuntimeException}
 import org.apache.spark.sql.delta.DeltaTestUtils.BOOLEAN_DOMAIN
+import org.apache.spark.sql.delta.amt.AMTPassthrough
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSingleActionSerializerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSingleActionSerializerSuite.scala
@@ -18,12 +18,14 @@ package org.apache.spark.sql.delta.amt
 
 import java.util.UUID
 
-import org.apache.spark.sql.delta.actions.{AddFile, DeletionVectorDescriptor}
+import org.apache.spark.sql.delta.actions.{Action, AddFile, DeletionVectorDescriptor, InMemoryLogReplay}
 import org.apache.spark.sql.delta.storage.dv.DeletionVectorStore
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
 import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.{StringType, StructField, StructType}
 
 /**
  * Shape, builder, invariant, and parquet round-trip tests for the AMT
@@ -362,5 +364,114 @@ class AMTSingleActionSerializerSuite extends QueryTest with SharedSparkSession {
       id = UUID.randomUUID(), sizeInBytes = 10, cardinality = 1L, offset = None)
     val ex = intercept[IllegalArgumentException](DeletionVector.fromDescriptor(dv, tableRoot))
     assert(ex.getMessage.contains("missing an offset"))
+  }
+
+  /** A DATA entry carrying the AMT-native `spec_id` that has no Delta equivalent. */
+  private def entryWithPassthrough: DataEntry = DataEntry(
+    location = "f.parquet",
+    file_format = AMTSingleAction.FileFormatParquet,
+    tracking = addedTracking,
+    record_count = 10L,
+    file_size_in_bytes = 100L,
+    spec_id = Some(7))
+
+  test("toAddFile carries no passthrough for the default parquet/v4 entry") {
+    val add = DataEntry(
+      location = "f.parquet", file_format = AMTSingleAction.FileFormatParquet,
+      tracking = addedTracking, record_count = 10L, file_size_in_bytes = 100L).toAddFile(tableRoot)
+    assert(add.amtPassthrough.isEmpty, "a default entry must add no per-file passthrough")
+  }
+
+  test("DataEntry round-trips toAddFile -> fromAddFile") {
+    val add = entryWithPassthrough.toAddFile(tableRoot)
+    assert(add.amtPassthrough.isDefined, "a genuine passthrough must be carried")
+    val restored = DataEntry.fromAddFile(add, addedTracking, tableRoot)
+    assert(restored.spec_id.contains(7))
+    // file_format / format_version are not carried; they are reconstructed at the M1 defaults.
+    assert(restored.file_format == AMTSingleAction.FileFormatParquet)
+    assert(restored.format_version == AMTSingleAction.FormatVersionV4)
+  }
+
+  test("fromAddFile falls back to defaults with no passthrough") {
+    val restored = DataEntry.fromAddFile(sampleAddFile, addedTracking, tableRoot)
+    assert(restored.file_format == AMTSingleAction.FileFormatParquet)
+    assert(restored.spec_id.isEmpty)
+    assert(restored.format_version == AMTSingleAction.FormatVersionV4)
+  }
+
+  test("amtPassthrough round-trips through the commit JSON") {
+    val add = entryWithPassthrough.toAddFile(tableRoot)
+    assert(add.amtPassthrough.isDefined)
+    val json = add.json
+    assert(json.contains("amtPassthrough"), s"amtPassthrough must be serialized; got $json")
+    assert(json.contains("spec_id"), s"spec_id must be serialized; got $json")
+
+    val roundTripped = Action.fromJson(json) match {
+      case a: AddFile => a
+      case other => fail(s"expected an AddFile, got $other")
+    }
+    assert(roundTripped.amtPassthrough == add.amtPassthrough)
+    assert(roundTripped.amtPassthrough.flatMap(_.spec_id).contains(7))
+  }
+
+  test("an AddFile with no amtPassthrough keeps it out of the commit JSON") {
+    // Include.NON_ABSENT: non-AMT tables must not gain a new key in their commit JSON.
+    assert(sampleAddFile.amtPassthrough.isEmpty)
+    assert(!sampleAddFile.json.contains("amtPassthrough"))
+  }
+
+  test("amtPassthrough survives copy and InMemoryLogReplay state reconstruction") {
+    val add = entryWithPassthrough.toAddFile(tableRoot).copy(path = "f.parquet")
+    val passthrough = add.amtPassthrough
+    assert(passthrough.isDefined)
+    // Below simulates the real write path in [[writeIncrementalMaterialization]]
+    assert(add.copy(dataChange = false).amtPassthrough == passthrough)
+    val replay = new InMemoryLogReplay(
+      minFileRetentionTimestamp = None, minSetTransactionRetentionTimestamp = None)
+    replay.append(0, Iterator(add))
+    val reconstructed = replay.allFiles
+    assert(reconstructed.length == 1)
+    // The passthrough survives replay and is still usable end-to-end.
+    assert(reconstructed.head.amtPassthrough == passthrough)
+    assert(DataEntry.fromAddFile(reconstructed.head, addedTracking, tableRoot).spec_id.contains(7))
+  }
+
+  test("amtPassthrough participates in AddFile equality") {
+    val base = sampleAddFile
+    val withA = base.copy(amtPassthrough = Some(AMTPassthrough(spec_id = Some(7))))
+    val withB = base.copy(amtPassthrough = Some(AMTPassthrough(spec_id = Some(7))))
+    assert(withA == withB && withA.hashCode == withB.hashCode,
+      "equal-content passthrough must compare equal")
+    val withC = base.copy(amtPassthrough = Some(AMTPassthrough(spec_id = Some(9))))
+    assert(withA != withC, "different passthrough content must compare unequal")
+    // Present vs absent -> unequal.
+    assert(withA != base && base != withA)
+  }
+
+  test("RowIndices.resolve returns None when the schema does not project amtPassthrough") {
+    val schema = StructType(Seq(StructField("path", StringType)))
+    assert(AMTPassthrough.RowIndices.resolve(schema).isEmpty)
+  }
+
+  test("RowIndices.resolve and fromRow read the passthrough positionally") {
+    val addSchema = Action.addFileSchema
+    val indices = AMTPassthrough.RowIndices.resolve(addSchema)
+      .getOrElse(fail("the AddFile schema must project amtPassthrough"))
+    assert(addSchema.fieldNames(indices.structIndex) == AMTPassthrough.FIELD_NAME)
+    assert(indices.numFields == AMTPassthrough.STRUCT_TYPE.fields.length)
+
+    // A row carrying spec_id -> read back; a row with a null struct -> None.
+    val withPassthrough = new GenericInternalRow(addSchema.fields.length)
+    withPassthrough.update(indices.structIndex, new GenericInternalRow(Array[Any](7)))
+    assert(AMTPassthrough.fromRow(withPassthrough, indices)
+      .contains(AMTPassthrough(spec_id = Some(7))))
+
+    val withoutPassthrough = new GenericInternalRow(addSchema.fields.length)
+    assert(AMTPassthrough.fromRow(withoutPassthrough, indices).isEmpty)
+
+    // A present struct whose own field is null -> present, but with no spec_id.
+    val nullSpecId = new GenericInternalRow(addSchema.fields.length)
+    nullSpecId.update(indices.structIndex, new GenericInternalRow(Array[Any](null)))
+    assert(AMTPassthrough.fromRow(nullSpecId, indices).contains(AMTPassthrough(spec_id = None)))
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotSuite.scala
@@ -16,7 +16,8 @@
 
 package org.apache.spark.sql.delta.amt
 
-import org.apache.spark.sql.delta.{Checkpoints, DeletionVectorsTestUtils, DeltaLog, DeltaOperations}
+import org.apache.spark.sql.delta.{Checkpoints, DeletionVectorsTestUtils, DeltaLog, DeltaOperations, Snapshot}
+import org.apache.spark.sql.delta.DeltaTestUtils.createTestAddFile
 import org.apache.spark.sql.delta.actions.{AddFile, Checkpoint, ContentRoot, DeletionVectorDescriptor}
 import org.apache.spark.sql.delta.deletionvectors.RoaringBitmapArray
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
@@ -52,6 +53,21 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
   }
 
   testAcrossAMTCheckpointScenarios(
+      "plain AMT tables reconstruct AddFiles with no amtPassthrough",
+      "amt_passthrough_roundtrip")(
+      setup = name => sql(s"INSERT INTO $name VALUES (1)"),
+      inlineCheckpointTriggerActionsOrSQL = Some(name => Right(
+        s"INSERT INTO $name VALUES (2)"))) { context =>
+    // These are plain parquet/v4 files with no Iceberg passthrough, so `toAddFile` carries
+    // nothing (avoids per-file overhead).
+    val files = context.postCheckpointSnapshot.allFiles.collect()
+    assert(files.nonEmpty)
+    assert(files.forall(_.amtPassthrough.isEmpty),
+      s"plain AMT files must carry no passthrough; got " +
+        s"${files.map(_.amtPassthrough).mkString(", ")}")
+  }
+
+  testAcrossAMTCheckpointScenarios(
       "snapshot.allFiles matches leaves across insert/overwrite/delete before a checkpoint",
       "amt_overwrite")(
       setup = name => {
@@ -67,6 +83,291 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
       "Only the surviving overwrite file should be live.")
     // The tree must capture exactly the surviving live files after overwrite + delete.
     assertReconstructsLiveFileSet(context)
+  }
+
+  // AMT inline or not should be irrelevant to test result.
+  testAcrossAMTCheckpointScenarios(
+    "amtPassthrough survives from one AMT into the next",
+    "amt_passthrough_amt_to_amt",
+    deferredScenarios = Seq.empty
+  )(
+    setup = name => {
+      sql(s"INSERT INTO $name VALUES (1)")
+      withSQLConf(
+        DeltaSQLConf.AMT_LARGE_COMMIT_ACTIONS_COUNT_THRESHOLD_FOR_INLINE_MANIFEST_COMMIT.key
+          -> "1"
+      ) {
+        deltaLogForName(name)
+          .startTransaction()
+          .commit(
+            Seq(
+              createTestAddFile(encodedPath = "passthrough-file")
+                .copy(amtPassthrough = Some(fullPassthrough))
+            ),
+            DeltaOperations.ManualUpdate
+          )
+      }
+      // At this point tree should be materialized.
+      val seeded =
+        amtFilesInTree(deltaLogForName(name).update(), Some("passthrough-file"))
+      assert(
+        seeded.length == 1,
+        s"expected one tree entry for passthrough-file, got: $seeded."
+      )
+      assert(
+        seeded.head.amtPassthrough.contains(fullPassthrough),
+        "sanity: passthrough must be in the seeded AMT before the checkpoint."
+      )
+    },
+    inlineCheckpointTriggerActionsOrSQL =
+      Some(name => Right(s"INSERT INTO $name VALUES (100)"))
+  ) { context =>
+    val seededVersion = amtProvider(context.preCheckpointSnapshot)
+      .getOrElse(fail("the seed commit must have emitted an AMT"))
+      .version
+    assert(
+      context.provider.version > seededVersion,
+      s"a new AMT must have re-materialized past the seeded one at v$seededVersion; " +
+        s"got v${context.provider.version}."
+    )
+
+    // The passthrough survives into the re-materialized AMT and reconstructs on read.
+    val snapshot = context.postCheckpointSnapshot
+    val inTree = amtFilesInTree(snapshot, Some("passthrough-file"))
+    assert(
+      inTree.length == 1,
+      s"expected one tree entry for passthrough-file, got: $inTree."
+    )
+    assert(
+      inTree.head.amtPassthrough.contains(fullPassthrough),
+      s"passthrough must propagate into the re-materialized AMT; got " +
+        s"${inTree.head.amtPassthrough}."
+    )
+    val liveFile =
+      snapshot.allFiles.collect().filter(_.path == "passthrough-file")
+    assert(
+      liveFile.length == 1,
+      s"expected exactly one seeded file, got: ${liveFile.toSeq}."
+    )
+    assert(
+      liveFile.head.amtPassthrough.contains(fullPassthrough),
+      s"passthrough must reconstruct from the re-materialized AMT; got " +
+        s"${liveFile.head.amtPassthrough}."
+    )
+  }
+
+  // AMT inline or not should be irrelevant to test result.
+  testAcrossAMTCheckpointScenarios(
+    "amtPassthrough survives from one AMT, with in-place rewrite, into the next",
+    "amt_passthrough_inplace",
+    deferredScenarios = Seq.empty
+  )(
+    setup = name => {
+      sql(s"INSERT INTO $name VALUES (1)")
+      val log = deltaLogForName(name)
+      withSQLConf(
+        DeltaSQLConf.AMT_LARGE_COMMIT_ACTIONS_COUNT_THRESHOLD_FOR_INLINE_MANIFEST_COMMIT.key
+          -> "1"
+      ) {
+        log
+          .startTransaction()
+          .commit(
+            Seq(
+              createTestAddFile(encodedPath = "passthrough-file")
+                .copy(
+                  amtPassthrough = Some(fullPassthrough),
+                  stats = """{"numRecords":1}"""
+                )
+            ),
+            DeltaOperations.ManualUpdate
+          )
+      }
+      val seedAMTVersion = amtProvider(log.update()).map(_.version)
+      // AMTPassthrough before the rewrite.
+      val seeded = amtFilesInTree(log.update(), Some("passthrough-file"))
+      assert(
+        seeded.length == 1,
+        s"expected one tree entry for passthrough-file, got: $seeded."
+      )
+      assert(
+        seeded.head.amtPassthrough.contains(fullPassthrough),
+        "passthrough seeded into the AMT."
+      )
+      val current = log
+        .update()
+        .allFiles
+        .collect()
+        .find(_.path == "passthrough-file")
+        .getOrElse(fail("passthrough-file must be live."))
+      assert(
+        current.amtPassthrough.contains(fullPassthrough),
+        s"the live file carries passthrough before the rewrite; got " +
+          s"${current.amtPassthrough}."
+      )
+
+      // The rewrite must land as a plain LOG commit.
+      withSQLConf(
+        DeltaSQLConf.AMT_LARGE_COMMIT_ACTIONS_COUNT_THRESHOLD_FOR_INLINE_MANIFEST_COMMIT.key
+          -> Long.MaxValue.toString
+      ) {
+        log
+          .startTransaction()
+          .commit(
+            Seq(
+              current.copy(
+                stats = """{"numRecords":1,"probe":true}""",
+                dataChange = false
+              )
+            ),
+            DeltaOperations.ComputeStats(predicate = Nil)
+          )
+      }
+      // Verify that AMT checkpoint version stays the same.
+      val afterRewriteAMTVersion = amtProvider(log.update()).map(_.version)
+      assert(
+        afterRewriteAMTVersion == seedAMTVersion,
+        s"the in-place rewrite must NOT be committed into an AMT; the tree moved from " +
+          s"$seedAMTVersion to $afterRewriteAMTVersion."
+      )
+
+      // The reconstructed live file keeps its passthrough, and the stats update lands.
+      val afterRewrite =
+        log.update().allFiles.collect().filter(_.path == "passthrough-file")
+      assert(afterRewrite.length == 1)
+      assert(
+        afterRewrite.head.stats == """{"numRecords":1,"probe":true}""",
+        "the in-place stats update itself must land."
+      )
+      assert(
+        afterRewrite.head.amtPassthrough.contains(fullPassthrough),
+        s"passthrough must survive the in-place rewrite; got " +
+          s"${afterRewrite.head.amtPassthrough}."
+      )
+    },
+    inlineCheckpointTriggerActionsOrSQL =
+      Some(name => Right(s"INSERT INTO $name VALUES (100)"))
+  ) { context =>
+    // A new AMT re-materialized past the rewrite and still carries the passthrough.
+    val seededVersion = amtProvider(context.preCheckpointSnapshot)
+      .getOrElse(fail("the seed commit must have emitted an AMT"))
+      .version
+    assert(
+      context.provider.version > seededVersion,
+      s"a new AMT must have re-materialized past the rewrite; the tree is still at " +
+        s"v${context.provider.version} (seeded at v$seededVersion)."
+    )
+    val snapshot = context.postCheckpointSnapshot
+    val survived = amtFilesInTree(snapshot, Some("passthrough-file"))
+    assert(
+      survived.length == 1,
+      s"expected one tree entry for passthrough-file, got: $survived."
+    )
+    assert(
+      survived.head.amtPassthrough.contains(fullPassthrough),
+      s"passthrough must survive into the re-materialized AMT; got " +
+        s"${survived.head.amtPassthrough}."
+    )
+    val finalLive =
+      snapshot.allFiles.collect().filter(_.path == "passthrough-file")
+    assert(
+      finalLive.length == 1 &&
+        finalLive.head.amtPassthrough.contains(fullPassthrough),
+      s"passthrough must survive the rewrite + re-materialization; got " +
+        s"${finalLive.map(_.amtPassthrough).toSeq}."
+    )
+  }
+
+  // Bypasses `testAcrossAMTCheckpointScenarios`: this test needs the table to have NO AMT at all
+  // while the passthrough is seeded.
+  test("amtPassthrough from a log commit is carried into the next AMT") {
+    withSQLConf(
+      DeltaSQLConf.AMT_LARGE_COMMIT_ACTIONS_COUNT_THRESHOLD_FOR_INLINE_MANIFEST_COMMIT.key
+        -> "1"
+    ) {
+      withTable("amt_passthrough_from_log_commit") {
+        val name = "amt_passthrough_from_log_commit"
+        createAMTTable(name, checkpointInterval = 10000)
+        val log = deltaLogForName(name)
+        assert(
+          amtProvider(log.update()).isEmpty,
+          "no AMT may exist before the first trigger."
+        )
+
+        // V1 is a LOG commit: the file's passthrough lives only in the commit JSON at this point.
+        val passthrough = fullPassthrough
+        val fileWithPassthrough = createTestAddFile(encodedPath = "passthrough-file")
+          .copy(amtPassthrough = Some(passthrough), stats = """{"numRecords":1}""")
+        log
+          .startTransaction()
+          .commit(Seq(fileWithPassthrough), DeltaOperations.ManualUpdate)
+        assert(
+          amtProvider(deltaLogForName(name).update()).isEmpty,
+          "the seeding commit must stay a LOG commit (no AMT yet)."
+        )
+        val fromLog = deltaLogForName(name)
+          .update()
+          .allFiles
+          .collect()
+          .filter(_.path == "passthrough-file")
+        assert(
+          fromLog.length == 1,
+          s"expected the seeded file to be live, got: ${fromLog.toSeq}."
+        )
+        assert(
+          fromLog.head.amtPassthrough.contains(passthrough),
+          s"the log-commit file must carry its passthrough; got " +
+            s"${fromLog.head.amtPassthrough}."
+        )
+
+        // Now trigger the table's first AMT.
+        sql(s"ALTER TABLE $name SET TBLPROPERTIES ('delta.checkpointInterval' = '2')")
+        sql(s"INSERT INTO $name VALUES (100)")
+        sql(s"INSERT INTO $name VALUES (101)")
+        val snapshot = deltaLogForName(name).update()
+        val amtVersion = amtProvider(snapshot).map(_.version)
+        assert(
+          amtVersion.contains(5L),
+          s"the first AMT must describe content version 5; got $amtVersion."
+        )
+
+        val inTree = amtFilesInTree(snapshot, Some("passthrough-file"))
+        assert(
+          inTree.length == 1,
+          s"expected one tree entry for passthrough-file, got: $inTree."
+        )
+        assert(
+          inTree.head.amtPassthrough.contains(passthrough),
+          s"the log commit's passthrough must be carried into the AMT; got " +
+            s"${inTree.head.amtPassthrough}."
+        )
+        val live = snapshot.allFiles.collect().filter(_.path == "passthrough-file")
+        assert(
+          live.length == 1 && live.head.amtPassthrough.contains(passthrough),
+          s"passthrough must reconstruct from the AMT; got " +
+            s"${live.map(_.amtPassthrough).toSeq}."
+        )
+      }
+    }
+  }
+
+  /**
+   * A passthrough with every [[AMTPassthrough]] field set, so tests use the whole carrier.
+   */
+  private def fullPassthrough: AMTPassthrough = AMTPassthrough(spec_id = Some(42))
+
+  /**
+   * The AMT-derived live [[AddFile]]s in the snapshot's current tree, optionally restricted to
+   * `path`.
+   */
+  private def amtFilesInTree(snapshot: Snapshot, path: Option[String] = None): Seq[AddFile] = {
+    val provider = amtProvider(snapshot).getOrElse(fail("Snapshot has no AMTCheckpointProvider."))
+    val live = provider.loadActionsForStateReconstruction(spark, snapshot.deltaLog)
+      .getOrElse(fail("AMT provider must contribute tree-derived file actions."))
+      .where("add is not null")
+      .select(col("add").as[AddFile])
+      .collect()
+      .toSeq
+    path.map(p => live.filter(_.path == p)).getOrElse(live)
   }
 
   testAcrossAMTCheckpointScenarios(


### PR DESCRIPTION
## Description

This PR adds an optional `amtPassthrough` field to the `AddFile` action. It
carries AMT-native fields (currently `spec_id`) alongside an `AddFile` so that
they can round-trip through the Delta log without being lost.

Changes:
- Add `AMTPassthrough` case class and a new optional `amtPassthrough` field on
  `AddFile`.
- Plumb the passthrough between `DataEntry` and `AddFile`
  (`AMTPassthrough.fromDataEntry`, `DataEntry.fromAddFile`), and add
  `fromRow` / `RowIndices` helpers to read the field out of an `InternalRow`.
- Wire the new field through the affected read/write and clone paths.

## How was this patch tested?

Added and updated unit tests:
- `AMTSingleActionSerializerSuite`, `AMTSnapshotSuite`, `AMTSingleCommitSuite`
- `ActionSerializerSuite`, `AddFileSuite`, `CheckpointsSuite`

## Does this PR introduce _any_ user-facing changes?

No.