### PR TITLE
[Storage] Fix S3 fast listing to exclude nested keys

### DIFF
--- a/storage/src/main/java/io/delta/storage/internal/S3LogStoreUtil.java
+++ b/storage/src/main/java/io/delta/storage/internal/S3LogStoreUtil.java
@@ -60,13 +60,18 @@ public final class S3LogStoreUtil {
             Path parentPath) throws IOException {
         int maxKeys = S3AUtils.intOption(s3afs.getConf(), MAX_PAGING_KEYS, DEFAULT_MAX_PAGING_KEYS, 1);
         Listing listing = s3afs.getListing();
+        String parentKey = s3afs.pathToKey(parentPath);
+        if (!parentKey.isEmpty() && !parentKey.endsWith("/")) {
+            parentKey += "/";
+        }
         // List files lexicographically after resolvedPath inclusive within the same directory
         return listing.createFileStatusListingIterator(resolvedPath,
                 S3ListRequest.v2(
                     ListObjectsV2Request.builder()
                         .bucket(s3afs.getBucket())
                         .maxKeys(maxKeys)
-                        .prefix(s3afs.pathToKey(parentPath))
+                        .prefix(parentKey)
+                        .delimiter("/")
                         .startAfter(keyBefore(s3afs.pathToKey(resolvedPath)))
                         .build()
                 ), ACCEPT_ALL,

--- a/storage/src/main/java/io/delta/storage/internal/S3LogStoreUtil.java
+++ b/storage/src/main/java/io/delta/storage/internal/S3LogStoreUtil.java
@@ -27,6 +27,7 @@ import java.util.HashSet;
 import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_MAX_PAGING_KEYS;
 import static org.apache.hadoop.fs.s3a.Constants.MAX_PAGING_KEYS;
 import static org.apache.hadoop.fs.s3a.S3AUtils.iteratorToStatuses;
+import static org.apache.hadoop.fs.s3a.S3AUtils.maybeAddTrailingSlash;
 
 
 /**
@@ -60,17 +61,13 @@ public final class S3LogStoreUtil {
             Path parentPath) throws IOException {
         int maxKeys = S3AUtils.intOption(s3afs.getConf(), MAX_PAGING_KEYS, DEFAULT_MAX_PAGING_KEYS, 1);
         Listing listing = s3afs.getListing();
-        String parentKey = s3afs.pathToKey(parentPath);
-        if (!parentKey.isEmpty() && !parentKey.endsWith("/")) {
-            parentKey += "/";
-        }
         // List files lexicographically after resolvedPath inclusive within the same directory
         return listing.createFileStatusListingIterator(resolvedPath,
                 S3ListRequest.v2(
                     ListObjectsV2Request.builder()
                         .bucket(s3afs.getBucket())
                         .maxKeys(maxKeys)
-                        .prefix(parentKey)
+                        .prefix(maybeAddTrailingSlash(s3afs.pathToKey(parentPath)))
                         .delimiter("/")
                         .startAfter(keyBefore(s3afs.pathToKey(resolvedPath)))
                         .build()


### PR DESCRIPTION
## Summary

The fast S3 listing path uses a `ListObjectsV2` request without a delimiter. As a result, listing a Delta log directory can also return objects from nested directories. If a nested object has the same Delta log filename as a direct child, Delta sees duplicate versions and fails to load an otherwise valid table.

## Changes

- Normalize the parent key with a trailing `/`.
- Set the S3 list delimiter to `/` so the request only returns direct children.
- Preserve the existing inclusive `startAfter` behavior.

## Testing

Reproduced against a UC table with the published `delta-storage` 4.4.0 implementation (and UC 0.6.0) and fast listing enabled:

```text
UC_READ_FAIL=<TABLE> ERROR=org.apache.spark.sql.delta.DeltaIllegalStateException: [DELTA_VERSIONS_NOT_CONTIGUOUS] Versions (0, 1, 1) are not contiguous. A gap in the delta log between versions 0 and 1 was detected while trying to load version -1.
```

Loaded only the patched `S3LogStoreUtil` class and reran the same query with fast listing enabled:

```text
FAST_LIST=true
PATCHED_QUERY_SUCCEEDED rows=1
```

Also ran `S3LogStoreUtilTest`: 6 tests passed.