### PR TITLE
Fix DataManifestEntry tracking.status across AMT write paths

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTCheckpointProvider.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTCheckpointProvider.scala
@@ -41,7 +41,7 @@ import org.apache.spark.util.SerializableConfiguration
  *                         carries the version, contentRoot, and inline non-file state.
  * @param leaves           The root's `DATA_MANIFEST` pointer entries, one per leaf reachable from
  *                         the root. Each entry's `location` is stored table-root-relative; use
- *                         [[leafManifestAbsolutePaths]] to resolve them against the table root.
+ *                         [[liveLeafManifestAbsolutePaths]] to resolve them against the table root.
  * @param tableRoot        The table's data path.
  */
 final class AMTCheckpointProvider(
@@ -59,14 +59,19 @@ final class AMTCheckpointProvider(
   /** Absolute [[Path]] to the root manifest parquet, resolved against the table root. */
   private val rootManifestAbsolutePath: Path = contentRoot.getAbsolutePath(tableRoot)
 
-  /** Absolute [[Path]]s to the leaf manifest parquet files, resolved against the table root. */
-  lazy val leafManifestAbsolutePaths: Seq[Path] = leaves.map(_.getAbsolutePath(tableRoot))
+  /** The live leaf pointers which must have all the live [[DataEntry]]s. */
+  private lazy val liveLeaves: Seq[DataManifestEntry] =
+    leaves.filter(l =>
+      AMTCheckpointProvider.liveDataManifestEntryStatuses.contains(l.tracking.status))
+
+  /** Absolute [[Path]]s to the live leaf manifest parquet files, resolved against the root. */
+  lazy val liveLeafManifestAbsolutePaths: Seq[Path] = liveLeaves.map(_.getAbsolutePath(tableRoot))
 
   /** The root manifest as a [[FileStatus]]. */
-  private lazy val rootStatus: FileStatus = contentRoot.toFileStatus(tableRoot)
+  private lazy val rootFile: FileStatus = contentRoot.toFileStatus(tableRoot)
 
-  /** The leaf manifests as [[FileStatus]]es. */
-  private lazy val leafStatuses: Seq[FileStatus] = leaves.map(_.toFileStatus(tableRoot))
+  /** Live leaf manifests as [[FileStatus]]es. */
+  private lazy val liveLeafFiles: Seq[FileStatus] = liveLeaves.map(_.toFileStatus(tableRoot))
 
   override def version: Long = checkpointAction.version
 
@@ -83,7 +88,7 @@ final class AMTCheckpointProvider(
   }
 
   override def effectiveCheckpointSizeInBytes(): Long =
-    contentRoot.sizeInBytes + leaves.map(_.file_size_in_bytes).sum
+    contentRoot.sizeInBytes + liveLeaves.map(_.file_size_in_bytes).sum
 
   override def checkpointPolicyForLogging: Option[CheckpointPolicy.Policy] = None
 
@@ -143,13 +148,13 @@ final class AMTCheckpointProvider(
     val encodedRootPath = SparkPath.fromPath(rootManifestAbsolutePath).urlEncoded
     val serializableConf = new SerializableConfiguration(deltaLog.newDeltaHadoopConf())
 
-    val files = rootStatus +: leafStatuses
+    val files = rootFile +: liveLeafFiles
     val fmt = DeltaLogFileIndex.CHECKPOINT_FILE_FORMAT_PARQUET
     // Read every leaf row, then drop the MDV-marked (leaf, rowIndex) entries with a filter on
     // top, using a broadcast of each leaf's manifest DV bitmap bytes keyed by its `_metadata`
     // file path.
     val index = DeltaLogFileIndex(fmt, files.toArray)
-    val mdvByLeaf: Map[String, Array[Byte]] = leaves.flatMap { leaf =>
+    val mdvByLeaf: Map[String, Array[Byte]] = liveLeaves.flatMap { leaf =>
       leaf.manifestDV.map { case (dvBytes, _) =>
         SparkPath.fromPath(leaf.getAbsolutePath(localTableRoot)).urlEncoded -> dvBytes
       }
@@ -158,7 +163,7 @@ final class AMTCheckpointProvider(
     val dataEntries = AMTCheckpointProvider.loadEntriesWithLocation(spark, deltaLog, index)
       .where(col("entry.content_type") === lit(AMTSingleAction.ContentType.Type.Data))
       .where(col("entry.tracking.status").isin(
-        AMTCheckpointProvider.liveTrackingStatuses.toSeq: _*))
+        AMTCheckpointProvider.liveDataEntryStatuses.toSeq: _*))
       .filter { entryWithLoc =>
         mdvBroadcast.value.get(entryWithLoc.leafPath)
           .forall(bytes => !RoaringBitmapArray.readFrom(bytes).contains(entryWithLoc.pos))
@@ -253,9 +258,9 @@ object AMTCheckpointProvider {
       deltaLog: DeltaLog,
       checkpoint: Checkpoint): AMTCheckpointProvider = {
     val tableRoot = deltaLog.dataPath
-    val rootStatus = checkpoint.contentRoot.toFileStatus(tableRoot)
+    val rootFile = checkpoint.contentRoot.toFileStatus(tableRoot)
     val index =
-      DeltaLogFileIndex(DeltaLogFileIndex.CHECKPOINT_FILE_FORMAT_PARQUET, Array(rootStatus))
+      DeltaLogFileIndex(DeltaLogFileIndex.CHECKPOINT_FILE_FORMAT_PARQUET, Array(rootFile))
     // The root manifest is small (one row per leaf), so collect it to the driver to enumerate the
     // leaf pointers.
     val leaves = loadEntries(spark, deltaLog, index).collect().toSeq
@@ -265,8 +270,12 @@ object AMTCheckpointProvider {
   }
 
   /** Tracking Status representing the live [[DataEntry]] in an AMT. */
-  private[amt] val liveTrackingStatuses: Set[Int] =
+  private[amt] val liveDataEntryStatuses: Set[Int] =
     Set(Tracking.Status.Existing, Tracking.Status.Added)
+
+  /** All Tracking Status for leafs which may have any live files. */
+  private[amt] val liveDataManifestEntryStatuses: Set[Int] =
+    Set(Tracking.Status.Added, Tracking.Status.Existing, Tracking.Status.Modified)
 
   /** Reads the AMT root and returns the live [[DataEntry]]s tracked by root. */
   private[amt] def readLiveRootDataEntries(
@@ -274,13 +283,13 @@ object AMTCheckpointProvider {
       deltaLog: DeltaLog,
       checkpoint: Checkpoint): Seq[AddFile] = {
     val tableRoot = deltaLog.dataPath
-    val rootStatus = checkpoint.contentRoot.toFileStatus(tableRoot)
+    val rootFile = checkpoint.contentRoot.toFileStatus(tableRoot)
     val index =
-      DeltaLogFileIndex(DeltaLogFileIndex.CHECKPOINT_FILE_FORMAT_PARQUET, Array(rootStatus))
+      DeltaLogFileIndex(DeltaLogFileIndex.CHECKPOINT_FILE_FORMAT_PARQUET, Array(rootFile))
     loadEntries(spark, deltaLog, index).collect().toSeq
       .filter(_.content_type == AMTSingleAction.ContentType.Type.Data)
       .map(_.unwrap.asInstanceOf[DataEntry])
-      .filter(e => liveTrackingStatuses.contains(e.tracking.status))
+      .filter(e => liveDataEntryStatuses.contains(e.tracking.status))
       .map(_.toAddFile(tableRoot))
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriteHelper.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriteHelper.scala
@@ -238,6 +238,8 @@ object AMTWriteHelper extends DeltaLogging {
           val conf = serConf.value
           val leafFile = FileNames.newAMTLeafManifestFile(metadataDirSparkPath.toPath)
 
+          var entryCount = 0L
+          val countingRows = iter.map { row => entryCount += 1; row }
           val status = Checkpoints.writeSingleFileOnExecutor(
             conf = conf,
             factory = factory,
@@ -247,19 +249,21 @@ object AMTWriteHelper extends DeltaLogging {
             useRename = false,
             partition = TaskContext.getPartitionId(),
             expectedNumParts = desiredNumLeaves,
-            rows = iter
+            rows = countingRows
           )
           val leafFs = leafFile.getFileSystem(conf)
+          // The root pointer to this leaf is newly ADDED, even though the leaf's own DATA
+          // entries are EXISTING (the referenced data files already lived in the table).
+          val (tracking, manifestInfo) =
+            addedTrackingForLeaf(existingFilesCount = entryCount.toInt)
           Iterator.single(DataManifestEntry(
             location = AMTUtils.relativizeManifestPathToTableRoot(
               leafFs, tableRootSparkPath.toPath, leafFile),
             file_format = AMTSingleAction.FileFormatParquet,
-            // The root pointer to this leaf is newly ADDED, even though the leaf's own DATA
-            // entries are EXISTING (the referenced data files already lived in the table).
-            tracking = trackingWithStatus(Tracking.Status.Added),
-            record_count = 0L,
+            tracking = tracking,
+            record_count = entryCount,
             file_size_in_bytes = status.length,
-            manifest_info = manifestInfoFor(Seq.empty)))
+            manifest_info = manifestInfo))
         }
       }.collect().toSeq
     }
@@ -285,6 +289,67 @@ object AMTWriteHelper extends DeltaLogging {
   private[amt] def removedTracking(deletedPositions: Option[Array[Byte]] = None): Tracking =
     trackingWithStatus(Tracking.Status.Deleted).copy(deleted_positions = deletedPositions)
 
+  /** Tracking + ManifestInfo for a newly written leaf file: the root pointer to it is ADDED. */
+  private[amt] def addedTrackingForLeaf(
+      addedFilesCount: Int = 0,
+      existingFilesCount: Int = 0): (Tracking, ManifestInfo) = {
+    val tracking = trackingWithStatus(Tracking.Status.Added)
+    val manifestInfo = emptyManifestInfo.copy(
+      added_files_count = addedFilesCount,
+      existing_files_count = existingFilesCount)
+    (tracking, manifestInfo)
+  }
+
+  /**
+   * Tracking + ManifestInfo for a leaf carried unchanged into this tree: re-emitted EXISTING with
+   * its MDV kept and per-commit CDF positions cleared.
+   */
+  private[amt] def existingTrackingForLeaf(
+      oldEntry: DataManifestEntry): (Tracking, ManifestInfo) = {
+    val newTracking = oldEntry.tracking.copy(
+      status = Tracking.Status.Existing,
+      deleted_positions = None,
+      replaced_positions = None)
+    // manifest_info file/row counts are immutable (they describe the leaf as written), and its MDV
+    // is unchanged here (no new masking), so carry manifest_info forward untouched.
+    (newTracking, oldEntry.manifest_info)
+  }
+
+  /**
+   * Tracking + ManifestInfo for a carried leaf whose MDV grew this commit: MODIFIED, with
+   * `mdvPositions` accumulated into the cumulative MDV and `cdfPositions` recorded for CDF.
+   * If all the MDV bits are set, change the Tracking.Status from MODIFIED to DELETED.
+   */
+  private[amt] def modifiedOrDeletedTrackingForLeaf(
+      oldEntry: DataManifestEntry,
+      mdvPositions: Seq[Long],
+      cdfPositions: Seq[Long]): (Tracking, ManifestInfo) = {
+    val cumulativeMdv = oldEntry.manifest_info.dv
+      .map(AMTUtils.deserializeMdv).getOrElse(new RoaringBitmapArray)
+    mdvPositions.foreach(cumulativeMdv.add)
+    val deletedPositions =
+      if (cdfPositions.isEmpty) None
+      else Some(AMTUtils.serializeMdv(RoaringBitmapArray(cdfPositions: _*)))
+    // A leaf's MDV masks positions within that leaf, so its cardinality can never exceed the
+    // leaf's entry count; a larger value signals a corrupt bitmap or a double-counted position.
+    assert(cumulativeMdv.cardinality <= oldEntry.record_count,
+      s"leaf ${oldEntry.location}: MDV cardinality ${cumulativeMdv.cardinality} exceeds " +
+        s"record_count ${oldEntry.record_count}.")
+    // A leaf whose every entry is masked by the cumulative MDV holds no live file, so it decays to
+    // DELETED rather than MODIFIED.
+    val allEntriesMasked = cumulativeMdv.cardinality == oldEntry.record_count
+    val status = if (allEntriesMasked) Tracking.Status.Deleted else Tracking.Status.Modified
+    val newTracking = oldEntry.tracking.copy(
+      status = status,
+      deleted_positions = deletedPositions,
+      replaced_positions = None)
+    // manifest_info file/row counts are immutable; only the MDV (dv/dv_cardinality) grows to mask
+    // the newly superseded positions. Live count is record_count - dv_cardinality, and this
+    // commit's CDF positions live on the tracking, not in the counts.
+    val manifestInfo = withUpdatedMdv(oldEntry.manifest_info, cumulativeMdv)
+    (newTracking, manifestInfo)
+  }
+
   /**
    * Writes a single leaf parquet file (DATA entries) and returns the DataManifestEntry
    * corresponding to it.
@@ -309,11 +374,11 @@ object AMTWriteHelper extends DeltaLogging {
       )
     writeAMTParquet(spark, hadoopConf, leafFile, rows)
     val status = fs.getFileStatus(leafFile)
-    val manifestInfo = manifestInfoFor(rows)
+    val (tracking, manifestInfo) = addedTrackingForLeaf(addedFilesCount = rows.size)
     DataManifestEntry(
       location = AMTUtils.relativizeManifestPathToTableRoot(fs, tableRoot, leafFile),
       file_format = AMTSingleAction.FileFormatParquet,
-      tracking = trackingWithStatus(Tracking.Status.Added),
+      tracking = tracking,
       // Number of content entries the referenced leaf manifest holds.
       record_count = manifestInfo.added_files_count.toLong,
       file_size_in_bytes = status.getLen,
@@ -343,21 +408,17 @@ object AMTWriteHelper extends DeltaLogging {
   // Deletion Vector.
   private[amt] def withUpdatedMdv(base: ManifestInfo, mdv: RoaringBitmapArray): ManifestInfo = {
     if (mdv.isEmpty) {
-      base.copy(dv = None, dv_cardinality = None, deleted_files_count = 0)
+      base.copy(dv = None, dv_cardinality = None)
     } else {
       base.copy(
         dv = Some(AMTUtils.serializeMdv(mdv)),
-        dv_cardinality = Some(mdv.cardinality),
-        deleted_files_count = mdv.cardinality.toInt)
+        dv_cardinality = Some(mdv.cardinality))
     }
   }
 
-  /**
-   * Summarizes a leaf's batch into a ManifestInfo.
-   */
-  private def manifestInfoFor(batch: Seq[AMTSingleAction]): ManifestInfo = {
+  private def emptyManifestInfo: ManifestInfo =
     ManifestInfo(
-      added_files_count = batch.size,
+      added_files_count = 0,
       existing_files_count = 0,
       deleted_files_count = 0,
       replaced_files_count = 0,
@@ -369,7 +430,6 @@ object AMTWriteHelper extends DeltaLogging {
       min_sequence_number = 0L,
       dv = None,
       dv_cardinality = None)
-  }
 
   /**
    * Writes a sequence of AMTSingleActions to a Parquet file.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriterManager.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriterManager.scala
@@ -67,12 +67,19 @@ case class SingleAMTWriteMetrics(
 
 case class IncrementalAMTWriteMetrics(
     numIntermediateCommits: Int,
-    numExistingLeavesUpdated: Int,
-    numExistingLeavesUntouched: Int,
+    numOldLeavesUpdated: Int,
+    numOldLeavesUntouched: Int,
     numNewLeaves: Int,
     numRootLiveAdds: Int,
     numRootTombstones: Int,
-    numLeafMdvBitsAdded: Int)
+    numLeafMdvBitsAdded: Int,
+    // Per-status breakdown over all leaf pointers in the new tree (see [[Tracking.Status]]), plus
+    // the stale DELETED tombstones from the previous tree that this rewrite dropped.
+    numLeavesAddedStatus: Int = 0,
+    numLeavesExistingStatus: Int = 0,
+    numLeavesModifiedStatus: Int = 0,
+    numLeavesDeletedStatus: Int = 0,
+    numStaleDeletedLeavesDropped: Int = 0)
 
 /**
  * The outcome of an AMT write for a single commit attempt.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/IncrementalAMTWriter.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/IncrementalAMTWriter.scala
@@ -52,6 +52,21 @@ import org.apache.spark.sql.SparkSession
  *   - The one without backreferences contributes to a tombstone [[DataEntry]] in the new root.
  * - If the root crosses the maxEntriesPerLeaf threshold, live [[DataEntry]]s are spilled to a new
  *   leaf.
+ *
+ * [[DataManifestEntry]] tracking.status state transitions (re-derived on every carry-forward to a
+ * new AMT, from the masking the leaf gains that commit -- prior live status does not matter):
+ * - A new leaf is born ADDED (from spilled live [[DataEntry]]s) or DELETED (from spilled
+ *   tombstones).
+ * - ADDED ->
+ *   - EXISTING -- the next AMT masks nothing new in the leaf (its MDV is unchanged).
+ *   - MODIFIED -- the next AMT masks some, but not all, of its entries.
+ *   - DELETED  -- the next AMT masks its last live entry (cumulative MDV cardinality reaches
+ *     record_count); the pointer becomes a tombstone.
+ * - EXISTING ->
+ *   - EXISTING / MODIFIED / DELETED -- same rule as ADDED, from this commit's masking.
+ * - MODIFIED ->
+ *   - MODIFIED / EXISTING / DELETED -- same rule as ADDED, from this commit's masking.
+ * - DELETED is terminal: the tombstone pointer is emitted once, then dropped from the next AMT.
  */
 class IncrementalAMTWriter(spark: SparkSession, deltaLog: DeltaLog) {
 
@@ -207,16 +222,27 @@ class IncrementalAMTWriter(spark: SparkSession, deltaLog: DeltaLog) {
       checkpoint = checkpoint,
       leaves = allLeafPointers,
       includeActionsInCommitJson = true)
-    val numExistingLeavesUpdated = carriedLeafPointers.count(p =>
+    val numOldLeavesUpdated = carriedLeafPointers.count(p =>
       mdvPositionsByLeaf.getOrElse(p.location, Set.empty[Long]).nonEmpty)
+    // Per-status breakdown over every leaf pointer in the new tree (carried + newly spilled).
+    val leavesByStatus = allLeafPointers.groupBy(_.tracking.status).map {
+      case (status, ps) => status -> ps.size
+    }
+    val numStaleDeletedLeavesDropped =
+      oldAMTCheckpointProvider.leaves.count(_.tracking.status == Tracking.Status.Deleted)
     val incrementalWriteMetrics = IncrementalAMTWriteMetrics(
       numIntermediateCommits = intermediateLogCommits.size,
-      numExistingLeavesUpdated = numExistingLeavesUpdated,
-      numExistingLeavesUntouched = carriedLeafPointers.size - numExistingLeavesUpdated,
+      numOldLeavesUpdated = numOldLeavesUpdated,
+      numOldLeavesUntouched = carriedLeafPointers.size - numOldLeavesUpdated,
       numNewLeaves = spilledLeafPointers.size,
       numRootLiveAdds = rootAdds.size,
       numRootTombstones = tombstoneEntries.size,
-      numLeafMdvBitsAdded = mdvPositionsByLeaf.valuesIterator.map(_.size).sum)
+      numLeafMdvBitsAdded = mdvPositionsByLeaf.valuesIterator.map(_.size).sum,
+      numLeavesAddedStatus = leavesByStatus.getOrElse(Tracking.Status.Added, 0),
+      numLeavesExistingStatus = leavesByStatus.getOrElse(Tracking.Status.Existing, 0),
+      numLeavesModifiedStatus = leavesByStatus.getOrElse(Tracking.Status.Modified, 0),
+      numLeavesDeletedStatus = leavesByStatus.getOrElse(Tracking.Status.Deleted, 0),
+      numStaleDeletedLeavesDropped = numStaleDeletedLeavesDropped)
     val metric = SingleAMTWriteMetrics(
       trigger = trigger,
       // This writer only ever produces an incremental tree.
@@ -227,8 +253,10 @@ class IncrementalAMTWriter(spark: SparkSession, deltaLog: DeltaLog) {
   }
 
   /**
-   * Carries the previous tree's leaf pointers forward. Two independent, differently-scoped updates
-   * are applied to each carried pointer:
+   * Carries the previous tree's leaf pointers forward. Three differently-scoped decisions apply
+   * per pointer:
+   *   - a pointer the previous AMT already marked DELETED is dropped, not carried forward: it was
+   *     kept only to emit that commit's CDF, and re-emitting it here would produce wrong CDF;
    *   - `manifest_info.dv` (MDV, masking) accumulates ALL leaf positions removed since the old AMT
    *     (`mdvRemoves` = window + commit), so the reader hides every entry deleted since the last
    *     full tree; and
@@ -254,31 +282,28 @@ class IncrementalAMTWriter(spark: SparkSession, deltaLog: DeltaLog) {
         .groupBy(_._1).map { case (leaf, pairs) => leaf -> pairs.map(_._2).toSet }
     val mdvPositionsByLeaf = positionsByLeaf(mdvRemoves)
     val cdfPositionsByLeaf = positionsByLeaf(cdfRemoves)
-    val pointers = provider.leaves
-      .map { pointer =>
-        val leafKey = pointer.location
-        val newMdvPositions = mdvPositionsByLeaf.getOrElse(leafKey, Set.empty[Long])
-        val cdfPositions = cdfPositionsByLeaf.getOrElse(leafKey, Set.empty[Long])
-        // Cumulative MDV = old dv + every position removed from this leaf since the old AMT.
-        val manifestInfo =
-          if (newMdvPositions.isEmpty) {
-            pointer.manifest_info
-          } else {
-            val cumulativeDV = pointer.manifest_info.dv
-              .map(AMTUtils.deserializeMdv).getOrElse(new RoaringBitmapArray)
-            newMdvPositions.foreach(cumulativeDV.add)
-            AMTWriteHelper.withUpdatedMdv(pointer.manifest_info, cumulativeDV)
-          }
-        // A carried leaf pointer stays live (ADDED); only deleted_positions conveys CDF. It is
-        // per-commit: reset to THIS commit's removed positions (empty when this commit did not
-        // delete from this leaf), never the old pointer's stale value.
-        val deletedPositions =
-          if (cdfPositions.isEmpty) None
-          else Some(AMTUtils.serializeMdv(RoaringBitmapArray(cdfPositions.toSeq: _*)))
-        val tracking = AMTWriteHelper.addedTracking.copy(deleted_positions = deletedPositions)
-        pointer.copy(manifest_info = manifestInfo, tracking = tracking)
+    val pointers = provider.leaves.flatMap { pointer =>
+      if (pointer.tracking.status == Tracking.Status.Deleted) None
+      else {
+        val newMdvPositions = mdvPositionsByLeaf.getOrElse(pointer.location, Set.empty[Long]).toSeq
+        val cdfPositions = cdfPositionsByLeaf.getOrElse(pointer.location, Set.empty[Long]).toSeq
+        Some(carryForwardOneLeaf(pointer, newMdvPositions, cdfPositions))
       }
+    }
     (pointers, mdvPositionsByLeaf)
+  }
+
+  private def carryForwardOneLeaf(
+      pointer: DataManifestEntry,
+      newMdvPositions: Seq[Long],
+      cdfPositions: Seq[Long]): DataManifestEntry = {
+    val (tracking, manifestInfo) =
+      if (newMdvPositions.isEmpty) {
+        AMTWriteHelper.existingTrackingForLeaf(pointer)
+      } else {
+        AMTWriteHelper.modifiedOrDeletedTrackingForLeaf(pointer, newMdvPositions, cdfPositions)
+      }
+    pointer.copy(manifest_info = manifestInfo, tracking = tracking)
   }
 
   /**

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTBackReferenceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTBackReferenceSuite.scala
@@ -42,7 +42,7 @@ class AMTBackReferenceSuite extends AMTCheckpointTestBase with DeletionVectorsTe
    */
   private def leafLocationByBackRef(snapshot: Snapshot): Map[(String, Long), String] = {
     val provider = amtProvider(snapshot).getOrElse(fail("expected AMTCheckpointProvider"))
-      provider.leafManifestAbsolutePaths.flatMap { leafPath =>
+      provider.liveLeafManifestAbsolutePaths.flatMap { leafPath =>
         val relManifest = relativeManifest(snapshot, leafPath)
         spark.read.parquet(leafPath.toString)
           .where(col("content_type") === AMTSingleAction.ContentType.Type.Data)
@@ -131,7 +131,7 @@ class AMTBackReferenceSuite extends AMTCheckpointTestBase with DeletionVectorsTe
       s"All $leafPackedFiles inserted files must be reconstructed from the leaves, " +
         s"got ${adds.size}.")
 
-    val leafPaths = context.provider.leafManifestAbsolutePaths
+    val leafPaths = context.provider.liveLeafManifestAbsolutePaths
       .map(relativeManifest(context.postCheckpointSnapshot, _)).toSet
     adds.foreach { add =>
       val br = add.backReference.getOrElse(

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointTestBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointTestBase.scala
@@ -467,7 +467,7 @@ trait AMTCheckpointTestBase
   protected def currentLeafDataEntries(snapshot: Snapshot): Long = {
     val provider = amtProvider(snapshot)
       .getOrElse(fail("Snapshot has no AMTCheckpointProvider."))
-      provider.leafManifestAbsolutePaths.map { leafPath =>
+      provider.liveLeafManifestAbsolutePaths.map { leafPath =>
         spark.read.parquet(leafPath.toString)
           .where(col("content_type") === AMTSingleAction.ContentType.Type.Data)
           .count()

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointWriteSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointWriteSuite.scala
@@ -121,14 +121,15 @@ class AMTCheckpointWriteSuite extends AMTCheckpointTestBase {
     }
 
     // The pointers are stored relative on disk; the provider re-absolutizes them via
-    // `leafManifestAbsolutePaths`, and reconstruction driven off the manifest tree (root +
+    // `liveLeafManifestAbsolutePaths`, and reconstruction driven off the manifest tree (root +
     // leaves, both stored relative) surfaces exactly the committed data files.
     val leafLocs = provider.leaves.map(_.location)
     assert(leafLocs.forall(loc =>
       loc == s"${FileNames.AMT_METADATA_DIR_NAME}/${new File(loc).getName}"),
       s"leaf pointer locations must be table-root-relative; got $leafLocs")
-    assert(provider.leafManifestAbsolutePaths.forall(_.isAbsolute),
-      s"resolved leaf manifest paths must be absolute; got ${provider.leafManifestAbsolutePaths}")
+    assert(provider.liveLeafManifestAbsolutePaths.forall(_.isAbsolute),
+      "resolved leaf manifest paths must be absolute; got " +
+        s"${provider.liveLeafManifestAbsolutePaths}")
     assertReconstructsLiveFileSet(context)
     // `setup` writes one file per id, and the trigger adds the last one.
     checkAnswer(spark.table(name), (0 until leafPackedFiles).map(Row(_)))
@@ -165,7 +166,7 @@ class AMTCheckpointWriteSuite extends AMTCheckpointTestBase {
           s"contentRoot.path must be table-root-relative; got $rootPointer")
         // The provider re-absolutizes leaf pointers to paths that live under the spaced root and
         // are not percent-encoded.
-        provider.leafManifestAbsolutePaths.foreach { leafPath =>
+        provider.liveLeafManifestAbsolutePaths.foreach { leafPath =>
           assert(leafPath.isAbsolute && leafPath.toString.contains("amt table with spaces"),
             s"resolved leaf path must live under the spaced table root; got $leafPath")
           assert(!leafPath.toString.contains("%20"),
@@ -233,10 +234,10 @@ class AMTCheckpointWriteSuite extends AMTCheckpointTestBase {
 
       val provider = AMTCheckpointProvider.fromCheckpoint(spark, deltaLog, checkpoint)
       // The provider resolves the spaced pointers to absolute, raw paths under the table root.
-      assert(provider.leafManifestAbsolutePaths.forall(p =>
+      assert(provider.liveLeafManifestAbsolutePaths.forall(p =>
         p.isAbsolute && p.toString.contains("leaf with space.parquet") &&
           !p.toString.contains("%20")),
-        s"resolved leaf paths must stay raw; got ${provider.leafManifestAbsolutePaths}")
+        s"resolved leaf paths must stay raw; got ${provider.liveLeafManifestAbsolutePaths}")
 
       // Reconstruction reads the DATA entry back through the spaced leaf path.
       val reconstructed = provider.loadActionsForStateReconstruction(spark, deltaLog)
@@ -290,8 +291,35 @@ class AMTCheckpointWriteSuite extends AMTCheckpointTestBase {
       s"Expected 21 live files, got ${context.postCheckpointSnapshot.allFiles.count()}.")
     assert(context.provider.leaves.size == 3,
       s"21 files at entriesPerLeaf=7 must pack into 3 leaves; got ${context.provider.leaves.size}.")
-    assert(context.provider.leaves.forall(_.record_count <= 7),
-      s"Every leaf must respect entriesPerLeaf=7: ${context.provider.leaves}")
+  }
+
+  testAcrossAMTCheckpointScenarios(
+      "full rewrite records each distributed leaf's entry count",
+      "amt_leaf_counts",
+      deferredScenarios = Seq(AMTCheckpointScenario.DeferredFull),
+      sqlConfs = leafPackingConfs)(
+      setup = name => appendRowsAsSeparateFiles(name, numRows = leafPackedFiles)) { context =>
+    val leaves = context.provider.leaves
+    assertLeafCount(leaves)
+    val totalLiveFiles = context.postCheckpointSnapshot.allFiles.count()
+    leaves.foreach { leaf =>
+      val mi = leaf.manifest_info
+      // The distributed writer counts the rows it flushes into each leaf and reports that count
+      // as record_count and existing_files_count (the data files already lived in the table, so
+      // they are EXISTING, not ADDED). Both fields were left 0 before this fix.
+      assert(leaf.record_count > 0L,
+        s"A full-rewrite leaf must report a non-zero record_count; got $leaf.")
+      assert(mi.existing_files_count.toLong == leaf.record_count,
+        s"existing_files_count must equal record_count; got $mi vs ${leaf.record_count}.")
+      assert(mi.added_files_count == 0 && mi.deleted_files_count == 0 &&
+        mi.replaced_files_count == 0,
+        s"A fresh full-rewrite leaf counts only existing files; got $mi.")
+    }
+    // Conservation: the per-leaf counts account for every live file (a multi-leaf tree keeps no
+    // root-resident data entries).
+    assert(leaves.map(_.record_count).sum == totalLiveFiles,
+      s"Leaf record_counts must sum to $totalLiveFiles; got ${leaves.map(_.record_count)}.")
+    assertReconstructsLiveFileSet(context)
   }
 
   /** Parses the `delta.commit.stats` [[CommitStats]] logged for `version`, or fails. */

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTIncrementalWriteSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTIncrementalWriteSuite.scala
@@ -100,7 +100,7 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
   }
 
   /** DATA-entry tracking statuses that reconstruct as live files (added/existing). */
-  private val liveTrackingStatuses = Set(Tracking.Status.Existing, Tracking.Status.Added)
+  private val liveDataEntryStatuses = Set(Tracking.Status.Existing, Tracking.Status.Added)
 
   /** DATA-entry tracking statuses that mark a root-resident entry as a CDF tombstone. */
   private val tombstoneTrackingStatuses = Set(Tracking.Status.Deleted, Tracking.Status.Replaced)
@@ -162,7 +162,7 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
       trackingStatusToAddFileCountMap(
         provider.checkpointAction.contentRoot.getAbsolutePath(provider.tableRoot).toString)
     val liveAdds =
-      byStatus.filter { case (status, _) => liveTrackingStatuses.contains(status) }.values.sum
+      byStatus.filter { case (status, _) => liveDataEntryStatuses.contains(status) }.values.sum
     val tombstones = tombstoneTrackingStatuses.toSeq.map(byStatus.getOrElse(_, 0L)).sum
     (liveAdds, tombstones)
   }
@@ -190,8 +190,14 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
       amtDeltaLog: DeltaLog,
       expectedAMTWriteMetrics: IncrementalAMTWriteMetrics,
       expectedNumIntermediateCommits: Option[Int] = None): Unit = {
-    // Snapshot the OLD tree's leaf pointers (location -> MDV cardinality) before the write.
+    // Snapshot the OLD tree's leaf pointers before the write: their MDV cardinality (for the shape
+    // derivation), the full pointers (to assert manifest_info counts stay immutable), and the count
+    // of DELETED tombstone pointers this rewrite is expected to drop.
     val leafToLeafMDVCardinality = leafToLeafMDVCardinalityMap(amtDeltaLog)
+    val oldLeaves = leafPointers(amtDeltaLog.update())
+    val oldDeletedLeafCount = amtProvider(amtDeltaLog.update())
+      .getOrElse(fail("AMT table must be checkpoint-provider-backed."))
+      .leaves.count(_.tracking.status == Tracking.Status.Deleted)
 
     val actualIncrementalAMTWriteMetrics = commitCheckpoint(amtDeltaLog, incremental = true)
       .getOrElse(fail("An incremental checkpoint must log IncrementalAMTWriteMetrics."))
@@ -207,9 +213,34 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
     }
     // 2) Reported metrics match a structural derivation from old-tree -> new-tree on disk.
     assertMetricsMatchTreeDelta(
-      amtDeltaLog, leafToLeafMDVCardinality, actualIncrementalAMTWriteMetrics)
+      amtDeltaLog, leafToLeafMDVCardinality, oldDeletedLeafCount,
+      actualIncrementalAMTWriteMetrics)
     // 3) Differential live set + white-box tree invariants.
     assertLiveAddFilesEquals(baselineDeltaLog, amtDeltaLog)
+    // 4) Carried-forward leaves keep their immutable manifest_info file counts.
+    assertCarriedLeafCountsImmutable(oldLeaves, amtDeltaLog)
+  }
+
+  /**
+   * Carried-forward leaves (present in both the old and new tree by location) keep their
+   * manifest_info file/row counts unchanged -- those counts describe the leaf as written and are
+   * immutable across trees; only the MDV and tracking evolve.
+   */
+  private def assertCarriedLeafCountsImmutable(
+      oldLeaves: Map[String, DataManifestEntry], amtDeltaLog: DeltaLog): Unit = {
+    def fileAndRowCounts(e: DataManifestEntry): (Int, Int, Int, Int, Long, Long, Long, Long) =
+      (e.manifest_info.added_files_count, e.manifest_info.existing_files_count,
+        e.manifest_info.deleted_files_count, e.manifest_info.replaced_files_count,
+        e.manifest_info.added_rows_count, e.manifest_info.existing_rows_count,
+        e.manifest_info.deleted_rows_count, e.manifest_info.replaced_rows_count)
+    val newLeaves = leafPointers(amtDeltaLog.update())
+    oldLeaves.foreach { case (location, oldLeaf) =>
+      newLeaves.get(location).foreach { newLeaf =>
+        assert(fileAndRowCounts(newLeaf) == fileAndRowCounts(oldLeaf),
+          s"Carried leaf $location: manifest_info file/row counts must be immutable; " +
+            s"old=${fileAndRowCounts(oldLeaf)} new=${fileAndRowCounts(newLeaf)}")
+      }
+    }
   }
 
 
@@ -238,6 +269,7 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
   private def assertMetricsMatchTreeDelta(
       amtDeltaLog: DeltaLog,
       oldAMTLeafToMDV: Map[String, Long],
+      oldDeletedLeafCount: Int,
       metrics: IncrementalAMTWriteMetrics): Unit = {
     val newAMTLeafToMDV = leafToLeafMDVCardinalityMap(amtDeltaLog)
     // Materialize the carried leaves once (a lazy key-view would give inconsistent re-traversals).
@@ -251,13 +283,25 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
     val mdvBitsAdded = perLeafBitsAdded.sum
     val (rootLiveAdds, rootTombstones) = liveAddsAndTombstonesCountInRoot(amtDeltaLog)
 
+    // Per-status breakdown over every leaf pointer in the new tree, derived independently of the
+    // writer's self-report; numStaleDeletedLeavesDropped is the old tree's DELETED tombstone count.
+    val newLeafPointers = amtProvider(amtDeltaLog.update())
+      .getOrElse(fail("AMT table must be checkpoint-provider-backed.")).leaves
+    val statusToLeafCountMapping =
+      newLeafPointers.groupBy(_.tracking.status).map { case (s, ps) => s -> ps.size }
+
     val derived = metrics.copy(
-      numExistingLeavesUpdated = updated,
-      numExistingLeavesUntouched = untouched,
+      numOldLeavesUpdated = updated,
+      numOldLeavesUntouched = untouched,
       numNewLeaves = newLeaves,
       numRootLiveAdds = rootLiveAdds.toInt,
       numRootTombstones = rootTombstones.toInt,
-      numLeafMdvBitsAdded = mdvBitsAdded.toInt)
+      numLeafMdvBitsAdded = mdvBitsAdded.toInt,
+      numLeavesAddedStatus = statusToLeafCountMapping.getOrElse(Tracking.Status.Added, 0),
+      numLeavesExistingStatus = statusToLeafCountMapping.getOrElse(Tracking.Status.Existing, 0),
+      numLeavesModifiedStatus = statusToLeafCountMapping.getOrElse(Tracking.Status.Modified, 0),
+      numLeavesDeletedStatus = statusToLeafCountMapping.getOrElse(Tracking.Status.Deleted, 0),
+      numStaleDeletedLeavesDropped = oldDeletedLeafCount)
     assert(metrics == derived,
       s"Reported metrics disagree with the old->new tree delta.\n" +
         s"  reported: $metrics\n  derived:  $derived\n" +
@@ -296,7 +340,7 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
     val statusToCountMap = trackingStatusToAddFileCountMap(rootPath)
     val rootLiveAdds =
       statusToCountMap
-        .filter { case (status, _) => liveTrackingStatuses.contains(status) }.values.sum
+        .filter { case (status, _) => liveDataEntryStatuses.contains(status) }.values.sum
 
     // Leaves: each pointer's MDV must be internally consistent, and the unmasked entries are the
     // leaf's live contribution to the reconstruction.
@@ -354,21 +398,33 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
   }
 
   /** Metrics with fields defaulted to 0; numIntermediateCommits is derived by the assertion. */
+  // scalastyle:off argcount
   private def createIncrementalAMTWriteMetrics(
-      numExistingLeavesUpdated: Int = 0,
-      numExistingLeavesUntouched: Int = 0,
+      numOldLeavesUpdated: Int = 0,
+      numOldLeavesUntouched: Int = 0,
       numNewLeaves: Int = 0,
       numRootLiveAdds: Int = 0,
       numRootTombstones: Int = 0,
-      numLeafMdvBitsAdded: Int = 0): IncrementalAMTWriteMetrics =
+      numLeafMdvBitsAdded: Int = 0,
+      numLeavesAddedStatus: Int = 0,
+      numLeavesExistingStatus: Int = 0,
+      numLeavesModifiedStatus: Int = 0,
+      numLeavesDeletedStatus: Int = 0,
+      numStaleDeletedLeavesDropped: Int = 0): IncrementalAMTWriteMetrics =
     IncrementalAMTWriteMetrics(
       numIntermediateCommits = 0,
-      numExistingLeavesUpdated = numExistingLeavesUpdated,
-      numExistingLeavesUntouched = numExistingLeavesUntouched,
+      numOldLeavesUpdated = numOldLeavesUpdated,
+      numOldLeavesUntouched = numOldLeavesUntouched,
       numNewLeaves = numNewLeaves,
       numRootLiveAdds = numRootLiveAdds,
       numRootTombstones = numRootTombstones,
-      numLeafMdvBitsAdded = numLeafMdvBitsAdded)
+      numLeafMdvBitsAdded = numLeafMdvBitsAdded,
+      numLeavesAddedStatus = numLeavesAddedStatus,
+      numLeavesExistingStatus = numLeavesExistingStatus,
+      numLeavesModifiedStatus = numLeavesModifiedStatus,
+      numLeavesDeletedStatus = numLeavesDeletedStatus,
+      numStaleDeletedLeavesDropped = numStaleDeletedLeavesDropped)
+  // scalastyle:on argcount
 
   /////////////////////////////////////////////////////////////
   // Section-A:                                              //
@@ -390,7 +446,8 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
         commitBoth(baselineDeltaLog, amtDeltaLog, Seq(fakeAdd(25)))
         createIncrementalAMTAndValidate(
           baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-          numExistingLeavesUntouched = 3, numRootLiveAdds = 1))
+          numOldLeavesUntouched = 3, numRootLiveAdds = 1,
+          numLeavesExistingStatus = 3))
       }
     }
   }
@@ -409,7 +466,8 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
         commitBoth(baselineDeltaLog, amtDeltaLog, (25 to 29).map(fakeAdd))
         createIncrementalAMTAndValidate(
           baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-          numExistingLeavesUntouched = 3, numRootLiveAdds = 5))
+          numOldLeavesUntouched = 3, numRootLiveAdds = 5,
+          numLeavesExistingStatus = 3))
       }
     }
   }
@@ -430,9 +488,11 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
         commitBoth(baselineDeltaLog, amtDeltaLog, (25 to 36).map(fakeAdd))
         createIncrementalAMTAndValidate(
           baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-          numExistingLeavesUntouched = 3,
+          numOldLeavesUntouched = 3,
           numNewLeaves = 1,
-          numRootLiveAdds = 4))
+          numRootLiveAdds = 4,
+          numLeavesExistingStatus = 3,
+          numLeavesAddedStatus = 1))
       }
     }
   }
