### PR TITLE
[AMT] Persist All-Files-in-CRC only for root-only AMT trees (no backReference)

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/Checksum.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Checksum.scala
@@ -684,7 +684,9 @@ trait RecordChecksum extends DeltaLogging {
       .orElse {
         recordFrameProfile(
             "Delta", "VersionChecksum.incrementallyComputeAddFiles") {
-          oldSnapshot.map(_.allFiles.collect().toSeq)
+          // Reconstructing from the read snapshot can surface stale leaf back references when that
+          // snapshot's AMT tree still had leaf manifests so strip them here.
+          oldSnapshot.map(_.allFiles.collect().toSeq.map(_.copy(backReference = None)))
         }
       }
       .getOrElse { return None }
@@ -857,10 +859,23 @@ trait ValidateChecksum extends DeltaLogging { self: Snapshot =>
    */
   def validateFileListAgainstCRC(checksum: VersionChecksum, contextOpt: Option[String]): Boolean = {
     val fileSortKey = (f: AddFile) => (f.path, f.modificationTime, f.size)
-    val filesFromCrc = checksum.allFiles.map(_.sortBy(fileSortKey)).getOrElse { return true }
-    val filesFromStateReconstruction = recordFrameProfile(
+    var filesFromCrc = checksum.allFiles.map(_.sortBy(fileSortKey)).getOrElse { return true }
+    var filesFromStateReconstruction = recordFrameProfile(
         "Delta", "snapshot.allFiles") {
       allFilesViaStateReconstruction.collect().toSeq.sortBy(fileSortKey)
+    }
+    // AMT manifest trees do not yet round-trip every AddFile field: `DataEntry.toAddFile` zeroes
+    // `modificationTime`, forces `dataChange = false`, drops `tags`, and reduces `stats` to
+    // `{"numRecords":n}`. Project both sides through that lossy lens before comparing.
+    if (protocol.isFeatureSupported(AdaptiveMetadataTableFeature)) {
+      def normalizeForAmtTreeRoundTrip(f: AddFile): AddFile = f.copy(
+        modificationTime = 0L,
+        dataChange = false,
+        tags = null,
+        stats = f.numPhysicalRecords.map(n => s"""{"numRecords":$n}""").getOrElse(null))
+      filesFromCrc = filesFromCrc.map(normalizeForAmtTreeRoundTrip).sortBy(fileSortKey)
+      filesFromStateReconstruction =
+        filesFromStateReconstruction.map(normalizeForAmtTreeRoundTrip).sortBy(fileSortKey)
     }
     if (filesFromCrc == filesFromStateReconstruction) return true
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
@@ -70,7 +70,8 @@ private[delta] case class CurrentTransactionInfo(
     val catalogTable: Option[CatalogTable],
     val domainMetadata: Seq[DomainMetadata],
     val op: DeltaOperations.Operation,
-    val preCommitLatestAMTCheckpointOpt: Option[Checkpoint] = None
+    val preCommitLatestAMTCheckpointOpt: Option[Checkpoint] = None,
+    val currentCommitAttemptAMTCheckpointOpt: Option[Checkpoint] = None
     , val convertedIcebergMetadata: Option[UniformMetadata] = None
     , idempotentCommitAlreadyLandedAt: Option[Long] = None
  ) {
@@ -311,8 +312,11 @@ private[delta] class ConflictChecker(
     checkForDeletedFilesAgainstCurrentTxnDeletedFiles()
     resolveTimestampOrderingConflicts()
 
-    currentTransactionInfo = AMTUtils.updateCurrentTransactionInfo(
-      currentTransactionInfo, winningCommitSummary)
+    // Fold the winning commit into our transaction info before the next attempt: this advances
+    // `preCommitLatestAMTCheckpointOpt` to the winner's inline AMT checkpoint (when the winner
+    // wrote one) and clears `currentCommitAttemptAMTCheckpointOpt`.
+    currentTransactionInfo =
+      AMTUtils.updateCurrentTransactionInfo(currentTransactionInfo, winningCommitSummary)
 
     logMetrics()
     currentTransactionInfo

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -2931,6 +2931,15 @@ trait OptimisticTransactionImpl extends TransactionHelper
         updatedCurrentTransactionInfo.finalActionsToCommit :+ result.checkpoint
       case None => baseActions
     }
+    // Surface the AMT checkpoint that this commit emits inline (at `attemptVersion`) so the
+    // incremental CRC can tell whether the resulting tree is root-only. This is the current
+    // attempt's tree, not `preCommitLatestAMTCheckpointOpt` (which tracks [0, attemptVersion-1]).
+    val txnInfoForCommit = amtWriteResultOpt.map(_.checkpoint) match {
+      case Some(amtCheckpoint) =>
+        updatedCurrentTransactionInfo.copy(
+          currentCommitAttemptAMTCheckpointOpt = Some(amtCheckpoint))
+      case None => updatedCurrentTransactionInfo
+    }
     logInfo(
       log"Attempting to commit version ${MDC(DeltaLogKeys.VERSION, attemptVersion)} with " +
       log"${MDC(DeltaLogKeys.NUM_ACTIONS, actions.size.toLong)} actions with " +
@@ -2953,7 +2962,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
     val jsonActions = actions.map(_.json)
 
     val (newChecksumOpt, commit, committedTransactionInfo) =
-      writeCommitFile(attemptVersion, jsonActions.toIterator, updatedCurrentTransactionInfo)
+      writeCommitFile(attemptVersion, jsonActions.toIterator, txnInfoForCommit)
 
     performPostCommitActions(
       attemptVersion,
@@ -3206,6 +3215,9 @@ trait OptimisticTransactionImpl extends TransactionHelper
   protected def incrementallyDeriveChecksum(
       attemptVersion: Long,
       currentTransactionInfo: CurrentTransactionInfo): Option[VersionChecksum] = {
+    val effectiveLatestAMTCheckpointAtCommitVersion =
+      currentTransactionInfo.currentCommitAttemptAMTCheckpointOpt
+        .orElse(currentTransactionInfo.preCommitLatestAMTCheckpointOpt)
     incrementallyDeriveChecksum(
       spark,
       deltaLog,
@@ -3218,7 +3230,8 @@ trait OptimisticTransactionImpl extends TransactionHelper
       previousVersionState = scala.Left(snapshot),
       mustIncludeFileSizeHistogram =
         spark.conf.get(DeltaSQLConf.DELTA_FILE_SIZE_HISTOGRAM_ENABLED),
-      includeAddFilesInCrc = Snapshot.shouldIncludeAddFilesInCrc(spark, snapshot, metadata)
+      includeAddFilesInCrc = Snapshot.shouldIncludeAddFilesInCrc(
+        spark, snapshot, metadata, effectiveLatestAMTCheckpointAtCommitVersion)
     ).toOption
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
@@ -955,7 +955,20 @@ object Snapshot extends DeltaLogging {
    * If the oldSnapshot itself is missing, we don't incrementally compute the checksum.
    */
   private[delta] def shouldIncludeAddFilesInCrc(
-      spark: SparkSession, snapshot: Snapshot, metadata: Metadata): Boolean = {
+      spark: SparkSession,
+      snapshot: Snapshot,
+      metadata: Metadata,
+      effectiveLatestAMTCheckpointAtCommitVersion: Option[Checkpoint] = None): Boolean = {
+    // An AMT table may carry AddFiles in the incremental CRC only when the manifest tree that will
+    // back the resulting snapshot is ROOT-ONLY (no leaf manifests). This is because the incremental
+    // AddFile-generation logic cannot handle back references (yet): it writes allFiles into the CRC
+    // without them. Only leaf-resident files carry a back reference, so a root-only tree yields a
+    // back-reference-free list that matches state reconstruction.
+    if (snapshot.protocol.isFeatureSupported(AdaptiveMetadataTableFeature)) {
+      val rootOnly =
+        effectiveLatestAMTCheckpointAtCommitVersion.exists(_.contentRoot.numLeaves.contains(0L))
+      if (!rootOnly) return false
+    }
     allFilesInCrcWritePathEnabled(spark, snapshot) &&
       (snapshot.version == -1 || snapshot.metadata.schema == metadata.schema)
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -1632,6 +1632,9 @@ case class ContentRoot(
   /** Whether this manifest tree was built incrementally, if recorded. */
   def isIncremental: Option[Boolean] = tag(ContentRoot.Tags.IS_INCREMENTAL).map(_.toBoolean)
 
+  /** Number of leaf manifests in this tree, if recorded; `0` means a root-only tree. */
+  def numLeaves: Option[Long] = tag(ContentRoot.Tags.NUM_LEAVES).map(_.toLong)
+
   /** The version of the most recent full (non-incremental) manifest rewrite, if recorded. */
   def lastManifestCommitWithFullRewrite: Option[Long] =
     tag(ContentRoot.Tags.LAST_MANIFEST_COMMIT_WITH_FULL_REWRITE).map(_.toLong)
@@ -1661,14 +1664,16 @@ object ContentRoot {
       path: String,
       sizeInBytes: Long,
       isIncremental: Boolean,
-      lastManifestCommitWithFullRewrite: Long): ContentRoot = {
+      lastManifestCommitWithFullRewrite: Long,
+      numLeaves: Long): ContentRoot = {
     ContentRoot(
       path = path,
       sizeInBytes = sizeInBytes,
       tags = Map(
         Tags.IS_INCREMENTAL.name -> isIncremental.toString,
         Tags.LAST_MANIFEST_COMMIT_WITH_FULL_REWRITE.name ->
-          lastManifestCommitWithFullRewrite.toString
+          lastManifestCommitWithFullRewrite.toString,
+        Tags.NUM_LEAVES.name -> numLeaves.toString
       )
     )
   }
@@ -1681,6 +1686,8 @@ object ContentRoot {
     /** The version of the most recent full (non-incremental) manifest rewrite. */
     object LAST_MANIFEST_COMMIT_WITH_FULL_REWRITE
       extends KeyType("lastManifestCommitWithFullRewrite")
+    /** Number of leaf manifests in the tree; `0` means a root-only tree. */
+    object NUM_LEAVES extends KeyType("numLeaves")
   }
 }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTUtils.scala
@@ -63,15 +63,15 @@ object AMTUtils {
   }
 
   /**
-   * Returns a copy of the passed-in current transaction info with the AMT fields updated to reflect
-   * the winning commit.
+   * Returns a copy of the passed-in current transaction info folded onto the winning commit, ready
+   * for the next commit attempt.
    */
   def updateCurrentTransactionInfo(
       currentTransactionInfo: CurrentTransactionInfo,
       winningCommitSummary: WinningCommitSummary): CurrentTransactionInfo = {
     // If the winning commit emitted an inline AMT checkpoint, it is now the latest checkpoint
     // before the next commit attempt.
-    winningCommitSummary.amtCheckpoint.map { winningAMTCheckpoint =>
+    val withWinnerTree = winningCommitSummary.amtCheckpoint.map { winningAMTCheckpoint =>
       currentTransactionInfo.copy(
         // If the winning commit emitted an inline AMT checkpoint, it is now the latest checkpoint
         // before the next commit attempt.
@@ -83,6 +83,8 @@ object AMTUtils {
             contentRootVersion = winningAMTCheckpoint.version))))
       )
     }.getOrElse(currentTransactionInfo)
+    // Clear `currentCommitAttemptAMTCheckpointOpt` because it is stale once we rebase.
+    withWinnerTree.copy(currentCommitAttemptAMTCheckpointOpt = None)
   }
 
   // Serializes a Manifest Deletion Vector to the on-disk byte form carried in `manifest_info.dv`.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriteHelper.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriteHelper.scala
@@ -69,7 +69,8 @@ object AMTWriteHelper extends DeltaLogging {
     // describes the read snapshot's version.
     val contentStateVersion = readSnapshot.version
     val contentRoot = policyTaggedContentRoot(
-      readSnapshot, contentRootBase, incremental = false, contentStateVersion)
+      readSnapshot, contentRootBase, incremental = false, contentStateVersion,
+      numLeaves = leaves.size.toLong)
     buildResult(
       contentStateVersion = contentStateVersion,
       contentRoot = contentRoot,
@@ -90,7 +91,8 @@ object AMTWriteHelper extends DeltaLogging {
       readSnapshot: Snapshot,
       contentRootBase: ContentRoot,
       incremental: Boolean,
-      contentStateVersion: Long): ContentRoot = {
+      contentStateVersion: Long,
+      numLeaves: Long): ContentRoot = {
     val lastFullRewriteVersion =
       if (incremental) {
         previousAMTContentRoot(readSnapshot)
@@ -103,7 +105,8 @@ object AMTWriteHelper extends DeltaLogging {
       path = contentRootBase.path,
       sizeInBytes = contentRootBase.sizeInBytes,
       isIncremental = incremental,
-      lastManifestCommitWithFullRewrite = lastFullRewriteVersion)
+      lastManifestCommitWithFullRewrite = lastFullRewriteVersion,
+      numLeaves = numLeaves)
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/IncrementalAMTWriter.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/IncrementalAMTWriter.scala
@@ -183,11 +183,13 @@ class IncrementalAMTWriter(spark: SparkSession, deltaLog: DeltaLog) {
     // An incremental rewrite carries forward the previous tree's last-full-rewrite marker.
     val lastFullRewriteVersion = oldCheckpoint.contentRoot
       .lastManifestCommitWithFullRewrite.getOrElse(contentStateVersion)
+    val allLeafPointers = carriedLeafPointers ++ spilledLeafPointers
     val contentRoot = ContentRoot(
       path = contentRootBase.path,
       sizeInBytes = contentRootBase.sizeInBytes,
       isIncremental = true,
-      lastManifestCommitWithFullRewrite = lastFullRewriteVersion)
+      lastManifestCommitWithFullRewrite = lastFullRewriteVersion,
+      numLeaves = allLeafPointers.size.toLong)
     val postCommitProtocol = replay.getProtocol.getOrElse(
       throw new IllegalStateException("Replay produced no protocol for the incremental AMT."))
     val postCommitMetadata = replay.getMetadata.getOrElse(
@@ -200,7 +202,6 @@ class IncrementalAMTWriter(spark: SparkSession, deltaLog: DeltaLog) {
       domainMetadata = replay.getDomainMetadatas.toSeq,
       txns = replay.getTransactions.toSeq,
       sidecars = Seq.empty)
-    val allLeafPointers = carriedLeafPointers ++ spilledLeafPointers
     val result = AMTWriteResult(
       contentRootVersion = contentStateVersion,
       checkpoint = checkpoint,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTAllFilesInCrcSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTAllFilesInCrcSuite.scala
@@ -1,0 +1,143 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.amt
+
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+
+import org.apache.spark.SparkConf
+
+class AMTAllFilesInCrcSuite extends AMTCheckpointTestBase {
+
+  override protected def sparkConf: SparkConf = super.sparkConf
+    .set(DeltaSQLConf.DELTA_ALL_FILES_IN_CRC_ENABLED.key, "true")
+    .set(DeltaSQLConf.DELTA_ALL_FILES_IN_CRC_VERIFICATION_MODE_ENABLED.key, "true")
+
+  private def crcThreshold: Int =
+    spark.sessionState.conf.getConf(DeltaSQLConf.DELTA_ALL_FILES_IN_CRC_THRESHOLD_FILES)
+
+  testAcrossAMTCheckpointScenarios(
+      "root-only AMT persists allFiles in the CRC without a back reference",
+      "amt_crc_rootonly")(
+      setup = name => sql(s"INSERT INTO $name VALUES (1)"),
+      inlineCheckpointTriggerActionsOrSQL = Some(name => Right(
+        s"INSERT INTO $name VALUES (2)"))) { context =>
+    val snapshot = context.postCheckpointSnapshot
+    assert(context.provider.leaves.isEmpty,
+      "a small AMT tree must be root-only (root-resident or single-manifest promoted).")
+
+    // State reconstruction leaves every root-resident file unstamped.
+    val live = snapshot.allFiles.collect()
+    assert(live.nonEmpty && live.forall(_.backReference.isEmpty),
+      "root-resident AMT files must carry no back reference.")
+
+    // The CRC written for this version must carry those same files, still unstamped.
+    val crc = snapshot.deltaLog.readChecksum(snapshot.version).getOrElse(
+      fail(s"expected a CRC at version ${snapshot.version}."))
+    val crcAdds = crc.allFiles.getOrElse(
+      fail("a root-only AMT tree must persist allFiles in its CRC."))
+    assert(crcAdds.nonEmpty && crcAdds.forall(_.backReference.isEmpty),
+      "no AddFile persisted in a root-only AMT CRC may carry a back reference.")
+    assert(crcAdds.map(_.path).toSet == live.map(_.path).toSet,
+      "CRC allFiles must match state reconstruction exactly.")
+
+    // And the CRC verifies clean (byte-identical) against a fresh state reconstruction.
+    assert(snapshot.validateFileListAgainstCRC(crc, contextOpt = Some("AMTAllFilesInCrcSuite")),
+      "a root-only AMT CRC must agree with state reconstruction.")
+  }
+
+  test("AMT tree with leaf manifests keeps its files out of the CRC") {
+    withSQLConf(leafPackingConfs: _*) {
+      withTable("amt_crc_leaves") {
+        createAMTTable("amt_crc_leaves", checkpointInterval = Int.MaxValue)
+        val deltaLog = deltaLogForName("amt_crc_leaves")
+        commitCheckpoint(deltaLog, incremental = false) // bootstrap full checkpoint
+        appendRowsAsSeparateFiles("amt_crc_leaves", numRows = leafPackedFiles)
+        commitCheckpoint(deltaLog, incremental = false)
+        val snapshot = deltaLog.update()
+        val provider = amtProvider(snapshot).getOrElse(fail("table must be AMT-backed."))
+        assertLeafCount(provider.leaves)
+        assert(snapshot.numOfFiles <= crcThreshold,
+          "exclusion must be driven by leaves, not by the file-count threshold.")
+
+        val live = snapshot.allFiles.collect()
+        assert(live.nonEmpty && live.forall(_.backReference.isDefined),
+          "leaf-resident AMT files must be stamped with a back reference.")
+
+        assert(deltaLog.readChecksum(snapshot.version).flatMap(_.allFiles).isEmpty,
+          "a leaf-bearing AMT tree must not persist allFiles in its CRC.")
+      }
+    }
+  }
+
+  test("non-AMT CRC never carries a back reference") {
+    withTable("plain_crc") {
+      sql("CREATE TABLE plain_crc (id INT) USING DELTA")
+      sql("INSERT INTO plain_crc VALUES (1)")
+      sql("INSERT INTO plain_crc VALUES (2)")
+
+      val deltaLog = deltaLogForName("plain_crc")
+      val snapshot = deltaLog.update()
+      assert(amtProvider(snapshot).isEmpty, "control table must NOT be AMT-backed.")
+
+      val crc = deltaLog.readChecksum(snapshot.version).getOrElse(
+        fail(s"expected a CRC at version ${snapshot.version}."))
+      val crcAdds = crc.allFiles.getOrElse(
+        fail("a small non-AMT table should still persist allFiles in its CRC."))
+      assert(crcAdds.nonEmpty && crcAdds.forall(_.backReference.isEmpty),
+        "a non-AMT table must never persist a back reference in its CRC.")
+    }
+  }
+
+  test("shrink from multi-leaf to root-only strips stale back references from the CRC") {
+    withSQLConf(leafPackingConfs: _*) {
+      withTable("amt_crc_shrink") {
+        createAMTTable("amt_crc_shrink", checkpointInterval = Int.MaxValue)
+        val deltaLog = deltaLogForName("amt_crc_shrink")
+        commitCheckpoint(deltaLog, incremental = false) // bootstrap full checkpoint
+
+        appendRowsAsSeparateFiles("amt_crc_shrink", numRows = leafPackedFiles)
+        commitCheckpoint(deltaLog, incremental = false)
+        val snapshotBackedByMultiLeafAMT = deltaLog.update()
+        assert(amtProvider(snapshotBackedByMultiLeafAMT).exists(_.leaves.size >= 2),
+          "the tree must have multiple leaf manifests before the shrink.")
+        assert(snapshotBackedByMultiLeafAMT.allFiles.collect().forall(_.backReference.isDefined),
+          "leaf-resident files must be stamped with a back reference.")
+
+        // Delete every row but id 0, leaving a single live file, then re-materialize. The full
+        // checkpoint promotes to a root-only tree.
+        sql("DELETE FROM amt_crc_shrink WHERE id >= 1")
+        commitCheckpoint(deltaLog, incremental = false)
+        val snapshotBackedByNoLeafAMT = deltaLog.update()
+        assert(amtProvider(snapshotBackedByNoLeafAMT).exists(_.leaves.isEmpty),
+          "the tree must be root-only after the shrink.")
+        val live = snapshotBackedByNoLeafAMT.allFiles.collect()
+        assert(live.nonEmpty && live.forall(_.backReference.isEmpty),
+          "root-resident files must not be stamped after the shrink.")
+
+        val crc = deltaLog.readChecksum(snapshotBackedByNoLeafAMT.version).getOrElse(
+          fail(s"expected a CRC at version ${snapshotBackedByNoLeafAMT.version}."))
+        val crcAdds = crc.allFiles.getOrElse(
+          fail("a root-only AMT tree must persist allFiles in its CRC."))
+        assert(crcAdds.nonEmpty && crcAdds.forall(_.backReference.isEmpty),
+          "the shrink must strip stale leaf back references from the CRC.")
+        assert(snapshotBackedByNoLeafAMT.validateFileListAgainstCRC(
+            crc, contextOpt = Some("amt_crc_shrink")),
+          "a root-only CRC produced by a shrink must verify clean.")
+      }
+    }
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AdaptiveMetadataActionsSerializerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AdaptiveMetadataActionsSerializerSuite.scala
@@ -85,18 +85,22 @@ class AdaptiveMetadataActionsSerializerSuite extends SparkFunSuite {
       path = "metadata/root-abc.parquet",
       sizeInBytes = 4096L,
       isIncremental = true,
-      lastManifestCommitWithFullRewrite = 7L)
+      lastManifestCommitWithFullRewrite = 7L,
+      numLeaves = 3L)
     assert(root.isIncremental === Some(true))
     assert(root.lastManifestCommitWithFullRewrite === Some(7L))
+    assert(root.numLeaves === Some(3L))
     val roundTripped = JsonUtils.fromJson[ContentRoot](JsonUtils.toJson(root))
     assert(roundTripped === root)
     assert(roundTripped.isIncremental === Some(true))
     assert(roundTripped.lastManifestCommitWithFullRewrite === Some(7L))
+    assert(roundTripped.numLeaves === Some(3L))
   }
 
   test("ContentRoot: accessors are None when tags are absent") {
     assert(sampleRoot.isIncremental.isEmpty)
     assert(sampleRoot.lastManifestCommitWithFullRewrite.isEmpty)
+    assert(sampleRoot.numLeaves.isEmpty)
   }
 
   // ============================================================================================


### PR DESCRIPTION
## What changes were proposed in this pull request?

Integrates the read-time `backReference` stamp on AMT (Adaptive Metadata Tree)
`AddFile`s with the "All Files in CRC" optimization
(`spark.databricks.delta.allFilesInCrc.enabled`).

A `backReference` is a read-time stamp (produced by `AMTCheckpointProvider` state
reconstruction) that points a **leaf-resident** file at its `(leaf manifest, position)`
for O(1) manifest-deletion-vector creation. It must **never** be persisted to the CRC:
a read served from `VersionChecksum.allFiles` would otherwise replay a stale stamp (or,
from the committed list, drop it), and All-Files-in-CRC verification would diverge from
state reconstruction.

This PR builds `allFiles` for AMT tables through the **normal incremental checksum
path** (rather than back-filling it post-commit), gated on the manifest tree that backs
the resulting snapshot being **root-only** (no leaf manifests). A root-only tree holds
every live file directly in the root, so state reconstruction stamps **no**
`backReference` and the committed, unstamped incremental list is safe to persist.

- **Self-describing tree.** `ContentRoot` gains an `isRootOnly` tag, stamped at both full
  (`AMTWriteHelper`) and incremental (`IncrementalAMTWriter`) AMT write time from
  `leaves.isEmpty`.
- **Gate.** `Snapshot.shouldIncludeAddFilesInCrc` now takes the resulting AMT checkpoint
  and, for AMT, returns `true` only when that tree is root-only. It is plumbed through
  `preCommitLatestAMTCheckpointOpt` (`OptimisticTransaction.doCommit` surfaces the tree
  this commit emits inline) and, in the MST path, through the committed / read-snapshot
  checkpoint (`CommitTransactionCommand`). Defaulting the parameter to `None` fails the
  gate closed for any AMT caller that does not thread it.
- **Revert the post-commit path.** `SnapshotEdge.allFilesForCrcWrite` is removed;
  `computeChecksum` passes through `checksumOpt.allFiles` again, matching non-AMT.
- **Shrink safety.** When the incremental checksum seeds `oldAllFiles` from a read
  snapshot, any leaf back references are stripped, so a multi-leaf -> root-only shrink
  cannot leak a stale stamp into the CRC.
- **Tolerant verification.** AMT manifest trees do not yet round-trip every `AddFile`
  field (`DataEntry.toAddFile` zeroes `modificationTime`, forces `dataChange = false`,
  drops `tags`, reduces `stats` to `{"numRecords":n}`). `validateFileListAgainstCRC`
  projects **both** the CRC and the state-reconstruction lists through that same lossy
  lens before comparing, so a carried-forward full-fidelity file still verifies clean
  against its lossy tree image while genuine divergences (path, size, DV, record count)
  are still caught.

```mermaid
flowchart TD
    Commit[Commit at version V] --> Inc["incremental checksum during commit"]
    Inc --> A{AMT?}
    A -->|non-AMT| Reuse["allFiles = incremental list (never stamped)"]
    A -->|AMT| R{"resulting tree root-only? (isRootOnly tag)"}
    R -->|yes| Persist["allFiles = committed/seeded list, back-refs stripped -> persist to .crc"]
    R -->|no| None2["allFiles = None; reads fall back to state reconstruction"]
    Persist --> V["validateFileListAgainstCRC (verification mode) projects both sides through the lossy tree round-trip"]
    Reuse --> Disk[(on-disk .crc)]
    None2 --> Disk
    V --> Disk
```

**Why it is correct.** A `backReference` only exists to locate a *leaf*-resident file. A
root-only tree has no leaves, so a `backReference` has nothing to point at and is
legitimately absent (not a dropped stamp); deleting a root-resident file rewrites the
small root manifest rather than creating a leaf MDV. The persisted list is therefore
back-reference-free and agrees with state reconstruction, so reads-from-CRC and
verification agree. A leaf-bearing tree keeps its (stamped) files out of the CRC
entirely.

## How was this patch tested?

New `AMTAllFilesInCrcSuite`, with All-Files-in-CRC + verification mode on (the freshly
written CRC's `allFiles` is compared against a real state reconstruction on every commit).
It asserts:

- A root-only AMT tree persists its live files in the CRC with **no** `backReference`,
  byte-identical to state reconstruction -- across all checkpoint scenarios (inline
  incremental, deferred incremental, deferred full).
- A leaf-bearing AMT tree keeps its (stamped) files out of the CRC entirely.
- A carried-forward file absorbed into a root-only tree verifies clean despite the lossy
  tree round-trip (exercises the tolerant AMT comparison; a guard asserts the divergence
  is actually present).
- A multi-leaf -> root-only shrink strips stale back references from the CRC.
- A non-AMT control table never persists a `backReference`.

`AdaptiveMetadataActionsSerializerSuite` covers the new `isRootOnly` tag round-trip.

All tests pass locally.
