### PR TITLE
Move NullType-columns-dropped text out of DELTA_NON_PARTITION_COLUMN_ABSENT parameter into a subclass

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -2316,6 +2316,11 @@
       "Data written into Delta needs to contain at least one non-partitioned column."
     ],
     "subClass" : {
+      "ALL_PARTITION_COLUMNS" : {
+        "message" : [
+          "All of the provided columns are partition columns."
+        ]
+      },
       "NULL_TYPE_COLUMNS_DROPPED" : {
         "message" : [
           "Columns which are of NullType have been dropped."

--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -2313,8 +2313,15 @@
   },
   "DELTA_NON_PARTITION_COLUMN_ABSENT" : {
     "message" : [
-      "Data written into Delta needs to contain at least one non-partitioned column.<details>"
+      "Data written into Delta needs to contain at least one non-partitioned column."
     ],
+    "subClass" : {
+      "NULL_TYPE_COLUMNS_DROPPED" : {
+        "message" : [
+          "Columns which are of NullType have been dropped."
+        ]
+      }
+    },
     "sqlState" : "KD005"
   },
   "DELTA_NON_PARTITION_COLUMN_REFERENCE" : {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -1271,14 +1271,14 @@ trait DeltaErrorsBase
   }
 
   def nonPartitionColumnAbsentException(colsDropped: Boolean): Throwable = {
-    val msg = if (colsDropped) {
-      " Columns which are of NullType have been dropped."
+    val errorClass = if (colsDropped) {
+      "DELTA_NON_PARTITION_COLUMN_ABSENT.NULL_TYPE_COLUMNS_DROPPED"
     } else {
-      ""
+      "DELTA_NON_PARTITION_COLUMN_ABSENT"
     }
     new DeltaAnalysisException(
-      errorClass = "DELTA_NON_PARTITION_COLUMN_ABSENT",
-      messageParameters = Array(msg)
+      errorClass = errorClass,
+      messageParameters = Array.empty
     )
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -1274,7 +1274,7 @@ trait DeltaErrorsBase
     val errorClass = if (colsDropped) {
       "DELTA_NON_PARTITION_COLUMN_ABSENT.NULL_TYPE_COLUMNS_DROPPED"
     } else {
-      "DELTA_NON_PARTITION_COLUMN_ABSENT"
+      "DELTA_NON_PARTITION_COLUMN_ABSENT.ALL_PARTITION_COLUMNS"
     }
     new DeltaAnalysisException(
       errorClass = errorClass,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -1339,14 +1339,14 @@ trait DeltaErrorsSuiteBase
       val e = intercept[DeltaAnalysisException] {
         throw DeltaErrors.nonPartitionColumnAbsentException(false)
       }
-      checkError(e, "DELTA_NON_PARTITION_COLUMN_ABSENT", "KD005", Map("details" -> ""))
+      checkError(e, "DELTA_NON_PARTITION_COLUMN_ABSENT", "KD005", Map.empty[String, String])
     }
     {
       val e = intercept[DeltaAnalysisException] {
         throw DeltaErrors.nonPartitionColumnAbsentException(true)
       }
-      checkError(e, "DELTA_NON_PARTITION_COLUMN_ABSENT", "KD005",
-        Map("details" -> " Columns which are of NullType have been dropped."))
+      checkError(e, "DELTA_NON_PARTITION_COLUMN_ABSENT.NULL_TYPE_COLUMNS_DROPPED", "KD005",
+        Map.empty[String, String])
     }
     {
       val e = intercept[DeltaAnalysisException] {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -1339,7 +1339,8 @@ trait DeltaErrorsSuiteBase
       val e = intercept[DeltaAnalysisException] {
         throw DeltaErrors.nonPartitionColumnAbsentException(false)
       }
-      checkError(e, "DELTA_NON_PARTITION_COLUMN_ABSENT", "KD005", Map.empty[String, String])
+      checkError(e, "DELTA_NON_PARTITION_COLUMN_ABSENT.ALL_PARTITION_COLUMNS", "KD005",
+        Map.empty[String, String])
     }
     {
       val e = intercept[DeltaAnalysisException] {


### PR DESCRIPTION
The `DELTA_NON_PARTITION_COLUMN_ABSENT` error embedded part of its message text (`Columns which are of NullType have been dropped.`) in a template parameter (`<details>`) rather than in the error class definition. This makes the text hard to audit and impossible to translate.

This change moves that text into the JSON error class definition by introducing a `NULL_TYPE_COLUMNS_DROPPED` subclass:
- `delta-error-classes.json`: drop the `<details>` parameter from the main message and add the `NULL_TYPE_COLUMNS_DROPPED` subclass carrying the previously-embedded text.
- `DeltaErrors.nonPartitionColumnAbsentException`: throw the bare `DELTA_NON_PARTITION_COLUMN_ABSENT` when no columns were dropped, and `DELTA_NON_PARTITION_COLUMN_ABSENT.NULL_TYPE_COLUMNS_DROPPED` when they were, passing no message parameters.

The rendered message text and the SQLSTATE (`KD005`) are unchanged.

Updated the existing unit tests in `DeltaErrorsSuite` to assert the new error condition names via `checkError` with empty message parameter maps.