### PR TITLE
[Kernel] Retry when winning commits are unavailable

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ConflictChecker.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ConflictChecker.java
@@ -137,8 +137,14 @@ public class ConflictChecker {
     AtomicReference<Optional<CommitInfo>> winningCommitInfoOpt =
         new AtomicReference<>(Optional.empty());
 
-    // no winning commits. why did we get the transaction conflict?
-    checkState(!winningCommits.isEmpty(), "No winning commits found.");
+    if (winningCommits.isEmpty()) {
+      if (TableFeatures.isCatalogManagedSupported(transaction.getProtocol())) {
+        // A winning commit may be ratified before it is published to the log. Without its actions,
+        // conflict resolution is unsafe; let the caller refresh the catalog snapshot and retry.
+        throw new ConcurrentWriteException();
+      }
+      checkState(false, "No winning commits found.");
+    }
 
     // Collect the data files removed by this (losing) transaction so we can detect delete-vs-delete
     // conflicts against the winning transactions below.
@@ -449,7 +455,9 @@ public class ConflictChecker {
 
       return ensureNoGapsInWinningCommits(winningCommitFiles);
     } catch (FileNotFoundException nfe) {
-      // no winning commits. why did we get here?
+      if (TableFeatures.isCatalogManagedSupported(transaction.getProtocol())) {
+        return Collections.emptyList();
+      }
       throw new IllegalStateException("No winning commits found.", nfe);
     } catch (IOException ioe) {
       throw new UncheckedIOException("Error listing files from " + firstWinningCommitFile, ioe);

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ConflictResolutionSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ConflictResolutionSuite.scala
@@ -19,17 +19,21 @@ import java.util.{Collections, Optional}
 
 import scala.collection.JavaConverters._
 
+import io.delta.kernel.{Operation, TableManager}
+import io.delta.kernel.commit.{CatalogCommitter, CommitFailedException, CommitMetadata, CommitResponse, Committer, PublishMetadata}
 import io.delta.kernel.data.Row
-import io.delta.kernel.defaults.utils.{TestUtilsWithTableManagerAPIs, WriteUtils}
+import io.delta.kernel.defaults.utils.{TestCommitterUtils, TestUtilsWithTableManagerAPIs, WriteUtils}
 import io.delta.kernel.engine.Engine
 import io.delta.kernel.exceptions.ConcurrentWriteException
 import io.delta.kernel.expressions.Literal
 import io.delta.kernel.internal.actions.{AddFile, DeletionVectorDescriptor, RemoveFile, SingleAction}
 import io.delta.kernel.internal.data.GenericRow
+import io.delta.kernel.internal.tablefeatures.TableFeatures
 import io.delta.kernel.internal.util.PartitionUtils
 import io.delta.kernel.internal.util.Utils.toCloseableIterator
 import io.delta.kernel.utils.CloseableIterable
 import io.delta.kernel.utils.CloseableIterable.{emptyIterable, inMemoryIterable}
+import io.delta.kernel.utils.CloseableIterator
 
 import org.scalatest.funsuite.AnyFunSuite
 
@@ -45,7 +49,8 @@ import org.scalatest.funsuite.AnyFunSuite
 class ConflictResolutionSuite
     extends AnyFunSuite
     with WriteUtils
-    with TestUtilsWithTableManagerAPIs {
+    with TestUtilsWithTableManagerAPIs
+    with TestCommitterUtils {
 
   private def iterableOf(rows: Row*): CloseableIterable[Row] =
     inMemoryIterable(toCloseableIterator(rows.toSeq.asJava.iterator()))
@@ -203,6 +208,72 @@ class ConflictResolutionSuite
 
       // The losing txn removes nothing, so the delete-vs-delete check must not fire.
       commitTransaction(losingTxn, engine, iterableOf(createAddFileRow("file3.parquet")))
+    }
+  }
+
+  test("conflict resolution - unavailable catalog-managed winning commits ask caller to retry") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      val catalogManagedProperties = Map(
+        TableFeatures.CATALOG_MANAGED_RW_FEATURE.getTableFeatureSupportKey -> "supported")
+      TableManager
+        .buildCreateTableTransaction(tablePath, testSchema, "test-engine")
+        .withTableProperties(catalogManagedProperties.asJava)
+        .withCommitter(customCatalogCommitter)
+        .build(engine)
+        .commit(engine, emptyIterable())
+
+      val conflictingCommitter = new CatalogCommitter {
+        override def commit(
+            engine: Engine,
+            finalizedActions: CloseableIterator[Row],
+            commitMetadata: CommitMetadata): CommitResponse = {
+          throw new CommitFailedException(
+            true, // retryable
+            true, // conflict
+            "Winning commit has not been published")
+        }
+
+        override def getRequiredTableProperties: java.util.Map[String, String] =
+          customCatalogCommitter.getRequiredTableProperties
+
+        override def publish(engine: Engine, publishMetadata: PublishMetadata): Unit = {}
+      }
+      val transaction = TableManager.loadSnapshot(tablePath)
+        .withCommitter(conflictingCommitter)
+        .withMaxCatalogVersionIfApplicable(true, 0)
+        .build(engine)
+        .buildUpdateTableTransaction("test-engine", Operation.WRITE)
+        .build(engine)
+
+      val exception = intercept[ConcurrentWriteException] {
+        commitTransaction(transaction, engine, emptyIterable())
+      }
+      assert(exception.getMessage.contains("re-executed using the latest version"))
+    }
+  }
+
+  test("conflict resolution - unavailable filesystem winning commits remain an invariant error") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      commitTransaction(getCreateTxn(engine, tablePath, testSchema), engine, emptyIterable())
+
+      val conflictingCommitter = new Committer {
+        override def commit(
+            engine: Engine,
+            finalizedActions: CloseableIterator[Row],
+            commitMetadata: CommitMetadata): CommitResponse = {
+          throw new CommitFailedException(true, true, "Winning commit is missing")
+        }
+      }
+      val transaction = TableManager.loadSnapshot(tablePath)
+        .withCommitter(conflictingCommitter)
+        .build(engine)
+        .buildUpdateTableTransaction("test-engine", Operation.WRITE)
+        .build(engine)
+
+      val exception = intercept[IllegalStateException] {
+        commitTransaction(transaction, engine, emptyIterable())
+      }
+      assert(exception.getMessage.contains("No winning commits found"))
     }
   }
 }


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/7402/files) to review incremental changes.
- [stack/kernel-unpublished-conflict-retry](https://github.com/delta-io/delta/pull/7402) [[Files changed](https://github.com/delta-io/delta/pull/7402/files)]

---------
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If this PR is unfinished, add '[WIP]' in the title.
  3. Keep the description updated as the change evolves.
-->

#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other

## Description

Two writers can start from the same table version. One writer may win the next version while the other writer is still trying to commit.

For a catalog-managed table, the winning commit can be accepted before its JSON file appears in the Delta log. Kernel knew that a conflict happened, but it could not read the winner's actions from the log. It then failed with the internal error `No winning commits found`.

Kernel cannot safely resolve a conflict without reading the winner's actions. This change reports a `ConcurrentWriteException` for this catalog-managed case. That tells the caller to load the latest table state and run the transaction again. Ordinary filesystem tables keep their previous invariant check because their winning JSON file must already exist.

## How was this patch tested?

- Added a regression where a catalog-managed committer reports a conflict before the winner is available in the Delta log. It now returns `ConcurrentWriteException`.
- Added the rejected path for a filesystem table, which must still report the missing winner as an invariant error.
- Ran `kernelDefaults/testOnly io.delta.kernel.defaults.ConflictResolutionSuite`: 6 tests passed.
- Ran a repeated three-writer append workload against a catalog-managed table: passed.

## Does this PR introduce _any_ user-facing changes?

Yes. A connector that supports retrying `ConcurrentWriteException` can now reload and retry this catalog-managed conflict instead of receiving an internal `IllegalStateException`. Filesystem-managed tables are unchanged.