### PR TITLE
[Spark] Respect catalog maintenance policy for managed tables

### DIFF
--- a/project/scripts/setup_unitycatalog_main.sh
+++ b/project/scripts/setup_unitycatalog_main.sh
@@ -83,7 +83,7 @@ set -euo pipefail
 # The pin. Bump both lines together if UC's version.sbt changed at the new SHA. build.sbt's
 # `unityCatalogVersion` is obtained by running this script with `--print-version`, so these two
 # values are the single source of truth.
-UC_PIN_SHA=b11188d2a92c9bf1395d03be4235706af26b2c45
+UC_PIN_SHA=afbd22666ddb0db41d68b29fee819d4c51b8ad40
 UC_BASE_VERSION=0.6.0-SNAPSHOT
 # ---------------------------------------------------------------------------------------------
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
@@ -341,7 +341,11 @@ trait Checkpoints extends DeltaLogging {
     val lastCheckpointInfo = writeCheckpointFiles(snapshotToCheckpoint, catalogTableOpt)
     writeLastCheckpointFile(
       snapshotToCheckpoint.deltaLog, lastCheckpointInfo, LastCheckpointInfo.checksumEnabled(spark))
-    doLogCleanup(snapshotToCheckpoint, catalogTableOpt)
+    // Checkpoints are allowed on catalog-managed tables, but expired log cleanup is a separate
+    // maintenance operation. No catalog permission for cleanup is defined yet.
+    if (!snapshotToCheckpoint.isCatalogOwned) {
+      doLogCleanup(snapshotToCheckpoint, catalogTableOpt)
+    }
   }
 
   protected[delta] def writeLastCheckpointFile(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
@@ -421,6 +421,11 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
 
       table match {
         case v1: V1Table if DeltaTableUtils.isDeltaTable(v1.catalogTable) =>
+          val maintenanceOperations = v1 match {
+            case policyTable: SupportsCatalogMaintenancePolicy =>
+              policyTable.additionalClientMaintenanceOperations
+            case _ => Set.empty[CatalogMaintenanceOperation]
+          }
           // Server-side planning only applies to Delta tables. Attempt it here, inside the
           // Delta-`V1Table` branch, rather than on every loaded table: a non-Delta table or a
           // catalog-specific shape (e.g. Unity Catalog's `MetadataTable` wrapping a `ViewInfo`
@@ -443,7 +448,8 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
           //     HMS case has credentials in practice, so the read succeeds; the "no `_delta_log`
           //     read" guarantee holds for the credential-less UC case, not universally.)
           if (ServerSidePlannedTable.isEnabled(spark)) {
-            val deltaTable = loadCatalogTable(ident, v1.catalogTable)
+            val deltaTable =
+              loadCatalogTableWithMaintenancePolicy(ident, v1.catalogTable, maintenanceOperations)
             val tableSchema = if (v1.schema.nonEmpty) v1.schema else deltaTable.schema()
             ServerSidePlannedTable
               .tryCreate(spark, ident, deltaTable, isUnityCatalog,
@@ -451,7 +457,7 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
                 tableSchema = tableSchema)
               .getOrElse(deltaTable)
           } else {
-            loadCatalogTable(ident, v1.catalogTable)
+            loadCatalogTableWithMaintenancePolicy(ident, v1.catalogTable, maintenanceOperations)
           }
         case o => o
       }
@@ -544,6 +550,18 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
       new Path(catalogTable.location),
       catalogTable = Some(catalogTable),
       tableIdentifier = Some(ident.toString))
