### PR TITLE
[Release] Bump version to 3.3.3 for release

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "3.3.3-SNAPSHOT"
+ThisBuild / version := "3.3.3"


### PR DESCRIPTION
## Description

Sets `version.sbt` to `3.3.3` in preparation for the Delta Lake 3.3.3 patch release.

### PR Stack

| Order | PR | Change |
|-------|-----|--------|
| **PR1 (this)** | Bump to `3.3.3` | `3.3.3-SNAPSHOT` → `3.3.3` |
| PR2 | Restore snapshot | `3.3.3` → `3.3.4-SNAPSHOT` |

### Workflow

1. Merge this PR
2. Tag the merge commit: `git tag v3.3.3 && git push oss v3.3.3`
3. Use tag `v3.3.3` as the `ref` in release workflow dispatches
4. Merge PR2 to restore development mode

### How was this patch tested?

Version-only change (`version.sbt`). No code changes.