@@ -453,7 +513,8 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
         commitBoth(baselineDeltaLog, amtDeltaLog, Seq(fakeAdd(25), fakeAdd(26), fakeAdd(27)))
         createIncrementalAMTAndValidate(
           baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-          numExistingLeavesUntouched = 3, numNewLeaves = 3, numRootLiveAdds = 0))
+          numOldLeavesUntouched = 3, numNewLeaves = 3, numRootLiveAdds = 0,
+          numLeavesExistingStatus = 3, numLeavesAddedStatus = 3))
       }
     }
   }
@@ -478,9 +539,11 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
         commitBoth(baselineDeltaLog, amtDeltaLog, (25 to 54).map(fakeAdd))
         createIncrementalAMTAndValidate(
           baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-          numExistingLeavesUntouched = 3,
+          numOldLeavesUntouched = 3,
           numNewLeaves = 4,
-          numRootLiveAdds = 0))
+          numRootLiveAdds = 0,
+          numLeavesExistingStatus = 3,
+          numLeavesAddedStatus = 4))
         // Every leaf this write SPILLED holds at most `cap` physical DATA entries, because
         // spillIfNeeded moves whole cap-sized batches. The bootstrap's own leaves are excluded: a
         // clustered full rewrite derives a leaf count from the cap but does not bound each leaf, so
