### PR TITLE
[Spark] Use immutable partition values in V2 scan descriptors

### DIFF
--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaScanFile.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaScanFile.java
@@ -15,10 +15,10 @@
  */
 package io.delta.spark.internal.v2.read;
 
-import io.delta.kernel.data.MapValue;
 import io.delta.kernel.internal.actions.AddFile;
 import io.delta.kernel.internal.actions.DeletionVectorDescriptor;
-import io.delta.kernel.internal.util.VectorUtils;
+import io.delta.spark.internal.v2.utils.PartitionUtils;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -26,7 +26,7 @@ import java.util.Optional;
 public final class DeltaScanFile {
 
   private final String path;
-  private final MapValue partitionValues;
+  private final Map<String, String> partitionValuesMap;
   private final long size;
   private final long modificationTime;
   private final Optional<Long> baseRowId;
@@ -36,7 +36,7 @@ public final class DeltaScanFile {
   DeltaScanFile(AddFile addFile) {
     this(
         Objects.requireNonNull(addFile, "addFile is null").getPath(),
-        addFile.getPartitionValues(),
+        PartitionUtils.buildPartitionValuesMap(addFile.getPartitionValues()),
         addFile.getSize(),
         addFile.getModificationTime(),
         addFile.getBaseRowId(),
@@ -46,14 +46,14 @@ public final class DeltaScanFile {
 
   private DeltaScanFile(
       String path,
-      MapValue partitionValues,
+      Map<String, String> partitionValuesMap,
       long size,
       long modificationTime,
       Optional<Long> baseRowId,
       Optional<Long> defaultRowCommitVersion,
       Optional<DeletionVectorDescriptor> deletionVector) {
     this.path = path;
-    this.partitionValues = partitionValues;
+    this.partitionValuesMap = partitionValuesMap;
     this.size = size;
     this.modificationTime = modificationTime;
     this.baseRowId = baseRowId;
@@ -63,13 +63,13 @@ public final class DeltaScanFile {
 
   /**
    * Builds a descriptor from a V1 AddFile selected by V1 data skipping rather than Kernel's {@code
-   * getScanFiles}. The V1 fields are converted to the Kernel-typed representation this descriptor
-   * exposes, so its public getters stay stable for the row-level ReplaceData write path.
+   * getScanFiles}. The V1 fields are copied into the same durable representation used for
+   * Kernel-selected files.
    */
   static DeltaScanFile fromV1AddFile(org.apache.spark.sql.delta.actions.AddFile v1AddFile) {
     Objects.requireNonNull(v1AddFile, "v1AddFile is null");
-    MapValue partitionValues =
-        VectorUtils.stringStringMapValue(
+    Map<String, String> partitionValues =
+        PartitionUtils.buildPartitionValuesMap(
             scala.jdk.javaapi.CollectionConverters.asJava(v1AddFile.partitionValues()));
     Optional<DeletionVectorDescriptor> dv =
         Optional.ofNullable(v1AddFile.deletionVector())
@@ -103,8 +103,9 @@ public final class DeltaScanFile {
     return path;
   }
 
-  public MapValue getPartitionValues() {
-    return partitionValues;
+  /** Returns partition values copied out of the selected file action. */
+  public Map<String, String> getPartitionValuesMap() {
+    return partitionValuesMap;
   }
 
   public long getSize() {

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/PartitionUtils.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/utils/PartitionUtils.java
@@ -36,6 +36,7 @@ import io.delta.spark.internal.v2.read.metadata.MetadataStructReadFunction;
 import io.delta.spark.internal.v2.read.metadata.MetadataStructSchemaContext;
 import java.time.ZoneId;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -162,45 +163,60 @@ public class PartitionUtils {
    */
   public static InternalRow getPartitionRow(
       MapValue partitionValues, StructType partitionSchema, ZoneId zoneId) {
+    return getPartitionRow(buildPartitionValuesMap(partitionValues), partitionSchema, zoneId);
+  }
+
+  /**
+   * Copies partition values out of a potentially batch-backed Kernel map.
+   *
+   * <p>The returned map remains valid after the Kernel batch is closed.
+   */
+  public static Map<String, String> buildPartitionValuesMap(MapValue partitionValues) {
+    Objects.requireNonNull(partitionValues, "partitionValues is null");
+    Map<String, String> result = new LinkedHashMap<>(partitionValues.getSize());
+    for (int index = 0; index < partitionValues.getSize(); index++) {
+      String key = partitionValues.getKeys().getString(index);
+      String value =
+          partitionValues.getValues().isNullAt(index)
+              ? null
+              : partitionValues.getValues().getString(index);
+      result.put(key, value);
+    }
+    return Collections.unmodifiableMap(result);
+  }
+
+  /** Returns an immutable copy of already materialized partition values. */
+  public static Map<String, String> buildPartitionValuesMap(Map<String, String> partitionValues) {
+    Objects.requireNonNull(partitionValues, "partitionValues is null");
+    return Collections.unmodifiableMap(new LinkedHashMap<>(partitionValues));
+  }
+
+  /**
+   * Build the partition {@link InternalRow} from durable partition values copied out of a Kernel
+   * row. This overload is for consumers that outlive the Kernel batch backing {@link MapValue}.
+   */
+  public static InternalRow getPartitionRow(
+      Map<String, String> partitionValues, StructType partitionSchema, ZoneId zoneId) {
     final int numPartCols = partitionSchema.fields().length;
-    assert partitionValues.getSize() == numPartCols
+    assert partitionValues.size() == numPartCols
         : String.format(
             java.util.Locale.ROOT,
             "Partition values size from add file %d != partition columns size %d",
-            partitionValues.getSize(),
+            partitionValues.size(),
             numPartCols);
 
     final Object[] values = new Object[numPartCols];
-
-    // Build physical name -> index map once
-    // Partition values use physical names as keys when column mapping is enabled
-    final Map<String, Integer> physicalNameToIndex = new HashMap<>(numPartCols);
-    for (int i = 0; i < numPartCols; i++) {
-      StructField field = partitionSchema.fields()[i];
-      String physicalName = DeltaColumnMapping.getPhysicalName(field);
-      physicalNameToIndex.put(physicalName, i);
-      values[i] = null;
-    }
-
-    // Fill values in a single pass over partitionValues
-    for (int idx = 0; idx < partitionValues.getSize(); idx++) {
-      final String key = partitionValues.getKeys().getString(idx);
-      // getString throws on a null entry, so check for null first.
-      final String strVal =
-          partitionValues.getValues().isNullAt(idx)
-              ? null
-              : partitionValues.getValues().getString(idx);
-      final Integer pos = physicalNameToIndex.get(key);
-      if (pos != null) {
-        final StructField field = partitionSchema.fields()[pos];
-        if (strVal == null) {
-          values[pos] = null;
-        } else if (field.dataType() instanceof StringType) {
-          values[pos] = UTF8String.fromString(strVal);
-        } else {
-          values[pos] =
-              PartitioningUtils.castPartValueToDesiredType(field.dataType(), strVal, zoneId);
-        }
+    for (int index = 0; index < numPartCols; index++) {
+      final StructField field = partitionSchema.fields()[index];
+      final String physicalName = DeltaColumnMapping.getPhysicalName(field);
+      final String strVal = partitionValues.get(physicalName);
+      if (strVal == null) {
+        values[index] = null;
+      } else if (field.dataType() instanceof StringType) {
+        values[index] = UTF8String.fromString(strVal);
+      } else {
+        values[index] =
+            PartitioningUtils.castPartValueToDesiredType(field.dataType(), strVal, zoneId);
       }
     }
     return new GenericInternalRow(values);
@@ -343,16 +359,32 @@ public class PartitionUtils {
    */
   public static PartitionedFile buildPartitionedFile(
       AddFile addFile, StructType partitionSchema, String tablePath, ZoneId zoneId) {
-    scala.collection.immutable.Map<String, Object> metadata =
-        mergeIntoScalaMap(
-            buildDvMetadataScala(addFile.getDeletionVector()),
-            buildRowTrackingMetadata(addFile.getBaseRowId(), addFile.getDefaultRowCommitVersion()));
-    return makePartitionedFile(
-        new Path(tablePath, addFile.getPath()).toString(),
+    return buildPartitionedFile(
+        addFile.getPath(),
         addFile.getSize(),
         addFile.getModificationTime(),
+        addFile.getDeletionVector(),
+        addFile.getBaseRowId(),
+        addFile.getDefaultRowCommitVersion(),
         getPartitionRow(addFile.getPartitionValues(), partitionSchema, zoneId),
-        metadata);
+        tablePath);
+  }
+
+  private static PartitionedFile buildPartitionedFile(
+      String path,
+      long size,
+      long modificationTime,
+      Optional<DeletionVectorDescriptor> deletionVector,
+      Optional<Long> baseRowId,
+      Optional<Long> defaultRowCommitVersion,
+      InternalRow partitionRow,
+      String tablePath) {
+    scala.collection.immutable.Map<String, Object> metadata =
+        mergeIntoScalaMap(
+            buildDvMetadataScala(deletionVector),
+            buildRowTrackingMetadata(baseRowId, defaultRowCommitVersion));
+    return makePartitionedFile(
+        new Path(tablePath, path).toString(), size, modificationTime, partitionRow, metadata);
   }
 
   /**

--- a/spark/v2/src/main/scala/org/apache/spark/sql/delta/v2/interop/KernelSnapshotUtils.scala
+++ b/spark/v2/src/main/scala/org/apache/spark/sql/delta/v2/interop/KernelSnapshotUtils.scala
@@ -27,7 +27,10 @@ import org.apache.spark.sql.delta.implicits._
 import io.delta.kernel.data.MapValue
 import io.delta.kernel.engine.Engine
 import io.delta.kernel.internal.{ScanImpl, SnapshotImpl}
-import io.delta.kernel.internal.actions.{AddFile => KernelAddFile}
+import io.delta.kernel.internal.actions.{
+  AddFile => KernelAddFile,
+  DeletionVectorDescriptor => KernelDeletionVectorDescriptor
+}
 
 import org.apache.spark.sql.{Dataset, SparkSession}
 
@@ -115,19 +118,20 @@ private[delta] object KernelSnapshotUtils {
    * V1 AddFile uses null when a file has no deletion vector, so this method does the same.
    */
   private def toV1DeletionVectorDescriptor(
-      kernelAddFile: KernelAddFile): V1DeletionVectorDescriptor = {
-    val deletionVector = kernelAddFile.getDeletionVector
-    if (deletionVector.isPresent) {
-      val kernelDeletionVector = deletionVector.get
-      V1DeletionVectorDescriptor(
-        storageType = kernelDeletionVector.getStorageType,
-        pathOrInlineDv = kernelDeletionVector.getPathOrInlineDv,
-        offset = kernelDeletionVector.getOffset.toScala.map(_.intValue()),
-        sizeInBytes = kernelDeletionVector.getSizeInBytes,
-        cardinality = kernelDeletionVector.getCardinality)
-    } else {
-      null
-    }
+      kernelAddFile: KernelAddFile): V1DeletionVectorDescriptor =
+    kernelAddFile.getDeletionVector.toScala
+      .map(toV1DeletionVectorDescriptor)
+      .orNull
+
+  /** Converts one Kernel deletion-vector descriptor to Delta's V1 value type. */
+  private[v2] def toV1DeletionVectorDescriptor(
+      kernelDeletionVector: KernelDeletionVectorDescriptor): V1DeletionVectorDescriptor = {
+    V1DeletionVectorDescriptor(
+      storageType = kernelDeletionVector.getStorageType,
+      pathOrInlineDv = kernelDeletionVector.getPathOrInlineDv,
+      offset = kernelDeletionVector.getOffset.toScala.map(_.intValue()),
+      sizeInBytes = kernelDeletionVector.getSizeInBytes,
+      cardinality = kernelDeletionVector.getCardinality)
   }
 
   /**


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

V2 selected-file descriptors expose partition values through MapValue while their other metadata is value-owned. Store partition values in immutable maps for consistent ownership across Kernel and V1 AddFile inputs.

Centralize partition-map construction and map-based InternalRow conversion while preserving null handling, physical-name lookup, and timezone-aware casts.

Factor Kernel-to-Delta deletion-vector descriptor conversion through one field-for-field helper.


<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
CI

and

- `build/sbt "sparkV2/testOnly io.delta.spark.internal.v2.utils.PartitionUtilsTest"`
- `build/sbt "sparkV2/testOnly io.delta.spark.internal.v2.read.DeltaV2ScanTest -- *testSelectedFilesTracksPlannedAndRuntimeFilteredFiles*"`
- `sparkV2 / Compile / javafmt

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No