### PR TITLE
[POC][Spark] Propagate relation options for bare `delta.'path'` reads

### DIFF
--- a/spark/src/main/scala/io/delta/sql/AbstractDeltaSparkSessionExtension.scala
+++ b/spark/src/main/scala/io/delta/sql/AbstractDeltaSparkSessionExtension.scala
@@ -55,7 +55,10 @@ class AbstractDeltaSparkSessionExtension extends (SparkSessionExtensions => Unit
     extensions.injectHintResolutionRule { session =>
       new SetDSv2SchemaEvolutionShims(session)
     }
-    extensions.injectResolutionRule { session =>
+    // Inject as a hint-resolution rule so it runs BEFORE Spark's built-in ResolveRelations, which
+    // would otherwise resolve a bare `delta.`path`` relation via the V2 session catalog
+    // `loadTable(ident)` (dropping per-relation options) before this rule can preserve them.
+    extensions.injectHintResolutionRule { session =>
       ResolveDeltaPathTable(session)
     }
     extensions.injectResolutionRule { session =>

--- a/spark/src/main/scala/org/apache/spark/sql/delta/ResolveDeltaPathTable.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ResolveDeltaPathTable.scala
@@ -19,11 +19,13 @@ package org.apache.spark.sql.delta
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.analysis.{ResolvedTable, UnresolvedRelation, UnresolvedTable}
-import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.plans.logical.{InsertIntoStatement, LogicalPlan}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.{CatalogHelper, MultipartIdentifierHelper}
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
+
+import scala.collection.JavaConverters._
 
 /**
  * Replaces [[UnresolvedTable]]s if the plan is for direct query on files.
@@ -35,6 +37,32 @@ case class ResolveDeltaPathTable(sparkSession: SparkSession) extends Rule[Logica
       ResolveDeltaPathTable
         .resolveAsPathTable(sparkSession, u.multipartIdentifier)
         .getOrElse(u)
+
+    // Resolve a bare `delta.`path`` read relation here (before it falls through to the generic
+    // V2 session-catalog `loadTable(ident)` path, which cannot carry per-relation options). This
+    // preserves `UnresolvedRelation.options` so file-system credentials injected on the relation
+    // reach DeltaLog's Hadoop configuration.
+    case u: UnresolvedRelation
+        if u.multipartIdentifier.length == 2 &&
+          u.multipartIdentifier.head.equalsIgnoreCase("delta") =>
+      ResolveDeltaPathTable
+        .resolveAsPathTableRelation(sparkSession, u)
+        .getOrElse(u)
+
+    // `InsertIntoStatement.table` is a non-child slot, so the `UnresolvedRelation` case above does
+    // not visit an INSERT target. Resolve a bare `delta.`path`` insert target here so its options
+    // (e.g. injected file-system credentials) reach `DeltaLog`, matching the read path.
+    case i: InsertIntoStatement =>
+      i.table match {
+        case u: UnresolvedRelation
+            if u.multipartIdentifier.length == 2 &&
+              u.multipartIdentifier.head.equalsIgnoreCase("delta") =>
+          ResolveDeltaPathTable
+            .resolveAsPathTableRelation(sparkSession, u)
+            .map(resolved => i.copy(table = resolved))
+            .getOrElse(i)
+        case _ => i
+      }
   }
 }
 
@@ -47,10 +75,14 @@ object ResolveDeltaPathTable {
   def resolveAsPathTableRelation(
       sparkSession: SparkSession,
       u: UnresolvedRelation) : Option[DataSourceV2Relation] = {
-    resolveAsPathTable(sparkSession, u.multipartIdentifier)
+    // Forward the relation options (e.g. file-system credentials injected by a catalog) so they
+    // reach DeltaLog's Hadoop configuration; otherwise bare `delta.`path`` reads cannot pick up
+    // per-relation storage credentials the way file-format path relations do.
+    resolveAsPathTable(sparkSession, u.multipartIdentifier, u.options.asScala.toMap)
       .map { resolvedTable =>
         DataSourceV2Relation.create(
-          resolvedTable.table, Some(resolvedTable.catalog), Some(resolvedTable.identifier))
+          resolvedTable.table, Some(resolvedTable.catalog), Some(resolvedTable.identifier),
+          u.options)
       }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaDataFrameHadoopOptionsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaDataFrameHadoopOptionsSuite.scala
@@ -77,6 +77,39 @@ class DeltaDataFrameHadoopOptionsSuite extends QueryTest
     }
   }
 
+  // POC: proves the one-line fix in ResolveDeltaPathTable.resolveAsPathTableRelation forwards
+  // UnresolvedRelation.options into DeltaLog's Hadoop conf. A catalog/session extension can inject
+  // per-relation storage credentials (fs.* options) onto a bare `delta.`path`` relation; before
+  // the fix these were dropped (Map.empty) and the fake:// read would fail. We simulate the
+  // injection by attaching options to the parsed UnresolvedRelation, then run the resolved plan.
+  test("bare delta.`path` read picks up per-relation Hadoop file system options") {
+    import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
+    import org.apache.spark.sql.util.CaseInsensitiveStringMap
+    import scala.collection.JavaConverters._
+    withTempPath { dir =>
+      val path = fakeFileSystemPath(dir)
+      // Seed a Delta table. Writing needs the options; that path already worked.
+      spark.range(1, 10).write.format("delta").options(fakeFileSystemOptions).save(path)
+      clearCachedDeltaLogToForceReload()
+
+      // Parse `SELECT * FROM delta.`fake://...`` and inject the fs.* options onto the bare
+      // relation, exactly like a credential-vending extension would.
+      val parsed = spark.sessionState.sqlParser.parsePlan(s"SELECT * FROM delta.`$path`")
+      val withOptions = parsed.transform {
+        case u: UnresolvedRelation if u.multipartIdentifier == Seq("delta", path) =>
+          u.copy(options = new CaseInsensitiveStringMap(fakeFileSystemOptions.asJava))
+      }
+      // Analyze + execute the plan. Without the fix, options are dropped and this fails to
+      // open fake://; with the fix, the fs.* options reach DeltaLog's Hadoop conf.
+      val df = DataFrameUtils.ofRows(spark, withOptions)
+      // DIAGNOSTIC: print the analyzed plan so we can see which rule resolved the relation.
+      // scalastyle:off println
+      println("=== ANALYZED PLAN ===\n" + df.queryExecution.analyzed.treeString)
+      // scalastyle:on println
+      assert(df.count() == 9)
+    }
+  }
+
   testQuietly("SC-86916: disabling the conf should not pick up Hadoop file system options") {
     withSQLConf(DeltaSQLConf.LOAD_FILE_SYSTEM_CONFIGS_FROM_DATAFRAME_OPTIONS.key -> "false") {
       withTempPath { dir =>


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Bare `delta.'path'` operations drop `UnresolvedRelation.options`, so per-relation file-system options (e.g. credentials a catalog injects onto the relation) never reach `DeltaLog`'s Hadoop conf. The options ride on the `DataSourceV2Relation` wrapper but not on the `DeltaTableV2` that opens storage, because `TableCatalog.loadTable(ident)` has no options slot.

- `ResolveDeltaPathTable`: add an `UnresolvedRelation` case that resolves bare `delta.'path'` (covers `SELECT`, `UPDATE`, `DELETE`) and forwards `u.options`.
- `ResolveDeltaPathTable`: add an `InsertIntoStatement` case — the insert target is a non-child `UnresolvedRelation`, so it needs its own arm to forward options for `INSERT INTO delta.'path'`.
- `resolveAsPathTableRelation`: pass `u.options` into `resolveAsPathTable`/`DeltaTableV2` and the `DataSourceV2Relation` (was `Map.empty`).
- Register `ResolveDeltaPathTable` as `injectHintResolutionRule` so it runs before Spark's `ResolveRelations`, which would otherwise build an options-less `DeltaTableV2` via `loadTable(ident)`.

Real tables under a schema named `delta` are unaffected: `isValidPath` still gates on `new Path(name).isAbsolute`.

## How was this patch tested?
Validated against the Unity Catalog Spark connector: bare `delta.`s3://...`` SELECT / INSERT INTO / UPDATE / DELETE fail on stock Delta (`missing vended credential fs.s3a.access.key`) and pass with this change. CTAS/RTAS credentials are injected connector-side into `writeOptions` (no Delta change needed).

## Does this PR introduce _any_ user-facing changes?
Yes. Path based tables can use connector populated credential instead of just ambient credential.