@@ -520,12 +583,14 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
         commitBoth(baselineDeltaLog, amtDeltaLog, Seq(fakeAdd(7)))
         val actual = commitCheckpoint(amtDeltaLog, incremental = true)
           .getOrElse(fail("An incremental checkpoint must log metrics."))
-        assert(actual.numExistingLeavesUntouched == numLeafCountBefore,
+        assert(actual.numOldLeavesUntouched == numLeafCountBefore,
           s"All $numLeafCountBefore carried leaves must be untouched by an append; got " +
-            s"${actual.numExistingLeavesUntouched}.")
+            s"${actual.numOldLeavesUntouched}.")
         assert(actual.numRootLiveAdds + actual.numNewLeaves == 1,
           "The one appended file must land in exactly one place (root or a spilled leaf).")
-        assertMetricsMatchTreeDelta(amtDeltaLog, oldAMTLeafToMDV, actual)
+        // The old tree is a fresh full rewrite, so it carries no DELETED tombstones to drop.
+        assertMetricsMatchTreeDelta(amtDeltaLog, oldAMTLeafToMDV, oldDeletedLeafCount = 0,
+          metrics = actual)
         assertLiveAddFilesEquals(baselineDeltaLog, amtDeltaLog)
       }
     }
@@ -549,7 +614,8 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
         commitBoth(baselineDeltaLog, amtDeltaLog, Seq(fakeAdd(28)))
         createIncrementalAMTAndValidate(
           baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-          numExistingLeavesUntouched = 3, numRootLiveAdds = 4),
