### PR TITLE
[Release] Restore version to 3.3.4-SNAPSHOT

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "3.3.3"
+ThisBuild / version := "3.3.4-SNAPSHOT"


### PR DESCRIPTION
## Description

Restores `version.sbt` to `3.3.4-SNAPSHOT` after the 3.3.3 release tag is cut.

### PR Stack

| Order | PR | Change |
|-------|-----|--------|
| PR1 | [#7424](https://github.com/delta-io/delta/pull/7424) — Bump to `3.3.3` | `3.3.3-SNAPSHOT` → `3.3.3` |
| **PR2 (this)** | Restore snapshot | `3.3.3` → `3.3.4-SNAPSHOT` |

### Workflow

Merge this PR **after** PR1 is merged and the `v3.3.3` tag is created. This returns `branch-3.3` to development mode.

### How was this patch tested?

Version-only change (`version.sbt`). No code changes.