### PR TITLE
Enrich _last_checkpoint for adaptive metadata checkpoints

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
@@ -27,6 +27,7 @@ import scala.util.control.NonFatal
 // scalastyle:off import.ordering.noEmptyLine
 import org.apache.spark.sql.delta.ClassicColumnConversions._
 import org.apache.spark.sql.delta.actions.{Action, CheckpointMetadata, Metadata, SidecarFile, SingleAction}
+import org.apache.spark.sql.delta.amt.AMTWriteResult
 import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
@@ -77,16 +78,17 @@ case class CheckpointInstance(
     fileName: Option[String] = None,
     numParts: Option[Int] = None) extends Ordered[CheckpointInstance] {
 
-  // Assert that numParts are present when checkpoint format is Format.WITH_PARTS.
+  import CheckpointInstance.Format
+
+  // Assert that numParts are present when checkpoint format is Format.WITH_PARTS or Format.AMT.
   // For other formats, numParts must be None.
-  require((format == CheckpointInstance.Format.WITH_PARTS) == numParts.isDefined,
-    s"numParts ($numParts) must be present for checkpoint format" +
-      s" ${CheckpointInstance.Format.WITH_PARTS.name}")
+  require(Set(Format.WITH_PARTS, Format.AMT).contains(format) == numParts.isDefined,
+    s"numParts ($numParts) must be present for checkpoint formats " +
+      s"${Format.WITH_PARTS.name} and ${Format.AMT.name}")
   // Assert that filePath is present only when checkpoint format is Format.V2.
   // For other formats, filePath must be None.
-  require((format == CheckpointInstance.Format.V2) == fileName.isDefined,
-    s"fileName ($fileName) must be present for checkpoint format" +
-      s" ${CheckpointInstance.Format.V2.name}")
+  require((format == Format.V2) == fileName.isDefined,
+    s"fileName ($fileName) must be present for checkpoint format ${Format.V2.name}")
 
   /**
    * Returns a [[CheckpointProvider]] which can tell the files corresponding to this
@@ -124,6 +126,9 @@ case class CheckpointInstance(
         }
       case CheckpointInstance.Format.WITH_PARTS =>
         PreloadedCheckpointProvider(cpFiles, lastCheckpointInfo)
+      case CheckpointInstance.Format.AMT =>
+        throw DeltaErrors.assertionFailedError(
+          s"checkpoint format ${CheckpointInstance.Format.AMT.name} is not readable yet")
       case CheckpointInstance.Format.SENTINEL =>
         throw DeltaErrors.assertionFailedError(
           s"invalid checkpoint format ${CheckpointInstance.Format.SENTINEL}")
@@ -134,6 +139,9 @@ case class CheckpointInstance(
                   filesForCheckpointConstruction: Seq[FileStatus]) : Seq[FileStatus] = {
     val logPath = deltaLog.logPath
     format match {
+      // An AMT checkpoint has no standalone checkpoint file to select from the listing; the
+      // manifest tree is reached through the inline Checkpoint action instead.
+      case CheckpointInstance.Format.AMT => Seq.empty
       // Treat Single File checkpoints also as V2 Checkpoints because we don't know if it is
       // actually a V2 checkpoint until we read it.
       case format if format.usesSidecars =>
@@ -197,6 +205,7 @@ object CheckpointInstance {
       case SINGLE.name => Some(SINGLE)
       case WITH_PARTS.name => Some(WITH_PARTS)
       case V2.name => Some(V2)
+      case AMT.name => Some(AMT)
       case _ => None
     }
 
@@ -206,6 +215,8 @@ object CheckpointInstance {
     object WITH_PARTS extends Format(1, "WITH_PARTS")
     /** V2 Checkpoint format */
     object V2 extends Format(2, "V2") with FormatUsesSidecars
+    /** AMT checkpoint format. */
+    object AMT extends Format(3, "AMT")
     /** Sentinel, for internal use only */
     object SENTINEL extends Format(Int.MaxValue, "SENTINEL")
   }