+          numOldLeavesUntouched = 3, numRootLiveAdds = 4,
+          numLeavesExistingStatus = 3),
           expectedNumIntermediateCommits = Some(5))
       }
     }
@@ -615,7 +681,8 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
         commitBoth(baselineDeltaLog, amtDeltaLog, (2 to 9).map(fakeAdd))
         createIncrementalAMTAndValidate(
           baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-          numNewLeaves = 1, numRootLiveAdds = 1))
+          numNewLeaves = 1, numRootLiveAdds = 1,
+          numLeavesAddedStatus = 1))
       }
     }
   }
@@ -632,7 +699,8 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
         commitBoth(baselineDeltaLog, amtDeltaLog, (2 to 24).map(fakeAdd))
         createIncrementalAMTAndValidate(
           baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-          numNewLeaves = 3, numRootLiveAdds = 0))
+          numNewLeaves = 3, numRootLiveAdds = 0,
+          numLeavesAddedStatus = 3))
       }
     }
   }
@@ -702,9 +770,11 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
         commitBoth(baselineDeltaLog, amtDeltaLog, Seq(victim.remove))
         createIncrementalAMTAndValidate(
           baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-          numExistingLeavesUpdated = 1,
-          numExistingLeavesUntouched = leafCount - 1,
-          numLeafMdvBitsAdded = 1))
+          numOldLeavesUpdated = 1,
+          numOldLeavesUntouched = leafCount - 1,
+          numLeafMdvBitsAdded = 1,
+          numLeavesModifiedStatus = 1,
+          numLeavesExistingStatus = leafCount - 1))
       }
     }
   }
