### PR TITLE
[Kernel] Allow field IDs without collection element IDs

### DIFF
--- a/flink/src/main/java/io/delta/flink/sink/DeltaWriterTask.java
+++ b/flink/src/main/java/io/delta/flink/sink/DeltaWriterTask.java
@@ -20,6 +20,7 @@ import io.delta.flink.table.DeltaTable;
 import io.delta.kernel.data.*;
 import io.delta.kernel.defaults.internal.data.DefaultColumnarBatch;
 import io.delta.kernel.expressions.Literal;
+import io.delta.kernel.internal.util.ColumnMapping;
 import io.delta.kernel.internal.util.Utils;
 import io.delta.kernel.types.*;
 import io.delta.kernel.utils.CloseableIterator;
@@ -86,7 +87,13 @@ public class DeltaWriterTask {
     this.partitionValues = partitionValues;
     this.deltaTable = deltaTable;
     this.conf = conf;
-    this.writeSchema = conf.getSinkSchema();
+    StructType tableSchema = deltaTable.getSchema();
+    boolean columnMappingEnabled =
+        tableSchema.fields().stream()
+            .anyMatch(
+                field ->
+                    field.getMetadata().contains(ColumnMapping.COLUMN_MAPPING_PHYSICAL_NAME_KEY));
+    this.writeSchema = columnMappingEnabled ? tableSchema : conf.getSinkSchema();
 
     this.fileRollingStrategy = conf.createFileRollingStrategy();
   }

--- a/flink/src/test/java/io/delta/flink/sink/DeltaSinkTest.java
+++ b/flink/src/test/java/io/delta/flink/sink/DeltaSinkTest.java
@@ -30,7 +30,9 @@ import io.delta.kernel.Snapshot.ChecksumWriteMode;
 import io.delta.kernel.TableManager;
 import io.delta.kernel.data.Row;
 import io.delta.kernel.defaults.engine.DefaultEngine;
+import io.delta.kernel.expressions.Column;
 import io.delta.kernel.internal.actions.AddFile;
+import io.delta.kernel.transaction.DataLayoutSpec;
 import io.delta.kernel.types.*;
 import io.delta.kernel.types.ArrayType;
 import io.delta.kernel.utils.CloseableIterable;
@@ -393,6 +395,50 @@ public class DeltaSinkTest extends TestHelper {
 
           assertNotNull(deltaSink.createWriter(new TestWriterInitContext(1, 1, 1)));
           assertNotNull(deltaSink.createCommitter(new TestCommitterInitContext(1, 1, 1)));
+        });
+  }
+
+  @Test
+  void testColumnMappedPartitionedWrite() {
+    withTempDir(
+        dir -> {
+          String tablePath = dir.getPath();
+          RowType flinkSchema =
+              RowType.of(
+                  new LogicalType[] {new IntType(), new VarCharType(VarCharType.MAX_LENGTH)},
+                  new String[] {"id", "region"});
+          StructType deltaSchema = Conversions.FlinkToDelta.schema(flinkSchema);
+          DefaultEngine engine = DefaultEngine.create(new Configuration());
+          TableManager.buildCreateTableTransaction(tablePath, deltaSchema, "test")
+              .withTableProperties(Map.of("delta.columnMapping.mode", "name"))
+              .withDataLayoutSpec(DataLayoutSpec.partitioned(List.of(new Column("region"))))
+              .build(engine)
+              .commit(engine, CloseableIterable.emptyIterable());
+
+          DeltaSink deltaSink =
+              DeltaSink.builder()
+                  .withTablePath(tablePath)
+                  .withFlinkSchema(flinkSchema)
+                  .withPartitionColNames(List.of("region"))
+                  .build();
+
+          runSink(
+              deltaSink,
+              flinkSchema,
+              2,
+              String::valueOf,
+              value -> {
+                int id = Integer.parseInt(value);
+                return GenericRowData.of(id, StringData.fromString(id == 0 ? "west" : "east"));
+              });
+
+          verifyTableContent(
+              tablePath,
+              (version, actions, props) -> {
+                List<AddFile> actionList = new ArrayList<>();
+                actions.iterator().forEachRemaining(actionList::add);
+                assertEquals(2, actionList.stream().mapToLong(a -> a.getNumRecords().get()).sum());
+              });
         });
   }
 

--- a/flink/src/test/java/io/delta/flink/sink/DeltaWriterTaskTest.java
+++ b/flink/src/test/java/io/delta/flink/sink/DeltaWriterTaskTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import io.delta.flink.TestHelper;
 import io.delta.flink.table.HadoopTable;
 import io.delta.kernel.data.Row;
