### PR TITLE
[Spark] Move DELTA_INVALID_IDEMPOTENT_WRITES_OPTIONS explanation into error subclasses

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -1839,8 +1839,20 @@
   },
   "DELTA_INVALID_IDEMPOTENT_WRITES_OPTIONS" : {
     "message" : [
-      "Invalid options for idempotent Dataframe writes: <reason>"
+      "Invalid options for idempotent DataFrame writes:"
     ],
+    "subClass" : {
+      "MISSING_DATAFRAME_WRITE_OPTIONS" : {
+        "message" : [
+          "Both txnVersion and txnAppId must be specified for idempotent DataFrame writes."
+        ]
+      },
+      "MISSING_SESSION_CONFS" : {
+        "message" : [
+          "Both spark.databricks.delta.write.txnAppId and spark.databricks.delta.write.txnVersion must be specified for idempotent Delta writes."
+        ]
+      }
+    },
     "sqlState" : "42616"
   },
   "DELTA_INVALID_INTERVAL" : {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -1310,10 +1310,16 @@ trait DeltaErrorsBase
       messageParameters = Array(input, name, explain))
   }
 
-  def invalidIdempotentWritesOptionsException(explain: String): Throwable = {
+  def invalidIdempotentWritesMissingWriteOptionsException(): Throwable = {
     new DeltaIllegalArgumentException(
-      errorClass = "DELTA_INVALID_IDEMPOTENT_WRITES_OPTIONS",
-      messageParameters = Array(explain))
+      errorClass = "DELTA_INVALID_IDEMPOTENT_WRITES_OPTIONS.MISSING_DATAFRAME_WRITE_OPTIONS",
+      messageParameters = Array.empty)
+  }
+
+  def invalidIdempotentWritesMissingSessionConfsException(): Throwable = {
+    new DeltaIllegalArgumentException(
+      errorClass = "DELTA_INVALID_IDEMPOTENT_WRITES_OPTIONS.MISSING_SESSION_CONFS",
+      messageParameters = Array.empty)
   }
 
   def invalidInterval(interval: String): Throwable = {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaOptions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaOptions.scala
@@ -154,8 +154,7 @@ trait DeltaWriteOptionsImpl extends DeltaOptionParser {
     // neither must be given. In all other cases, throw an exception.
     val numOptions = txnVersion.size + txnAppId.size
     if (numOptions != 0 && numOptions != 2) {
-      throw DeltaErrors.invalidIdempotentWritesOptionsException("Both txnVersion and txnAppId " +
-      "must be specified for idempotent data frame writes")
+      throw DeltaErrors.invalidIdempotentWritesMissingWriteOptionsException()
     }
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeltaCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeltaCommand.scala
@@ -432,10 +432,7 @@ trait DeltaCommand extends DeltaLogging with DeltaCommandInvariants {
       // check that both session configs are set
       numOptions = txnVersion.size + txnAppId.size
       if (numOptions != 0 && numOptions != 2) {
-        throw DeltaErrors.invalidIdempotentWritesOptionsException(
-          "Both spark.databricks.delta.write.txnAppId and " +
-            "spark.databricks.delta.write.txnVersion must be specified for " +
-            "idempotent Delta writes")
+        throw DeltaErrors.invalidIdempotentWritesMissingSessionConfsException()
       }
       fromSessionConf = true
     }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -1621,10 +1621,19 @@ trait DeltaErrorsSuiteBase
     }
     {
       val e = intercept[DeltaIllegalArgumentException] {
-        throw DeltaErrors.invalidIdempotentWritesOptionsException("someReason")
+        throw DeltaErrors.invalidIdempotentWritesMissingWriteOptionsException()
       }
-      checkError(e, "DELTA_INVALID_IDEMPOTENT_WRITES_OPTIONS", "42616",
-        Map("reason" -> "someReason"))
+      checkError(e,
+        "DELTA_INVALID_IDEMPOTENT_WRITES_OPTIONS.MISSING_DATAFRAME_WRITE_OPTIONS", "42616",
+        Map.empty[String, String])
+    }
+    {
+      val e = intercept[DeltaIllegalArgumentException] {
+        throw DeltaErrors.invalidIdempotentWritesMissingSessionConfsException()
+      }
+      checkError(e,
+        "DELTA_INVALID_IDEMPOTENT_WRITES_OPTIONS.MISSING_SESSION_CONFS", "42616",
+        Map.empty[String, String])
     }
     {
       val e = intercept[DeltaAnalysisException] {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
@@ -2795,10 +2795,8 @@ class DeltaSuite extends QueryTest
       val e1 = intercept[DeltaIllegalArgumentException] {
         spark.sql(s"INSERT INTO $tableName (col1, col2) VALUES (4, 0)")
       }
-      checkError(e1, "DELTA_INVALID_IDEMPOTENT_WRITES_OPTIONS", "42616", Map("reason" -> (
-        "Both spark.databricks.delta.write.txnAppId and spark.databricks.delta.write.txnVersion " +
-          "must be specified for idempotent Delta writes")
-      ))
+      checkError(e1, "DELTA_INVALID_IDEMPOTENT_WRITES_OPTIONS.MISSING_SESSION_CONFS", "42616",
+        Map.empty[String, String])
       // this write should succeed as it's using a newer version than the latest
       spark.conf.set("spark.databricks.delta.write.txnVersion", "10")
       spark.sql(s"INSERT INTO $tableName (col1, col2) VALUES (2, 0)")
@@ -2806,10 +2804,8 @@ class DeltaSuite extends QueryTest
       val e2 = intercept[DeltaIllegalArgumentException] {
         spark.sql(s"INSERT INTO $tableName (col1, col2) VALUES (3, 0)")
       }
-      checkError(e2, "DELTA_INVALID_IDEMPOTENT_WRITES_OPTIONS", "42616", Map("reason" -> (
-        "Both spark.databricks.delta.write.txnAppId and spark.databricks.delta.write.txnVersion " +
-          "must be specified for idempotent Delta writes")
-      ))
+      checkError(e2, "DELTA_INVALID_IDEMPOTENT_WRITES_OPTIONS.MISSING_SESSION_CONFS", "42616",
+        Map.empty[String, String])
 
       val res = spark.sql(s"SELECT col1 FROM $tableName")
         .orderBy(asc("col1"))
@@ -2881,7 +2877,7 @@ class DeltaSuite extends QueryTest
               idempotentWrite(mode, appId2, df, path, name, 5, 12, 4, isSaveAsTable)
 
               // Verify that specifying only one of the options -- either appId or version -- fails.
-              val e1 = intercept[Exception] {
+              val e1 = intercept[DeltaIllegalArgumentException] {
                 val stage = df.write.format("delta").option(DeltaOptions.TXN_APP_ID, 1).mode(mode)
                 if (isSaveAsTable) {
                   stage.option("path", path).saveAsTable(name)
@@ -2889,8 +2885,10 @@ class DeltaSuite extends QueryTest
                   stage.save(path)
                 }
               }
-              assert(e1.getMessage.contains("Invalid options for idempotent Dataframe writes"))
-              val e2 = intercept[Exception] {
+              checkError(e1,
+                "DELTA_INVALID_IDEMPOTENT_WRITES_OPTIONS.MISSING_DATAFRAME_WRITE_OPTIONS", "42616",
+                Map.empty[String, String])
+              val e2 = intercept[DeltaIllegalArgumentException] {
                 val stage = df.write.format("delta").option(DeltaOptions.TXN_VERSION, 1).mode(mode)
                 if (isSaveAsTable) {
                   stage.option("path", path).saveAsTable(name)
@@ -2898,7 +2896,9 @@ class DeltaSuite extends QueryTest
                   stage.save(path)
                 }
               }
-              assert(e2.getMessage.contains("Invalid options for idempotent Dataframe writes"))
+              checkError(e2,
+                "DELTA_INVALID_IDEMPOTENT_WRITES_OPTIONS.MISSING_DATAFRAME_WRITE_OPTIONS", "42616",
+                Map.empty[String, String])
             }
           }
         }
@@ -2927,16 +2927,20 @@ class DeltaSuite extends QueryTest
             idempotentWrite(mode, appId2, df, path, name, 5, 3, 4, isSaveAsTable)
 
             // Verify that specifying only one of the options -- either appId or version -- fails.
-            val e1 = intercept[Exception] {
+            val e1 = intercept[DeltaIllegalArgumentException] {
               val stage = df.write.format("delta").option(DeltaOptions.TXN_APP_ID, 1).mode(mode)
               if (isSaveAsTable) stage.option("path", path).saveAsTable(name) else stage.save(path)
             }
-            assert(e1.getMessage.contains("Invalid options for idempotent Dataframe writes"))
-            val e2 = intercept[Exception] {
+            checkError(e1,
+              "DELTA_INVALID_IDEMPOTENT_WRITES_OPTIONS.MISSING_DATAFRAME_WRITE_OPTIONS", "42616",
+              Map.empty[String, String])
+            val e2 = intercept[DeltaIllegalArgumentException] {
               val stage = df.write.format("delta").option(DeltaOptions.TXN_VERSION, 1).mode(mode)
               if (isSaveAsTable) stage.option("path", path).saveAsTable(name) else stage.save(path)
             }
-            assert(e2.getMessage.contains("Invalid options for idempotent Dataframe writes"))
+            checkError(e2,
+              "DELTA_INVALID_IDEMPOTENT_WRITES_OPTIONS.MISSING_DATAFRAME_WRITE_OPTIONS", "42616",
+              Map.empty[String, String])
           }
         }
       }


### PR DESCRIPTION
## Description

The `DELTA_INVALID_IDEMPOTENT_WRITES_OPTIONS` error passed its explanation as a
`reason` string parameter constructed in code. This moves the two explanations
into dedicated error subclasses, so all the message text lives in the error class
definitions rather than in Scala:

- `MISSING_DATAFRAME_WRITE_OPTIONS` — only one of the `txnVersion` / `txnAppId`
  DataFrame writer options was specified.
- `MISSING_SESSION_CONFS` — only one of the corresponding session configs was set.

The single factory method is replaced by two parameter-free methods. The
top-level error condition and SQLSTATE (`42616`) are unchanged. The message also
spells "DataFrame" consistently.

## How was this patch tested?

Existing unit tests were updated to assert the subclass and SQLSTATE via
`checkError` (converted from rendered-message substring checks):
`DeltaErrorsSuite` (both subclasses) and `DeltaSuite`
(`MISSING_DATAFRAME_WRITE_OPTIONS`, via the write path).

## Does this PR introduce _any_ user-facing changes?

The error raised for invalid idempotent-write options now reports a subclass in
its condition name (`DELTA_INVALID_IDEMPOTENT_WRITES_OPTIONS.MISSING_DATAFRAME_WRITE_OPTIONS`
or `.MISSING_SESSION_CONFS`). The SQLSTATE is unchanged, and the message text is
unchanged apart from consistent "DataFrame" spelling.
