### PR TITLE
[Flink] Preserve column mapping metadata when writing

### DIFF
--- a/flink/src/main/java/io/delta/flink/sink/DeltaWriterTask.java
+++ b/flink/src/main/java/io/delta/flink/sink/DeltaWriterTask.java
@@ -20,6 +20,7 @@ import io.delta.flink.table.DeltaTable;
 import io.delta.kernel.data.*;
 import io.delta.kernel.defaults.internal.data.DefaultColumnarBatch;
 import io.delta.kernel.expressions.Literal;
+import io.delta.kernel.internal.util.ColumnMapping;
 import io.delta.kernel.internal.util.Utils;
 import io.delta.kernel.types.*;
 import io.delta.kernel.utils.CloseableIterator;
@@ -86,7 +87,13 @@ public class DeltaWriterTask {
     this.partitionValues = partitionValues;
     this.deltaTable = deltaTable;
     this.conf = conf;
-    this.writeSchema = conf.getSinkSchema();
+    StructType tableSchema = deltaTable.getSchema();
+    boolean columnMappingEnabled =
+        tableSchema.fields().stream()
+            .anyMatch(
+                field ->
+                    field.getMetadata().contains(ColumnMapping.COLUMN_MAPPING_PHYSICAL_NAME_KEY));
+    this.writeSchema = columnMappingEnabled ? tableSchema : conf.getSinkSchema();
 
     this.fileRollingStrategy = conf.createFileRollingStrategy();
   }

--- a/flink/src/test/java/io/delta/flink/sink/DeltaWriterTaskTest.java
+++ b/flink/src/test/java/io/delta/flink/sink/DeltaWriterTaskTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import io.delta.flink.TestHelper;
 import io.delta.flink.table.HadoopTable;
 import io.delta.kernel.data.Row;
+import io.delta.kernel.internal.TableConfig;
 import io.delta.kernel.internal.actions.AddFile;
 import io.delta.kernel.internal.actions.SingleAction;
 import io.delta.kernel.types.*;
@@ -103,6 +104,44 @@ class DeltaWriterTaskTest extends TestHelper {
                   assertEquals(idx, rows.get(idx).getInt(0));
                 }
               });