+import io.delta.kernel.internal.TableConfig;
 import io.delta.kernel.internal.actions.AddFile;
 import io.delta.kernel.internal.actions.SingleAction;
 import io.delta.kernel.types.*;
@@ -103,6 +104,44 @@ class DeltaWriterTaskTest extends TestHelper {
                   assertEquals(idx, rows.get(idx).getInt(0));
                 }
               });
+        });
+  }
+
+  @Test
+  void testWriteToColumnMappedTable() {
+    withTempDir(
+        dir -> {
+          String tablePath = dir.getAbsolutePath();
+          StructType schema =
+              new StructType().add("id", IntegerType.INTEGER).add("payload", StringType.STRING);
+          HadoopTable table =
+              new HadoopTable(
+                  URI.create(tablePath),
+                  Map.of(TableConfig.COLUMN_MAPPING_MODE.getKey(), "name"),
+                  schema,
+                  Collections.emptyList());
+          table.open();
+
+          DeltaWriterTask writerTask =
+              new DeltaWriterTask(
+                  "test-job-id",
+                  0,
+                  0,
+                  table,
+                  new DeltaSinkConf(schema, Collections.emptyMap()),
+                  Collections.emptyMap());
+          writerTask.write(
+              GenericRowData.of(1, StringData.fromString("one")), new TestSinkWriterContext(0, 0));
+
+          DeltaWriterResult result = writerTask.complete().get(0);
+          AddFile addFile =
+              new AddFile(result.getDeltaActions().get(0).getStruct(SingleAction.ADD_FILE_ORDINAL));
+          Path fullPath = dir.toPath().resolve(addFile.getPath()).toAbsolutePath();
+          List<Row> rows = readParquet(fullPath, table.getPhysicalSchema());
+
+          assertEquals(1, rows.size());
+          assertEquals(1, rows.get(0).getInt(0));
+          assertEquals("one", rows.get(0).getString(1));
         });
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Transaction.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Transaction.java
@@ -19,7 +19,6 @@ import static io.delta.kernel.internal.DeltaErrors.dataSchemaMismatch;
 import static io.delta.kernel.internal.DeltaErrors.partitionColumnMissingInData;
 import static io.delta.kernel.internal.TransactionImpl.getStatisticsColumns;
 import static io.delta.kernel.internal.data.TransactionStateRow.*;
-import static io.delta.kernel.internal.util.ColumnMapping.blockIfColumnMappingEnabled;
 import static io.delta.kernel.internal.util.PartitionUtils.getTargetDirectory;
 import static io.delta.kernel.internal.util.PartitionUtils.validateAndSanitizePartitionValues;
 import static io.delta.kernel.internal.util.Preconditions.checkArgument;
@@ -183,6 +182,16 @@ public interface Transaction {
     List<String> partitionColNames = getPartitionColumnsList(transactionState);
     validateAndSanitizePartitionValues(tableSchema, partitionColNames, partitionValues);
 
+    ColumnMapping.ColumnMappingMode columnMappingMode = getColumnMappingMode(transactionState);
+    boolean columnMappingEnabled = ColumnMapping.isColumnMappingModeEnabled(columnMappingMode);
+    StructType physicalTableSchema =
+        columnMappingEnabled ? getPhysicalSchema(transactionState) : tableSchema;
+    List<String> physicalPartitionColNames =
+        columnMappingEnabled
+            ? PartitionUtils.toPhysicalPartitionColNames(
+                tableSchema, partitionColNames, columnMappingMode)
+            : partitionColNames;
+
     // TODO: add support for:
     // - enforcing the constraints
     // - generating the default value columns
@@ -193,13 +202,11 @@ public interface Transaction {
     Protocol protocol = getProtocol(transactionState);
     boolean materializePartitionColumnsEnabled =
         protocol.supportsFeature(TableFeatures.MATERIALIZE_PARTITION_COLUMNS_W_FEATURE);
-    blockIfColumnMappingEnabled(transactionState);
     blockIfVariantDataTypeIsDefined(tableSchema);
     // We recognize the AllowColumnDefaults feature for Iceberg v3
     // but do not support writing with it yet
     ColumnDefaults.blockWriteIfEnabled(transactionState);
 
-    // TODO: set the correct schema once writing into column mapping enabled table is supported.
     String tablePath = getTablePath(transactionState);
     return dataIter.map(
         filteredBatch -> {
@@ -208,10 +215,14 @@ public interface Transaction {
             throw dataSchemaMismatch(tablePath, tableSchema, data.getSchema());
           }
 
+          if (columnMappingEnabled) {
+            data = data.withNewSchema(physicalTableSchema);
+          }
+
           if (isIcebergCompatEnabled || materializePartitionColumnsEnabled) {
             // Move partition columns to the end of the schema for iceberg compat enabled tables
             // or when materialize partition columns feature is enabled.
-            for (String partitionColName : partitionColNames) {
+            for (String partitionColName : physicalPartitionColNames) {
               int partitionColIndex = findColIndex(data.getSchema(), partitionColName);
               if (partitionColIndex < 0) {
                 throw partitionColumnMissingInData(tablePath, partitionColName);
@@ -227,7 +238,7 @@ public interface Transaction {
           } else {
             // Remove partition columns entirely for non-materialized partitions, and non-iceberg
             // compat tables.
-            for (String partitionColName : partitionColNames) {
+            for (String partitionColName : physicalPartitionColNames) {
               int partitionColIndex = findColIndex(data.getSchema(), partitionColName);
               if (partitionColIndex < 0) {
                 throw partitionColumnMissingInData(tablePath, partitionColName);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
@@ -87,12 +87,16 @@ public class TransactionImpl implements Transaction {
         TableConfig.DATA_SKIPPING_NUM_INDEXED_COLS.fromMetadata(
             TransactionStateRow.getConfiguration(transactionState));
 
-    // Get the list of partition columns to exclude
+    // Statistics use the physical schema, so partition columns must use physical names too.
     Set<String> partitionColumns =
-        new HashSet<>(TransactionStateRow.getPartitionColumnsList(transactionState));
+        new HashSet<>(
+            PartitionUtils.toPhysicalPartitionColNames(
+                TransactionStateRow.getLogicalSchema(transactionState),
+                TransactionStateRow.getPartitionColumnsList(transactionState),
+                TransactionStateRow.getColumnMappingMode(transactionState)));
 
     // Collect the leaf-level columns for statistics calculation.
-    // This call selects only the first 'numIndexedCols' leaf columns from the logical schema,
+    // This call selects only the first 'numIndexedCols' leaf columns from the physical schema,
     // excluding any column whose top-level name appears in 'partitionColumns'.
     // NOTE: Nested columns (i.e. each leaf within a StructType) count individually toward the
     // numIndexedCols limit (not Map/ArrayTypes - they're not stats compatible types).

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/TransactionSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/TransactionSuite.scala
@@ -269,20 +269,37 @@ class TransactionSuite extends AnyFunSuite with VectorTestUtils with MockEngineU
   }
 
   Seq("name", "id").foreach { cmMode =>
-    test(s"transformLogicalData: CM tables are blocked: cmMode=$cmMode") {
-      val txnState = testTxnState(new StructType(), cmMode = cmMode)
-      val engine = mockEngine()
+    Seq(false, true).foreach { partitioned =>
+      test(s"transformLogicalData: column-mapped table: " +
+        s"cmMode=$cmMode, partitioned=$partitioned") {
+        val logicalSchema = if (partitioned) {
+          columnMappedPartitionSchema
+        } else {
+          columnMappedSchema
+        }
+        val partitionColumns = if (partitioned) testPartitionColNames else Seq.empty
+        val partitionValues = if (partitioned) {
+          Map("state" -> Literal.ofString("CA"), "country" -> Literal.ofString("USA"))
+        } else {
+          Map.empty[String, Literal]
+        }
+        val txnState = testTxnState(logicalSchema, partitionColumns, cmMode = cmMode)
+        val logicalData = testData(includePartitionCols = partitioned).map { batch =>
+          new FilteredColumnarBatch(
+            batch.getData.withNewSchema(logicalSchema),
+            batch.getSelectionVector)
+        }
 
-      val ex = intercept[UnsupportedOperationException] {
         transformLogicalData(
-          engine,
+          mockEngine(),
           txnState,
-          testData(includePartitionCols = false),
-          Map.empty[String, Literal].asJava /* partition values */ )
-          .forEachRemaining(_ => ()) // consume the iterator
+          logicalData,
+          partitionValues.asJava)
+          .map(_.getData)
+          .forEachRemaining { batch =>
+            assert(batch.getSchema === expectedColumnMappedDataSchema(cmMode))
+          }
       }
-      assert(ex.getMessage.contains(
-        "Writing into column mapping enabled table is not supported yet."))
     }
   }
 
@@ -375,6 +392,14 @@ object TransactionSuite extends VectorTestUtils with MockEngineUtils {
     .add("state", StringType.STRING, true, columnMappingMetadata("col-state", 4))
     .add("country", StringType.STRING, true, columnMappingMetadata("col-country", 5))
 
+  val columnMappedSchema: StructType =
+    new StructType(columnMappedPartitionSchema.fields().subList(0, 3))
+
+  def expectedColumnMappedDataSchema(cmMode: String): StructType = {
+    val txnState = testTxnState(columnMappedSchema, cmMode = cmMode)
+    TransactionStateRow.getPhysicalSchema(txnState)
+  }
+
   def columnarBatch(schema: StructType, vectors: Seq[ColumnVector]): ColumnarBatch = {
     new ColumnarBatch {
       override def getSchema: StructType = schema
@@ -391,6 +416,11 @@ object TransactionSuite extends VectorTestUtils with MockEngineUtils {
         val newColumnVectors = vectors.toBuffer
         newColumnVectors.remove(ordinal)
         columnarBatch(newSchema, newColumnVectors.toSeq)
+      }
+
+      override def withNewSchema(newSchema: StructType): ColumnarBatch = {
+        require(schema.equivalent(newSchema))
+        columnarBatch(newSchema, vectors)
       }
 
       override def withNewColumn(

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/TransactionSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/TransactionSuite.scala
@@ -155,6 +155,11 @@ class TransactionSuite extends AnyFunSuite with VectorTestUtils with MockEngineU
       val partitionKeys =
         ctx.asInstanceOf[DataWriteContextImpl].getPartitionValues.keySet().asScala
       assert(partitionKeys === Set("col-state", "col-country"))
+
+      assert(ctx.getStatisticsColumns.asScala.toSet === Set(
+        new Column("col-name"),
+        new Column("col-id"),
+        new Column("col-city")))
     }
   }
 

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetSchemaUtils.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetSchemaUtils.java
@@ -572,7 +572,7 @@ class ParquetSchemaUtils {
         if (isNestedFieldId) {
           seemNestedWithNoId.set(true);
           checkArgument(
-              !seenNestedFieldWithId.get() && !seenFieldWithId.get(),
+              !seenNestedFieldWithId.get(),
               "Some of the fields are missing field ids.\n%s",
               structType);
         } else {

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ColumnDefaultsSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ColumnDefaultsSuite.scala
@@ -114,7 +114,7 @@ class ColumnDefaultsSuite extends AnyFunSuite with WriteUtils {
         val e = intercept[UnsupportedOperationException] {
           appendData(engine, tablePath, data = Seq(Map.empty[String, Literal] -> dataBatches1))
         }
-        assert(e.getMessage == "Writing into column mapping enabled table is not supported yet.")
+        assert(e.getMessage == "Writing with Column Default values is not supported yet.")
       }
     }
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaColumnMappingSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaColumnMappingSuite.scala
@@ -246,16 +246,23 @@ trait DeltaColumnMappingSuiteBase extends AnyFunSuite with AbstractWriteUtils
   }
 
   Seq("name", "id").foreach { cmMode =>
-    test(s"test writing data into a column mapping enabled table is blocked: $cmMode") {
+    test(s"write data into a column mapping enabled table: $cmMode") {
       withTempDirAndEngine { (tablePath, engine) =>
         val props = Map(TableConfig.COLUMN_MAPPING_MODE.getKey -> cmMode)
         createEmptyTable(engine, tablePath, testSchema, tableProperties = props)
 
-        val ex = intercept[UnsupportedOperationException] {
-          appendData(engine, tablePath, data = Seq(Map.empty[String, Literal] -> dataBatches1))
-        }
-        assert(ex.getMessage.contains(
-          "Writing into column mapping enabled table is not supported yet."))
+        val logicalSchema = getMetadata(engine, tablePath).getSchema
+        val data = generateData(logicalSchema, Seq.empty, Map.empty, 200, 3)
+        appendData(engine, tablePath, data = Seq(Map.empty[String, Literal] -> data))
+
+        val kernelRowCount = readTableUsingKernel(engine, tablePath, logicalSchema)
+          .map(_.getData.getSize)
+          .sum
+        assert(kernelRowCount === 600)
+
+        val sparkRows = spark.read.format("delta").load(tablePath).select("id").collect()
+        assert(sparkRows.length === 600)
+        assert(sparkRows.count(_.isNullAt(0)) === 30)
       }
     }
   }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/parquet/ParquetSchemaUtilsSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/parquet/ParquetSchemaUtilsSuite.scala
@@ -442,6 +442,20 @@ class ParquetSchemaUtilsSuite extends AnyFunSuite with TestUtils {
       }
   }
 
+  test("field ids do not require ids for array and map elements") {
+    val parquetSchema = ParquetSchemaUtils.toParquetSchema(testParquetFileDeltaSchema)
+    val arrayField = parquetSchema.getFields.get(1)
+    val mapField = parquetSchema.getFields.get(2)
+
+    assert(arrayField.getId.intValue() === 4)
+    assert(parquetSchema.getType("f1", "list").getId === null)
+    assert(parquetSchema.getType("f1", "list", "element").getId === null)
+    assert(mapField.getId.intValue() === 7)
+    assert(parquetSchema.getType("f2", "key_value").getId === null)
+    assert(parquetSchema.getType("f2", "key_value", "key").getId === null)
+    assert(parquetSchema.getType("f2", "key_value", "value").getId === null)
+  }
+
   test("toParquetSchema - GeometryType maps to BINARY with GEOMETRY annotation") {
     val deltaSchema = new StructType()
       .add("geom", new GeometryType("OGC:CRS84"))


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/7397/files/e86280ef9fbd22d481ff2adca740233e729109a0..dd861b6fb46614784ae118420f9e8730ee96d67e) to review incremental changes.
- [stack/kernel-column-mapping-data-writes](https://github.com/delta-io/delta/pull/7394) [[Files changed](https://github.com/delta-io/delta/pull/7394/files)]
  - [stack/flink-column-mapping-data-writes](https://github.com/delta-io/delta/pull/7395) [[Files changed](https://github.com/delta-io/delta/pull/7395/files/b969fc92b84f49ef34a2fe78f0c86b0caab0241a..971c11d81ea8845a3caf414c078ec947539531e0)]
    - [stack/kernel-column-mapping-partition-stats](https://github.com/delta-io/delta/pull/7396) [[Files changed](https://github.com/delta-io/delta/pull/7396/files/971c11d81ea8845a3caf414c078ec947539531e0..e86280ef9fbd22d481ff2adca740233e729109a0)]
      - [**stack/kernel-field-id-validation-collections**](https://github.com/delta-io/delta/pull/7397) [[Files changed](https://github.com/delta-io/delta/pull/7397/files/e86280ef9fbd22d481ff2adca740233e729109a0..dd861b6fb46614784ae118420f9e8730ee96d67e)] ← _this PR_
        - [stack/flink-schema-evolution-logical-validation](https://github.com/delta-io/delta/pull/7399) [[Files changed](https://github.com/delta-io/delta/pull/7399/files/dd861b6fb46614784ae118420f9e8730ee96d67e..186aee80adafbd16178a299c50595d5085aa0ffd)]
          - [stack/flink-schema-evolution-null-padding](https://github.com/delta-io/delta/pull/7400) [[Files changed](https://github.com/delta-io/delta/pull/7400/files/186aee80adafbd16178a299c50595d5085aa0ffd..8f610cf10858bd9725a2964bbcf7633c75a4f51c)]

---------
#### Which Delta project/connector is this regarding?

Delta Kernel

Signed-off-by: Timothy Wang <timothy.art@gmail.com>

## Description

A Delta schema can give field IDs to regular columns without giving IDs to the synthetic Parquet nodes used for array elements and map keys or values. This is the normal shape of a column-mapped table containing an array or map.

Kernel incorrectly rejected that valid schema with `Some of the fields are missing field ids`. The validator mixed the regular-column checks with the collection-node checks.

This patch changes one condition so a missing collection-node ID is compared only with other collection-node IDs. Regular field-ID validation is unchanged, and a schema that mixes collection nodes with and without IDs is still rejected.

## How was this patch tested?

- `build/sbt 'kernelDefaults/testOnly io.delta.kernel.defaults.internal.parquet.ParquetSchemaUtilsSuite io.delta.kernel.defaults.internal.parquet.ParquetFileWriterSuite'` (47 tests passed)
- Cross-engine tests wrote `id`-mapped arrays, maps, and nested structs from Flink and read the same values from two independent Spark readers.
- A second cross-engine test added nested fields between Flink commits and verified every row from both Spark readers.

## Does this PR introduce _any_ user-facing changes?

Yes. Kernel writers can now write valid schemas that have regular field IDs but no array-element or map key/value IDs. Previously, these writes failed before a Parquet file was created.