+  }
+
+  private def loadCatalogTableWithMaintenancePolicy(
+      ident: Identifier,
+      catalogTable: CatalogTable,
+      additionalClientMaintenanceOperations: Set[CatalogMaintenanceOperation]): Table = {
+    loadCatalogTable(ident, catalogTable) match {
+      case table: DeltaTableV2 =>
+        table.withAdditionalClientMaintenanceOperations(
+          additionalClientMaintenanceOperations)
+      case table => table
+    }
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/CatalogMaintenancePolicy.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/CatalogMaintenancePolicy.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.catalog
+
+import org.apache.spark.sql.delta.{DeltaErrors, Snapshot}
+
+private[delta] sealed abstract class CatalogMaintenanceOperation(val name: String)
+
+private[delta] object CatalogMaintenanceOperation {
+  case object Optimize extends CatalogMaintenanceOperation("OPTIMIZE")
+  case object Vacuum extends CatalogMaintenanceOperation("VACUUM")
+
+  // REORG is not part of the operations recognized by this client version. Keeping it as a
+  // distinct command identity prevents OPTIMIZE permission from authorizing delegated REORG work.
+  case object Reorg extends CatalogMaintenanceOperation("REORG")
+}
+
+/** Optional client-only policy carried by a catalog's resolved Spark table. */
+private[delta] trait SupportsCatalogMaintenancePolicy {
+  def additionalClientMaintenanceOperations: Set[CatalogMaintenanceOperation]
+}
+
+private[delta] object CatalogMaintenancePolicy {
+
+  def requireAllowed(
+      table: DeltaTableV2,
+      snapshot: Snapshot,
+      operation: CatalogMaintenanceOperation): Unit = {
+    if (
+      !isAllowed(
+        snapshot.isCatalogOwned,
+        table.additionalClientMaintenanceOperations,
+        operation)
+    ) {
+      throw DeltaErrors.operationBlockedOnCatalogManagedTable(operation.name)
+    }
+  }
+
+  private[delta] def isAllowed(
+      isCatalogOwned: Boolean,
+      additionalOperations: Set[CatalogMaintenanceOperation],
+      operation: CatalogMaintenanceOperation): Boolean = {
+    !isCatalogOwned || (operation != CatalogMaintenanceOperation.Reorg &&
+      additionalOperations.contains(operation))
+  }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableV2.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableV2.scala
@@ -67,7 +67,9 @@ class DeltaTableV2 private(
     val catalogTable: Option[CatalogTable],
     val tableIdentifier: Option[String],
     val timeTravelOpt: Option[DeltaTimeTravelSpec],
-    val options: Map[String, String])
+    val options: Map[String, String],
+    private[delta] val additionalClientMaintenanceOperations:
+      Set[CatalogMaintenanceOperation] = Set.empty)
   extends Table
   with SupportsWrite
   with V2TableWithV1Fallback
@@ -431,9 +433,43 @@ class DeltaTableV2 private(
     tableIdentifier: Option[String] = this.tableIdentifier,
     timeTravelOpt: Option[DeltaTimeTravelSpec] = this.timeTravelOpt,
     options: Map[String, String] = this.options
+  ): DeltaTableV2 = copyWithMaintenancePolicy(
+    spark,
+    path,
+    catalogTable,
+    tableIdentifier,
+    timeTravelOpt,
+    options,
+    additionalClientMaintenanceOperations)
+
+  private[delta] def withAdditionalClientMaintenanceOperations(
+      operations: Set[CatalogMaintenanceOperation]): DeltaTableV2 = copyWithMaintenancePolicy(
+    spark,
+    path,
+    catalogTable,
+    tableIdentifier,
+    timeTravelOpt,
+    options,
+    operations)
+
+  private def copyWithMaintenancePolicy(
+      spark: SparkSession,
+      path: Path,
+      catalogTable: Option[CatalogTable],
+      tableIdentifier: Option[String],
+      timeTravelOpt: Option[DeltaTimeTravelSpec],
+      options: Map[String, String],
+      additionalClientMaintenanceOperations: Set[CatalogMaintenanceOperation]
   ): DeltaTableV2 = {
     val deltaTableV2 =
-      new DeltaTableV2(spark, path, catalogTable, tableIdentifier, timeTravelOpt, options)
+      new DeltaTableV2(
+        spark,
+        path,
+        catalogTable,
+        tableIdentifier,
+        timeTravelOpt,
+        options,
+        additionalClientMaintenanceOperations)
     deltaTableV2.pathInfo.timeTravelByPath = timeTravelByPath
     deltaTableV2.pathInfo.partitionFilters = partitionFilters
     deltaTableV2

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImpl.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImpl.scala
@@ -29,7 +29,10 @@ import io.delta.storage.commit.actions.{AbstractDomainMetadata, AbstractProtocol
 import io.delta.storage.commit.uccommitcoordinator.{UCConfigUtils, UCDeltaClient, UCDeltaModels}
 import io.delta.storage.commit.uniform.{UniformMetadata => StorageUniformMetadata}
 import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorClient.UC_TABLE_ID_KEY
-import io.delta.storage.commit.uccommitcoordinator.UCDeltaModels.TableInfo
+import io.delta.storage.commit.uccommitcoordinator.UCDeltaModels.{
+  ClientMaintenanceOperation,
+  TableInfo
+}
 import io.delta.storage.commit.uccommitcoordinator.exceptions.{
   CredentialFetchFailedException,
   UnsupportedTableFormatException,
@@ -633,7 +636,12 @@ private[catalog] class UCDeltaCatalogClientImpl(
       comment = Option(m.getDescription),
       createTime = if (m.getCreatedTime != null) m.getCreatedTime else 0L,
       tracksPartitionsInCatalog = false)
-    V1Table(catalogTable)
+    new UCDeltaV1Table(
+      catalogTable,
+      info.getAdditionalClientMaintenanceOperations.asScala.flatMap {
+        case ClientMaintenanceOperation.OPTIMIZE => Some(CatalogMaintenanceOperation.Optimize)
+        case ClientMaintenanceOperation.VACUUM => Some(CatalogMaintenanceOperation.Vacuum)
+      }.toSet)
   }
 
   private def toUcTableType(t: CatalogTableType): UCDeltaModels.TableType = t match {
@@ -648,6 +656,12 @@ private[catalog] class UCDeltaCatalogClientImpl(
     case UCDeltaModels.TableType.EXTERNAL => CatalogTableType.EXTERNAL
   }
 }
+
+/** A UC-loaded V1 table with catalog policy kept outside Delta table properties. */
+private[delta] final class UCDeltaV1Table(
+    catalogTable: CatalogTable,
+    val additionalClientMaintenanceOperations: Set[CatalogMaintenanceOperation])
+  extends V1Table(catalogTable) with SupportsCatalogMaintenancePolicy
 
 object UCDeltaCatalogClientImpl extends AbstractDeltaCatalogClientFactory with Logging {
   // Test-only instrumentation. The mutable counters are encapsulated so production code

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeltaReorgTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeltaReorgTableCommand.scala
@@ -16,8 +16,9 @@
 
 package org.apache.spark.sql.delta.commands
 
-import org.apache.spark.sql.delta.{DeltaColumnMapping, DeltaErrors, SnapshotDescriptor}
+import org.apache.spark.sql.delta.{DeltaColumnMapping, SnapshotDescriptor}
 import org.apache.spark.sql.delta.actions.AddFile
+import org.apache.spark.sql.delta.catalog.{CatalogMaintenanceOperation, CatalogMaintenancePolicy}
 
 import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.catalyst.plans.logical.{LeafCommand, LogicalPlan, UnaryCommand}
@@ -75,9 +76,8 @@ case class DeltaReorgTableCommand(
       optimizeByReorg(sparkSession)
     case DeltaReorgTableSpec(DeltaReorgTableMode.UNIFORM_ICEBERG, Some(icebergCompatVersion)) =>
       val table = getDeltaTable(target, "REORG")
-      if (table.update().isCatalogOwned) {
-        throw DeltaErrors.operationBlockedOnCatalogManagedTable("REORG")
-      }
+      CatalogMaintenancePolicy.requireAllowed(
+        table, table.update(), CatalogMaintenanceOperation.Reorg)
       upgradeUniformIcebergCompatVersion(table, sparkSession, icebergCompatVersion)
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
@@ -25,6 +25,7 @@ import org.apache.spark.sql.delta.skipping.clustering.{ClusteredTableUtils, Clus
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.DeltaOperations.Operation
 import org.apache.spark.sql.delta.actions.{Action, AddFile, DeletionVectorDescriptor, FileAction, RemoveFile}
+import org.apache.spark.sql.delta.catalog.{CatalogMaintenanceOperation, CatalogMaintenancePolicy}
 import org.apache.spark.sql.delta.commands.optimize._
 import org.apache.spark.sql.delta.files.SQLMetricsReporting
 import org.apache.spark.sql.delta.logging.DeltaLogKeys
@@ -113,6 +114,16 @@ abstract class OptimizeTableCommandBase extends RunnableCommand with DeltaComman
 }
 
 object OptimizeTableCommand {
+
+  private[delta] def maintenanceOperation(
+      optimizeContext: DeltaOptimizeContext): CatalogMaintenanceOperation = {
+    if (optimizeContext.reorg.nonEmpty) {
+      CatalogMaintenanceOperation.Reorg
+    } else {
+      CatalogMaintenanceOperation.Optimize
+    }
+  }
+
   /**
    * Alternate constructor that converts a provided path or table identifier into the
    * correct child LogicalPlan node. If both path and tableIdentifier are specified (or
@@ -162,9 +173,8 @@ case class OptimizeTableCommand(
       throw DeltaErrors.notADeltaTableException(table.deltaLog.dataPath.toString)
     }
 
-    if (snapshot.isCatalogOwned) {
-      throw DeltaErrors.operationBlockedOnCatalogManagedTable("OPTIMIZE")
-    }
+    CatalogMaintenancePolicy.requireAllowed(
+      table, snapshot, OptimizeTableCommand.maintenanceOperation(optimizeContext))
 
     val isClusteredTable = ClusteredTableUtils.isSupported(snapshot.protocol)
     if (isClusteredTable) {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/VacuumCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/VacuumCommand.scala
@@ -28,7 +28,11 @@ import scala.math.min
 import scala.util.control.NonFatal
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.actions.{AddCDCFile, AddFile, FileAction, RemoveFile, SingleAction}
-import org.apache.spark.sql.delta.catalog.DeltaTableV2
+import org.apache.spark.sql.delta.catalog.{
+  CatalogMaintenanceOperation,
+  CatalogMaintenancePolicy,
+  DeltaTableV2
+}
 import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.{DeltaCommitFileProvider, DeltaFileOperations, FileNames, JsonUtils, Utils => DeltaUtils}
@@ -175,8 +179,9 @@ object VacuumCommand extends VacuumCommandImpl with Serializable {
               s"but found ${catalogTable.tableType} for table ${catalogTable.identifier}."
           )
         }
-        throw DeltaErrors.operationBlockedOnCatalogManagedTable("VACUUM")
       }
+      CatalogMaintenancePolicy.requireAllowed(
+        table, snapshot, CatalogMaintenanceOperation.Vacuum)
 
       // By default, we will do full vacuum unless LITE vacuum conf is set
       val isLiteVacuumEnabled = spark.sessionState.conf.getConf(DeltaSQLConf.LITE_VACUUM_ENABLED)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/CheckpointsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CheckpointsSuite.scala
@@ -1226,6 +1226,20 @@ class CheckpointsSuite
     }
   }
 
+  test("catalog-managed checkpoint is written without metadata cleanup") {
+    withCatalogManagedTable() { tableName =>
+      val deltaLog = DeltaLog.forTable(spark, TableIdentifier(tableName))
+      val snapshot = deltaLog.update()
+
+      val usageRecords = Log4jUsageLogger.track {
+        deltaLog.checkpoint(snapshot)
+      }
+
+      assert(deltaLog.readLastCheckpointFile().exists(_.version == snapshot.version))
+      assert(filterUsageRecords(usageRecords, "delta.log.cleanup").isEmpty)
+    }
+  }
+
   testDifferentCheckpoints("Ensure variant stats in checkpoint") { (policy, _) =>
     // Test all combinations of (writeStatsAsJson, writeStatsAsStruct)
     // Skip (false, false) as that would have no stats at all
@@ -2027,4 +2041,3 @@ class CheckpointsWithCatalogOwnedBatch2Suite extends CheckpointsSuite {
 class CheckpointsWithCatalogOwnedBatch100Suite extends CheckpointsSuite {
   override def catalogOwnedCoordinatorBackfillBatchSize: Option[Int] = Some(100)
 }
-

--- a/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
@@ -25,7 +25,7 @@ import scala.jdk.CollectionConverters._
 import io.delta.storage.commit.{Commit, GetCommitsResponse, TableIdentifier => StorageTableIdentifier}
 import io.delta.storage.commit.actions.{AbstractDomainMetadata, AbstractMetadata, AbstractProtocol}
 import io.delta.storage.commit.uccommitcoordinator.{UCClient, UCDeltaClient, UCDeltaModels}
-import io.delta.storage.commit.uccommitcoordinator.UCDeltaModels.{DeltaProtocol, StagingTableInfo, TableInfo, TableType => UcTableType}
+import io.delta.storage.commit.uccommitcoordinator.UCDeltaModels.{ClientMaintenanceOperation, DeltaProtocol, StagingTableInfo, TableInfo, TableType => UcTableType}
 import io.delta.storage.commit.uccommitcoordinator.exceptions.{CredentialFetchFailedException, UnsupportedTableFormatException, NoSuchTableException => StorageNoSuchTableException}
 import io.delta.storage.commit.uniform.{IcebergMetadata, UniformMetadata}
 
@@ -713,14 +713,19 @@ class AbstractDeltaCatalogClientRoutingSuite extends QueryTest with DeltaSQLComm
       "s3://bucket/table",
       metadata,
       util.Map.of("fs.s3a.access.key", "key"),
-      Optional.empty())
+      Optional.empty(),
+      util.Set.of(ClientMaintenanceOperation.OPTIMIZE, ClientMaintenanceOperation.VACUUM))
 
     val client = new UCDeltaCatalogClientImpl(
       catalogName = "main",
       ucClient = new StubUCDeltaClient(info))
 
     val table = client.loadTable(Identifier.of(Array("sch"), "tbl"))
-    val v1 = table.asInstanceOf[V1Table].catalogTable
+    val ucV1 = table.asInstanceOf[UCDeltaV1Table]
+    assert(ucV1.additionalClientMaintenanceOperations === Set(
+      CatalogMaintenanceOperation.Optimize,
+      CatalogMaintenanceOperation.Vacuum))
+    val v1 = ucV1.catalogTable
     assert(v1.identifier.table === "tbl")
     assert(v1.identifier.database === Some("sch"))
     assert(v1.identifier.catalog === Some("main"))
@@ -734,6 +739,8 @@ class AbstractDeltaCatalogClientRoutingSuite extends QueryTest with DeltaSQLComm
     val merged = v1.storage.properties
     assert(merged.get("ucTableId") === Some(tableId.toString))
     assert(merged.get("fs.s3a.access.key") === Some("key"))
+    assert(!merged.contains("additional-client-maintenance-operations"))
+    assert(!v1.properties.contains("additional-client-maintenance-operations"))
   }
 
   test("loadTable falls back to SSP on CredentialFetchFailedException when SSP is enabled") {
@@ -745,7 +752,8 @@ class AbstractDeltaCatalogClientRoutingSuite extends QueryTest with DeltaSQLComm
       "s3://bucket/no-creds-table",
       metadata,
       Collections.emptyMap(), // no storage properties either
-      Optional.empty())
+      Optional.empty(),
+      util.Set.of(ClientMaintenanceOperation.OPTIMIZE, ClientMaintenanceOperation.VACUUM))
     val credEx = new CredentialFetchFailedException(
       "creds exhausted", new RuntimeException("simulated"), tableInfoNoCreds)
 
@@ -760,7 +768,11 @@ class AbstractDeltaCatalogClientRoutingSuite extends QueryTest with DeltaSQLComm
     spark.conf.unset(sspKey)
     try {
       val table = client.loadTable(Identifier.of(Array("sch"), "tbl"))
-      val v1 = table.asInstanceOf[V1Table].catalogTable
+      val ucV1 = table.asInstanceOf[UCDeltaV1Table]
+      assert(ucV1.additionalClientMaintenanceOperations === Set(
+        CatalogMaintenanceOperation.Optimize,
+        CatalogMaintenanceOperation.Vacuum))
+      val v1 = ucV1.catalogTable
       assert(v1.identifier.table === "tbl")
       assert(v1.storage.locationUri.map(_.toString) === Some("s3://bucket/no-creds-table"))
       assert(v1.storage.properties.isEmpty,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/catalog/CatalogMaintenancePolicySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/catalog/CatalogMaintenancePolicySuite.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.catalog
+
+import org.apache.spark.SparkFunSuite
+
+class CatalogMaintenancePolicySuite extends SparkFunSuite {
+
+  test("filesystem tables retain existing maintenance behavior") {
+    assert(CatalogMaintenancePolicy.isAllowed(
+      isCatalogOwned = false,
+      additionalOperations = Set.empty,
+      operation = CatalogMaintenanceOperation.Optimize))
+    assert(CatalogMaintenancePolicy.isAllowed(
+      isCatalogOwned = false,
+      additionalOperations = Set.empty,
+      operation = CatalogMaintenanceOperation.Vacuum))
+  }
+
+  test("catalog-managed tables require the matching advertised operation") {
+    val optimizeOnly = Set[CatalogMaintenanceOperation](CatalogMaintenanceOperation.Optimize)
+    val vacuumOnly = Set[CatalogMaintenanceOperation](CatalogMaintenanceOperation.Vacuum)
+    val optimizeAndVacuum = optimizeOnly ++ vacuumOnly
+
+    assert(CatalogMaintenancePolicy.isAllowed(
+      isCatalogOwned = true,
+      additionalOperations = optimizeOnly,
+      operation = CatalogMaintenanceOperation.Optimize))
+    assert(!CatalogMaintenancePolicy.isAllowed(
+      isCatalogOwned = true,
+      additionalOperations = optimizeOnly,
+      operation = CatalogMaintenanceOperation.Vacuum))
+    assert(!CatalogMaintenancePolicy.isAllowed(
+      isCatalogOwned = true,
+      additionalOperations = Set.empty,
+      operation = CatalogMaintenanceOperation.Optimize))
+    assert(CatalogMaintenancePolicy.isAllowed(
+      isCatalogOwned = true,
+      additionalOperations = vacuumOnly,
+      operation = CatalogMaintenanceOperation.Vacuum))
+    assert(!CatalogMaintenancePolicy.isAllowed(
+      isCatalogOwned = true,
+      additionalOperations = vacuumOnly,
+      operation = CatalogMaintenanceOperation.Optimize))
+    assert(CatalogMaintenancePolicy.isAllowed(
+      isCatalogOwned = true,
+      additionalOperations = optimizeAndVacuum,
+      operation = CatalogMaintenanceOperation.Optimize))
+    assert(CatalogMaintenancePolicy.isAllowed(
+      isCatalogOwned = true,
+      additionalOperations = optimizeAndVacuum,
+      operation = CatalogMaintenanceOperation.Vacuum))
+  }
+
+  test("REORG remains denied even if a caller tries to add it to the policy") {
+    assert(!CatalogMaintenancePolicy.isAllowed(
+      isCatalogOwned = true,
+      additionalOperations =
+        Set(CatalogMaintenanceOperation.Optimize, CatalogMaintenanceOperation.Reorg),
+      operation = CatalogMaintenanceOperation.Reorg))
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/optimize/DeltaReorgSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/optimize/DeltaReorgSuite.scala
@@ -18,6 +18,13 @@ package org.apache.spark.sql.delta.optimize
 
 import org.apache.spark.sql.delta.{DeletionVectorsTestUtils, DeltaColumnMapping, DeltaLog, DeltaUnsupportedOperationException}
 import org.apache.spark.sql.delta.actions.AddFile
+import org.apache.spark.sql.delta.catalog.CatalogMaintenanceOperation
+import org.apache.spark.sql.delta.commands.{
+  DeltaOptimizeContext,
+  DeltaPurgeOperation,
+  DeltaRewriteTypeWideningOperation,
+  OptimizeTableCommand
+}
 import org.apache.spark.sql.delta.commands.VacuumCommand.generateCandidateFileMap
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.{DeltaSQLCommandTest, DeltaSQLTestUtils}
@@ -301,15 +308,32 @@ class DeltaReorgSuite extends QueryTest
     }
   }
 
-  test("reorg on a catalog managed table should fail") {
+  test("public reorg operations on a catalog managed table should fail") {
     withCatalogManagedTable() { tableName =>
-      checkError(
-        intercept[DeltaUnsupportedOperationException] {
-          spark.sql(s"REORG TABLE $tableName APPLY (PURGE)")
-        },
-        "DELTA_UNSUPPORTED_CATALOG_MANAGED_TABLE_OPERATION",
-        parameters = Map("operation" -> "OPTIMIZE")
-      )
+      Seq(
+        s"REORG TABLE $tableName APPLY (PURGE)",
+        s"REORG TABLE $tableName " +
+          "APPLY (UPGRADE UNIFORM (ICEBERG_COMPAT_VERSION = 2))"
+      ).foreach { command =>
+        checkError(
+          intercept[DeltaUnsupportedOperationException] {
+            spark.sql(command)
+          },
+          "DELTA_UNSUPPORTED_CATALOG_MANAGED_TABLE_OPERATION",
+          parameters = Map("operation" -> "REORG")
+        )
+      }
+    }
+  }
+
+  test("delegated reorg operations retain their command identity") {
+    Seq(new DeltaPurgeOperation(), new DeltaRewriteTypeWideningOperation()).foreach { reorg =>
+      val context = DeltaOptimizeContext(
+        reorg = Some(reorg),
+        minFileSize = Some(0L),
+        maxDeletedRowsRatio = Some(0d))
+      assert(OptimizeTableCommand.maintenanceOperation(context) ===
+        CatalogMaintenanceOperation.Reorg)
     }
   }
 }

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaUtilityTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaUtilityTest.java
@@ -20,6 +20,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -140,25 +142,85 @@ public class UCDeltaUtilityTest extends UCDeltaTableIntegrationBaseTest {
   }
 
   @Test
-  public void testMaintenanceOpsBlockedOnManagedTable() throws Exception {
+  public void testManagedTableMaintenancePolicy() throws Exception {
     withNewTable(
         "maintenance_blocked",
         "id INT",
         TableType.MANAGED,
         tableName -> {
-          sql("INSERT INTO %s VALUES (1)", tableName);
+          for (int id = 1; id <= 4; id++) {
+            sql("INSERT INTO %s VALUES (%d)", tableName, id);
+          }
 
-          assertThatThrownBy(() -> sql("OPTIMIZE %s", tableName))
-              .hasMessageContaining("DELTA_UNSUPPORTED_CATALOG_MANAGED_TABLE_OPERATION")
-              .hasMessageContaining("OPTIMIZE");
+          long filesBeforeOptimize =
+              ((Number)
+                      spark()
+                          .sql(String.format("DESCRIBE DETAIL %s", tableName))
+                          .head()
+                          .getAs("numFiles"))
+                  .longValue();
+          Assertions.assertThat(filesBeforeOptimize).isGreaterThan(1L);
 
-          assertThatThrownBy(() -> sql("VACUUM %s", tableName))
-              .hasMessageContaining("DELTA_UNSUPPORTED_CATALOG_MANAGED_TABLE_OPERATION")
-              .hasMessageContaining("VACUUM");
+          sql("OPTIMIZE %s", tableName);
+          long filesAfterOptimize =
+              ((Number)
+                      spark()
+                          .sql(String.format("DESCRIBE DETAIL %s", tableName))
+                          .head()
+                          .getAs("numFiles"))
+                  .longValue();
+          Assertions.assertThat(filesAfterOptimize).isLessThan(filesBeforeOptimize);
+
+          String tableLocation =
+              spark().sql(String.format("DESCRIBE DETAIL %s", tableName)).head().getAs("location");
+          Path rejectedStagedCommit =
+              new Path(
+                  tableLocation,
+                  "_delta_log/_staged_commits/"
+                      + "00000000000000000999.00000000-0000-0000-0000-000000000000.json");
+          FileSystem tableFileSystem =
+              rejectedStagedCommit.getFileSystem(spark().sparkContext().hadoopConfiguration());
+          tableFileSystem.create(rejectedStagedCommit, false).close();
+          tableFileSystem.setTimes(rejectedStagedCommit, 1L, -1L);
+          Assertions.assertThat(tableFileSystem.exists(rejectedStagedCommit)).isTrue();
+
+          String retentionCheck = "spark.databricks.delta.retentionDurationCheck.enabled";
+          String previousRetentionCheck = spark().conf().get(retentionCheck, "true");
+          try {
+            spark().conf().set(retentionCheck, "false");
+            List<List<String>> vacuumCandidates =
+                sql("VACUUM %s RETAIN 0 HOURS DRY RUN", tableName);
+            Assertions.assertThat(vacuumCandidates).isNotEmpty();
+            List<Path> vacuumCandidatePaths = new ArrayList<>();
+            for (List<String> candidate : vacuumCandidates) {
+              Assertions.assertThat(candidate).hasSize(1);
+              Path candidatePath = new Path(candidate.get(0));
+              Assertions.assertThat(candidatePath.toUri().getPath())
+                  .isNotEqualTo(rejectedStagedCommit.toUri().getPath());
+              vacuumCandidatePaths.add(candidatePath);
+            }
+            sql("VACUUM %s RETAIN 0 HOURS", tableName);
+            for (Path candidatePath : vacuumCandidatePaths) {
+              FileSystem candidateFileSystem =
+                  candidatePath.getFileSystem(spark().sparkContext().hadoopConfiguration());
+              Assertions.assertThat(candidateFileSystem.exists(candidatePath)).isFalse();
+            }
+            Assertions.assertThat(tableFileSystem.exists(rejectedStagedCommit)).isTrue();
+          } finally {
+            spark().conf().set(retentionCheck, previousRetentionCheck);
+          }
 
           assertThatThrownBy(() -> sql("REORG TABLE %s APPLY (PURGE)", tableName))
               .hasMessageContaining("DELTA_UNSUPPORTED_CATALOG_MANAGED_TABLE_OPERATION")
-              .hasMessageContaining("OPTIMIZE");
+              .hasMessageContaining("REORG");
+          assertThatThrownBy(
+                  () ->
+                      sql(
+                          "REORG TABLE %s APPLY "
+                              + "(UPGRADE UNIFORM (ICEBERG_COMPAT_VERSION = 2))",
+                          tableName))
+              .hasMessageContaining("DELTA_UNSUPPORTED_CATALOG_MANAGED_TABLE_OPERATION")
+              .hasMessageContaining("REORG");
         });
   }
 }

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaModels.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaModels.java
@@ -21,6 +21,7 @@ import io.delta.storage.commit.actions.AbstractProtocol;
 import io.delta.storage.commit.uniform.UniformMetadata;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -40,6 +41,32 @@ public final class UCDeltaModels {
   public enum TableType {
     MANAGED,
     EXTERNAL
+  }
+
+  /** Maintenance operations that this Delta client can run when a catalog permits them. */
+  public enum ClientMaintenanceOperation {
+    OPTIMIZE,
+    VACUUM;
+
+    /**
+     * Parses the catalog's case-sensitive operation names. Unknown names and duplicates are
+     * ignored so a newer catalog can add operations without breaking an older client.
+     */
+    public static Set<ClientMaintenanceOperation> fromNames(Collection<String> names) {
+      if (names == null || names.isEmpty()) {
+        return Collections.emptySet();
+      }
+      EnumSet<ClientMaintenanceOperation> operations =
+          EnumSet.noneOf(ClientMaintenanceOperation.class);
+      for (String name : names) {
+        try {
+          operations.add(ClientMaintenanceOperation.valueOf(name));
+        } catch (IllegalArgumentException | NullPointerException ignored) {
+          // Unknown and null entries do not change the policy.
+        }
+      }
+      return Collections.unmodifiableSet(operations);
+    }
   }
 
   public static class DeltaProtocol implements AbstractProtocol {
@@ -115,6 +142,7 @@ public final class UCDeltaModels {
     private final AbstractMetadata metadata;
     private final Map<String, String> storageProperties;
     private final Optional<UniformMetadata> uniformMetadata;
+    private final Set<ClientMaintenanceOperation> additionalClientMaintenanceOperations;
 
     public TableInfo(
         UUID tableId,
@@ -123,12 +151,36 @@ public final class UCDeltaModels {
         AbstractMetadata metadata,
         Map<String, String> storageProperties,
         Optional<UniformMetadata> uniformMetadata) {
+      this(
+          tableId,
+          tableType,
+          location,
+          metadata,
+          storageProperties,
+          uniformMetadata,
+          Collections.emptySet());
+    }
+
+    public TableInfo(
+        UUID tableId,
+        TableType tableType,
+        String location,
+        AbstractMetadata metadata,
+        Map<String, String> storageProperties,
+        Optional<UniformMetadata> uniformMetadata,
+        Set<ClientMaintenanceOperation> additionalClientMaintenanceOperations) {
       this.tableId = tableId;
       this.tableType = tableType;
       this.location = location;
       this.metadata = metadata;
       this.storageProperties = storageProperties;
       this.uniformMetadata = uniformMetadata;
+      this.additionalClientMaintenanceOperations =
+          additionalClientMaintenanceOperations == null
+                  || additionalClientMaintenanceOperations.isEmpty()
+              ? Collections.emptySet()
+              : Collections.unmodifiableSet(
+                  EnumSet.copyOf(additionalClientMaintenanceOperations));
     }
 
     /** UC's {@code table_uuid}; distinct from {@link AbstractMetadata#getId()} (the Delta id). */
@@ -156,6 +208,11 @@ public final class UCDeltaModels {
     /** UniForm conversion metadata, or empty if the table has no UniForm enabled. */
     public Optional<UniformMetadata> getUniformMetadata() {
       return uniformMetadata;
+    }
+
+    /** Catalog permissions that are client-only and are never persisted in Delta metadata. */
+    public Set<ClientMaintenanceOperation> getAdditionalClientMaintenanceOperations() {
+      return additionalClientMaintenanceOperations;
     }
   }
 

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
@@ -28,6 +28,7 @@ import io.delta.storage.commit.UCDeltaGetCommitsResponse;
 import io.delta.storage.commit.actions.AbstractDomainMetadata;
 import io.delta.storage.commit.actions.AbstractMetadata;
 import io.delta.storage.commit.actions.AbstractProtocol;
+import io.delta.storage.commit.uccommitcoordinator.UCDeltaModels.ClientMaintenanceOperation;
 import io.delta.storage.commit.uccommitcoordinator.UCDeltaModels.TableInfo;
 import io.delta.storage.commit.uccommitcoordinator.exceptions.CredentialFetchFailedException;
 import io.delta.storage.commit.uccommitcoordinator.exceptions.NoSuchTableException;
@@ -86,6 +87,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.Supplier;
 
@@ -617,9 +619,18 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
     AdaptedTableMetadata adapted = new AdaptedTableMetadata(name, m);
     Optional<UniformMetadata> uniformMetadata =
         toStorageUniformMetadata(response.getUniform());
+    Set<ClientMaintenanceOperation> maintenanceOperations =
+        ClientMaintenanceOperation.fromNames(
+            response.getAdditionalClientMaintenanceOperations());
     if (!credentialVendingEnabled) {
       return new TableInfo(
-          ucTableId, tableType, location, adapted, Collections.emptyMap(), uniformMetadata);
+          ucTableId,
+          tableType,
+          location,
+          adapted,
+          Collections.emptyMap(),
+          uniformMetadata,
+          maintenanceOperations);
     }
     Map<String, String> storageProps;
     try {
@@ -629,13 +640,26 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
       // recover. The exception carries the catalog-side TableInfo (with empty storageProperties)
       // so the caller can still build a CatalogTable.
       TableInfo withoutCreds = new TableInfo(
-          ucTableId, tableType, location, adapted, Collections.emptyMap(), uniformMetadata);
+          ucTableId,
+          tableType,
+          location,
+          adapted,
+          Collections.emptyMap(),
+          uniformMetadata,
+          maintenanceOperations);
       throw new CredentialFetchFailedException(
           String.format("Credential fetch failed for table %s.%s.%s (HTTP %s): %s",
               catalog, schema, name, e.getCode(), e.getResponseBody()),
           e, withoutCreds);
     }
-    return new TableInfo(ucTableId, tableType, location, adapted, storageProps, uniformMetadata);
+    return new TableInfo(
+        ucTableId,
+        tableType,
+        location,
+        adapted,
+        storageProps,
+        uniformMetadata,
+        maintenanceOperations);
   }
 
   private static Optional<UniformMetadata> toStorageUniformMetadata(

--- a/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClientSuite.scala
+++ b/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClientSuite.scala
@@ -85,16 +85,22 @@ class UCDeltaTokenBasedRestClientSuite
       location: String = "s3://bucket/table",
       tableType: String = "MANAGED",
       commitsJson: String = "[]",
-      latestTableVersion: Long = -1L): String =
+      latestTableVersion: Long = -1L,
+      additionalMaintenanceOperationsJson: Option[String] = None): String = {
+    val maintenanceOperations = additionalMaintenanceOperationsJson
+      .map(value => s""","additional-client-maintenance-operations":$value""")
+      .getOrElse("")
     s"""{"metadata":{"table-uuid":"$tableUuid","data-source-format":"$format",""" +
-    s""""table-type":"$tableType",""" +
-    s""""location":"$location",""" +
-    s""""columns":{"type":"struct","fields":[""" +
-    s"""{"name":"date","type":"string","nullable":true,"metadata":{}},""" +
-    s"""{"name":"value","type":"integer","nullable":true,"metadata":{}}""" +
-    s"""]},""" +
-    s""""properties":{"key1":"val1"},"partition-columns":["date"],"created-time":1000},""" +
-    s""""commits":$commitsJson,"latest-table-version":$latestTableVersion}"""
+      s""""table-type":"$tableType",""" +
+      s""""location":"$location",""" +
+      s""""columns":{"type":"struct","fields":[""" +
+      s"""{"name":"date","type":"string","nullable":true,"metadata":{}},""" +
+      s"""{"name":"value","type":"integer","nullable":true,"metadata":{}}""" +
+      s"""]},""" +
+      s""""properties":{"key1":"val1"},"partition-columns":["date"],"created-time":1000},""" +
+      s""""commits":$commitsJson,"latest-table-version":$latestTableVersion""" +
+      s"""$maintenanceOperations}"""
+  }
 
   private def deltaCommitJson(
       version: Long,
@@ -228,6 +234,44 @@ class UCDeltaTokenBasedRestClientSuite
       assert(parsed.get("fields").size() === 2)
       assert(parsed.get("fields").get(0).get("name").asText() === "date")
       assert(parsed.get("fields").get(1).get("type").asText() === "integer")
+      assert(info.getAdditionalClientMaintenanceOperations.isEmpty)
+    }
+  }
+
+  test("loadTable parses recognized maintenance operations as a case-sensitive set") {
+    deltaHandler = (exchange, _) => sendJson(
+      exchange,
+      HttpStatus.SC_OK,
+      loadTableJson(additionalMaintenanceOperationsJson = Some(
+        """["OPTIMIZE","VACUUM","OPTIMIZE","optimize","REORG","FUTURE",null]""")))
+
+    withClient { c =>
+      assert(c.loadTable(testIdentifier).getAdditionalClientMaintenanceOperations.asScala ===
+        Set(
+          UCDeltaModels.ClientMaintenanceOperation.OPTIMIZE,
+          UCDeltaModels.ClientMaintenanceOperation.VACUUM))
+    }
+  }
+
+  test("loadTable ignores maintenance operation names with the wrong case") {
+    deltaHandler = (exchange, _) => sendJson(
+      exchange,
+      HttpStatus.SC_OK,
+      loadTableJson(additionalMaintenanceOperationsJson = Some("""["optimize","Vacuum"]""")))
+
+    withClient { c =>
+      assert(c.loadTable(testIdentifier).getAdditionalClientMaintenanceOperations.isEmpty)
+    }
+  }
+
+  test("loadTable treats an empty maintenance operation list as no additions") {
+    deltaHandler = (exchange, _) => sendJson(
+      exchange,
+      HttpStatus.SC_OK,
+      loadTableJson(additionalMaintenanceOperationsJson = Some("[]")))
+
+    withClient { c =>
+      assert(c.loadTable(testIdentifier).getAdditionalClientMaintenanceOperations.isEmpty)
     }
   }
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (storage)

## Description

Catalog-managed Delta tables prohibit optional maintenance unless their catalog explicitly permits it. Delta Spark currently sees only that a table is catalog-managed, so it rejects every external `OPTIMIZE`, `VACUUM`, and `REORG` command.

For example, UC OSS has no background service that compacts small data files. Even when UC OSS wants the client to run `OPTIMIZE`, it has no way to communicate that decision.

This change reads `additional-client-maintenance-operations` from the UC Delta table response and carries it as typed, client-only state. It never copies the policy into Delta table properties or `_delta_log` metadata.

The command behavior is:

- A matching `OPTIMIZE` or `VACUUM` entry permits that command.
- A missing, empty, partial, or unrecognized policy remains restrictive.
- `REORG` remains denied and keeps its own identity when it delegates to the optimize implementation.
- Filesystem-managed tables keep their existing behavior.
- Creating a checkpoint for a catalog-managed table no longer triggers prohibited metadata cleanup.

The response only removes Delta's default prohibition. It does not grant catalog privileges or storage access, and clients still apply all normal command checks.

Depends on unitycatalog/unitycatalog#1765. This branch pins the exact UC PR commit. The pin must be updated to the resulting UC `main` commit after that PR merges, so this PR is intentionally a draft.

## How was this patch tested?

Tested against the UC change from unitycatalog/unitycatalog#1765 published locally:

- `UCDeltaTokenBasedRestClientSuite`: 45 passed
- `CatalogMaintenancePolicySuite` and catalog-routing coverage: 56 passed
- Catalog-managed `OPTIMIZE` rejection with missing policy: passed
- Catalog-managed `VACUUM` and `VACUUM DRY RUN` rejection with missing policy: passed
- Both public `REORG` forms and the internal type-widening rewrite remain classified as `REORG`: passed
- Catalog-managed checkpoint creation without metadata cleanup: passed
- `UCDeltaUtilityTest`: 5 passed, including real file compaction by `OPTIMIZE`, file deletion by `VACUUM`, preservation of an unratified staged file, and `REORG` denial
- Scala style, Java formatting, checkstyle, and `git diff --check`: passed

## Does this PR introduce _any_ user-facing changes?

Yes. A catalog-managed table can now allow external Delta Spark clients to run `OPTIMIZE` and `VACUUM` by advertising those operations. Older servers and missing policies remain restrictive.