@@ -724,9 +794,11 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
         commitBoth(baselineDeltaLog, amtDeltaLog, victims.map(_.remove))
         createIncrementalAMTAndValidate(
           baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-          numExistingLeavesUpdated = 2,
-          numExistingLeavesUntouched = untouchedLeaves,
-          numLeafMdvBitsAdded = 2))
+          numOldLeavesUpdated = 2,
+          numOldLeavesUntouched = untouchedLeaves,
+          numLeafMdvBitsAdded = 2,
+          numLeavesModifiedStatus = 2,
+          numLeavesExistingStatus = untouchedLeaves))
       }
     }
   }
@@ -744,9 +816,11 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
         commitBoth(baselineDeltaLog, amtDeltaLog, files.take(2).map(_.remove))
         createIncrementalAMTAndValidate(
           baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-          numExistingLeavesUpdated = 1,
-          numExistingLeavesUntouched = untouchedLeaves,
-          numLeafMdvBitsAdded = 2))
+          numOldLeavesUpdated = 1,
+          numOldLeavesUntouched = untouchedLeaves,
+          numLeafMdvBitsAdded = 2,
+          numLeavesModifiedStatus = 1,
+          numLeavesExistingStatus = untouchedLeaves))
       }
     }
   }
@@ -770,9 +844,11 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
         commitBoth(baselineDeltaLog, amtDeltaLog, Seq(victimFromLeaf2.remove))
         createIncrementalAMTAndValidate(
           baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-          numExistingLeavesUpdated = 2,
-          numExistingLeavesUntouched = byLeaf.size - 2,
-          numLeafMdvBitsAdded = 2))
+          numOldLeavesUpdated = 2,
+          numOldLeavesUntouched = byLeaf.size - 2,
+          numLeafMdvBitsAdded = 2,
+          numLeavesModifiedStatus = 2,
+          numLeavesExistingStatus = byLeaf.size - 2))
       }
     }
   }
@@ -792,17 +868,21 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
         commitBoth(baselineDeltaLog, amtDeltaLog, Seq(victims.head.remove))
         createIncrementalAMTAndValidate(
           baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-          numExistingLeavesUpdated = 1,
-          numExistingLeavesUntouched = untouched,
-          numLeafMdvBitsAdded = 1))
+          numOldLeavesUpdated = 1,
+          numOldLeavesUntouched = untouched,
+          numLeafMdvBitsAdded = 1,
+          numLeavesModifiedStatus = 1,
+          numLeavesExistingStatus = untouched))
         // The second write adds only its own bit; the leaf's cumulative MDV covers both, checked
         // by the live-set baselineDeltaLog.
         commitBoth(baselineDeltaLog, amtDeltaLog, Seq(victims(1).remove))
         createIncrementalAMTAndValidate(
           baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-          numExistingLeavesUpdated = 1,
-          numExistingLeavesUntouched = untouched,
-          numLeafMdvBitsAdded = 1))
+          numOldLeavesUpdated = 1,
+          numOldLeavesUntouched = untouched,
+          numLeafMdvBitsAdded = 1,
+          numLeavesModifiedStatus = 1,
+          numLeavesExistingStatus = untouched))
       }
     }
   }
