### PR TITLE
[Spark] Persist typed Iceberg partition values in adaptive metadata manifests

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
@@ -1482,7 +1482,7 @@ trait SnapshotManagement { self: DeltaLog =>
           spark, catalogTableOpt, previousSnapshot
         )
         val amtCheckpointProviderOpt =
-          amtCheckpointOpt.map(cp => AMTCheckpointProvider.fromCheckpoint(spark, this, cp))
+          amtCheckpointOpt.map(cp => AMTCheckpointProvider.fromCheckpoint(this, cp))
         val segment = if (isIdempotentRetry) {
           // The commit already landed and the preCommitLogSegment has been advanced to a
           // segment at  >= committedVersion by conflict checking, so it is already the

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTCheckpointProvider.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTCheckpointProvider.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.delta.amt
 
 import org.apache.spark.sql.delta.{CheckpointPolicy, CheckpointProvider, DeltaLog, DeltaLogFileIndex, Snapshot}
 import org.apache.spark.sql.delta.DeltaLogFileIndex.COMMIT_VERSION_COLUMN
-import org.apache.spark.sql.delta.actions.{Action, AddFile, BackReference, Checkpoint, ContentRoot, RemoveFile, SingleAction}
+import org.apache.spark.sql.delta.actions.{Action, AddFile, BackReference, Checkpoint, ContentRoot, Metadata, RemoveFile, SingleAction}
 import org.apache.spark.sql.delta.deletionvectors.RoaringBitmapArray
 import org.apache.spark.sql.delta.util.DeltaEncoder
 import org.apache.hadoop.fs.{FileStatus, Path}
@@ -160,7 +160,8 @@ final class AMTCheckpointProvider(
       }
     }.toMap
     val mdvBroadcast = spark.sparkContext.broadcast(mdvByLeaf)
-    val dataEntries = AMTCheckpointProvider.loadEntriesWithLocation(spark, deltaLog, index)
+    val dataEntries = AMTCheckpointProvider.loadEntriesWithLocation(
+      deltaLog, index, checkpointAction.metaData)
       .where(col("entry.content_type") === lit(AMTSingleAction.ContentType.Type.Data))
       .where(col("entry.tracking.status").isin(
         AMTCheckpointProvider.liveDataEntryStatuses.toSeq: _*))
