### PR TITLE
[Spark] Exclude duplicate transitive dependencies for Spark

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -635,12 +635,58 @@ lazy val spark = (project in file("spark-unified"))
       import scala.xml._
       import scala.xml.transform._
 
+      // Exclude dependencies provided by Spark
+      val jacksonExclusions = Seq(
+        "com.fasterxml.jackson.core" -> "jackson-annotations",
+        "com.fasterxml.jackson.core" -> "jackson-core",
+        "com.fasterxml.jackson.core" -> "jackson-databind"
+      )
+      val deltaStorageExclusions = Seq(
+        "com.google.code.findbugs" -> "jsr305",
+        "org.apache.logging.log4j" -> "log4j-api",
+        "org.apache.logging.log4j" -> "log4j-slf4j2-impl",
+        "org.slf4j" -> "slf4j-api"
+      )
+      val deltaSparkDependencyExclusions = Map(
+        "delta-storage" -> deltaStorageExclusions,
+        "delta-kernel-api" -> (jacksonExclusions ++ Seq(
+          "com.google.code.findbugs" -> "jsr305",
+          "org.roaringbitmap" -> "RoaringBitmap",
+          "org.slf4j" -> "slf4j-api"
+        )),
+        "delta-kernel-defaults" -> (deltaStorageExclusions ++ jacksonExclusions ++ Seq(
+          "org.apache.hadoop" -> "hadoop-client-runtime",
+          "org.apache.parquet" -> "parquet-hadoop"
+        )),
+        "delta-kernel-unitycatalog" -> deltaStorageExclusions
+      )
+
+      def exclusionNodes(artifactId: String): Seq[Elem] = {
+        deltaSparkDependencyExclusions.getOrElse(artifactId, Seq.empty).map {
+          case (groupId, dependencyArtifactId) =>
+            <exclusion>
+              <groupId>{groupId}</groupId>
+              <artifactId>{dependencyArtifactId}</artifactId>
+            </exclusion>
+        }
+      }
+
       def kernelDependencyNode(artifactId: String): Elem = {
         <dependency>
           <groupId>io.delta</groupId>
           <artifactId>{artifactId}</artifactId>
           <version>{ver}</version>
+          <exclusions>{exclusionNodes(artifactId)}</exclusions>
         </dependency>
+      }
+
+      def addSparkExclusions(dependency: Elem, artifactId: String): Elem = {
+        val childrenWithoutExclusions = dependency.child.filter {
+          case child: Elem if child.label == "exclusions" => false
+          case _ => true
+        }
+        dependency.copy(
+          child = childrenWithoutExclusions ++ Seq(<exclusions>{exclusionNodes(artifactId)}</exclusions>))
       }
 
       val kernelDeps = Seq(
@@ -657,6 +703,10 @@ lazy val spark = (project in file("spark-unified"))
                 val artifactId = (child \ "artifactId").text
                 !internalModules.exists(module => artifactId.startsWith(module))
               case _ => true
+            }.map {
+              case child: Elem if (child \ "artifactId").text == "delta-storage" =>
+                addSparkExclusions(child, "delta-storage")
+              case child => child
             }
             Seq(e.copy(child = filtered ++ kernelDeps))
           case _ => Seq(n)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Resolves #7415

Add exclusions to delta-storage and kernel deps for delta-spark to not include duplicative dependencies Spark already includes. I believe Spark's dependencies would take precedence regardless, but this helps avoid wasting time downloading these extra dependencies.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Manual.

