### PR TITLE
[Kernel] Fix pagination over published staged commits

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/PaginatedScanFilesIteratorImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/PaginatedScanFilesIteratorImpl.java
@@ -27,6 +27,7 @@ import io.delta.kernel.internal.util.Utils;
 import io.delta.kernel.utils.CloseableIterator;
 import java.io.IOException;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -284,6 +285,8 @@ public class PaginatedScanFilesIteratorImpl implements PaginatedScanFilesIterato
       if (isSidecar(batchFilePath)) {
         lastSidecarIndex++;
       }
+    } else if (!batchFilePath.equals(lastReadLogFilePath)) {
+      lastReadLogFilePath = batchFilePath;
     }
 
     // Calculate the row index of the last row in current batch within the file.
@@ -329,7 +332,7 @@ public class PaginatedScanFilesIteratorImpl implements PaginatedScanFilesIterato
       // If the current batch’s log file name is greater than the last one recorded in the token,
       // it means this file appeared earlier in the segment and has already been processed.
       return !isSidecar(batchFilePath)
-          && batchFilePath.compareTo(tokenLastReadLogFilePathOpt.get()) > 0;
+          && compareLogicalLogFilePaths(batchFilePath, tokenLastReadLogFilePathOpt.get()) > 0;
     }
     return false;
   }
@@ -346,7 +349,7 @@ public class PaginatedScanFilesIteratorImpl implements PaginatedScanFilesIterato
     // present).
     boolean isSameFilePath =
         tokenLastReadFilePathOpt.isPresent()
