### PR TITLE
[Spark] Rebuild adaptive metadata deletion vectors as absolute-path descriptors

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/actions.scala
@@ -16,10 +16,6 @@
 
 package org.apache.spark.sql.delta.amt
 
-import java.util.UUID
-
-import scala.util.Try
-
 import org.apache.spark.sql.delta.DeltaColumnMapping
 import org.apache.spark.sql.delta.actions.{Action, AddFile, DeletionVectorDescriptor}
 import org.apache.spark.sql.delta.stats.DeltaStatistics
@@ -746,49 +742,20 @@ object DeletionVector {
       cardinality = dv.cardinality)
   }
 
-  /** Rebuilds the Delta [[DeletionVectorDescriptor]] from the AMT sub-struct. */
+  /**
+   * Rebuilds the Delta [[DeletionVectorDescriptor]] from the AMT sub-struct.
+   */
   def toDescriptor(dv: DeletionVector, tableRoot: Path): DeletionVectorDescriptor = {
     val rawSize = dv.size_in_bytes.toInt -
-      (DeletionVectorStore.getTotalSizeOfDVFieldsInFile(0))
-    recoverRelativeUuid(dv.location, tableRoot) match {
-      case Some((id, randomPrefix)) =>
-        DeletionVectorDescriptor.onDiskWithRelativePath(
-          id = id,
-          randomPrefix = randomPrefix,
-          sizeInBytes = rawSize,
-          cardinality = dv.cardinality,
-          offset = Some(dv.offset.toInt))
-      case None =>
-        DeletionVectorDescriptor.onDiskWithAbsolutePath(
-          path = dv.location,
-          sizeInBytes = rawSize,
-          cardinality = dv.cardinality,
-          offset = Some(dv.offset.toInt))
-    }
-  }
-
-  /**
-   * If `location` is a Delta-written DV blob under `tableRoot` (a `deletion_vector_<uuid>.bin` file
-   * directly under it or under one random-prefix directory), returns its UUID and prefix so the `u`
-   * descriptor can be rebuilt; None otherwise (treated as an absolute `p`).
-   */
-  private def recoverRelativeUuid(location: String, tableRoot: Path): Option[(UUID, String)] = {
-    val path = new Path(location)
-    val parent = path.getParent
-    val uuid =
-      Try(DeletionVectorDescriptor.getUUIDFromDeletionVectorFileName(path.getName)).toOption
-    val rootStr = tableRoot.toString
-    uuid.flatMap { id =>
-      if (parent.toString == rootStr) {
-        // <tableRoot>/deletion_vector_<uuid>.bin -- no random prefix.
-        Some((id, ""))
-      } else if (parent.getParent.toString == rootStr) {
-        // <tableRoot>/<prefix>/deletion_vector_<uuid>.bin -- one random-prefix directory.
-        Some((id, parent.getName))
-      } else {
-        None
-      }
-    }
+      DeletionVectorStore.getTotalSizeOfDVFieldsInFile(0)
+    // AMT stored paths are unencoded.
+    val absolutePath = DeletionVectorStore.unescapedStringToPath(dv.location)
+    require(absolutePath.isAbsolute)
+    DeletionVectorDescriptor.onDiskWithAbsolutePath(
+      path = DeletionVectorStore.pathToEscapedString(absolutePath),
+      sizeInBytes = rawSize,
+      cardinality = dv.cardinality,
+      offset = Some(dv.offset.toInt))
   }
 }
 