@@ -833,9 +913,11 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
           commitBoth(baselineDeltaLog, amtDeltaLog, Seq(victim.remove))
           createIncrementalAMTAndValidate(
             baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-            numExistingLeavesUpdated = 1,
-            numExistingLeavesUntouched = byLeaf.size - 1,
-            numLeafMdvBitsAdded = 1))
+            numOldLeavesUpdated = 1,
+            numOldLeavesUntouched = byLeaf.size - 1,
+            numLeafMdvBitsAdded = 1,
+            numLeavesModifiedStatus = 1,
+            numLeavesExistingStatus = byLeaf.size - 1))
         }
       }
     }
@@ -865,9 +947,11 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
         commitBoth(baselineDeltaLog, amtDeltaLog, Seq(victim.remove))
         createIncrementalAMTAndValidate(
           baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-          numExistingLeavesUpdated = 1,
-          numExistingLeavesUntouched = byLeaf.size - 1,
-          numLeafMdvBitsAdded = 1))
+          numOldLeavesUpdated = 1,
+          numOldLeavesUntouched = byLeaf.size - 1,
+          numLeafMdvBitsAdded = 1,
+          numLeavesModifiedStatus = 1,
+          numLeavesExistingStatus = byLeaf.size - 1))
         val after =
           leafFingerprints(amtProvider(amtDeltaLog.update()).getOrElse(fail("expected AMT")))
         assert(after == before,
@@ -888,9 +972,11 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
         commitBoth(baselineDeltaLog, amtDeltaLog, Seq(victimFiles.head.remove))
         createIncrementalAMTAndValidate(
           baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-          numExistingLeavesUpdated = 1,
-          numExistingLeavesUntouched = byLeaf.size - 1,
-          numLeafMdvBitsAdded = 1))
+          numOldLeavesUpdated = 1,
+          numOldLeavesUntouched = byLeaf.size - 1,
+          numLeafMdvBitsAdded = 1,
+          numLeavesModifiedStatus = 1,
+          numLeavesExistingStatus = byLeaf.size - 1))
         val provider = amtProvider(amtDeltaLog.update()).getOrElse(fail("expected AMT"))
         provider.leaves.foreach { leaf =>
           val card = leaf.manifest_info.dv_cardinality.getOrElse(0L)
@@ -904,12 +990,43 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
     }
   }
 
-  test("C9: deleting every leaf-resident file masks every leaf fully, leaving an empty tree") {
+  test("C9: a stale DELETED leaf is dropped by the next incremental rewrite") {
+    withSQLConf(leafPackingConfs: _*) {
+      withTables() { (baselineDeltaLog, amtDeltaLog) =>
+        // First reach the fully-masked state: every leaf carried as a DELETED tombstone.
+        commitBoth(baselineDeltaLog, amtDeltaLog, (1 to leafPackedFiles).map(fakeAdd))
+        commitCheckpoint(amtDeltaLog, incremental = false)
+        val leafCount = leafToAddFileMap(amtDeltaLog).size
+        assert(leafCount >= 2, s"Need a tree-shaped bootstrap; got $leafCount leaves.")
+        commitBoth(baselineDeltaLog, amtDeltaLog,
+          leafToAddFileMap(amtDeltaLog).values.flatten.toSeq.map(_.remove))
+        commitCheckpoint(amtDeltaLog, incremental = true)
+        assert(amtProvider(amtDeltaLog.update()).getOrElse(fail("expected AMT"))
+          .leaves.count(_.tracking.status == Tracking.Status.Deleted) == leafCount,
+          "precondition: the first incremental rewrite must leave DELETED tombstones.")
+
+        // A second bare incremental rewrite carries nothing new, so it must drop the stale DELETED
+        // pointers and report them as numStaleDeletedLeavesDropped, leaving an empty tree.
+        val metrics = commitCheckpoint(amtDeltaLog, incremental = true)
+          .getOrElse(fail("An incremental checkpoint must log metrics."))
+        assert(metrics.numStaleDeletedLeavesDropped == leafCount,
+          s"All $leafCount stale DELETED leaves must be dropped; got " +
+            s"${metrics.numStaleDeletedLeavesDropped}.")
+        assert(amtProvider(amtDeltaLog.update()).getOrElse(fail("expected AMT")).leaves.isEmpty,
+          "The stale DELETED pointers must be gone from the new tree.")
+        assert(livePathsInLatestAMTCheckpoint(amtDeltaLog).isEmpty,
+          "The AMT tree must reconstruct an empty live set.")
+      }
+    }
+  }
+
+  test("C10: deleting every leaf-resident file masks every leaf fully, marking each DELETED") {
     withSQLConf(leafPackingConfs: _*) {
       withTables() { (baselineDeltaLog, amtDeltaLog) =>
         // The extreme end of C1-C3: instead of masking one position on one leaf, mask EVERY
-        // position on EVERY leaf. The leaves must still be carried forward and fully MDV-masked
-        // rather than dropped, and the tree must reconstruct an empty live set off them.
+        // position on EVERY leaf. Each leaf's cumulative MDV then covers all its entries, so the
+        // pointer is carried this commit as a DELETED tombstone (the reader skips it), and the tree
+        // reconstructs an empty live set.
         commitBoth(baselineDeltaLog, amtDeltaLog, (1 to leafPackedFiles).map(fakeAdd))
         commitCheckpoint(amtDeltaLog, incremental = false)
         val byLeaf = leafToAddFileMap(amtDeltaLog)
@@ -918,12 +1035,29 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
         commitBoth(baselineDeltaLog, amtDeltaLog, allLeafFiles.map(_.remove))
         createIncrementalAMTAndValidate(
           baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-          numExistingLeavesUpdated = byLeaf.size,
-          numLeafMdvBitsAdded = allLeafFiles.size))
+          numOldLeavesUpdated = byLeaf.size,
+          numLeafMdvBitsAdded = allLeafFiles.size,
+          numLeavesDeletedStatus = byLeaf.size))
+        // Every carried leaf pointer is now a DELETED tombstone.
+        val statuses = amtProvider(amtDeltaLog.update()).getOrElse(fail("expected AMT"))
+          .leaves.map(_.tracking.status)
+        assert(statuses.forall(_ == Tracking.Status.Deleted) && statuses.size == byLeaf.size,
+          s"Every fully-masked leaf must be DELETED; got $statuses.")
         assert(livePathsInLatestSnapshot(baselineDeltaLog).isEmpty,
           "The baseline table must have no live files.")
         assert(livePathsInLatestAMTCheckpoint(amtDeltaLog).isEmpty,
           "The AMT tree must reconstruct an empty live set.")
+
+        // The next incremental rewrite drops every DELETED tombstone, leaving a fully empty tree:
+        // no leaf pointers, and a root that holds no DATA entries.
+        commitCheckpoint(amtDeltaLog, incremental = true)
+        val provider = amtProvider(amtDeltaLog.update()).getOrElse(fail("expected AMT"))
+        assert(provider.leaves.isEmpty,
+          s"The next rewrite must drop all DELETED leaves; got ${provider.leaves.size}.")
+        assert(liveAddsAndTombstonesCountInRoot(amtDeltaLog) == (0L, 0L),
+          "The new root must hold no DATA entries (no live adds, no tombstones).")
+        assert(livePathsInLatestAMTCheckpoint(amtDeltaLog).isEmpty,
+          "The fully empty tree must reconstruct an empty live set.")
       }
     }
   }
@@ -950,12 +1084,14 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
         commitBoth(baselineDeltaLog, amtDeltaLog, Seq(fakeAdd(leafPackedFiles + 1)))
         createIncrementalAMTAndValidate(
           baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-          numExistingLeavesUntouched = numLeafCountBefore, numRootLiveAdds = 1))
+          numOldLeavesUntouched = numLeafCountBefore, numRootLiveAdds = 1,
+          numLeavesExistingStatus = numLeafCountBefore))
         // Delete id=31 (root-resident): remove has NO backref -> dropped by replay, no MDV bit.
         commitBoth(baselineDeltaLog, amtDeltaLog, Seq(removeOf(amtDeltaLog, leafPackedFiles + 1)))
         createIncrementalAMTAndValidate(
           baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-          numExistingLeavesUntouched = numLeafCountBefore, numLeafMdvBitsAdded = 0))
+          numOldLeavesUntouched = numLeafCountBefore, numLeafMdvBitsAdded = 0,
+          numLeavesExistingStatus = numLeafCountBefore))
       }
     }
   }
@@ -975,7 +1111,8 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
         commitBoth(baselineDeltaLog, amtDeltaLog, Seq(removeOf(amtDeltaLog, leafPackedFiles + 1)))
         createIncrementalAMTAndValidate(
           baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-          numExistingLeavesUntouched = numLeafCountBefore, numLeafMdvBitsAdded = 0))
+          numOldLeavesUntouched = numLeafCountBefore, numLeafMdvBitsAdded = 0,
+          numLeavesExistingStatus = numLeafCountBefore))
       }
     }
   }
@@ -997,10 +1134,12 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
         commitBoth(baselineDeltaLog, amtDeltaLog, Seq(victim))
         createIncrementalAMTAndValidate(
           baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-          numExistingLeavesUpdated = 1,
-          numExistingLeavesUntouched = byLeaf.size - 1,
+          numOldLeavesUpdated = 1,
+          numOldLeavesUntouched = byLeaf.size - 1,
           numRootLiveAdds = 1,
-          numLeafMdvBitsAdded = 1))
+          numLeafMdvBitsAdded = 1,
+          numLeavesModifiedStatus = 1,
+          numLeavesExistingStatus = byLeaf.size - 1))
       }
     }
   }
