### PR TITLE
[Flink] Preserve collection nullability in Unity Catalog schemas

### DIFF
--- a/flink/src/main/java/io/delta/flink/sink/sql/FlinkUnityCatalogTable.java
+++ b/flink/src/main/java/io/delta/flink/sink/sql/FlinkUnityCatalogTable.java
@@ -153,8 +153,7 @@ public class FlinkUnityCatalogTable implements CatalogTable {
                     String.format(
                         "{\"type\":%s, \"nullable\": \"%s\"}", elementTypeString, elementNullable));
             return new CollectionDataType(
-                new ArrayType(
-                    elementType.getLogicalType().isNullable(), elementType.getLogicalType()),
+                new ArrayType(nullable, elementType.getLogicalType()),
                 elementType);
           case "map":
             DataType keyType =
@@ -168,7 +167,7 @@ public class FlinkUnityCatalogTable implements CatalogTable {
                         rootType.get("valueType"), rootType.get("valueContainsNull").asBoolean()));
             return new KeyValueDataType(
                 new MapType(
-                    valueType.getLogicalType().isNullable(),
+                    nullable,
                     keyType.getLogicalType(),
                     valueType.getLogicalType()),
                 keyType,

--- a/flink/src/test/java/io/delta/flink/sink/sql/FlinkUnityCatalogTableTest.java
+++ b/flink/src/test/java/io/delta/flink/sink/sql/FlinkUnityCatalogTableTest.java
@@ -33,6 +33,7 @@ import org.apache.flink.table.catalog.GenericInMemoryCatalog;
 import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.flink.table.types.AtomicDataType;
 import org.apache.flink.table.types.KeyValueDataType;
+import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.MapType;
 import org.apache.flink.table.types.logical.NullType;
 import org.apache.flink.table.types.logical.SmallIntType;
@@ -130,6 +131,50 @@ class FlinkUnityCatalogTableTest {
         new SmallIntType(false),
         FlinkUnityCatalogTable.fromJson("{\"type\":\"short\",\"nullable\":false}")
             .getLogicalType());
+  }
+
+  @Test
+  void testArrayNullability() {
+    ArrayType nonNullableArray =
+        (ArrayType)
+            FlinkUnityCatalogTable.fromJson(
+                    "{\"type\":{\"type\":\"array\",\"elementType\":\"string\","
+                        + "\"containsNull\":true},\"nullable\":false}")
+                .getLogicalType();
+    assertFalse(nonNullableArray.isNullable());
+    assertTrue(nonNullableArray.getElementType().isNullable());
+
+    ArrayType nullableArray =
+        (ArrayType)
+            FlinkUnityCatalogTable.fromJson(
+                    "{\"type\":{\"type\":\"array\",\"elementType\":\"string\","
+                        + "\"containsNull\":false},\"nullable\":true}")
+                .getLogicalType();
+    assertTrue(nullableArray.isNullable());
+    assertFalse(nullableArray.getElementType().isNullable());
+  }
+
+  @Test
+  void testMapNullability() {
+    MapType nonNullableMap =
+        (MapType)
+            FlinkUnityCatalogTable.fromJson(
+                    "{\"type\":{\"type\":\"map\",\"keyType\":\"string\","
+                        + "\"valueType\":\"integer\",\"valueContainsNull\":true},"
+                        + "\"nullable\":false}")
+                .getLogicalType();
+    assertFalse(nonNullableMap.isNullable());
+    assertTrue(nonNullableMap.getValueType().isNullable());
+
+    MapType nullableMap =
+        (MapType)
+            FlinkUnityCatalogTable.fromJson(
+                    "{\"type\":{\"type\":\"map\",\"keyType\":\"string\","
+                        + "\"valueType\":\"integer\",\"valueContainsNull\":false},"
+                        + "\"nullable\":true}")
+                .getLogicalType();
+    assertTrue(nullableMap.isNullable());
+    assertFalse(nullableMap.getValueType().isNullable());
   }
 
   @Test


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [x] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This fixes Unity Catalog array and map conversion so the collection nullable flag comes from the outer field instead of the element or value nullability. The child nullability is still preserved separately.

Previously, crossed combinations such as a non-null array with nullable elements were converted with the wrong container nullability.

## How was this patch tested?

Added unit coverage for both crossed nullability combinations for arrays and maps.

## Does this PR introduce any user-facing changes?

Yes. Flink now preserves collection and child nullability independently when reading Unity Catalog schemas.