@@ -841,4 +808,3 @@ case class ManifestInfo(
  * @param raw_stats Column-stats payload; M1 writers leave it None.
  */
 case class ContentStats(raw_stats: Option[Array[Byte]] = None)
-

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSingleActionSerializerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSingleActionSerializerSuite.scala
@@ -306,41 +306,31 @@ class AMTSingleActionSerializerSuite extends QueryTest with SharedSparkSession {
   // Framing bytes that DeletionVectorStore adds around the raw bitmap on disk (length + checksum).
   private val dvFraming = DeletionVectorStore.getTotalSizeOfDVFieldsInFile(0)
 
-  test("DeletionVector.fromDescriptor maps a UUID-relative DV to an absolute location") {
+  test("DeletionVector.fromDescriptor maps a UUID-relative DV to an unencoded absolute location") {
     val id = UUID.randomUUID()
     val dv = DeletionVectorDescriptor.onDiskWithRelativePath(
-      id = id, sizeInBytes = 20, cardinality = 3L, offset = Some(8))
+      id = id,
+      randomPrefix = "test%dv%prefix-",
+      sizeInBytes = 20,
+      cardinality = 3L,
+      offset = Some(8))
     val amtDv = DeletionVector.fromDescriptor(dv, tableRoot)
-    // location is the absolute path the u-DV resolves to under the table root.
     assert(amtDv.location == dv.absolutePath(tableRoot).toString)
+    assert(amtDv.location.contains("test%dv%prefix-"))
     assert(amtDv.offset == 8L)
     assert(amtDv.cardinality == 3L)
     // size_in_bytes is the total on-disk size: raw bitmap plus framing.
     assert(amtDv.size_in_bytes == 20L + dvFraming)
-  }
 
-  test("DeletionVector round-trips a UUID-relative DV (matching uniqueId)") {
-    // Cover both a bare and a random-prefixed UUID-relative DV.
-    Seq("", "abc123").foreach { prefix =>
-      val dv = DeletionVectorDescriptor.onDiskWithRelativePath(
-        id = UUID.randomUUID(), randomPrefix = prefix,
-        sizeInBytes = 34, cardinality = 5L, offset = Some(16))
-      val roundTripped = DeletionVector.toDescriptor(
-        DeletionVector.fromDescriptor(dv, tableRoot), tableRoot)
-      assert(roundTripped.storageType == DeletionVectorDescriptor.UUID_DV_MARKER,
-        s"prefix='$prefix': expected a UUID-relative DV, got ${roundTripped.storageType}.")
-      // uniqueId (storageType + pathOrInlineDv + @offset) must survive the round-trip -- it is the
-      // (path, dv) dedup key state reconstruction relies on.
-      assert(roundTripped.uniqueId == dv.uniqueId,
-        s"prefix='$prefix': ${roundTripped.uniqueId} != ${dv.uniqueId}.")
-      assert(roundTripped.sizeInBytes == dv.sizeInBytes)
-      assert(roundTripped.cardinality == dv.cardinality)
-      assert(roundTripped.offset == dv.offset)
-    }
+    val roundTripped = DeletionVector.toDescriptor(amtDv, tableRoot)
+    assert(roundTripped.storageType == DeletionVectorDescriptor.PATH_DV_MARKER)
+    assert(roundTripped.pathOrInlineDv == dv.urlEncodedPath(tableRoot))
+    assert(roundTripped.pathOrInlineDv.contains("test%25dv%25prefix-"))
+    assert(roundTripped.absolutePath(tableRoot) == dv.absolutePath(tableRoot))
   }
 
   test("DeletionVector round-trips an absolute-path DV outside the table root") {
-    // An absolute DV whose path is not a Delta DV file under the table root stays `p`.
+    // An absolute DV whose path is outside the table root stays `p`.
     val dv = DeletionVectorDescriptor.onDiskWithAbsolutePath(
       path = "s3://other-bucket/dvs/custom.bin",
       sizeInBytes = 12, cardinality = 1L, offset = Some(4))

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotSuite.scala
@@ -389,22 +389,22 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
   }
 
   testAcrossAMTCheckpointScenarios(
-      "deletion vector round-trips through the leaves with a matching uniqueId",
+      "deletion vector round-trips through the leaves as an absolute-path DV",
       "amt_dv",
       sqlConfs = Seq(DeltaSQLConf.DELTA_HISTORY_METRICS_ENABLED.key -> "false"))(
       setup = name => {
-        Seq(1, 2).toDF("id").coalesce(1)
-          .write.mode("append").insertInto(name) // one file, two rows.
+        Seq(10, 20, 30, 40, 50).toDF("id").coalesce(1)
+          .write.mode("append").insertInto(name)
         // Attach a persistent DV directly rather than relying on DELETE's rewrite heuristic.
         val log = deltaLogForName(name)
         val fileToDv = log.unsafeVolatileSnapshot.allFiles.collect()
-        assert(fileToDv.length == 1, "The two rows must land in a single file.")
-        val dvActions = writeFileWithDVOnDisk(log, fileToDv.head, RoaringBitmapArray(0L))
+        assert(fileToDv.length == 1, "The five rows must land in a single file.")
+        val dvActions = writeFileWithDVOnDisk(log, fileToDv.head, RoaringBitmapArray(0L, 2L, 4L))
         log.startTransaction().commit(dvActions, DeltaOperations.Delete(predicate = Seq.empty))
       }) { context =>
     val snapshot = context.postCheckpointSnapshot
     val provider = context.provider
-    checkAnswer(spark.read.table(context.tableName), Seq(Row(2)))
+    checkAnswer(spark.read.table(context.tableName), Seq(Row(20), Row(40)))
 
     // The one surviving live file must carry a deletion vector in committed state.
     val committed = snapshot.allFiles.collect()
@@ -412,14 +412,10 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
     val committedFile = committed.head
     val committedDv = committedFile.deletionVector
     assert(committedDv != null, "The committed file must carry a deletion vector.")
-    // Two physical rows, one deleted by the DV -> one logical row.
-    assert(committedFile.numPhysicalRecords.contains(2L))
-    assert(committedFile.numLogicalRecords.contains(1L))
+    // Five physical rows, three deleted by the DV -> two logical rows.
+    assert(committedFile.numPhysicalRecords.contains(5L))
+    assert(committedFile.numLogicalRecords.contains(2L))
 
-    // The leaf-reconstructed AddFile must recover a DV with the SAME uniqueId, so the
-    // (path, deletionVectorUniqueId) dedup key matches the committed file exactly (no
-    // double-count in the reader path). uniqueId is
-    // storageType + pathOrInlineDv (+ "@offset"), so compare it from the reconstructed fields.
     val dvRow = provider
       .loadActionsForStateReconstruction(spark, snapshot.deltaLog)
       .getOrElse(fail("AMT provider must contribute leaf-derived file actions."))
@@ -434,9 +430,10 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
       offset = Option(dvRow.head.get(2)).map(_ => dvRow.head.getInt(2)),
       sizeInBytes = committedDv.sizeInBytes,
       cardinality = committedDv.cardinality)
-    assert(reconstructedDv.uniqueId == committedDv.uniqueId,
-      s"Reconstructed DV uniqueId ${reconstructedDv.uniqueId} must equal committed " +
-        s"${committedDv.uniqueId}.")
+    val tableRoot = snapshot.deltaLog.dataPath
+    // Not comparing the uniqueId here as it will soon not be the identity of the DV.
+    assert(reconstructedDv.absolutePath(tableRoot) == committedDv.absolutePath(tableRoot))
+    assert(reconstructedDv.offset == committedDv.offset)
 
     // The leaf-reconstructed AddFile must recover the same physical/logical record counts as the
     // committed file: `numRecords` in stats is the physical count, so it must round-trip without
@@ -450,10 +447,147 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
       .as[AddFile]
       .collect()
     assert(reconstructed.length == 1)
-    assert(reconstructed.head.numPhysicalRecords.contains(2L),
+    assert(reconstructed.head.numPhysicalRecords.contains(5L),
       "Reconstructed physical record count must match the committed file.")
-    assert(reconstructed.head.numLogicalRecords.contains(1L),
+    assert(reconstructed.head.numLogicalRecords.contains(2L),
       "Reconstructed logical record count must match the committed file.")
+  }
+
+  testAcrossAMTCheckpointScenarios(
+      "DV that fully deletes a file",
+      "amt_dv_full_delete",
+      sqlConfs = Seq(DeltaSQLConf.DELTA_HISTORY_METRICS_ENABLED.key -> "false"))(
+      setup = name => {
+        Seq(1, 2).toDF("id").coalesce(1).write.mode("append").insertInto(name)
+        val log = deltaLogForName(name)
+        val fileToDv = log.unsafeVolatileSnapshot.allFiles.collect()
+        assert(fileToDv.length == 1)
+        val dvActions = writeFileWithDVOnDisk(log, fileToDv.head, RoaringBitmapArray(0L, 1L))
+        log.startTransaction().commit(dvActions, DeltaOperations.Delete(predicate = Seq.empty))
+      }) { context =>
+    val snapshot = context.postCheckpointSnapshot
+    checkAnswer(spark.read.table(context.tableName), Seq.empty)
+
+    val committed = snapshot.allFiles.collect()
+    assert(committed.length == 1, "The fully-deleted file must stay live.")
+    assert(committed.head.numPhysicalRecords.contains(2L))
+    assert(committed.head.numLogicalRecords.contains(0L))
+
+    // The tree reconstructs the same file.
+    val reconstructed = amtFilesInTree(snapshot)
+    assert(reconstructed.length == 1, "The fully-deleted file must stay live.")
+    val dv = reconstructed.head.deletionVector
+    assert(dv != null)
+    assert(dv.cardinality == 2L)
+    assert(reconstructed.head.numPhysicalRecords.contains(2L))
+    assert(reconstructed.head.numLogicalRecords.contains(0L))
+  }
+
+  testAcrossAMTCheckpointScenarios(
+      "two files sharing one DV file on disk",
+      "amt_dv_shared_blob",
+      sqlConfs = Seq(DeltaSQLConf.DELTA_HISTORY_METRICS_ENABLED.key -> "false"))(
+      setup = name => {
+        Seq(1, 2).toDF("id").coalesce(1).write.mode("append").insertInto(name)
+        Seq(3, 4).toDF("id").coalesce(1).write.mode("append").insertInto(name)
+        val log = deltaLogForName(name)
+        val files = log.unsafeVolatileSnapshot.allFiles.collect()
+        assert(files.length == 2)
+        val dvActions = writeFilesWithDVsOnDisk(log, Seq(
+          files(0) -> RoaringBitmapArray(0L),
+          files(1) -> RoaringBitmapArray(0L)))
+        log.startTransaction().commit(dvActions, DeltaOperations.Delete(predicate = Seq.empty))
+      }) { context =>
+    val snapshot = context.postCheckpointSnapshot
+    // Each file drops its row 0 and the row-1 values (2 and 4) survive.
+    checkAnswer(spark.read.table(context.tableName), Seq(Row(2), Row(4)))
+
+    // Both DV'd files stay live, each with one logical row left.
+    val committed = snapshot.allFiles.collect()
+    assert(committed.length == 2, "Both DV'd files must remain live.")
+    assert(committed.forall(_.numLogicalRecords.contains(1L)))
+
+    // The tree reconstructs the same files.
+    val tableRoot = snapshot.deltaLog.dataPath
+    val reconstructed = amtFilesInTree(snapshot)
+    assert(reconstructed.length == 2)
+    val dvs = reconstructed.map(_.deletionVector)
+    assert(dvs.forall(dv => dv != null))
+    // Both AddFiles reference the same DV file on disk.
+    val blobPaths = dvs.map(_.absolutePath(tableRoot)).toSet
+    assert(blobPaths.size == 1)
+    // Offsets are still different.
+    val offsets = dvs.map(_.offset).toSet
+    assert(offsets.size == 2)
+  }
+
+  testAcrossAMTCheckpointScenarios(
+      "DVs on files across multiple leaf manifests",
+      "amt_dv_multi_leaf",
+      sqlConfs = Seq(
+        DeltaSQLConf.AMT_ENTRIES_PER_LEAF.key -> "2",
+        DeltaSQLConf.DELTA_HISTORY_METRICS_ENABLED.key -> "false"))(
+      setup = name => {
+        // Four two-row files
+        Seq((10, 11), (20, 21), (30, 31), (40, 41)).foreach { case (a, b) =>
+          Seq(a, b).toDF("id").coalesce(1).write.mode("append").insertInto(name)
+        }
+        val log = deltaLogForName(name)
+        val files = log.unsafeVolatileSnapshot.allFiles.collect()
+        assert(files.length == 4)
+        val dvActions = writeFilesWithDVsOnDisk(log, files.map(_ -> RoaringBitmapArray(0L)).toSeq)
+        log.startTransaction().commit(dvActions, DeltaOperations.Delete(predicate = Seq.empty))
+      }) { context =>
+    val snapshot = context.postCheckpointSnapshot
+    checkAnswer(spark.read.table(context.tableName), Seq(Row(11), Row(21), Row(31), Row(41)))
+
+    val committed = snapshot.allFiles.collect()
+    assert(committed.length == 4, "All four DV'd files remain live.")
+    assert(committed.forall(_.numLogicalRecords.contains(1L)))
+
+    // The tree reconstructs the same files.
+    val reconstructed = amtFilesInTree(snapshot)
+    assert(reconstructed.length == 4)
+    val filesWithDvs = reconstructed.filter(_.deletionVector != null)
+    assert(filesWithDvs.length == 4)
+  }
+
+  test("DV with shallow cloned table") {
+    withSQLConf(DeltaSQLConf.DELTA_HISTORY_METRICS_ENABLED.key -> "false") {
+      withTable("amt_dv_clone_src", "amt_dv_clone_tgt") {
+        val src = "amt_dv_clone_src"
+        // The source needs no AMT of its own, the clone reads its files.
+        createAMTTable(src, checkpointInterval = 100)
+        Seq(1, 2).toDF("id").coalesce(1).write.mode("append").insertInto(src)
+        val srcLog = deltaLogForName(src)
+        val srcFile = srcLog.unsafeVolatileSnapshot.allFiles.collect()
+        assert(srcFile.length == 1, "The two rows must land in a single file.")
+        val dvActions = writeFileWithDVOnDisk(srcLog, srcFile.head, RoaringBitmapArray(0L))
+        srcLog.startTransaction().commit(dvActions, DeltaOperations.Delete(predicate = Seq.empty))
+
+        val tgt = "amt_dv_clone_tgt"
+        sql(s"CREATE TABLE $tgt SHALLOW CLONE $src")
+        // Materialize the target's AMT.
+        commitCheckpoint(deltaLogForName(tgt), incremental = false)
+
+        val tgtLog = deltaLogForName(tgt)
+        val snapshot = tgtLog.update()
+        amtProvider(snapshot).getOrElse(
+          fail("the clone target must have an AMTCheckpointProvider."))
+        checkAnswer(spark.read.table(tgt), Seq(Row(2)))
+
+        val reconstructed = amtFilesInTree(snapshot)
+        assert(reconstructed.length == 1)
+        val dv = reconstructed.head.deletionVector
+        assert(dv != null)
+        assert(dv.storageType == DeletionVectorDescriptor.PATH_DV_MARKER,
+          "An outside-root DV must reconstruct as a p DV")
+        // The DV blob physically lives outside the target's root.
+        val tgtRoot = tgtLog.dataPath
+        val dvPath = dv.absolutePath(tgtRoot).toString
+        assert(!dvPath.startsWith(tgtRoot.toString))
+      }
+    }
   }
 
   testAcrossAMTCheckpointScenarios(


### PR DESCRIPTION
## What changes were proposed in this pull request?

When reconstructing a `DeletionVectorDescriptor` from an adaptive metadata tree (AMT) sub-struct, `DeletionVector.toDescriptor` previously attempted to recover a UUID-relative (`u`) descriptor when the stored blob happened to live under the table root, and only fell back to an absolute-path (`p`) descriptor otherwise.

This change simplifies the conversion to always rebuild an absolute-path (`p`) descriptor. AMT stores full, unencoded blob paths, so the reconstruction now decodes the stored location with `DeletionVectorStore.unescapedStringToPath`, requires it to be absolute, and re-encodes it with `DeletionVectorStore.pathToEscapedString` before building the descriptor. The now-unused `recoverRelativeUuid` helper (and its `UUID`/`Try` imports) is removed.

## How was this patch tested?

Updated `AMTSingleActionSerializerSuite` and `AMTSnapshotSuite`, and added coverage for:
- a DV that fully deletes a file,
- two files sharing a single on-disk DV blob (distinct offsets),
- DVs on files spread across multiple leaf manifests,
- a shallow-cloned table whose DV blob lives outside the target root.

## Does this PR introduce _any_ user-facing changes?

No.
