### PR TITLE
[Flink] Validate logical schema evolution

### DIFF
--- a/flink/src/main/java/io/delta/flink/sink/DeltaSinkConf.java
+++ b/flink/src/main/java/io/delta/flink/sink/DeltaSinkConf.java
@@ -20,13 +20,14 @@ import io.delta.flink.sink.mergestrategy.AppendOnly;
 import io.delta.flink.sink.mergestrategy.MoRUpsert;
 import io.delta.flink.sink.mergestrategy.Upsert;
 import io.delta.kernel.internal.types.DataTypeJsonSerDe;
+import io.delta.kernel.types.ArrayType;
+import io.delta.kernel.types.DataType;
+import io.delta.kernel.types.MapType;
 import io.delta.kernel.types.StructField;
 import io.delta.kernel.types.StructType;
 import java.io.Serializable;
 import java.util.Locale;
 import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.Configuration;
@@ -392,44 +393,80 @@ public class DeltaSinkConf implements Serializable {
     boolean allowEvolve(StructType tableSchema, StructType sinkSchema);
   }
 
-  /** Disallows any schema change. Table schema must be equivalent to sink schema. */
+  /** Disallows any schema change. Logical field names, types, order, and nullability must match. */
   static class NoEvolution implements SchemaEvolutionPolicy {
     @Override
     public boolean allowEvolve(StructType tableSchema, StructType sinkSchema) {
-      return tableSchema.equivalent(sinkSchema);
+      return sameLogicalType(tableSchema, sinkSchema);
     }
   }
 
   /**
    * Allows adding new columns in the table schema only.
    *
-   * <p>All fields in the sink schema must exist in the table schema with:
+   * <p>All fields in the sink schema must be the leading fields in the table schema with:
    *
    * <ul>
    *   <li>same name
    *   <li>equivalent data type
    *   <li>same nullability
+   *   <li>same order
    * </ul>
    *
-   * <p>This means the table schema may contain extra fields that the sink does not write yet.
+   * <p>This means the table schema may contain extra nullable trailing fields that the sink does
+   * not write yet. Reordering existing fields is rejected because writer, partition, and upsert
+   * rows use the sink schema's ordinals.
    */
   static class NewColumnEvolution implements SchemaEvolutionPolicy {
     @Override
     public boolean allowEvolve(StructType tableSchema, StructType sinkSchema) {
-      Map<String, StructField> tableFields =
-          tableSchema.fields().stream()
-              .collect(Collectors.toMap(StructField::getName, Function.identity()));
-
-      // Every field of sink schema must exist in table schema with same definition.
-      return sinkSchema.fields().stream()
-          .allMatch(
-              field -> {
-                StructField tableField = tableFields.getOrDefault(field.getName(), null);
-                return tableField != null
-                    && tableField.getDataType().equivalent(field.getDataType())
-                    && tableField.isNullable() == field.isNullable();
-              });
+      if (tableSchema.length() < sinkSchema.length()) {
+        return false;
+      }
+      for (int i = 0; i < sinkSchema.length(); i++) {
+        if (!sameLogicalField(tableSchema.at(i), sinkSchema.at(i))) {
+          return false;
+        }
+      }
+      for (int i = sinkSchema.length(); i < tableSchema.length(); i++) {
+        if (!tableSchema.at(i).isNullable()) {
+          return false;
+        }
+      }
+      return true;
     }
+  }
+
+  private static boolean sameLogicalField(StructField tableField, StructField sinkField) {
+    return tableField.getName().equals(sinkField.getName())
+        && tableField.isNullable() == sinkField.isNullable()
+        && sameLogicalType(tableField.getDataType(), sinkField.getDataType());
+  }
+
+  private static boolean sameLogicalType(DataType tableType, DataType sinkType) {
+    if (!tableType.equivalent(sinkType)) {
+      return false;
+    }
+    if (tableType instanceof StructType) {
+      StructType tableStruct = (StructType) tableType;
+      StructType sinkStruct = (StructType) sinkType;
+      for (int i = 0; i < tableStruct.length(); i++) {
+        if (!sameLogicalField(tableStruct.at(i), sinkStruct.at(i))) {
+          return false;
+        }
+      }
+    } else if (tableType instanceof ArrayType) {
+      ArrayType tableArray = (ArrayType) tableType;
+      ArrayType sinkArray = (ArrayType) sinkType;
+      return tableArray.containsNull() == sinkArray.containsNull()
+          && sameLogicalType(tableArray.getElementType(), sinkArray.getElementType());
+    } else if (tableType instanceof MapType) {
+      MapType tableMap = (MapType) tableType;
+      MapType sinkMap = (MapType) sinkType;
+      return sameLogicalType(tableMap.getKeyType(), sinkMap.getKeyType())
+          && sameLogicalType(tableMap.getValueType(), sinkMap.getValueType());
+    }
+    return true;
   }
 
   // ----------------------------------------------------------------------

