### PR TITLE
Support startingTimestamp for Delta Sharing streaming when a version range has no file actions

### DIFF
--- a/sharing/src/main/scala/io/delta/sharing/spark/DeltaFormatSharingSource.scala
+++ b/sharing/src/main/scala/io/delta/sharing/spark/DeltaFormatSharingSource.scala
@@ -17,7 +17,7 @@
 package io.delta.sharing.spark
 
 import java.lang.ref.WeakReference
-import java.util.UUID
+import java.util.{Locale, UUID}
 import java.util.concurrent.TimeUnit
 
 import org.apache.spark.sql.delta.{
@@ -134,7 +134,7 @@ case class DeltaFormatSharingSource(
       spark = spark,
       deltaLog = localDeltaLog,
       catalogTableOpt = None,
-      options = new DeltaOptions(parameters, sqlConf),
+      options = new DeltaOptions(parametersForDeltaSource, sqlConf),
       snapshotAtSourceInit = snapshotDescriptor,
       metadataPath = metadataPath,
       metadataTrackingLog = schemaTrackingLogOpt
@@ -1085,6 +1085,38 @@ case class DeltaFormatSharingSource(
       Some(client.getTableVersion(table, options.startingTimestamp))
     } else {
       None
+    }
+  }
+
+  /**
+   * The parameters for the wrapped DeltaSource, with startingTimestamp replaced by the version
+   * [[getStartingVersion]] resolved it to. Otherwise the wrapped DeltaSource resolves it again on
+   * the local delta log, where commits with no file actions have a modificationTime of 0 and an
+   * empty version range fails with DELTA_TIMESTAMP_GREATER_THAN_COMMIT. Replaced rather than
+   * dropped, since without a starting option it would read a snapshot of the latest version.
+   */
+  private def parametersForDeltaSource: Map[String, String] = {
+    val convertStartingTimestamp = sqlConf.getConf(
+      DeltaSQLConf.DELTA_SHARING_STREAMING_CONVERT_STARTING_TIMESTAMP_TO_VERSION)
+    if (!convertStartingTimestamp || options.startingTimestamp.isEmpty) {
+      return parameters
+    }
+    getStartingVersion match {
+      case Some(version) =>
+        logInfo(s"Replacing startingTimestamp with the resolved startingVersion($version) for " +
+          "the wrapped DeltaSource," + getTableInfoForLogging)
+        // `parameters` keeps the user's casing, so drop the key case-insensitively.
+        val startingTimestampKey =
+          DeltaOptions.STARTING_TIMESTAMP_OPTION.toLowerCase(Locale.ROOT)
+        parameters.filterNot {
+          case (key, _) => key.toLowerCase(Locale.ROOT) == startingTimestampKey
+        } + (DeltaOptions.STARTING_VERSION_OPTION -> version.toString)
+      case None =>
+        // Unreachable unless code changes: getStartingVersion always resolves a defined
+        // startingTimestamp to Some. Log and fall back to the original parameters.
+        logWarning("getStartingVersion returned None despite startingTimestamp being defined," +
+          getTableInfoForLogging)
+        parameters
     }
   }
 

--- a/sharing/src/test/scala/io/delta/sharing/spark/DeltaFormatSharingSourceSuite.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/DeltaFormatSharingSourceSuite.scala
@@ -3673,4 +3673,83 @@ class DeltaFormatSharingSourceSuite
         assertBlocksAreCleanedUp()
     }
   }