Before:
```% pyspark --packages io.delta:delta-spark_4.1_2.13:4.3.1
Python 3.13.12 (main, Feb  3 2026, 17:53:27) [Clang 17.0.0 (clang-1700.6.3.2)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
...
io.delta#delta-spark_4.1_2.13 added as a dependency
:: resolving dependencies :: org.apache.spark#spark-submit-parent-bed25a83-7643-4668-a3b6-1cc6c71f97ab;1.0
        confs: [default]
        found io.delta#delta-spark_4.1_2.13;4.3.1 in central
        found io.delta#delta-storage;4.3.1 in central
        found io.unitycatalog#unitycatalog-client;0.5.0 in central
        found org.slf4j#slf4j-api;2.0.13 in local-m2-cache
        found org.apache.logging.log4j#log4j-slf4j2-impl;2.25.3 in central
        found org.apache.logging.log4j#log4j-api;2.25.3 in local-m2-cache
        found com.google.code.findbugs#jsr305;3.0.2 in local-m2-cache
        found io.unitycatalog#unitycatalog-hadoop;0.5.0 in central
        found org.apache.logging.log4j#log4j-core;2.25.3 in local-m2-cache
        found io.delta#delta-kernel-api;4.3.1 in central
        found org.roaringbitmap#RoaringBitmap;0.9.25 in local-m2-cache
        found com.fasterxml.jackson.core#jackson-databind;2.13.5 in local-m2-cache
        found com.fasterxml.jackson.core#jackson-annotations;2.13.5 in local-m2-cache
        found com.fasterxml.jackson.core#jackson-core;2.13.5 in local-m2-cache
        found com.fasterxml.jackson.datatype#jackson-datatype-jdk8;2.13.5 in central
        found org.roaringbitmap#shims;0.9.25 in local-m2-cache
        found io.delta#delta-kernel-defaults;4.3.1 in central
        found org.apache.hadoop#hadoop-client-runtime;3.4.2 in local-m2-cache
        found org.apache.parquet#parquet-hadoop;1.16.0 in local-m2-cache
        found org.apache.parquet#parquet-column;1.16.0 in local-m2-cache
        found org.apache.parquet#parquet-common;1.16.0 in local-m2-cache
        found org.apache.parquet#parquet-format-structures;1.16.0 in local-m2-cache
        found javax.annotation#javax.annotation-api;1.3.2 in local-m2-cache
        found org.apache.parquet#parquet-encoding;1.16.0 in local-m2-cache
        found org.locationtech.jts#jts-core;1.20.0 in local-m2-cache
        found org.xerial.snappy#snappy-java;1.1.10.7 in local-m2-cache
        found io.airlift#aircompressor;2.0.2 in local-m2-cache
        found commons-pool#commons-pool;1.6 in local-m2-cache
        found com.github.luben#zstd-jni;1.5.7-3 in central
        found org.apache.hadoop#hadoop-client-api;3.4.2 in local-m2-cache
        found commons-logging#commons-logging;1.3.0 in local-m2-cache
        found org.apache.parquet#parquet-jackson;1.16.0 in local-m2-cache
        found io.delta#delta-kernel-unitycatalog;4.3.1 in central
:: resolution report :: resolve 382ms :: artifacts dl 11ms
        :: modules in use:
        com.fasterxml.jackson.core#jackson-annotations;2.13.5 from local-m2-cache in [default]
        com.fasterxml.jackson.core#jackson-core;2.13.5 from local-m2-cache in [default]
        com.fasterxml.jackson.core#jackson-databind;2.13.5 from local-m2-cache in [default]
        com.fasterxml.jackson.datatype#jackson-datatype-jdk8;2.13.5 from central in [default]
        com.github.luben#zstd-jni;1.5.7-3 from central in [default]
        com.google.code.findbugs#jsr305;3.0.2 from local-m2-cache in [default]
        commons-logging#commons-logging;1.3.0 from local-m2-cache in [default]
        commons-pool#commons-pool;1.6 from local-m2-cache in [default]
        io.airlift#aircompressor;2.0.2 from local-m2-cache in [default]
        io.delta#delta-kernel-api;4.3.1 from central in [default]
        io.delta#delta-kernel-defaults;4.3.1 from central in [default]
        io.delta#delta-kernel-unitycatalog;4.3.1 from central in [default]
        io.delta#delta-spark_4.1_2.13;4.3.1 from central in [default]
        io.delta#delta-storage;4.3.1 from central in [default]
        io.unitycatalog#unitycatalog-client;0.5.0 from central in [default]
        io.unitycatalog#unitycatalog-hadoop;0.5.0 from central in [default]
        javax.annotation#javax.annotation-api;1.3.2 from local-m2-cache in [default]
        org.apache.hadoop#hadoop-client-api;3.4.2 from local-m2-cache in [default]
        org.apache.hadoop#hadoop-client-runtime;3.4.2 from local-m2-cache in [default]
        org.apache.logging.log4j#log4j-api;2.25.3 from local-m2-cache in [default]
        org.apache.logging.log4j#log4j-core;2.25.3 from local-m2-cache in [default]
        org.apache.logging.log4j#log4j-slf4j2-impl;2.25.3 from central in [default]
        org.apache.parquet#parquet-column;1.16.0 from local-m2-cache in [default]
        org.apache.parquet#parquet-common;1.16.0 from local-m2-cache in [default]
        org.apache.parquet#parquet-encoding;1.16.0 from local-m2-cache in [default]
        org.apache.parquet#parquet-format-structures;1.16.0 from local-m2-cache in [default]
        org.apache.parquet#parquet-hadoop;1.16.0 from local-m2-cache in [default]
        org.apache.parquet#parquet-jackson;1.16.0 from local-m2-cache in [default]
        org.locationtech.jts#jts-core;1.20.0 from local-m2-cache in [default]
        org.roaringbitmap#RoaringBitmap;0.9.25 from local-m2-cache in [default]
        org.roaringbitmap#shims;0.9.25 from local-m2-cache in [default]
        org.slf4j#slf4j-api;2.0.13 from local-m2-cache in [default]
        org.xerial.snappy#snappy-java;1.1.10.7 from local-m2-cache in [default]
        :: evicted modules:
        org.slf4j#slf4j-api;2.0.17 by [org.slf4j#slf4j-api;2.0.13] in [default]
        org.slf4j#slf4j-api;1.7.36 by [org.slf4j#slf4j-api;2.0.13] in [default]
        org.slf4j#slf4j-api;1.7.33 by [org.slf4j#slf4j-api;2.0.13] in [default]
        org.xerial.snappy#snappy-java;1.1.10.4 by [org.xerial.snappy#snappy-java;1.1.10.7] in [default]
```

