### PR TITLE
[Spark] Support scan-reported statistics in Delta connector scans

### DIFF
--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2Scan.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2Scan.java
@@ -50,7 +50,6 @@ import org.apache.spark.sql.execution.datasources.parquet.ParquetUtils;
 import org.apache.spark.sql.execution.datasources.v2.DeltaV2FilterTranslator;
 import org.apache.spark.sql.internal.SQLConf;
 import org.apache.spark.sql.sources.Filter;
-import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 import scala.Option;
@@ -347,7 +346,6 @@ class DeltaV2Scan implements Scan, SupportsReportStatistics, SupportsRuntimeV2Fi
     return pushedLimit.isPresent() && pushedLimit.getAsInt() == 0;
   }
 
-
   private Statistics statistics(
       OptionalLong sizeInBytes,
       OptionalLong numRows,
@@ -367,7 +365,6 @@ class DeltaV2Scan implements Scan, SupportsReportStatistics, SupportsRuntimeV2Fi
       public Map<NamedReference, ColumnStatistics> columnStats() {
         return columnStats;
       }
-
     };
   }
 
@@ -386,7 +383,6 @@ class DeltaV2Scan implements Scan, SupportsReportStatistics, SupportsRuntimeV2Fi
   boolean reflectsFullyPushedDownFiltersInternal() {
     return false;
   }
-
 
   /**
    * Get the table path from the scan state.
@@ -468,7 +464,6 @@ class DeltaV2Scan implements Scan, SupportsReportStatistics, SupportsRuntimeV2Fi
         totalRows = ((Number) scannedRows.get()).longValue();
       }
     }
-
   }
 
   /**
@@ -628,20 +623,18 @@ class DeltaV2Scan implements Scan, SupportsReportStatistics, SupportsRuntimeV2Fi
 
   /**
    * Returns whether Delta should collect per-file row counts for scan metadata. The scan builder
-   * evaluates the same condition when deciding whether to ask {@code filesForScan} to retain
-   * record counts; the two must stay in sync.
+   * evaluates the same condition when deciding whether to ask {@code filesForScan} to retain record
+   * counts; the two must stay in sync.
    *
    * <p>This does not gate {@link #estimateStatistics()}. Spark's {@code
    * DataSourceV2ScanRelation.computeStats()} chooses between the full-statistics and size-only APIs
-   * based on CBO and plan-statistics settings. Once Spark calls either API, Delta returns that API's
-   * connector statistics independently of the planner-side gate.
+   * based on CBO and plan-statistics settings. Once Spark calls either API, Delta returns that
+   * API's connector statistics independently of the planner-side gate.
    */
   private boolean arePlanStatsEnabled() {
     return sqlConf.cboEnabled() || sqlConf.planStatsEnabled();
   }
-  /**
-   * Returns whether the catalog-provided statistics include a numRows value.
-   */
+  /** Returns whether the catalog-provided statistics include a numRows value. */
   private boolean catalogHasNumRows() {
     return catalogStats.isPresent() && catalogStats.get().numRows().isPresent();
   }

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2Scan.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2Scan.java
@@ -50,7 +50,6 @@ import org.apache.spark.sql.execution.datasources.parquet.ParquetUtils;
 import org.apache.spark.sql.execution.datasources.v2.DeltaV2FilterTranslator;
 import org.apache.spark.sql.internal.SQLConf;
 import org.apache.spark.sql.sources.Filter;
-import org.apache.spark.sql.types.StringType;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
@@ -105,9 +104,6 @@ class DeltaV2Scan implements Scan, SupportsReportStatistics, SupportsRuntimeV2Fi
   private long totalRows = 0L;
   // true iff every AddFile in the scan had numRecords in its stats JSON.
   private boolean rowCountKnown = false;
-  // Estimated size in bytes accounting for column projection, used for query optimizer cost
-  // estimation
-  private long estimatedSizeInBytes = 0L;
   private volatile boolean planned = false;
 
   // Runtime predicates applied after planning (using Set for order-independent comparison)
@@ -299,153 +295,98 @@ class DeltaV2Scan implements Scan, SupportsReportStatistics, SupportsRuntimeV2Fi
     return description.toString();
   }
 