+
+  /**
+   * Runs a startingTimestamp streaming query over a version range with no file actions, and
+   * returns the JSON of the last offset it committed.
+   */
+  private def runEmptyRangeStartingTimestampQuery(
+      testName: String,
+      convertToVersion: Boolean): Option[String] = {
+    var offsetJson: Option[String] = None
+    withTempDirs { (inputDir, outputDir, checkpointDir) =>
+      val deltaTableName = s"delta_table_empty_range_$testName"
+      withTable(deltaTableName) {
+        createTableForStreaming(deltaTableName)
+        sql(s"INSERT INTO $deltaTableName VALUES ('a')")
+        sql(s"INSERT INTO $deltaTableName VALUES ('b')")
+        // Version 3's actions all have dataChange = false, so [3, 3] has no file actions.
+        sql(s"OPTIMIZE $deltaTableName")
+
+        val sharedTableName = s"shared_empty_range_$testName"
+        prepareMockedClientMetadata(deltaTableName, sharedTableName)
+        // The mocked client returns this version for any timestamp.
+        prepareMockedClientGetTableVersion(deltaTableName, sharedTableName, Some(3L))
+        prepareMockedClientAndFileSystemResultForStreaming(
+          deltaTableName, sharedTableName, 3, 3)
+
+        val startingTimestamp = new java.sql.Timestamp(
+          getTimeStampForVersion(deltaTableName, 3L)).toInstant.toString
+
+        val profileFile = prepareProfileFile(inputDir)
+        val tablePath = profileFile.getCanonicalPath + s"#share1.default.$sharedTableName"
+
+        withSQLConf(
+          (getDeltaSharingClassesSQLConf.toSeq :+
+            (DeltaSQLConf.DELTA_SHARING_STREAMING_CONVERT_STARTING_TIMESTAMP_TO_VERSION.key ->
+              convertToVersion.toString)): _*) {
+          val q = spark.readStream
+            .format("deltaSharing")
+            .option("responseFormat", "delta")
+            .option(SKIP_CHANGE_COMMITS_OPTION, "true")
+            .option("startingTimestamp", startingTimestamp)
+            .load(tablePath)
+            .writeStream
+            .format("delta")
+            .option("checkpointLocation", checkpointDir.toString)
+            .trigger(Trigger.Once())
+            .start(outputDir.toString)
+          try {
+            q.processAllAvailable()
+          } finally {
+            q.stop()
+          }
+
+          checkAnswer(spark.read.format("delta").load(outputDir.getCanonicalPath), Seq.empty[Row])
+
+          val offsetLog = new OffsetSeqLog(
+            spark, s"${checkpointDir.getCanonicalPath}/offsets")
+          offsetJson = offsetLog.getLatest().flatMap(_._2.offsets.head).map(_.json())
+        }
+      }
+    }
+    offsetJson
+  }
+
+  test("startingTimestamp with an empty first batch yields an empty batch and advances offset") {
+    val offsetJson = runEmptyRangeStartingTimestampQuery("fixed", convertToVersion = true)
+
+    assert(offsetJson.isDefined, "the query should have committed an offset")
+    assert(offsetJson.get.contains("\"reservoirVersion\":4"),
+      s"offset should have advanced past the empty range, but got ${offsetJson.get}")
+    assert(offsetJson.get.contains("\"isStartingVersion\":false"),
+      s"offset should not be in the initial snapshot, but got ${offsetJson.get}")
+  }
+
+  test("startingTimestamp with an empty first batch fails when the fix is disabled") {
+    val e = intercept[StreamingQueryException] {
+      runEmptyRangeStartingTimestampQuery("legacy", convertToVersion = false)
+    }
+    assert(e.getMessage.contains("DELTA_TIMESTAMP_GREATER_THAN_COMMIT"))
+  }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -3327,6 +3327,16 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .booleanConf
       .createWithDefault(false)
 
+  val DELTA_SHARING_STREAMING_CONVERT_STARTING_TIMESTAMP_TO_VERSION =
+    buildConf("spark.sql.delta.sharing.streamingConvertStartingTimestampToVersion")
+      .doc("When true, a Delta Sharing streaming query converts startingTimestamp to a version " +
+        "on the sharing server, passing that version to the wrapped DeltaSource. When false, the " +
+        "wrapped DeltaSource resolves the timestamp again on the local delta log, where an empty " +
+        "version range fails with DELTA_TIMESTAMP_GREATER_THAN_COMMIT.")
+      .internal()
+      .booleanConf
+      .createWithDefault(false)
+
   val DELTA_SHARING_ENABLE_AUTO_RESOLVE_FOR_CDF =
     buildConf("spark.sql.delta.sharing.enableAutoResolveForCdf")
       .doc("When true, Delta Sharing CDF queries without an explicit responseFormat will " +


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

A Delta Sharing streaming query started with `startingTimestamp` fails on its first batch when the requested version range contains no file actions:

```
[DELTA_TIMESTAMP_GREATER_THAN_COMMIT] The provided timestamp (...) is after
the latest version available to this table (1970-01-01 00:00:00.499)
```

The root cause is that `startingTimestamp` is resolved twice. `DeltaFormatSharingSource` resolves it against the sharing server, but it also passes the raw user options to the wrapped `DeltaSource`, which resolves the timestamp again against the locally constructed delta log. That local log is synthetic: versions with no file actions get a commit `modificationTime` of 0, which the history manager monotonizes into small millisecond values and reports as the table's latest commit. When the range does contain file actions, real timestamps land in the log and the second lookup happens to succeed, which is why this only reproduces on an empty first batch.

This change adds `parametersForDeltaSource`, which converts `startingTimestamp` into the version it resolves to before building the wrapped `DeltaSource`'s options. A concrete version only needs an existence check against commit filenames, never a timestamp lookup. The timestamp is converted rather than dropped, because with no starting option the wrapped `DeltaSource` would instead read a snapshot of the latest version.

The behavior is gated by a new, default-off internal flag, `spark.sql.delta.sharing.streamingConvertStartingTimestampToVersion`. `startingVersion` is left untouched.

## How was this patch tested?

Two new unit tests in `DeltaFormatSharingSourceSuite`, over a table whose last version is an `OPTIMIZE` (no `dataChange` actions, so the server returns no file actions for that range):

- With the flag on, the first batch is empty and the offset advances past the range.
- With the flag off, the query still fails with `DELTA_TIMESTAMP_GREATER_THAN_COMMIT`, pinning the regression.

## Does this PR introduce _any_ user-facing changes?

No. The new behavior is gated behind a default-off internal configuration flag.