--- a/flink/src/test/java/io/delta/flink/sink/DeltaSinkConfTest.java
+++ b/flink/src/test/java/io/delta/flink/sink/DeltaSinkConfTest.java
@@ -18,6 +18,7 @@ package io.delta.flink.sink;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -57,8 +58,24 @@ class DeltaSinkConfTest {
     List<StructType> blockTableSchemas =
         List.of(
             new StructType().add("id", IntegerType.INTEGER),
+            new StructType().add("name", StringType.STRING).add("id", IntegerType.INTEGER),
+            new StructType()
+                .add("id", IntegerType.INTEGER)
+                .add("inserted", StringType.STRING)
+                .add("name", StringType.STRING),
             new StructType().add("id", IntegerType.INTEGER).add("name", IntegerType.INTEGER),
-            new StructType().add("id", IntegerType.INTEGER).add("name", StringType.STRING, false));
+            new StructType().add("id", IntegerType.INTEGER).add("name", StringType.STRING, false),
+            new StructType()
+                .add("id", IntegerType.INTEGER)
+                .add("name", StringType.STRING)
+                .add("required", LongType.LONG, false),
+            new StructType()
+                .add("id", IntegerType.INTEGER)
+                .add(
+                    "name",
+                    new StructType()
+                        .add("last", StringType.STRING)
+                        .add("first", StringType.STRING)));
     assertTrue(
         blockTableSchemas.stream()
             .allMatch(
@@ -76,14 +93,14 @@ class DeltaSinkConfTest {
         List.of(
             new StructType()
                 .add(
-                    "name",
-                    StringType.STRING,
+                    "id",
+                    IntegerType.INTEGER,
                     true,
                     FieldMetadata.builder()
                         .putString(ColumnMapping.COLUMN_MAPPING_PHYSICAL_NAME_KEY, "uuid1")
                         .putString(ColumnMapping.COLUMN_MAPPING_ID_KEY, "1")
                         .build())
-                .add("id", IntegerType.INTEGER),
+                .add("name", StringType.STRING),
             new StructType()
                 .add(
                     "id",
@@ -109,6 +126,98 @@ class DeltaSinkConfTest {
     assertTrue(
         allowTableSchemas.stream()
             .allMatch(
+                tableSchema -> conf.getSchemaEvolutionPolicy().allowEvolve(tableSchema, schema)));
+
+    StructType reorderedTableSchema =
+        new StructType()
+            .add(
+                "name",
+                StringType.STRING,
+                true,
+                FieldMetadata.builder()
+                    .putString(ColumnMapping.COLUMN_MAPPING_PHYSICAL_NAME_KEY, "uuid1")
+                    .putString(ColumnMapping.COLUMN_MAPPING_ID_KEY, "1")
+                    .build())
+            .add("id", IntegerType.INTEGER);
+    assertFalse(conf.getSchemaEvolutionPolicy().allowEvolve(reorderedTableSchema, schema));
+  }
+
+  @Test
+  void testNoEvolutionChecksLogicalNamesRecursively() {
+    StructType schema =
+        new StructType()
+            .add("id", IntegerType.INTEGER)
+            .add(
+                "profile",
+                new StructType().add("first", StringType.STRING).add("last", StringType.STRING));
+    DeltaSinkConf conf = new DeltaSinkConf(schema, Map.of());
+
+    assertTrue(conf.getSchemaEvolutionPolicy().allowEvolve(schema, schema));
+    assertFalse(
+        conf.getSchemaEvolutionPolicy()
+            .allowEvolve(
+                new StructType()
+                    .add("renamed", IntegerType.INTEGER)
+                    .add("profile", schema.at(1).getDataType()),
+                schema));
+    assertFalse(
+        conf.getSchemaEvolutionPolicy()
+            .allowEvolve(
+                new StructType()
+                    .add("id", IntegerType.INTEGER)
+                    .add(
+                        "profile",
+                        new StructType()
+                            .add("last", StringType.STRING)
+                            .add("first", StringType.STRING)),
+                schema));
+  }
+
+  @Test
+  void testNoEvolutionChecksCollectionTypesRecursively() {
+    StructType child =
+        new StructType().add("first", StringType.STRING).add("last", StringType.STRING);
+    StructType schema =
+        new StructType()
+            .add("items", new ArrayType(child, true))
+            .add("lookup", new MapType(StringType.STRING, child, true));
+    DeltaSinkConf conf = new DeltaSinkConf(schema, Map.of());
+    StructType reorderedChild =
+        new StructType().add("last", StringType.STRING).add("first", StringType.STRING);
+    StructType mappedChild =
+        new StructType()
+            .add(
+                "first",
+                StringType.STRING,
+                true,
+                FieldMetadata.builder()
+                    .putString(ColumnMapping.COLUMN_MAPPING_PHYSICAL_NAME_KEY, "uuid1")
+                    .build())
+            .add("last", StringType.STRING);
+
+    StructType mappedSchema =
+        new StructType()
+            .add("items", new ArrayType(mappedChild, true))
+            .add("lookup", new MapType(StringType.STRING, mappedChild, true));
+    assertTrue(conf.getSchemaEvolutionPolicy().allowEvolve(mappedSchema, schema));
+
+    List<StructType> incompatibleSchemas =
+        List.of(
+            new StructType()
+                .add("items", new ArrayType(reorderedChild, true))
+                .add("lookup", new MapType(StringType.STRING, child, true)),
+            new StructType()
+                .add("items", new ArrayType(child, false))
+                .add("lookup", new MapType(StringType.STRING, child, true)),
+            new StructType()
+                .add("items", new ArrayType(child, true))
+                .add("lookup", new MapType(StringType.STRING, reorderedChild, true)),
+            new StructType()
+                .add("items", new ArrayType(child, true))
+                .add("lookup", new MapType(StringType.STRING, child, false)));
+    assertTrue(
+        incompatibleSchemas.stream()
+            .noneMatch(
                 tableSchema -> conf.getSchemaEvolutionPolicy().allowEvolve(tableSchema, schema)));
   }
 


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/7399/files) to review incremental changes.
- [**stack/flink-schema-evolution-logical-validation**](https://github.com/delta-io/delta/pull/7399) [[Files changed](https://github.com/delta-io/delta/pull/7399/files)] ← _this PR_
  - [stack/flink-schema-evolution-null-padding](https://github.com/delta-io/delta/pull/7400) [[Files changed](https://github.com/delta-io/delta/pull/7400/files/69aeac6322a5720a3323d1e57618d8e1ea0160e5..dc9f309425bbdb04b368b7602023dd7edcf0dc9a)]

---------
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [x] Flink
- [ ] Kernel
- [ ] Other

## Description

Flink rows store values by position. Before this change, schema evolution could accept a table whose fields had the same data types but different logical names or order. For example, a sink row shaped as `(id, name)` could be accepted after the table changed to `(name, id)`. The writer, partition handling, and upsert lookup could then read the wrong value from each position.

This PR validates the logical schema recursively. Field names, types, order, and nullability must match. The `newcolumn` mode accepts only nullable fields added at the end of the table schema, because that keeps every existing field at its original position. Rename, reorder, middle insertion, required-field addition, and incompatible nested array, map, or struct changes are rejected.

Column-mapping metadata is intentionally ignored by this comparison because it does not change the logical row layout.

## How was this patch tested?

- `build/sbt 'flink / Test / javafmt'`
- `build/sbt 'flink/testOnly io.delta.flink.sink.DeltaSinkConfTest io.delta.flink.sink.DeltaCommitterTest'`

The focused tests cover accepted nullable trailing fields and rejected top-level, struct, array, and map changes, including nested order and nullability. All 20 focused tests passed.

## Does this PR introduce _any_ user-facing changes?

Yes. Unsafe schema changes that were previously accepted by the `newcolumn` mode now fail instead of allowing position-based rows to be written incorrectly. Compatible nullable fields added at the end remain allowed.
