### PR TITLE
Fix typo in DELTA_CREATE_TABLE_SCHEME_MISMATCH error class name

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -922,7 +922,7 @@
     ],
     "sqlState" : "42601"
   },
-  "DELTA_CREATE_TABLE_SCHEME_MISMATCH" : {
+  "DELTA_CREATE_TABLE_SCHEMA_MISMATCH" : {
     "message" : [
       "The specified schema does not match the existing schema at <path>.",
       "",

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -1718,7 +1718,7 @@ trait DeltaErrorsBase
       existingSchema: StructType,
       diffs: Seq[String]): Throwable = {
     new DeltaAnalysisException(
-      errorClass = "DELTA_CREATE_TABLE_SCHEME_MISMATCH",
+      errorClass = "DELTA_CREATE_TABLE_SCHEMA_MISMATCH",
       messageParameters = Array(path.toString,
         specifiedSchema.treeString, existingSchema.treeString,
         diffs.map("\n".r.replaceAllIn(_, "\n  ")).mkString("- ", "\n- ", "")))

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -1058,7 +1058,7 @@ trait DeltaErrorsSuiteBase
       val e = intercept[DeltaAnalysisException] {
         throw DeltaErrors.createTableWithDifferentSchemaException(path, specifiedSchema, existingSchema, diffs)
       }
-      checkError(e, "DELTA_CREATE_TABLE_SCHEME_MISMATCH", "42KD7", Map(
+      checkError(e, "DELTA_CREATE_TABLE_SCHEMA_MISMATCH", "42KD7", Map(
         "path" -> path.toString,
         "specifiedSchema" -> specifiedSchema.treeString,
         "existingSchema" -> existingSchema.treeString,


### PR DESCRIPTION
## Description

The error class `DELTA_CREATE_TABLE_SCHEME_MISMATCH` contains a spelling mistake: `SCHEME` should be `SCHEMA`. The error is raised on a schema mismatch when creating a table, as reflected in its message ("The specified schema does not match the existing schema..."), so `SCHEMA` is the intended word.

This PR renames the error class to `DELTA_CREATE_TABLE_SCHEMA_MISMATCH` across all three references:

- `spark/src/main/resources/error/delta-error-classes.json` (the definition)
- `spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala` (the `errorClass` reference)
- `spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala` (the test)

The message text, `sqlState` (`42KD7`), and alphabetical position of the entry are unchanged.

## How was this patch tested?

Existing test `DeltaErrorsSuite` covers this error class and was updated to reference the corrected name.

## Does this PR introduce _any_ user-facing changes?

Yes. The error class name reported to users changes from `DELTA_CREATE_TABLE_SCHEME_MISMATCH` to `DELTA_CREATE_TABLE_SCHEMA_MISMATCH`.

This pull request and its description were written by Isaac.