### PR TITLE
Use error subclasses for DELTA_UNIVERSAL_FORMAT_VIOLATION

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -3153,8 +3153,25 @@
   },
   "DELTA_UNIVERSAL_FORMAT_VIOLATION" : {
     "message" : [
-      "The validation of Universal Format (<format>) has failed: <violation>"
+      "The validation of Universal Format (<format>) has failed:"
     ],
+    "subClass" : {
+      "HUDI_DELETE_VECTORS_NOT_SUPPORTED" : {
+        "message" : [
+          "Requires deletion vectors to be disabled."
+        ]
+      },
+      "HUDI_UNSUPPORTED_DATA_TYPE" : {
+        "message" : [
+          "DataType <dataType> is not currently supported."
+        ]
+      },
+      "ICEBERG_COMPAT_REQUIRED" : {
+        "message" : [
+          "Requires IcebergCompat to be explicitly enabled in order for Universal Format (Iceberg) to be enabled on an existing table. Supported versions are IcebergCompatV1 and IcebergCompatV2."
+        ]
+      }
+    },
     "sqlState" : "KD00E"
   },
   "DELTA_UNKNOWN_CONFIGURATION" : {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -3778,33 +3778,22 @@ trait DeltaErrorsBase
 
   def uniFormIcebergRequiresIcebergCompat(): Throwable = {
     new DeltaUnsupportedOperationException(
-      errorClass = "DELTA_UNIVERSAL_FORMAT_VIOLATION",
-      messageParameters = Array(
-        UniversalFormat.ICEBERG_FORMAT,
-        "Requires IcebergCompat to be explicitly enabled in order for Universal Format (Iceberg) " +
-        "to be enabled on an existing table. Supported versions are IcebergCompatV1 and " +
-        "IcebergCompatV2."
-      )
+      errorClass = "DELTA_UNIVERSAL_FORMAT_VIOLATION.ICEBERG_COMPAT_REQUIRED",
+      messageParameters = Array(UniversalFormat.ICEBERG_FORMAT)
     )
   }
 
   def uniFormHudiDeleteVectorCompat(): Throwable = {
     new DeltaUnsupportedOperationException(
-      errorClass = "DELTA_UNIVERSAL_FORMAT_VIOLATION",
-      messageParameters = Array(
-        UniversalFormat.HUDI_FORMAT,
-        "Requires delete vectors to be disabled."
-      )
+      errorClass = "DELTA_UNIVERSAL_FORMAT_VIOLATION.HUDI_DELETE_VECTORS_NOT_SUPPORTED",
+      messageParameters = Array(UniversalFormat.HUDI_FORMAT)
     )
   }
 
   def uniFormHudiSchemaCompat(unsupportedType: DataType): Throwable = {
     new DeltaUnsupportedOperationException(
-      errorClass = "DELTA_UNIVERSAL_FORMAT_VIOLATION",
-      messageParameters = Array(
-        UniversalFormat.HUDI_FORMAT,
-        s"DataType: $unsupportedType is not currently supported."
-      )
+      errorClass = "DELTA_UNIVERSAL_FORMAT_VIOLATION.HUDI_UNSUPPORTED_DATA_TYPE",
+      messageParameters = Array(UniversalFormat.HUDI_FORMAT, unsupportedType.toString)
     )
   }
 

--- a/spark/src/test/scala-shims/spark-4.1/org/apache/spark/sql/delta/DeltaGeoSuite.scala
+++ b/spark/src/test/scala-shims/spark-4.1/org/apache/spark/sql/delta/DeltaGeoSuite.scala
@@ -591,7 +591,7 @@ class DeltaGeoSuite extends QueryTest
           "'delta.enableDeletionVectors' = 'false'" +
           ")")
       }
-      assert(ex.getErrorClass == "DELTA_UNIVERSAL_FORMAT_VIOLATION",
+      assert(ex.getErrorClass == "DELTA_UNIVERSAL_FORMAT_VIOLATION.HUDI_UNSUPPORTED_DATA_TYPE",
         s"Expected DELTA_UNIVERSAL_FORMAT_VIOLATION, got: ${ex.getErrorClass}")
       assert(ex.getMessage.toLowerCase(java.util.Locale.ROOT).contains("geometry"),
         s"Expected message to mention GeometryType, got: ${ex.getMessage}")
@@ -607,7 +607,7 @@ class DeltaGeoSuite extends QueryTest
           "'delta.enableDeletionVectors' = 'false'" +
           ")")
       }
