### PR TITLE
[Build] Bump version to 4.5.0-SNAPSHOT

### DIFF
--- a/python/delta/version.py
+++ b/python/delta/version.py
@@ -18,4 +18,4 @@
 # Do not edit manually - edit version.sbt instead and run:
 #   build/sbt sparkV1/generatePythonVersion
 
-__version__ = "4.4.0"
+__version__ = "4.5.0"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "4.4.0-SNAPSHOT"
+ThisBuild / version := "4.5.0-SNAPSHOT"


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (build and version metadata)

## Description

Now that `branch-4.4` is used for the Delta 4.4.0 release, development on `master` should identify itself as the next version.

For example, builds from `master` previously reported `4.4.0-SNAPSHOT`. This change updates them to report `4.5.0-SNAPSHOT`. It also updates the generated Python version from `4.4.0` to `4.5.0` so both version files stay in sync.

## How was this patch tested?

- Ran `git diff --check`.
- Verified that the Python version matches the SBT version after removing the `-SNAPSHOT` suffix.

## Does this PR introduce _any_ user-facing changes?

No.
