### PR TITLE
[Flink] Introduce versioned artifacts across Flink lines

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,7 +39,7 @@ jobs:
           key: delta-sbt-cache-cross-spark-${{ hashFiles('project/scripts/setup_unitycatalog_main.sh') }}
 
       # publishM2 compiles every aggregated project, including storage, which has
-      # unitycatalog-client as a compile-scope dependency. test_cross_spark_publish.py also
+      # unitycatalog-client as a compile-scope dependency. test_published_artifacts.py also
       # iterates over released Spark versions (sbt -DsparkVersion=<X.Y>), so we need UC's
       # spark connector published for each variant Delta will resolve. Discover the version list
       # at runtime from project/spark-versions.json (same source the matrix workflows use) and
@@ -54,8 +54,8 @@ jobs:
             echo "::endgroup::"
           done
 
-      - name: Run cross-Spark build test
-        run: python project/tests/test_cross_spark_publish.py
+      - name: Test published artifacts
+        run: python project/tests/test_published_artifacts.py
 
       - name: Save SBT cache
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'

--- a/.github/workflows/flink_test.yaml
+++ b/.github/workflows/flink_test.yaml
@@ -6,6 +6,8 @@ on:
     paths:
       - 'flink/**'
       - 'kernel/**'
+      - 'build.sbt'
+      - '.github/workflows/flink_test.yaml'
       - '!**/*.md'
       - '!**/*.txt'
   pull_request:
@@ -13,6 +15,8 @@ on:
     paths:
       - 'flink/**'
       - 'kernel/**'
+      - 'build.sbt'
+      - '.github/workflows/flink_test.yaml'
       - '!**/*.md'
       - '!**/*.txt'
 
@@ -27,8 +31,16 @@ env:
 
 jobs:
   test:
-    name: "DF"
+    name: "DF: Flink ${{ matrix.flink }}"
     runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        flink:
+          - "2.0.2"
+          - "2.1.3"
+          - "2.2.1"
+          - "2.3.0"
     steps:
       - name: Show runner specs
         run: |
@@ -56,7 +68,7 @@ jobs:
             ~/.sbt
             ~/.ivy2
             ~/.cache/coursier
-          key: sbt-flink
+          key: sbt-flink-${{ matrix.flink }}
       - name: Check cache status
         run: |
           if [ "${{ steps.cache-sbt.outputs.cache-hit }}" == "true" ]; then
@@ -70,7 +82,7 @@ jobs:
         uses: ./.github/actions/setup-unitycatalog
       - name: Run unit tests
         run: |
-          build/sbt flinkGroup/test
+          build/sbt -DflinkVersion=${{ matrix.flink }} flinkGroup/test
       - name: Save SBT cache
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
@@ -79,4 +91,4 @@ jobs:
             ~/.sbt
             ~/.ivy2
             ~/.cache/coursier
-          key: sbt-flink
+          key: sbt-flink-${{ matrix.flink }}

--- a/.github/workflows/flink_test.yaml
+++ b/.github/workflows/flink_test.yaml
@@ -7,6 +7,7 @@ on:
       - 'flink/**'
       - 'kernel/**'
       - 'build.sbt'
+      - 'project/CrossFlinkVersions.scala'
       - '.github/workflows/flink_test.yaml'
       - '!**/*.md'
       - '!**/*.txt'
@@ -16,6 +17,7 @@ on:
       - 'flink/**'
       - 'kernel/**'
       - 'build.sbt'
+      - 'project/CrossFlinkVersions.scala'
       - '.github/workflows/flink_test.yaml'
       - '!**/*.md'
       - '!**/*.txt'
@@ -38,9 +40,6 @@ jobs:
       matrix:
         flink:
           - "2.0.2"
-          - "2.1.3"
-          - "2.2.1"
-          - "2.3.0"
     steps:
       - name: Show runner specs
         run: |
@@ -83,6 +82,14 @@ jobs:
       - name: Run unit tests
         run: |
           build/sbt -DflinkVersion=${{ matrix.flink }} flinkGroup/test
