### PR TITLE
[Spark] Renew server-side scan-plan credentials

### DIFF
--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/serverSidePlanning/IcebergRESTCatalogPlanningClient.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/serverSidePlanning/IcebergRESTCatalogPlanningClient.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql.delta.serverSidePlanning
 
 import java.io.IOException
 import java.lang.reflect.Method
+import java.net.URI
 import java.util.Locale
 
 import scala.jdk.CollectionConverters._
@@ -68,11 +69,14 @@ private case class CatalogConfigResponse(
  * @param catalogName Name of the catalog for config endpoint query parameter.
  * @param tokenSupplier Supplier of auth tokens, called per-request to support OAuth.
  *                      Returns empty string if no auth is needed.
+ * @param credentialRefreshConfig Optional catalog URI and auth configuration retained so a
+ *                                returned plan ID can enable executor-side credential renewal.
  */
 class IcebergRESTCatalogPlanningClient(
     baseUriRaw: String,
     catalogName: String,
-    tokenSupplier: () => String
+    tokenSupplier: () => String,
+    credentialRefreshConfig: Option[ScanPlanCredentialRefreshConfig] = None
 ) extends ServerSidePlanningClient with Logging {
 
   // Normalize baseUri to handle trailing slashes
@@ -356,7 +360,9 @@ class IcebergRESTCatalogPlanningClient(
     // icebergRestCatalogUriRoot is lazily constructed as: {baseUri}/{prefix}
     // where prefix comes from /v1/config?warehouse=<catalogName> per Iceberg REST spec.
     // See: https://iceberg.apache.org/rest-catalog-spec/
-    val planTableScanUri = s"$icebergRestCatalogUriRoot/namespaces/$database/tables/$table/plan"
+    val tableEndpoint = s"$icebergRestCatalogUriRoot/namespaces/$database/tables/$table"
+    val planTableScanUri = s"$tableEndpoint/plan"
+    val credentialsEndpoint = s"$tableEndpoint/credentials"
 
     // Request planning for current snapshot. snapshotId = 0 means "use current snapshot"
     // in the Iceberg REST API spec. Time-travel queries are not yet supported.
@@ -418,7 +424,7 @@ class IcebergRESTCatalogPlanningClient(
             s"expected 'completed'. Table: $database.$table")
         }
 
-        convertToScanPlan(icebergResponse, responseBody)
+        convertToScanPlan(icebergResponse, responseBody, credentialsEndpoint)
       } else {
         // TODO: Parse structured ErrorResponse JSON from Iceberg REST spec instead of raw body
         throw new IOException(
@@ -437,7 +443,8 @@ class IcebergRESTCatalogPlanningClient(
    */
   private def convertToScanPlan(
       response: PlanTableScanResponse,
-      responseBody: String): ScanPlan = {
+      responseBody: String,
+      credentialsEndpoint: String): ScanPlan = {
     require(response != null, "PlanTableScanResponse cannot be null")
     require(response.fileScanTasks() != null, "File scan tasks cannot be null")
 
@@ -471,7 +478,26 @@ class IcebergRESTCatalogPlanningClient(
     }.toSeq
 
     val credentials = extractCredentials(responseBody)
-    ScanPlan(files = files, credentials = credentials)
+    val storageSchemes = files.flatMap { file =>
+      Try(new URI(file.filePath).getScheme)
+        .toOption
+        .filter(_ != null)
+        .map(_.toLowerCase(Locale.ROOT))
+    }.distinct
+    val credentialRefresh = for {
+      config <- credentialRefreshConfig
+      planId <- Option(response.planId()).filter(_.nonEmpty)
+    } yield ScanPlanCredentialRefresh(
+      catalogUri = config.catalogUri,
+      credentialsEndpoint = credentialsEndpoint,
+      planId = planId,
+      authConfig = config.authConfig,
+      storageSchemes = storageSchemes)
+
+    ScanPlan(
+      files = files,
+      credentials = credentials,
+      credentialRefresh = credentialRefresh)
   }
 
   /**

--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/serverSidePlanning/IcebergRESTCatalogPlanningClientFactory.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/serverSidePlanning/IcebergRESTCatalogPlanningClientFactory.scala
@@ -31,8 +31,13 @@ class IcebergRESTCatalogPlanningClientFactory extends ServerSidePlanningClientFa
     val catalogName = metadata.catalogName
     val supplier: () => String =
       metadata.tokenSupplier.getOrElse(() => "")
+    val credentialRefreshConfig = metadata match {
+      case uc: UnityCatalogMetadata if uc.ucUri.nonEmpty && uc.authConfig.nonEmpty =>
+        Some(ScanPlanCredentialRefreshConfig(uc.ucUri, uc.authConfig))
+      case _ => None
+    }
 
     new IcebergRESTCatalogPlanningClient(
-      baseUri, catalogName, supplier)
+      baseUri, catalogName, supplier, credentialRefreshConfig)
   }
 }

--- a/iceberg/src/test/java/shadedForDelta/org/apache/iceberg/rest/IcebergRESTCatalogAdapterWithPlanSupport.java
+++ b/iceberg/src/test/java/shadedForDelta/org/apache/iceberg/rest/IcebergRESTCatalogAdapterWithPlanSupport.java
@@ -406,6 +406,7 @@ class IcebergRESTCatalogAdapterWithPlanSupport extends RESTCatalogAdapter {
 
     // Build response (Pattern 1: COMPLETED with direct tasks)
     return PlanTableScanResponse.builder()
+        .withPlanId("test-plan-id")
         .withPlanStatus(PlanStatus.COMPLETED)
         .withFileScanTasks(tasksToReturn)
         .withSpecsById(specsById)

--- a/iceberg/src/test/scala/org/apache/spark/sql/delta/serverSidePlanning/IcebergRESTCatalogPlanningClientSuite.scala
+++ b/iceberg/src/test/scala/org/apache/spark/sql/delta/serverSidePlanning/IcebergRESTCatalogPlanningClientSuite.scala
@@ -85,8 +85,42 @@ class IcebergRESTCatalogPlanningClientSuite extends QueryTest with SharedSparkSe
         assert(scanPlan.files != null, "Scan plan files should not be null")
         assert(scanPlan.files.isEmpty,
           s"Empty table should have 0 files, got ${scanPlan.files.length}")
+        assert(scanPlan.credentialRefresh.isEmpty,
+          "Credential refresh requires catalog auth context")
       } finally {
         client.close()
+      }
+    }
+  }
+
+  test("plan ID produces credential refresh context with the resolved catalog prefix") {
+    withTempTable("credentialRefreshContext") { table =>
+      val tableName = s"rest_catalog.${defaultNamespace}.credentialRefreshContext"
+      populateTestData(tableName)
+      server.setCatalogPrefix("catalogs/test-catalog-prefix")
+
+      val refreshConfig = ScanPlanCredentialRefreshConfig(
+        catalogUri = "https://uc.example.com",
+        authConfig = Map("type" -> "static", "token" -> "secret"))
+      val client = new IcebergRESTCatalogPlanningClient(
+        s"$serverUri/v1", "test_catalog", () => "secret", Some(refreshConfig))
+      try {
+        val plan = client.planScan(defaultNamespace.toString, "credentialRefreshContext")
+        val refresh = plan.credentialRefresh.getOrElse(
+          fail("Expected credential refresh context when plan ID and auth config are present"))
+
+        assert(refresh.planId == "test-plan-id")
+        assert(refresh.catalogUri == "https://uc.example.com")
+        assert(refresh.credentialsEndpoint ==
+          s"$serverUri/v1/catalogs/test-catalog-prefix/namespaces/$defaultNamespace/" +
+            "tables/credentialRefreshContext/credentials")
+        assert(refresh.authConfig == refreshConfig.authConfig)
+        // The test JDBC catalog stores local paths without an explicit URI scheme. Cloud-backed
+        // scan files carry s3/abfs/gs schemes, which are retained for credential configuration.
+        assert(refresh.storageSchemes.isEmpty)
+      } finally {
+        client.close()
+        server.setCatalogPrefix(null)
       }
     }
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/serverSidePlanning/ServerSidePlannedTable.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/serverSidePlanning/ServerSidePlannedTable.scala
@@ -21,6 +21,9 @@ import java.util.Locale
 
 import scala.collection.JavaConverters._
 
+import io.unitycatalog.client.auth.TokenProvider
+import io.unitycatalog.hadoop.UCCredentialHadoopConfs
+
 import org.apache.spark.paths.SparkPath
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
@@ -391,7 +394,7 @@ class ServerSidePlannedScan(
 
   override def createReaderFactory(): PartitionReaderFactory = {
     new ServerSidePlannedFilePartitionReaderFactory(
-      spark, tableSchema, requiredSchema, scanPlan.credentials)
+      spark, tableSchema, requiredSchema, scanPlan.credentials, scanPlan.credentialRefresh)
   }
 }
 
@@ -410,12 +413,14 @@ case class ServerSidePlannedFileInputPartition(
  * @param tableSchema The full table schema (all columns in the file)
  * @param requiredSchema The required schema (columns to read after projection pushdown)
  * @param credentials Optional storage credentials from server-side planning response
+ * @param credentialRefresh Optional plan-scoped context for renewable credentials
  */
 class ServerSidePlannedFilePartitionReaderFactory(
     spark: SparkSession,
     tableSchema: StructType,
     requiredSchema: StructType,
-    credentials: Option[ScanPlanStorageCredentials])
+    credentials: Option[ScanPlanStorageCredentials],
+    credentialRefresh: Option[ScanPlanCredentialRefresh] = None)
     extends PartitionReaderFactory {
 
   import org.apache.spark.util.SerializableConfiguration
@@ -428,18 +433,33 @@ class ServerSidePlannedFilePartitionReaderFactory(
   // - ServerSidePlannedTable is NOT a Delta table, so we don't want Delta-specific options
   //   from deltaLog.newDeltaHadoopConf()
   // - General Spark options from spark.hadoop.* are included and work for all tables
-  private val hadoopConf = {
+  private[serverSidePlanning] val hadoopConf = {
     val conf = spark.sessionState.newHadoopConf()
 
-    // Inject temporary credentials from IRC server response.
-    // Disable FileSystem cache for S3, Azure, and GCS so each scan uses fresh credentials
-    // (avoids AccessDenied when temp creds expire and a cached FS is reused).
-    // Aligns with CredPropsUtil in the Unity Catalog connector.
-    credentials.foreach(_.configure(conf))
+    credentialRefresh match {
+      case Some(refresh) => configureRenewableCredentials(conf, refresh)
+      case None => credentials.foreach(_.configure(conf))
+    }
 
     new SerializableConfiguration(conf)
   }
   // scalastyle:on deltahadoopconfiguration
+
+  private def configureRenewableCredentials(
+      conf: org.apache.hadoop.conf.Configuration,
+      refresh: ScanPlanCredentialRefresh): Unit = {
+    val tokenProvider = TokenProvider.create(refresh.authConfig.asJava)
+    val appVersions = Map("Spark" -> spark.version).asJava
+
+    refresh.storageSchemes.distinct.foreach { scheme =>
+      val props = UCCredentialHadoopConfs.builder(refresh.catalogUri, scheme)
+        .tokenProvider(tokenProvider)
+        .hadoopConf(conf)
+        .addAppVersions(appVersions)
+        .buildForIcebergPlan(refresh.credentialsEndpoint, refresh.planId)
+      props.asScala.foreach { case (key, value) => conf.set(key, value) }
+    }
+  }
 
   // Pre-build reader function for Parquet on the driver
   // This function will be serialized and sent to executors

--- a/spark/src/main/scala/org/apache/spark/sql/delta/serverSidePlanning/ServerSidePlanningClient.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/serverSidePlanning/ServerSidePlanningClient.scala
@@ -189,8 +189,26 @@ trait ScanPlanStorageCredentials {
 }
 
 /**
+ * Information needed to renew credentials for one authorized Iceberg server-side scan plan.
+ * The opaque plan ID, rather than a source table ID, keeps each refresh request scoped to the
+ * same FGAC plan that produced the scan files.
+ */
+case class ScanPlanCredentialRefresh(
+    catalogUri: String,
+    credentialsEndpoint: String,
+    planId: String,
+    authConfig: Map[String, String],
+    storageSchemes: Seq[String])
+
+/** Catalog-level inputs retained by a planning client until the server returns a plan ID. */
+case class ScanPlanCredentialRefreshConfig(
+    catalogUri: String,
+    authConfig: Map[String, String])
+
+/**
  * Result of a table scan plan operation.
  */
 case class ScanPlan(
     files: Seq[ScanFile],
-    credentials: Option[ScanPlanStorageCredentials] = None)
+    credentials: Option[ScanPlanStorageCredentials] = None,
+    credentialRefresh: Option[ScanPlanCredentialRefresh] = None)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/serverSidePlanning/ServerSidePlanningMetadata.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/serverSidePlanning/ServerSidePlanningMetadata.scala
@@ -39,6 +39,13 @@ private[serverSidePlanning] trait ServerSidePlanningMetadata {
   def tokenSupplier: Option[() => String]
 
   /**
+   * Authentication configuration used to reconstruct a renewable token provider on executors.
+   * Keys use the Unity Catalog TokenProvider format (for example, `type`, `token`, and
+   * `oauth.*`).
+   */
+  def authConfig: Map[String, String] = Map.empty
+
+  /**
    * Catalog name for configuration lookups.
    */
   def catalogName: String

--- a/spark/src/main/scala/org/apache/spark/sql/delta/serverSidePlanning/UnityCatalogMetadata.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/serverSidePlanning/UnityCatalogMetadata.scala
@@ -31,7 +31,8 @@ case class UnityCatalogMetadata(
     catalogName: String,
     ucUri: String,
     override val tokenSupplier: Option[() => String],
-    tableProps: Map[String, String]) extends ServerSidePlanningMetadata {
+    tableProps: Map[String, String],
+    override val authConfig: Map[String, String] = Map.empty) extends ServerSidePlanningMetadata {
 
   override def planningEndpointUri: String = {
     val base = if (ucUri.endsWith("/")) ucUri.dropRight(1) else ucUri
@@ -67,7 +68,7 @@ object UnityCatalogMetadata {
     }
 
     val tableProps = Map.empty[String, String]
-    UnityCatalogMetadata(catalogName, ucUri, supplier, tableProps)
+    UnityCatalogMetadata(catalogName, ucUri, supplier, tableProps, authConfig)
   }
 
   /**

--- a/spark/src/test/scala/org/apache/spark/sql/delta/serverSidePlanning/ServerSidePlanningCredentialRefreshSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/serverSidePlanning/ServerSidePlanningCredentialRefreshSuite.scala
@@ -1,0 +1,99 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.serverSidePlanning
+
+import java.net.InetSocketAddress
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.atomic.AtomicReference
+
+import com.sun.net.httpserver.{HttpExchange, HttpServer}
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.StructType
+
+class ServerSidePlanningCredentialRefreshSuite extends QueryTest with SharedSparkSession {
+
+  private var server: HttpServer = _
+
+  override def afterEach(): Unit = {
+    if (server != null) {
+      server.stop(0)
+      server = null
+    }
+    super.afterEach()
+  }
+
+  test("reader Hadoop configuration uses plan-scoped renewable credentials") {
+    val observedQuery = new AtomicReference[String]()
+    val observedAuthorization = new AtomicReference[String]()
+    server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0)
+    server.createContext("/v1/ns/t/credentials", exchange => {
+      observedQuery.set(exchange.getRequestURI.getRawQuery)
+      observedAuthorization.set(exchange.getRequestHeaders.getFirst("Authorization"))
+      respond(exchange, 200,
+        """{"storage-credentials":[{"prefix":"s3://bucket/table","config":{
+          |"s3.access-key-id":"ak","s3.secret-access-key":"sk",
+          |"s3.session-token":"st",
+          |"s3.session-token-expires-at-ms":"4102444800000"}}]}""".stripMargin)
+    })
+    server.start()
+
+    val baseUri = s"http://127.0.0.1:${server.getAddress.getPort}"
+    val refresh = ScanPlanCredentialRefresh(
+      catalogUri = baseUri,
+      credentialsEndpoint = s"$baseUri/v1/ns/t/credentials",
+      planId = "plan-1",
+      authConfig = Map("type" -> "static", "token" -> "token-1"),
+      storageSchemes = Seq("s3"))
+    val schema = StructType.fromDDL("id INT")
+
+    val factory = new ServerSidePlannedFilePartitionReaderFactory(
+      spark, schema, schema, credentials = None, credentialRefresh = Some(refresh))
+    val conf = factory.hadoopConf.value
+
+    assert(observedQuery.get() == "planId=plan-1")
+    assert(observedAuthorization.get() == "Bearer token-1")
+    assert(conf.get("fs.unitycatalog.credentials.type") == "iceberg-plan")
+    assert(conf.get("fs.unitycatalog.iceberg.credentials.endpoint") ==
+      s"$baseUri/v1/ns/t/credentials")
+    assert(conf.get("fs.unitycatalog.iceberg.plan.id") == "plan-1")
+    assert(conf.get("fs.s3a.aws.credentials.provider").contains("AwsVendedTokenProvider"))
+  }
+
+  test("reader keeps static credential fallback without plan refresh context") {
+    val staticCredentials = new ScanPlanStorageCredentials {
+      override def configure(conf: org.apache.hadoop.conf.Configuration): Unit = {
+        conf.set("fs.test.static.credential", "configured")
+      }
+    }
+    val schema = StructType.fromDDL("id INT")
+
+    val factory = new ServerSidePlannedFilePartitionReaderFactory(
+      spark, schema, schema, credentials = Some(staticCredentials))
+
+    assert(factory.hadoopConf.value.get("fs.test.static.credential") == "configured")
+    assert(factory.hadoopConf.value.get("fs.unitycatalog.iceberg.plan.id") == null)
+  }
+
+  private def respond(exchange: HttpExchange, status: Int, body: String): Unit = {
+    val bytes = body.getBytes(StandardCharsets.UTF_8)
+    exchange.getResponseHeaders.set("Content-Type", "application/json")
+    exchange.sendResponseHeaders(status, bytes.length)
+    exchange.getResponseBody.write(bytes)
+    exchange.close()
+  }
+}


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other

## Description

Depends on unitycatalog/unitycatalog#1776.

Server-side scan planning can return short-lived storage credentials. Long-running FGAC reads currently keep those static credentials for the lifetime of the scan and fail after they expire.

This change:

- retains the Unity Catalog authentication configuration used for planning;
- preserves the opaque Iceberg `plan-id` returned by the server;
- constructs the standard sibling table credentials endpoint using the catalog prefix resolved from `/config`;
- records the storage schemes used by planned files;
- builds renewable executor Hadoop credentials through the new UC `buildForIcebergPlan` API; and
- keeps the existing static response credentials as the fallback when plan/auth refresh context is unavailable.

Refresh uses:

`GET .../namespaces/{namespace}/tables/{table}/credentials?planId=<plan-id>`

It deliberately does not use the source table ID or the UC temporary-table-credentials API. The opaque plan ID keeps every renewal tied to the same fine-grained authorization decision that produced the scan files.

This PR is draft only because Delta pins Unity Catalog to a commit on UC `main`. Once unitycatalog/unitycatalog#1776 merges, this branch will bump that pin to the merged commit and become ready for review.

## How was this patch tested?

Using a locally published UC artifact containing unitycatalog/unitycatalog#1776:

- `build/sbt -DunityCatalogVersion=0.6.0-SNAPSHOT-sspcred "spark / Test / compile" "iceberg / Test / compile"`
- `build/sbt -DunityCatalogVersion=0.6.0-SNAPSHOT-sspcred "spark / Test / testOnly org.apache.spark.sql.delta.serverSidePlanning.ServerSidePlanningCredentialRefreshSuite"`
- `build/sbt -DunityCatalogVersion=0.6.0-SNAPSHOT-sspcred "spark / Test / testOnly org.apache.spark.sql.delta.serverSidePlanning.ServerSidePlannedTableSuite"`
- `build/sbt -DsparkVersion=4.1 -DunityCatalogVersion=0.6.0-SNAPSHOT-sspcred "iceberg / Test / testOnly org.apache.spark.sql.delta.serverSidePlanning.IcebergRESTCatalogPlanningClientSuite"`
- `build/sbt -DsparkVersion=4.1 -DunityCatalogVersion=0.6.0-SNAPSHOT-sspcred "iceberg / Test / testOnly org.apache.spark.sql.delta.serverSidePlanning.ServerSidePlanningCredentialsSuite"`

All 51 focused tests passed (31 Spark and 20 Iceberg), along with compile, Checkstyle, and Scalastyle.

## Does this PR introduce _any_ user-facing changes?

Yes. FGAC server-side-planned reads can renew expiring AWS, Azure, or GCS credentials without changing the authorized scan scope. No new user configuration is required.