### PR TITLE
[CI] Enable Spark 4.2 support and CI

### DIFF
--- a/.github/workflows/iceberg_test.yaml
+++ b/.github/workflows/iceberg_test.yaml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         # These Scala versions must match those in the build.sbt
         scala: [2.13.16]
-        spark_version: ["4.0", "4.1"]
+        spark_version: ["4.0", "4.1", "4.2"]
     env:
       SCALA_VERSION: ${{ matrix.scala }}
     steps:

--- a/project/CrossSparkVersions.scala
+++ b/project/CrossSparkVersions.scala
@@ -312,7 +312,7 @@ object SparkVersionSpec {
     fullVersion = "4.2.0",
     targetJvm = "17",
     additionalSourceDirs = Seq("scala-shims/spark-4.2", "scala-shims/spark-4.1-4.2"),
-    supportIceberg = false,
+    supportIceberg = true,
     supportHudi = false,
     antlr4Version = "4.13.1",
     additionalJavaOptions = java17TestSettings,


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Spark 4.2 is the default Spark version, but its profile currently disables the Delta Iceberg modules. As a result, the default build does not compile, test, or publish `delta-iceberg` against Spark 4.2. The Delta Iceberg workflow also tests only Spark 4.0 and 4.1.

This change enables Iceberg for the Spark 4.2 profile, making Spark 4.2 the default build target for `delta-iceberg`. It also adds Spark 4.2 to the Delta Iceberg workflow matrix so the `iceberg` and `testDeltaIcebergJar` projects run in CI.

## How was this patch tested?

- Confirmed that the Spark 4.2 `icebergGroup` contains `iceberg` and `testDeltaIcebergJar` and that Iceberg tests are not skipped.
- `git diff --check`
- Dependency resolution currently reports that `org.apache.iceberg:iceberg-spark-runtime-4.2_2.13:1.11.0` is not published. The new CI job exposes the same missing Spark 4.2 dependency.

## Does this PR introduce _any_ user-facing changes?

Yes. The default `delta-iceberg` build and published package now target Spark 4.2.
