### PR TITLE
[Flink] Propagate writer completion failures

### DIFF
--- a/flink/src/main/java/io/delta/flink/sink/mergestrategy/AppendOnly.java
+++ b/flink/src/main/java/io/delta/flink/sink/mergestrategy/AppendOnly.java
@@ -49,9 +49,13 @@ public class AppendOnly
 
   private List<DeltaWriterResult> completedWrites;
 
+  /** First task failure, saved because Caffeine does not propagate removal-listener exceptions. */
+  private RuntimeException writerCompletionFailure;
+
   public void init(DeltaSinkWriter writer) {
     this.writer = writer;
     this.completedWrites = new ArrayList<>();
+    this.writerCompletionFailure = null;
     this.writerTasksByPartition =
         Caffeine.newBuilder()
             .executor(Runnable::run)
@@ -99,6 +103,9 @@ public class AppendOnly
   @Override
   public List<DeltaWriterResult> merge() {
     writerTasksByPartition.invalidateAll();
+    if (writerCompletionFailure != null) {
+      throw writerCompletionFailure;
+    }
     List<DeltaWriterResult> results = List.copyOf(completedWrites);
     completedWrites.clear();
     return results;
@@ -112,8 +119,10 @@ public class AppendOnly
       if (value != null) {
         completedWrites.addAll(value.complete());
       }
-    } catch (IOException e) {
-      throw new RuntimeException(e);
+    } catch (IOException | RuntimeException e) {
+      if (writerCompletionFailure == null) {
+        writerCompletionFailure = ExceptionUtils.wrap(e);
+      }
     }
   }
 }

--- a/flink/src/main/java/io/delta/flink/sink/mergestrategy/Upsert.java
+++ b/flink/src/main/java/io/delta/flink/sink/mergestrategy/Upsert.java
@@ -69,6 +69,9 @@ public abstract class Upsert
 
   private final List<DeltaWriterResult> completedWrites;
 
+  /** First task failure, saved because Caffeine does not propagate removal-listener exceptions. */
+  private RuntimeException writerCompletionFailure;
+
   /**
    * @param rowLocator selects which existing files to scan for PKs that need pre-image removal when
    *     {@link #merge} runs at checkpoint boundaries.
@@ -88,6 +91,7 @@ public abstract class Upsert
   public void init(DeltaSinkWriter writer) {
     this.writer = writer;
     table = (AbstractKernelTable) writer.getTable();
+    writerCompletionFailure = null;
   }
 
   @Override
@@ -142,6 +146,9 @@ public abstract class Upsert
 
     // Dump all Writer Tasks
     writerTasksByPartition.invalidateAll();
+    if (writerCompletionFailure != null) {
+      throw writerCompletionFailure;
+    }
 
     if (!upsertedPrimaryKeys.isEmpty() || !deletedPrimaryKeys.isEmpty()) {
       try {
@@ -179,8 +186,10 @@ public abstract class Upsert
       if (value != null) {
         completedWrites.addAll(value.complete());
       }
-    } catch (IOException e) {
-      throw new RuntimeException(e);
+    } catch (IOException | RuntimeException e) {
+      if (writerCompletionFailure == null) {
+        writerCompletionFailure = ExceptionUtils.wrap(e);
+      }
     }
   }
 

--- a/flink/src/test/java/io/delta/flink/sink/DeltaSinkWriterTest.java
+++ b/flink/src/test/java/io/delta/flink/sink/DeltaSinkWriterTest.java
@@ -153,6 +153,16 @@ class DeltaSinkWriterTest extends TestHelper {
   }
 
   @Test
+  void testPrepareCommitPropagatesAppendWriterFailure() {
+    assertPrepareCommitPropagatesWriterFailure(/* upsert= */ false);
+  }
+
+  @Test
+  void testPrepareCommitPropagatesUpsertWriterFailure() {
+    assertPrepareCommitPropagatesWriterFailure(/* upsert= */ true);
+  }
+
+  @Test
   void testWriteToEmptyTableUsingMultiplePartitions() {
     withTempDir(
         dir -> {
@@ -752,6 +762,31 @@ class DeltaSinkWriterTest extends TestHelper {
         .withConf(conf)
         .withMetricGroup(UnregisteredMetricsGroup.createSinkWriterMetricGroup())
         .build();
+  }
+
+  private void assertPrepareCommitPropagatesWriterFailure(boolean upsert) {
+    withTempDir(
+        dir -> {
+          StructType schema =
+              new StructType().add("id", IntegerType.INTEGER).add("name", StringType.STRING);
+          HadoopTable table =
+              new HadoopTable(
+                  URI.create(dir.getAbsolutePath()),
+                  Collections.emptyMap(),
+                  schema,
+                  Collections.emptyList());
+          table.open();
+
+          DeltaSinkConf conf =
+              upsert
+                  ? upsertConf(schema, new int[] {0})
+                  : new DeltaSinkConf(schema, Collections.emptyMap());
+          DeltaSinkWriter sinkWriter = newSinkWriter(table, conf);
+
+          // The missing string field is detected while the cached writer task is completed.
+          sinkWriter.write(GenericRowData.of(1), new TestSinkWriterContext(0, 0));
+          assertThrows(ArrayIndexOutOfBoundsException.class, sinkWriter::prepareCommit);
+        });
   }
 
   /**


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/7398/files) to review incremental changes.
- [stack/flink-writer-completion-failures](https://github.com/delta-io/delta/pull/7398) [[Files changed](https://github.com/delta-io/delta/pull/7398/files)]

---------
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [x] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Flink keeps one file writer for each active table partition. At checkpoint time, it closes those writers and collects the new Delta files.

Before this patch, a failure while closing a writer was sent through a Caffeine cache callback. Caffeine logged the exception but did not return it to the caller. Flink could therefore report a successful checkpoint with no data files, even though writing the rows had failed.

This patch saves the first writer-completion failure and throws it immediately after all cached writers are closed. The same small check is applied to append and upsert mode. A failed writer stays failed, so a later checkpoint cannot silently skip its rows.

## How was this patch tested?

- Added append and upsert regression cases that buffer a malformed row, then verify that `prepareCommit()` returns the exact file-completion failure instead of an empty result.
- `build/sbt 'flink/testOnly io.delta.flink.sink.DeltaSinkWriterTest io.delta.flink.sink.DeltaSinkTest'` (27 tests passed, 1 existing test ignored)
- `build/sbt 'flink/javafmt'`

## Does this PR introduce _any_ user-facing changes?

Yes. A Flink job now fails its checkpoint when a cached file writer cannot finish. Previously, that failure could be logged while the checkpoint continued with an empty set of files.
