### PR TITLE
RFC: detail the _last_checkpoint fields for adaptive metadata

### DIFF
--- a/protocol_rfcs/iceberg-v4-metadata.md
+++ b/protocol_rfcs/iceberg-v4-metadata.md
@@ -71,13 +71,19 @@ This design enables:
 
 <ins>The `_last_checkpoint` file remains a non-authoritative hint, as defined in the existing protocol. Readers discover whether a table supports `adaptiveMetadata` from the `protocol` action in the log or checkpoint, not from `_last_checkpoint`.</ins>
 
-<ins>When the `adaptiveMetadata` table feature is enabled and a manifest commit has been written, the `_last_checkpoint` file may embed the [`checkpoint` action](#checkpoint-action) for the latest checkpoint version:</ins>
+<ins>When the `adaptiveMetadata` table feature is enabled and a manifest commit has been written, the `_last_checkpoint` file may carry these additional fields:</ins>
 
 | Field Name | Data Type | Description |
 | - | - | - |
-| <ins>checkpoint</ins> | <ins>Struct</ins> | <ins>The `checkpoint` action for the latest manifest commit. Schema defined in [Checkpoint Action](#checkpoint-action).</ins> |
+| <ins>checkpointType</ins> | <ins>String</ins> | <ins>Optional. `adaptiveMetadata` if the latest checkpoint is a [`checkpoint` action](#checkpoint-action); absent for classic/multi-part/V2 checkpoints. Unrecognized values are ignored (reader falls back to log replay).</ins> |
+| <ins>manifestCommitVersion</ins> | <ins>Long</ins> | <ins>Present when `checkpointType` is `adaptiveMetadata`. The `checkpointMetadata.version` of the latest [`checkpoint` action](#checkpoint-action). Distinct from `contentRoot.version`.</ins> |
+| <ins>checkpoint</ins> | <ins>Struct</ins> | <ins>Optional, only when `checkpointType` is `adaptiveMetadata`. The embedded [`checkpoint` action](#checkpoint-action) for the latest manifest commit. May be omitted (see below). Schema in [Checkpoint Action](#checkpoint-action).</ins> |
 
-<ins>When the embedded `checkpoint` action is present, readers can use `contentRoot.path` to begin prefetching the root manifest immediately, and the action provides the complete table state at `checkpointMetadata.version`. If the hint is absent, stale, or does not contain a `checkpoint` action, readers fall back to log replay to locate the latest `checkpoint` action.</ins>
+<ins>`checkpoint` and `v2Checkpoint` are mutually exclusive, as are the `adaptiveMetadata` and `v2Checkpoint` features.</ins>
+
+<ins>The embedded `checkpoint` is a prefetch optimization only; readers must not require it. When present, a reader uses `contentRoot.path` to prefetch the root manifest for the state at `checkpointMetadata.version`. When absent or stale (`manifestCommitVersion` older than a `checkpoint` action found in the log), the reader seeks to the latest `checkpoint` action in the log via `manifestCommitVersion`, or falls back to log replay.</ins>
+
+<ins>`_last_checkpoint` is overwritten non-atomically on some object stores, so it must stay small. Since a `checkpoint` action embeds all non-content metadata, writers must bound it — as V2 checkpoints trim their inline caches above a threshold — omitting the `checkpoint` struct (while still writing `checkpointType` and `manifestCommitVersion`) when it would exceed that threshold.</ins>
 
 ### Checkpoints
 

--- a/protocol_rfcs/iceberg-v4-metadata.md
+++ b/protocol_rfcs/iceberg-v4-metadata.md
@@ -82,7 +82,7 @@ This design enables:
 
 | Field Name | Data Type | Description |
 | - | - | - |
-| <ins>manifestCommitVersion</ins> | <ins>Long</ins> | <ins>The `checkpointMetadata.version` of the latest [`checkpoint` action](#checkpoint-action). Distinct from `contentRoot.version`.</ins> |
+| <ins>manifestCommitVersion</ins> | <ins>Long</ins> | <ins>The version of the commit that emitted the latest [`checkpoint` action](#checkpoint-action). Distinct from the checkpoint's `contentRoot.version`.</ins> |
 | <ins>checkpoint</ins> | <ins>Struct</ins> | <ins>Optional. The embedded [`checkpoint` action](#checkpoint-action) for that manifest commit, for prefetch. May be omitted (see below).</ins> |
 | <ins>leaves</ins> | <ins>Array</ins> | <ins>Optional. The checkpoint's embedded [content entries](#content-entry-schema), prefetched alongside `checkpoint`.</ins> |
 
@@ -90,7 +90,7 @@ This design enables:
 
 <ins>`amtCheckpoint` and `v2Checkpoint` are mutually exclusive, as are the `adaptiveMetadata` and `v2Checkpoint` features.</ins>
 
-<ins>The embedded `checkpoint` and `leaves` are a prefetch optimization only; readers must not require them. When absent or stale (`manifestCommitVersion` older than a `checkpoint` action found in the log), the reader seeks to the latest `checkpoint` action in the log via `manifestCommitVersion`, or falls back to log replay.</ins>
+<ins>The embedded `checkpoint` and `leaves` are a prefetch optimization only; readers must not require them. When absent, the reader reads the `checkpoint` action from the commit at `manifestCommitVersion` (superseded by any newer `checkpoint` action in the log), or falls back to log replay.</ins>
 
 <ins>`_last_checkpoint` is overwritten non-atomically on some object stores, so it must stay small. Writers bound it — as V2 checkpoints trim their inline caches above a threshold — omitting `checkpoint` and `leaves` (while still writing `checkpointType` and `manifestCommitVersion`) when they would exceed that threshold.</ins>
 

--- a/protocol_rfcs/iceberg-v4-metadata.md
+++ b/protocol_rfcs/iceberg-v4-metadata.md
@@ -86,13 +86,13 @@ This design enables:
 | <ins>checkpoint</ins> | <ins>Struct</ins> | <ins>Optional. The embedded [`checkpoint` action](#checkpoint-action) for that manifest commit, for prefetch. May be omitted (see below).</ins> |
 | <ins>leaves</ins> | <ins>Array</ins> | <ins>Optional. The checkpoint's embedded [content entries](#content-entry-schema), prefetched alongside `checkpoint`.</ins> |
 
-<ins>For an `adaptiveMetadata` checkpoint the reused `version`, `parts`, and `size` fields hold the `contentRoot.version`, the number of `leaves`, and `-1` respectively.</ins>
+<ins>An `adaptiveMetadata` checkpoint writes the existing required fields in `_last_checkpoint` file such that `version` holds `contentRoot.version`, `size` holds `-1`, and `parts` holds the `<number of leaves> + 1`, respectively.</ins>
 
 <ins>`amtCheckpoint` and `v2Checkpoint` are mutually exclusive, as are the `adaptiveMetadata` and `v2Checkpoint` features.</ins>
 
-<ins>The embedded `checkpoint` and `leaves` are a prefetch optimization only; readers must not require them. When absent, the reader reads the `checkpoint` action from the commit at `manifestCommitVersion` (superseded by any newer `checkpoint` action in the log), or falls back to log replay.</ins>
+<ins>The embedded optional fields `checkpoint` and `leaves` are a prefetch optimization only; readers must not require them. When absent, the reader reads the `checkpoint` action from the commit file at `manifestCommitVersion`, and derives the `leaves` from the `checkpoint` action.</ins>
 
-<ins>`_last_checkpoint` is overwritten non-atomically on some object stores, so it must stay small. Writers bound it — as V2 checkpoints trim their inline caches above a threshold — omitting `checkpoint` and `leaves` (while still writing `checkpointType` and `manifestCommitVersion`) when they would exceed that threshold.</ins>
+<ins>If the size of `amtCheckpoint` is very large, writing it to `_last_checkpoint` file could take a long time in some object stores, resulting in concurrent readers seeing an empty `_last_checkpoint` file. Thus, writers should bound the size of `amtCheckpoint` by omitting `checkpoint` and `leaves` when their sizes exceed some threshold. `checkpointType` and `manifestCommitVersion` should still be written.</ins>
 
 ### Checkpoints
 

--- a/protocol_rfcs/iceberg-v4-metadata.md
+++ b/protocol_rfcs/iceberg-v4-metadata.md
@@ -75,15 +75,24 @@ This design enables:
 
 | Field Name | Data Type | Description |
 | - | - | - |
-| <ins>checkpointType</ins> | <ins>String</ins> | <ins>Optional. `adaptiveMetadata` if the latest checkpoint is a [`checkpoint` action](#checkpoint-action); absent for classic/multi-part/V2 checkpoints. Unrecognized values are ignored (reader falls back to log replay).</ins> |
-| <ins>manifestCommitVersion</ins> | <ins>Long</ins> | <ins>Present when `checkpointType` is `adaptiveMetadata`. The `checkpointMetadata.version` of the latest [`checkpoint` action](#checkpoint-action). Distinct from `contentRoot.version`.</ins> |
-| <ins>checkpoint</ins> | <ins>Struct</ins> | <ins>Optional, only when `checkpointType` is `adaptiveMetadata`. The embedded [`checkpoint` action](#checkpoint-action) for the latest manifest commit. May be omitted (see below). Schema in [Checkpoint Action](#checkpoint-action).</ins> |
+| <ins>checkpointType</ins> | <ins>String</ins> | <ins>Optional. `AdaptiveMetadataTree` if the latest checkpoint is a [`checkpoint` action](#checkpoint-action); absent for classic/multi-part/V2 checkpoints. Unrecognized values are ignored (reader falls back to log replay).</ins> |
+| <ins>amtCheckpoint</ins> | <ins>Struct</ins> | <ins>Present iff `checkpointType` is `AdaptiveMetadataTree`. Describes the latest [`checkpoint` action](#checkpoint-action); fields below.</ins> |
 
-<ins>`checkpoint` and `v2Checkpoint` are mutually exclusive, as are the `adaptiveMetadata` and `v2Checkpoint` features.</ins>
+<ins>The `amtCheckpoint` struct has these fields:</ins>
 
-<ins>The embedded `checkpoint` is a prefetch optimization only; readers must not require it. When present, a reader uses `contentRoot.path` to prefetch the root manifest for the state at `checkpointMetadata.version`. When absent or stale (`manifestCommitVersion` older than a `checkpoint` action found in the log), the reader seeks to the latest `checkpoint` action in the log via `manifestCommitVersion`, or falls back to log replay.</ins>
+| Field Name | Data Type | Description |
+| - | - | - |
+| <ins>manifestCommitVersion</ins> | <ins>Long</ins> | <ins>The `checkpointMetadata.version` of the latest [`checkpoint` action](#checkpoint-action). Distinct from `contentRoot.version`.</ins> |
+| <ins>checkpoint</ins> | <ins>Struct</ins> | <ins>Optional. The embedded [`checkpoint` action](#checkpoint-action) for that manifest commit, for prefetch. May be omitted (see below).</ins> |
+| <ins>leaves</ins> | <ins>Array</ins> | <ins>Optional. The checkpoint's embedded [content entries](#content-entry-schema), prefetched alongside `checkpoint`.</ins> |
 
-<ins>`_last_checkpoint` is overwritten non-atomically on some object stores, so it must stay small. Since a `checkpoint` action embeds all non-content metadata, writers must bound it — as V2 checkpoints trim their inline caches above a threshold — omitting the `checkpoint` struct (while still writing `checkpointType` and `manifestCommitVersion`) when it would exceed that threshold.</ins>
+<ins>For an `adaptiveMetadata` checkpoint the reused `version`, `parts`, and `size` fields hold the `contentRoot.version`, the number of `leaves`, and `-1` respectively.</ins>
+
+<ins>`amtCheckpoint` and `v2Checkpoint` are mutually exclusive, as are the `adaptiveMetadata` and `v2Checkpoint` features.</ins>
+
+<ins>The embedded `checkpoint` and `leaves` are a prefetch optimization only; readers must not require them. When absent or stale (`manifestCommitVersion` older than a `checkpoint` action found in the log), the reader seeks to the latest `checkpoint` action in the log via `manifestCommitVersion`, or falls back to log replay.</ins>
+
+<ins>`_last_checkpoint` is overwritten non-atomically on some object stores, so it must stay small. Writers bound it — as V2 checkpoints trim their inline caches above a threshold — omitting `checkpoint` and `leaves` (while still writing `checkpointType` and `manifestCommitVersion`) when they would exceed that threshold.</ins>
 
 ### Checkpoints
 


### PR DESCRIPTION
## Description

This updates the **Iceberg V4 Adaptive Metadata Tree** RFC
(`protocol_rfcs/iceberg-v4-metadata.md`) to specify how the `_last_checkpoint`
hint carries adaptive-metadata checkpoint state.

The RFC currently says only that `_last_checkpoint` "may embed the `checkpoint`
action". Implementation and review of the adaptive-metadata write path surfaced
the need to say more, so this PR expands the "Last Checkpoint File" section:

- **`checkpointType`** (optional String): identifies how the latest checkpoint is
  materialized, so a reader can interpret the file without first reading the log.
  Absent/`null` = classic single-file, multi-part, or V2 checkpoint (existing
  behavior); `adaptiveMetadata` = an embedded tree `checkpoint` action.
  Unrecognized values are ignored and the reader falls back to log replay.
- **`manifestCommitVersion`** (optional Long): the latest manifest commit's
  `checkpointMetadata.version`, promoted to a top-level scalar so a reader can
  detect a stale hint and seek to the latest checkpoint even when the embedded
  action is omitted. This is deliberately distinct from the content root's own
  `contentRoot.version`.
- **Bounding rule**: `_last_checkpoint` is overwritten non-atomically on some
  object stores, so it must stay small. An embedded `checkpoint` action (which
  carries all non-content metadata) can grow large, so writers omit the embedded
  `checkpoint` struct above a size threshold — following the existing V2-checkpoint
  trimming precedent — while still writing `checkpointType` and
  `manifestCommitVersion`. Readers must treat the embedded `checkpoint` as a
  prefetch optimization only, never a requirement.
- States the **`checkpoint`/`v2Checkpoint` mutual exclusion** in `_last_checkpoint`,
  consistent with the `adaptiveMetadata`/`v2Checkpoint` table-feature exclusion the
  RFC already defines.

This is a spec-doc change only; it touches neither `PROTOCOL.md` (updated at RFC
acceptance) nor any implementation.

see #6640
