### PR TITLE
[Spark] Increase concurrent commit coordinator test wait

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CommitCoordinatorClientImplSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CommitCoordinatorClientImplSuiteBase.scala
@@ -361,7 +361,7 @@ trait CommitCoordinatorClientImplSuiteBase extends QueryTest
               }
             }
         }
-        tasks.foreach(ThreadUtils.awaitResult(_, 150.seconds))
+        tasks.foreach(ThreadUtils.awaitResult(_, 5.minutes))
       } catch {
         case e: InterruptedException =>
           fail("Test interrupted: " + e.getMessage)


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other

## Description

The concurrent commit coordinator test launches 11 writers and requires each writer to complete
11 commits while checking coordinator and backfill invariants after every attempt. Under heavy CPU
and local-filesystem contention, the fixed 150-second future wait can expire even while writers
are continuing to make progress.

Increase the per-writer wait to five minutes. The independent 20-minute suite timeout remains in
place to detect a genuine hang, and the writer count, retry behavior, and invariant coverage are
unchanged.

## How was this patch tested?

- Reproduced the timeout at the original bound with 20 parallel test groups on a 6-CPU stress
  profile; the wait expired after about 152 seconds.
- Ran the identical stress profile with the five-minute bound; the test passed after about
  327 seconds.
- Ran five clean repetitions with 20 parallel test groups on 16 CPUs; all five passed.
- The Scala 2.13 test matrix completed with 21,994 passing tests.

## Does this PR introduce _any_ user-facing changes?

No.