@@ -247,14 +248,12 @@ object AMTCheckpointProvider {
    * Builds a provider from an emitted [[Checkpoint]] action by reading the leaf pointers out of the
    * root manifest parquet.
    *
-   * @param spark      Active SparkSession used to read the root parquet.
    * @param deltaLog   The table's DeltaLog, used to read the root via `loadIndex` (which bypasses
    *                   the path-based Delta format check the root file under the table root would
    *                   otherwise trip).
    * @param checkpoint The inline-emitted checkpoint action carrying the `contentRoot`.
    */
   def fromCheckpoint(
-      spark: SparkSession,
       deltaLog: DeltaLog,
       checkpoint: Checkpoint): AMTCheckpointProvider = {
     val tableRoot = deltaLog.dataPath
@@ -263,7 +262,7 @@ object AMTCheckpointProvider {
       DeltaLogFileIndex(DeltaLogFileIndex.CHECKPOINT_FILE_FORMAT_PARQUET, Array(rootFile))
     // The root manifest is small (one row per leaf), so collect it to the driver to enumerate the
     // leaf pointers.
-    val leaves = loadEntries(spark, deltaLog, index).collect().toSeq
+    val leaves = loadEntries(deltaLog, index, checkpoint.metaData).collect().toSeq
       .filter(_.content_type == AMTSingleAction.ContentType.Type.DataManifest)
       .map(_.unwrap.asInstanceOf[DataManifestEntry])
     new AMTCheckpointProvider(checkpointAction = checkpoint, leaves = leaves, tableRoot = tableRoot)
@@ -279,14 +278,13 @@ object AMTCheckpointProvider {
 
   /** Reads the AMT root and returns the live [[DataEntry]]s tracked by root. */
   private[amt] def readLiveRootDataEntries(
-      spark: SparkSession,
       deltaLog: DeltaLog,
       checkpoint: Checkpoint): Seq[AddFile] = {
     val tableRoot = deltaLog.dataPath
     val rootFile = checkpoint.contentRoot.toFileStatus(tableRoot)
     val index =
       DeltaLogFileIndex(DeltaLogFileIndex.CHECKPOINT_FILE_FORMAT_PARQUET, Array(rootFile))
-    loadEntries(spark, deltaLog, index).collect().toSeq
+    loadEntries(deltaLog, index, checkpoint.metaData).collect().toSeq
       .filter(_.content_type == AMTSingleAction.ContentType.Type.Data)
       .map(_.unwrap.asInstanceOf[DataEntry])
       .filter(e => liveDataEntryStatuses.contains(e.tracking.status))
@@ -298,29 +296,42 @@ object AMTCheckpointProvider {
    * [[AMTSingleAction]].
    */
   private def loadEntries(
-      spark: SparkSession,
       deltaLog: DeltaLog,
-      index: DeltaLogFileIndex): Dataset[AMTSingleAction] = {
+      index: DeltaLogFileIndex,
+      metadata: Metadata): Dataset[AMTSingleAction] = {
     import org.apache.spark.sql.delta.implicits._
-    deltaLog.loadIndex(index, spark.emptyDataset[AMTSingleAction].schema).as[AMTSingleAction]
+    val persistedSchema = AMTSingleAction.persistedSchema(metadata.partitionSchema)
+    val persisted = deltaLog.loadIndex(index, persistedSchema)
+    AMTPartitionValues.forRead(persisted, metadata.partitionSchema)
+      .as[AMTSingleAction]
   }
 
   /**
    * Like [[loadEntries]], but also captures each row's physical read location.
    */
   private def loadEntriesWithLocation(
-      spark: SparkSession,
       deltaLog: DeltaLog,
-      index: DeltaLogFileIndex): Dataset[AMTDataEntryWithLocation] = {
+      index: DeltaLogFileIndex,
+      metadata: Metadata): Dataset[AMTDataEntryWithLocation] = {
     import org.apache.spark.sql.delta.implicits._
     implicit val entryLocEncoder: Encoder[AMTDataEntryWithLocation] =
       amtDataEntryWithLocationEncoder
-    val amtSchema = spark.emptyDataset[AMTSingleAction].schema
-    deltaLog.loadIndex(index, amtSchema)
+    val persistedSchema = AMTSingleAction.persistedSchema(metadata.partitionSchema)
+    val persisted = deltaLog.loadIndex(index, persistedSchema)
       .select(
-        struct(amtSchema.fieldNames.toIndexedSeq.map(col): _*).as("entry"),
-        col(s"$METADATA_NAME.$FILE_PATH").as("leafPath"),
-        col(s"$METADATA_NAME.${ParquetFileFormat.ROW_INDEX}").as("pos"))
+        persistedSchema.fieldNames.toIndexedSeq.map(col) :+
+          col(s"$METADATA_NAME.$FILE_PATH").as("leafPath") :+
+          col(s"$METADATA_NAME.${ParquetFileFormat.ROW_INDEX}").as("pos"): _*)
+    AMTPartitionValues.forRead(persisted, metadata.partitionSchema)
+      .select(
+        struct(
+          amtSingleActionEncoder
+            .schema
+            .fieldNames
+            .toIndexedSeq
+            .map(col): _*).as("entry"),
+        col("leafPath"),
+        col("pos"))
       .as[AMTDataEntryWithLocation]
   }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTPartitionValues.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTPartitionValues.scala
@@ -1,0 +1,129 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.amt
+
+import org.apache.spark.sql.delta.ClassicColumnConversions._
+import org.apache.spark.sql.delta.DeltaColumnMapping
+import org.apache.spark.sql.delta.util.PartitionUtils
+
+import org.apache.spark.sql.{Column, DataFrame}
+import org.apache.spark.sql.catalyst.expressions.Cast
+import org.apache.spark.sql.execution.datasources.parquet.ParquetUtils
+import org.apache.spark.sql.functions.{array, col, element_at, lit, map_from_arrays, struct, when}
+import org.apache.spark.sql.types.{MapType, MetadataBuilder, StringType, StructType}
+
+/**
+ * Converts between Delta's physical-name string map and Iceberg's typed partition struct.
+ *
+ * TODO(v4amt): shrink this converter. It exists because the two sides disagree on
+ *   representation: Delta stores partition values as `AddFile.partitionValues`, a physical-name to
+ *   string map, while the Iceberg V4 `partition` field is a struct with one typed field per
+ *   partition column.
+ *
+ *   https://github.com/delta-io/delta/issues/6953 proposes typing partitionValues in the Delta log
+ *   itself. That removes [[forWrite]]'s per-field cast, since the source would already be typed,
+ *   but it does not remove [[forRead]]'s render: log replay materializes an in-memory `AddFile`,
+ *   whose `partitionValues` is a `Map[String, String]`, so something still has to turn the typed
+ *   struct back into strings. Retiring the converter outright needs that field typed as well, not
+ *   just the log format.
+ */
+private[amt] object AMTPartitionValues {
+
+  /** Iceberg assigns partition-field ids from 1000, in partition-spec order. */
+  private val PARTITION_FIELD_ID_START: Long = 1000L
+
+  /**
+   * The partition struct as persisted: every column keeps its real type and logical name, with
+   * Iceberg partition-field ids stamped from 1000 in partition-spec order.
+   */
+  def persistedSchema(partitionSchema: StructType): StructType =
+    StructType(partitionSchema.fields.zipWithIndex.map { case (field, ordinal) =>
+      field.copy(
+        nullable = true,
+        metadata = new MetadataBuilder()
+          .withMetadata(field.metadata)
+          .putLong(ParquetUtils.FIELD_ID_METADATA_KEY, PARTITION_FIELD_ID_START + ordinal)
+          .build())
+    })
+
+  /**
+   * Physical-name string map -> persisted partition struct.
+   *
+   * The struct's fields carry the partition columns' *logical* names, as Iceberg expects. That is
+   * safe because an Iceberg reader resolves partition fields by field ID (stamped from 1000 in
+   * partition-spec order, see `AMTSingleAction.persistedSchema`), not by name, so the names here
+   * are informational and a column rename does not change how the struct is read.
+   */
+  def forWrite(df: DataFrame, partitionSchema: StructType): DataFrame = {
+    if (partitionSchema.isEmpty) return df.drop("partition")
+    val raw = col("partition")
+    // String -> typed mirrors what UniForm's Iceberg conversion does when it parses partition
+    // values out of a directory path: `PartitionUtils.parsePartitionValue` casts the string to the
+    // partition column's type. The cast is ANSI here so an unparseable value fails the write rather
+    // than silently writing a null partition value into the manifest.
+    val typedFields = partitionSchema.map { field =>
+      val physicalName = DeltaColumnMapping.getPhysicalName(field)
+      Column(Cast(
+        element_at(raw, lit(physicalName)).expr,
+        field.dataType,
+        ansiEnabled = true)).as(field.name)
+    }
+    val partition = when(raw.isNull, lit(null).cast(persistedSchema(partitionSchema)))
+      .otherwise(struct(typedFields: _*))
+    replacePartition(df, partition)
+  }
+
+  /** Persisted partition struct -> physical-name string map. */
+  def forRead(df: DataFrame, partitionSchema: StructType): DataFrame = {
+    val values = if (partitionSchema.isEmpty) {
+      lit(null).cast(MapType(StringType, StringType, valueContainsNull = true))
+    } else {
+      val typedPartition = col("partition")
+      val keys = array(partitionSchema.map(f => lit(DeltaColumnMapping.getPhysicalName(f))): _*)
+      // typed -> String reuses the renderer UniForm writes its partition values with:
+      // `ConvertUtils` calls `PartitionUtils.literalToNormalizedString` on each parsed literal.
+      // `expressionToNormalizedString` is that function in expression form, so a value converted
+      // here is byte-identical to what Delta would have logged for it.
+      //
+      // AMT always renders a timestamp UTC-normalized, rather than following
+      // `write.utcTimestampPartitionValues`. That conf exists to preserve a legacy write format,
+      // and it is a session conf the log does not record per file -- so honoring it here would make
+      // reading a manifest depend on the session doing the read, and a manifest written by one
+      // session unreadable by another. A UTC-normalized timestamp also needs no time zone to
+      // interpret, which is why `timeZoneId` is left unset: it would only be consulted on the
+      // branch this never takes.
+      val stringValues = array(partitionSchema.map { field =>
+        Column(PartitionUtils.expressionToNormalizedString(
+          value = typedPartition.getField(field.name).expr,
+          dataType = field.dataType,
+          timeZoneId = None,
+          useUtcNormalizedTimestamp = true))
+      }: _*)
+      when(typedPartition.isNull, lit(null)).otherwise(map_from_arrays(keys, stringValues))
+    }
+    if (df.columns.contains("partition")) {
+      replacePartition(df, values)
+    } else {
+      df.withColumn("partition", values)
+    }
+  }
+
+  private def replacePartition(df: DataFrame, partition: Column): DataFrame =
+    df.select(df.columns.map { name =>
+      if (name == "partition") partition.as(name) else col(name)
+    }: _*)
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriteHelper.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriteHelper.scala
@@ -64,6 +64,7 @@ object AMTWriteHelper extends DeltaLogging {
       deltaLog = deltaLog,
       readSnapshot = readSnapshot,
       hadoopConf = hadoopConf,
+      metadata = readSnapshot.metadata,
       entriesPerLeaf = entriesPerLeaf)
     // A full rewrite of the read snapshot's live files; it carries no commit actions, so the tree
     // describes the read snapshot's version.
@@ -165,6 +166,7 @@ object AMTWriteHelper extends DeltaLogging {
       deltaLog: DeltaLog,
       readSnapshot: Snapshot,
       hadoopConf: Configuration,
+      metadata: Metadata,
       entriesPerLeaf: Int): (ContentRoot, Seq[DataManifestEntry]) = {
     require(entriesPerLeaf > 0, "entriesPerLeaf must be positive.")
     val tableRoot = deltaLog.dataPath
@@ -183,6 +185,7 @@ object AMTWriteHelper extends DeltaLogging {
       tableRoot = tableRoot,
       metadataDir = metadataDir,
       addFilesDf = addFilesDf,
+      metadata = metadata,
       desiredNumLeaves = desiredNumLeaves)
     leafEntries match {
       case Seq(onlyLeaf) =>
@@ -191,8 +194,8 @@ object AMTWriteHelper extends DeltaLogging {
           ContentRoot(path = onlyLeaf.location, sizeInBytes = onlyLeaf.file_size_in_bytes)
         (contentRoot, Seq.empty)
       case _ =>
-        val contentRoot =
-          writeRoot(spark, fs, hadoopConf, tableRoot, metadataDir, leafEntries.map(_.wrap))
+        val contentRoot = writeRoot(
+          spark, fs, hadoopConf, tableRoot, metadataDir, metadata, leafEntries.map(_.wrap))
         (contentRoot, leafEntries)
     }
   }
@@ -204,6 +207,7 @@ object AMTWriteHelper extends DeltaLogging {
       tableRoot: Path,
       metadataDir: Path,
       addFilesDf: DataFrame,
+      metadata: Metadata,
       desiredNumLeaves: Int): Seq[DataManifestEntry] = {
     import org.apache.spark.sql.delta.implicits._
     val addFilesDs = addFilesDf.as[AddFile]
@@ -217,7 +221,8 @@ object AMTWriteHelper extends DeltaLogging {
     val amtDs = addFilesDs.map { add =>
       DataEntry.fromAddFile(add, tracking, tableRootSparkPath.toPath).wrap
     }
-    val schema = AMTSingleAction.schemaWithFieldId
+    val amtDf = AMTPartitionValues.forWrite(amtDs.toDF(), metadata.partitionSchema)
+    val schema = AMTSingleAction.persistedSchema(metadata.partitionSchema)
     val (factory, serConf) = {
       val format = new ParquetFileFormat()
       val job = Job.getInstance(hadoopConf)
@@ -228,7 +233,7 @@ object AMTWriteHelper extends DeltaLogging {
       (f, new SerializableConfiguration(job.getConfiguration))
     }
 
-    val qe = amtDs.queryExecution
+    val qe = amtDf.queryExecution
     SQLExecution.withNewExecutionId(qe, Some("AMT leaf checkpoint")) {
       qe.executedPlan.execute().mapPartitions { iter =>
         // Skip empty partitions (so the root never points at an empty leaf for a non-empty table).
@@ -360,19 +365,16 @@ object AMTWriteHelper extends DeltaLogging {
       hadoopConf: Configuration,
       tableRoot: Path,
       metadataDir: Path,
+      metadata: Metadata,
       batch: Seq[AddFile]): DataManifestEntry = {
     val leafFile = FileNames.newAMTLeafManifestFile(metadataDir)
     val rows: Seq[AMTSingleAction] =
       batch.map(add =>
         DataEntry
-          .fromAddFile(
-            add,
-            trackingWithStatus(Tracking.Status.Added),
-            tableRoot
-          )
+          .fromAddFile(add, trackingWithStatus(Tracking.Status.Added), tableRoot)
           .wrap
       )
-    writeAMTParquet(spark, hadoopConf, leafFile, rows)
+    writeAMTParquet(spark, hadoopConf, leafFile, metadata, rows)
     val status = fs.getFileStatus(leafFile)
     val (tracking, manifestInfo) = addedTrackingForLeaf(addedFilesCount = rows.size)
     DataManifestEntry(
@@ -395,9 +397,10 @@ object AMTWriteHelper extends DeltaLogging {
       hadoopConf: Configuration,
       tableRoot: Path,
       metadataDir: Path,
+      metadata: Metadata,
       rows: Seq[AMTSingleAction]): ContentRoot = {
     val rootFile = FileNames.newAMTRootManifestFile(metadataDir)
-    writeAMTParquet(spark, hadoopConf, rootFile, rows)
+    writeAMTParquet(spark, hadoopConf, rootFile, metadata, rows)
     val status = fs.getFileStatus(rootFile)
     ContentRoot(
       path = AMTUtils.relativizeManifestPathToTableRoot(fs, tableRoot, rootFile),
@@ -438,16 +441,18 @@ object AMTWriteHelper extends DeltaLogging {
       spark: SparkSession,
       hadoopConf: Configuration,
       finalPath: Path,
+      metadata: Metadata,
       rows: Seq[AMTSingleAction]): Unit = {
     import org.apache.spark.sql.delta.implicits._
-    val df = spark.createDataset(rows).toDF()
+    val df = AMTPartitionValues.forWrite(
+      spark.createDataset(rows).toDF(), metadata.partitionSchema)
     Checkpoints.writeAtomicCheckpointParquetFile(
       spark = spark,
       df = df,
       finalPath = finalPath,
       hadoopConf = hadoopConf,
       useRename = false,
-      outputSchema = Some(AMTSingleAction.schemaWithFieldId),
+      outputSchema = Some(AMTSingleAction.persistedSchema(metadata.partitionSchema)),
       useDeltaParquetWriteSupport = true)
   }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/IncrementalAMTWriter.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/IncrementalAMTWriter.scala
@@ -21,7 +21,7 @@ import java.util.concurrent.TimeUnit.NANOSECONDS
 import scala.collection.mutable.ArrayBuffer
 
 import org.apache.spark.sql.delta.{DeltaFileProviderUtils, DeltaLog, SingleCommit}
-import org.apache.spark.sql.delta.actions.{Action, AddFile, Checkpoint, ContentRoot, InMemoryLogReplay, RemoveFile}
+import org.apache.spark.sql.delta.actions.{Action, AddFile, Checkpoint, ContentRoot, InMemoryLogReplay, Metadata, RemoveFile}
 import org.apache.spark.sql.delta.actions.InMemoryLogReplay.UniqueFileActionTuple
 import org.apache.spark.sql.delta.deletionvectors.RoaringBitmapArray
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
@@ -111,7 +111,7 @@ class IncrementalAMTWriter(spark: SparkSession, deltaLog: DeltaLog) {
     // 1.a: old AMT root -- its live root-resident files, plus its inline non-content state
     // (protocol, metadata, setTxns, domainMetadata). Leaf-resident files are NOT read here.
     val fileActionsFromOldRoot = AMTCheckpointProvider.readLiveRootDataEntries(
-      spark, deltaLog, oldCheckpoint)
+      deltaLog, oldCheckpoint)
     val nonContentFromOldRoot: Iterator[Action] =
       Iterator(oldCheckpoint.protocol, oldCheckpoint.metaData) ++
         oldCheckpoint.txns.iterator ++ oldCheckpoint.domainMetadata.iterator
@@ -177,9 +177,13 @@ class IncrementalAMTWriter(spark: SparkSession, deltaLog: DeltaLog) {
     val tombstoneEntries = buildTombstones(cdfNoBackrefRemoves, liveAdds, rootAndWindowAdds)
 
     // ---- Step 6: spill live adds into new leaves if the root would exceed the per-leaf cap. ----
+    // The post-commit metadata shapes the persisted manifest schema (the Iceberg partition struct),
+    // so every manifest written below needs it, as does the Checkpoint action in step 8.
+    val postCommitMetadata = replay.getMetadata.getOrElse(
+      throw new IllegalStateException("Replay produced no metadata for the incremental AMT."))
     val fixedRootCount = carriedLeafPointers.size + tombstoneEntries.size
     val (rootAdds, spilledLeafPointers) =
-      spillIfNeeded(liveAdds, fixedRootCount)
+      spillIfNeeded(liveAdds, fixedRootCount, postCommitMetadata)
 
     // ---- Step 7: write the new root. ----
     val addedTracking = AMTWriteHelper.addedTracking
@@ -187,8 +191,8 @@ class IncrementalAMTWriter(spark: SparkSession, deltaLog: DeltaLog) {
       (carriedLeafPointers ++ spilledLeafPointers).map(_.wrap) ++
         rootAdds.map(add => DataEntry.fromAddFile(add, addedTracking, tableRoot).wrap) ++
         tombstoneEntries.map(_.wrap)
-    val contentRootBase =
-      AMTWriteHelper.writeRoot(spark, fs, hadoopConf, tableRoot, metadataDir, rootRows)
+    val contentRootBase = AMTWriteHelper.writeRoot(
+      spark, fs, hadoopConf, tableRoot, metadataDir, postCommitMetadata, rootRows)
 
     // ---- Step 8: generate the Checkpoint action. ----
     // The version the tree describes: an inline commit describes itself; a deferred OPTIMIZE
@@ -207,8 +211,6 @@ class IncrementalAMTWriter(spark: SparkSession, deltaLog: DeltaLog) {
       numLeaves = allLeafPointers.size.toLong)
     val postCommitProtocol = replay.getProtocol.getOrElse(
       throw new IllegalStateException("Replay produced no protocol for the incremental AMT."))
-    val postCommitMetadata = replay.getMetadata.getOrElse(
-      throw new IllegalStateException("Replay produced no metadata for the incremental AMT."))
     val checkpoint = Checkpoint(
       version = contentStateVersion,
       contentRoot = contentRoot,
@@ -343,7 +345,8 @@ class IncrementalAMTWriter(spark: SparkSession, deltaLog: DeltaLog) {
    */
   private def spillIfNeeded(
       liveAdds: Seq[AddFile],
-      fixedRootCount: Int): (Seq[AddFile], Seq[DataManifestEntry]) = {
+      fixedRootCount: Int,
+      metadata: Metadata): (Seq[AddFile], Seq[DataManifestEntry]) = {
     var remaining = liveAdds
     val spilled = ArrayBuffer.empty[DataManifestEntry]
     // Each spill adds one leaf pointer to the fixed root count; keep spilling while the root would
@@ -351,7 +354,7 @@ class IncrementalAMTWriter(spark: SparkSession, deltaLog: DeltaLog) {
     while (fixedRootCount + spilled.size + remaining.size > entriesPerLeaf && remaining.nonEmpty) {
       val (batch, rest) = remaining.splitAt(entriesPerLeaf)
       spilled += AMTWriteHelper.writeLeaf(
-        spark, fs, hadoopConf, tableRoot, metadataDir, batch)
+        spark, fs, hadoopConf, tableRoot, metadataDir, metadata, batch)
       remaining = rest
     }
     (remaining, spilled.toSeq)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/actions.scala
@@ -16,6 +16,10 @@
 
 package org.apache.spark.sql.delta.amt
 
+import java.util.UUID
+
+import scala.util.Try
+
 import org.apache.spark.sql.delta.DeltaColumnMapping
 import org.apache.spark.sql.delta.actions.{Action, AddFile, DeletionVectorDescriptor}
 import org.apache.spark.sql.delta.stats.DeltaStatistics
@@ -57,9 +61,9 @@ case class AMTSingleAction(
     location: String,                           // ID: 100, required.
     file_format: String,                        // ID: 101, required ("parquet" for now).
     tracking: Tracking,                         // ID: 147, required.
-    deletion_vector: Option[DeletionVector], // ID: 148, optional (only when content_type=0).
+    deletion_vector: Option[DeletionVector],    // ID: 148, optional (only when content_type=0).
     spec_id: Option[Int],                       // ID: 141, optional.
-    partition: Partition,                       // ID: 102, required.
+    partition: Option[Map[String, String]],     // ID: 102, optional.
     sort_order_id: Option[Int],                 // ID: 140, optional (only when content_type=0).
     record_count: Long,                         // ID: 103, required.
     file_size_in_bytes: Long,                   // ID: 104, required.
@@ -249,8 +253,6 @@ object AMTSingleAction {
 
   /** Iceberg V4 field id for the `split_offsets` list element. */
   private val SPLIT_OFFSETS_ELEMENT_FIELD_ID: Long = 133L
-  private val PARTITION_VALUES_KEY_PLACEHOLDER_ID: Long = 100002L
-  private val PARTITION_VALUES_VALUE_PLACEHOLDER_ID: Long = 100003L
 
   /** Top-level specs by name, for lookup during stamping. */
   private val topLevelFieldByName: Map[String, AMTFieldSpec] =
@@ -258,36 +260,31 @@ object AMTSingleAction {
 
   /**
    * Test-only Parquet field-id map for an AMT checkpoint schema, keyed by dotted path. Keys are the
-   * top-level field name (`content_type`), a nested-struct scalar (`tracking.status`), a list
-   * element (`split_offsets.element`), or a map key/value (`partition.values.key`,
-   * `partition.values.value`).
+   * top-level field name (`content_type`), a nested-struct scalar (`tracking.status`), or a list
+   * element (`split_offsets.element`).
    */
   private[amt] val allFieldIdByName: Map[String, Int] = {
-    val topLevel = topLevelFields.map(f => f.name -> f.id.toInt)
+    val topLevel = topLevelFields.filterNot(_.name == "partition").map(f => f.name -> f.id.toInt)
     val nested = nestedStructFields.flatMap { case (parent, children) =>
       children.map(f => s"$parent.${f.name}" -> f.id.toInt)
     }
     val nestedContainers = Map(
-      "split_offsets.element" -> SPLIT_OFFSETS_ELEMENT_FIELD_ID.toInt,
-      "partition.values.key" -> PARTITION_VALUES_KEY_PLACEHOLDER_ID.toInt,
-      "partition.values.value" -> PARTITION_VALUES_VALUE_PLACEHOLDER_ID.toInt)
+      "split_offsets.element" -> SPLIT_OFFSETS_ELEMENT_FIELD_ID.toInt)
     (topLevel ++ nested ++ nestedContainers).toMap
   }
 
-  /**
-   * The persisted [[AMTSingleAction]] schema with Iceberg field ids stamped onto its Parquet
-   * schema. Everything here is static, so it is computed once.
-   */
-  lazy val schemaWithFieldId: StructType = {
+  private lazy val staticStampedSchema: StructType = {
     import org.apache.spark.sql.delta.implicits._
-    val base = amtSingleActionEncoder.schema
-    StructType(base.map(stampFieldSpec))
+    StructType(amtSingleActionEncoder.schema.map(stampFieldSpec))
   }
 
   /**
    * Applies the Iceberg [[AMTFieldSpec]] to a single top-level [[AMTSingleAction]] field:
    * stamps the field id (and any nested element/map ids) and sets nullability from
    * `spec.required`.
+   *
+   * `partition` keeps the encoder's data type here; [[persistedSchema]] substitutes the table's
+   * typed partition struct, or drops the field, once the partition schema is known.
    */
   private def stampFieldSpec(field: StructField): StructField = {
     val spec = topLevelFieldByName.getOrElse(field.name,
@@ -307,16 +304,16 @@ object AMTSingleAction {
             elementId)
           .build())
     }
-    // Rewrite the field's data type: apply nested-struct field specs (id + nullability).
+    // Rewrite the field's data type by applying nested-struct field specs (id + nullability).
     val stampedDataType = field.dataType match {
       case struct: StructType =>
         nestedStructFields.get(field.name) match {
           case Some(specs) => stampNestedStructFieldSpecs(field.name, struct, specs)
           case None =>
-            assert(field.name == "partition" || field.name == "content_stats",
+            assert(field.name == "content_stats",
               s"Unexpected struct-typed AMTSingleAction field '${field.name}': expected a " +
-                "nested-id struct, partition, or content_stats.")
-            if (field.name == "partition") stampPartitionValuesNestedIds(struct) else struct
+                "nested-id struct or content_stats.")
+            struct
         }
       case other =>
         assert(!nestedStructFields.contains(field.name),
@@ -361,25 +358,18 @@ object AMTSingleAction {
     })
   }
 
-  /** Stamps placeholder map key/value ids onto the interim `partition.values` field. */
-  private def stampPartitionValuesNestedIds(struct: StructType): StructType =
-    StructType(struct.map { field =>
-      if (field.name == "values") {
-        val nestedIds = new MetadataBuilder()
-          .putLong(
-            Seq("values", DeltaColumnMapping.PARQUET_MAP_KEY_FIELD_NAME).mkString("."),
-            PARTITION_VALUES_KEY_PLACEHOLDER_ID)
-          .putLong(
-            Seq("values", DeltaColumnMapping.PARQUET_MAP_VALUE_FIELD_NAME).mkString("."),
-            PARTITION_VALUES_VALUE_PLACEHOLDER_ID)
-          .build()
-        field.copy(metadata = new MetadataBuilder()
-          .withMetadata(field.metadata)
-          .putMetadata(DeltaColumnMapping.PARQUET_FIELD_NESTED_IDS_METADATA_KEY, nestedIds)
-          .build())
-      } else {
-        field
-      }
+  /**
+   * The [[AMTSingleAction]] schema as written to disk, which differs from the encoder's in-memory
+   * schema in four ways: every mapped field carries its Iceberg field id, required/optional is
+   * driven by the field spec rather than the encoder, `partition` holds the table's typed partition
+   * struct instead of a string map, and `partition` is absent entirely for an unpartitioned table.
+   */
+  def persistedSchema(partitionSchema: StructType): StructType =
+    StructType(staticStampedSchema.flatMap {
+      case field if field.name == "partition" =>
+        if (partitionSchema.isEmpty) None
+        else Some(field.copy(dataType = AMTPartitionValues.persistedSchema(partitionSchema)))
+      case field => Some(field)
     })
 }
 
@@ -424,7 +414,7 @@ case class DataEntry(
     tracking: Tracking,
     record_count: Long,
     file_size_in_bytes: Long,
-    partition: Partition = Partition(),
+    partition: Option[Map[String, String]] = None,
     deletion_vector: Option[DeletionVector] = None,
     spec_id: Option[Int] = None,
     sort_order_id: Option[Int] = None,
@@ -460,7 +450,7 @@ case class DataEntry(
     val stats = s"""{"${DeltaStatistics.NUM_RECORDS}":$record_count}"""
     AddFile(
       path = location,
-      partitionValues = partition.values.getOrElse(Map.empty),
+      partitionValues = partition.getOrElse(Map.empty),
       size = file_size_in_bytes,
       modificationTime = 0L,
       dataChange = false,
@@ -490,7 +480,7 @@ object DataEntry {
         throw new IllegalArgumentException(
           s"Cannot build AMT entry: AddFile has no record count (missing stats): ${add.path}.")),
       file_size_in_bytes = add.size,
-      partition = Partition(Option(add.partitionValues).filter(_.nonEmpty)),
+      partition = Option(add.partitionValues).filter(_.nonEmpty),
       deletion_vector =
         Option(add.deletionVector).map(DeletionVector.fromDescriptor(_, tableRoot)),
       spec_id = passthrough.flatMap(_.spec_id),
@@ -588,7 +578,7 @@ case class DataManifestEntry(
     record_count: Long,
     file_size_in_bytes: Long,
     manifest_info: ManifestInfo,
-    partition: Partition = Partition(),
+    partition: Option[Map[String, String]] = None,
     spec_id: Option[Int] = None,
     content_stats: Option[ContentStats] = None,
     key_metadata: Option[Array[Byte]] = None,
@@ -697,20 +687,6 @@ object Tracking {
     val all: Set[Int] = Set(Existing, Added, Deleted, Replaced, Modified)
   }
 }
-
-/**
- * Partition-values carrier for [[AMTSingleAction]] (Iceberg V4 `partition`, field 102).
- *
- * Iceberg models `partition` as a per-table dynamic struct (one typed field per
- * partition column); that shape cannot be expressed statically here, so this PR carries
- * Delta's raw `AddFile.partitionValues`. The struct is present at field 102 (the spec
- * marks it required); binary interop with a strict V4 reader that expects the typed
- * per-column struct is deferred.
- *
- *
- * @param values Raw Delta partition values (column name to value); None when unpartitioned.
- */
-case class Partition(values: Option[Map[String, String]] = None)
 
 /**
  * Pointer to a deletion-vector blob, mirroring the Iceberg V4 `deletion_vector` struct.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/PartitionUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/PartitionUtils.scala
@@ -56,10 +56,11 @@ import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis._
 import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
-import org.apache.spark.sql.catalyst.expressions.{Attribute, Cast, Literal}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Cast, DateFormatClass, Expression, Literal}
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
 import org.apache.spark.sql.types._
+import org.apache.spark.util.Utils
 
 /**
  * This file is forked from [[org.apache.spark.sql.execution.datasources.PartitioningUtils]].
@@ -120,7 +121,9 @@ object PartitionSpec {
 private[delta] object PartitionUtils {
 
   lazy val timestampPartitionPattern = s"yyyy-MM-dd HH:mm:ss${precisionMatchPatterns(6)}"
-  lazy val utcFormatter = TimestampFormatter(s"yyyy-MM-dd'T'HH:mm:ss.SSSSSSz", ZoneId.of("Z"))
+  private val utcZoneId: ZoneId = ZoneId.of("Z")
+  private val utcTimestampPartitionFormat = s"yyyy-MM-dd'T'HH:mm:ss.SSSSSSz"
+  lazy val utcFormatter = TimestampFormatter(utcTimestampPartitionFormat, utcZoneId)
 
   private def precisionMatchPatterns(maxDigits: Int): String =
     (maxDigits to 1 by -1)
@@ -760,6 +763,13 @@ private[delta] object PartitionUtils {
 
   /**
    * Converts a typed literal to a normalized string representation for correct comparisons.
+   * This must be kept in sync with [[expressionToNormalizedString]].
+   *
+   * TODO(v4amt): make this delegate to [[expressionToNormalizedString]] so the two cannot drift.
+   *   The duplication is what makes drift possible at all: a partition value written through the
+   *   literal path and read back through the expression path has to render identically, and only
+   *   the two implementations agreeing enforces that today.
+   *
    * @param literal The Literal to convert to a string. Must have the correct type set.
    * @param timeZoneId Optional timezone ID for timestamp types.
    * @param useUtcNormalizedTimestamp If true, formats timestamp types into UTC ISO 8601 format.
@@ -776,13 +786,52 @@ private[delta] object PartitionUtils {
     literal.dataType match {
       case TimestampType if useUtcNormalizedTimestamp =>
         // Format timestamp in UTC ISO 8601 format: "2000-01-01T12:00:00.000000Z"
-        utcFormatter.format(literal.value.asInstanceOf[Long])
+        val normalized = utcFormatter.format(literal.value.asInstanceOf[Long])
+        if (Utils.isTesting) {
+          val fromExpression = expressionToNormalizedString(
+            value = literal,
+            dataType = literal.dataType,
+            timeZoneId = timeZoneId,
+            useUtcNormalizedTimestamp = useUtcNormalizedTimestamp).eval()
+          assert(Option(fromExpression).map(_.toString).orNull == normalized,
+            s"literalToNormalizedString and expressionToNormalizedString disagree on " +
+              s"${literal.dataType}: '$normalized' vs '$fromExpression'.")
+        }
+        normalized
 
       case _ =>
         // All other types can safely be converted to a string.
         val castedValue = Cast(literal, StringType, timeZoneId, ansiEnabled = false).eval()
         Option(castedValue).map(_.toString).orNull
     }
+  }
+
+  /**
+   * Converts a typed value to a normalized string representation for correct comparisons.
+   * This must be kept in sync with [[literalToNormalizedString]].
+   * @param value The value expression to convert to a string.
+   * @param dataType The data type of the value.
+   * @param timeZoneId Optional timezone ID for timestamp types.
+   * @param useUtcNormalizedTimestamp If true, formats timestamp types into UTC ISO 8601 format.
+   * @return The string representation of the value as an expression.
+   */
+  def expressionToNormalizedString(
+      value: Expression,
+      dataType: DataType,
+      timeZoneId: Option[String] = None,
+      useUtcNormalizedTimestamp: Boolean = false): Expression = dataType match {
+    // TODO(v4amt): follow the Iceberg rule for timestamps that carry a zone. Per the spec such a
+    //   value "represents a point in time: values are stored as UTC and do not retain a source time
+    //   zone", so `2017-11-16 17:10:34 PST` and `2017-11-17 01:10:34 UTC` are the same value. The
+    //   UTC normalization below gives that for a TimestampType read through this path, but the rule
+    //   has to hold for every path that compares partition values, not just this one.
+    case TimestampType if useUtcNormalizedTimestamp =>
+      // Format timestamp in UTC ISO 8601 format: "2000-01-01T12:00:00.000000Z"
+      DateFormatClass(value, Literal(utcTimestampPartitionFormat), Some(utcZoneId.getId))
+
+    case _ =>
+      // All other types can safely be converted to a string.
+      Cast(value, StringType, timeZoneId, ansiEnabled = false)
   }
 
   /**

--- a/spark/src/test/scala/org/apache/spark/sql/delta/LastCheckpointInfoSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/LastCheckpointInfoSuite.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.delta
 
 // scalastyle:off import.ordering.noEmptyLine
 import org.apache.spark.sql.delta.actions.{Checkpoint, ContentRoot, Metadata, Protocol}
-import org.apache.spark.sql.delta.amt.{AMTLeafComparisons, AMTSingleAction, AMTWriteResult, ContentStats, DataManifestEntry, ManifestInfo, Partition, Tracking}
+import org.apache.spark.sql.delta.amt.{AMTLeafComparisons, AMTSingleAction, AMTWriteResult, ContentStats, DataManifestEntry, ManifestInfo, Tracking}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
@@ -293,7 +293,7 @@ class LastCheckpointInfoSuite extends SharedSparkSession
       min_sequence_number = 7L,
       dv = Some(Array[Byte](9, 8, 7)),
       dv_cardinality = Some(5L)),
-    partition = Partition(values = Some(Map("part_col" -> "part_val"))),
+    partition = Some(Map("part_col" -> "part_val")),
     spec_id = Some(1),
     content_stats = Some(ContentStats(raw_stats = Some(Array[Byte](42, 43)))),
     key_metadata = Some(Array[Byte](16, 17, 18)),

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTBackReferenceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTBackReferenceSuite.scala
@@ -52,12 +52,6 @@ class AMTBackReferenceSuite extends AMTCheckpointTestBase with DeletionVectorsTe
       }.toMap
   }
 
-  /**
-   * All live [[AddFile]]s of snapshot.
-   */
-  private def liveAddFiles(snapshot: Snapshot): Seq[AddFile] =
-    snapshot.allFiles.collect().toSeq
-
   /** All actions committed after `afterVersion`, up to the latest version. */
   private def actionsAfter(deltaLog: DeltaLog, afterVersion: Long): Seq[Action] = {
     val latest = deltaLog.update().version

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointTestBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointTestBase.scala
@@ -32,6 +32,7 @@ import org.apache.spark.SparkConf
 import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.types.{BinaryType, BooleanType, ByteType, DateType, DecimalType, DoubleType, FloatType, IntegerType, LongType, ShortType, StringType, StructField, StructType, TimestampNTZType, TimestampType}
 
 /**
  * Shared fixtures for AMT (`adaptiveMetadata-preview`) test suites: table creation, manifest-tree
@@ -81,11 +82,17 @@ trait AMTCheckpointTestBase
   protected def createAMTTable(
       tableName: String,
       checkpointInterval: Int = 2,
-      location: Option[String] = None): Unit = {
+      location: Option[String] = None,
+      tableSchema: String = "id INT",
+      partitionColumns: Seq[String] = Seq.empty): Unit = {
     val locationClause = location.map(l => s"LOCATION '$l'").getOrElse("")
+    val partitionClause =
+      if (partitionColumns.isEmpty) ""
+      else s"PARTITIONED BY (${partitionColumns.mkString(", ")})"
     sql(
-      s"""CREATE TABLE $tableName (id INT) USING DELTA
+      s"""CREATE TABLE $tableName ($tableSchema) USING DELTA
          |$locationClause
+         |$partitionClause
          |TBLPROPERTIES (
          |  '${propertyKey(AdaptiveMetadataTableFeature)}' = '$FEATURE_PROP_SUPPORTED',
          |  'delta.columnMapping.mode' = 'id',
@@ -96,15 +103,95 @@ trait AMTCheckpointTestBase
   /**
    * Appends `numRows` rows (ids `startId` until `startId + numRows`) to `tableName` as `numRows`
    * separate data files in a single commit. `startId` lets successive calls append disjoint id
-   * ranges.
+   * ranges. `columnExprs` is the projection over `range`'s `id`, one expression per table column;
+   * a partitioned table passes its partition columns here too.
    */
   protected def appendRowsAsSeparateFiles(
-      tableName: String, numRows: Int, startId: Int = 0): Unit = {
+      tableName: String,
+      numRows: Int,
+      startId: Int = 0,
+      columnExprs: Seq[String] = Seq("CAST(id AS INT)")): Unit = {
     withSQLConf(
         "spark.sql.files.maxRecordsPerFile" -> "1",
         DeltaSQLConf.DELTA_OPTIMIZE_WRITE_ENABLED.key -> "false") {
       sql(
-        s"INSERT INTO $tableName SELECT CAST(id AS INT) FROM range($startId, ${startId + numRows})")
+        s"""INSERT INTO $tableName
+           |SELECT ${columnExprs.mkString(", ")} FROM range($startId, ${startId + numRows})"""
+          .stripMargin)
+    }
+  }
+
+  /** All live [[AddFile]]s of `snapshot`. */
+  protected def liveAddFiles(snapshot: Snapshot): Seq[AddFile] =
+    snapshot.allFiles.collect().toSeq
+
+  /**
+   * Partition spec covering one column per partition type Delta supports.
+   */
+  protected val allTypesPartitionSchema: StructType = StructType(Seq(
+    StructField("p_int", IntegerType),
+    StructField("p_long", LongType),
+    StructField("p_short", ShortType),
+    StructField("p_byte", ByteType),
+    StructField("p_str", StringType),
+    StructField("p_date", DateType),
+    StructField("p_ts", TimestampType),
+    StructField("p_ts_ntz", TimestampNTZType),
+    StructField("p_dec", DecimalType(9, 3)),
+    StructField("p_bool", BooleanType),
+    StructField("p_float", FloatType),
+    StructField("p_double", DoubleType),
+    StructField("p_binary", BinaryType)))
+
+  /** `allTypesPartitionSchema` as SQL column definitions, for a `CREATE TABLE` schema. */
+  protected def allTypesPartitionColumns: Seq[String] =
+    allTypesPartitionSchema.map(f => s"${f.name} ${f.dataType.sql}")
+
+  /**
+   * One projection over `range`'s `id` per column of [[allTypesPartitionSchema]], giving each row a
+   * distinct value in every partition column.
+   */
+  protected def allTypesPartitionExprs: Seq[String] = allTypesPartitionSchema.map { field =>
+    field.dataType match {
+      case StringType => "CONCAT('r', CAST(id AS STRING))"
+      case DateType => "DATE '2026-07-25' + CAST(id AS INT)"
+      case TimestampType =>
+        "TIMESTAMP '2026-07-25 01:02:03.456' + MAKE_INTERVAL(0, 0, 0, CAST(id AS INT))"
+      case TimestampNTZType =>
+        "CAST(TIMESTAMP_NTZ '2026-07-25 01:02:03.456' + " +
+          "MAKE_INTERVAL(0, 0, 0, CAST(id AS INT)) AS TIMESTAMP_NTZ)"
+      case BooleanType => "CAST(id % 2 AS BOOLEAN)"
+      case BinaryType => "CAST(CONCAT('b', CAST(id AS STRING)) AS BINARY)"
+      case d: DecimalType => s"CAST(id AS ${d.sql}) / 8"
+      case other => s"CAST(id AS ${other.sql})"
+    }
+  }
+
+  /**
+   * Creates an AMT table partitioned by every column of [[allTypesPartitionSchema]] and appends
+   * `numFiles` single-row files, one distinct partition value per row per column, then runs `body`
+   * with the table's [[DeltaLog]]. No checkpoint is committed -- the caller decides which
+   * checkpoint shape it needs.
+   */
+  protected def withAllPartitionTypesTable(
+      tableName: String,
+      numFiles: Int,
+      maxEntriesPerLeaf: Int)(body: DeltaLog => Unit): Unit = {
+    val dataColumns = Seq("d_int INT", "d_str STRING")
+    withSQLConf(DeltaSQLConf.AMT_ENTRIES_PER_LEAF.key -> maxEntriesPerLeaf.toString) {
+      withTable(tableName) {
+        createAMTTable(
+          tableName,
+          checkpointInterval = Int.MaxValue,
+          tableSchema = (dataColumns ++ allTypesPartitionColumns).mkString(", "),
+          partitionColumns = allTypesPartitionSchema.map(_.name))
+        appendRowsAsSeparateFiles(
+          tableName,
+          numRows = numFiles,
+          columnExprs =
+            Seq("CAST(id AS INT)", "CONCAT('d', CAST(id AS STRING))") ++ allTypesPartitionExprs)
+        body(deltaLogForName(tableName))
+      }
     }
   }
 
@@ -219,7 +306,9 @@ trait AMTCheckpointTestBase
       deferredScenarios: Seq[AMTCheckpointScenario] = Seq(
         AMTCheckpointScenario.DeferredIncremental,
         AMTCheckpointScenario.DeferredFull),
-      sqlConfs: Seq[(String, String)] = Seq.empty)(
+      sqlConfs: Seq[(String, String)] = Seq.empty,
+      tableSchema: String = "id INT",
+      partitionColumns: Seq[String] = Seq.empty)(
       setup: String => Unit = _ => (),
       inlineCheckpointTriggerActionsOrSQL: Option[AMTCheckpointTrigger] = None)(
       body: AMTCheckpointScenarioContext => Unit): Unit = {
@@ -237,7 +326,11 @@ trait AMTCheckpointTestBase
         val scenarioTable = s"${tableName}_${scenario.name.replace(' ', '_')}"
         withSQLConf(sqlConfs: _*) {
           withTable(scenarioTable) {
-            createAMTTable(scenarioTable, checkpointInterval = Int.MaxValue)
+            createAMTTable(
+              scenarioTable,
+              checkpointInterval = Int.MaxValue,
+              tableSchema = tableSchema,
+              partitionColumns = partitionColumns)
             // Incremental checkpoints require an existing full checkpoint.
             commitCheckpoint(deltaLogForName(scenarioTable), incremental = false)
             setup(scenarioTable)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointWriteSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointWriteSuite.scala
@@ -26,8 +26,11 @@ import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.{FileNames, JsonUtils}
 import org.apache.hadoop.fs.Path
 
+import org.apache.spark.SparkConf
 import org.apache.spark.sql.Row
+import org.apache.spark.sql.execution.datasources.parquet.ParquetUtils
 import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.types.StructType
 
 class AMTCheckpointWriteSuite extends AMTCheckpointTestBase {
 
@@ -81,6 +84,72 @@ class AMTCheckpointWriteSuite extends AMTCheckpointTestBase {
 
     // The promoted root alone must reconstruct exactly the table's live files.
     assertReconstructsLiveFileSet(context)
+  }
+
+  testAcrossAMTCheckpointScenarios(
+      "partition values use the typed Iceberg struct and round-trip",
+      "amt_typed_partition",
+      sqlConfs = leafPackingConfs,
+      tableSchema = ("id INT" +: allTypesPartitionColumns).mkString(", "),
+      partitionColumns = allTypesPartitionSchema.map(_.name))(
+      setup = name => appendRowsAsSeparateFiles(
+        name,
+        numRows = leafPackedFiles - 1,
+        columnExprs = "CAST(id AS INT)" +: allTypesPartitionExprs),
+      inlineCheckpointTriggerActionsOrSQL = Some(name => Right(
+        s"""INSERT INTO $name
+           |SELECT ${("CAST(id AS INT)" +: allTypesPartitionExprs).mkString(", ")}
+           |FROM range(${leafPackedFiles - 1}, $leafPackedFiles)""".stripMargin))) { context =>
+    val leafDf = spark.read.parquet(
+      context.provider.liveLeafManifestAbsolutePaths.map(_.toString): _*)
+    val partitionSchema = context.postCheckpointSnapshot.metadata.partitionSchema
+    // The persisted struct carries the table's partition types under their logical names, with
+    // Iceberg partition-field ids from 1000 in partition-spec order.
+    val partition = leafDf.schema("partition")
+    assert(partition.nullable)
+    val fields = partition.dataType.asInstanceOf[StructType].fields
+    assert(fields.map(f => f.name -> f.dataType).toSeq ==
+      AMTPartitionValues.persistedSchema(partitionSchema).map(f => f.name -> f.dataType))
+    assert(fields.map(_.metadata.getLong(ParquetUtils.FIELD_ID_METADATA_KEY)).toSeq ==
+      fields.indices.map(1000L + _))
+    assert(leafDf.select("partition.p_int").collect().map(_.getInt(0)).toSet ==
+      (0 until leafPackedFiles).toSet)
+
+    // Every physical-name -> string entry must come back exactly as the log recorded it; a cast
+    // that disagrees with Delta's own serialization would corrupt these silently.
+    val restored = context.provider
+      .loadActionsForStateReconstruction(spark, context.postCheckpointSnapshot.deltaLog)
+      .getOrElse(fail("AMT provider must contribute reconstructed actions."))
+      .where(col("add").isNotNull)
+      .select("add.partitionValues")
+      .collect()
+      .map(_.getMap[String, String](0).toMap)
+      .toSet
+    assert(restored == liveAddFiles(context.postCheckpointSnapshot).map(_.partitionValues).toSet)
+  }
+
+  testAcrossAMTCheckpointScenarios(
+      "an unpartitioned table writes no partition column at all",
+      "amt_unpartitioned",
+      sqlConfs = leafPackingConfs)(
+      setup = name => appendRowsAsSeparateFiles(name, numRows = leafPackedFiles - 1),
+      inlineCheckpointTriggerActionsOrSQL = Some(name => Right(
+        s"INSERT INTO $name VALUES (${leafPackedFiles - 1})"))) { context =>
+    // An unpartitioned table has no partition struct to persist, so `partition` is dropped from the
+    // schema rather than written as a null -- Iceberg field 102 is optional. Checking the parquet
+    // itself, since the reconstructed AddFile carries a `partition` either way (`forRead` adds one
+    // back as a null map).
+    val manifests =
+      (context.provider.topLevelFiles.map(_.getPath.toString) ++
+        context.provider.liveLeafManifestAbsolutePaths.map(_.toString))
+    assert(manifests.nonEmpty, "Expected at least a root manifest.")
+    manifests.foreach { manifest =>
+      val columns = {
+        spark.read.parquet(manifest).columns.toSeq
+      }
+      assert(!columns.contains("partition"),
+        s"an unpartitioned manifest must have no `partition` column; $manifest has $columns")
+    }
   }
 
   testAcrossAMTCheckpointScenarios(
@@ -203,8 +272,17 @@ class AMTCheckpointWriteSuite extends AMTCheckpointTestBase {
       // contain spaces, storing raw table-root-relative pointers, to prove the pointer round-trips.
       def writeManifest(fileName: String, rows: Seq[AMTSingleAction]): (String, Long) = {
         val file = new Path(metadataDir, fileName)
-        val df = spark.createDataset(rows)(enc).toDF()
-        Checkpoints.writeAtomicCheckpointParquetFile(spark, df, file, hadoopConf, useRename = false)
+        val metadata = base.metaData
+        val df = AMTPartitionValues.forWrite(
+          spark.createDataset(rows)(enc).toDF(), metadata.partitionSchema)
+        Checkpoints.writeAtomicCheckpointParquetFile(
+          spark,
+          df,
+          file,
+          hadoopConf,
+          useRename = false,
+          outputSchema = Some(AMTSingleAction.persistedSchema(metadata.partitionSchema)),
+          useDeltaParquetWriteSupport = true)
         val relative = AMTUtils.relativizeManifestPathToTableRoot(
           file.getFileSystem(hadoopConf), dataPath, file)
         assert(relative == s"${FileNames.AMT_METADATA_DIR_NAME}/$fileName" &&
@@ -232,7 +310,7 @@ class AMTCheckpointWriteSuite extends AMTCheckpointTestBase {
       assert(rootLoc.contains("root with space.parquet") && !rootLoc.contains("%20"))
       assert(leafLoc.contains("leaf with space.parquet") && !leafLoc.contains("%20"))
 
-      val provider = AMTCheckpointProvider.fromCheckpoint(spark, deltaLog, checkpoint)
+      val provider = AMTCheckpointProvider.fromCheckpoint(deltaLog, checkpoint)
       // The provider resolves the spaced pointers to absolute, raw paths under the table root.
       assert(provider.liveLeafManifestAbsolutePaths.forall(p =>
         p.isAbsolute && p.toString.contains("leaf with space.parquet") &&

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTFieldSpecSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTFieldSpecSuite.scala
@@ -1,0 +1,160 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.amt
+
+import java.io.File
+
+import scala.collection.JavaConverters._
+
+import org.apache.spark.sql.delta.DeltaColumnMapping
+import org.apache.spark.sql.delta.util.JsonUtils
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+import org.apache.parquet.format.converter.ParquetMetadataConverter
+import org.apache.parquet.hadoop.ParquetFileReader
+import org.apache.parquet.schema.GroupType
+
+import org.apache.spark.sql.execution.datasources.parquet.ParquetUtils
+import org.apache.spark.sql.types.{StructField, StructType}
+
+/**
+ * Pins the Iceberg V4 field ids an AMT checkpoint puts on disk:
+ * `AMTSingleAction.persistedSchema` must reproduce the authoritative name-to-id map, and every leaf
+ * and root footer written by the incremental and full write paths must carry those ids on its
+ * parquet schema.
+ */
+class AMTFieldSpecSuite extends AMTCheckpointTestBase {
+
+  /**
+   * Collects field-id assignments from a Parquet footer as dotted paths. Intermediate LIST/MAP
+   * groups (`list`, `key_value`) are omitted so paths match Spark/Iceberg names
+   * (e.g. `split_offsets.element`).
+   */
+  private def actualFieldIdByName(group: GroupType): Map[String, Int] = {
+    def collect(current: GroupType, prefix: Seq[String]): Map[String, Int] =
+      current.getFields.asScala.foldLeft(Map.empty[String, Int]) { (acc, field) =>
+        val skipInPath = field.getName == "list" || field.getName == "key_value"
+        val path = if (skipInPath) prefix else prefix :+ field.getName
+        val withOwn = Option(field.getId).map(_.intValue()) match {
+          case Some(id) if !skipInPath => acc + (path.mkString(".") -> id)
+          case _ => acc
+        }
+        if (field.isPrimitive) withOwn
+        else withOwn ++ collect(field.asGroupType(), path)
+      }
+
+    collect(group, Seq.empty)
+  }
+
+  private def assertFieldIds(hadoopConf: Configuration, file: File, label: String): Unit = {
+    val schema = ParquetFileReader.readFooter(
+      hadoopConf, new Path(file.getAbsolutePath), ParquetMetadataConverter.NO_FILTER)
+      .getFileMetaData.getSchema
+    val actual = actualFieldIdByName(schema)
+    assert(
+      actual.values.toSet.size == actual.size,
+      s"$label contains duplicate field ids: $actual")
+    assert(
+      actual == AMTSingleAction.allFieldIdByName,
+      s"$label field ids did not match AMTSingleAction.allFieldIdByName\n" +
+        s"  missing=${AMTSingleAction.allFieldIdByName.toSet.diff(actual.toSet)}\n" +
+        s"  unexpected=${actual.toSet.diff(AMTSingleAction.allFieldIdByName.toSet)}")
+  }
+
+  /**
+   * Collects the field-id assignments actually stamped on `AMTSingleAction.persistedSchema` as
+   * dotted paths, mirroring [[actualFieldIdByName]]'s convention: a scalar/struct id comes from the
+   * field's own `parquet.field.id`; list-element and map key/value ids come from the parent's
+   * `parquet.field.nested.ids` (keyed `<field>.element` / `values.key` / `values.value`).
+   */
+  private def stampedFieldIdByName(schema: StructType): Map[String, Int] = {
+    // Read the nested-id sub-metadata (an opaque `Metadata` whose entries are keyed by the
+    // relative element/key/value path) via its public JSON form, since the key set is not known
+    // to the reader and `Metadata`'s underlying map is not publicly accessible.
+    def nestedIds(field: StructField): Map[String, Int] = {
+      val key = DeltaColumnMapping.PARQUET_FIELD_NESTED_IDS_METADATA_KEY
+      if (!field.metadata.contains(key)) Map.empty
+      else {
+        val json = field.metadata.getMetadata(key).json
+        JsonUtils.fromJson[Map[String, Long]](json).map { case (k, id) => k -> id.toInt }
+      }
+    }
+    def collect(fields: Seq[StructField], prefix: Seq[String]): Map[String, Int] =
+      fields.foldLeft(Map.empty[String, Int]) { (acc, field) =>
+        val path = prefix :+ field.name
+        val ownId =
+          if (field.metadata.contains(ParquetUtils.FIELD_ID_METADATA_KEY)) {
+            Map(path.mkString(".") ->
+              field.metadata.getLong(ParquetUtils.FIELD_ID_METADATA_KEY).toInt)
+          } else Map.empty[String, Int]
+        // Nested (list-element / map key-value) ids are stamped as `<field>.<suffix>` relative to
+        // the field name, so join them under the current prefix.
+        val nested = nestedIds(field).map { case (rel, id) =>
+          (prefix :+ rel).mkString(".") -> id
+        }
+        val children = field.dataType match {
+          case s: StructType => collect(s.fields.toSeq, path)
+          case _ => Map.empty[String, Int]
+        }
+        acc ++ ownId ++ nested ++ children
+      }
+    collect(schema.fields.toSeq, Seq.empty)
+  }
+
+  test("persistedSchema stamps an id on every mapped field of AMTSingleAction") {
+    val stamped = stampedFieldIdByName(
+      AMTSingleAction.persistedSchema(allTypesPartitionSchema))
+    // Partition fields take Iceberg ids from 1000 in partition-spec order, whatever their type.
+    val expected = AMTSingleAction.allFieldIdByName ++ Map("partition" -> 102) ++
+      allTypesPartitionSchema.fields.zipWithIndex.map { case (field, ordinal) =>
+        s"partition.${field.name}" -> (1000 + ordinal)
+      }
+    assert(
+      stamped == expected,
+      "persistedSchema field ids did not match AMTSingleAction.allFieldIdByName\n" +
+        s"  missing=${expected.toSet.diff(stamped.toSet)}\n" +
+        s"  unexpected=${stamped.toSet.diff(expected.toSet)}")
+
+    // Guard against a field added to a nested id-bearing struct (tracking / deletion_vector /
+    // manifest_info) without a corresponding id: every scalar of those structs must be stamped.
+    val schema = AMTSingleAction.persistedSchema(allTypesPartitionSchema)
+    Seq("tracking", "deletion_vector", "manifest_info").foreach { parent =>
+      val struct = schema(parent).dataType.asInstanceOf[StructType]
+      struct.fields.foreach { f =>
+        assert(f.metadata.contains(ParquetUtils.FIELD_ID_METADATA_KEY),
+          s"nested field '$parent.${f.name}' has no stamped Iceberg field id.")
+      }
+    }
+  }
+
+  testAcrossAMTCheckpointScenarios(
+      "writes stamp field ids on every leaf and root field",
+      "amt_fieldid_write",
+      sqlConfs = leafPackingConfs)(
+      setup = name => appendRowsAsSeparateFiles(name, numRows = leafPackedFiles - 1),
+      inlineCheckpointTriggerActionsOrSQL = Some(name => Right(
+        s"INSERT INTO $name VALUES (${leafPackedFiles - 1})"))) { context =>
+    val hadoopConf = context.postCheckpointSnapshot.deltaLog.newDeltaHadoopConf()
+    // `leaf.location` and `contentRoot.path` are stored table-root-relative, so go through the
+    // provider, which resolves them against the table root.
+    val leaves = context.provider.liveLeafManifestAbsolutePaths.map(path => new File(path.toUri))
+    val root = new File(context.provider.topLevelFiles.head.getPath.toUri)
+    assert(leaves.nonEmpty, "Expected at least one leaf manifest.")
+    leaves.foreach(f => assertFieldIds(hadoopConf, f, s"leaf ${f.getName}"))
+    assertFieldIds(hadoopConf, root, s"root ${root.getName}")
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTPartitionValuesSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTPartitionValuesSuite.scala
@@ -1,0 +1,181 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.amt
+
+import org.apache.spark.sql.delta.DeltaColumnMapping
+import org.apache.spark.sql.delta.actions.AddFile
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.types.{BooleanType, DataType, DateType, DecimalType, IntegerType, LongType, MapType, MetadataBuilder, StringType, StructField, StructType, TimestampType}
+
+/**
+ * Tests for [[AMTPartitionValues]], the converter between Delta's physical-name partition string
+ * map and the typed Iceberg partition struct a manifest persists. Covers the conversion in
+ * isolation, on hand-built entries, and end to end against a real checkpoint's leaves.
+ */
+class AMTPartitionValuesSuite extends AMTCheckpointTestBase {
+
+  import testImplicits._
+
+  /** A stand-in table root; the entries here carry no DV, so it is only a path placeholder. */
+  private val tableRoot = new Path("file:/tmp/amt-test-table")
+
+  /** A minimal leaf tracking envelope (ADDED status). */
+  private def addedTracking: Tracking = Tracking(
+    status = Tracking.Status.Added,
+    snapshot_id = None,
+    dv_snapshot_id = None,
+    sequence_number = None,
+    file_sequence_number = None,
+    first_row_id = None,
+    deleted_positions = None,
+    replaced_positions = None)
+
+  private def sampleAddFile: AddFile = AddFile(
+    path = "part-00000.parquet",
+    partitionValues = Map("p" -> "1"),
+    size = 1024L,
+    modificationTime = 100L,
+    dataChange = true,
+    stats = """{"numRecords":42}""")
+
+  /** A DataFrame of one wrapped DATA entry carrying `partitionValues`. */
+  private def entryWith(partitionValues: Map[String, String]) =
+    Seq(sampleAddFile.copy(partitionValues = partitionValues))
+      .map(DataEntry.fromAddFile(_, addedTracking, tableRoot).wrap).toDS().toDF()
+
+  /** A partition column whose physical name differs from its logical one, as column mapping
+   *  assigns them. */
+  private def partitionColumn(logical: String, physical: String, dataType: DataType) =
+    StructField(logical, dataType, nullable = true,
+      new MetadataBuilder()
+        .putString(DeltaColumnMapping.COLUMN_MAPPING_PHYSICAL_NAME_KEY, physical)
+        .build())
+
+  test("partition adapter writes typed logical values and restores the physical-name map") {
+    val partitionSchema = StructType(Seq(
+      partitionColumn("region", "col-1", IntegerType),
+      partitionColumn("day", "col-2", DateType),
+      partitionColumn("name", "col-3", StringType),
+      partitionColumn("count", "col-4", LongType),
+      partitionColumn("active", "col-5", BooleanType),
+      partitionColumn("amount", "col-6", DecimalType(9, 3)),
+      partitionColumn("at", "col-7", TimestampType)))
+    // The values a Delta log would hold for these columns. `col-7` is already UTC-normalized
+    // because that is the form `literalToNormalizedString` writes a timestamp in; the round trip
+    // below is only lossless for the form the writer actually produces.
+    val logged = Map(
+      "col-1" -> "7",
+      "col-2" -> "2026-07-25",
+      "col-3" -> "us-west-2",
+      "col-4" -> "9007199254740993",
+      "col-5" -> "true",
+      "col-6" -> "1.250",
+      "col-7" -> "2026-07-25T08:02:03.456000Z")
+    val input = entryWith(logged)
+
+    // The persisted struct is keyed by *logical* name and typed, while the source map was keyed by
+    // physical name with string values.
+    val persistedDF = AMTPartitionValues.forWrite(input, partitionSchema)
+    assert(persistedDF.schema("partition").dataType.asInstanceOf[StructType]
+      .map(f => f.name -> f.dataType) == partitionSchema.map(f => f.name -> f.dataType))
+
+    val partition = persistedDF.select("partition.*").head()
+    assert(partition.getInt(0) == 7)
+    assert(partition.getDate(1).toString == "2026-07-25")
+    assert(partition.getString(2) == "us-west-2")
+    // Wider than a Double can hold exactly, so this also shows the value is not going through one.
+    assert(partition.getLong(3) == 9007199254740993L)
+    assert(partition.getBoolean(4))
+    assert(partition.getDecimal(5) == new java.math.BigDecimal("1.250"))
+    assert(partition.getTimestamp(6).toInstant.toString == "2026-07-25T08:02:03.456Z")
+
+    // The whole struct collects as a nested Row of typed values, not as a map of strings.
+    val persistedRow = persistedDF.select("partition").collect().head.getStruct(0)
+    assert(persistedRow.schema.fieldNames.toSeq == partitionSchema.map(_.name))
+    assert(persistedRow.getInt(0) == 7)
+
+    // Reading it back restores exactly the physical-name string map the Delta log held.
+    val restoredDF = AMTPartitionValues.forRead(persistedDF, partitionSchema)
+    assert(restoredDF.select("partition").collect().toSeq == Seq(Row(logged)))
+    val restored = restoredDF.select(col("partition")).as[Map[String, String]].head()
+    assert(restored == logged)
+  }
+
+  test("partition adapter rejects an invalid non-null typed value") {
+    val schema = StructType(Seq(StructField("p", IntegerType)))
+    val input = entryWith(Map("p" -> "not-an-int"))
+
+    // `forWrite` casts with ANSI on, so an unparseable value fails the write rather than silently
+    // persisting a null partition value.
+    val error = intercept[Exception] {
+      AMTPartitionValues.forWrite(input, schema).collect()
+    }
+    assert(error.toString.contains("CAST_INVALID_INPUT"))
+  }
+
+  /**
+   * The physical-name partition-value maps `forRead` reconstructs from `leaves`' DATA entries.
+   */
+  private def reconstructPartitionValues(
+      leaves: Seq[String],
+      partitionSchema: StructType): Set[Map[String, String]] =
+    allowReadWithinDeltaLog {
+      val entries = spark.read.parquet(leaves: _*)
+        .where(col("content_type") === AMTSingleAction.ContentType.Type.Data)
+      AMTPartitionValues.forRead(entries, partitionSchema)
+        .select(col("partition"))
+        .collect()
+        .map(_.getMap[String, String](0).toMap)
+        .toSet
+    }
+
+  test("forRead reproduces the partition values the delta log holds, for every type") {
+    val numFiles = 4
+    withAllPartitionTypesTable(
+        "amt_partition_roundtrip", numFiles = numFiles, maxEntriesPerLeaf = 2) { deltaLog =>
+      commitCheckpoint(deltaLog, incremental = false)
+      val snapshot = deltaLog.update()
+      val provider = amtProvider(snapshot).getOrElse(fail("expected AMTCheckpointProvider"))
+      val partitionSchema = snapshot.metadata.partitionSchema
+      val leaves = provider.liveLeafManifestAbsolutePaths.map(_.toString)
+      assert(leaves.nonEmpty, "Expected at least one leaf manifest.")
+
+      // Read the commit json directly rather than going through the snapshot: an AMT snapshot
+      // reconstructs its AddFiles through `forRead`, so comparing against it would compare
+      // `forRead` with itself and hold even if the conversion were wrong.
+      val loggedSchema = StructType(Seq(StructField("add", StructType(Seq(
+        StructField("partitionValues", MapType(StringType, StringType)))))))
+      val logged = spark.read
+        .schema(loggedSchema)
+        .json(new Path(deltaLog.logPath, "*.json").toString)
+        .where(col("add").isNotNull)
+        .select(col("add.partitionValues"))
+        .collect()
+        .map(_.getMap[String, String](0).toMap)
+        .toSet
+      assert(logged.size == numFiles, s"Expected one logged add per file, got ${logged.size}.")
+
+      val reconstructed = reconstructPartitionValues(leaves, partitionSchema)
+      assert(reconstructed == logged,
+        s"forRead did not reproduce the logged partition values.\n" +
+          s"  logged=$logged\n  reconstructed=$reconstructed")
+    }
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSingleActionSerializerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSingleActionSerializerSuite.scala
@@ -144,7 +144,7 @@ class AMTSingleActionSerializerSuite extends QueryTest with SharedSparkSession {
     tracking = tracking,
     deletion_vector = deletion_vector,
     spec_id = None,
-    partition = Partition(),
+    partition = None,
     sort_order_id = sort_order_id,
     record_count = 1L,
     file_size_in_bytes = 1L,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotSuite.scala
@@ -672,7 +672,7 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
       val checkpoint =
         checkpointWithSyntheticRoot(deltaLog, provider.checkpointAction, rootDataRows)
 
-      val rootProvider = AMTCheckpointProvider.fromCheckpoint(spark, deltaLog, checkpoint)
+      val rootProvider = AMTCheckpointProvider.fromCheckpoint(deltaLog, checkpoint)
       assert(rootProvider.leaves.isEmpty, "A DATA-only root must yield no leaf pointers.")
 
       val expected = rootAdds.map(_.path).toSet
@@ -933,8 +933,17 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
     val rootFile = FileNames.newAMTRootManifestFile(metadataDir)
     val useRename = deltaLog.store.isPartialWriteVisible(deltaLog.logPath, hadoopConf)
     val enc = org.apache.spark.sql.delta.implicits.amtSingleActionEncoder
-    val df = spark.createDataset(rows)(enc).toDF()
-    Checkpoints.writeAtomicCheckpointParquetFile(spark, df, rootFile, hadoopConf, useRename)
+    val metadata = base.metaData
+    val df = AMTPartitionValues.forWrite(
+      spark.createDataset(rows)(enc).toDF(), metadata.partitionSchema)
+    Checkpoints.writeAtomicCheckpointParquetFile(
+      spark,
+      df,
+      rootFile,
+      hadoopConf,
+      useRename,
+      outputSchema = Some(AMTSingleAction.persistedSchema(metadata.partitionSchema)),
+      useDeltaParquetWriteSupport = true)
     val size = rootFile.getFileSystem(hadoopConf).getFileStatus(rootFile).getLen
     base.copy(contentRoot = ContentRoot(path = rootFile.toString, sizeInBytes = size))
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/SnapshotLastManifestCommitSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/SnapshotLastManifestCommitSuite.scala
@@ -379,7 +379,7 @@ class SnapshotLastManifestCommitWithoutCRCSuite extends SnapshotLastManifestComm
       val checkpoint = checkpointAt(deltaLog, 4).getOrElse {
         fail("v4 must emit an inline AMT checkpoint action.")
       }
-      val provider = AMTCheckpointProvider.fromCheckpoint(spark, deltaLog, checkpoint)
+      val provider = AMTCheckpointProvider.fromCheckpoint(deltaLog, checkpoint)
       val coldSnapshot = freshSnapshotAt(name, 4)
       val segment = coldSnapshot.logSegment.copy(checkpointProvider = provider, deltas = Nil)
       val snapshot = new Snapshot(


### PR DESCRIPTION
## Description

Adaptive metadata manifests stored partition values as the physical-name string map that `AddFile` carries. The Iceberg V4 `partition` field is a struct with one typed field per partition column, so this persists it that way.

`AMTPartitionValues` converts in both directions:

- **On write**, each value is cast to its partition column's type with ANSI enabled, so an unparseable value fails the write rather than silently persisting a null partition value.
- **On read**, each typed value is rendered with the same normalizer the writer used (`PartitionUtils.expressionToNormalizedString`, added alongside the existing `literalToNormalizedString`), so a round trip reproduces exactly what the log holds.

Partition field ids start at 1000 in partition-spec order, and field 102 (`partition`) is optional per the spec. The struct's fields carry the partition columns' logical names, which is safe because a reader resolves partition fields by id rather than by name, so a column rename does not change how the struct is read.

A timestamp is always rendered UTC-normalized rather than following `write.utcTimestampPartitionValues`. That conf preserves a legacy write format and is a session conf the log does not record per file, so honoring it on the read path would make reading a manifest depend on the session doing the read, and a manifest written by one session unreadable by another.

Manifest loading now takes the partition schema from the checkpoint's own metadata, so a manifest stays self-describing and a later rename or repartition cannot misread an older one.

`AMTSingleAction.schemaWithFieldId` is renamed to `persistedSchema`, since stamping field ids is only one of the ways the persisted schema differs from the encoder's in-memory one: required/optional comes from the field spec, `partition` holds the typed struct rather than a string map, and `partition` is dropped entirely for an unpartitioned table.

## How was this patch tested?

New `AMTPartitionValuesSuite` covers the converter two ways:

- On hand-built entries, over seven partition types whose physical names differ from their logical ones, asserting the persisted struct is typed and keyed by logical name and that reading it back restores exactly the physical-name string map. It also asserts an unparseable value fails the write.
- End to end against a real checkpoint's leaves, over a table partitioned by one column per partition type supported (13, including binary). The expected values are read from the commit json rather than from the snapshot: a snapshot reconstructs its `AddFile`s through the same read path, so comparing against it would compare that path with itself and hold even if the conversion were wrong. Verified by disabling the UTC-normalization branch and confirming this test fails.

`AMTFieldIdSuite` is renamed to `AMTFieldSpecSuite`, and asserts partition fields take ids from 1000 in partition-spec order whatever their type, alongside the existing field-id checks. `AMTCheckpointWriteSuite`'s partition round-trip test now shares the all-types partition spec (moved to `AMTCheckpointTestBase`) instead of maintaining a parallel 6-type schema, so it covers all 13 types.
