### PR TITLE
[Branch-3.3][Delta Sharing] Upgrade delta-sharing-client to 1.2.8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -547,7 +547,7 @@ lazy val sharing = (project in file("sharing"))
     libraryDependencies ++= Seq(
       "org.apache.spark" %% "spark-sql" % sparkVersion.value % "provided",
 
-      "io.delta" %% "delta-sharing-client" % "1.2.2",
+      "io.delta" %% "delta-sharing-client" % "1.2.8",
 
       // Test deps
       "org.scalatest" %% "scalatest" % scalaTestVersion % "test",

--- a/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingCDFUtilsSuite.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingCDFUtilsSuite.scala
@@ -73,8 +73,9 @@ private object CDFTesTUtils {
 class TestDeltaSharingClientForCDFUtils(
     profileProvider: DeltaSharingProfileProvider,
     timeoutInSeconds: Int = 120,
-    numRetries: Int = 10,
+    numRetries: Int = 3,
     maxRetryDuration: Long = Long.MaxValue,
+    retrySleepInterval: Long = 1000,
     sslTrustAll: Boolean = false,
     forStreaming: Boolean = false,
     responseFormat: String = DeltaSharingRestClient.RESPONSE_FORMAT_DELTA,

--- a/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingFileIndexSuite.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingFileIndexSuite.scala
@@ -85,8 +85,9 @@ private object TestUtils {
 class TestDeltaSharingClientForFileIndex(
     profileProvider: DeltaSharingProfileProvider,
     timeoutInSeconds: Int = 120,
-    numRetries: Int = 10,
+    numRetries: Int = 3,
     maxRetryDuration: Long = Long.MaxValue,
+    retrySleepInterval: Long = 1000,
     sslTrustAll: Boolean = false,
     forStreaming: Boolean = false,
     responseFormat: String = DeltaSharingRestClient.RESPONSE_FORMAT_DELTA,

--- a/sharing/src/test/scala/io/delta/sharing/spark/TestClientForDeltaFormatSharing.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/TestClientForDeltaFormatSharing.scala
@@ -44,8 +44,9 @@ import org.apache.spark.storage.BlockId
 private[spark] class TestClientForDeltaFormatSharing(
     profileProvider: DeltaSharingProfileProvider,
     timeoutInSeconds: Int = 120,
-    numRetries: Int = 10,
+    numRetries: Int = 3,
     maxRetryDuration: Long = Long.MaxValue,
+    retrySleepInterval: Long = 1000,
     sslTrustAll: Boolean = false,
     forStreaming: Boolean = false,
     responseFormat: String = DeltaSharingRestClient.RESPONSE_FORMAT_DELTA,


### PR DESCRIPTION
## Summary
- Upgrade `delta-sharing-client` from 1.2.2 to 1.2.8 on `branch-3.3`.
  - see release diff: https://github.com/delta-io/delta-sharing/compare/v1.2.2...v1.2.8
- Add `retrySleepInterval` to test client constructors so they match the reflection signature used by `DeltaSharingRestClient.apply` (same adjustment as #4342).

## Test plan
- [ ] Sharing module compiles against delta-sharing-client 1.2.8
- [ ] Existing Delta Sharing unit tests pass (including suites that inject custom client classes)