-      assert(ex.getErrorClass == "DELTA_UNIVERSAL_FORMAT_VIOLATION",
+      assert(ex.getErrorClass == "DELTA_UNIVERSAL_FORMAT_VIOLATION.HUDI_UNSUPPORTED_DATA_TYPE",
         s"Expected DELTA_UNIVERSAL_FORMAT_VIOLATION, got: ${ex.getErrorClass}")
       assert(ex.getMessage.toLowerCase(java.util.Locale.ROOT).contains("geography"),
         s"Expected message to mention GeographyType, got: ${ex.getMessage}")
@@ -625,7 +625,7 @@ class DeltaGeoSuite extends QueryTest
           "'delta.enableDeletionVectors' = 'false'" +
           ")")
       }
-      assert(ex.getErrorClass == "DELTA_UNIVERSAL_FORMAT_VIOLATION",
+      assert(ex.getErrorClass == "DELTA_UNIVERSAL_FORMAT_VIOLATION.HUDI_UNSUPPORTED_DATA_TYPE",
         s"Expected DELTA_UNIVERSAL_FORMAT_VIOLATION, got: ${ex.getErrorClass}")
     }
   }
@@ -787,7 +787,7 @@ class DeltaGeoSuite extends QueryTest
           "'delta.enableDeletionVectors' = 'false', " +
           "'delta.columnMapping.mode' = 'name')")
       }
-      assert(ex.getErrorClass == "DELTA_UNIVERSAL_FORMAT_VIOLATION",
+      assert(ex.getErrorClass == "DELTA_UNIVERSAL_FORMAT_VIOLATION.HUDI_UNSUPPORTED_DATA_TYPE",
         s"Unexpected error class: ${ex.getErrorClass}")
       assert(ex.getMessage.contains("hudi"),
         s"Expected message to mention hudi, got: ${ex.getMessage}")

--- a/spark/src/test/scala-shims/spark-4.2/org/apache/spark/sql/delta/DeltaGeoSuite.scala
+++ b/spark/src/test/scala-shims/spark-4.2/org/apache/spark/sql/delta/DeltaGeoSuite.scala
@@ -606,7 +606,7 @@ class DeltaGeoSuite extends QueryTest
           "'delta.enableDeletionVectors' = 'false'" +
           ")")
       }
-      assert(ex.getErrorClass == "DELTA_UNIVERSAL_FORMAT_VIOLATION",
+      assert(ex.getErrorClass == "DELTA_UNIVERSAL_FORMAT_VIOLATION.HUDI_UNSUPPORTED_DATA_TYPE",
         s"Expected DELTA_UNIVERSAL_FORMAT_VIOLATION, got: ${ex.getErrorClass}")
       assert(ex.getMessage.toLowerCase(java.util.Locale.ROOT).contains("geometry"),
         s"Expected message to mention GeometryType, got: ${ex.getMessage}")
@@ -622,7 +622,7 @@ class DeltaGeoSuite extends QueryTest
           "'delta.enableDeletionVectors' = 'false'" +
           ")")
       }
-      assert(ex.getErrorClass == "DELTA_UNIVERSAL_FORMAT_VIOLATION",
+      assert(ex.getErrorClass == "DELTA_UNIVERSAL_FORMAT_VIOLATION.HUDI_UNSUPPORTED_DATA_TYPE",
         s"Expected DELTA_UNIVERSAL_FORMAT_VIOLATION, got: ${ex.getErrorClass}")
       assert(ex.getMessage.toLowerCase(java.util.Locale.ROOT).contains("geography"),
         s"Expected message to mention GeographyType, got: ${ex.getMessage}")
@@ -640,7 +640,7 @@ class DeltaGeoSuite extends QueryTest
           "'delta.enableDeletionVectors' = 'false'" +
           ")")
       }
-      assert(ex.getErrorClass == "DELTA_UNIVERSAL_FORMAT_VIOLATION",
+      assert(ex.getErrorClass == "DELTA_UNIVERSAL_FORMAT_VIOLATION.HUDI_UNSUPPORTED_DATA_TYPE",
         s"Expected DELTA_UNIVERSAL_FORMAT_VIOLATION, got: ${ex.getErrorClass}")
     }
   }
@@ -1161,7 +1161,7 @@ class DeltaGeoSuite extends QueryTest
           "'delta.enableDeletionVectors' = 'false', " +
           "'delta.columnMapping.mode' = 'name')")
       }