@@ -1027,9 +1166,11 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
         // derives the bits from the on-disk dv_cardinality delta.
         createIncrementalAMTAndValidate(
           baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-          numExistingLeavesUpdated = 1,
-          numExistingLeavesUntouched = byLeaf.size - 1,
-          numLeafMdvBitsAdded = 1))
+          numOldLeavesUpdated = 1,
+          numOldLeavesUntouched = byLeaf.size - 1,
+          numLeafMdvBitsAdded = 1,
+          numLeavesModifiedStatus = 1,
+          numLeavesExistingStatus = byLeaf.size - 1))
         val maskedLeaf = leafPointers(amtDeltaLog.update()).getOrElse(victimLeaf,
           fail(s"Leaf $victimLeaf must still be carried forward."))
         assert(mdvCardinality(maskedLeaf) == 1L,
@@ -1053,10 +1194,12 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
         commitBoth(baselineDeltaLog, amtDeltaLog, Seq(fakeAdd(leafPackedFiles + 1)))
         createIncrementalAMTAndValidate(
           baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-          numExistingLeavesUpdated = 1,
-          numExistingLeavesUntouched = byLeaf.size - 1,
+          numOldLeavesUpdated = 1,
+          numOldLeavesUntouched = byLeaf.size - 1,
           numRootLiveAdds = 1,
-          numLeafMdvBitsAdded = 1))
+          numLeafMdvBitsAdded = 1,
+          numLeavesModifiedStatus = 1,
+          numLeavesExistingStatus = byLeaf.size - 1))
       }
     }
   }
@@ -1074,7 +1217,9 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
         createIncrementalAMTAndValidate(
           baselineDeltaLog,
           amtDeltaLog,
-          createIncrementalAMTWriteMetrics(numExistingLeavesUntouched = numLeafCountBefore))
+          createIncrementalAMTWriteMetrics(
+            numOldLeavesUntouched = numLeafCountBefore,
+            numLeavesExistingStatus = numLeafCountBefore))
       }
     }
   }
@@ -1100,8 +1245,9 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
           baselineDeltaLog,
           amtDeltaLog,
           createIncrementalAMTWriteMetrics(
-            numExistingLeavesUntouched = numLeafCountBefore,
-            numRootLiveAdds = businessCommits),
+            numOldLeavesUntouched = numLeafCountBefore,
+            numRootLiveAdds = businessCommits,
+            numLeavesExistingStatus = numLeafCountBefore),
           expectedNumIntermediateCommits = Some(businessCommits + 1))
       }
     }
@@ -1147,7 +1293,8 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
         commitBoth(baselineDeltaLog, amtDeltaLog, Seq(fakeAdd(leafPackedFiles + 1)))
         createIncrementalAMTAndValidate(
           baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-          numExistingLeavesUntouched = numLeafCountBefore, numRootLiveAdds = 1))
+          numOldLeavesUntouched = numLeafCountBefore, numRootLiveAdds = 1,
+          numLeavesExistingStatus = numLeafCountBefore))
 
         // incr 2: delete a leaf-resident file -> its leaf gets one MDV bit. numRootLiveAdds is
         // still 1: the file appended by incr 1 must survive as a root-resident live add, which is
@@ -1156,10 +1303,12 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
         commitBoth(baselineDeltaLog, amtDeltaLog, Seq(victim.remove))
         createIncrementalAMTAndValidate(
           baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-          numExistingLeavesUpdated = 1,
-          numExistingLeavesUntouched = numLeafCountBefore - 1,
+          numOldLeavesUpdated = 1,
+          numOldLeavesUntouched = numLeafCountBefore - 1,
           numRootLiveAdds = 1,
-          numLeafMdvBitsAdded = 1))
+          numLeafMdvBitsAdded = 1,
+          numLeavesModifiedStatus = 1,
+          numLeavesExistingStatus = numLeafCountBefore - 1))
 
         // incr 3: append enough files to push the root past the cap, forcing a spill.
         commitBoth(
@@ -1203,10 +1352,12 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
           baselineDeltaLog,
           amtDeltaLog,
           createIncrementalAMTWriteMetrics(
-            numExistingLeavesUpdated = 2,
-            numExistingLeavesUntouched = byLeaf.size - 2,
+            numOldLeavesUpdated = 2,
+            numOldLeavesUntouched = byLeaf.size - 2,
             numRootLiveAdds = 4,
-            numLeafMdvBitsAdded = 2),
+            numLeafMdvBitsAdded = 2,
+            numLeavesModifiedStatus = 2,
+            numLeavesExistingStatus = byLeaf.size - 2),
           expectedNumIntermediateCommits = Some(8))
       }
     }
@@ -1230,7 +1381,8 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
         val lastCommitted = amtDeltaLog.update().version
         createIncrementalAMTAndValidate(
           baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-          numExistingLeavesUntouched = numLeafCountBefore, numRootLiveAdds = 1))
+          numOldLeavesUntouched = numLeafCountBefore, numRootLiveAdds = 1,
+          numLeavesExistingStatus = numLeafCountBefore))
         val provider = amtProvider(amtDeltaLog.update()).getOrElse(fail("expected AMT"))
         // A deferred OPTIMIZE CHECKPOINT (no user actions) describes the last committed version,
         // i.e. attemptVersion - 1.
@@ -1264,18 +1416,200 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
         commitBoth(baselineDeltaLog, amtDeltaLog, Seq(fakeAdd(leafPackedFiles + 1)))
         createIncrementalAMTAndValidate(
           baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-          numExistingLeavesUntouched = numLeafCountBefore, numRootLiveAdds = 1))
+          numOldLeavesUntouched = numLeafCountBefore, numRootLiveAdds = 1,
+          numLeavesExistingStatus = numLeafCountBefore))
         assertCheckpointDescribesVersion(amtDeltaLog, expectedVersion = 3L)
         commitBoth(baselineDeltaLog, amtDeltaLog, Seq(fakeAdd(leafPackedFiles + 2)))
         createIncrementalAMTAndValidate(
           baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-          numExistingLeavesUntouched = numLeafCountBefore, numRootLiveAdds = 2))
+          numOldLeavesUntouched = numLeafCountBefore, numRootLiveAdds = 2,
+          numLeavesExistingStatus = numLeafCountBefore))
         assertCheckpointDescribesVersion(amtDeltaLog, expectedVersion = 5L)
         val marker = amtProvider(amtDeltaLog.update()).getOrElse(fail("expected AMT"))
           .checkpointAction.contentRoot.lastManifestCommitWithFullRewrite
         assert(marker == fullMarker,
           s"Incrementals must carry the full-rewrite marker forward unchanged: " +
             s"full=$fullMarker incr=$marker.")