-            && batchFilePath.equals(tokenLastReadFilePathOpt.get());
+            && isSameLogicalLogFile(batchFilePath, tokenLastReadFilePathOpt.get());
     if (!isSameFilePath) return false;
     // For sidecar files, if file path matches, sidecar index must also present and match.
     if (isSidecar(batchFilePath)) {
@@ -366,13 +369,13 @@ public class PaginatedScanFilesIteratorImpl implements PaginatedScanFilesIterato
   private boolean isFirstBatchFromUnseenFile(String batchFilePath) {
     // If the batch's file path differs from {@code lastReadLogFilePath}, it's considered an
     // unseen file.
-    if (!batchFilePath.equals(lastReadLogFilePath)) {
+    if (!isSameLogicalLogFile(batchFilePath, lastReadLogFilePath)) {
       // For non-sidecar files, files must appear in reverse lexicographic order —
       // i.e., the current file must come *before* the last seen file.
       checkArgument(
           isSidecar(batchFilePath)
               || lastReadLogFilePath == null
-              || batchFilePath.compareTo(lastReadLogFilePath) < 0,
+              || compareLogicalLogFilePaths(batchFilePath, lastReadLogFilePath) < 0,
           "Expected file '%s' to appear after last read file '%s' in reverse lexicographic order, "
               + "unless it's a sidecar file",
           batchFilePath,
@@ -380,6 +383,18 @@ public class PaginatedScanFilesIteratorImpl implements PaginatedScanFilesIterato
       return true;
     }
     return false;
+  }
+
+  private boolean isSameLogicalLogFile(String filePath1, String filePath2) {
+    return Objects.equals(canonicalizeLogFilePath(filePath1), canonicalizeLogFilePath(filePath2));
+  }
+
+  private int compareLogicalLogFilePaths(String filePath1, String filePath2) {
+    return canonicalizeLogFilePath(filePath1).compareTo(canonicalizeLogFilePath(filePath2));
+  }
+
+  private String canonicalizeLogFilePath(String filePath) {
+    return filePath == null ? null : FileNames.canonicalizeStagedDeltaFilePath(filePath);
   }
 
   // TODO: move isSidecar() to FileNames

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/LogSegment.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/LogSegment.java
@@ -418,8 +418,23 @@ public class LogSegment {
 
   @Override
   public int hashCode() {
-    // TODO: support staged commits #4927
-    return Objects.hash(deltas, checkpoints, compactions);
+    return Objects.hash(
+        canonicalizeFileStatuses(deltas),
+        canonicalizeFileStatuses(checkpoints),
+        canonicalizeFileStatuses(compactions));
+  }
+
+  private static List<Object> canonicalizeFileStatuses(List<FileStatus> fileStatuses) {
+    return fileStatuses.stream()
+        .map(LogSegment::canonicalizeFileStatus)
+        .collect(Collectors.toList());
+  }
+
+  private static Object canonicalizeFileStatus(FileStatus fileStatus) {
+    if (FileNames.isCommitFile(fileStatus.getPath())) {
+      return FileNames.canonicalizeStagedDeltaFilePath(fileStatus.getPath());
+    }
+    return fileStatus;
   }
 
   //////////////////////////////

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/FileNames.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/FileNames.java
@@ -336,6 +336,22 @@ public final class FileNames {
     return UUID_DELTA_FILE_REGEX.matcher(p.getName()).matches();
   }
 
+  /**
+   * Returns the published commit-file path for staged delta files, and the original path otherwise.
+   *
+   * <p>This lets pagination treat a staged commit and its published copy as the same logical commit
+   * file.
+   */
+  public static String canonicalizeStagedDeltaFilePath(String path) {
+    if (!isStagedDeltaFile(path)) {
+      return path;
+    }
+
+    final Path stagedDeltaFile = new Path(path);
+    final Path logPath = stagedDeltaFile.getParent().getParent();
+    return deltaFile(logPath, deltaVersion(stagedDeltaFile));
+  }
+
   public static boolean isLogCompactionFile(String path) {
     final String fileName = new Path(path).getName();
     return COMPACTION_FILE_PATTERN.matcher(fileName).matches();

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/replay/PaginatedScanFilesIteratorSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/replay/PaginatedScanFilesIteratorSuite.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.kernel.internal.replay
+
+import java.util.Optional
+
+import scala.collection.JavaConverters._
+
+import io.delta.kernel.Meta
+import io.delta.kernel.TransactionSuite.columnarBatch
+import io.delta.kernel.data.{ColumnVector, FilteredColumnarBatch}
+import io.delta.kernel.internal.util.{FileNames, Utils}
+import io.delta.kernel.test.{MockFileSystemClientUtils, VectorTestUtils}
+import io.delta.kernel.types.{LongType, StructType}
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class PaginatedScanFilesIteratorSuite extends AnyFunSuite
+    with MockFileSystemClientUtils
+    with VectorTestUtils {
+
+  private val testSchema = new StructType().add("id", LongType.LONG)
+
+  private def filteredBatch(filePath: String, values: Seq[Long]): FilteredColumnarBatch = {
+    new FilteredColumnarBatch(
+      columnarBatch(testSchema, Seq(longVector(values.map(java.lang.Long.valueOf)))),
+      Optional.empty[ColumnVector](),
+      filePath,
+      values.size)
+  }
+
+  test("resume from staged commit file after it is published") {
+    val stagedCommitPath = FileNames.stagedCommitFile(logPath, 1)
+    val publishedCommitPath = FileNames.deltaFile(logPath, 1)
+    val predicateHash = 123
+    val logSegmentHash = 456
+    val pageToken = new PageToken(
+      stagedCommitPath,
+      2,
+      Optional.empty(),
+      Meta.KERNEL_VERSION,
+      dataPath.toString,
+      1,
+      predicateHash,
+      logSegmentHash)
+    val paginationContext = PaginationContext.forPageWithPageToken(
+      dataPath.toString,
+      1,
+      logSegmentHash,
+      predicateHash,
+      5,
+      pageToken)
+    val iterator = new PaginatedScanFilesIteratorImpl(
+      Utils.toCloseableIterator(
+        Seq(
+          filteredBatch(publishedCommitPath, Seq(0, 1, 2)),
+          filteredBatch(publishedCommitPath, Seq(3, 4, 5, 6, 7))).asJava.iterator()),
+      paginationContext)
+
+    try {
+      assert(iterator.hasNext)
+      val batch = iterator.next()
+      assert(batch.getData.getSize === 5)
+
+      val nextPageToken = PageToken.fromRow(iterator.getCurrentPageToken.get)
+      assert(nextPageToken.getLastReadLogFilePath === publishedCommitPath)
+      assert(nextPageToken.getLastReturnedRowIndex === 7)
+    } finally {
+      iterator.close()
+    }
+  }
+}

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/snapshot/LogSegmentSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/snapshot/LogSegmentSuite.scala
@@ -561,6 +561,24 @@ class LogSegmentSuite extends AnyFunSuite with MockFileSystemClientUtils with Ve
     assert(exMsg.contains("Currently, only file-based deltas are supported"))
   }
 
+  test("hashCode remains stable when staged commit is published") {
+    val stagedCommit = FileStatus.of(FileNames.stagedCommitFile(logPath, 1), 1, 10)
+    val publishedCommit = FileStatus.of(FileNames.deltaFile(logPath, 1), 1, 100)
+
+    val segmentWithStagedCommit = createLogSegmentForTest(
+      version = 1,
+      deltas = Seq(deltaFileStatus(0), stagedCommit).asJava,
+      deltaAtEndVersion = Some(stagedCommit),
+      maxPublishedDeltaVersion = Optional.of(0L))
+    val segmentWithPublishedCommit = createLogSegmentForTest(
+      version = 1,
+      deltas = Seq(deltaFileStatus(0), publishedCommit).asJava,
+      deltaAtEndVersion = Some(publishedCommit),
+      maxPublishedDeltaVersion = Optional.of(1L))
+
+    assert(segmentWithStagedCommit.hashCode === segmentWithPublishedCommit.hashCode)
+  }
+
   ////////////////////////////////
   // newAsPublished tests       //
   ////////////////////////////////


### PR DESCRIPTION
## Description
Fixes #4927.

Kernel paginated scan page tokens use the log segment hash and last-read log file path to detect changes between page requests and resume from the previous position. When a catalog-managed staged commit is published, the same logical commit can move from `_staged_commits/<version>.<uuid>.json` to `<version>.json`; this should not be treated as a changed log segment or a different file for pagination resume.

This change canonicalizes staged commit paths to their published commit path for pagination identity:
- log segment hash generation treats staged and published commit files for the same version as the same logical commit file
- paginated scan resume comparisons treat staged and published paths for the same commit as equivalent
- the next page token is refreshed to the path actually read after publication

## Tests
- `./build/sbt "kernelApi/testOnly io.delta.kernel.internal.snapshot.LogSegmentSuite io.delta.kernel.internal.replay.PaginatedScanFilesIteratorSuite"`