### PR TITLE
[Flink] Resolve VOID columns in catalog schemas

### DIFF
--- a/flink/src/main/java/io/delta/flink/sink/sql/FlinkUnityCatalogTable.java
+++ b/flink/src/main/java/io/delta/flink/sink/sql/FlinkUnityCatalogTable.java
@@ -209,6 +209,8 @@ public class FlinkUnityCatalogTable implements CatalogTable {
           return new AtomicDataType(new BigIntType(nullable));
         case "short":
           return new AtomicDataType(new SmallIntType(nullable));
+        case "void":
+          return new AtomicDataType(new NullType());
         case "string":
           return new AtomicDataType(new VarCharType(nullable, VarCharType.MAX_LENGTH));
         case "timestamp":

--- a/flink/src/test/java/io/delta/flink/sink/sql/FlinkUnityCatalogTableTest.java
+++ b/flink/src/test/java/io/delta/flink/sink/sql/FlinkUnityCatalogTableTest.java
@@ -24,12 +24,17 @@ import io.unitycatalog.client.model.TableInfo;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
+import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.Schema;
 import org.apache.flink.table.api.Schema.UnresolvedPhysicalColumn;
+import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.catalog.CatalogTable;
+import org.apache.flink.table.catalog.GenericInMemoryCatalog;
+import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.flink.table.types.AtomicDataType;
 import org.apache.flink.table.types.KeyValueDataType;
 import org.apache.flink.table.types.logical.MapType;
+import org.apache.flink.table.types.logical.NullType;
 import org.apache.flink.table.types.logical.SmallIntType;
 import org.apache.flink.table.types.logical.TinyIntType;
 import org.apache.flink.table.types.logical.VarBinaryType;
@@ -124,6 +129,39 @@ class FlinkUnityCatalogTableTest {
     assertEquals(
         new SmallIntType(false),
         FlinkUnityCatalogTable.fromJson("{\"type\":\"short\",\"nullable\":false}")
+            .getLogicalType());
+  }
+
+  @Test
+  void testResolveTableWithVoidColumn() throws Exception {
+    TableInfo tableInfo =
+        new TableInfo()
+            .name("events")
+            .columns(
+                List.of(
+                    column("id"),
+                    new ColumnInfo()
+                        .name("pending")
+                        .typeJson(
+                            "{\"name\":\"pending\",\"type\":\"void\",\"nullable\":true,"
+                                + "\"metadata\":{}}")))
+            .dataSourceFormat(DataSourceFormat.DELTA)
+            .properties(Map.of());
+    FlinkUnityCatalogTable table =
+        new FlinkUnityCatalogTable(tableInfo, URI.create("https://example.com"), "token");
+    GenericInMemoryCatalog catalog = new GenericInMemoryCatalog("test_catalog");
+    catalog.createTable(new ObjectPath("default", "events"), table, false);
+    TableEnvironment tableEnvironment =
+        TableEnvironment.create(EnvironmentSettings.newInstance().inBatchMode().build());
+    tableEnvironment.registerCatalog("test_catalog", catalog);
+
+    assertEquals(
+        new NullType(),
+        tableEnvironment
+            .from("`test_catalog`.`default`.`events`")
+            .getResolvedSchema()
+            .getColumnDataTypes()
+            .get(1)
             .getLogicalType());
   }
 


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/7392/files) to review incremental changes.
- [stack/flink-uc-void-catalog-schema](https://github.com/delta-io/delta/pull/7392) [[Files changed](https://github.com/delta-io/delta/pull/7392/files)]

---------
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [x] Flink
- [ ] Kernel
- [ ] Other

## Description

A Delta table schema can contain a `VOID` column. For example, a column created from `CAST(NULL AS VOID)` is stored in the table schema even though Parquet files do not contain physical values for it.

The Flink catalog schema parser did not recognize `void`, so Flink could not resolve the table. This change maps `void` to the existing Flink `NullType`. It changes only schema parsing; values in a `VOID` column remain null.

## How was this patch tested?

Added a focused regression test that builds a catalog table with an `id` column and a `pending VOID` column, registers it in a Flink catalog, and resolves it through `TableEnvironment`.

Passed:

- `build/sbt "flink / javafmtCheckAll"`
- `build/sbt "flink / testOnly io.delta.flink.sink.sql.FlinkUnityCatalogTableTest"` (4 tests)

## Does this PR introduce _any_ user-facing changes?

Yes. Flink can now resolve a Delta catalog table whose schema contains a top-level `VOID` column.