+      }
+    }
+  }
+
+  /////////////////////////////////////////////////////////////
+  // Section-F:                                              //
+  //     Leaf-pointer tracking.status transition chains      //
+  //      followed across a sequence of incremental rewrites //
+  /////////////////////////////////////////////////////////////
+
+  /** Human-readable [[Tracking.Status]] name, used in transition-failure messages. */
+  private def statusName(status: Int): String = status match {
+    case Tracking.Status.Added => "ADDED"
+    case Tracking.Status.Existing => "EXISTING"
+    case Tracking.Status.Modified => "MODIFIED"
+    case Tracking.Status.Deleted => "DELETED"
+    case Tracking.Status.Replaced => "REPLACED"
+    case other => s"status($other)"
+  }
+
+  /** The leaf pointer's tracking.status at `location`, or None if it is no longer listed. */
+  private def leafStatusAt(amtDeltaLog: DeltaLog, location: String): Option[Int] =
+    amtProvider(amtDeltaLog.update()).getOrElse(fail("expected AMT"))
+      .leaves.find(_.location == location).map(_.tracking.status)
+
+  /** The leaf at `location` must currently carry `expected`; `step` labels the transition edge. */
+  private def assertLeafStatus(
+      amtDeltaLog: DeltaLog, location: String, expected: Int, step: String): Unit = {
+    val actual = leafStatusAt(amtDeltaLog, location)
+    assert(actual.contains(expected),
+      s"$step: leaf $location must be ${statusName(expected)}; " +
+        s"got ${actual.map(statusName).getOrElse("<dropped>")}.")
+  }
+
+  /** The leaf's still-live files (read via back reference), sorted by path. */
+  private def liveLeafFiles(amtDeltaLog: DeltaLog, location: String): Seq[AddFile] =
+    leafToAddFileMap(amtDeltaLog).getOrElse(location, Seq.empty).sortBy(_.path)
+
+  /**
+   * Bootstraps a multi-leaf full AMT ([[leafPackedFiles]] files) and returns the location of its
+   * largest leaf, asserting that leaf starts ADDED. The largest leaf packs at least
+   * `ceil(leafPackedFiles / numLeaves)` files -- headroom to mask across several commits before it
+   * empties. Every transition chain below begins from this freshly written ADDED leaf.
+   */
+  private def bootstrapTargetLeaf(baselineDeltaLog: DeltaLog, amtDeltaLog: DeltaLog): String = {
+    commitBoth(baselineDeltaLog, amtDeltaLog, (1 to leafPackedFiles).map(fakeAdd))
+    commitCheckpoint(amtDeltaLog, incremental = false)
+    val byLeaf = leafToAddFileMap(amtDeltaLog)
+    assert(byLeaf.size >= 2, s"Need a tree-shaped bootstrap; got ${byLeaf.size} leaves.")
+    val target = byLeaf.toSeq.sortBy { case (loc, files) => (-files.size, loc) }.head._1
+    assertLeafStatus(amtDeltaLog, target, Tracking.Status.Added, "bootstrap")
+    target
+  }
+
+  /** Removes `files` from both tables, then lands one incremental AMT checkpoint. */
+  private def removeFilesAndCheckpoint(
+      baselineDeltaLog: DeltaLog, amtDeltaLog: DeltaLog, files: Seq[AddFile]): Unit = {
+    commitBoth(baselineDeltaLog, amtDeltaLog, files.map(_.remove))
+    commitCheckpoint(amtDeltaLog, incremental = true)
+  }
+
+  test("F1: ADDED -> EXISTING (a freshly written leaf carried untouched)") {
+    withSQLConf(leafPackingConfs: _*) {
+      withTables() { (baselineDeltaLog, amtDeltaLog) =>
+        val leaf = bootstrapTargetLeaf(baselineDeltaLog, amtDeltaLog)
+        // A bare incremental rewrite carries the leaf forward with no new masking.
+        commitCheckpoint(amtDeltaLog, incremental = true)
+        assertLeafStatus(amtDeltaLog, leaf, Tracking.Status.Existing, "ADDED -> EXISTING")
+        assertLiveAddFilesEquals(baselineDeltaLog, amtDeltaLog)
+      }
+    }
+  }
+
+  test("F2: ADDED -> DELETED -> removed (fully masked, then dropped)") {
+    withSQLConf(leafPackingConfs: _*) {
+      withTables() { (baselineDeltaLog, amtDeltaLog) =>
+        val leaf = bootstrapTargetLeaf(baselineDeltaLog, amtDeltaLog)
+        // Mask every entry of the leaf: its cumulative MDV covers the whole leaf -> DELETED.
+        removeFilesAndCheckpoint(baselineDeltaLog, amtDeltaLog, liveLeafFiles(amtDeltaLog, leaf))
+        assertLeafStatus(amtDeltaLog, leaf, Tracking.Status.Deleted, "ADDED -> DELETED")
+        // The next rewrite drops the stale DELETED tombstone.
+        commitCheckpoint(amtDeltaLog, incremental = true)
+        assert(leafStatusAt(amtDeltaLog, leaf).isEmpty,
+          s"DELETED -> removed: leaf $leaf must be dropped by the next rewrite.")
+        assertLiveAddFilesEquals(baselineDeltaLog, amtDeltaLog)
+      }
+    }
+  }
+
+  test("F3: ADDED -> MODIFIED (a freshly written leaf partially masked)") {
+    withSQLConf(leafPackingConfs: _*) {
+      withTables() { (baselineDeltaLog, amtDeltaLog) =>
+        val leaf = bootstrapTargetLeaf(baselineDeltaLog, amtDeltaLog)
+        // Mask one entry: some live, some masked -> MODIFIED.
+        removeFilesAndCheckpoint(
+          baselineDeltaLog, amtDeltaLog, Seq(liveLeafFiles(amtDeltaLog, leaf).head))
+        assertLeafStatus(amtDeltaLog, leaf, Tracking.Status.Modified, "ADDED -> MODIFIED")
+        assertLiveAddFilesEquals(baselineDeltaLog, amtDeltaLog)
+      }
+    }
+  }
+
+  test("F4: ADDED -> EXISTING -> EXISTING (carried untouched twice)") {
+    withSQLConf(leafPackingConfs: _*) {
+      withTables() { (baselineDeltaLog, amtDeltaLog) =>
+        val leaf = bootstrapTargetLeaf(baselineDeltaLog, amtDeltaLog)
+        commitCheckpoint(amtDeltaLog, incremental = true)
+        assertLeafStatus(amtDeltaLog, leaf, Tracking.Status.Existing, "ADDED -> EXISTING")
+        commitCheckpoint(amtDeltaLog, incremental = true)
+        assertLeafStatus(amtDeltaLog, leaf, Tracking.Status.Existing, "EXISTING -> EXISTING")
+        assertLiveAddFilesEquals(baselineDeltaLog, amtDeltaLog)
+      }
+    }
+  }
+
+  test("F5: ADDED -> EXISTING -> DELETED -> removed") {
+    withSQLConf(leafPackingConfs: _*) {
+      withTables() { (baselineDeltaLog, amtDeltaLog) =>
+        val leaf = bootstrapTargetLeaf(baselineDeltaLog, amtDeltaLog)
+        commitCheckpoint(amtDeltaLog, incremental = true)
+        assertLeafStatus(amtDeltaLog, leaf, Tracking.Status.Existing, "ADDED -> EXISTING")
+        // Mask every entry of the carried leaf -> DELETED.
+        removeFilesAndCheckpoint(baselineDeltaLog, amtDeltaLog, liveLeafFiles(amtDeltaLog, leaf))
+        assertLeafStatus(amtDeltaLog, leaf, Tracking.Status.Deleted, "EXISTING -> DELETED")
+        commitCheckpoint(amtDeltaLog, incremental = true)
+        assert(leafStatusAt(amtDeltaLog, leaf).isEmpty,
+          s"DELETED -> removed: leaf $leaf must be dropped by the next rewrite.")
+        assertLiveAddFilesEquals(baselineDeltaLog, amtDeltaLog)
+      }
+    }
+  }
+
+  test("F6: ADDED -> EXISTING -> MODIFIED -> EXISTING") {
+    withSQLConf(leafPackingConfs: _*) {
+      withTables() { (baselineDeltaLog, amtDeltaLog) =>
+        val leaf = bootstrapTargetLeaf(baselineDeltaLog, amtDeltaLog)
+        commitCheckpoint(amtDeltaLog, incremental = true)
+        assertLeafStatus(amtDeltaLog, leaf, Tracking.Status.Existing, "ADDED -> EXISTING")
+        removeFilesAndCheckpoint(
+          baselineDeltaLog, amtDeltaLog, Seq(liveLeafFiles(amtDeltaLog, leaf).head))
+        assertLeafStatus(amtDeltaLog, leaf, Tracking.Status.Modified, "EXISTING -> MODIFIED")
+        // A carried leaf whose MDV does not grow this commit falls back to EXISTING.
+        commitCheckpoint(amtDeltaLog, incremental = true)
+        assertLeafStatus(amtDeltaLog, leaf, Tracking.Status.Existing, "MODIFIED -> EXISTING")
+        assertLiveAddFilesEquals(baselineDeltaLog, amtDeltaLog)
+      }
+    }
+  }
+
+  test("F7: ADDED -> EXISTING -> MODIFIED -> MODIFIED") {
+    withSQLConf(leafPackingConfs: _*) {
+      withTables() { (baselineDeltaLog, amtDeltaLog) =>
+        val leaf = bootstrapTargetLeaf(baselineDeltaLog, amtDeltaLog)
+        commitCheckpoint(amtDeltaLog, incremental = true)
+        assertLeafStatus(amtDeltaLog, leaf, Tracking.Status.Existing, "ADDED -> EXISTING")
+        removeFilesAndCheckpoint(
+          baselineDeltaLog, amtDeltaLog, Seq(liveLeafFiles(amtDeltaLog, leaf).head))
+        assertLeafStatus(amtDeltaLog, leaf, Tracking.Status.Modified, "EXISTING -> MODIFIED")
+        // Mask one more still-live entry: the MDV grows again but some entries remain live.
+        removeFilesAndCheckpoint(
+          baselineDeltaLog, amtDeltaLog, Seq(liveLeafFiles(amtDeltaLog, leaf).head))
+        assertLeafStatus(amtDeltaLog, leaf, Tracking.Status.Modified, "MODIFIED -> MODIFIED")
+        assertLiveAddFilesEquals(baselineDeltaLog, amtDeltaLog)
+      }
+    }
+  }
+
+  test("F8: ADDED -> EXISTING -> MODIFIED -> DELETED") {
+    withSQLConf(leafPackingConfs: _*) {
+      withTables() { (baselineDeltaLog, amtDeltaLog) =>
+        val leaf = bootstrapTargetLeaf(baselineDeltaLog, amtDeltaLog)
+        commitCheckpoint(amtDeltaLog, incremental = true)
+        assertLeafStatus(amtDeltaLog, leaf, Tracking.Status.Existing, "ADDED -> EXISTING")
+        removeFilesAndCheckpoint(
+          baselineDeltaLog, amtDeltaLog, Seq(liveLeafFiles(amtDeltaLog, leaf).head))
+        assertLeafStatus(amtDeltaLog, leaf, Tracking.Status.Modified, "EXISTING -> MODIFIED")
+        // Mask every remaining live entry: the cumulative MDV now covers the whole leaf -> DELETED.
+        removeFilesAndCheckpoint(baselineDeltaLog, amtDeltaLog, liveLeafFiles(amtDeltaLog, leaf))
+        assertLeafStatus(amtDeltaLog, leaf, Tracking.Status.Deleted, "MODIFIED -> DELETED")
+        assertLiveAddFilesEquals(baselineDeltaLog, amtDeltaLog)
       }
     }
   }


### PR DESCRIPTION
## Description

Fixes the `tracking.status` stamped on `DataManifestEntry` leaf pointers across the incremental and
full manifest-tree checkpoint write paths, so a carried-forward leaf pointer reflects its correct
lifecycle status instead of always being marked ADDED.

- A carried-forward leaf pointer's `tracking.status` is re-derived each write from the masking the
  leaf gains that commit: EXISTING when nothing new is masked, MODIFIED when some of its entries are
  masked, and DELETED when its last live entry is masked. A DELETED pointer is emitted once and then
  dropped from the next tree.
- The reader treats MODIFIED as a live leaf-pointer status and reconstructs live leaves via an
  allow-list of live statuses.
- `manifest_info` file/row counts are immutable across carried-forward trees; masking is tracked
  only by the manifest deletion vector, not by recomputing the counts.

## How was this patch tested?

Unit tests for the leaf-pointer tracking constructors (`AMTLeafTrackingStatusSuite`) plus end-to-end
coverage in `AMTIncrementalWriteSuite` / `AMTCheckpointWriteSuite` (per-status transitions across
checkpoints, an independent old-tree-vs-new-tree delta derivation, and the immutable-count invariant).

## Does this PR introduce _any_ user-facing changes?

No.
