### PR TITLE
[Python] Resolve Maven coordinates for prerelease packages

### DIFF
--- a/python/delta/pip_utils.py
+++ b/python/delta/pip_utils.py
@@ -13,9 +13,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import re
 from typing import List, Optional
 
 from pyspark.sql import SparkSession
+
+
+def _python_to_maven_version(python_version: str) -> str:
+    """Convert a PEP 440 package version to Delta's Maven version format."""
+    match = re.fullmatch(r"(\d+\.\d+\.\d+)(rc\d+)?(\.dev\d+)?", python_version)
+    if match is None:
+        return python_version
+
+    release, release_candidate, snapshot = match.groups()
+    maven_version = release
+    if release_candidate:
+        maven_version += f"-{release_candidate}"
+    if snapshot:
+        maven_version += "-SNAPSHOT"
+    return maven_version
 
 
 def configure_spark_with_delta_pip(
@@ -90,7 +106,8 @@ See the online documentation for the correct usage of this function.
         # Fallback to artifact without suffix for backward compatibility
         artifact_name = f"delta-spark_{scala_version}"
 
-    maven_artifact = f"io.delta:{artifact_name}:{delta_version}"
+    maven_version = _python_to_maven_version(delta_version)
+    maven_artifact = f"io.delta:{artifact_name}:{maven_version}"
 
     extra_packages = extra_packages if extra_packages is not None else []
     all_artifacts = [maven_artifact] + extra_packages

--- a/python/delta/tests/test_pip_utils.py
+++ b/python/delta/tests/test_pip_utils.py
@@ -19,9 +19,39 @@ import shutil
 import tempfile
 import unittest
 from typing import List, Optional
+from unittest.mock import patch
 
 from pyspark.sql import SparkSession
 import delta
+from delta.pip_utils import _python_to_maven_version
+
+
+class PipUtilsVersionTests(unittest.TestCase):
+
+    def test_python_to_maven_version(self) -> None:
+        test_cases = {
+            "4.4.0": "4.4.0",
+            "4.4.0.dev0": "4.4.0-SNAPSHOT",
+            "4.4.0rc1": "4.4.0-rc1",
+            "4.4.0rc1.dev0": "4.4.0-rc1-SNAPSHOT",
+            "4.4.0rc1.dev1": "4.4.0-rc1-SNAPSHOT",
+            "4.4.0.post1": "4.4.0.post1",
+        }
+
+        for python_version, expected_maven_version in test_cases.items():
+            with self.subTest(python_version=python_version):
+                self.assertEqual(
+                    _python_to_maven_version(python_version),
+                    expected_maven_version)
+
+    @patch("importlib_metadata.version", return_value="4.4.0rc1.dev0")
+    @patch("pyspark.__version__", "4.2.0")
+    def test_configure_uses_maven_version(self, _) -> None:
+        builder = delta.configure_spark_with_delta_pip(SparkSession.builder)
+
+        self.assertEqual(
+            builder._options["spark.jars.packages"],
+            "io.delta:delta-spark_4.2_2.13:4.4.0-rc1-SNAPSHOT")
 
 
 class PipUtilsTests(unittest.TestCase):


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (Python)

## Description

Python package metadata normalizes `4.4.0-rc1-SNAPSHOT` to `4.4.0rc1.dev0`. `configure_spark_with_delta_pip` previously used that normalized value as a Maven version, so it requested an artifact that did not exist.

This change translates the stable, snapshot, release-candidate, and release-candidate snapshot forms used by Delta into their Maven spelling when constructing the coordinate.

For example, the Python package can report `4.4.0rc1.dev0` in its package metadata while requesting the original `4.4.0-rc1-SNAPSHOT` Maven artifact.

## How was this patch tested?

Added focused tests for the supported version forms and the complete Spark 4.2 Maven coordinate.

```shell
PYTHONPATH=python python3 -m unittest \
  delta.tests.test_pip_utils.PipUtilsVersionTests
```

## Does this PR introduce _any_ user-facing changes?

Yes. Python prerelease packages now configure Spark with the corresponding Maven artifact version.
