### PR TITLE
[Protocol RFC] Column Updates

### DIFF
--- a/protocol_rfcs/README.md
+++ b/protocol_rfcs/README.md
@@ -26,6 +26,7 @@ Here is the history of all the RFCs propose/accepted/rejected since Feb 6, 2024,
 | 2025-11-20    | [materialize-partition-columns.md](https://github.com/delta-io/delta/blob/master/protocol_rfcs/materialize-partition-columns.md)                         | https://github.com/delta-io/delta/issues/5555 | Materialize Partition Columns                      |
 | 2026-04-22    | [iceberg-v4-metadata.md](https://github.com/delta-io/delta/blob/master/protocol_rfcs/iceberg-v4-metadata.md)                     | https://github.com/delta-io/delta/issues/6640 | Iceberg V4 Adaptive Metadata Tree      |
 | 2026-06-23    | [interval-types.md](https://github.com/delta-io/delta/blob/master/protocol_rfcs/interval-types.md)                                         | https://github.com/delta-io/delta/issues/7077 | Interval Types                         |
+| 2026-08-10    | [column-updates.md](https://github.com/delta-io/delta/blob/master/protocol_rfcs/column-updates.md)                                     | https://github.com/delta-io/delta/issues/7414 | Column Updates                         |
 
 ### Accepted RFCs
 

--- a/protocol_rfcs/column-updates.md
+++ b/protocol_rfcs/column-updates.md
@@ -81,7 +81,9 @@ A column file is a Parquet file associated with exactly one base data file. Its 
 
 `_pos` is the physical offset of the corresponding row in the base file.
 
-`_last_updated_sequence_number` stores row lineage information for Iceberg V4 change detection. It contains either the sequence number of the update that last changed this row, or `NULL` to indicate that the most recent update changed this row.
+`_last_updated_sequence_number` stores row lineage information for Iceberg V4 change detection. In Delta, it contains either the commit version of the update that last changed this row, or `NULL` to indicate that the most recent update changed this row. The name mentions sequence numbers only for Iceberg compatibility, in Delta it still stores the Delta commit version.
+
+The rest is value columns that represent the current values for the associated base file columns. Values associated with base file rows that are already deleted by a DV might either contain stale values (so that we don't need to overwrite the column file with each DV update) or `NULL`s (so that we don't need to read the old values when writing new copy-on-write column files).
 
 For examples of column files see [Column Updates examples](#column-updates-examples).
 
@@ -95,9 +97,9 @@ fieldIds | Array[Integer] | The Column Mapping IDs of the table fields supplied 
 path | String | A relative path to a column file from the root of the table, or an absolute path to the column file. The path uses the same URI encoding as `add.path`. | required
 sizeInBytes | Long | The size of the column file in bytes. | required
 
-`fieldIds` must not be empty and must not contain duplicates. A field ID must occur in at most one `ColumnFileDescriptor` within a single `add`.
+`fieldIds` must not be empty and must not contain duplicates. A field ID must occur in at most one `ColumnFileDescriptor` within a single `add`. At the moment, only top-level fields are supported for Column Updates.
 
-`_pos` does not get a field id is not included in `fieldIds` as it is a metadata column that is always present. `_last_updated_sequence_number` does get a field id (2147483539) and might be included to indicate that the associated column file is the most recently written one. This implies that for file actions that contain any amount of column files, there should be exactly one `ColumnFileDescriptor` that contains the field id for `_last_updated_sequence_number`.
+`_pos` does not get a field id and is not included in `fieldIds` as it is a metadata column that is always present. `_last_updated_sequence_number` does get a field id (2147483539) and might be included to indicate that the associated column file is the most recently written one. This implies that for file actions that contain any amount of column files, there should be exactly one `ColumnFileDescriptor` that contains the field id for `_last_updated_sequence_number`.
 
 ## Column File Set Identity
 
@@ -121,7 +123,7 @@ During a write that uses the Column Updates feature, the writer must:
 
 ## Column File Cleanup
 
-Column files are table data. VACUUM must preserve all column files referenced by a retained file action. A column file may be deleted only when no retained file action references its path an the retention period has passed.
+Column files are table data. VACUUM must preserve all column files referenced by a retained file action. A column file may be deleted only when no retained file action references its path and the retention period has passed.
 
 The `columnUpdates` feature must not be removed while any retained table version references a column file.
 

--- a/protocol_rfcs/column-updates.md
+++ b/protocol_rfcs/column-updates.md
@@ -1,7 +1,7 @@
-# Efficient Column Updates
+# Column Updates
 **Associated GitHub issue for discussions: https://github.com/delta-io/delta/issues/7414**
 
-This protocol change introduces the Efficient Column Updates feature, which allows a writer to
+This protocol change introduces the Column Updates feature, which allows a writer to
 replace selected columns of a data file without rewriting the other columns in that file.
 
 The writer stores the replacement values in a Parquet column file. The column file
@@ -16,7 +16,7 @@ data file and its column files by physical row position.
 
 > ***In [Add File and Remove File](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#add-file-and-remove-file), replace the two paragraphs starting with "Every logical file" and ending with "`(path, NULL)` instead" with the following text.***
 
-Every _logical file_ of the table is represented by a path to a data file, combined with an optional Deletion Vector (DV) and zero or more column files. A DV identifies which rows of the data file are no longer in the table. A column file supplies current values for a set of columns in the data file. Deletion Vectors and column files are optional features. See [Deletion Vectors](#deletion-vectors) and [Efficient Column Updates](#efficient-column-updates) for details.
+Every _logical file_ of the table is represented by a path to a data file, combined with an optional Deletion Vector (DV) and zero or more column files. A DV identifies which rows of the data file are no longer in the table. A column file supplies current values for a set of columns in the data file. Deletion Vectors and column files are optional features. See [Deletion Vectors](#deletion-vectors) and [Column Updates](#column-updates) for details.
 
 When an `add` action is encountered for a logical file that is already present in the table, statistics and other information from the latest version should replace that from any previous version.
 The primary key for the entry of a logical file in the set of files is a tuple of the data file's `path`, a unique id describing the DV, and a unique id describing the column file set. If no DV is part of this logical file, then the DV part of the primary key is `NULL`. If no column files are part of this logical file, then the column file set part of the primary key is `NULL`.
@@ -38,13 +38,13 @@ That means specifically that for any commit…
 
 Field Name | Data Type | Description | optional/required
 -|-|-|-
-columnFiles | Array[[ColumnFileDescriptor Struct](#column-file-descriptor-struct)] | The column files associated with this data file. See also [Efficient Column Updates](#efficient-column-updates). | optional
+columnFiles | Array[[ColumnFileDescriptor Struct](#column-file-descriptor-struct)] | The column files associated with this data file. See also [Column Updates](#column-updates). | optional
 
 > ***Add the following row to the schema of the `remove` action, after `defaultRowCommitVersion`.***
 
 Field Name | Data Type | Description | optional/required
 -|-|-|-
-columnFiles | Array[[ColumnFileDescriptor Struct](#column-file-descriptor-struct)] | The column files associated with the logical file being removed. See also [Efficient Column Updates](#efficient-column-updates). | optional
+columnFiles | Array[[ColumnFileDescriptor Struct](#column-file-descriptor-struct)] | The column files associated with the logical file being removed. See also [Column Updates](#column-updates). | optional
 
 ## Action Reconciliation
 
@@ -61,9 +61,9 @@ columnFiles | Array[[ColumnFileDescriptor Struct](#column-file-descriptor-struct
 
 > ***Add the following section after [Deletion Vectors](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#deletion-vectors) and before Catalog-managed Tables.***
 
-# Efficient Column Updates
+# Column Updates
 
-Efficient Column Updates allow a logical file to obtain selected column values from one or more Parquet column files. The feature name is `columnUpdates`. This is a reader-writer feature.
+Column Updates allow a logical file to obtain selected column values from one or more Parquet column files. The feature name is `columnUpdates`. This is a reader-writer feature. Column Updates require Column Mapping to be enabled for the stable column IDs.
 
 To support this feature:
 
@@ -71,6 +71,19 @@ To support this feature:
 - The feature `columnUpdates` must exist in the table protocol's `readerFeatures` and `writerFeatures`.
 - The feature `columnMapping` must exist in the table protocol's `readerFeatures` and `writerFeatures`.
 - The table property `delta.columnMapping.mode` must be set to `name` or `id`.
+
+Column Updates store values in [Column Files](#column-file-format) that are tracked in metadata
+using [Column File Descriptors](#column-file-descriptor-struct).
+
+## Column File Format
+
+A column file is a Parquet file associated with exactly one base data file. Its columns are `_pos`, `_last_updated_sequence_number`, and a subset of columns of the base file with nullability on top (i.e. `INTEGER NOT NULL` in the base file becomes `INTEGER` in the column file). It has one row for each physical row in the base file.
+
+`_pos` is the physical offset of the corresponding row in the base file.
+
+`_last_updated_sequence_number` stores row lineage information for Iceberg V4 change detection. It contains either the sequence number of the update that last changed this row, or `NULL` to indicate that the most recent update changed this row.
+
+For examples of column files see [Column Updates examples](#column-updates-examples).
 
 ## Column File Descriptor Struct
 
@@ -90,30 +103,20 @@ sizeInBytes | Long | The size of the column file in bytes. | required
 
 The identity of a column file set is the sorted list of each descriptor's `path` and sorted `fieldIds`. These are the only fields that affect the logical data.
 
-## Column File Format
-
-A column file is a Parquet file associated with exactly one base data file. Its columns are `_pos`, `_last_updated_sequence_number`, and a subset of columns of the base file with nullability on top (i.e. `INTEGER NOT NULL` in the base file becomes `INTEGER` in the column file). It has one row for each physical row in the base file.
-
-`_pos` is the physical offset of the corresponding row in the base file.
-
-`_last_updated_sequence_number` stores row lineage information for Iceberg V4 change detection. It contains either the sequence number of the update that last changed this row, or `NULL` to indicate that the most recent update changed this row.
-
-For examples of column files see [Efficient Column Updates examples](#efficient-column-updates-examples).
-
-## Reader Requirements for Efficient Column Updates
+## Reader Requirements for Column Updates
 
 During a read, if a field is present in `columnFiles[].fieldIds`, the reader must consider the corresponding values for that column in the base file as invalid and read them from the column file instead.
 
 The row-group boundaries of a column file and its base data file may differ. A reader
 must align records by physical row position, not by row-group number.
 
-## Writer Requirements for Efficient Column Updates
+## Writer Requirements for Column Updates
 
 During a write that replaces an `add` action with a new `add` action and a `remove`
 tombstone on the same `path`, without rewriting the base data file, the writer must
 carry over all `columnFiles` entries.
 
-During a write that uses an Efficient Column Update, the writer must:
+During a write that uses the Column Updates feature, the writer must:
 
 - retain entries that do not contain a field ID written by the update;
 - remove the newly written field IDs from each overlapping entry;
@@ -134,9 +137,9 @@ RESTORE must restore the complete column file state for the selected snapshot.
 The `columnUpdates` feature must not be removed while any retained table version
 references a column file.
 
-## Efficient Column Updates Examples
+## Column Updates Examples
 
-This table shows the Parquet files and log actions after each statement, assuming every `UPDATE` uses Efficient Column Updates. The example assumes that the column `foo` has Column Mapping ID 7, and column `bar` has ID 8. The table abbreviates `_last_updated_sequence_number` to `_lusn`, and `add`/`remove` actions only contain relevant fields.
+This table shows the Parquet files and log actions after each statement, assuming every `UPDATE` uses the Column Updates feature. The example assumes that the column `foo` has Column Mapping ID 7, and column `bar` has ID 8. The table abbreviates `_last_updated_sequence_number` to `_lusn`, and `add`/`remove` actions only contain relevant fields.
 
 <table>
 <tr>
@@ -304,4 +307,4 @@ WHERE key = 'a'
 
 Feature | Name | Readers or Writers?
 -|-|-
-[Efficient Column Updates](#efficient-column-updates) | `columnUpdates` | Readers and writers
+[Column Updates](#column-updates) | `columnUpdates` | Readers and writers

--- a/protocol_rfcs/column-updates.md
+++ b/protocol_rfcs/column-updates.md
@@ -63,7 +63,7 @@ columnFiles | Array[[ColumnFileDescriptor Struct](#column-file-descriptor-struct
 
 # Column Updates
 
-Column Updates allow a logical file to obtain selected column values from one or more Parquet column files. The feature name is `columnUpdates`. This is a reader-writer feature. Column Updates require Column Mapping to be enabled for the stable column IDs.
+Column Updates allow a logical file to obtain selected column values from one or more Parquet column files. The feature name is `columnUpdates`. This is a reader-writer feature. Column Updates require Column Mapping to be enabled as Column Updates apply to physical columns, not logical column names.
 
 To support this feature:
 
@@ -77,7 +77,7 @@ using [Column File Descriptors](#column-file-descriptor-struct).
 
 ## Column File Format
 
-A column file is a Parquet file associated with exactly one base data file. Its columns are `_pos`, `_last_updated_sequence_number`, and a subset of columns of the base file with nullability on top (i.e. `INTEGER NOT NULL` in the base file becomes `INTEGER` in the column file). It has one row for each physical row in the base file.
+A column file is a Parquet file associated with exactly one base data file. Its columns are `_pos`, `_last_updated_sequence_number`, and a subset of columns of the base file with nullability on top (i.e. `INTEGER NOT NULL`/`Int` in the base file becomes `INTEGER`/`Option[Int]` in the column file). It has one row for each physical row in the base file.
 
 `_pos` is the physical offset of the corresponding row in the base file.
 
@@ -97,7 +97,7 @@ sizeInBytes | Long | The size of the column file in bytes. | required
 
 `fieldIds` must not be empty and must not contain duplicates. A field ID must occur in at most one `ColumnFileDescriptor` within a single `add`.
 
-`_pos` is not included in `fieldIds` as it is a metadata column that is always present. `_last_updated_sequence_number` might be included to indicate that the associated column file is the most recently written one.
+`_pos` does not get a field id is not included in `fieldIds` as it is a metadata column that is always present. `_last_updated_sequence_number` does get a field id (2147483539) and might be included to indicate that the associated column file is the most recently written one. This implies that for file actions that contain any amount of column files, there should be exactly one `ColumnFileDescriptor` that contains the field id for `_last_updated_sequence_number`.
 
 ## Column File Set Identity
 
@@ -107,35 +107,23 @@ The identity of a column file set is the sorted list of each descriptor's `path`
 
 During a read, if a field is present in `columnFiles[].fieldIds`, the reader must consider the corresponding values for that column in the base file as invalid and read them from the column file instead.
 
-The row-group boundaries of a column file and its base data file may differ. A reader
-must align records by physical row position, not by row-group number.
+The row-group boundaries of a column file and its base data file may differ. A reader must align column file rows with base data file rows using the `_pos` column. This version of the spec disallows row counts being different between column files and the base data file, so aligning using `_pos` is equivalent to aligning positionally.
 
 ## Writer Requirements for Column Updates
 
-During a write that replaces an `add` action with a new `add` action and a `remove`
-tombstone on the same `path`, without rewriting the base data file, the writer must
-carry over all `columnFiles` entries.
-
 During a write that uses the Column Updates feature, the writer must:
 
-- retain entries that do not contain a field ID written by the update;
-- remove the newly written field IDs from each overlapping entry;
-- remove an old entry if no field IDs remain; and
-- add an entry for the new column file and its newly written field IDs.
+1. copy over all previous `ColumnFileDescriptor`s;
+2. for each field id that contains changes in the current write, remove that field id from all `ColumnFileDescriptor`s;
+3. remove field id for `_last_updated_sequence_number` from any `ColumnFileDescriptor`s that contain it;
+4. add a new `ColumnFileDescriptor` that contains the newly written column file path, along with all field ids that contain changes in the current write and field id for `_last_updated_sequence_number`;
+5. remove all `ColumnFileDescriptor`s that contain no associated field ids as a result of step (2).
 
 ## Column File Cleanup
 
-Column files are table data. VACUUM must preserve all column files referenced by a
-retained `add` action, an unexpired `remove` action, or a retained historical table
-version. A column file may be deleted only when no retained descriptor references
-its path and the retention period has passed.
+Column files are table data. VACUUM must preserve all column files referenced by a retained file action. A column file may be deleted only when no retained file action references its path an the retention period has passed.
 
-OPTIMIZE must read the reconstructed logical rows and write replacement base data
-files without column files. CLONE must preserve or copy each referenced column file.
-RESTORE must restore the complete column file state for the selected snapshot.
-
-The `columnUpdates` feature must not be removed while any retained table version
-references a column file.
+The `columnUpdates` feature must not be removed while any retained table version references a column file.
 
 ## Column Updates Examples
 

--- a/protocol_rfcs/column-updates.md
+++ b/protocol_rfcs/column-updates.md
@@ -14,25 +14,52 @@ data file and its column files by physical row position.
 
 ## Add File and Remove File
 
-> ***In [Add File and Remove File](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#add-file-and-remove-file), replace the two paragraphs starting with "Every logical file" and ending with "`(path, NULL)` instead" with the following text.***
+> ***In [Add File and Remove
+> File](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#add-file-and-remove-file), replace
+> the two paragraphs starting with "Every logical file" and ending with "`(path, NULL)` instead"
+> with the following text.***
 
-Every _logical file_ of the table is represented by a path to a data file, combined with an optional Deletion Vector (DV) and zero or more column files. A DV identifies which rows of the data file are no longer in the table. A column file supplies current values for a set of columns in the data file. Deletion Vectors and column files are optional features. See [Deletion Vectors](#deletion-vectors) and [Column Updates](#column-updates) for details.
+Every _logical file_ of the table is represented by a path to a data file, combined with an optional
+Deletion Vector (DV) and zero or more column files. A DV identifies which rows of the data file are
+no longer in the table. A column file supplies current values for a set of columns in the data file.
+Deletion Vectors and column files are optional features. See [Deletion Vectors](#deletion-vectors)
+and [Column Updates](#column-updates) for details.
 
-When an `add` action is encountered for a logical file that is already present in the table, statistics and other information from the latest version should replace that from any previous version.
-The primary key for the entry of a logical file in the set of files is a tuple of the data file's `path`, a unique id describing the DV, and a unique id describing the column file set. If no DV is part of this logical file, then the DV part of the primary key is `NULL`. If no column files are part of this logical file, then the column file set part of the primary key is `NULL`.
+When an `add` action is encountered for a logical file that is already present in the table,
+statistics and other information from the latest version should replace that from any previous
+version.
+The primary key for the entry of a logical file in the set of files is a tuple of the data file's
+`path`, a unique id describing the DV, and a unique id describing the column file set. If no DV is
+part of this logical file, then the DV part of the primary key is `NULL`. If no column files are
+part of this logical file, then the column file set part of the primary key is `NULL`.
 
-> ***In the same section, replace the paragraph starting with "In the following statements" and the five bullets that follow it with the following text.***
+> ***In the same section, replace the paragraph starting with "In the following statements" and the
+> five bullets that follow it with the following text.***
 
-In the following statements, `dvId` refers to either the unique ID of a specific Deletion Vector (`deletionVector.uniqueId`) or to `NULL`, indicating that no rows are invalidated. `columnFileSetId` refers to either the identity of a specific column file set or to `NULL`, indicating that there are no associated column files.
+In the following statements, `dvId` refers to either the unique ID of a specific Deletion Vector
+(`deletionVector.uniqueId`) or to `NULL`, indicating that no rows are invalidated; and
+`columnFileSetId` refers to either the identity of a specific column file set or to `NULL`,
+indicating that there are no associated column files (see [Column File Set
+Identity](#column-file-set-identity) for details).
 
-Since actions within a given Delta commit are not guaranteed to be applied in order, a **valid** version is restricted to contain at most one file action *of the same type* (i.e. `add`/`remove`) for any one combination of `path`, `dvId` and `columnFileSetId`. Moreover, for simplicity, it is required that there is at most one file action of the same type for any `path` (regardless of `dvId` and `columnFileSetId`).
+Since actions within a given Delta commit are not guaranteed to be applied in order, a **valid**
+version is restricted to contain at most one file action *of the same type* (i.e. `add`/`remove`)
+for any one combination of `path`, `dvId` and `columnFileSetId`. Moreover, for simplicity, it is
+required that there is at most one file action of the same type for any `path` (regardless of `dvId`
+and `columnFileSetId`).
 That means specifically that for any commit…
 
-- it is **legal** for the same `path` to occur in an `add` action and a `remove` action, but with two different `dvId`s or `columnFileSetId`s.
+- it is **legal** for the same `path` to occur in an `add` action and a `remove` action, but with
+  two different `dvId`s or `columnFileSetId`s.
 - it is **legal** for the same `path` to be added and/or removed and also occur in a `cdc` action.
-- it is **illegal** for the same `path` to occur twice within the set of `add` actions or within the set of `remove` actions, regardless of its `dvId` or `columnFileSetId`.
-- it is **illegal** for a `path` to occur in an `add` action that already occurs with a different `dvId` or `columnFileSetId` in the list of `add` actions from the snapshot of the version immediately preceding the commit, unless the commit also contains a `remove` for the later combination.
-- it is **legal** to commit an existing `path`, `dvId` and `columnFileSetId` combination again (this allows metadata updates).
+- it is **illegal** for the same `path` to occur twice within the set of `add` actions or within the
+  set of `remove` actions, regardless of its `dvId` or `columnFileSetId`.
+- it is **illegal** for a `path` to occur in an `add` action that already occurs with a different
+  `dvId` or `columnFileSetId` in the list of `add` actions from the snapshot of the version
+  immediately preceding the commit, unless the commit also contains a `remove` for the later
+  combination.
+- it is **legal** to commit an existing `path`, `dvId` and `columnFileSetId` combination again (this
+  allows metadata updates).
 
 > ***Add the following row to the schema of the `add` action, after `clusteringProvider`.***
 
@@ -48,28 +75,46 @@ columnFiles | Array[[ColumnFileDescriptor Struct](#column-file-descriptor-struct
 
 ## Action Reconciliation
 
-> ***In [Action Reconciliation](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#action-reconciliation), replace the two collection bullets for `add` and `remove` actions with the following bullets.***
+> ***In [Action
+> Reconciliation](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#action-reconciliation),
+> replace the two collection bullets for `add` and `remove` actions with the following bullets.***
 
-- A collection of `add` actions with unique `path` keys, corresponding to the newest `(path, deletionVector.uniqueId, columnFileSetId)` tuple encountered for each path.
-- A collection of `remove` actions with unique `(path, deletionVector.uniqueId, columnFileSetId)` keys. The intersection of the primary keys in the `add` collection and `remove` collection must be empty. That means a logical file cannot exist in both the `remove` and `add` collections at the same time; however, the same *data file* can exist with *different* DVs in the `remove` collection, as logically they represent different content. The `remove` actions act as _tombstones_, and only exist for the benefit of the VACUUM command. Snapshot reads only return `add` actions on the read path.
+- A collection of `add` actions with unique `path` keys, corresponding to the newest `(path,
+  deletionVector.uniqueId, columnFileSetId)` tuple encountered for each path.
+- A collection of `remove` actions with unique `(path, deletionVector.uniqueId, columnFileSetId)`
+  keys. The intersection of the primary keys in the `add` collection and `remove` collection must be
+  empty. That means a logical file cannot exist in both the `remove` and `add` collections at the
+  same time; however, the same *data file* can exist with *different* DVs in the `remove`
+  collection, as logically they represent different content. The `remove` actions act as
+  _tombstones_, and only exist for the benefit of the VACUUM command. Snapshot reads only return
+  `add` actions on the read path.
 
-> ***In the reconciliation rules in the same section, replace the bullet starting with "Logical files in a table" with the following bullet.***
+> ***In the reconciliation rules in the same section, replace the bullet starting with "Logical
+> files in a table" with the following bullet.***
 
-- Logical files in a table are identified by their `(path, deletionVector.uniqueId, columnFileSetId)` primary key. File actions (`add` or `remove`) reference logical files, and a log can contain any number of references to a single file.
+- Logical files in a table are identified by their `(path, deletionVector.uniqueId,
+  columnFileSetId)` primary key. File actions (`add` or `remove`) reference logical files, and a log
+  can contain any number of references to a single file.
 
 --------
 
-> ***Add the following section after [Deletion Vectors](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#deletion-vectors) and before Catalog-managed Tables.***
+> ***Add the following section after [Deletion
+> Vectors](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#deletion-vectors) and before
+> Catalog-managed Tables.***
 
 # Column Updates
 
-Column Updates allow a logical file to obtain selected column values from one or more Parquet column files. The feature name is `columnUpdates`. This is a reader-writer feature. Column Updates require Column Mapping to be enabled as Column Updates apply to physical columns, not logical column names.
+Column Updates allow a logical file to obtain selected column values from one or more Parquet column
+files. The feature name is `columnUpdates`. This is a reader-writer feature. Column Updates require
+Column Mapping to be enabled as Column Updates apply to physical columns, not logical column names.
 
 To support this feature:
 
 - The table must be on Reader Version 3 and Writer Version 7.
-- The feature `columnUpdates` must exist in the table protocol's `readerFeatures` and `writerFeatures`.
-- The feature `columnMapping` must exist in the table protocol's `readerFeatures` and `writerFeatures`.
+- The feature `columnUpdates` must exist in the table protocol's `readerFeatures` and
+  `writerFeatures`.
+- The feature `columnMapping` must exist in the table protocol's `readerFeatures` and
+  `writerFeatures`.
 - The table property `delta.columnMapping.mode` must be set to `name` or `id`.
 
 Column Updates store values in [Column Files](#column-file-format) that are tracked in metadata
@@ -77,15 +122,22 @@ using [Column File Descriptors](#column-file-descriptor-struct).
 
 ## Column File Format
 
-A column file is a Parquet file associated with exactly one base data file. Its columns are `_pos`, `_last_updated_sequence_number`, and a subset of columns of the base file with nullability on top (i.e. `INTEGER NOT NULL`/`Int` in the base file becomes `INTEGER`/`Option[Int]` in the column file). It has one row for each physical row in the base file.
+A column file is a Parquet file associated with exactly one base data file. Its columns are
+`_last_updated_sequence_number` and a subset of columns of the base file with nullability on top
+(i.e. `INTEGER NOT NULL`/`Int` in the base file becomes `INTEGER`/`Option[Int]` in the column file).
+It has one row for each physical row in the base file.
 
-`_pos` is the physical offset of the corresponding row in the base file.
+`_last_updated_sequence_number` stores row lineage information for Iceberg V4 change detection. In
+Delta, it contains either the commit version of the update that last changed this row, or `NULL` to
+indicate that the most recent update changed this row. The name mentions sequence numbers only for
+Iceberg compatibility, in Delta it still stores the Delta commit version.
 
-`_last_updated_sequence_number` stores row lineage information for Iceberg V4 change detection. In Delta, it contains either the commit version of the update that last changed this row, or `NULL` to indicate that the most recent update changed this row. The name mentions sequence numbers only for Iceberg compatibility, in Delta it still stores the Delta commit version.
+The rest are value columns that represent the current values for the associated base file columns.
+Values associated with base file rows that are already deleted by a DV might contain either stale
+values (so that we don't need to overwrite the column file with each DV update) or `NULL`s (so that
+we don't need to read the old values when writing new copy-on-write column files).
 
-The rest is value columns that represent the current values for the associated base file columns. Values associated with base file rows that are already deleted by a DV might either contain stale values (so that we don't need to overwrite the column file with each DV update) or `NULL`s (so that we don't need to read the old values when writing new copy-on-write column files).
-
-For examples of column files see [Column Updates examples](#column-updates-examples).
+For examples of column files, see [Column Updates examples](#column-updates-examples).
 
 ## Column File Descriptor Struct
 
@@ -97,39 +149,71 @@ fieldIds | Array[Integer] | The Column Mapping IDs of the table fields supplied 
 path | String | A relative path to a column file from the root of the table, or an absolute path to the column file. The path uses the same URI encoding as `add.path`. | required
 sizeInBytes | Long | The size of the column file in bytes. | required
 
-`fieldIds` must not be empty and must not contain duplicates. A field ID must occur in at most one `ColumnFileDescriptor` within a single `add`. At the moment, only top-level fields are supported for Column Updates.
+`fieldIds` must not be empty and must not contain duplicates. A field ID must occur in at most one
+`ColumnFileDescriptor` within a single `add`. At the moment, only top-level fields are supported for
+Column Updates.
 
-`_pos` does not get a field id and is not included in `fieldIds` as it is a metadata column that is always present. `_last_updated_sequence_number` does get a field id (2147483539) and might be included to indicate that the associated column file is the most recently written one. This implies that for file actions that contain any amount of column files, there should be exactly one `ColumnFileDescriptor` that contains the field id for `_last_updated_sequence_number`.
+`_last_updated_sequence_number`, despite being a metadata column that is always included in the
+file, gets field id 2147483539, which must only be included to indicate that the associated column
+file is the most recently written one. This implies that for file actions that contain any non-zero
+amount of column files, there must be exactly one `ColumnFileDescriptor` that contains the field id
+for `_last_updated_sequence_number`.
 
 ## Column File Set Identity
 
-The identity of a column file set is the sorted list of each descriptor's `path` and sorted `fieldIds`. These are the only fields that affect the logical data.
+The identity of a column file set is the relative path to the latest column file within a single
+`add` action.
+
+Keeping only the latest file path, and not including the entirety of the column file set is a
+deliberate choice to keep the identity for a single action small and independent of amount of
+columns in the file (in the worst case, there is as many column files as columns).
+
+Using the latest file path is still sound (i.e. the identity changes every time DML affects the
+logical data within the table):
+
+- all previous DML operations still change the key;
+- any DML that wants to write a Column Update produces a new column file, thus affecting the latest
+  file path.
 
 ## Reader Requirements for Column Updates
 
-During a read, if a field is present in `columnFiles[].fieldIds`, the reader must consider the corresponding values for that column in the base file as invalid and read them from the column file instead.
+During a read, if a field is present in `columnFiles[].fieldIds`, the reader must consider the
+corresponding values for that column in the base file as invalid and read them from the column file
+instead.
 
-The row-group boundaries of a column file and its base data file may differ. A reader must align column file rows with base data file rows using the `_pos` column. This version of the spec disallows row counts being different between column files and the base data file, so aligning using `_pos` is equivalent to aligning positionally.
+The row-group boundaries of a column file and its base data file may differ. A reader must align
+column file rows with base data file rows by position -- column files are required to contain the
+same number of physical rows as base files.
 
 ## Writer Requirements for Column Updates
 
 During a write that uses the Column Updates feature, the writer must:
 
 1. copy over all previous `ColumnFileDescriptor`s;
-2. for each field id that contains changes in the current write, remove that field id from all `ColumnFileDescriptor`s;
-3. remove field id for `_last_updated_sequence_number` from any `ColumnFileDescriptor`s that contain it;
-4. add a new `ColumnFileDescriptor` that contains the newly written column file path, along with all field ids that contain changes in the current write and field id for `_last_updated_sequence_number`;
+2. for each field that contains changes in the current write, remove its field id from all
+   `ColumnFileDescriptor`s;
+3. remove field id for `_last_updated_sequence_number` from any `ColumnFileDescriptor`s that contain
+   it;
+4. add a new `ColumnFileDescriptor` that contains the newly written column file path, along with all
+   field ids that contain changes in the current write and field id for
+   `_last_updated_sequence_number`;
 5. remove all `ColumnFileDescriptor`s that contain no associated field ids as a result of step (2).
 
 ## Column File Cleanup
 
-Column files are table data. VACUUM must preserve all column files referenced by a retained file action. A column file may be deleted only when no retained file action references its path and the retention period has passed.
+Column files are table data. VACUUM must preserve all column files referenced by a retained file
+action. A column file may be deleted only when no retained file action references its path and the
+retention period has passed.
 
-The `columnUpdates` feature must not be removed while any retained table version references a column file.
+The `columnUpdates` feature must not be removed while any retained table version references a column
+file.
 
 ## Column Updates Examples
 
-This table shows the Parquet files and log actions after each statement, assuming every `UPDATE` uses the Column Updates feature. The example assumes that the column `foo` has Column Mapping ID 7, and column `bar` has ID 8. The table abbreviates `_last_updated_sequence_number` to `_lusn`, and `add`/`remove` actions only contain relevant fields.
+This table shows the Parquet files and log actions after each statement, assuming every `UPDATE`
+uses the Column Updates feature. The example assumes that the column `foo` has Column Mapping ID 7,
+and column `bar` has ID 8. The table abbreviates `_last_updated_sequence_number` to `_lusn`, and
+`add`/`remove` actions only contain relevant fields.
 
 <table>
 <tr>
@@ -195,10 +279,10 @@ UPDATE t SET
 
 `column-1.parquet`:
 
-| _pos | _lusn | foo (7) | bar (8) |
-|-|-|-|-|
-| 0 | NULL | 200 | 100 |
-| 1 | NULL | 200 | 100 |
+| _lusn | foo (7) | bar (8) |
+|-|-|-|
+| NULL | 200 | 100 |
+| NULL | 200 | 100 |
 
 </td>
 <td>
@@ -243,17 +327,17 @@ WHERE key = 'a'
 
 `column-1.parquet`:
 
-| _pos | _lusn | foo (7) | bar (8) |
-|-|-|-|-|
-| 0 | NULL | 200 | 100 |
-| 1 | NULL | 200 | 100 |
+| _lusn | foo (7) | bar (8) |
+|-|-|-|
+| NULL | 200 | 100 |
+| NULL | 200 | 100 |
 
 `column-2.parquet`:
 
-| _pos | _lusn | foo (7) |
-|-|-|-|
-| 0 | NULL | 500 |
-| 1 | 2 | 200 |
+| _lusn | foo (7) |
+|-|-|
+| NULL | 500 |
+| 2 | 200 |
 
 </td>
 <td>
@@ -293,7 +377,8 @@ WHERE key = 'a'
 
 ## Valid Feature Names in Table Features
 
-> ***Add the following row after Deletion Vectors in [Valid Feature Names in Table Features](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#valid-feature-names-in-table-features).***
+> ***Add the following row after Deletion Vectors in [Valid Feature Names in Table
+> Features](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#valid-feature-names-in-table-features).***
 
 Feature | Name | Readers or Writers?
 -|-|-

--- a/protocol_rfcs/efficient-column-updates.md
+++ b/protocol_rfcs/efficient-column-updates.md
@@ -1,0 +1,307 @@
+# Efficient Column Updates
+**Associated GitHub issue for discussions: https://github.com/delta-io/delta/issues/7414**
+
+This protocol change introduces the Efficient Column Updates feature, which allows a writer to
+replace selected columns of a data file without rewriting the other columns in that file.
+
+The writer stores the replacement values in a Parquet column file. The column file
+has one row for each physical row in its base data file. Readers combine the base
+data file and its column files by physical row position.
+
+--------
+
+# Changes to existing sections
+
+## Add File and Remove File
+
+> ***In [Add File and Remove File](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#add-file-and-remove-file), replace the two paragraphs starting with "Every logical file" and ending with "`(path, NULL)` instead" with the following text.***
+
+Every _logical file_ of the table is represented by a path to a data file, combined with an optional Deletion Vector (DV) and zero or more column files. A DV identifies which rows of the data file are no longer in the table. A column file supplies current values for a set of columns in the data file. Deletion Vectors and column files are optional features. See [Deletion Vectors](#deletion-vectors) and [Efficient Column Updates](#efficient-column-updates) for details.
+
+When an `add` action is encountered for a logical file that is already present in the table, statistics and other information from the latest version should replace that from any previous version.
+The primary key for the entry of a logical file in the set of files is a tuple of the data file's `path`, a unique id describing the DV, and a unique id describing the column file set. If no DV is part of this logical file, then the DV part of the primary key is `NULL`. If no column files are part of this logical file, then the column file set part of the primary key is `NULL`.
+
+> ***In the same section, replace the paragraph starting with "In the following statements" and the five bullets that follow it with the following text.***
+
+In the following statements, `dvId` refers to either the unique ID of a specific Deletion Vector (`deletionVector.uniqueId`) or to `NULL`, indicating that no rows are invalidated. `columnFileSetId` refers to either the identity of a specific column file set or to `NULL`, indicating that there are no associated column files.
+
+Since actions within a given Delta commit are not guaranteed to be applied in order, a **valid** version is restricted to contain at most one file action *of the same type* (i.e. `add`/`remove`) for any one combination of `path`, `dvId` and `columnFileSetId`. Moreover, for simplicity, it is required that there is at most one file action of the same type for any `path` (regardless of `dvId` and `columnFileSetId`).
+That means specifically that for any commit…
+
+- it is **legal** for the same `path` to occur in an `add` action and a `remove` action, but with two different `dvId`s or `columnFileSetId`s.
+- it is **legal** for the same `path` to be added and/or removed and also occur in a `cdc` action.
+- it is **illegal** for the same `path` to occur twice within the set of `add` actions or within the set of `remove` actions, regardless of its `dvId` or `columnFileSetId`.
+- it is **illegal** for a `path` to occur in an `add` action that already occurs with a different `dvId` or `columnFileSetId` in the list of `add` actions from the snapshot of the version immediately preceding the commit, unless the commit also contains a `remove` for the later combination.
+- it is **legal** to commit an existing `path`, `dvId` and `columnFileSetId` combination again (this allows metadata updates).
+
+> ***Add the following row to the schema of the `add` action, after `clusteringProvider`.***
+
+Field Name | Data Type | Description | optional/required
+-|-|-|-
+columnFiles | Array[[ColumnFileDescriptor Struct](#column-file-descriptor-struct)] | The column files associated with this data file. See also [Efficient Column Updates](#efficient-column-updates). | optional
+
+> ***Add the following row to the schema of the `remove` action, after `defaultRowCommitVersion`.***
+
+Field Name | Data Type | Description | optional/required
+-|-|-|-
+columnFiles | Array[[ColumnFileDescriptor Struct](#column-file-descriptor-struct)] | The column files associated with the logical file being removed. See also [Efficient Column Updates](#efficient-column-updates). | optional
+
+## Action Reconciliation
+
+> ***In [Action Reconciliation](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#action-reconciliation), replace the two collection bullets for `add` and `remove` actions with the following bullets.***
+
+- A collection of `add` actions with unique `path` keys, corresponding to the newest `(path, deletionVector.uniqueId, columnFileSetId)` tuple encountered for each path.
+- A collection of `remove` actions with unique `(path, deletionVector.uniqueId, columnFileSetId)` keys. The intersection of the primary keys in the `add` collection and `remove` collection must be empty. That means a logical file cannot exist in both the `remove` and `add` collections at the same time; however, the same *data file* can exist with *different* DVs in the `remove` collection, as logically they represent different content. The `remove` actions act as _tombstones_, and only exist for the benefit of the VACUUM command. Snapshot reads only return `add` actions on the read path.
+
+> ***In the reconciliation rules in the same section, replace the bullet starting with "Logical files in a table" with the following bullet.***
+
+- Logical files in a table are identified by their `(path, deletionVector.uniqueId, columnFileSetId)` primary key. File actions (`add` or `remove`) reference logical files, and a log can contain any number of references to a single file.
+
+--------
+
+> ***Add the following section after [Deletion Vectors](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#deletion-vectors) and before Catalog-managed Tables.***
+
+# Efficient Column Updates
+
+Efficient Column Updates allow a logical file to obtain selected column values from one or more Parquet column files. The feature name is `columnUpdates`. This is a reader-writer feature.
+
+To support this feature:
+
+- The table must be on Reader Version 3 and Writer Version 7.
+- The feature `columnUpdates` must exist in the table protocol's `readerFeatures` and `writerFeatures`.
+- The feature `columnMapping` must exist in the table protocol's `readerFeatures` and `writerFeatures`.
+- The table property `delta.columnMapping.mode` must be set to `name` or `id`.
+
+## Column File Descriptor Struct
+
+The `ColumnFileDescriptor` struct has the following schema:
+
+Field Name | Data Type | Description | optional/required
+-|-|-|-
+fieldIds | Array[Integer] | The Column Mapping IDs of the table fields supplied by this column file. | required
+path | String | A relative path to a column file from the root of the table, or an absolute path to the column file. The path uses the same URI encoding as `add.path`. | required
+sizeInBytes | Long | The size of the column file in bytes. | required
+
+`fieldIds` must not be empty and must not contain duplicates. A field ID must occur in at most one `ColumnFileDescriptor` within a single `add`.
+
+`_pos` is not included in `fieldIds` as it is a metadata column that is always present. `_last_updated_sequence_number` might be included to indicate that the associated column file is the most recently written one.
+
+## Column File Set Identity
+
+The identity of a column file set is the sorted list of each descriptor's `path` and sorted `fieldIds`. These are the only fields that affect the logical data.
+
+## Column File Format
+
+A column file is a Parquet file associated with exactly one base data file. Its columns are `_pos`, `_last_updated_sequence_number`, and a subset of columns of the base file with nullability on top (i.e. `INTEGER NOT NULL` in the base file becomes `INTEGER` in the column file). It has one row for each physical row in the base file.
+
+`_pos` is the physical offset of the corresponding row in the base file.
+
+`_last_updated_sequence_number` stores row lineage information for Iceberg V4 change detection. It contains either the sequence number of the update that last changed this row, or `NULL` to indicate that the most recent update changed this row.
+
+For examples of column files see [Efficient Column Updates examples](#efficient-column-updates-examples).
+
+## Reader Requirements for Efficient Column Updates
+
+During a read, if a field is present in `columnFiles[].fieldIds`, the reader must consider the corresponding values for that column in the base file as invalid and read them from the column file instead.
+
+The row-group boundaries of a column file and its base data file may differ. A reader
+must align records by physical row position, not by row-group number.
+
+## Writer Requirements for Efficient Column Updates
+
+During a write that replaces an `add` action with a new `add` action and a `remove`
+tombstone on the same `path`, without rewriting the base data file, the writer must
+carry over all `columnFiles` entries.
+
+During a write that uses an Efficient Column Update, the writer must:
+
+- retain entries that do not contain a field ID written by the update;
+- remove the newly written field IDs from each overlapping entry;
+- remove an old entry if no field IDs remain; and
+- add an entry for the new column file and its newly written field IDs.
+
+## Column File Cleanup
+
+Column files are table data. VACUUM must preserve all column files referenced by a
+retained `add` action, an unexpired `remove` action, or a retained historical table
+version. A column file may be deleted only when no retained descriptor references
+its path and the retention period has passed.
+
+OPTIMIZE must read the reconstructed logical rows and write replacement base data
+files without column files. CLONE must preserve or copy each referenced column file.
+RESTORE must restore the complete column file state for the selected snapshot.
+
+The `columnUpdates` feature must not be removed while any retained table version
+references a column file.
+
+## Efficient Column Updates Examples
+
+This table shows the Parquet files and log actions after each statement, assuming every `UPDATE` uses Efficient Column Updates. The example assumes that the column `foo` has Column Mapping ID 7, and column `bar` has ID 8. The table abbreviates `_last_updated_sequence_number` to `_lusn`, and `add`/`remove` actions only contain relevant fields.
+
+<table>
+<tr>
+<td> <b> Statement </b> </td> <td> <b> Parquet </b> </td> <td> <b> Log </b> </td>
+</tr>
+<tr>
+<td>
+
+```
+CREATE TABLE t (
+  key STRING,
+  foo INTEGER NOT NULL,
+  bar INTEGER
+)
+
+INSERT INTO t
+  VALUES
+    ("a", 1, 1)
+    ("b", 2, 2)
+```
+
+</td>
+<td>
+
+`base.parquet`:
+
+| key | foo (7) | bar (8) |
+|-|-|-|
+| a | 1 | 1 |
+| b | 2 | 2 |
+
+</td>
+<td>
+
+```
+{
+  "add": {
+    "path": "base.parquet"
+  }
+}
+```
+
+</td>
+</tr>
+<tr>
+<td>
+
+```
+UPDATE t SET
+  foo = 200,
+  bar = 100
+```
+
+</td>
+<td>
+
+`base.parquet`:
+
+| key | foo (7) | bar (8) |
+|-|-|-|
+| a | 1 | 1 |
+| b | 2 | 2 |
+
+`column-1.parquet`:
+
+| _pos | _lusn | foo (7) | bar (8) |
+|-|-|-|-|
+| 0 | NULL | 200 | 100 |
+| 1 | NULL | 200 | 100 |
+
+</td>
+<td>
+
+```
+{
+  "remove": {
+    "path": "base.parquet"
+  },
+  "add": {
+    "path": "base.parquet",
+    "columnFiles": [
+      {
+        "path": "column-1.parquet",
+        "fieldIds": [7, 8, 2147483539]
+      }
+    ]
+  }
+}
+```
+
+</td>
+</tr>
+<tr>
+<td>
+
+```
+UPDATE t SET
+  foo = 500
+WHERE key = 'a'
+```
+
+</td>
+<td>
+
+`base.parquet`:
+
+| key | foo (7) | bar (8) |
+|-|-|-|
+| a | 1 | 1 |
+| b | 2 | 2 |
+
+`column-1.parquet`:
+
+| _pos | _lusn | foo (7) | bar (8) |
+|-|-|-|-|
+| 0 | NULL | 200 | 100 |
+| 1 | NULL | 200 | 100 |
+
+`column-2.parquet`:
+
+| _pos | _lusn | foo (7) |
+|-|-|-|
+| 0 | NULL | 500 |
+| 1 | 2 | 200 |
+
+</td>
+<td>
+
+```
+{
+  "remove": {
+    "path": "base.parquet",
+    "columnFiles": [
+      {
+        "path": "column-1.parquet",
+        "fieldIds": [7, 8, 2147483539]
+      }
+    ]
+  },
+  "add": {
+    "path": "base.parquet",
+    "columnFiles": [
+      {
+        "path": "column-1.parquet",
+        "fieldIds": [8]
+      },
+      {
+        "path": "column-2.parquet",
+        "fieldIds": [7, 2147483539]
+      }
+    ]
+  }
+}
+```
+
+</td>
+</tr>
+</table>
+
+--------
+
+## Valid Feature Names in Table Features
+
+> ***Add the following row after Deletion Vectors in [Valid Feature Names in Table Features](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#valid-feature-names-in-table-features).***
+
+Feature | Name | Readers or Writers?
+-|-|-
+[Efficient Column Updates](#efficient-column-updates) | `columnUpdates` | Readers and writers


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Other (Protocol)

## Description

RFC for Column Updates, which stores replacement columns in Parquet files instead of rewriting complete base files.

See #7414.

## How was this patch tested?

Documentation only.

## Does this PR introduce _any_ user-facing changes?

No.