### PR TITLE
[Spark] Allow decimal partition columns in IcebergCompatV2 partition type check

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/IcebergCompat.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/IcebergCompat.scala
@@ -616,7 +616,9 @@ object CheckTypeInV2AllowList extends CheckTypeInAllowList {
 object CheckPartitionDataTypeInV2AllowList extends IcebergCompatCheck {
   private val allowedTypes = Set[Class[_]] (
     ByteType.getClass, ShortType.getClass, IntegerType.getClass, LongType.getClass,
-    FloatType.getClass, DoubleType.getClass, DecimalType.getClass,
+    // DecimalType is parameterized by precision and scale, so schema fields contain
+    // DecimalType instances rather than the companion object.
+    FloatType.getClass, DoubleType.getClass, classOf[DecimalType],
     StringType.getClass, BinaryType.getClass,
     BooleanType.getClass,
     TimestampType.getClass, TimestampNTZType.getClass, DateType.getClass


### PR DESCRIPTION
## Description

`CheckPartitionDataTypeInV2AllowList` builds its set of allowed partition-column types from `Class[_]` values. For decimal it used `DecimalType.getClass`, which returns the companion object class (`DecimalType$`). Partition schema fields, however, carry `DecimalType` *instances* (parameterized by precision and scale), whose runtime class is `classOf[DecimalType]`. The membership check therefore compared against the wrong class and rejected decimal partition columns, even though decimal is an allowed partition type for IcebergCompat V2/V3.

The schema-level `CheckTypeInV2AllowList` already uses `classOf[DecimalType]`; this change makes the partition-level check consistent.

Before this fix, enabling IcebergCompat on a table partitioned by a decimal column (or committing metadata on such a table) could fail with `DELTA_ICEBERG_COMPAT_VIOLATION.UNSUPPORTED_PARTITION_DATA_TYPE`.

## How was this patch tested?

Existing IcebergCompat test suites.

## Does this PR introduce _any_ user-facing changes?

Yes. Tables with decimal partition columns and IcebergCompat V2/V3 enabled no longer fail metadata commits with an unsupported-partition-data-type error; decimal partition columns are now correctly accepted.