-      assert(ex.getErrorClass == "DELTA_UNIVERSAL_FORMAT_VIOLATION",
+      assert(ex.getErrorClass == "DELTA_UNIVERSAL_FORMAT_VIOLATION.HUDI_UNSUPPORTED_DATA_TYPE",
         s"Unexpected error class: ${ex.getErrorClass}")
       assert(ex.getMessage.contains("hudi"),
         s"Expected message to mention hudi, got: ${ex.getMessage}")

--- a/spark/src/test/scala/org/apache/spark/sql/delta/UniversalFormatSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/UniversalFormatSuiteBase.scala
@@ -227,7 +227,7 @@ trait UniversalFormatSuiteBase extends IcebergCompatUtilsBase
           executeSql(s"ALTER TABLE $id SET TBLPROPERTIES " +
             s"('delta.universalFormat.enabledFormats' = 'iceberg')")
         }
-        assert(e.getErrorClass === "DELTA_UNIVERSAL_FORMAT_VIOLATION")
+        assert(e.getErrorClass === "DELTA_UNIVERSAL_FORMAT_VIOLATION.ICEBERG_COMPAT_REQUIRED")
       }
     }
   }
@@ -453,7 +453,7 @@ trait UniversalFormatMiscSuiteBase extends IcebergCompatUtilsBase with Universal
       val e = intercept[DeltaUnsupportedOperationException] {
         updatedConfiguration = getUpdatedConfiguration(configurationUnderTest)
       }
-      assert(e.getErrorClass == "DELTA_UNIVERSAL_FORMAT_VIOLATION")
+      assert(e.getErrorClass == "DELTA_UNIVERSAL_FORMAT_VIOLATION.ICEBERG_COMPAT_REQUIRED")
 
       for (icv <- allCompatObjects.map(_.version)) {
         configurationUnderTest = Map(
@@ -571,7 +571,7 @@ trait UniversalFormatMiscSuiteBase extends IcebergCompatUtilsBase with Universal
                  |  'delta.minWriterVersion' = $w
                  |)""".stripMargin)
         }
-        assert(e.getErrorClass == "DELTA_UNIVERSAL_FORMAT_VIOLATION")
+        assert(e.getErrorClass == "DELTA_UNIVERSAL_FORMAT_VIOLATION.ICEBERG_COMPAT_REQUIRED")
 
         val e1 = intercept[DeltaUnsupportedOperationException] {
           executeSql(s"""
@@ -581,7 +581,7 @@ trait UniversalFormatMiscSuiteBase extends IcebergCompatUtilsBase with Universal
                  |  'delta.minWriterVersion' = $w
                  |) AS SELECT 1""".stripMargin)
         }
-        assert(e1.getErrorClass == "DELTA_UNIVERSAL_FORMAT_VIOLATION")
+        assert(e1.getErrorClass == "DELTA_UNIVERSAL_FORMAT_VIOLATION.ICEBERG_COMPAT_REQUIRED")
       }
     }
   }
@@ -599,7 +599,7 @@ trait UniversalFormatMiscSuiteBase extends IcebergCompatUtilsBase with Universal
           executeSql(s"ALTER TABLE $id SET TBLPROPERTIES " +
             s"('delta.universalFormat.enabledFormats' = 'iceberg')")
         }
-        assert(e.getErrorClass === "DELTA_UNIVERSAL_FORMAT_VIOLATION")
+        assert(e.getErrorClass === "DELTA_UNIVERSAL_FORMAT_VIOLATION.ICEBERG_COMPAT_REQUIRED")
       }
     }
   }


### PR DESCRIPTION
## Description

The `DELTA_UNIVERSAL_FORMAT_VIOLATION` error class took a free-text `violation`
parameter whose value was assembled in Scala. Injecting the reason text through a
parameter keeps English out of `delta-error-classes.json`, which makes the messages
harder to maintain and localize.

This PR moves each reason into a dedicated subclass so all message text lives in the
error-classes JSON. The parent message keeps only the `format` parameter, and the
following subclasses are added:

- `ICEBERG_COMPAT_REQUIRED`
- `HUDI_DELETE_VECTORS_NOT_SUPPORTED`
- `HUDI_UNSUPPORTED_DATA_TYPE` (keeps a `dataType` parameter)

The SQLSTATE (`KD00E`) is unchanged.

## How was this patch tested?

Existing unit tests in `UniversalFormatSuiteBase` were updated to assert the new
error subclass names.
