### PR TITLE
[Flink] Pad nullable columns after schema evolution

### DIFF
--- a/flink/src/main/java/io/delta/flink/sink/DeltaSinkConf.java
+++ b/flink/src/main/java/io/delta/flink/sink/DeltaSinkConf.java
@@ -20,13 +20,14 @@ import io.delta.flink.sink.mergestrategy.AppendOnly;
 import io.delta.flink.sink.mergestrategy.MoRUpsert;
 import io.delta.flink.sink.mergestrategy.Upsert;
 import io.delta.kernel.internal.types.DataTypeJsonSerDe;
+import io.delta.kernel.types.ArrayType;
+import io.delta.kernel.types.DataType;
+import io.delta.kernel.types.MapType;
 import io.delta.kernel.types.StructField;
 import io.delta.kernel.types.StructType;
 import java.io.Serializable;
 import java.util.Locale;
 import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.Configuration;
@@ -392,44 +393,80 @@ public class DeltaSinkConf implements Serializable {
     boolean allowEvolve(StructType tableSchema, StructType sinkSchema);
   }
 
-  /** Disallows any schema change. Table schema must be equivalent to sink schema. */
+  /** Disallows any schema change. Logical field names, types, order, and nullability must match. */
   static class NoEvolution implements SchemaEvolutionPolicy {
     @Override
     public boolean allowEvolve(StructType tableSchema, StructType sinkSchema) {
-      return tableSchema.equivalent(sinkSchema);
+      return sameLogicalType(tableSchema, sinkSchema);
     }
   }
 
   /**
    * Allows adding new columns in the table schema only.
    *
-   * <p>All fields in the sink schema must exist in the table schema with:
+   * <p>All fields in the sink schema must be the leading fields in the table schema with:
    *
    * <ul>
    *   <li>same name
    *   <li>equivalent data type
    *   <li>same nullability
+   *   <li>same order
    * </ul>
    *
-   * <p>This means the table schema may contain extra fields that the sink does not write yet.
+   * <p>This means the table schema may contain extra nullable trailing fields that the sink does
+   * not write yet. Reordering existing fields is rejected because writer, partition, and upsert
+   * rows use the sink schema's ordinals.
    */
   static class NewColumnEvolution implements SchemaEvolutionPolicy {
     @Override
     public boolean allowEvolve(StructType tableSchema, StructType sinkSchema) {
-      Map<String, StructField> tableFields =
-          tableSchema.fields().stream()
-              .collect(Collectors.toMap(StructField::getName, Function.identity()));
-
-      // Every field of sink schema must exist in table schema with same definition.
-      return sinkSchema.fields().stream()
-          .allMatch(
-              field -> {
-                StructField tableField = tableFields.getOrDefault(field.getName(), null);
-                return tableField != null
-                    && tableField.getDataType().equivalent(field.getDataType())
-                    && tableField.isNullable() == field.isNullable();
-              });
+      if (tableSchema.length() < sinkSchema.length()) {
+        return false;
+      }
+      for (int i = 0; i < sinkSchema.length(); i++) {
+        if (!sameLogicalField(tableSchema.at(i), sinkSchema.at(i))) {
+          return false;
+        }
+      }
+      for (int i = sinkSchema.length(); i < tableSchema.length(); i++) {
+        if (!tableSchema.at(i).isNullable()) {
+          return false;
+        }
+      }
+      return true;
     }
+  }
+
+  private static boolean sameLogicalField(StructField tableField, StructField sinkField) {
+    return tableField.getName().equals(sinkField.getName())
+        && tableField.isNullable() == sinkField.isNullable()
+        && sameLogicalType(tableField.getDataType(), sinkField.getDataType());
+  }
+
+  private static boolean sameLogicalType(DataType tableType, DataType sinkType) {
+    if (!tableType.equivalent(sinkType)) {
+      return false;
+    }
+    if (tableType instanceof StructType) {
+      StructType tableStruct = (StructType) tableType;
+      StructType sinkStruct = (StructType) sinkType;
+      for (int i = 0; i < tableStruct.length(); i++) {
+        if (!sameLogicalField(tableStruct.at(i), sinkStruct.at(i))) {
+          return false;
+        }
+      }
+    } else if (tableType instanceof ArrayType) {
+      ArrayType tableArray = (ArrayType) tableType;
+      ArrayType sinkArray = (ArrayType) sinkType;
+      return tableArray.containsNull() == sinkArray.containsNull()
+          && sameLogicalType(tableArray.getElementType(), sinkArray.getElementType());
+    } else if (tableType instanceof MapType) {
+      MapType tableMap = (MapType) tableType;
+      MapType sinkMap = (MapType) sinkType;
+      return sameLogicalType(tableMap.getKeyType(), sinkMap.getKeyType())
+          && sameLogicalType(tableMap.getValueType(), sinkMap.getValueType());
+    }
+    return true;
   }
 
   // ----------------------------------------------------------------------