+  /**
+   * Returns the catalog size when available, or the compression-adjusted post-pruning file size,
+   * without constructing row or column statistics.
+   *
+   * <p>Intentionally no {@code @Override}: Delta also compiles this source against supported Spark
+   * versions whose {@link SupportsReportStatistics} interface predates this optional method. The
+   * method still overrides the interface default when Delta is built against a Spark version that
+   * provides it.
+   */
+  public OptionalLong estimateSizeInBytes() {
+    return estimateSizeInBytesInternal();
+  }
+
+  /** Package-private entry point for Scala wrappers compiled together with this Java source. */
+  OptionalLong estimateSizeInBytesInternal() {
+    if (isZeroLimit()) {
+      return OptionalLong.of(0L);
+    }
+    if (catalogStats.isPresent()) {
+      return catalogStats.get().sizeInBytes();
+    }
+    return estimateSelectedFileSizeInBytes();
+  }
+
   @Override
   public Statistics estimateStatistics() {
-    ensurePlanned();
-    // Capture mutable scan state as final locals so the returned Statistics object reflects a
-    // consistent snapshot. A subsequent filter() call mutates rowCountKnown and totalRows
-    // (see ensurePlanned(runtimePredicates)), and we don't want those mutations to leak into a
-    // Statistics instance the caller is still holding.
-    final long plannedBytes = estimatedSizeInBytes;
-    final boolean rowCountKnownSnapshot = rowCountKnown;
-    final long totalRowsSnapshot = totalRows;
-
-    // When catalog stats are available and CBO is enabled, combine table-level stats
-    // (for columnStats) with planned file stats (for sizeInBytes and numRows).
-    // This mirrors V1's LogicalRelation.computeStats() which gates column stats on
-    // conf.cboEnabled || conf.planStatsEnabled.
-    if (arePlanStatsEnabled() && catalogStats.isPresent()) {
-      final Statistics stats = catalogStats.get();
-      return new Statistics() {
-        @Override
-        public OptionalLong sizeInBytes() {
-          // Planned file size is authoritative (even if 0 for an empty table)
-          return OptionalLong.of(plannedBytes);
-        }
-
-        @Override
-        public OptionalLong numRows() {
-          // Prefer per-file (post-prune) numRows when known. Fall back to catalog numRows
-          // when per-file is unavailable (e.g. some AddFile lacks numRecords). The catalog
-          // value is table-level and may be stale, but it's better than reporting unknown.
-          if (rowCountKnownSnapshot) {
-            return OptionalLong.of(totalRowsSnapshot);
-          }
-          return stats.numRows();
-        }
-
-        @Override
-        public Map<NamedReference, ColumnStatistics> columnStats() {
-          // TODO: After partition pruning, column stats (e.g. min, max, nullCount,
-          //  distinctCount) could be tightened based on the pruned file-level stats.
-          return stats.columnStats();
-        }
-      };
+    if (isZeroLimit()) {
+      return statistics(OptionalLong.of(0L), OptionalLong.of(0L), Collections.emptyMap());
     }
+    if (catalogHasNumRows()) {
+      final Statistics stats = catalogStats.get();
+      return statistics(OptionalLong.empty(), stats.numRows(), stats.columnStats());
+    }
+    return statistics(
+        estimateSelectedFileSizeInBytes(), OptionalLong.empty(), Collections.emptyMap());
+  }
 
-    // No catalog stats available or CBO disabled — return stats from planned files only
+  private OptionalLong estimateSelectedFileSizeInBytes() {
+    ensurePlanned();
+    // Do not scale the selected-file bytes by readSchema. Delta returns false from
+    // reflectsFullyPushedDownFilters(), so Spark re-adds fully pushed filters when adjusting
+    // statistics. Delta's scan builder retains filter-only columns in readSchema; when that makes
+    // the scan output wider than the query output, Spark also leaves the Project that restores the
+    // query output above the relation. The Filter and Project in Spark's logical plan, rather than
+    // this scan, own those statistics adjustments.
+    return OptionalLong.of(totalBytes);
+  }
+
+  private boolean isZeroLimit() {
+    return pushedLimit.isPresent() && pushedLimit.getAsInt() == 0;
+  }
+
+
+  private Statistics statistics(
+      OptionalLong sizeInBytes,
+      OptionalLong numRows,
+      Map<NamedReference, ColumnStatistics> columnStats) {
     return new Statistics() {
       @Override
       public OptionalLong sizeInBytes() {
-        return OptionalLong.of(plannedBytes);
+        return sizeInBytes;
       }
 
       @Override
       public OptionalLong numRows() {
-        return rowCountKnownSnapshot ? OptionalLong.of(totalRowsSnapshot) : OptionalLong.empty();
+        return numRows;
       }
+
+      @Override
+      public Map<NamedReference, ColumnStatistics> columnStats() {
+        return columnStats;
+      }
+
     };
   }
 
   /**
-   * Computes the estimated size in bytes accounting for column projection.
+   * Delta requires Spark to retain fully pushed predicates when adjusting scan statistics. In
+   * particular, catalog statistics describe the unfiltered table and must not be treated as if
+   * every connector-pushed predicate were already reflected.
    *
-   * <p>This mirrors what {@code SizeInBytesOnlyStatsPlanVisitor.visitUnaryNode} (from Spark code)
-   * would compute for a {@code Project} over a {@code LogicalRelation}: {@code sizeInBytes =
-   * childSizeInBytes * outputRowSize / childRowSize}
-   *
-   * <p>Where:
-   *
-   * <ul>
-   *   <li><b>childRowSize</b> = {@code ROW_OVERHEAD + dataSchema + partitionSchema} (equivalent to
-   *       LogicalRelation output)
-   *   <li><b>outputRowSize</b> = {@code ROW_OVERHEAD + readDataSchema + partitionSchema}
-   *       (equivalent to Project output)
-   * </ul>
-   *
-   * <p>When catalog column stats are available, uses per-column {@code avgLen} instead of {@code
-   * defaultSize()} for more accurate size estimation, mirroring {@code
-   * EstimationUtils.getSizePerRow()} behavior.
-   *
-   * <p>This provides consistent statistics with the v1 code path (LogicalRelation + visitUnaryNode
-   * from Spark code directory).
-   *
-   * @param totalBytes the total size in bytes of the planned files (raw physical size)
-   * @return the estimated size in bytes after accounting for column projection
+   * <p>Intentionally no {@code @Override}; see {@link #estimateSizeInBytes()}.
    */
-  private long computeEstimatedSizeWithColumnProjection(long totalBytes) {
-    if (totalBytes <= 0) {
-      return totalBytes;
-    }
-
-    // Row overhead constant, matching EstimationUtils.getSizePerRow (from Spark)
-    final int ROW_OVERHEAD = 8;
-
-    // Use avgLen from catalog column stats when available for more accurate estimation
-    Map<String, OptionalLong> avgLenByColumn = getAvgLenByColumn();
-
-    final long fullSchemaRowSize =
-        ROW_OVERHEAD
-            + getSchemaSize(dataSchema, avgLenByColumn)
-            + getSchemaSize(partitionSchema, avgLenByColumn);
-    final long outputRowSize = ROW_OVERHEAD + getSchemaSize(readSchema(), avgLenByColumn);
-
-    long estimatedBytes = (totalBytes * outputRowSize) / fullSchemaRowSize;
-
-    return Math.max(1L, estimatedBytes);
+  public boolean reflectsFullyPushedDownFilters() {
+    return reflectsFullyPushedDownFiltersInternal();
   }
 
-  /**
-   * Returns a map of column name to avgLen from catalog column stats, used to improve size
-   * estimation accuracy when catalog stats are available.
-   */
-  private Map<String, OptionalLong> getAvgLenByColumn() {
-    if (!catalogStats.isPresent()) {
-      return Collections.emptyMap();
-    }
-    Map<NamedReference, ColumnStatistics> colStats = catalogStats.get().columnStats();
-    if (colStats.isEmpty()) {
-      return Collections.emptyMap();
-    }
-    Map<String, OptionalLong> result = new HashMap<>();
-    for (Map.Entry<NamedReference, ColumnStatistics> entry : colStats.entrySet()) {
-      result.put(entry.getKey().fieldNames()[0], entry.getValue().avgLen());
-    }
-    return result;
+  /** Package-private entry point for Scala wrappers compiled together with this Java source. */
+  boolean reflectsFullyPushedDownFiltersInternal() {
+    return false;
   }
 
-  /**
-   * Computes the estimated in-memory size for a schema, using avgLen from catalog stats when
-   * available, falling back to defaultSize(). Mirrors EstimationUtils.getSizePerRow(). For
-   * StringType columns with avgLen, adds UTF8String overhead (base + offset + numBytes = 12 bytes).
-   */
-  private static long getSchemaSize(StructType schema, Map<String, OptionalLong> avgLenByColumn) {
-    long size = 0;
-    for (StructField field : schema.fields()) {
-      OptionalLong avgLen = avgLenByColumn.getOrDefault(field.name(), OptionalLong.empty());
-      if (avgLen.isPresent()) {
-        if (field.dataType() instanceof StringType) {
-          // UTF8String: base + offset + numBytes (matching EstimationUtils.getSizePerRow)
-          size += avgLen.getAsLong() + 8 + 4;
-        } else {
-          size += avgLen.getAsLong();
-        }
-      } else {
-        size += field.dataType().defaultSize();
-      }
-    }
-    return size;
-  }
 
   /**
    * Get the table path from the scan state.
@@ -528,8 +469,6 @@ class DeltaV2Scan implements Scan, SupportsReportStatistics, SupportsRuntimeV2Fi
       }
     }
 
-    // Pre-compute estimated size accounting for column projection
-    estimatedSizeInBytes = computeEstimatedSizeWithColumnProjection(totalBytes);
   }
 
   /**
@@ -577,14 +516,13 @@ class DeltaV2Scan implements Scan, SupportsReportStatistics, SupportsRuntimeV2Fi
         }
       }
 
-      // Update partitionedFiles, totalBytes, totalRows, and estimatedSizeInBytes if any partition
-      // is filtered out
+      // Update the filtered file set and totalBytes; recompute totalRows only when per-file counts
+      // are available.
       if (runtimeFilteredPartitionedFiles.size() < this.partitionedFiles.size()) {
         this.partitionedFiles = runtimeFilteredPartitionedFiles;
         this.selectedFiles = runtimeFilteredFiles;
         this.totalBytes =
             runtimeFilteredPartitionedFiles.stream().mapToLong(PartitionedFile::fileSize).sum();
-        this.estimatedSizeInBytes = computeEstimatedSizeWithColumnProjection(this.totalBytes);
         if (perFileCountsAvailable) {
           // Recompute totalRows from per-file counts of files that survived pruning so
           // numRows() reports the post-prune count rather than a stale pre-filter value.
@@ -689,27 +627,23 @@ class DeltaV2Scan implements Scan, SupportsReportStatistics, SupportsRuntimeV2Fi
   }
 
   /**
-   * Returns whether plan-time statistics should be collected and reported. Matches V1 behavior:
-   * {@code LogicalRelation.computeStats()} only surfaces stats when {@code spark.sql.cbo.enabled}
-   * or {@code spark.sql.cbo.planStats.enabled} is true.
+   * Returns whether Delta should collect per-file row counts for scan metadata. The scan builder
+   * evaluates the same condition when deciding whether to ask {@code filesForScan} to retain
+   * record counts; the two must stay in sync.
    *
-   * <p>Despite the row-count-flavored framing in V1, this gate controls multiple things in the V2
-   * scan path:
-   *
-   * <ul>
-   *   <li>whether {@code numRows()} is reported in {@link #estimateStatistics()}
-   *   <li>whether the catalog-stats branch is entered (which also governs {@code columnStats}
-   *       propagation from the catalog)
-   *   <li>whether per-file stats JSON is parsed in {@link #planScanFiles()}
-   * </ul>
-   *
-   * <p>The scan builder evaluates the same condition to decide whether to ask {@code filesForScan}
-   * for per-file record counts; the two must stay in sync.
-   *
-   * <p>Future readers touching any of these paths should treat this helper as load-bearing.
+   * <p>This does not gate {@link #estimateStatistics()}. Spark's {@code
+   * DataSourceV2ScanRelation.computeStats()} chooses between the full-statistics and size-only APIs
+   * based on CBO and plan-statistics settings. Once Spark calls either API, Delta returns that API's
+   * connector statistics independently of the planner-side gate.
    */
   private boolean arePlanStatsEnabled() {
     return sqlConf.cboEnabled() || sqlConf.planStatsEnabled();
+  }
+  /**
+   * Returns whether the catalog-provided statistics include a numRows value.
+   */
+  private boolean catalogHasNumRows() {
+    return catalogStats.isPresent() && catalogStats.get().numRows().isPresent();
   }
 
   @Override

--- a/spark/v2/src/main/scala/io/delta/spark/internal/v2/read/DeltaV2ScanBuilder.scala
+++ b/spark/v2/src/main/scala/io/delta/spark/internal/v2/read/DeltaV2ScanBuilder.scala
@@ -156,10 +156,11 @@ private[read] class DeltaV2ScanBuilder(
     // running filesForScan until DeltaV2Scan actually plans a batch. A MicroBatchStream performs
     // its own snapshot and commit-range reads and never consumes batch-selected files.
     //
-    // Ask for per-file record counts exactly when DeltaV2Scan will consume numRows: this must stay
-    // in sync with DeltaV2Scan.arePlanStatsEnabled, which gates the reading side. Note this only
-    // affects the no-limit branch below -- V1's limit-aware filesForScan takes no keepNumRecords
-    // and always drops per-file stats, so there DeltaV2Scan falls back to DeltaScan.scanned.rows.
+    // Ask for per-file record counts exactly when DeltaV2Scan will consume them for scan metadata.
+    // This must stay in sync with DeltaV2Scan.arePlanStatsEnabled, which gates the reading side.
+    // Note this only affects the no-limit branch below -- V1's limit-aware filesForScan takes no
+    // keepNumRecords and always drops per-file stats, so DeltaV2Scan falls back to
+    // DeltaScan.scanned.rows there.
     val sparkSession = SparkSession.active
     val sqlConf = SQLConf.get
     val keepNumRecords = sqlConf.cboEnabled || sqlConf.planStatsEnabled

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2ScanBuilderTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2ScanBuilderTest.java
@@ -248,6 +248,19 @@ public class DeltaV2ScanBuilderTest extends DeltaV2TestBase {
   }
 
   @Test
+  public void testPruneColumnsRetainsFullyPushedFilterColumn(@TempDir File tempDir) throws Exception {
+    DeltaV2ScanBuilder builder = newFilterScanBuilder(tempDir);
+    pushFilters(builder, new EqualTo("dep_id", 1));
+    builder.pruneColumns(
+        new StructType().add("id", DataTypes.IntegerType, true /* nullable */));
+
+    Scan scan = builder.build();
+    assertEquals(
+        Arrays.asList("id", "dep_id", "dep_name"),
+        Arrays.asList(scan.readSchema().fieldNames()));
+  }
+
+  @Test
   public void testPushFilters_singleUnsupportedPartitionFilter(@TempDir File tempDir)
       throws Exception {
     // A partition filter Kernel could not represent is still exact, so it is a partition filter.

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2ScanBuilderTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2ScanBuilderTest.java
@@ -248,16 +248,15 @@ public class DeltaV2ScanBuilderTest extends DeltaV2TestBase {
   }
 
   @Test
-  public void testPruneColumnsRetainsFullyPushedFilterColumn(@TempDir File tempDir) throws Exception {
+  public void testPruneColumnsRetainsFullyPushedFilterColumn(@TempDir File tempDir)
+      throws Exception {
     DeltaV2ScanBuilder builder = newFilterScanBuilder(tempDir);
     pushFilters(builder, new EqualTo("dep_id", 1));
-    builder.pruneColumns(
-        new StructType().add("id", DataTypes.IntegerType, true /* nullable */));
+    builder.pruneColumns(new StructType().add("id", DataTypes.IntegerType, true /* nullable */));
 
     Scan scan = builder.build();
     assertEquals(
-        Arrays.asList("id", "dep_id", "dep_name"),
-        Arrays.asList(scan.readSchema().fieldNames()));
+        Arrays.asList("id", "dep_id", "dep_name"), Arrays.asList(scan.readSchema().fieldNames()));
   }
 
   @Test

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2ScanTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2ScanTest.java
@@ -583,6 +583,7 @@ public class DeltaV2ScanTest extends DeltaV2TestBase {
     field.setAccessible(true);
     return (org.apache.spark.sql.catalyst.expressions.Expression[]) field.get(scan);
   }
+
   private static boolean getPlanned(DeltaV2Scan scan) throws Exception {
     Field field = DeltaV2Scan.class.getDeclaredField("planned");
     field.setAccessible(true);
@@ -1028,8 +1029,7 @@ public class DeltaV2ScanTest extends DeltaV2TestBase {
                 "spark.sql.cbo.planStats.enabled",
                 "false",
                 () -> {
-                  DeltaV2ScanBuilder builder =
-                      (DeltaV2ScanBuilder) table.newScanBuilder(options);
+                  DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) table.newScanBuilder(options);
                   builder.pruneColumns(new StructType().add("name", DataTypes.StringType));
                   DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
@@ -1044,8 +1044,7 @@ public class DeltaV2ScanTest extends DeltaV2TestBase {
 
   @Test
   public void testStatisticsRequireSparkPostPushdownFilterAdjustment() {
-    DeltaV2Scan scan =
-        (DeltaV2Scan) ((DeltaV2ScanBuilder) table.newScanBuilder(options)).build();
+    DeltaV2Scan scan = (DeltaV2Scan) ((DeltaV2ScanBuilder) table.newScanBuilder(options)).build();
     assertFalse(scan.reflectsFullyPushedDownFilters());
   }
 
@@ -1320,8 +1319,7 @@ public class DeltaV2ScanTest extends DeltaV2TestBase {
     Statistics stats = scan.estimateStatistics();
 
     assertTrue(stats.numRows().isPresent(), "numRows should be present");
-    assertEquals(
-        999L, stats.numRows().getAsLong(), "numRows should come from catalog statistics");
+    assertEquals(999L, stats.numRows().getAsLong(), "numRows should come from catalog statistics");
     assertFalse(getPlanned(scan), "catalog full statistics should not plan Delta files");
   }
 

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2ScanTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2ScanTest.java
@@ -503,7 +503,7 @@ public class DeltaV2ScanTest extends DeltaV2TestBase {
     long beforeDppTotalBytes = getTotalBytes(deltaV2Scan);
     long beforeDppEstimatedSize = getEstimatedSizeInBytes(deltaV2Scan);
     assert (beforeDppFiles.size() == 5);
-    // Without column pruning, estimatedSizeInBytes should equal totalBytes
+    // Snappy tables use the selected-file byte sum directly.
     assertEquals(beforeDppTotalBytes, beforeDppEstimatedSize);
 
     deltaV2Scan.filter(runtimeFilters);
@@ -528,7 +528,7 @@ public class DeltaV2ScanTest extends DeltaV2TestBase {
     assertEquals(expectedPartitionFilesAfterDpp.size(), afterDppFiles.size());
     assertEquals(new HashSet<>(expectedPartitionFilesAfterDpp), new HashSet<>(afterDppFiles));
     assertEquals(expectedTotalBytesAfterDpp, afterDppTotalBytes);
-    // Without column pruning, estimatedSizeInBytes should equal totalBytes after filtering too
+    // Runtime filtering updates the selected-file byte sum used by the size API.
     assertEquals(afterDppTotalBytes, afterDppEstimatedSize);
   }
 
@@ -574,10 +574,7 @@ public class DeltaV2ScanTest extends DeltaV2TestBase {
   }
 
   private static long getEstimatedSizeInBytes(DeltaV2Scan scan) throws Exception {
-    scan.estimateStatistics(); // ensurePlanned
-    Field field = DeltaV2Scan.class.getDeclaredField("estimatedSizeInBytes");
-    field.setAccessible(true);
-    return (long) field.get(scan);
+    return scan.estimateSizeInBytes().getAsLong();
   }
 
   private static org.apache.spark.sql.catalyst.expressions.Expression[] getDataFilters(
@@ -585,6 +582,11 @@ public class DeltaV2ScanTest extends DeltaV2TestBase {
     Field field = DeltaV2Scan.class.getDeclaredField("dataFilters");
     field.setAccessible(true);
     return (org.apache.spark.sql.catalyst.expressions.Expression[]) field.get(scan);
+  }
+  private static boolean getPlanned(DeltaV2Scan scan) throws Exception {
+    Field field = DeltaV2Scan.class.getDeclaredField("planned");
+    field.setAccessible(true);
+    return (boolean) field.get(scan);
   }
 
   private static long getTotalRows(DeltaV2Scan scan) throws Exception {
@@ -607,20 +609,30 @@ public class DeltaV2ScanTest extends DeltaV2TestBase {
 
   @Test
   public void testNumRowsEmptyWhenStatsDisabled() throws Exception {
-    // With CBO and planStats disabled (the default), numRows() should return empty even when all
-    // files have stats, matching V1 behavior (LogicalRelation.computeStats()).
-    DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) table.newScanBuilder(options);
-    DeltaV2Scan scan = (DeltaV2Scan) builder.build();
+    // Explicitly disable both settings so the test does not depend on environment defaults.
+    withSQLConf(
+        "spark.sql.cbo.enabled",
+        "false",
+        () -> {
+          withSQLConf(
+              "spark.sql.cbo.planStats.enabled",
+              "false",
+              () -> {
+                DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+                DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
-    assertFalse(
-        isRowCountKnown(scan), "rowCountKnown should be false when CBO and planStats are disabled");
-    assertFalse(
-        scan.estimateStatistics().numRows().isPresent(),
-        "numRows() should be empty when CBO and planStats are disabled");
+                assertFalse(
+                    isRowCountKnown(scan),
+                    "rowCountKnown should be false when CBO and planStats are disabled");
+                assertFalse(
+                    scan.estimateStatistics().numRows().isPresent(),
+                    "numRows() should be empty when CBO and planStats are disabled");
+              });
+        });
   }
 
   @Test
-  public void testNumRowsInStatistics() throws Exception {
+  public void testPathStatisticsDoNotReportPerFileNumRows() throws Exception {
     // Table has 5 rows inserted as 5 separate partitions (1 row each), all with stats.
     withSQLConf(
         "spark.sql.cbo.planStats.enabled",
@@ -631,16 +643,16 @@ public class DeltaV2ScanTest extends DeltaV2TestBase {
 
           assertTrue(isRowCountKnown(scan), "Row count should be known when all files have stats");
           assertEquals(5L, getTotalRows(scan), "Total rows should match the 5 inserted rows");
-          assertTrue(scan.estimateStatistics().numRows().isPresent(), "numRows should be present");
-          assertEquals(5L, scan.estimateStatistics().numRows().getAsLong());
+          assertFalse(
+              scan.estimateStatistics().numRows().isPresent(),
+              "path-based optimizer statistics should not expose per-file row counts");
         });
   }
 
   @Test
   public void testNumRowsAfterRuntimeFiltering() throws Exception {
-    // Runtime partition filtering recomputes totalRows from the per-file counts of files that
-    // survive pruning, so numRows() reflects the post-prune row count rather than the
-    // pre-filter total or empty.
+    // Runtime partition filtering still recomputes the internal per-file row count used by Delta
+    // metrics, even though path-based optimizer statistics intentionally omit numRows().
     withSQLConf(
         "spark.sql.cbo.planStats.enabled",
         "true",
@@ -648,26 +660,25 @@ public class DeltaV2ScanTest extends DeltaV2TestBase {
           DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) table.newScanBuilder(options);
           DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
-          assertEquals(
-              5L, scan.estimateStatistics().numRows().getAsLong(), "5 rows before filtering");
+          scan.estimateStatistics();
+          assertEquals(5L, getTotalRows(scan), "5 rows before filtering");
 
           // Two rows in the table have city=hz (Alice and Bob, in different date partitions).
           scan.filter(new Predicate[] {cityPredicate}); // city=hz
 
-          assertTrue(
+          assertFalse(
               scan.estimateStatistics().numRows().isPresent(),
-              "numRows should remain known after runtime filtering");
+              "path-based optimizer statistics should not expose per-file row counts");
           assertEquals(
               2L,
-              scan.estimateStatistics().numRows().getAsLong(),
-              "numRows should be recomputed to the post-prune count (2 city=hz rows)");
+              getTotalRows(scan),
+              "the internal row count should be recomputed after runtime filtering");
         });
   }
 
   @Test
   public void testNumRowsZeroAfterFilteringOutAllFiles() throws Exception {
-    // When runtime filtering prunes every file, totalRows recomputes to 0 (still a known
-    // value, not OptionalLong.empty()).
+    // When runtime filtering prunes every file, the internal totalRows recomputes to 0.
     withSQLConf(
         "spark.sql.cbo.planStats.enabled",
         "true",
@@ -677,13 +688,13 @@ public class DeltaV2ScanTest extends DeltaV2TestBase {
 
           scan.filter(new Predicate[] {negativeCityPredicate}); // city=zz doesn't exist
 
-          assertTrue(
+          assertFalse(
               scan.estimateStatistics().numRows().isPresent(),
-              "numRows should remain known after runtime filtering (even when all files filtered)");
+              "path-based optimizer statistics should not expose per-file row counts");
           assertEquals(
               0L,
-              scan.estimateStatistics().numRows().getAsLong(),
-              "numRows should be 0 when all files are filtered out");
+              getTotalRows(scan),
+              "the internal row count should be 0 when all files are filtered out");
         });
   }
 
@@ -993,119 +1004,49 @@ public class DeltaV2ScanTest extends DeltaV2TestBase {
   }
 
   // ================================================================================================
-  // Tests for estimated size with column projection
+  // Tests for selected-file size estimates
   // ================================================================================================
 
   @Test
   public void testEstimatedSizeMatchesStatistics() throws Exception {
-    // Test that estimateStatistics().sizeInBytes() returns the estimatedSizeInBytes field
     DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) table.newScanBuilder(options);
     DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
     long estimatedSizeFromStats = scan.estimateStatistics().sizeInBytes().getAsLong();
-    long estimatedSizeFromField = getEstimatedSizeInBytes(scan);
+    long estimatedSizeFromSizeOnlyApi = scan.estimateSizeInBytes().getAsLong();
 
-    assertEquals(estimatedSizeFromField, estimatedSizeFromStats);
+    assertEquals(estimatedSizeFromSizeOnlyApi, estimatedSizeFromStats);
   }
 
   @Test
-  public void testEstimatedSizeWithColumnPruning() throws Exception {
-    // Test that with column pruning, estimatedSizeInBytes is computed correctly
-    // Table schema: (part INT, date STRING, city STRING, name STRING, cnt INT)
-    // Partition columns: (date STRING, city STRING, part INT)
-    // Data columns: (name STRING, cnt INT)
-    //
-    // Formula: estimatedBytes = (totalBytes * outputRowSize) / fullSchemaRowSize
-    // Where:
-    //   ROW_OVERHEAD = 8
-    //   dataSchema.defaultSize() = 20 (STRING) + 4 (INT) = 24
-    //   partitionSchema.defaultSize() = 20 + 20 + 4 = 44
-    //   fullSchemaRowSize = 8 + 24 + 44 = 76
-    //
-    // With pruning to only 'name' column:
-    //   readDataSchema.defaultSize() = 20 (STRING only)
-    //   readSchema().defaultSize() = 20 + 44 = 64
-    //   outputRowSize = 8 + 64 = 72
-    //   estimatedBytes = (totalBytes * 72) / 76
-    DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+  public void testEstimateSizeInBytesUsesCheapFileSizePath() throws Exception {
+    withSQLConf(
+        "spark.sql.cbo.enabled",
+        "false",
+        () ->
+            withSQLConf(
+                "spark.sql.cbo.planStats.enabled",
+                "false",
+                () -> {
+                  DeltaV2ScanBuilder builder =
+                      (DeltaV2ScanBuilder) table.newScanBuilder(options);
+                  builder.pruneColumns(new StructType().add("name", DataTypes.StringType));
+                  DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
-    // Prune columns to only include 'name' (a data column) and partition columns
-    // This simulates: SELECT name, date, city, part FROM table
-    StructType prunedSchema =
-        new StructType()
-            .add("name", DataTypes.StringType) // only one data column
-            .add("date", DataTypes.StringType) // partition columns are always included
-            .add("city", DataTypes.StringType)
-            .add("part", DataTypes.IntegerType);
-    builder.pruneColumns(prunedSchema);
-
-    DeltaV2Scan scan = (DeltaV2Scan) builder.build();
-
-    long totalBytes = getTotalBytes(scan);
-    long estimatedSize = getEstimatedSizeInBytes(scan);
-
-    // Calculate expected estimated size using the formula
-    // outputRowSize = 8 + 64 = 72, fullSchemaRowSize = 8 + 24 + 44 = 76
-    // Note: We don't use Math.max(1, ...) here because totalBytes is guaranteed to be large enough
-    // (parquet files with actual data) that the division result won't be zero.
-    long expectedEstimatedSize = (totalBytes * 72) / 76;
-
-    assertTrue(totalBytes > 0, "totalBytes should be positive");
-    assertEquals(
-        expectedEstimatedSize,
-        estimatedSize,
-        String.format(
-            "estimatedSize should be (totalBytes * 72) / 76 = (%d * 72) / 76 = %d",
-            totalBytes, expectedEstimatedSize));
+                  long sizeInBytes = scan.estimateSizeInBytes().getAsLong();
+                  assertEquals(getTotalBytes(scan), sizeInBytes);
+                  assertTrue(sizeInBytes > 0, "post-pruning size should be positive");
+                  assertFalse(
+                      isRowCountKnown(scan),
+                      "the size-only path must not request per-file row statistics");
+                }));
   }
 
   @Test
-  public void testEstimatedSizeWithColumnPruningAndFiltering() throws Exception {
-    // Test that column pruning and runtime filtering work together correctly
-    // Using same formula as testEstimatedSizeWithColumnPruning:
-    //   estimatedBytes = (totalBytes * 72) / 76
-    DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) table.newScanBuilder(options);
-
-    // Prune columns to only include 'name' column
-    StructType prunedSchema =
-        new StructType()
-            .add("name", DataTypes.StringType)
-            .add("date", DataTypes.StringType)
-            .add("city", DataTypes.StringType)
-            .add("part", DataTypes.IntegerType);
-    builder.pruneColumns(prunedSchema);
-
-    DeltaV2Scan scan = (DeltaV2Scan) builder.build();
-
-    // Get initial stats with column pruning
-    long initialTotalBytes = getTotalBytes(scan);
-    long initialEstimatedSize = getEstimatedSizeInBytes(scan);
-
-    // Verify initial estimated size matches formula
-    // Note: No Math.max(1, ...) needed - totalBytes from parquet files is large enough
-    long expectedInitialEstimated = (initialTotalBytes * 72) / 76;
-    assertEquals(
-        expectedInitialEstimated,
-        initialEstimatedSize,
-        "Initial estimatedSize should match formula");
-
-    // Apply a runtime filter
-    scan.filter(new Predicate[] {cityPredicate}); // city=hz
-
-    // After filtering, verify both values are updated correctly
-    long afterFilterTotalBytes = getTotalBytes(scan);
-    long afterFilterEstimatedSize = getEstimatedSizeInBytes(scan);
-
-    // Verify estimated size matches formula with new totalBytes
-    long expectedAfterFilterEstimated = (afterFilterTotalBytes * 72) / 76;
-    assertEquals(
-        expectedAfterFilterEstimated,
-        afterFilterEstimatedSize,
-        "After filter, estimatedSize should match formula with new totalBytes");
-
-    // Verify both values were reduced
-    assertTrue(afterFilterTotalBytes < initialTotalBytes, "totalBytes should be reduced");
-    assertTrue(afterFilterEstimatedSize < initialEstimatedSize, "estimatedSize should be reduced");
+  public void testStatisticsRequireSparkPostPushdownFilterAdjustment() {
+    DeltaV2Scan scan =
+        (DeltaV2Scan) ((DeltaV2ScanBuilder) table.newScanBuilder(options)).build();
+    assertFalse(scan.reflectsFullyPushedDownFilters());
   }
 
   @Test
@@ -1295,10 +1236,9 @@ public class DeltaV2ScanTest extends DeltaV2TestBase {
   }
 
   @Test
-  public void testEstimateStatisticsWithCatalogStats_cboEnabled(@TempDir File tempDir)
-      throws Exception {
+  public void testEstimateStatisticsWithCatalogStats(@TempDir File tempDir) throws Exception {
     String path = tempDir.getAbsolutePath();
-    String tblName = "stats_cbo_enabled";
+    String tblName = "catalog_stats";
     spark.sql(
         String.format(
             "CREATE TABLE %s (id INT, name STRING, value DOUBLE) USING delta LOCATION '%s'",
@@ -1325,49 +1265,37 @@ public class DeltaV2ScanTest extends DeltaV2TestBase {
 
     CatalogTable catalogTable = injectCatalogStats(tblName, catalogStats);
 
-    withSQLConf(
-        "spark.sql.cbo.enabled",
-        "true",
-        () -> {
-          Identifier id = Identifier.of(new String[] {"default"}, tblName);
-          DeltaV2Table sparkTable = new DeltaV2Table(id, catalogTable, Collections.emptyMap());
+    Identifier id = Identifier.of(new String[] {"default"}, tblName);
+    DeltaV2Table sparkTable = new DeltaV2Table(id, catalogTable, Collections.emptyMap());
 
-          DeltaV2ScanBuilder builder =
-              (DeltaV2ScanBuilder)
-                  sparkTable.newScanBuilder(new CaseInsensitiveStringMap(new HashMap<>()));
-          DeltaV2Scan scan = (DeltaV2Scan) builder.build();
-          Statistics stats = scan.estimateStatistics();
+    DeltaV2ScanBuilder builder =
+        (DeltaV2ScanBuilder)
+            sparkTable.newScanBuilder(new CaseInsensitiveStringMap(new HashMap<>()));
+    DeltaV2Scan scan = (DeltaV2Scan) builder.build();
+    Statistics stats = scan.estimateStatistics();
 
-          // numRows comes from per-file (post-prune) stats
-          assertTrue(stats.numRows().isPresent(), "numRows should be present with CBO enabled");
-          assertEquals(2L, stats.numRows().getAsLong(), "numRows should be 2");
+    // Catalog rows and columns are returned without an explicit size so Spark can derive a
+    // projection-aware size from the retained output.
+    assertTrue(stats.numRows().isPresent(), "numRows should be present");
+    assertEquals(2L, stats.numRows().getAsLong(), "numRows should be 2");
+    assertFalse(stats.sizeInBytes().isPresent(), "Spark should derive projected size");
 
-          // sizeInBytes should still come from planned files (more accurate)
-          assertTrue(stats.sizeInBytes().isPresent(), "sizeInBytes should be present");
-          assertTrue(stats.sizeInBytes().getAsLong() > 0, "sizeInBytes should be positive");
+    Map<NamedReference, ColumnStatistics> colStats = stats.columnStats();
+    assertNotNull(colStats, "columnStats should not be null");
+    assertFalse(colStats.isEmpty(), "columnStats should not be empty");
 
-          // Should have column stats
-          Map<NamedReference, ColumnStatistics> colStats = stats.columnStats();
-          assertNotNull(colStats, "columnStats should not be null");
-          assertFalse(colStats.isEmpty(), "columnStats should not be empty");
-
-          // Check that column stats contain expected columns
-          ColumnStatistics idStats = colStats.get(FieldReference.apply("id"));
-          assertNotNull(idStats, "id column stats should be present");
-          assertTrue(idStats.nullCount().isPresent(), "id nullCount should be present");
-          assertTrue(idStats.distinctCount().isPresent(), "id distinctCount should be present");
-          assertTrue(idStats.min().isPresent(), "id min should be present");
-          assertTrue(idStats.max().isPresent(), "id max should be present");
-          assertEquals(1, idStats.min().get(), "id min should be 1");
-          assertEquals(2, idStats.max().get(), "id max should be 2");
-        });
+    ColumnStatistics idStats = colStats.get(FieldReference.apply("id"));
+    assertNotNull(idStats, "id column stats should be present");
+    assertTrue(idStats.nullCount().isPresent(), "id nullCount should be present");
+    assertTrue(idStats.distinctCount().isPresent(), "id distinctCount should be present");
+    assertTrue(idStats.min().isPresent(), "id min should be present");
+    assertTrue(idStats.max().isPresent(), "id max should be present");
+    assertEquals(1, idStats.min().get(), "id min should be 1");
+    assertEquals(2, idStats.max().get(), "id max should be 2");
   }
 
   @Test
-  public void testPerFileNumRowsPreferredOverCatalog(@TempDir File tempDir) throws Exception {
-    // Verifies that per-file (post-prune) numRows is used in preference to catalog numRows.
-    // numRows() reflects the row count for this scan after pruning, while catalog stats are
-    // table-level and unpruned.
+  public void testCatalogNumRowsPreferredForFullStatistics(@TempDir File tempDir) throws Exception {
     String path = tempDir.getAbsolutePath();
     String tblName = "stats_per_file_wins";
     spark.sql(
@@ -1383,172 +1311,18 @@ public class DeltaV2ScanTest extends DeltaV2TestBase {
             buildColStatsMap(new String[] {}, new CatalogColumnStat[] {}));
     CatalogTable catalogTable = injectCatalogStats(tblName, catalogStats);
 
-    withSQLConf(
-        "spark.sql.cbo.enabled",
-        "true",
-        () -> {
-          Identifier id = Identifier.of(new String[] {"default"}, tblName);
-          DeltaV2Table sparkTable = new DeltaV2Table(id, catalogTable, Collections.emptyMap());
-          DeltaV2ScanBuilder builder =
-              (DeltaV2ScanBuilder)
-                  sparkTable.newScanBuilder(new CaseInsensitiveStringMap(new HashMap<>()));
-          DeltaV2Scan scan = (DeltaV2Scan) builder.build();
-          Statistics stats = scan.estimateStatistics();
+    Identifier id = Identifier.of(new String[] {"default"}, tblName);
+    DeltaV2Table sparkTable = new DeltaV2Table(id, catalogTable, Collections.emptyMap());
+    DeltaV2ScanBuilder builder =
+        (DeltaV2ScanBuilder)
+            sparkTable.newScanBuilder(new CaseInsensitiveStringMap(new HashMap<>()));
+    DeltaV2Scan scan = (DeltaV2Scan) builder.build();
+    Statistics stats = scan.estimateStatistics();
 
-          // Per-file numRows wins over catalog stats.
-          assertTrue(stats.numRows().isPresent(), "numRows should be present");
-          assertEquals(
-              2L,
-              stats.numRows().getAsLong(),
-              "numRows should come from per-file (2), not catalog (999)");
-        });
-  }
-
-  @Test
-  public void testCatalogNumRowsFallbackWhenPerFileUnknown(@TempDir File tempDir) throws Exception {
-    // When per-file numRecords is unavailable for any AddFile (rowCountKnown=false), numRows()
-    // should fall back to the catalog value rather than return OptionalLong.empty().
-    String path = tempDir.getAbsolutePath();
-    String tblName = "stats_catalog_fallback";
-    try {
-      spark.sql(
-          String.format(
-              "CREATE TABLE %s (id INT, name STRING) USING delta LOCATION '%s'", tblName, path));
-      spark.sql(String.format("INSERT INTO %s VALUES (1, 'a')", tblName));
-
-      // Disable stats collection so the next AddFile has no numRecords. With one file lacking
-      // numRecords, rowCountKnown is false for the whole scan.
-      withSQLConf(
-          "spark.databricks.delta.stats.collect",
-          "false",
-          () -> spark.sql(String.format("INSERT INTO %s VALUES (2, 'b')", tblName)));
-
-      // Inject catalog stats with a distinguishable row count (777) so the fallback is observable.
-      CatalogStatistics catalogStats =
-          new CatalogStatistics(
-              scala.math.BigInt.apply(1024L),
-              scala.Option.apply(scala.math.BigInt.apply(777L)),
-              buildColStatsMap(new String[] {}, new CatalogColumnStat[] {}));
-      CatalogTable catalogTable = injectCatalogStats(tblName, catalogStats);
-
-      withSQLConf(
-          "spark.sql.cbo.enabled",
-          "true",
-          () -> {
-            Identifier id = Identifier.of(new String[] {"default"}, tblName);
-            DeltaV2Table sparkTable = new DeltaV2Table(id, catalogTable, Collections.emptyMap());
-            DeltaV2ScanBuilder builder =
-                (DeltaV2ScanBuilder)
-                    sparkTable.newScanBuilder(new CaseInsensitiveStringMap(new HashMap<>()));
-            DeltaV2Scan scan = (DeltaV2Scan) builder.build();
-
-            assertFalse(
-                isRowCountKnown(scan),
-                "rowCountKnown should be false when an AddFile lacks numRecords");
-
-            Statistics stats = scan.estimateStatistics();
-            assertTrue(
-                stats.numRows().isPresent(),
-                "numRows should fall back to catalog when per-file unknown");
-            assertEquals(
-                777L,
-                stats.numRows().getAsLong(),
-                "numRows should come from catalog stats (777) when per-file is unknown");
-          });
-    } finally {
-      spark.sql("DROP TABLE IF EXISTS " + tblName);
-    }
-  }
-
-  @Test
-  public void testEstimateStatisticsWithCatalogStats_cboDisabled(@TempDir File tempDir)
-      throws Exception {
-    String path = tempDir.getAbsolutePath();
-    String tblName = "stats_cbo_disabled";
-    spark.sql(
-        String.format(
-            "CREATE TABLE %s (id INT, name STRING) USING delta LOCATION '%s'", tblName, path));
-    spark.sql(String.format("INSERT INTO %s VALUES (1, 'a'), (2, 'b')", tblName));
-
-    // Inject catalog stats
-    CatalogStatistics catalogStats =
-        new CatalogStatistics(
-            scala.math.BigInt.apply(512L),
-            scala.Option.apply(scala.math.BigInt.apply(2L)),
-            scala.collection.immutable.Map$.MODULE$.empty());
-
-    CatalogTable catalogTable = injectCatalogStats(tblName, catalogStats);
-
-    withSQLConf(
-        "spark.sql.cbo.enabled",
-        "false",
-        () -> {
-          Identifier id = Identifier.of(new String[] {"default"}, tblName);
-          DeltaV2Table sparkTable = new DeltaV2Table(id, catalogTable, Collections.emptyMap());
-
-          DeltaV2ScanBuilder builder =
-              (DeltaV2ScanBuilder)
-                  sparkTable.newScanBuilder(new CaseInsensitiveStringMap(new HashMap<>()));
-          DeltaV2Scan scan = (DeltaV2Scan) builder.build();
-          Statistics stats = scan.estimateStatistics();
-
-          // With CBO disabled, numRows should be empty (matching V1 behavior)
-          assertFalse(stats.numRows().isPresent(), "numRows should be empty with CBO disabled");
-
-          // sizeInBytes should still come from planned files
-          assertTrue(stats.sizeInBytes().isPresent(), "sizeInBytes should be present");
-          assertTrue(stats.sizeInBytes().getAsLong() > 0, "sizeInBytes should be positive");
-        });
-  }
-
-  @Test
-  public void testEstimateStatisticsWithCatalogStats_planStatsEnabled(@TempDir File tempDir)
-      throws Exception {
-    String path = tempDir.getAbsolutePath();
-    String tblName = "stats_plan_stats_enabled";
-    spark.sql(
-        String.format(
-            "CREATE TABLE %s (id INT, name STRING) USING delta LOCATION '%s'", tblName, path));
-    spark.sql(String.format("INSERT INTO %s VALUES (1, 'a'), (2, 'b')", tblName));
-
-    // Inject catalog stats with numRows
-    CatalogStatistics catalogStats =
-        new CatalogStatistics(
-            scala.math.BigInt.apply(512L),
-            scala.Option.apply(scala.math.BigInt.apply(2L)),
-            scala.collection.immutable.Map$.MODULE$.empty());
-
-    CatalogTable catalogTable = injectCatalogStats(tblName, catalogStats);
-
-    // CBO disabled but planStatsEnabled=true should still surface catalog stats
-    withSQLConf(
-        "spark.sql.cbo.enabled",
-        "false",
-        () -> {
-          withSQLConf(
-              "spark.sql.cbo.planStats.enabled",
-              "true",
-              () -> {
-                Identifier id = Identifier.of(new String[] {"default"}, tblName);
-                DeltaV2Table sparkTable =
-                    new DeltaV2Table(id, catalogTable, Collections.emptyMap());
-
-                DeltaV2ScanBuilder builder =
-                    (DeltaV2ScanBuilder)
-                        sparkTable.newScanBuilder(new CaseInsensitiveStringMap(new HashMap<>()));
-                DeltaV2Scan scan = (DeltaV2Scan) builder.build();
-                Statistics stats = scan.estimateStatistics();
-
-                // With planStatsEnabled, numRows should be present (from per-file stats)
-                assertTrue(
-                    stats.numRows().isPresent(), "numRows should be present with planStatsEnabled");
-                assertEquals(2L, stats.numRows().getAsLong(), "numRows should be 2");
-
-                // sizeInBytes should still come from planned files
-                assertTrue(stats.sizeInBytes().isPresent(), "sizeInBytes should be present");
-                assertTrue(stats.sizeInBytes().getAsLong() > 0, "sizeInBytes should be positive");
-              });
-        });
+    assertTrue(stats.numRows().isPresent(), "numRows should be present");
+    assertEquals(
+        999L, stats.numRows().getAsLong(), "numRows should come from catalog statistics");
+    assertFalse(getPlanned(scan), "catalog full statistics should not plan Delta files");
   }
 
   @Test
@@ -1561,28 +1335,21 @@ public class DeltaV2ScanTest extends DeltaV2TestBase {
             "CREATE TABLE %s (id INT, name STRING) USING delta LOCATION '%s'", tblName, path));
     spark.sql(String.format("INSERT INTO %s VALUES (1, 'a')", tblName));
 
-    withSQLConf(
-        "spark.sql.cbo.enabled",
-        "true",
-        () -> {
-          // Path-based table - no catalog table, no ANALYZE TABLE stats
-          Identifier id = Identifier.of(new String[] {"default"}, tblName);
-          DeltaV2Table sparkTable = new DeltaV2Table(id, path);
+    // Path-based table - no catalog table, no ANALYZE TABLE stats
+    Identifier id = Identifier.of(new String[] {"default"}, tblName);
+    DeltaV2Table sparkTable = new DeltaV2Table(id, path);
 
-          DeltaV2ScanBuilder builder =
-              (DeltaV2ScanBuilder)
-                  sparkTable.newScanBuilder(new CaseInsensitiveStringMap(new HashMap<>()));
-          DeltaV2Scan scan = (DeltaV2Scan) builder.build();
-          Statistics stats = scan.estimateStatistics();
+    DeltaV2ScanBuilder builder =
+        (DeltaV2ScanBuilder)
+            sparkTable.newScanBuilder(new CaseInsensitiveStringMap(new HashMap<>()));
+    DeltaV2Scan scan = (DeltaV2Scan) builder.build();
+    Statistics stats = scan.estimateStatistics();
 
-          // Per-file Delta stats (numRecords in the transaction log) are available even without
-          // catalog stats from ANALYZE TABLE, so numRows should be present.
-          assertTrue(stats.numRows().isPresent(), "numRows should be present from per-file stats");
-          assertEquals(
-              1L, stats.numRows().getAsLong(), "numRows should match the inserted row count");
-          assertTrue(stats.sizeInBytes().isPresent(), "sizeInBytes should be present");
-          assertTrue(stats.sizeInBytes().getAsLong() > 0, "sizeInBytes should be positive");
-        });
+    assertFalse(
+        stats.numRows().isPresent(),
+        "path-based full statistics should not expose per-file row counts");
+    assertTrue(stats.sizeInBytes().isPresent(), "sizeInBytes should be present");
+    assertTrue(stats.sizeInBytes().getAsLong() > 0, "sizeInBytes should be positive");
   }
 
   @Test
@@ -1630,40 +1397,35 @@ public class DeltaV2ScanTest extends DeltaV2TestBase {
 
     CatalogTable catalogTable = injectCatalogStats(tblName, catalogStats);
 
-    withSQLConf(
-        "spark.sql.cbo.enabled",
-        "true",
-        () -> {
-          Identifier id = Identifier.of(new String[] {"default"}, tblName);
-          DeltaV2Table sparkTable = new DeltaV2Table(id, catalogTable, Collections.emptyMap());
+    Identifier id = Identifier.of(new String[] {"default"}, tblName);
+    DeltaV2Table sparkTable = new DeltaV2Table(id, catalogTable, Collections.emptyMap());
 
-          DeltaV2ScanBuilder builder =
-              (DeltaV2ScanBuilder)
-                  sparkTable.newScanBuilder(new CaseInsensitiveStringMap(new HashMap<>()));
-          DeltaV2Scan scan = (DeltaV2Scan) builder.build();
-          Statistics stats = scan.estimateStatistics();
+    DeltaV2ScanBuilder builder =
+        (DeltaV2ScanBuilder)
+            sparkTable.newScanBuilder(new CaseInsensitiveStringMap(new HashMap<>()));
+    DeltaV2Scan scan = (DeltaV2Scan) builder.build();
+    Statistics stats = scan.estimateStatistics();
 
-          assertTrue(stats.numRows().isPresent(), "numRows should be present");
-          assertEquals(3L, stats.numRows().getAsLong(), "numRows should be 3");
+    assertTrue(stats.numRows().isPresent(), "numRows should be present");
+    assertEquals(3L, stats.numRows().getAsLong(), "numRows should be 3");
 
-          // Verify column stats include both data and partition columns
-          Map<NamedReference, ColumnStatistics> colStats = stats.columnStats();
-          assertNotNull(colStats.get(FieldReference.apply("id")), "id stats should be present");
-          assertNotNull(colStats.get(FieldReference.apply("part")), "part stats should be present");
+    // Verify column stats include both data and partition columns
+    Map<NamedReference, ColumnStatistics> colStats = stats.columnStats();
+    assertNotNull(colStats.get(FieldReference.apply("id")), "id stats should be present");
+    assertNotNull(colStats.get(FieldReference.apply("part")), "part stats should be present");
 
-          // Check partition column stats
-          ColumnStatistics partStats = colStats.get(FieldReference.apply("part"));
-          assertTrue(partStats.min().isPresent(), "part min should be present");
-          assertTrue(partStats.max().isPresent(), "part max should be present");
-          assertEquals(1, partStats.min().get(), "part min should be 1");
-          assertEquals(2, partStats.max().get(), "part max should be 2");
-        });
+    ColumnStatistics partStats = colStats.get(FieldReference.apply("part"));
+    assertTrue(partStats.min().isPresent(), "part min should be present");
+    assertTrue(partStats.max().isPresent(), "part max should be present");
+    assertEquals(1, partStats.min().get(), "part min should be 1");
+    assertEquals(2, partStats.max().get(), "part max should be 2");
   }
 
   @Test
-  public void testEstimatedSizeUsesAvgLenFromCatalogStats(@TempDir File tempDir) throws Exception {
-    // Verify that computeEstimatedSizeWithColumnProjection uses avgLen from catalog stats
-    // instead of defaultSize(), mirroring EstimationUtils.getSizePerRow() (#5952).
+  public void testSizeOnlyEstimateDoesNotUseCatalogColumnStats(@TempDir File tempDir)
+      throws Exception {
+    // The size-only API should return the catalog size directly without consulting column stats or
+    // planning Delta files.
     String path = tempDir.getAbsolutePath();
     String tblName = "stats_avglen";
     spark.sql(
@@ -1691,101 +1453,36 @@ public class DeltaV2ScanTest extends DeltaV2TestBase {
 
     CatalogTable catalogTable = injectCatalogStats(tblName, catalogStats);
 
-    // avgLen is used for sizeInBytes estimation regardless of CBO/planStats settings
-    withSQLConf(
-        "spark.sql.cbo.enabled",
-        "false",
-        () -> {
-          withSQLConf(
-              "spark.sql.cbo.planStats.enabled",
-              "false",
-              () -> {
-                Identifier id = Identifier.of(new String[] {"default"}, tblName);
-                DeltaV2Table sparkTable =
-                    new DeltaV2Table(id, catalogTable, Collections.emptyMap());
+    Identifier id = Identifier.of(new String[] {"default"}, tblName);
+    DeltaV2Table sparkTable = new DeltaV2Table(id, catalogTable, Collections.emptyMap());
+    DeltaV2ScanBuilder builder =
+        (DeltaV2ScanBuilder)
+            sparkTable.newScanBuilder(new CaseInsensitiveStringMap(new HashMap<>()));
 
-                DeltaV2ScanBuilder builder =
-                    (DeltaV2ScanBuilder)
-                        sparkTable.newScanBuilder(new CaseInsensitiveStringMap(new HashMap<>()));
+    // Pruning must not affect the catalog size fast path.
+    StructType prunedSchema = new StructType().add("name", DataTypes.StringType);
+    builder.pruneColumns(prunedSchema);
 
-                // Prune to only 'name' column to trigger column projection estimation
-                StructType prunedSchema = new StructType().add("name", DataTypes.StringType);
-                builder.pruneColumns(prunedSchema);
+    DeltaV2Scan scan = (DeltaV2Scan) builder.build();
+    assertFalse(getPlanned(scan));
+    assertEquals(OptionalLong.of(1024L), scan.estimateSizeInBytes());
+    assertFalse(getPlanned(scan), "catalog size lookup should not plan Delta files");
 
-                DeltaV2Scan scan = (DeltaV2Scan) builder.build();
-
-                long totalBytes = getTotalBytes(scan);
-                long estimatedSize = getEstimatedSizeInBytes(scan);
-                assertTrue(totalBytes > 0, "totalBytes should be positive");
-
-                // Schema: dataSchema = (id INT, name STRING), partitionSchema = empty
-                // readSchema = (name STRING) after pruning
-                //
-                // With avgLen=5 for name (STRING: avgLen + 12 = 17, vs defaultSize 20):
-                //   fullSchemaRowSize = 8 + (4 [INT default] + 17 [STRING avgLen]) = 29
-                //   outputRowSize     = 8 + 17 = 25
-                //   estimated = (totalBytes * 25) / 29
-                //
-                // Without avgLen (defaultSize only):
-                //   fullSchemaRowSize = 8 + (4 + 20) = 32
-                //   outputRowSize     = 8 + 20 = 28
-                //   estimated = (totalBytes * 28) / 32
-                long expectedWithAvgLen = (totalBytes * 25) / 29;
-                long expectedWithoutAvgLen = (totalBytes * 28) / 32;
-
-                assertEquals(
-                    expectedWithAvgLen,
-                    estimatedSize,
-                    "estimatedSize should use avgLen from catalog stats");
-                assertNotEquals(
-                    expectedWithoutAvgLen,
-                    estimatedSize,
-                    "estimatedSize should differ from defaultSize-only calculation");
-              });
-        });
-  }
-
-  @Test
-  public void testEstimateStatisticsWithoutAnalyze(@TempDir File tempDir) throws Exception {
-    // Table exists in catalog but no stats were injected
-    String path = tempDir.getAbsolutePath();
-    String tblName = "stats_no_analyze";
-    spark.sql(
-        String.format(
-            "CREATE TABLE %s (id INT, name STRING) USING delta LOCATION '%s'", tblName, path));
-    spark.sql(String.format("INSERT INTO %s VALUES (1, 'a')", tblName));
-
-    withSQLConf(
-        "spark.sql.cbo.enabled",
-        "true",
-        () -> {
-          CatalogTable catalogTable =
-              spark.sessionState().catalog().getTableMetadata(new TableIdentifier(tblName));
-          Identifier id = Identifier.of(new String[] {"default"}, tblName);
-          DeltaV2Table sparkTable = new DeltaV2Table(id, catalogTable, Collections.emptyMap());
-
-          DeltaV2ScanBuilder builder =
-              (DeltaV2ScanBuilder)
-                  sparkTable.newScanBuilder(new CaseInsensitiveStringMap(new HashMap<>()));
-          DeltaV2Scan scan = (DeltaV2Scan) builder.build();
-          Statistics stats = scan.estimateStatistics();
-
-          // Per-file Delta stats (numRecords in the transaction log) provide numRows even when
-          // ANALYZE TABLE has not been run and no catalog stats exist.
-          assertTrue(stats.numRows().isPresent(), "numRows should be present from per-file stats");
-          assertEquals(
-              1L, stats.numRows().getAsLong(), "numRows should match the inserted row count");
-          assertTrue(stats.sizeInBytes().isPresent(), "sizeInBytes should be present");
-          assertTrue(stats.sizeInBytes().getAsLong() > 0, "sizeInBytes should be positive");
-        });
+    Statistics stats = scan.estimateStatistics();
+    assertFalse(stats.sizeInBytes().isPresent());
+    assertEquals(OptionalLong.of(3L), stats.numRows());
+    assertTrue(
+        stats.columnStats().containsKey(FieldReference.apply("name")),
+        "full statistics should preserve catalog column statistics");
+    assertFalse(getPlanned(scan), "catalog full statistics should not plan Delta files");
   }
 
   @Test
   public void testEstimateStatisticsWithCatalogStats_noNumRows(@TempDir File tempDir)
       throws Exception {
-    // Catalog stats with sizeInBytes but no numRows: when per-file stats are available,
-    // numRows should still be reported from per-file numRecords (not from catalog stats).
-    // sizeInBytes should come from planned files, not the stale catalog value.
+    // Catalog stats with sizeInBytes but no numRows: the size-only API should use the catalog
+    // size without planning files, while full statistics should use the planned file size and
+    // leave row and column statistics empty.
     String path = tempDir.getAbsolutePath();
     String tblName = "stats_no_numrows";
     spark.sql(
@@ -1802,37 +1499,35 @@ public class DeltaV2ScanTest extends DeltaV2TestBase {
 
     CatalogTable catalogTable = injectCatalogStats(tblName, catalogStats);
 
-    withSQLConf(
-        "spark.sql.cbo.enabled",
-        "true",
-        () -> {
-          Identifier id = Identifier.of(new String[] {"default"}, tblName);
-          DeltaV2Table sparkTable = new DeltaV2Table(id, catalogTable, Collections.emptyMap());
+    Identifier id = Identifier.of(new String[] {"default"}, tblName);
+    DeltaV2Table sparkTable = new DeltaV2Table(id, catalogTable, Collections.emptyMap());
 
-          DeltaV2ScanBuilder builder =
-              (DeltaV2ScanBuilder)
-                  sparkTable.newScanBuilder(new CaseInsensitiveStringMap(new HashMap<>()));
-          DeltaV2Scan scan = (DeltaV2Scan) builder.build();
-          Statistics stats = scan.estimateStatistics();
+    DeltaV2ScanBuilder builder =
+        (DeltaV2ScanBuilder)
+            sparkTable.newScanBuilder(new CaseInsensitiveStringMap(new HashMap<>()));
+    DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
-          // Per-file stats provide numRows even when catalog stats lack it
-          assertTrue(stats.numRows().isPresent(), "numRows should be present from per-file stats");
-          assertEquals(
-              2L, stats.numRows().getAsLong(), "numRows should reflect per-file row count");
-          assertTrue(stats.sizeInBytes().isPresent(), "sizeInBytes should be present");
-          assertTrue(stats.sizeInBytes().getAsLong() > 0, "sizeInBytes should be positive");
+    assertFalse(getPlanned(scan));
+    assertEquals(
+        OptionalLong.of(99999L),
+        scan.estimateSizeInBytes(),
+        "size-only statistics should use the catalog size");
+    assertFalse(getPlanned(scan), "reading the catalog size should not plan Delta files");
 
-          // sizeInBytes should NOT be the catalog sizeInBytes (99999)
-          assertNotEquals(
-              99999L,
-              stats.sizeInBytes().getAsLong(),
-              "sizeInBytes should come from planned files, not catalog stats");
+    Statistics stats = scan.estimateStatistics();
 
-          // columnStats should be empty (catalog stats had no column stats)
-          assertTrue(
-              stats.columnStats().isEmpty(),
-              "columnStats should be empty when catalog stats have no column stats");
-        });
+    // A catalog entry without rowCount stays on the size-only branch.
+    assertFalse(stats.numRows().isPresent(), "numRows should be absent without catalog rows");
+    assertTrue(stats.sizeInBytes().isPresent(), "sizeInBytes should be present");
+    assertTrue(stats.sizeInBytes().getAsLong() > 0, "sizeInBytes should be positive");
+
+    assertNotEquals(
+        99999L,
+        stats.sizeInBytes().getAsLong(),
+        "sizeInBytes should come from planned files, not catalog stats");
+    assertTrue(
+        stats.columnStats().isEmpty(),
+        "columnStats should be empty when catalog stats have no column stats");
   }
 
   @SuppressWarnings({"rawtypes", "unchecked"})
@@ -1933,9 +1628,8 @@ public class DeltaV2ScanTest extends DeltaV2TestBase {
   @Test
   public void testLimitPushdown_limit0ReportsZeroNumRowsNotStaleCatalog(@TempDir File tempDir)
       throws Exception {
-    // The LIMIT 0 short-circuit reads no files. Under CBO with catalog stats present, numRows()
-    // must report 0 (the scan logically returns zero rows), NOT the stale table-level catalog
-    // count. This adds regression guard for the short-circuit setting rowCountKnown/totalRows.
+    // The LIMIT 0 short-circuit reads no files and reports exact zero statistics instead of stale
+    // table-level catalog values.
     String path = tempDir.getAbsolutePath();
     String tblName = "stats_limit0_numrows";
     spark.sql(
@@ -1963,7 +1657,7 @@ public class DeltaV2ScanTest extends DeltaV2TestBase {
           builder.pushLimit(0);
           DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
-          assertTrue(isRowCountKnown(scan), "LIMIT 0 under CBO should mark the row count known");
+          assertFalse(getPlanned(scan), "LIMIT 0 statistics should not plan Delta files");
           Statistics stats = scan.estimateStatistics();
           assertTrue(stats.numRows().isPresent(), "numRows should be present under CBO");
           assertEquals(
@@ -1972,15 +1666,15 @@ public class DeltaV2ScanTest extends DeltaV2TestBase {
               "LIMIT 0 must report 0 rows, not the stale catalog count (999)");
           assertEquals(
               0L, getTotalBytes(scan), "LIMIT 0 should read zero bytes even with catalog stats");
+          assertFalse(getPlanned(scan), "LIMIT 0 statistics should remain on the fast path");
         });
   }
 
   @Test
-  public void testLimitPushdown_numRowsKnownUnderPlanStats() throws Exception {
-    // LIMIT + plan stats: V1's limit-aware filesForScan takes no keepNumRecords and nulls out
-    // per-file AddFile.stats, so the count has to come from the scan-level aggregate
-    // (DeltaScan.scanned.rows) instead. Without that fallback numRows() regresses to empty for
-    // every limit-pushdown query whenever CBO or planStats is on.
+  public void testLimitPushdown_numRowsRemainsInternalUnderPlanStats() throws Exception {
+    // Delta retains per-file or scan-level row counts for its internal scan statistics, but the
+    // generic SupportsReportStatistics handoff intentionally exposes only scan-local size when
+    // catalog row statistics are absent.
     withSQLConf(
         "spark.sql.cbo.planStats.enabled",
         "true",
@@ -1989,7 +1683,7 @@ public class DeltaV2ScanTest extends DeltaV2TestBase {
           DeltaV2Scan noLimit =
               (DeltaV2Scan) ((DeltaV2ScanBuilder) table.newScanBuilder(options)).build();
           assertTrue(isRowCountKnown(noLimit), "row count should be known without a limit");
-          assertEquals(5L, noLimit.estimateStatistics().numRows().getAsLong());
+          assertFalse(noLimit.estimateStatistics().numRows().isPresent());
 
           // With a pushed limit, the per-file counts are gone but the aggregate still reports the
           // rows the limited scan will read.
@@ -1997,13 +1691,9 @@ public class DeltaV2ScanTest extends DeltaV2TestBase {
           assertTrue(
               isRowCountKnown(withLimit),
               "row count must stay known for a pushed limit (aggregate fallback)");
-          assertTrue(
+          assertFalse(
               withLimit.estimateStatistics().numRows().isPresent(),
-              "numRows must be present for LIMIT + planStats");
-          assertEquals(
-              3L,
-              withLimit.estimateStatistics().numRows().getAsLong(),
-              "numRows should be the limited row count reported by DeltaScan.scanned.rows");
+              "generic relation statistics must not expose the internal limited row count");
         });
   }
 

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2ScanTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2ScanTest.java
@@ -15,6 +15,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.OptionalInt;
+import java.util.OptionalLong;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.spark.sql.catalyst.TableIdentifier;
 import org.apache.spark.sql.catalyst.catalog.CatalogColumnStat;


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Spark's DSv2 API asks connector-owned scans to report both size-only and full statistics through `SupportsReportStatistics`. This change adopts that contract for Delta's DSv2 connector scans (`DeltaV2Scan`) while preserving the existing catalog, per-file, projection, zero-row, and missing-row-count behavior.

- Implements a cheaper `estimateSizeInBytes()` path: it returns the catalog size when available, and otherwise the post-pruning selected-file byte sum, without constructing row or column statistics.
- Simplifies `estimateStatistics()` so it preserves the previous catalog and path-based semantics, including exact zero-row scans (limit 0) and the missing-row-count case.
- Reports `reflectsFullyPushedDownFilters() = false`. Delta retains filter-only columns in the read schema during column pruning, so Spark keeps the `Filter`/`Project` above the relation and owns the statistics adjustment for fully pushed predicates rather than folding it into the scan.
- Removes the previous column-projection size heuristic (`computeEstimatedSizeWithColumnProjection` and helpers), which is no longer needed now that Spark re-adjusts statistics above the scan.

Note: `estimateSizeInBytes()` and `reflectsFullyPushedDownFilters()` are declared without `@Override` on purpose, since Delta also compiles this source against supported Spark versions whose `SupportsReportStatistics` interface predates these optional methods; the methods still override the interface defaults when built against a Spark version that provides them.

## How was this patch tested?

New and existing unit tests:
- `DeltaV2ScanBuilderTest.testPruneColumnsRetainsFullyPushedFilterColumn` verifies that columns referenced only by fully pushed filters are retained in the read schema during column pruning.
- `DeltaV2ScanTest` is updated to cover the size-only and full-statistics paths for catalog-backed, path-based, and zero-row scans.

## Does this PR introduce _any_ user-facing changes?

No.