+      - name: Verify published Maven artifact
+        run: |
+          flink_line="${{ matrix.flink }}"
+          flink_line="${flink_line%.*}"
+          delta_version="$(sed -n 's/.*"\(.*\)".*/\1/p' version.sbt)"
+          build/sbt -DflinkVersion=${{ matrix.flink }} flink/publishM2
+          artifact="$HOME/.m2/repository/io/delta/delta-flink_${flink_line}/${delta_version}"
+          test -f "$artifact/delta-flink_${flink_line}-${delta_version}.jar"
       - name: Save SBT cache
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0

--- a/.github/workflows/flink_test.yaml
+++ b/.github/workflows/flink_test.yaml
@@ -32,14 +32,34 @@ env:
   SBT_OPTS: "-Dsbt.coursier.home-dir=/home/runner/.cache/coursier -Dsbt.ivy.home=/home/runner/.ivy2"
 
 jobs:
+  generate-matrix:
+    name: "Generate Flink versions matrix"
+    runs-on: ubuntu-24.04
+    outputs:
+      flink-versions: ${{ steps.versions.outputs.flink-versions }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - name: Install Java
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
+        with:
+          distribution: "zulu"
+          java-version: "17"
+      - name: Generate matrix
+        id: versions
+        run: |
+          build/sbt exportFlinkVersionsJson
+          versions="$(jq -c '[.[].fullVersion]' target/flink-versions.json)"
+          echo "flink-versions=$versions" >> "$GITHUB_OUTPUT"
+
   test:
     name: "DF: Flink ${{ matrix.flink }}"
+    needs: generate-matrix
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
-        flink:
-          - "2.0.2"
+        flink: ${{ fromJson(needs.generate-matrix.outputs.flink-versions) }}
     steps:
       - name: Show runner specs
         run: |

--- a/build.sbt
+++ b/build.sbt
@@ -64,7 +64,7 @@ val scalaTestVersionForConnectors = "3.0.8"
 val parquet4sVersion = "1.9.4"
 val protoVersion = "3.25.1"
 val grpcVersion = "1.62.2"
-val flinkVersion = "2.0.1"
+val flinkVersion = sys.props.getOrElse("flinkVersion", "2.3.0")
 val gcsConnectorVersion = "4.0.4"
 
 // Optional kernel version override. See `project/KernelVersion.scala` for the

--- a/build.sbt
+++ b/build.sbt
@@ -64,7 +64,9 @@ val scalaTestVersionForConnectors = "3.0.8"
 val parquet4sVersion = "1.9.4"
 val protoVersion = "3.25.1"
 val grpcVersion = "1.62.2"
-val flinkVersion = sys.props.getOrElse("flinkVersion", "2.3.0")
+val flinkVersion = FlinkVersionSpec.selectedVersion
+// Publish one artifact per compatible Flink minor line, for example delta-flink_2.0.
+val flinkCompatibilityVersion = FlinkVersionSpec.compatibilityVersion(flinkVersion)
 val gcsConnectorVersion = "4.0.4"
 
 // Optional kernel version override. See `project/KernelVersion.scala` for the
@@ -1636,12 +1638,13 @@ lazy val flink = (project in file("flink"))
   .dependsOn(kernelUnityCatalog)
   .settings(
     name := "delta-flink",
+    moduleName := s"delta-flink_$flinkCompatibilityVersion",
     commonSettings,
     releaseSettings,
     javafmtCheckSettings(),
     publishArtifact := scalaBinaryVersion.value == "2.13", // only publish once
     autoScalaLibrary := false, // exclude scala-library from dependencies
-    assembly / assemblyJarName := s"delta-flink-$flinkVersion-${version.value}.jar",
+    assembly / assemblyJarName := s"${moduleName.value}-${version.value}.jar",
     assembly / assemblyMergeStrategy := {
       // Discard module-info.class files from Java 9+ modules and multi-release JARs
       case "module-info.class" => MergeStrategy.discard
@@ -1946,7 +1949,8 @@ releaseProcess := Seq[ReleaseStep](
   setReleaseVersion,
   commitReleaseVersion,
   tagRelease
-) ++ CrossSparkVersions.crossSparkReleaseSteps("publishSigned") ++ Seq[ReleaseStep](
+) ++ CrossSparkVersions.crossSparkReleaseSteps("publishSigned") ++
+  CrossFlinkVersions.crossFlinkReleaseSteps("publishSigned") ++ Seq[ReleaseStep](
 
   // Do NOT use `sonatypeBundleRelease` - it will actually release to Maven! We want to do that
   // manually.

--- a/build.sbt
+++ b/build.sbt
@@ -65,8 +65,6 @@ val parquet4sVersion = "1.9.4"
 val protoVersion = "3.25.1"
 val grpcVersion = "1.62.2"
 val flinkVersion = FlinkVersionSpec.selectedVersion
-// Publish one artifact per compatible Flink minor line, for example delta-flink_2.0.
-val flinkCompatibilityVersion = FlinkVersionSpec.compatibilityVersion(flinkVersion)
 val gcsConnectorVersion = "4.0.4"
 
 // Optional kernel version override. See `project/KernelVersion.scala` for the
@@ -1638,7 +1636,8 @@ lazy val flink = (project in file("flink"))
   .dependsOn(kernelUnityCatalog)
   .settings(
     name := "delta-flink",
-    moduleName := s"delta-flink_$flinkCompatibilityVersion",
+    // Publish one artifact per compatible Flink minor line, for example delta-flink_2.0.
+    moduleName := s"delta-flink_${FlinkVersionSpec.compatibilityVersion(flinkVersion)}",
     commonSettings,
     releaseSettings,
     javafmtCheckSettings(),

--- a/build.sbt
+++ b/build.sbt
@@ -64,7 +64,7 @@ val scalaTestVersionForConnectors = "3.0.8"
 val parquet4sVersion = "1.9.4"
 val protoVersion = "3.25.1"
 val grpcVersion = "1.62.2"
-val flinkVersion = FlinkVersionSpec.selectedVersion
+val flinkVersion = CrossFlinkVersions.selectedVersion
 val gcsConnectorVersion = "4.0.4"
 
 // Optional kernel version override. See `project/KernelVersion.scala` for the
@@ -1637,7 +1637,7 @@ lazy val flink = (project in file("flink"))
   .settings(
     name := "delta-flink",
     // Publish one artifact per compatible Flink minor line, for example delta-flink_2.0.
-    moduleName := s"delta-flink_${FlinkVersionSpec.compatibilityVersion(flinkVersion)}",
+    moduleName := s"delta-flink_${CrossFlinkVersions.compatibilityVersion(flinkVersion)}",
     commonSettings,
     releaseSettings,
     javafmtCheckSettings(),

--- a/flink/README.md
+++ b/flink/README.md
@@ -19,7 +19,7 @@ The default build uses Flink 2.0.2. To test another Flink version during develop
 `flinkVersion` on the command line:
 
 ```bash
-sbt -DflinkVersion=2.0.2 flink/test
+build/sbt -DflinkVersion=2.0.2 flink/test
 ```
 
 ### Connector Overview

--- a/flink/README.md
+++ b/flink/README.md
@@ -13,13 +13,13 @@ Delta tests the latest patch release from each supported Flink minor line:
 
 | Flink line | Tested version |
 |------------|----------------|
-| 2.0        | 2.0.2          |
+| 2.3        | 2.3.0          |
 
-The default build uses Flink 2.0.2. To test another Flink version during development, set
+The default build uses Flink 2.3.0. To select a supported Flink version during development, set
 `flinkVersion` on the command line:
 
 ```bash
-build/sbt -DflinkVersion=2.0.2 flink/test
+build/sbt -DflinkVersion=2.3.0 flink/test
 ```
 
 ### Connector Overview

--- a/flink/README.md
+++ b/flink/README.md
@@ -14,11 +14,8 @@ Delta tests the latest patch release from each supported Flink minor line:
 | Flink line | Tested version |
 |------------|----------------|
 | 2.0        | 2.0.2          |
-| 2.1        | 2.1.3          |
-| 2.2        | 2.2.1          |
-| 2.3        | 2.3.0          |
 
-The default build uses Flink 2.3.0. To build and test another supported version, set
+The default build uses Flink 2.0.2. To test another Flink version during development, set
 `flinkVersion` on the command line:
 
 ```bash
@@ -60,7 +57,7 @@ sbt flink/assembly
 #### Build Output
 
 After a successful build:
-- An **assembly JAR** will be generated
+- An assembly JAR named `delta-flink_<flink_line>-<delta_version>.jar` will be generated
 - The JAR already contains **Delta Kernel**
 - The JAR must be made available to Flink (see quick start below)
 
@@ -97,7 +94,7 @@ This repository includes a local Flink environment for quick testing via Docker 
 
    We provide two Flink version under `docker`
    ```bash
-   cp flink/target/delta-flink-<flink_version>-*.jar flink/docker/<flink_version>/usrlib
+   cp flink/target/delta-flink_<flink_line>-*.jar flink/docker/<flink_version>/usrlib
    ```
 3. **(Only the first time) Download Additional Jars**
    ```bash

--- a/flink/README.md
+++ b/flink/README.md
@@ -8,7 +8,22 @@ Note: this is a private build right now. Suggestions and feedbacks are welcome.
 ```
 
 ### Supported Flink Versions
-- **Flink v2.0**
+
+Delta tests the latest patch release from each supported Flink minor line:
+
+| Flink line | Tested version |
+|------------|----------------|
+| 2.0        | 2.0.2          |
+| 2.1        | 2.1.3          |
+| 2.2        | 2.2.1          |
+| 2.3        | 2.3.0          |
+
+The default build uses Flink 2.3.0. To build and test another supported version, set
+`flinkVersion` on the command line:
+
+```bash
+sbt -DflinkVersion=2.0.2 flink/test
+```
 
 ### Connector Overview
 - Built on **Flink Connector V2 API**

--- a/flink/README.md
+++ b/flink/README.md
@@ -13,6 +13,9 @@ Delta tests the latest patch release from each supported Flink minor line:
 
 | Flink line | Tested version |
 |------------|----------------|
+| 2.0        | 2.0.2          |
+| 2.1        | 2.1.3          |
+| 2.2        | 2.2.1          |
 | 2.3        | 2.3.0          |
 
 The default build uses Flink 2.3.0. To select a supported Flink version during development, set

--- a/project/CrossFlinkVersions.scala
+++ b/project/CrossFlinkVersions.scala
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
+import java.io.{File, PrintWriter}
+
 import sbt._
+import sbt.Keys._
 import sbtrelease.ReleasePlugin.autoImport.ReleaseStep
 
 object FlinkVersionSpec {
@@ -30,12 +33,16 @@ object FlinkVersionSpec {
 
   def compatibilityVersion(fullVersion: String): String = {
     val parts = fullVersion.split("\\.")
-    require(parts.length >= 2, s"Flink version must contain a major and minor version: $fullVersion")
+    require(
+      parts.length >= 2,
+      s"Flink version must contain a major and minor version: $fullVersion")
     parts.take(2).mkString(".")
   }
 }
 
-object CrossFlinkVersions {
+object CrossFlinkVersions extends AutoPlugin {
+  override def trigger = allRequirements
+
   /**
    * Adds release steps for every supported Flink version not already published by the initial
    * all-module release step.
@@ -59,4 +66,42 @@ object CrossFlinkVersions {
       }: ReleaseStep
     }
   }
+
+  override lazy val projectSettings = Seq(
+    commands += Command.args("publishAdditionalFlinkVersions", "<task>") { (state, args) =>
+      if (args.isEmpty) {
+        sys.error(
+          "Usage: publishAdditionalFlinkVersions <task>\n" +
+            "Example: build/sbt \"publishAdditionalFlinkVersions publishM2\"")
+      }
+      crossFlinkReleaseSteps(args.mkString(" ")).foldLeft(state) { (currentState, step) =>
+        step(currentState)
+      }
+    },
+    commands += Command.command("exportFlinkVersionsJson") { state =>
+      val extracted = Project.extract(state)
+      val baseDir = extracted.get(ThisBuild / Keys.baseDirectory)
+      val outputFile = new File(baseDir, "target/flink-versions.json")
+      outputFile.getParentFile.mkdirs()
+
+      val writer = new PrintWriter(outputFile)
+      try {
+        writer.println("[")
+        FlinkVersionSpec.SUPPORTED.zipWithIndex.foreach { case (version, index) =>
+          val comma = if (index < FlinkVersionSpec.SUPPORTED.size - 1) "," else ""
+          writer.println("  {")
+          writer.println(s"""    "fullVersion": "$version",""")
+          writer.println(
+            s"""    "compatibilityVersion": "${FlinkVersionSpec.compatibilityVersion(version)}",""")
+          writer.println(s"""    "isDefault": ${version == FlinkVersionSpec.DEFAULT}""")
+          writer.println(s"  }$comma")
+        }
+        writer.println("]")
+      } finally {
+        writer.close()
+      }
+
+      println(s"[info] Flink version information exported to: ${outputFile.getAbsolutePath}")
+      state
+    })
 }

--- a/project/CrossFlinkVersions.scala
+++ b/project/CrossFlinkVersions.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import sbt._
+import sbtrelease.ReleasePlugin.autoImport.ReleaseStep
+
+object FlinkVersionSpec {
+  val DEFAULT: String = "2.0.2"
+  val SUPPORTED: Seq[String] = Seq(DEFAULT)
+
+  require(SUPPORTED.headOption.contains(DEFAULT), "The default Flink version must be supported")
+  require(
+    SUPPORTED.map(compatibilityVersion).distinct.size == SUPPORTED.size,
+    "Only one patch release can be published for each Flink compatibility line")
+
+  def selectedVersion: String = sys.props.getOrElse("flinkVersion", DEFAULT)
+
+  def compatibilityVersion(fullVersion: String): String = {
+    val parts = fullVersion.split("\\.")
+    require(parts.length >= 2, s"Flink version must contain a major and minor version: $fullVersion")
+    parts.take(2).mkString(".")
+  }
+}
+
+object CrossFlinkVersions {
+  /**
+   * Adds release steps for every supported Flink version not already published by the initial
+   * all-module release step.
+   */
+  def crossFlinkReleaseSteps(task: String): Seq[ReleaseStep] = {
+    FlinkVersionSpec.SUPPORTED.filterNot(_ == FlinkVersionSpec.DEFAULT).map { version =>
+      { (state: State) =>
+        val extracted = Project.extract(state)
+        val baseDir = extracted.get(ThisBuild / Keys.baseDirectory)
+        val command = Seq(
+          s"${baseDir.getAbsolutePath}/build/sbt",
+          s"-DflinkVersion=$version",
+          s"flink/$task")
+
+        println(s"[info] Publishing Flink module for Flink $version")
+        val exitCode = scala.sys.process.Process(command, baseDir).!
+        if (exitCode != 0) {
+          sys.error(s"Publishing Flink module for Flink $version failed with exit code $exitCode")
+        }
+        state
+      }: ReleaseStep
+    }
+  }
+}

--- a/project/CrossFlinkVersions.scala
+++ b/project/CrossFlinkVersions.scala
@@ -29,8 +29,10 @@ object FlinkVersionSpec {
     SUPPORTED.map(compatibilityVersion).distinct.size == SUPPORTED.size,
     "Only one patch release can be published for each Flink compatibility line")
 
+  /** Selects the requested full Flink version, falling back to the default build version. */
   def selectedVersion: String = sys.props.getOrElse("flinkVersion", DEFAULT)
 
+  /** Returns the major.minor line used in the Maven artifact name. */
   def compatibilityVersion(fullVersion: String): String = {
     val parts = fullVersion.split("\\.")
     require(
@@ -68,6 +70,8 @@ object CrossFlinkVersions extends AutoPlugin {
   }
 
   override lazy val projectSettings = Seq(
+    // Runs the same non-default Flink publication steps used by releaseProcess. This command lets
+    // CI exercise the real release path with a non-releasing task such as publishM2.
     commands += Command.args("publishAdditionalFlinkVersions", "<task>") { (state, args) =>
       if (args.isEmpty) {
         sys.error(
@@ -78,6 +82,8 @@ object CrossFlinkVersions extends AutoPlugin {
         step(currentState)
       }
     },
+    // Exports the supported Flink versions so CI can build its test matrix from the SBT source of
+    // truth instead of maintaining a separate version list in the workflow.
     commands += Command.command("exportFlinkVersionsJson") { state =>
       val extracted = Project.extract(state)
       val baseDir = extracted.get(ThisBuild / Keys.baseDirectory)

--- a/project/CrossFlinkVersions.scala
+++ b/project/CrossFlinkVersions.scala
@@ -20,17 +20,23 @@ import sbt._
 import sbt.Keys._
 import sbtrelease.ReleasePlugin.autoImport.ReleaseStep
 
-object FlinkVersionSpec {
-  val DEFAULT: String = "2.0.2"
-  val SUPPORTED: Seq[String] = Seq(DEFAULT)
+object CrossFlinkVersions extends AutoPlugin {
+  private val defaultVersion = "2.3.0"
+  private val supportedVersions = Seq(defaultVersion)
 
-  require(SUPPORTED.headOption.contains(DEFAULT), "The default Flink version must be supported")
   require(
-    SUPPORTED.map(compatibilityVersion).distinct.size == SUPPORTED.size,
+    supportedVersions.map(compatibilityVersion).distinct.size == supportedVersions.size,
     "Only one patch release can be published for each Flink compatibility line")
 
-  /** Selects the requested full Flink version, falling back to the default build version. */
-  def selectedVersion: String = sys.props.getOrElse("flinkVersion", DEFAULT)
+  /** Selects the requested supported Flink version, falling back to the default build version. */
+  def selectedVersion: String = {
+    val input = sys.props.getOrElse("flinkVersion", defaultVersion)
+    if (!supportedVersions.contains(input)) {
+      throw new IllegalArgumentException(
+        s"Invalid flinkVersion: $input. Valid values: ${supportedVersions.mkString(", ")}")
+    }
+    input
+  }
 
   /** Returns the major.minor line used in the Maven artifact name. */
   def compatibilityVersion(fullVersion: String): String = {
@@ -40,9 +46,6 @@ object FlinkVersionSpec {
       s"Flink version must contain a major and minor version: $fullVersion")
     parts.take(2).mkString(".")
   }
-}
-
-object CrossFlinkVersions extends AutoPlugin {
   override def trigger = allRequirements
 
   /**
@@ -50,7 +53,7 @@ object CrossFlinkVersions extends AutoPlugin {
    * all-module release step.
    */
   def crossFlinkReleaseSteps(task: String): Seq[ReleaseStep] = {
-    FlinkVersionSpec.SUPPORTED.filterNot(_ == FlinkVersionSpec.DEFAULT).map { version =>
+    supportedVersions.filterNot(_ == defaultVersion).map { version =>
       { (state: State) =>
         val extracted = Project.extract(state)
         val baseDir = extracted.get(ThisBuild / Keys.baseDirectory)
@@ -93,13 +96,13 @@ object CrossFlinkVersions extends AutoPlugin {
       val writer = new PrintWriter(outputFile)
       try {
         writer.println("[")
-        FlinkVersionSpec.SUPPORTED.zipWithIndex.foreach { case (version, index) =>
-          val comma = if (index < FlinkVersionSpec.SUPPORTED.size - 1) "," else ""
+        supportedVersions.zipWithIndex.foreach { case (version, index) =>
+          val comma = if (index < supportedVersions.size - 1) "," else ""
           writer.println("  {")
           writer.println(s"""    "fullVersion": "$version",""")
           writer.println(
-            s"""    "compatibilityVersion": "${FlinkVersionSpec.compatibilityVersion(version)}",""")
-          writer.println(s"""    "isDefault": ${version == FlinkVersionSpec.DEFAULT}""")
+            s"""    "compatibilityVersion": "${compatibilityVersion(version)}",""")
+          writer.println(s"""    "isDefault": ${version == defaultVersion}""")
           writer.println(s"  }$comma")
         }
         writer.println("]")

--- a/project/CrossFlinkVersions.scala
+++ b/project/CrossFlinkVersions.scala
@@ -22,7 +22,8 @@ import sbtrelease.ReleasePlugin.autoImport.ReleaseStep
 
 object CrossFlinkVersions extends AutoPlugin {
   private val defaultVersion = "2.3.0"
-  private val supportedVersions = Seq(defaultVersion)
+  private val supportedVersions =
+    Seq("2.0.2", "2.1.3", "2.2.1", "2.3.0", defaultVersion).distinct
 
   require(
     supportedVersions.map(compatibilityVersion).distinct.size == supportedVersions.size,

--- a/project/tests/test_cross_spark_publish.py
+++ b/project/tests/test_cross_spark_publish.py
@@ -61,7 +61,7 @@ NON_SPARK_RELATED_JAR_TEMPLATES = [
     "delta-kernel-defaults-{version}.jar",
     "delta-storage-s3-dynamodb-{version}.jar",
     "delta-kernel-unitycatalog-{version}.jar",
-    "delta-flink-{version}.jar",
+    "delta-flink_2.0-{version}.jar",
     "delta-contribs_2.13-{version}.jar",
 ]
 

--- a/project/tests/test_published_artifacts.py
+++ b/project/tests/test_published_artifacts.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python3
 """
-Cross-Spark Version Build Testing
+Published Artifact Build Testing
 
-Tests the Delta Lake build system by validating JAR file names for:
+Tests the Delta Lake build system by validating published JAR file names for:
 1. Default publish (publishM2) - publishes ALL modules WITH Spark suffix
 2. Backward-compat publish (skipSparkSuffix=true) - publishes WITHOUT suffix
 3. Full cross-version workflow publishes both with and without suffix
 
 Usage:
-    python project/tests/test_cross_spark_publish.py
+    python project/tests/test_published_artifacts.py
 
 The script will:
 1. Test default publishM2 command publishes all modules WITH Spark suffix
@@ -127,8 +127,8 @@ def substitute_xversion(jar_templates: List[str], delta_version: str) -> Set[str
     return {jar.format(version=delta_version) for jar in jar_templates}
 
 
-class CrossSparkPublishTest:
-    """Tests cross-Spark version builds."""
+class PublishedArtifactsTest:
+    """Tests the artifacts produced by default and cross-version builds."""
 
     def __init__(self, delta_root: Path):
         self.delta_root = delta_root
@@ -850,7 +850,7 @@ def main():
             sys.exit(1)
 
         print("="*70)
-        print("Cross-Spark Build Test Suite")
+        print("Published Artifact Build Test Suite")
         print("="*70)
         print()
 
@@ -873,7 +873,7 @@ def main():
         print("\n" + "="*70)
         print("PART 2: Cross-Spark Build Tests")
         print("="*70)
-        build_test = CrossSparkPublishTest(delta_root)
+        build_test = PublishedArtifactsTest(delta_root)
         build_test.validate_spark_versions()
 
         # Run all build tests

--- a/project/tests/test_published_artifacts.py
+++ b/project/tests/test_published_artifacts.py
@@ -61,7 +61,7 @@ NON_SPARK_RELATED_JAR_TEMPLATES = [
     "delta-kernel-defaults-{version}.jar",
     "delta-storage-s3-dynamodb-{version}.jar",
     "delta-kernel-unitycatalog-{version}.jar",
-    "delta-flink_2.0-{version}.jar",
+    "delta-flink_2.3-{version}.jar",
     "delta-contribs_2.13-{version}.jar",
 ]
 
@@ -182,6 +182,23 @@ class PublishedArtifactsTest:
         except subprocess.CalledProcessError:
             print(f"  ✗ Command failed: {' '.join(command)}")
             return False
+
+    def test_rejects_unsupported_flink_version(self) -> bool:
+        """An unsupported Flink version should fail before any build tasks run."""
+        result = subprocess.run(
+            ["build/sbt", "-DflinkVersion=9.9.9", "show flink/name"],
+            cwd=self.delta_root,
+            capture_output=True,
+            text=True,
+        )
+        output = result.stdout + result.stderr
+        expected_error = "Invalid flinkVersion: 9.9.9."
+        if result.returncode == 0 or expected_error not in output:
+            print("  ✗ Unsupported Flink version was not rejected as expected")
+            return False
+
+        print("  ✓ Unsupported Flink version is rejected")
+        return True
 
     def validate_jars(self, expected: Set[str], test_name: str) -> bool:
         """Validates that found JARs match expected JARs exactly."""
@@ -877,6 +894,7 @@ def main():
         build_test.validate_spark_versions()
 
         # Run all build tests
+        build_test0_passed = build_test.test_rejects_unsupported_flink_version()
         build_test1_passed = build_test.test_default_publish()
         build_test2_passed = build_test.test_backward_compat_publish()
         build_test3_passed = build_test.test_cross_spark_workflow()
@@ -896,6 +914,7 @@ def main():
         print(f"  Source-Build Artifact Version:          {'✓ PASSED' if script_test6c_passed else '✗ FAILED'}")
         print(f"  Get Field Functionality:                {'✓ PASSED' if script_test7_passed else '✗ FAILED'}")
         print("\nPart 2: Cross-Spark Build Tests")
+        print(f"  Reject unsupported Flink version:       {'✓ PASSED' if build_test0_passed else '✗ FAILED'}")
         print(f"  Default publishM2 (with suffix):        {'✓ PASSED' if build_test1_passed else '✗ FAILED'}")
         print(f"  skipSparkSuffix (backward compat):      {'✓ PASSED' if build_test2_passed else '✗ FAILED'}")
         print(f"  Cross-Spark Workflow (both):            {'✓ PASSED' if build_test3_passed else '✗ FAILED'}")
@@ -905,7 +924,7 @@ def main():
             script_test1_passed and script_test2_passed and script_test3_passed and script_test4_passed and
             script_test5_passed and script_test6_passed and script_test6b_passed and
             script_test6c_passed and script_test7_passed and
-            build_test1_passed and build_test2_passed and build_test3_passed
+            build_test0_passed and build_test1_passed and build_test2_passed and build_test3_passed
         )
 
         if all_tests_passed:


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta/pull/7446/files/2d9518f5fdf95e8582a97150703b3b97391fca30..e2d0b129cfacfccc4826aee7f07d8746bcb6952c) to review incremental changes.
- [stack/flink-version-matrix](https://github.com/delta-io/delta/pull/7421) [[Files changed](https://github.com/delta-io/delta/pull/7421/files)]
  - [stack/flink-cross-version-release](https://github.com/delta-io/delta/pull/7464) [[Files changed](https://github.com/delta-io/delta/pull/7464/files/2d9518f5fdf95e8582a97150703b3b97391fca30..bba13403fd51e124937d9e19b273df52ff996aed)]
  - [**stack/flink-four-version-demo**](https://github.com/delta-io/delta/pull/7446) [[Files changed](https://github.com/delta-io/delta/pull/7446/files/2d9518f5fdf95e8582a97150703b3b97391fca30..e2d0b129cfacfccc4826aee7f07d8746bcb6952c)] ← _this PR_

---------
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [x] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

The parent PR (#7421, which doesn't need to be ) publishes the Flink 2.0 connector as `delta-flink_2.0`. This child demonstrates that the same release path works for four Flink minor lines.

It adds Flink 2.1.3, 2.2.1, and 2.3.0 to the release version list. During a release, separate SBT processes publish these additional Maven artifacts:

- `delta-flink_2.1`
- `delta-flink_2.2`
- `delta-flink_2.3`

The normal all-module release step still publishes the default `delta-flink_2.0` artifact. CI builds, tests, and runs `publishM2` for all four versions, then checks each generated JAR in the local Maven repository.

The documentation lists the exact patch release tested for each minor line. Flink 2.0.2 remains the default build version.

## How was this patch tested?

- Parsed `.github/workflows/flink_test.yaml` as YAML.
- Verified SBT resolves assembly names from `delta-flink_2.0-4.4.0-SNAPSHOT.jar` through `delta-flink_2.3-4.4.0-SNAPSHOT.jar`.
- Ran `git diff --check`.

CI runs `flinkGroup/test` and `flink/publishM2` independently for all four Flink versions and checks the resulting Maven artifact names.

## Does this PR introduce _any_ user-facing changes?

Yes. The documented, tested, and published Flink compatibility range expands from Flink 2.0 to Flink 2.0 through 2.3.