--- a/flink/src/main/java/io/delta/flink/sink/DeltaWriterTask.java
+++ b/flink/src/main/java/io/delta/flink/sink/DeltaWriterTask.java
@@ -86,7 +86,12 @@ public class DeltaWriterTask {
     this.partitionValues = partitionValues;
     this.deltaTable = deltaTable;
     this.conf = conf;
-    this.writeSchema = conf.getSinkSchema();
+    StructType tableSchema = deltaTable.getSchema();
+    if (!conf.getSchemaEvolutionPolicy().allowEvolve(tableSchema, conf.getSinkSchema())) {
+      throw new IllegalStateException("Invalid schema evolution observed");
+    }
+    this.writeSchema =
+        tableSchema.length() > conf.getSinkSchema().length() ? tableSchema : conf.getSinkSchema();
 
     this.fileRollingStrategy = conf.createFileRollingStrategy();
   }
@@ -143,7 +148,10 @@ public class DeltaWriterTask {
     RowAccess rowAccess = new RowDataListAccess(buffer);
     for (int colIdx = 0; colIdx < numColumns; colIdx++) {
       final DataType colDataType = writeSchema.at(colIdx).getDataType();
-      columnVectors[colIdx] = new RowDataColumnVectorView(rowAccess, colIdx, colDataType);
+      columnVectors[colIdx] =
+          colIdx < conf.getSinkSchema().length()
+              ? new RowDataColumnVectorView(rowAccess, colIdx, colDataType)
+              : new NullColumnVectorView(rowAccess.size(), colDataType);
     }
     return Utils.singletonCloseableIterator(
         new FilteredColumnarBatch(
@@ -214,6 +222,40 @@ public class DeltaWriterTask {
           return valueView;
         }
       };
+    }
+  }
+
+  static class NullColumnVectorView extends AbstractColumnVectorView {
+    private final int size;
+
+    NullColumnVectorView(int size, DataType dataType) {
+      super(dataType);
+      this.size = size;
+    }
+
+    @Override
+    public DataType getDataType() {
+      return dataType;
+    }
+
+    @Override
+    public int getSize() {
+      return size;
+    }
+
+    @Override
+    public void close() {}
+
+    @Override
+    public boolean isNullAt(int rowId) {
+      checkValidRowId(rowId);
+      return true;
+    }
+
+    @Override
+    public ColumnVector getChild(int ordinal) {
+      StructType structType = (StructType) dataType;
+      return new NullColumnVectorView(size, structType.at(ordinal).getDataType());
     }
   }
 