After:
```
% pyspark --packages io.delta:delta-spark_4.1_2.13:4.4.0-SNAPSHOT             
Python 3.13.12 (main, Feb  3 2026, 17:53:27) [Clang 17.0.0 (clang-1700.6.3.2)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
...
io.delta#delta-spark_4.1_2.13 added as a dependency
:: resolving dependencies :: org.apache.spark#spark-submit-parent-439f5502-8442-4a65-aef0-c160b290ff1e;1.0
        confs: [default]
        found io.delta#delta-spark_4.1_2.13;4.4.0-SNAPSHOT in local-m2-cache
        found io.delta#delta-storage;4.4.0-SNAPSHOT in local-m2-cache
        found io.unitycatalog#unitycatalog-client;0.5.0 in central
        found io.unitycatalog#unitycatalog-hadoop;0.5.0 in central
        found io.delta#delta-kernel-api;4.4.0-SNAPSHOT in local-m2-cache
        found com.fasterxml.jackson.datatype#jackson-datatype-jdk8;2.13.5 in central
        found io.delta#delta-kernel-defaults;4.4.0-SNAPSHOT in local-m2-cache
        found io.delta#delta-kernel-unitycatalog;4.4.0-SNAPSHOT in local-m2-cache
:: resolution report :: resolve 166ms :: artifacts dl 6ms
        :: modules in use:
        com.fasterxml.jackson.datatype#jackson-datatype-jdk8;2.13.5 from central in [default]
        io.delta#delta-kernel-api;4.4.0-SNAPSHOT from local-m2-cache in [default]
        io.delta#delta-kernel-defaults;4.4.0-SNAPSHOT from local-m2-cache in [default]
        io.delta#delta-kernel-unitycatalog;4.4.0-SNAPSHOT from local-m2-cache in [default]
        io.delta#delta-spark_4.1_2.13;4.4.0-SNAPSHOT from local-m2-cache in [default]
        io.delta#delta-storage;4.4.0-SNAPSHOT from local-m2-cache in [default]
        io.unitycatalog#unitycatalog-client;0.5.0 from central in [default]
        io.unitycatalog#unitycatalog-hadoop;0.5.0 from central in [default]
        ---------------------------------------------------------------------
        |                  |            modules            ||   artifacts   |
        |       conf       | number| search|dwnlded|evicted|| number|dwnlded|
        ---------------------------------------------------------------------
        |      default     |   8   |   0   |   0   |   0   ||   8   |   0   |
        ---------------------------------------------------------------------
:: retrieving :: org.apache.spark#spark-submit-parent-439f5502-8442-4a65-aef0-c160b290ff1e
        confs: [default]
        0 artifacts copied, 8 already retrieved (0kB/5ms)
```

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No, just doesn't waste time downloading extra dependencies.