+        });
+  }
+
+  @Test
+  void testWriteToColumnMappedTable() {
+    withTempDir(
+        dir -> {
+          String tablePath = dir.getAbsolutePath();
+          StructType schema =
+              new StructType().add("id", IntegerType.INTEGER).add("payload", StringType.STRING);
+          HadoopTable table =
+              new HadoopTable(
+                  URI.create(tablePath),
+                  Map.of(TableConfig.COLUMN_MAPPING_MODE.getKey(), "name"),
+                  schema,
+                  Collections.emptyList());
+          table.open();
+
+          DeltaWriterTask writerTask =
+              new DeltaWriterTask(
+                  "test-job-id",
+                  0,
+                  0,
+                  table,
+                  new DeltaSinkConf(schema, Collections.emptyMap()),
+                  Collections.emptyMap());
+          writerTask.write(
+              GenericRowData.of(1, StringData.fromString("one")), new TestSinkWriterContext(0, 0));
+
+          DeltaWriterResult result = writerTask.complete().get(0);
+          AddFile addFile =
+              new AddFile(result.getDeltaActions().get(0).getStruct(SingleAction.ADD_FILE_ORDINAL));
+          Path fullPath = dir.toPath().resolve(addFile.getPath()).toAbsolutePath();
+          List<Row> rows = readParquet(fullPath, table.getPhysicalSchema());
+
+          assertEquals(1, rows.size());
+          assertEquals(1, rows.get(0).getInt(0));
+          assertEquals("one", rows.get(0).getString(1));
         });
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Transaction.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Transaction.java
@@ -19,7 +19,6 @@ import static io.delta.kernel.internal.DeltaErrors.dataSchemaMismatch;
 import static io.delta.kernel.internal.DeltaErrors.partitionColumnMissingInData;
 import static io.delta.kernel.internal.TransactionImpl.getStatisticsColumns;
 import static io.delta.kernel.internal.data.TransactionStateRow.*;
-import static io.delta.kernel.internal.util.ColumnMapping.blockIfColumnMappingEnabled;
 import static io.delta.kernel.internal.util.PartitionUtils.getTargetDirectory;
 import static io.delta.kernel.internal.util.PartitionUtils.validateAndSanitizePartitionValues;
 import static io.delta.kernel.internal.util.Preconditions.checkArgument;
@@ -183,6 +182,16 @@ public interface Transaction {
     List<String> partitionColNames = getPartitionColumnsList(transactionState);
     validateAndSanitizePartitionValues(tableSchema, partitionColNames, partitionValues);
 
+    ColumnMapping.ColumnMappingMode columnMappingMode = getColumnMappingMode(transactionState);
+    boolean columnMappingEnabled = ColumnMapping.isColumnMappingModeEnabled(columnMappingMode);
+    StructType physicalTableSchema =
+        columnMappingEnabled ? getPhysicalSchema(transactionState) : tableSchema;
+    List<String> physicalPartitionColNames =
+        columnMappingEnabled
+            ? PartitionUtils.toPhysicalPartitionColNames(
+                tableSchema, partitionColNames, columnMappingMode)
+            : partitionColNames;
+
     // TODO: add support for:
     // - enforcing the constraints
     // - generating the default value columns
@@ -193,13 +202,11 @@ public interface Transaction {
     Protocol protocol = getProtocol(transactionState);
     boolean materializePartitionColumnsEnabled =
         protocol.supportsFeature(TableFeatures.MATERIALIZE_PARTITION_COLUMNS_W_FEATURE);
-    blockIfColumnMappingEnabled(transactionState);
     blockIfVariantDataTypeIsDefined(tableSchema);
     // We recognize the AllowColumnDefaults feature for Iceberg v3
     // but do not support writing with it yet
     ColumnDefaults.blockWriteIfEnabled(transactionState);
 
-    // TODO: set the correct schema once writing into column mapping enabled table is supported.
     String tablePath = getTablePath(transactionState);
     return dataIter.map(
         filteredBatch -> {
@@ -208,10 +215,14 @@ public interface Transaction {
             throw dataSchemaMismatch(tablePath, tableSchema, data.getSchema());
           }
 
+          if (columnMappingEnabled) {
+            data = data.withNewSchema(physicalTableSchema);
+          }
+
           if (isIcebergCompatEnabled || materializePartitionColumnsEnabled) {
             // Move partition columns to the end of the schema for iceberg compat enabled tables
             // or when materialize partition columns feature is enabled.
-            for (String partitionColName : partitionColNames) {
+            for (String partitionColName : physicalPartitionColNames) {
               int partitionColIndex = findColIndex(data.getSchema(), partitionColName);
               if (partitionColIndex < 0) {
                 throw partitionColumnMissingInData(tablePath, partitionColName);
@@ -227,7 +238,7 @@ public interface Transaction {
           } else {
             // Remove partition columns entirely for non-materialized partitions, and non-iceberg
             // compat tables.
-            for (String partitionColName : partitionColNames) {
+            for (String partitionColName : physicalPartitionColNames) {
               int partitionColIndex = findColIndex(data.getSchema(), partitionColName);
               if (partitionColIndex < 0) {
                 throw partitionColumnMissingInData(tablePath, partitionColName);

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/TransactionSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/TransactionSuite.scala
@@ -269,20 +269,37 @@ class TransactionSuite extends AnyFunSuite with VectorTestUtils with MockEngineU
   }
 
   Seq("name", "id").foreach { cmMode =>
-    test(s"transformLogicalData: CM tables are blocked: cmMode=$cmMode") {
-      val txnState = testTxnState(new StructType(), cmMode = cmMode)
-      val engine = mockEngine()
+    Seq(false, true).foreach { partitioned =>
+      test(s"transformLogicalData: column-mapped table: " +
+        s"cmMode=$cmMode, partitioned=$partitioned") {
+        val logicalSchema = if (partitioned) {
+          columnMappedPartitionSchema
+        } else {
+          columnMappedSchema
+        }
+        val partitionColumns = if (partitioned) testPartitionColNames else Seq.empty
+        val partitionValues = if (partitioned) {
+          Map("state" -> Literal.ofString("CA"), "country" -> Literal.ofString("USA"))
+        } else {
+          Map.empty[String, Literal]
+        }
+        val txnState = testTxnState(logicalSchema, partitionColumns, cmMode = cmMode)
+        val logicalData = testData(includePartitionCols = partitioned).map { batch =>
+          new FilteredColumnarBatch(
+            batch.getData.withNewSchema(logicalSchema),
+            batch.getSelectionVector)
+        }
 
-      val ex = intercept[UnsupportedOperationException] {
         transformLogicalData(
-          engine,
+          mockEngine(),
           txnState,
-          testData(includePartitionCols = false),
-          Map.empty[String, Literal].asJava /* partition values */ )
-          .forEachRemaining(_ => ()) // consume the iterator
+          logicalData,
+          partitionValues.asJava)
+          .map(_.getData)
+          .forEachRemaining { batch =>
+            assert(batch.getSchema === expectedColumnMappedDataSchema(cmMode))
+          }
       }
-      assert(ex.getMessage.contains(
-        "Writing into column mapping enabled table is not supported yet."))
     }
   }
 
@@ -375,6 +392,14 @@ object TransactionSuite extends VectorTestUtils with MockEngineUtils {
     .add("state", StringType.STRING, true, columnMappingMetadata("col-state", 4))
     .add("country", StringType.STRING, true, columnMappingMetadata("col-country", 5))
 
+  val columnMappedSchema: StructType =
+    new StructType(columnMappedPartitionSchema.fields().subList(0, 3))
+
+  def expectedColumnMappedDataSchema(cmMode: String): StructType = {
+    val txnState = testTxnState(columnMappedSchema, cmMode = cmMode)
+    TransactionStateRow.getPhysicalSchema(txnState)
+  }
+
   def columnarBatch(schema: StructType, vectors: Seq[ColumnVector]): ColumnarBatch = {
     new ColumnarBatch {
       override def getSchema: StructType = schema
@@ -391,6 +416,11 @@ object TransactionSuite extends VectorTestUtils with MockEngineUtils {
         val newColumnVectors = vectors.toBuffer
         newColumnVectors.remove(ordinal)
         columnarBatch(newSchema, newColumnVectors.toSeq)
+      }
+
+      override def withNewSchema(newSchema: StructType): ColumnarBatch = {
+        require(schema.equivalent(newSchema))
+        columnarBatch(newSchema, vectors)
       }
 
       override def withNewColumn(

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ColumnDefaultsSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ColumnDefaultsSuite.scala
@@ -114,7 +114,7 @@ class ColumnDefaultsSuite extends AnyFunSuite with WriteUtils {
         val e = intercept[UnsupportedOperationException] {
           appendData(engine, tablePath, data = Seq(Map.empty[String, Literal] -> dataBatches1))
         }
-        assert(e.getMessage == "Writing into column mapping enabled table is not supported yet.")
+        assert(e.getMessage == "Writing with Column Default values is not supported yet.")
       }
     }
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaColumnMappingSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaColumnMappingSuite.scala
@@ -246,16 +246,23 @@ trait DeltaColumnMappingSuiteBase extends AnyFunSuite with AbstractWriteUtils
   }
 
   Seq("name", "id").foreach { cmMode =>
-    test(s"test writing data into a column mapping enabled table is blocked: $cmMode") {
+    test(s"write data into a column mapping enabled table: $cmMode") {
       withTempDirAndEngine { (tablePath, engine) =>
         val props = Map(TableConfig.COLUMN_MAPPING_MODE.getKey -> cmMode)
         createEmptyTable(engine, tablePath, testSchema, tableProperties = props)
 
-        val ex = intercept[UnsupportedOperationException] {
-          appendData(engine, tablePath, data = Seq(Map.empty[String, Literal] -> dataBatches1))
-        }
-        assert(ex.getMessage.contains(
-          "Writing into column mapping enabled table is not supported yet."))
+        val logicalSchema = getMetadata(engine, tablePath).getSchema
+        val data = generateData(logicalSchema, Seq.empty, Map.empty, 200, 3)
+        appendData(engine, tablePath, data = Seq(Map.empty[String, Literal] -> data))
+
+        val kernelRowCount = readTableUsingKernel(engine, tablePath, logicalSchema)
+          .map(_.getData.getSize)
+          .sum
+        assert(kernelRowCount === 600)
+
+        val sparkRows = spark.read.format("delta").load(tablePath).select("id").collect()
+        assert(sparkRows.length === 600)
+        assert(sparkRows.count(_.isNullAt(0)) === 30)
       }
     }
   }


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/7395/files/b969fc92b84f49ef34a2fe78f0c86b0caab0241a..971c11d81ea8845a3caf414c078ec947539531e0) to review incremental changes.
- [stack/kernel-column-mapping-data-writes](https://github.com/delta-io/delta/pull/7394) [[Files changed](https://github.com/delta-io/delta/pull/7394/files)]
  - [**stack/flink-column-mapping-data-writes**](https://github.com/delta-io/delta/pull/7395) [[Files changed](https://github.com/delta-io/delta/pull/7395/files/b969fc92b84f49ef34a2fe78f0c86b0caab0241a..971c11d81ea8845a3caf414c078ec947539531e0)] ← _this PR_
    - [stack/kernel-column-mapping-partition-stats](https://github.com/delta-io/delta/pull/7396) [[Files changed](https://github.com/delta-io/delta/pull/7396/files/971c11d81ea8845a3caf414c078ec947539531e0..e86280ef9fbd22d481ff2adca740233e729109a0)]
      - [stack/kernel-field-id-validation-collections](https://github.com/delta-io/delta/pull/7397) [[Files changed](https://github.com/delta-io/delta/pull/7397/files/e86280ef9fbd22d481ff2adca740233e729109a0..dd861b6fb46614784ae118420f9e8730ee96d67e)]
        - [stack/flink-schema-evolution-logical-validation](https://github.com/delta-io/delta/pull/7399) [[Files changed](https://github.com/delta-io/delta/pull/7399/files/dd861b6fb46614784ae118420f9e8730ee96d67e..186aee80adafbd16178a299c50595d5085aa0ffd)]
          - [stack/flink-schema-evolution-null-padding](https://github.com/delta-io/delta/pull/7400) [[Files changed](https://github.com/delta-io/delta/pull/7400/files/186aee80adafbd16178a299c50595d5085aa0ffd..8f610cf10858bd9725a2964bbcf7633c75a4f51c)]

---------
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [x] Flink
- [ ] Kernel
- [ ] Other

## Description

A column-mapped Delta table stores a logical-to-physical name for each field. For example:

```text
Flink row:     customer_id = 1
Delta mapping: customer_id -> col-a1b2...
Parquet field: col-a1b2... = 1
```

Flink's sink schema does not keep this Delta field metadata. As a result, Kernel could not translate Flink's logical column names to the physical Parquet names.

This change detects column mapping metadata on the table schema. For those tables only, `DeltaWriterTask` attaches the table's logical schema to each outgoing batch so Kernel can perform the translation. Tables without column mapping continue to use the configured sink schema exactly as before.

## How was this patch tested?

Passed:

- `build/sbt "flink / testOnly io.delta.flink.sink.DeltaWriterTaskTest"` (11 tests)
- `build/sbt "flink / javafmtCheckAll"`

The regression test uses a framework-managed temporary directory, writes a row to a `name`-mapped table, reads the Parquet file through its physical schema, and checks both values.

## Does this PR introduce _any_ user-facing changes?

Yes. The Flink sink can now preserve column mapping metadata while writing to a column-mapped Delta table.