--- a/flink/src/test/java/io/delta/flink/sink/DeltaSinkConfTest.java
+++ b/flink/src/test/java/io/delta/flink/sink/DeltaSinkConfTest.java
@@ -18,6 +18,7 @@ package io.delta.flink.sink;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -57,8 +58,24 @@ class DeltaSinkConfTest {
     List<StructType> blockTableSchemas =
         List.of(
             new StructType().add("id", IntegerType.INTEGER),
+            new StructType().add("name", StringType.STRING).add("id", IntegerType.INTEGER),
+            new StructType()
+                .add("id", IntegerType.INTEGER)
+                .add("inserted", StringType.STRING)
+                .add("name", StringType.STRING),
             new StructType().add("id", IntegerType.INTEGER).add("name", IntegerType.INTEGER),
-            new StructType().add("id", IntegerType.INTEGER).add("name", StringType.STRING, false));
+            new StructType().add("id", IntegerType.INTEGER).add("name", StringType.STRING, false),
+            new StructType()
+                .add("id", IntegerType.INTEGER)
+                .add("name", StringType.STRING)
+                .add("required", LongType.LONG, false),
+            new StructType()
+                .add("id", IntegerType.INTEGER)
+                .add(
+                    "name",
+                    new StructType()
+                        .add("last", StringType.STRING)
+                        .add("first", StringType.STRING)));
     assertTrue(
         blockTableSchemas.stream()
             .allMatch(
@@ -76,14 +93,14 @@ class DeltaSinkConfTest {
         List.of(
             new StructType()
                 .add(
-                    "name",
-                    StringType.STRING,
+                    "id",
+                    IntegerType.INTEGER,
                     true,
                     FieldMetadata.builder()
                         .putString(ColumnMapping.COLUMN_MAPPING_PHYSICAL_NAME_KEY, "uuid1")
                         .putString(ColumnMapping.COLUMN_MAPPING_ID_KEY, "1")
                         .build())
-                .add("id", IntegerType.INTEGER),
+                .add("name", StringType.STRING),
             new StructType()
                 .add(
                     "id",
@@ -109,6 +126,98 @@ class DeltaSinkConfTest {
     assertTrue(
         allowTableSchemas.stream()
             .allMatch(
+                tableSchema -> conf.getSchemaEvolutionPolicy().allowEvolve(tableSchema, schema)));
+
+    StructType reorderedTableSchema =
+        new StructType()
+            .add(
+                "name",
+                StringType.STRING,
+                true,
+                FieldMetadata.builder()
+                    .putString(ColumnMapping.COLUMN_MAPPING_PHYSICAL_NAME_KEY, "uuid1")
+                    .putString(ColumnMapping.COLUMN_MAPPING_ID_KEY, "1")
+                    .build())
+            .add("id", IntegerType.INTEGER);
+    assertFalse(conf.getSchemaEvolutionPolicy().allowEvolve(reorderedTableSchema, schema));
+  }
+
+  @Test
+  void testNoEvolutionChecksLogicalNamesRecursively() {
+    StructType schema =
+        new StructType()
+            .add("id", IntegerType.INTEGER)
+            .add(
+                "profile",
+                new StructType().add("first", StringType.STRING).add("last", StringType.STRING));
+    DeltaSinkConf conf = new DeltaSinkConf(schema, Map.of());
+
+    assertTrue(conf.getSchemaEvolutionPolicy().allowEvolve(schema, schema));
+    assertFalse(
+        conf.getSchemaEvolutionPolicy()
+            .allowEvolve(
+                new StructType()
+                    .add("renamed", IntegerType.INTEGER)
+                    .add("profile", schema.at(1).getDataType()),
+                schema));
+    assertFalse(
+        conf.getSchemaEvolutionPolicy()
+            .allowEvolve(
+                new StructType()
+                    .add("id", IntegerType.INTEGER)
+                    .add(
+                        "profile",
+                        new StructType()
+                            .add("last", StringType.STRING)
+                            .add("first", StringType.STRING)),
+                schema));
+  }
+
+  @Test
+  void testNoEvolutionChecksCollectionTypesRecursively() {
+    StructType child =
+        new StructType().add("first", StringType.STRING).add("last", StringType.STRING);
+    StructType schema =
+        new StructType()
+            .add("items", new ArrayType(child, true))
+            .add("lookup", new MapType(StringType.STRING, child, true));
+    DeltaSinkConf conf = new DeltaSinkConf(schema, Map.of());
+    StructType reorderedChild =
+        new StructType().add("last", StringType.STRING).add("first", StringType.STRING);
+    StructType mappedChild =
+        new StructType()
+            .add(
+                "first",
+                StringType.STRING,
+                true,
+                FieldMetadata.builder()
+                    .putString(ColumnMapping.COLUMN_MAPPING_PHYSICAL_NAME_KEY, "uuid1")
+                    .build())
+            .add("last", StringType.STRING);
+
+    StructType mappedSchema =
+        new StructType()
+            .add("items", new ArrayType(mappedChild, true))
+            .add("lookup", new MapType(StringType.STRING, mappedChild, true));
+    assertTrue(conf.getSchemaEvolutionPolicy().allowEvolve(mappedSchema, schema));
+
+    List<StructType> incompatibleSchemas =
+        List.of(
+            new StructType()
+                .add("items", new ArrayType(reorderedChild, true))
+                .add("lookup", new MapType(StringType.STRING, child, true)),
+            new StructType()
+                .add("items", new ArrayType(child, false))
+                .add("lookup", new MapType(StringType.STRING, child, true)),
+            new StructType()
+                .add("items", new ArrayType(child, true))
+                .add("lookup", new MapType(StringType.STRING, reorderedChild, true)),
+            new StructType()
+                .add("items", new ArrayType(child, true))
+                .add("lookup", new MapType(StringType.STRING, child, false)));
+    assertTrue(
+        incompatibleSchemas.stream()
+            .noneMatch(
                 tableSchema -> conf.getSchemaEvolutionPolicy().allowEvolve(tableSchema, schema)));
   }
 

--- a/flink/src/test/java/io/delta/flink/sink/DeltaWriterTaskTest.java
+++ b/flink/src/test/java/io/delta/flink/sink/DeltaWriterTaskTest.java
@@ -17,6 +17,7 @@
 package io.delta.flink.sink;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.delta.flink.TestHelper;
@@ -103,6 +104,77 @@ class DeltaWriterTaskTest extends TestHelper {
                   assertEquals(idx, rows.get(idx).getInt(0));
                 }
               });
+        });
+  }
+
+  @Test
+  void testNewColumnEvolutionPadsMissingNullableColumns() {
+    withTempDir(
+        dir -> {
+          StructType tableSchema =
+              new StructType()
+                  .add("id", IntegerType.INTEGER)
+                  .add("added", new StructType().add("value", StringType.STRING));
+          HadoopTable table =
+              new HadoopTable(
+                  URI.create(dir.getAbsolutePath()),
+                  Collections.emptyMap(),
+                  tableSchema,
+                  Collections.emptyList());
+          table.open();
+
+          StructType sinkSchema = new StructType().add("id", IntegerType.INTEGER);
+          DeltaWriterTask writerTask =
+              new DeltaWriterTask(
+                  "test-job-id",
+                  0,
+                  0,
+                  table,
+                  new DeltaSinkConf(
+                      sinkSchema, Map.of(DeltaSinkConf.SCHEMA_EVOLUTION_MODE.key(), "newcolumn")),
+                  Collections.emptyMap());
+          writerTask.write(GenericRowData.of(1), new TestSinkWriterContext(0, 0));
+
+          DeltaWriterResult result = writerTask.complete().get(0);
+          AddFile addFile =
+              new AddFile(result.getDeltaActions().get(0).getStruct(SingleAction.ADD_FILE_ORDINAL));
+          Path fullPath = dir.toPath().resolve(addFile.getPath()).toAbsolutePath();
+          List<Row> rows = readParquet(fullPath, table.getPhysicalSchema());
+
+          assertEquals(1, rows.size());
+          assertEquals(1, rows.get(0).getInt(0));
+          assertTrue(rows.get(0).isNullAt(1));
+        });
+  }
+
+  @Test
+  void testWriterRejectsReorderedSinkSchema() {
+    withTempDir(
+        dir -> {
+          StructType tableSchema =
+              new StructType().add("first", StringType.STRING).add("second", StringType.STRING);
+          HadoopTable table =
+              new HadoopTable(
+                  URI.create(dir.getAbsolutePath()),
+                  Collections.emptyMap(),
+                  tableSchema,
+                  Collections.emptyList());
+          table.open();
+
+          StructType sinkSchema =
+              new StructType().add("second", StringType.STRING).add("first", StringType.STRING);
+          assertThrows(
+              IllegalStateException.class,
+              () ->
+                  new DeltaWriterTask(
+                      "test-job-id",
+                      0,
+                      0,
+                      table,
+                      new DeltaSinkConf(
+                          sinkSchema,
+                          Map.of(DeltaSinkConf.SCHEMA_EVOLUTION_MODE.key(), "newcolumn")),
+                      Collections.emptyMap()));
         });
   }
 


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/7400/files/69aeac6322a5720a3323d1e57618d8e1ea0160e5..dc9f309425bbdb04b368b7602023dd7edcf0dc9a) to review incremental changes.
- [stack/flink-schema-evolution-logical-validation](https://github.com/delta-io/delta/pull/7399) [[Files changed](https://github.com/delta-io/delta/pull/7399/files)]
  - [**stack/flink-schema-evolution-null-padding**](https://github.com/delta-io/delta/pull/7400) [[Files changed](https://github.com/delta-io/delta/pull/7400/files/69aeac6322a5720a3323d1e57618d8e1ea0160e5..dc9f309425bbdb04b368b7602023dd7edcf0dc9a)] ← _this PR_

---------
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [x] Flink
- [ ] Kernel
- [ ] Other

## Description

When a table adds a nullable field at the end, a running Flink job may still produce the older, shorter row shape. Before this change, the writer kept using that short schema, so Kernel rejected the write because it did not match the current table schema.

This PR uses the current table schema after #7399 has confirmed that the change contains only safe nullable fields added at the end. It supplies an all-null column for each new field. Nested struct fields also receive all-null child vectors when the Parquet writer asks for them.

For example, an older row `(id = 1)` can safely write to a table shaped as `(id, optional_note)`. The file stores `optional_note = null`. Rename, reorder, nested-layout changes, and required trailing fields fail before a file is written.

## How was this patch tested?

- `build/sbt 'flink/javafmt'`
- `build/sbt 'flink/testOnly io.delta.flink.sink.DeltaWriterTaskTest io.delta.flink.sink.DeltaSinkConfTest io.delta.flink.sink.DeltaCommitterTest'`

The focused tests verify null padding for a nested nullable field and early rejection of reordered fields. All 32 focused tests passed.

## Does this PR introduce _any_ user-facing changes?

Yes. A Flink job using the `newcolumn` mode can continue writing after nullable fields are added at the end of a table. The new fields are written as null until the job starts producing them.
