### PR TITLE
[UniForm] Round timestamp upper_bounds up to the end of the millisecond

### DIFF
--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergStatsConverter.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergStatsConverter.scala
@@ -61,10 +61,10 @@ case class IcebergStatsConverter(statsRow: InternalRow, statsSchema: StructType)
   }
 
   val lowerBoundsStat: Option[Map[Integer, ByteBuffer]] =
-    getByteBufferBackedColStats(DeltaStatistics.MIN)
+    getByteBufferBackedColStats(DeltaStatistics.MIN, isUpperBound = false)
 
   val upperBoundsStat: Option[Map[Integer, ByteBuffer]] =
-    getByteBufferBackedColStats(DeltaStatistics.MAX)
+    getByteBufferBackedColStats(DeltaStatistics.MAX, isUpperBound = true)
 
   val nullValueCountsStat: Option[Map[Integer, JLong]] =
     statsSchema.getFieldIndex(DeltaStatistics.NULL_COUNT) match {
@@ -89,11 +89,14 @@ case class IcebergStatsConverter(statsRow: InternalRow, statsSchema: StructType)
    * @param stats An internal row holding the `ByteBuffer`-based Delta column stats
    *              (i.e. lower bound).
    * @param statsSchema The schema of the `stats` internal row.
+   * @param isUpperBound Whether `stats` holds MAX statistics, which need adjusting for
+   *                     timestamp columns (see the timestamp case below).
    * @return Iceberg's ByteBuffer-backed metric representation.
    */
   private def generateIcebergByteBufferMetricMap(
       stats: InternalRow,
-      statsSchema: StructType): Map[Integer, ByteBuffer] = {
+      statsSchema: StructType,
+      isUpperBound: Boolean): Map[Integer, ByteBuffer] = {
     // If the entire Delta stats struct is missing (for example, min or max values are missing for
     // all columns), then the stats row may be null.
     if (stats == null) return Map.empty
@@ -114,11 +117,23 @@ case class IcebergStatsConverter(statsRow: InternalRow, statsSchema: StructType)
           Map[Integer, ByteBuffer](Integer.valueOf(DeltaColumnMapping.getColumnId(field)) ->
             variantBytes)
         case st: StructType =>
-          generateIcebergByteBufferMetricMap(stats.getStruct(idx, st.fields.length), st)
+          generateIcebergByteBufferMetricMap(stats.getStruct(idx, st.fields.length), st,
+            isUpperBound)
         // Ignore the Delta statistic if the conversion doesn't support the given data type or the
         // column ID for this field is missing.
         case dt if !DeltaColumnMapping.hasColumnId(field) ||
             !IcebergStatsConverter.isMinMaxStatTypeSupported(dt) => Map[Integer, ByteBuffer]().empty
+        // Delta's JSON stats serialization truncates timestamps down to millisecond precision
+        // (see PROTOCOL.md, "Per-file Statistics"). Delta readers compensate by adding 1ms when
+        // reading MAX stats (DataSkippingReader.getAdjustedTimestamp), but Iceberg upper bounds
+        // are required to be inclusive, so the truncation must be undone here instead: advance
+        // the value to the last microsecond of its millisecond, so the bound stays >= every
+        // value in the file. Lower bounds need no adjustment (truncating down keeps them valid).
+        case ts @ (_: TimestampType | _: TimestampNTZType) if isUpperBound =>
+          val micros = stats.getLong(idx)
+          val adjusted = if (micros > Long.MaxValue - 999L) Long.MaxValue else micros + 999L
+          Map[Integer, ByteBuffer](Integer.valueOf(DeltaColumnMapping.getColumnId(field)) ->
+            Conversions.toByteBuffer(IcebergSchemaUtils.convertAtomic(ts), JLong.valueOf(adjusted)))
         case b: ByteType =>
           // Iceberg stores bytes using integers.
           val statVal = stats.getByte(idx).toInt
@@ -185,16 +200,20 @@ case class IcebergStatsConverter(statsRow: InternalRow, statsSchema: StructType)
   /**
    * @param statName The name of the Delta stat that is being converted. Must be one of the field
    *                 names in the `DeltaStatistics` object.
+   * @param isUpperBound Whether `statName` refers to MAX statistics.
    * @return An option holding Iceberg's statistic representation. Returns `None` if the output
    *         would otherwise be empty.
    */
-  private def getByteBufferBackedColStats(statName: String): Option[Map[Integer, ByteBuffer]] = {
+  private def getByteBufferBackedColStats(
+      statName: String,
+      isUpperBound: Boolean): Option[Map[Integer, ByteBuffer]] = {
     statsSchema.getFieldIndex(statName) match {
       case Some(statFieldIdx) =>
         val colStatSchema = statsSchema.fields(statFieldIdx).dataType.asInstanceOf[StructType]
         val icebergMetricsMap = generateIcebergByteBufferMetricMap(
           statsRow.getStruct(statFieldIdx, colStatSchema.fields.length),
-          colStatSchema
+          colStatSchema,
+          isUpperBound
         )
         if (icebergMetricsMap.nonEmpty) {
           Some(icebergMetricsMap)


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (UniForm / delta-iceberg)

## Description

Resolves #7444.

Delta stats JSON stores timestamp MAX truncated down to milliseconds (PROTOCOL.md, "Per-file Statistics"). Delta readers compensate by adding 1ms to MAX stats on the read path (`DataSkippingReader.getAdjustedTimestamp`, Kernel `StatsSchemaHelper.getMaxColumn`), but the UniForm conversion copied the truncated value verbatim into Iceberg `upper_bounds`, which the Iceberg spec defines as inclusive (>= the actual column max). Files end up with an upper bound up to 999µs below their true max, and bounds-pruning readers (Iceberg Spark/Java, Trino, DuckDB, pyiceberg) silently skip them for predicates in the file's last millisecond — see the issue for a production case (watermark-based incremental consumer permanently lost rows).

This PR advances the converted MAX for `TimestampType`/`TimestampNTZType` to the last microsecond of its millisecond (+999µs, saturating at `Long.MaxValue`). If a stats value ever carries exact microseconds the bound becomes slightly loose, never invalid. MIN is unchanged: truncating down keeps a lower bound valid.

## How was this patch tested?

Existing suites. I didn't find a unit suite covering `IcebergStatsConverter` — happy to add one if you point me to the preferred location.

The failure itself was verified against real UniForm metadata: parquet footer max `2026-08-10 20:04:53.080758` vs Iceberg upper bound `2026-08-10 20:04:53.080000`; equality/range predicates in that last millisecond return 0 rows through Iceberg readers, and return the rows again once the bound is corrected.

## Does this PR introduce _any_ user-facing changes?

No. Iceberg metadata generated after this change carries correct (inclusive) timestamp upper bounds.