@@ -342,6 +353,15 @@ trait Checkpoints extends DeltaLogging {
     writeLastCheckpointFile(
       snapshotToCheckpoint.deltaLog, lastCheckpointInfo, LastCheckpointInfo.checksumEnabled(spark))
     doLogCleanup(snapshotToCheckpoint, catalogTableOpt)
+  }
+
+  /** Builds the LastCheckpointInfo for AMT and writes it to `_last_checkpoint` file. */
+  def writeLastCheckpointFileForAMT(
+      manifestCommitVersion: Long,
+      writeResult: AMTWriteResult): Unit = {
+    val lastCheckpointInfo = Checkpoints.buildLastCheckpointInfoForAMT(
+      manifestCommitVersion, writeResult)
+    writeLastCheckpointFile(this, lastCheckpointInfo, LastCheckpointInfo.checksumEnabled(spark))
   }
 
   protected[delta] def writeLastCheckpointFile(
@@ -658,6 +678,27 @@ object Checkpoints
     val checkpointSchemaSizeThreshold = spark.sessionState.conf.getConf(
       DeltaSQLConf.CHECKPOINT_SCHEMA_WRITE_THRESHOLD_LENGTH)
     Some(schema).filter(s => JsonUtils.toJson(s).length <= checkpointSchemaSizeThreshold)
+  }
+
+  private[delta] def buildLastCheckpointInfoForAMT(
+      manifestCommitVersion: Long,
+      writeResult: AMTWriteResult): LastCheckpointInfo = {
+    val AMTWriteResult(contentRootVersion, checkpoint, leaves, _) = writeResult
+    val lastAMTCheckpoint = LastAMTCheckpoint(
+      manifestCommitVersion = manifestCommitVersion,
+      checkpoint = Some(checkpoint),
+      leaves = Some(leaves))
+    LastCheckpointInfo(
+      version = contentRootVersion,
+      // `size` (total action count) and `numOfAddFiles` are unavailable for AMT: the file actions
+      // live in the manifest tree, not in memory here.
+      size = -1,
+      parts = Some(leaves.size),
+      sizeInBytes = Some(checkpoint.contentRoot.sizeInBytes + leaves.map(_.file_size_in_bytes).sum),
+      numOfAddFiles = None,
+      checkpointSchema = None,
+      checkpointType = Some(LastCheckpointInfo.CheckpointType.AMT),
+      amtCheckpoint = Some(lastAMTCheckpoint))
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/LastCheckpointInfo.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/LastCheckpointInfo.scala
@@ -18,12 +18,14 @@ package org.apache.spark.sql.delta
 
 import scala.collection.mutable.ArrayBuffer
 
-import org.apache.spark.sql.delta.actions.{CheckpointMetadata, SidecarFile, SingleAction}
+import org.apache.spark.sql.delta.actions.{Checkpoint, CheckpointMetadata, SidecarFile, SingleAction}
+import org.apache.spark.sql.delta.amt.DataManifestEntry
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.FileNames.{checkpointVersion, numCheckpointParts}
 import org.apache.spark.sql.delta.util.JsonUtils
-import com.fasterxml.jackson.annotation.{JsonIgnore, JsonIgnoreProperties, JsonPropertyOrder}
-import com.fasterxml.jackson.databind.{DeserializationFeature, JsonNode}
+import com.fasterxml.jackson.annotation.{JsonIgnore, JsonPropertyOrder, JsonValue}
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.{DeserializationContext, DeserializationFeature, JsonDeserializer, JsonNode}
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.apache.commons.codec.digest.DigestUtils
@@ -31,6 +33,12 @@ import org.apache.hadoop.fs.FileStatus
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.types.StructType
+
+/** Information about the AMT checkpoint in the LAST_CHECKPOINT file. */
+case class LastAMTCheckpoint(
+    manifestCommitVersion: Long,
+    checkpoint: Option[Checkpoint],
+    leaves: Option[Seq[DataManifestEntry]])
 
 /**
  * Information about the V2 Checkpoint in the LAST_CHECKPOINT file
@@ -89,13 +97,16 @@ object LastCheckpointV2 {
  * from one read request. For this reason, we use `JsonPropertyOrder` to force them in the beginning
  * together.
  *
- * @param version the version of this checkpoint
- * @param size the number of actions in the checkpoint, -1 if the information is unavailable.
- * @param parts the number of parts when the checkpoint has multiple parts. None if this is a
- *              singular checkpoint
+ * @param version the version of this checkpoint. Represents the content root version if this is an
+ *                AMT checkpoint.
+ * @param size the number of actions in the checkpoint. -1 if this is an AMT checkpoint or the
+ *             information is unavailable.
+ * @param parts the number of parts when the checkpoint has multiple parts. Represents the number of
+ *              leaves if this is an AMT checkpoint. None if this is a singular checkpoint.
  * @param sizeInBytes the number of bytes of the checkpoint
- * @param numOfAddFiles the number of AddFile actions in the checkpoint
+ * @param numOfAddFiles the number of AddFile actions in the checkpoint. None for AMT checkpoints.
  * @param checkpointSchema the schema of the underlying checkpoint files
+ * @param amtCheckpoint information about the AMT checkpoint, present only for AMT tables
  * @param checksum the checksum of the [[LastCheckpointInfo]].
  */
 @JsonPropertyOrder(Array("version", "size", "parts"))
@@ -108,11 +119,20 @@ case class LastCheckpointInfo(
     @JsonDeserialize(contentAs = classOf[java.lang.Long])
     numOfAddFiles: Option[Long],
     checkpointSchema: Option[StructType],
+    @JsonDeserialize(contentUsing = classOf[LastCheckpointInfo.CheckpointTypeDeserializer])
+    checkpointType: Option[LastCheckpointInfo.CheckpointType] = None,
+    amtCheckpoint: Option[LastAMTCheckpoint] = None,
     v2Checkpoint: Option[LastCheckpointV2] = None,
     checksum: Option[String] = None) {
 
+  // Format-specific fields are mutually exclusive.
+  require(!(amtCheckpoint.nonEmpty && v2Checkpoint.nonEmpty))
+  require(Seq(LastCheckpointInfo.CheckpointType.AMT, LastCheckpointInfo.CheckpointType.UNKNOWN)
+    .exists(checkpointType.contains) == amtCheckpoint.nonEmpty)
+
   @JsonIgnore
   def getFormatEnum(): CheckpointInstance.Format = parts match {
+    case _ if amtCheckpoint.nonEmpty => CheckpointInstance.Format.AMT
     case _ if v2Checkpoint.nonEmpty => CheckpointInstance.Format.V2
     case Some(_) => CheckpointInstance.Format.WITH_PARTS
     case None => CheckpointInstance.Format.SINGLE
@@ -125,6 +145,30 @@ case class LastCheckpointInfo(
 }
 
 object LastCheckpointInfo {
+  /** The checkpoint type described by a [[LastCheckpointInfo]]. */
+  sealed abstract class CheckpointType(val name: String) {
+    @JsonValue
+    override def toString: String = name
+  }
+
+  /** Reads a [[CheckpointType]] back from its bare `name` string. */
+  class CheckpointTypeDeserializer extends JsonDeserializer[CheckpointType] {
+    override def deserialize(p: JsonParser, ctxt: DeserializationContext): CheckpointType =
+      CheckpointType.fromName(p.readValueAs(classOf[String]))
+  }
+
+  object CheckpointType {
+    object AMT extends CheckpointType("AdaptiveMetadataTree")
+    object UNKNOWN extends CheckpointType("Unknown")
+
+    /** All known checkpoint types. Extend this when adding a new [[CheckpointType]]. */
+    val ALL: Seq[CheckpointType] = Seq(AMT)
+
+    def unapply(name: String): Option[CheckpointType] = ALL.find(_.name == name)
+
+    /** Used for deserialization. */
+    def fromName(name: String): CheckpointType = unapply(name).getOrElse(UNKNOWN)
+  }
 
   val STORED_CHECKSUM_KEY = "checksum"
 
@@ -150,6 +194,8 @@ object LastCheckpointInfo {
           lastCheckpointInfo.parts,
           sizeInBytes = None,
           numOfAddFiles = None,
+          checkpointType = None,
+          amtCheckpoint = None,
           v2Checkpoint = None,
           checkpointSchema = None))
     }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -3009,6 +3009,11 @@ trait OptimisticTransactionImpl extends TransactionHelper
       // if needed.
       amtWriterManager.planMaintenance(attemptVersion, postCommitSnapshot)
     } else {
+      // The _last_checkpoint file must be updated here rather than the checkpoint hook, because the
+      // hook does not know about the new AMT checkpoint emitted in this commit.
+      amtWriteResultOpt.foreach { writeResult =>
+        deltaLog.writeLastCheckpointFileForAMT(manifestCommitVersion = attemptVersion, writeResult)
+      }
       // The AMT was written inline with this commit (always incremental). A full rewrite is never
       // inlined, so schedule a follow-up full OPTIMIZE CHECKPOINT commit when the full-rewrite
       // cadence is due -- otherwise a table whose commits consistently inline would never get a

--- a/spark/src/test/scala/org/apache/spark/sql/delta/CheckpointInstanceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CheckpointInstanceSuite.scala
@@ -25,10 +25,12 @@ class CheckpointInstanceSuite extends SparkFunSuite {
   test("checkpoint instance comparisons") {
     val ci1_single_1 = CheckpointInstance(1, Format.SINGLE, numParts = None)
     val ci1_withparts_2 = CheckpointInstance(1, Format.WITH_PARTS, numParts = Some(2))
+    val ci1_amt_2 = CheckpointInstance(1, Format.AMT, numParts = Some(2))
     val ci1_sentinel = CheckpointInstance.sentinelValue(Some(1))
 
     val ci2_single_1 = CheckpointInstance(2, Format.SINGLE, numParts = None)
     val ci2_withparts_4 = CheckpointInstance(2, Format.WITH_PARTS, numParts = Some(4))
+    val ci2_amt_3 = CheckpointInstance(2, Format.AMT, numParts = Some(3))
     val ci2_sentinel = CheckpointInstance.sentinelValue(Some(2))
 
     val ci3_single_1 = CheckpointInstance(3, Format.SINGLE, numParts = None)
@@ -37,10 +39,20 @@ class CheckpointInstanceSuite extends SparkFunSuite {
     assert(ci1_single_1 < ci2_single_1) // version takes priority
     assert(ci1_single_1 < ci1_withparts_2) // parts takes priority when versions are same
     assert(ci2_withparts_4 < ci3_withparts_2) // version takes priority over parts
+    // An AMT checkpoint has the highest priority among checkpoints of the same version.
+    assert(ci1_amt_2 > ci1_withparts_2 && ci1_amt_2 > ci1_single_1)
+    assert(ci2_amt_3 > ci2_withparts_4 && ci2_amt_3 > ci2_single_1)
+    // AMT still yields to the Sentinel value, and to any checkpoint of a later version.
+    assert(ci1_amt_2 < ci1_sentinel)
+    assert(ci1_amt_2 < ci2_single_1)
+    // AMT reuses `numParts` for its leaf count, and carries no `fileName`.
+    assert(ci1_amt_2.numParts == Some(2) && ci1_amt_2.fileName.isEmpty)
 
     // all checkpoint instances for version 1/2 are less than sentinel value for version 2.
-    Seq(ci1_single_1, ci1_withparts_2, ci1_sentinel, ci2_single_1, ci2_withparts_4)
-      .foreach(ci => assert(ci < ci2_sentinel))
+    Seq(
+      ci1_single_1, ci1_withparts_2, ci1_sentinel, ci2_single_1, ci2_withparts_4,
+      ci1_amt_2, ci2_amt_3
+    ).foreach(ci => assert(ci < ci2_sentinel))
 
     // all checkpoint instances for version 3 are greater than sentinel value for version 2.
     Seq(ci3_single_1, ci3_withparts_2).foreach(ci => assert(ci > ci2_sentinel))
@@ -49,7 +61,8 @@ class CheckpointInstanceSuite extends SparkFunSuite {
     Seq(
       ci1_single_1, ci1_withparts_2, ci1_sentinel,
       ci2_single_1, ci2_withparts_4, ci2_sentinel,
-      ci3_single_1, ci3_withparts_2
+      ci3_single_1, ci3_withparts_2,
+      ci1_amt_2, ci2_amt_3
     ).foreach(ci => assert(ci < CheckpointInstance.MaxValue))
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/LastCheckpointInfoSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/LastCheckpointInfoSuite.scala
@@ -17,6 +17,8 @@
 package org.apache.spark.sql.delta
 
 // scalastyle:off import.ordering.noEmptyLine
+import org.apache.spark.sql.delta.actions.{Checkpoint, ContentRoot, Metadata, Protocol}
+import org.apache.spark.sql.delta.amt.{AMTLeafComparisons, AMTSingleAction, AMTWriteResult, ContentStats, DataManifestEntry, ManifestInfo, Partition, Tracking}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
@@ -234,6 +236,238 @@ class LastCheckpointInfoSuite extends SharedSparkSession
       === LastCheckpointInfo.serializeToJson(ci2, addChecksum = true))
   }
 
+  /** A [[Checkpoint]] action describing `version`, with a root manifest at `rootPath`. */
+  private def sampleCheckpointAction(
+      version: Long = 1L,
+      rootPath: String = "metadata/root-abc.parquet",
+      rootSizeInBytes: Long = 4096L): Checkpoint = Checkpoint(
+    version = version,
+    contentRoot = ContentRoot(path = rootPath, sizeInBytes = rootSizeInBytes),
+    protocol = Protocol(minReaderVersion = 3, minWriterVersion = 7),
+    metaData = Metadata(id = "metadata-id", name = "t"),
+    domainMetadata = Nil,
+    txns = Nil,
+    sidecars = Nil)
+
+  private def sampleAMTCheckpoint(
+      version: Long = 1L,
+      leaves: Seq[DataManifestEntry] =
+        Seq(sampleLeaf("metadata/leaf-1.parquet"))): LastAMTCheckpoint =
+    LastAMTCheckpoint(
+      manifestCommitVersion = version,
+      checkpoint = Some(sampleCheckpointAction(version)),
+      leaves = Some(leaves))
+
+  /**
+   * A leaf pointer carrying `recordCount` entries and occupying `sizeInBytes` on disk. Every
+   * optional field is populated with a distinct non-empty value so the round-trip tests actually
+   * exercise their serialization -- in particular the byte-array fields (`key_metadata`,
+   * `deleted_positions`, `dv`) whose base64 encoding is easy to get wrong.
+   */
+  private def sampleLeaf(
+      location: String,
+      recordCount: Long = 1L,
+      sizeInBytes: Long = 1024L): DataManifestEntry = DataManifestEntry(
+    location = location,
+    file_format = AMTSingleAction.FileFormatParquet,
+    tracking = Tracking(
+      status = Tracking.Status.Added,
+      snapshot_id = Some(11L),
+      dv_snapshot_id = Some(12L),
+      sequence_number = Some(13L),
+      file_sequence_number = Some(14L),
+      first_row_id = Some(15L),
+      deleted_positions = Some(Array[Byte](1, 2, 3)),
+      replaced_positions = Some(Array[Byte](4, 5))),
+    record_count = recordCount,
+    file_size_in_bytes = sizeInBytes,
+    manifest_info = ManifestInfo(
+      added_files_count = recordCount.toInt,
+      existing_files_count = 2,
+      deleted_files_count = 3,
+      replaced_files_count = 4,
+      added_rows_count = 100L,
+      existing_rows_count = 200L,
+      deleted_rows_count = 300L,
+      replaced_rows_count = 400L,
+      min_sequence_number = 7L,
+      dv = Some(Array[Byte](9, 8, 7)),
+      dv_cardinality = Some(5L)),
+    partition = Partition(values = Some(Map("part_col" -> "part_val"))),
+    spec_id = Some(1),
+    content_stats = Some(ContentStats(raw_stats = Some(Array[Byte](42, 43)))),
+    key_metadata = Some(Array[Byte](16, 17, 18)),
+    split_offsets = Some(Seq(0L, 128L, 256L)))
+
+  private def sampleAMTWriteResult(
+      contentRootVersion: Long = 1L,
+      leaves: Seq[DataManifestEntry] = Seq(sampleLeaf("metadata/leaf-1.parquet"))): AMTWriteResult =
+    AMTWriteResult(
+      contentRootVersion = contentRootVersion,
+      checkpoint = sampleCheckpointAction(contentRootVersion),
+      leaves = leaves,
+      includeActionsInCommitJson = true)
+
+  /** Reads `_last_checkpoint` back as raw json. */
+  private def readLastCheckpointFileAsJson(log: DeltaLog): String = {
+    val fs = log.LAST_CHECKPOINT.getFileSystem(log.newDeltaHadoopConf())
+    val is = fs.open(log.LAST_CHECKPOINT)
+    try {
+      IOUtils.toString(is, "UTF-8")
+    } finally {
+      is.close()
+    }
+  }
+
+  ////////////////////////////////////////
+  // writeLastCheckpointFileForAMT
+  ////////////////////////////////////////
+
+  test("writeLastCheckpointFileForAMT - writes an AMT-format _last_checkpoint") {
+    withTempDir { dir =>
+      spark.range(10).write.format("delta").save(dir.getAbsolutePath)
+      val log = DeltaLog.forTable(spark, dir)
+      val writeResult = sampleAMTWriteResult(contentRootVersion = 3)
+
+      log.writeLastCheckpointFileForAMT(manifestCommitVersion = 4, writeResult)
+
+      val info = log.readLastCheckpointFile().getOrElse(
+        fail("writeLastCheckpointFileForAMT must produce a readable _last_checkpoint."))
+      // The pointer describes the manifest tree's content-root version, and records the leaf count
+      // in `parts`.
+      assert(info.version == 3)
+      assert(info.parts == Some(writeResult.leaves.size))
+      // `size` (action count) and `numOfAddFiles` are intentionally unavailable for AMT.
+      assert(info.size == -1)
+      assert(info.numOfAddFiles.isEmpty)
+      // The embedded Checkpoint action survives the round trip, so a cold reader can locate the
+      // root manifest without reading the commit json.
+      val amt = info.amtCheckpoint.getOrElse(fail("The written info must carry an amtCheckpoint."))
+      assert(amt.checkpoint == Some(writeResult.checkpoint))
+      assert(amt.manifestCommitVersion == 4)
+      assert(amt.checkpoint.map(_.contentRoot.path) == Some("metadata/root-abc.parquet"))
+      AMTLeafComparisons.assertLeavesEqual(amt.leaves.get, writeResult.leaves)
+    }
+  }
+
+  test("writeLastCheckpointFileForAMT - records the leaf count") {
+    withTempDir { dir =>
+      spark.range(10).write.format("delta").save(dir.getAbsolutePath)
+      val log = DeltaLog.forTable(spark, dir)
+      val leaves = Seq(sampleLeaf("metadata/leaf-1.parquet"), sampleLeaf("metadata/leaf-2.parquet"))
+      log.writeLastCheckpointFileForAMT(
+        manifestCommitVersion = 4, sampleAMTWriteResult(contentRootVersion = 3, leaves = leaves))
+
+      val info = log.readLastCheckpointFile().get
+      assert(info.parts == Some(2), "`parts` carries the number of leaves for an AMT checkpoint.")
+      assert(info.version == 3, "`version` carries the content root version.")
+      assert(info.amtCheckpoint.map(_.manifestCommitVersion) == Some(4L))
+    }
+  }
+
+  test("writeLastCheckpointFileForAMT - overwrites the previous pointer") {
+    withTempDir { dir =>
+      spark.range(10).write.format("delta").save(dir.getAbsolutePath)
+      val log = DeltaLog.forTable(spark, dir)
+
+      log.writeLastCheckpointFileForAMT(
+        manifestCommitVersion = 4, sampleAMTWriteResult(contentRootVersion = 3))
+      assert(log.readLastCheckpointFile().map(_.version) == Some(3L))
+
+      // A later manifest commit replaces the pointer wholesale: `_last_checkpoint` names only the
+      // latest checkpoint, so the newer content root must win.
+      val newer = AMTWriteResult(
+        contentRootVersion = 5,
+        checkpoint = sampleCheckpointAction(version = 5, rootPath = "metadata/root-def.parquet"),
+        leaves = Seq(sampleLeaf("metadata/leaf-9.parquet")),
+        includeActionsInCommitJson = true)
+      log.writeLastCheckpointFileForAMT(manifestCommitVersion = 6, newer)
+
+      val info = log.readLastCheckpointFile().get
+      assert(info.version == 5)
+      assert(info.amtCheckpoint.flatMap(_.checkpoint).map(_.contentRoot.path)
+        == Some("metadata/root-def.parquet"))
+      assert(info.amtCheckpoint.map(_.manifestCommitVersion) == Some(6))
+    }
+  }
+
+  test("writeLastCheckpointFileForAMT - honors the checksum config") {
+    withTempDir { dir =>
+      spark.range(10).write.format("delta").save(dir.getAbsolutePath)
+      val log = DeltaLog.forTable(spark, dir)
+      val writeResult = sampleAMTWriteResult(contentRootVersion = 1)
+
+      withSQLConf(DeltaSQLConf.LAST_CHECKPOINT_CHECKSUM_ENABLED.key -> "true") {
+        log.writeLastCheckpointFileForAMT(manifestCommitVersion = 1, writeResult)
+        assert(readLastCheckpointFileAsJson(log).contains("checksum"))
+      }
+
+      withSQLConf(DeltaSQLConf.LAST_CHECKPOINT_CHECKSUM_ENABLED.key -> "false") {
+        log.writeLastCheckpointFileForAMT(manifestCommitVersion = 1, writeResult)
+        assert(!readLastCheckpointFileAsJson(log).contains("checksum"))
+      }
+    }
+  }
+
+  test("LastCheckpointInfo - amtCheckpoint serialize/deserialize round-trip") {
+    val ci = LastCheckpointInfo(version = 1, size = -1, parts = None, sizeInBytes = None,
+      numOfAddFiles = None, checkpointSchema = None,
+      checkpointType = Some(LastCheckpointInfo.CheckpointType.AMT),
+      amtCheckpoint = Some(sampleAMTCheckpoint()))
+    val json = LastCheckpointInfo.serializeToJson(ci, addChecksum = true)
+    val deserialized = LastCheckpointInfo.deserializeFromJson(json, validate = true)
+    val amt = deserialized.amtCheckpoint.getOrElse(fail("round-trip dropped the amtCheckpoint."))
+    val expectedAmt = ci.amtCheckpoint.get
+    assert(amt.manifestCommitVersion == expectedAmt.manifestCommitVersion)
+    assert(amt.checkpoint == expectedAmt.checkpoint) // Checkpoint carries no Array[Byte] fields.
+    AMTLeafComparisons.assertLeavesEqual(amt.leaves.get, expectedAmt.leaves.get)
+    assert(deserialized.checkpointType == Some(LastCheckpointInfo.CheckpointType.AMT))
+    // Compare the rest non-array fields by `==`.
+    assert(deserialized.copy(amtCheckpoint = None, checkpointType = None, checksum = None)
+      == ci.copy(amtCheckpoint = None, checkpointType = None))
+  }
+
+  test("LastCheckpointInfo - checkpointType serializes as a bare string") {
+    val ci = LastCheckpointInfo(version = 1, size = -1, parts = None, sizeInBytes = None,
+      numOfAddFiles = None, checkpointSchema = None,
+      checkpointType = Some(LastCheckpointInfo.CheckpointType.AMT),
+      amtCheckpoint = Some(sampleAMTCheckpoint()))
+    val json = LastCheckpointInfo.serializeToJson(ci, addChecksum = false)
+    // The type must land as its bare `name`, not as a nested `{"name":...}` object. Jackson would
+    // bean-serialize the sealed type without `@JsonValue`, which also changes the checksum shape
+    // (one `"checkpointType"` entry instead of a `"checkpointType"+"name"` entry) and breaks
+    // deserialization.
+    assert(json.contains(s""""checkpointType":"${LastCheckpointInfo.CheckpointType.AMT.name}""""),
+      s"Expected a bare-string checkpointType in: $json")
+    assert(!json.contains(""""checkpointType":{"""),
+      s"checkpointType must not serialize as an object: $json")
+
+    // And it deserializes back to the same singleton, with the checksum validating over it.
+    val withChecksum = LastCheckpointInfo.serializeToJson(ci, addChecksum = true)
+    val deserialized = LastCheckpointInfo.deserializeFromJson(withChecksum, validate = true)
+    assert(deserialized.checkpointType == Some(LastCheckpointInfo.CheckpointType.AMT))
+  }
+
+  test("LastCheckpointInfo - an unknown checkpointType decodes to UNKNOWN") {
+    val ci = LastCheckpointInfo(version = 1, size = -1, parts = None, sizeInBytes = None,
+      numOfAddFiles = None, checkpointSchema = None,
+      checkpointType = Some(LastCheckpointInfo.CheckpointType.UNKNOWN),
+      amtCheckpoint = Some(sampleAMTCheckpoint()))
+    val json = LastCheckpointInfo.serializeToJson(ci, addChecksum = false)
+    val forged = json.replace(
+      s""""checkpointType":"${LastCheckpointInfo.CheckpointType.UNKNOWN.name}"""",
+      """"checkpointType":"SomeFutureTree"""")
+    val deserialized = LastCheckpointInfo.deserializeFromJson(forged, validate = false)
+    assert(deserialized.checkpointType == Some(LastCheckpointInfo.CheckpointType.UNKNOWN),
+      s"An unrecognized checkpointType must decode to UNKNOWN, got ${deserialized.checkpointType}.")
+    // The amtCheckpoint alongside the unknown type must still be decoded, not dropped.
+    val amt = deserialized.amtCheckpoint.getOrElse(
+      fail("The amtCheckpoint must survive an unknown checkpointType."))
+    assert(amt.manifestCommitVersion == ci.amtCheckpoint.get.manifestCommitVersion)
+    assert(amt.checkpoint == ci.amtCheckpoint.get.checkpoint)
+    AMTLeafComparisons.assertLeavesEqual(amt.leaves.get, ci.amtCheckpoint.get.leaves.get)
+  }
+
   test("LastCheckpointInfo - json with duplicate keys should fail") {
     val jsonString =
       """{"version":1,"size":3,"parts":3,"checksum":"d84a0aa11c93304d57feca6acaceb7fb","size":2}"""
@@ -250,25 +484,15 @@ class LastCheckpointInfoSuite extends SharedSparkSession
       spark.range(10).write.format("delta").save(dir.getAbsolutePath)
       val log = DeltaLog.forTable(spark, dir)
 
-      def readLastCheckpointFile(): String = {
-        val fs = log.LAST_CHECKPOINT.getFileSystem(log.newDeltaHadoopConf())
-        val is = fs.open(log.LAST_CHECKPOINT)
-        try {
-          IOUtils.toString(is, "UTF-8")
-        } finally {
-          is.close()
-        }
-      }
-
       withSQLConf(DeltaSQLConf.LAST_CHECKPOINT_CHECKSUM_ENABLED.key -> "true") {
         DeltaLog.forTable(spark, dir).checkpoint()
-        assert(readLastCheckpointFile().contains("checksum"))
+        assert(readLastCheckpointFileAsJson(log).contains("checksum"))
       }
 
       spark.range(10).write.mode("append").format("delta").save(dir.getAbsolutePath)
       withSQLConf(DeltaSQLConf.LAST_CHECKPOINT_CHECKSUM_ENABLED.key -> "false") {
         DeltaLog.forTable(spark, dir).checkpoint()
-        assert(!readLastCheckpointFile().contains("checksum"))
+        assert(!readLastCheckpointFileAsJson(log).contains("checksum"))
       }
     }
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointTestBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointTestBase.scala
@@ -136,6 +136,11 @@ trait AMTCheckpointTestBase
         s"got ${leaves.size}.")
   }
 
+  /** Asserts two leaf sequences are field-by-field equal. */
+  protected def assertLeavesEqual(
+      actual: Seq[DataManifestEntry], expected: Seq[DataManifestEntry]): Unit =
+    AMTLeafComparisons.assertLeavesEqual(actual, expected)
+
   /** A production-supported combination of AMT placement and materialization strategy. */
   protected sealed abstract class AMTCheckpointScenario(
       val name: String,
@@ -431,4 +436,48 @@ trait AMTCheckpointTestBase
       }.sum
   }
 
+}
+
+/**
+ * Field-by-field equality for AMT leaf pointers, shared across suites (some of which do not extend
+ * [[AMTCheckpointTestBase]]). Compares by content rather than case-class `==` (which compares the
+ * `Array[Byte]` fields by reference) and rather than a json comparison (tests of serialization must
+ * not rely on serialization to check their result).
+ */
+object AMTLeafComparisons {
+  /** Value equality for `Option[Array[Byte]]` (case-class `==` compares arrays by reference). */
+  private def sameBytes(a: Option[Array[Byte]], b: Option[Array[Byte]]): Boolean =
+    (a, b) match {
+      case (Some(x), Some(y)) => x.sameElements(y)
+      case (None, None) => true
+      case _ => false
+    }
+
+  /** Asserts two leaf pointers are field-by-field equal, comparing byte-array fields by content. */
+  def assertLeafEquals(actual: DataManifestEntry, expected: DataManifestEntry): Unit = {
+    // Blank the array-bearing members so a single `==` covers every other field structurally.
+    def blanked(e: DataManifestEntry): DataManifestEntry = e.copy(
+      tracking = e.tracking.copy(deleted_positions = None, replaced_positions = None),
+      manifest_info = e.manifest_info.copy(dv = None),
+      content_stats = None,
+      key_metadata = None)
+    assert(blanked(actual) == blanked(expected),
+      s"leaf non-array fields differ: $actual vs $expected")
+    assert(sameBytes(actual.tracking.deleted_positions, expected.tracking.deleted_positions),
+      "tracking.deleted_positions differ")
+    assert(sameBytes(actual.tracking.replaced_positions, expected.tracking.replaced_positions),
+      "tracking.replaced_positions differ")
+    assert(sameBytes(actual.manifest_info.dv, expected.manifest_info.dv), "manifest_info.dv differ")
+    assert(sameBytes(actual.key_metadata, expected.key_metadata), "key_metadata differ")
+    assert(sameBytes(
+        actual.content_stats.flatMap(_.raw_stats), expected.content_stats.flatMap(_.raw_stats)),
+      "content_stats.raw_stats differ")
+  }
+
+  /** Asserts two leaf sequences are field-by-field equal (see [[assertLeafEquals]]). */
+  def assertLeavesEqual(
+      actual: Seq[DataManifestEntry], expected: Seq[DataManifestEntry]): Unit = {
+    assert(actual.size == expected.size, s"leaf count differs: ${actual.size} vs ${expected.size}")
+    actual.zip(expected).foreach { case (a, e) => assertLeafEquals(a, e) }
+  }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointWriteSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointWriteSuite.scala
@@ -20,7 +20,7 @@ import java.io.File
 
 // scalastyle:off import.ordering.noEmptyLine
 import com.databricks.spark.util.{Log4jUsageLogger, MetricDefinitions}
-import org.apache.spark.sql.delta.{Checkpoints, CommitStats, CurrentTransactionInfo, DeltaOperations, Snapshot}
+import org.apache.spark.sql.delta.{Checkpoints, CommitStats, CurrentTransactionInfo, DeltaOperations, LastCheckpointInfo, Snapshot}
 import org.apache.spark.sql.delta.actions.{AddFile, Checkpoint, ContentRoot, RemoveFile}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.{FileNames, JsonUtils}
@@ -340,6 +340,82 @@ class AMTCheckpointWriteSuite extends AMTCheckpointTestBase {
 
       assert(commitStats.amtWriteMetrics.isEmpty,
         "Commit stats must not carry AMT write metrics when no AMT is emitted.")
+    }
+  }
+
+  testAcrossAMTCheckpointScenarios(
+      "an emitted AMT populates _last_checkpoint",
+      "amt_last_checkpoint")(
+      setup = name => sql(s"INSERT INTO $name VALUES (1)"),
+      inlineCheckpointTriggerActionsOrSQL = Some(name => Right(
+        s"INSERT INTO $name VALUES (2)"))) { context =>
+    val deltaLog = context.postCheckpointSnapshot.deltaLog
+    val info = deltaLog.readLastCheckpointFile().getOrElse {
+      fail("An AMT emission must write _last_checkpoint.")
+    }
+
+    // `version` names the tree's content-root version, and `parts` the leaf count.
+    assert(info.version == context.checkpoint.version,
+      s"Expected content root v${context.checkpoint.version}, got v${info.version}.")
+    assert(info.parts.contains(context.provider.leaves.size),
+      s"Expected ${context.provider.leaves.size} leaves, got ${info.parts}.")
+    assert(info.sizeInBytes.exists(_ > 0L), "The AMT size in bytes must be recorded.")
+    // `size` (action count) and `numOfAddFiles` are intentionally unavailable for AMT.
+    assert(info.size == -1, s"AMT size must be -1, got ${info.size}.")
+    assert(info.numOfAddFiles.isEmpty,
+      s"AMT numOfAddFiles must be empty, got ${info.numOfAddFiles}.")
+
+    assert(info.checkpointType == Some(LastCheckpointInfo.CheckpointType.AMT))
+    val amt = info.amtCheckpoint.getOrElse {
+      fail("_last_checkpoint must carry amtCheckpoint.")
+    }
+    assert(amt.checkpoint == Some(context.checkpoint))
+    assertLeavesEqual(amt.leaves.get, context.provider.leaves)
+    assert(amt.manifestCommitVersion == context.manifestCommitVersion,
+      s"Expected manifest at v${context.manifestCommitVersion}, got v${amt.manifestCommitVersion}.")
+  }
+
+  test("_last_checkpoint is not updated when no AMT is emitted") {
+    withTable("amt_last_checkpoint_unchanged") {
+      val name = "amt_last_checkpoint_unchanged"
+      // Interval 3. Emission triggers only when the version distance from the last AMT is an exact
+      // positive multiple of the interval, so the timeline is:
+      //   v1: below the first boundary  -> no emission
+      //   v2: below the first boundary  -> no emission
+      //   v3: first boundary            -> deferred AMT recorded at v4, describing v3
+      //   v4: OPTIMIZE CHECKPOINT      -> emits an AMT
+      //   v5: one past the last AMT    -> no emission (the next boundary is v6)
+      createAMTTable(name, checkpointInterval = 3)
+      val deltaLog = deltaLogForName(name)
+
+      // -- Before any emission: no pointer at all. --
+      sql(s"INSERT INTO $name VALUES (1)")
+      sql(s"INSERT INTO $name VALUES (2)")
+      assert(deltaLog.update().version == 2, "Neither v1 nor v2 should schedule a follow-up AMT.")
+      assert(checkpointAt(deltaLog, 1).isEmpty, "v1 emits no AMT.")
+      assert(checkpointAt(deltaLog, 2).isEmpty, "v2 emits no AMT.")
+      assert(deltaLog.readLastCheckpointFile().isEmpty,
+        "Commits that emit no AMT must not write _last_checkpoint.")
+
+      // -- The boundary commit emits, and the follow-up commit writes the pointer. --
+      sql(s"INSERT INTO $name VALUES (3)")
+      assert(deltaLog.update().version == 4, "The v3 boundary defers its AMT to v4.")
+      val afterEmission = deltaLog.readLastCheckpointFile().getOrElse {
+        fail("The deferred AMT must write _last_checkpoint.")
+      }
+      assert(afterEmission.version == 3, "The tree describes state as of the v3 boundary.")
+      assert(afterEmission.amtCheckpoint.map(_.manifestCommitVersion) == Some(4L),
+        "The manifest commit version should be v4.")
+
+      // -- A later commit that emits nothing must leave the existing pointer untouched. --
+      sql(s"INSERT INTO $name VALUES (4)")
+      assert(deltaLog.update().version == 5, "v5 should not schedule a follow-up AMT.")
+      assert(checkpointAt(deltaLog, 5).isEmpty, "v5 emits no AMT.")
+      val afterNonAMTCommit = deltaLog.readLastCheckpointFile().getOrElse {
+        fail("_last_checkpoint must survive commits that emit no AMT.")
+      }
+      assert(afterNonAMTCommit == afterEmission,
+        "A non-AMT commit must not modify _last_checkpoint.")
     }
   }
 


### PR DESCRIPTION
## Description

Enriches the `_last_checkpoint` file for tables using the adaptive metadata tree
(`adaptiveMetadata` feature), so a reader can act on the latest manifest-commit
checkpoint without first reading the log.

When the latest checkpoint is an adaptive-metadata `checkpoint` action, the
writer records checkpoint information into `_last_checkpoint`:
- `checkpointType` identifying the checkpoint as an adaptive-metadata one, and
  the manifest-commit version, so a reader can detect a stale hint and seek to
  the latest checkpoint directly.
- The embedded `checkpoint` action itself when it is small enough, letting a
  reader begin prefetching the content root immediately. Since a `checkpoint`
  action embeds all non-content metadata, the writer bounds the embedded value
  and omits it above a size threshold (following the existing V2-checkpoint
  trimming precedent), while still recording the type and version.

`LastCheckpointInfo` is extended to carry these fields and
`Checkpoints`/`OptimisticTransaction` populate them on the write path. Reading
remains a non-authoritative hint: absent, stale, or oversized entries fall back
to log replay.

## How was this patch tested?

New and expanded unit tests in `LastCheckpointInfoSuite`, `CheckpointInstanceSuite`,
and `AMTCheckpointWriteSuite` cover serialization of the new fields, the
size-bounding/omission path, and the read-time fallbacks.

## Does this PR introduce _any_ user-facing change?

No.
