### PR TITLE
[Spark] Reuse the shared Jackson mapper when parsing AddFile stats

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -841,7 +841,7 @@ trait HasNumRecords {
   @transient
   protected lazy val parsedStatsFields: Option[ParsedStatsFields] = Option(stats).collect {
     case stats if stats.nonEmpty =>
-      val node = new ObjectMapper().readTree(stats)
+      val node = JsonUtils.mapper.readTree(stats)
       val numLogicalRecords = if (node.has("numRecords")) {
         Some(node.get("numRecords")).filterNot(_.isNull).map(_.asLong())
           .map(_ - numDeletedRecords)


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

`HasNumRecords.parsedStatsFields` constructs a new `ObjectMapper` for every file action whose stats it parses:

```scala
val node = new ObjectMapper().readTree(stats)
```

`parsedStatsFields` backs `numLogicalRecords` and `tightBounds`, which are read per file by `OptimisticTransaction`, `Checksum`, `ConflictChecker`, `RowId`, `DeltaSink`, `NumRecordsStats` and `AutoCompactPartitionStats`, so this allocates and configures one mapper per `AddFile`/`RemoveFile` on hot paths.

Delta already has a shared, pre-configured mapper for exactly this, and the same file uses it a few hundred lines further down (`AddFile` tight-bounds handling calls `JsonUtils.mapper.readTree`), so this looks like an oversight rather than a deliberate choice.

A secondary difference: `JsonUtils.mapper` raises Jackson's `maxStringLength` to `Int.MaxValue`, which a bare `ObjectMapper` leaves at the 20,000,000 character default. That limit applies to individual string values rather than the whole document, and stats min/max strings are truncated, so it is not reachable in practice today — but the codebase deliberately opts out of that limit everywhere else it parses delta log JSON.

Found while investigating #7459.

## How was this patch tested?
Existing tests.

## Does this PR introduce _any_ user-facing changes?
No.