### PR TITLE
[Spark] Add the "r" relative-path deletion vector storage type

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/DeletionVectorDescriptor.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/DeletionVectorDescriptor.scala
@@ -33,6 +33,7 @@ import org.apache.spark.sql.{Column, Encoder}
 import org.apache.spark.sql.functions.{concat, lit, when}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
+import org.apache.spark.util.Utils
 
 /** Information about a deletion vector attached to a file action. */
 case class DeletionVectorDescriptor(
@@ -45,7 +46,7 @@ case class DeletionVectorDescriptor(
     /**
      * Contains the actual data that allows accessing the DV.
      *
-     * Three options are currently supported:
+     * Four options are currently supported:
      * - `storageType="u"` format: `<random prefix - optional><base85 encoded uuid>`
      *                            The deletion vector is stored in a file with a path relative to
      *                            the data directory of this Delta Table, and the file name can be
@@ -57,6 +58,12 @@ case class DeletionVectorDescriptor(
      * - `storageType="p"` format: `<absolute path>`
      *                             The DV is stored in a file with an absolute path given by this
      *                             url. Special characters in this path must be escaped.
+     * - `storageType="r"` format: `<relative path>`
+     *                             The DV is stored in a file at this path, relative to the root of
+     *                             this Delta Table. Unlike `u`, the file name is arbitrary rather
+     *                             than derived from a UUID; unlike `p`, the path is neither
+     *                             absolute nor URL-encoded. Only permitted when the
+     *                             `adaptiveMetadata` table feature is enabled.
      */
     pathOrInlineDv: String,
     /**
@@ -100,7 +107,10 @@ case class DeletionVectorDescriptor(
   protected[delta] def isInline: Boolean = storageType == INLINE_DV_MARKER
 
   @JsonIgnore
-  protected[delta] def isRelative: Boolean = storageType == UUID_DV_MARKER
+  protected[delta] def isUuidRelative: Boolean = storageType == UUID_DV_MARKER
+
+  @JsonIgnore
+  protected[delta] def isUnencodedRelative: Boolean = storageType == RELATIVE_DV_MARKER
 
   @JsonIgnore
   protected[delta] def isAbsolute: Boolean = storageType == PATH_DV_MARKER
@@ -115,11 +125,12 @@ case class DeletionVectorDescriptor(
         val (randomPrefix, uuid) = getRandomPrefixAndUuid.get
         assembleDeletionVectorPath(tableLocation, uuid, randomPrefix)
       case PATH_DV_MARKER =>
-        // Since there is no need for legacy support for relative paths for DVs,
-        // relative DVs should *always* use the UUID variant.
         val parsedUri = new URI(pathOrInlineDv)
         assert(parsedUri.isAbsolute, "Relative URIs are not supported for DVs")
         new Path(parsedUri)
+      case RELATIVE_DV_MARKER =>
+        val path = new Path(pathOrInlineDv)
+        new Path(tableLocation, path)
       case _ => throw DeltaErrors.cannotReconstructPathFromURI(pathOrInlineDv)
     }
   }
@@ -133,7 +144,7 @@ case class DeletionVectorDescriptor(
    * If the DV path is outside the table directory, returns None.
    */
   def urlEncodedRelativePathIfExists(tablePath: Path): Option[String] = {
-    if (isRelative) {
+    if (isUuidRelative) {
       return Some(SparkPath.fromPath(absolutePath(new Path("."))).urlEncoded)
     }
 
@@ -149,7 +160,7 @@ case class DeletionVectorDescriptor(
   }
 
   /**
-   * Parse the prefix and UUID of a relative DV. Returns None if the DV is not relative.
+   * Parse the prefix and UUID of a u DV. Returns None if the DV is not of type u.
    */
   @JsonIgnore
   def getRandomPrefixAndUuid: Option[(String, UUID)] = storageType match {
@@ -169,7 +180,7 @@ case class DeletionVectorDescriptor(
    */
   def copyWithAbsolutePath(tableLocation: Path): DeletionVectorDescriptor = {
     storageType match {
-      case UUID_DV_MARKER =>
+      case UUID_DV_MARKER | RELATIVE_DV_MARKER =>
         this.copy(
           storageType = PATH_DV_MARKER,
           pathOrInlineDv = urlEncodedPath(tableLocation))
@@ -183,13 +194,14 @@ case class DeletionVectorDescriptor(
    *
    * If the DV already has a relative path or is inline, then this is just a normal copy.
    */
-  def copyWithNewRelativePath(id: UUID, randomPrefix: String): DeletionVectorDescriptor = {
+  def copyWithNewUuidRelativePath(id: UUID, randomPrefix: String): DeletionVectorDescriptor = {
     storageType match {
       case PATH_DV_MARKER =>
         this.copy(storageType = UUID_DV_MARKER, pathOrInlineDv = encodeUUID(id, randomPrefix))
-      case UUID_DV_MARKER | INLINE_DV_MARKER => this.copy()
+      case UUID_DV_MARKER | RELATIVE_DV_MARKER | INLINE_DV_MARKER => this.copy()
     }
   }
+
 
   @JsonIgnore
   def inlineData: Array[Byte] = {
@@ -256,6 +268,7 @@ object DeletionVectorDescriptor {
   final val PATH_DV_MARKER: String = "p"
   final val INLINE_DV_MARKER: String = "i"
   final val UUID_DV_MARKER: String = "u"
+  final val RELATIVE_DV_MARKER: String = "r"
 
   private final val deletionVectorFileNameRegex =
     raw"${new Path(DELETION_VECTOR_FILE_NAME_CORE).toUri}_([^.]+)\.bin".r
@@ -268,7 +281,7 @@ object DeletionVectorDescriptor {
   implicit def encoder: Encoder[DeletionVectorDescriptor] = _encoder.get
 
   /** Utility method to create an on-disk [[DeletionVectorDescriptor]] */
-  def onDiskWithRelativePath(
+  def onDiskWithUuidRelativePath(
       id: UUID,
       randomPrefix: String = "",
       sizeInBytes: Int,
@@ -297,6 +310,30 @@ object DeletionVectorDescriptor {
       sizeInBytes = sizeInBytes,
       cardinality = cardinality,
       maxRowIndex = maxRowIndex)
+
+  /**
+   * Utility method to create a [[DeletionVectorDescriptor]] for an unencoded path relative to the
+   * table root. Callers are responsible for relativizing the path before invoking this method.
+   */
+  def createRelativePathDVDescriptor(
+      relativePath: String,
+      sizeInBytes: Int,
+      cardinality: Long,
+      offset: Option[Int] = None,
+      maxRowIndex: Option[Long] = None): DeletionVectorDescriptor = {
+    if (Utils.isTesting) {
+      require(!new Path(relativePath).isAbsolute,
+        s"A '$RELATIVE_DV_MARKER' deletion vector must have a relative path, " +
+          s"but got: $relativePath")
+    }
+    DeletionVectorDescriptor(
+      storageType = RELATIVE_DV_MARKER,
+      pathOrInlineDv = relativePath,
+      offset = offset,
+      sizeInBytes = sizeInBytes,
+      cardinality = cardinality,
+      maxRowIndex = maxRowIndex)
+  }
 
   /** Utility method to create an inline [[DeletionVectorDescriptor]] */
   def inlineInLog(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DMLWithDeletionVectorsHelper.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DMLWithDeletionVectorsHelper.scala
@@ -691,7 +691,7 @@ object DeletionVectorWriter extends DeltaLogging {
       DeletionVectorDescriptor.EMPTY
     } else {
       val dvRange = ctx.writer.write(bitmapData)
-      DeletionVectorDescriptor.onDiskWithRelativePath(
+      DeletionVectorDescriptor.onDiskWithUuidRelativePath(
         id = ctx.fileId,
         randomPrefix = ctx.prefix,
         sizeInBytes = bitmapData.length,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/VacuumCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/VacuumCommand.scala
@@ -744,7 +744,7 @@ trait VacuumCommandImpl extends DeltaCommand {
 
     dv match {
       case Some(dv) if dv.isOnDisk =>
-        if (dv.isRelative) {
+        if (dv.isUuidRelative) {
           // We actually want a relative path here.
           Some((pathToUrlEncodedString(dv.absolutePath(new Path("."))), dv.sizeInBytes))
         } else {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/ActionSerializerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/ActionSerializerSuite.scala
@@ -529,7 +529,7 @@ class ActionSerializerSuite extends QueryTest with SharedSparkSession with Delta
       """"extendedFileMetadata":true,"partitionValues":{"x":"2"},"size":10}}""")
 
   private def deletionVectorWithRelativePath: DeletionVectorDescriptor =
-    DeletionVectorDescriptor.onDiskWithRelativePath(
+    DeletionVectorDescriptor.onDiskWithUuidRelativePath(
       id = UUID.randomUUID(),
       randomPrefix = "a1",
       sizeInBytes = 10,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeletionVectorsTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeletionVectorsTestUtils.scala
@@ -382,7 +382,7 @@ trait DeletionVectorsTestUtils extends QueryTest with SharedSparkSession with De
     withDVWriter(log, dvFileId) { writer =>
       filesWithDVs.flatMap { case (currentFile, dv) =>
         val range = writer.write(serializeRoaringBitmapArrayWithDefaultFormat(dv))
-        val dvData = DeletionVectorDescriptor.onDiskWithRelativePath(
+        val dvData = DeletionVectorDescriptor.onDiskWithUuidRelativePath(
           id = dvFileId,
           sizeInBytes = range.length,
           cardinality = dv.cardinality,
@@ -457,7 +457,7 @@ trait DeletionVectorsTestUtils extends QueryTest with SharedSparkSession with De
     val dvFileId = UUID.randomUUID()
     withDVWriter(log, dvFileId) { writer =>
       val range = writer.write(serializeRoaringBitmapArrayWithDefaultFormat(bitmapArray))
-      DeletionVectorDescriptor.onDiskWithRelativePath(
+      DeletionVectorDescriptor.onDiskWithUuidRelativePath(
         id = dvFileId,
         sizeInBytes = range.length,
         cardinality = bitmapArray.cardinality,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/actions/DeletionVectorDescriptorSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/actions/DeletionVectorDescriptorSuite.scala
@@ -57,7 +57,7 @@ class DeletionVectorDescriptorSuite extends SparkFunSuite {
     // expect the returned DV is same as input, since this is inline
     // so paths are irrelevant.
     assert(dv.copyWithAbsolutePath(testTablePath) === dv)
-    assert(dv.copyWithNewRelativePath(UUID.randomUUID(), "predix2") === dv)
+    assert(dv.copyWithNewUuidRelativePath(UUID.randomUUID(), "predix2") === dv)
   }
 
   for (offset <- Seq(None, Some(25))) {
@@ -87,17 +87,17 @@ class DeletionVectorDescriptorSuite extends SparkFunSuite {
 
       // Copy DV as a relative path DV
       val uuid = UUID.randomUUID()
-      val dvCopyWithRelativePath = dv.copyWithNewRelativePath(uuid, "prefix")
-      assert(dvCopyWithRelativePath.isRelative)
-      assert(dvCopyWithRelativePath.isOnDisk)
-      assert(dvCopyWithRelativePath.pathOrInlineDv === encodeUUID(uuid, "prefix"))
+      val dvCopyWithUuidRelativePath = dv.copyWithNewUuidRelativePath(uuid, "prefix")
+      assert(dvCopyWithUuidRelativePath.isUuidRelative)
+      assert(dvCopyWithUuidRelativePath.isOnDisk)
+      assert(dvCopyWithUuidRelativePath.pathOrInlineDv === encodeUUID(uuid, "prefix"))
     }
   }
 
   for (offset <- Seq(None, Some(25))) {
     test(s"On-disk DV with relative path with offset=$offset") {
       val uuid = UUID.randomUUID()
-      val dv = onDiskWithRelativePath(
+      val dv = onDiskWithUuidRelativePath(
         uuid, randomPrefix = "prefix", sizeInBytes = 15, cardinality = 25, offset)
 
       // Make sure the metadata (type, size etc.) in the DV is as expected
@@ -131,7 +131,89 @@ class DeletionVectorDescriptorSuite extends SparkFunSuite {
 
       // Copy DV as a relative path DV - expect to return the same DV as the current
       // DV already contains relative path.
-      assert(dv.copyWithNewRelativePath(UUID.randomUUID(), "predix2") === dv)
+      assert(dv.copyWithNewUuidRelativePath(UUID.randomUUID(), "predix2") === dv)
+    }
+  }
+
+  for (offset <- Seq(None, Some(25))) {
+    test(s"On-disk DV with un-encoded relative path with offset=$offset") {
+      val dv = createRelativePathDVDescriptor(
+        testDVRelPath, sizeInBytes = 15, cardinality = 7, offset)
+
+      // Make sure the metadata (type, size etc.) in the DV is as expected
+      assert(dv.isOnDisk && !dv.isInline, s"Incorrect DV storage type: $dv")
+      assertCardinality(dv, 7)
+
+      assert(dv.isUnencodedRelative)
+      assert(!dv.isUuidRelative)
+      assert(!dv.isAbsolute)
+      // It carries no UUID, so there is no prefix/UUID pair to recover.
+      assert(dv.getRandomPrefixAndUuid.isEmpty)
+
+      assert(dv.pathOrInlineDv === testDVRelPath)
+      assert(dv.sizeInBytes === 15)
+      intercept[Exception] { dv.inlineData }
+      assert(dv.offset === offset)
+
+      // Unique id to identify the DV
+      val offsetSuffix = offset.map(o => s"@$o").getOrElse("")
+      assert(dv.uniqueId === s"r$testDVRelPath$offsetSuffix")
+      assert(dv.uniqueFileId === s"r$testDVRelPath")
+
+      // Expect the DV path to resolve under the given table path.
+      assert(dv.absolutePath(testTablePath) === new Path(s"$testTablePath/$testDVRelPath"))
+      // And to relativize back to exactly what we started with.
+      assert(dv.urlEncodedRelativePathIfExists(testTablePath).contains(testDVRelPath))
+
+      val dvCopyWithAbsPath = dv.copyWithAbsolutePath(testTablePath)
+      assert(dvCopyWithAbsPath.isAbsolute)
+      assert(dvCopyWithAbsPath.isOnDisk)
+      assert(dvCopyWithAbsPath.pathOrInlineDv ===
+        SparkPath.fromPath(dv.absolutePath(testTablePath)).urlEncoded)
+      assert(dvCopyWithAbsPath.absolutePath(testTablePath) === dv.absolutePath(testTablePath))
+      assert(dvCopyWithAbsPath.sizeInBytes === dv.sizeInBytes)
+      assert(dvCopyWithAbsPath.cardinality === dv.cardinality)
+      assert(dvCopyWithAbsPath.offset === dv.offset)
+    }
+  }
+
+  test("absolutePath() resolves p, u, r DVs with space (%20) to the same unencoded path") {
+    // Following paths are all equivalent and follow Delta's path encoding rules.
+    val uuid = UUID.fromString("f92b8939-98dc-41c0-ae52-ffb7df72a37f")
+    val fileName = assembleDeletionVectorFileName(uuid)
+    val relativePath = s"dv dir/$fileName"
+    val absolutePath = s"s3a://table/test/dv%20dir/${fileName.replace("%", "%25")}"
+    val expectedPath = s"s3a://table/test/dv dir/$fileName"
+
+    val testCases = Seq(
+      (PATH_DV_MARKER,
+        onDiskWithAbsolutePath(absolutePath, sizeInBytes = 15, cardinality = 10)),
+      (UUID_DV_MARKER,
+        onDiskWithUuidRelativePath(uuid, randomPrefix = "dv dir", sizeInBytes = 15, cardinality = 10)),
+      (RELATIVE_DV_MARKER,
+        createRelativePathDVDescriptor(relativePath, sizeInBytes = 15, cardinality = 10)))
+
+    for ((storageType, dv) <- testCases) {
+      withClue(s"$storageType DV: ") {
+        assert(dv.absolutePath(testTablePath).toString === expectedPath)
+      }
+    }
+  }
+
+  test("r DV copyWithAbsolutePath emits URL-encoded path") {
+    val path = "data/test%dv%prefix-deletes file.puffin"
+    val dv = createRelativePathDVDescriptor(path, sizeInBytes = 15, cardinality = 7)
+    val dvCopyWithAbsPath = dv.copyWithAbsolutePath(testTablePath)
+
+    assert(dvCopyWithAbsPath.isAbsolute)
+    assert(dvCopyWithAbsPath.pathOrInlineDv.contains("test%25dv%25prefix-deletes%20file"))
+    assert(dvCopyWithAbsPath.absolutePath(testTablePath) === dv.absolutePath(testTablePath))
+  }
+
+  test("r DV rejects an absolute path") {
+    intercept[IllegalArgumentException] {
+      createRelativePathDVDescriptor(
+        "s3a://other/dv.bin", sizeInBytes = 15, cardinality = 7)
     }
   }
 
@@ -144,14 +226,16 @@ class DeletionVectorDescriptorSuite extends SparkFunSuite {
 
   for {
     offset <- Seq(None, Some(0), Some(25))
-    label <- Seq("relative path", "absolute path")
+    label <- Seq("uuid relative path", "absolute path", "unencoded relative path")
   } {
     test(s"base64 round-trip for $label DV with offset=$offset") {
       val dv = label match {
-        case "relative path" => onDiskWithRelativePath(
+        case "uuid relative path" => onDiskWithUuidRelativePath(
           UUID.randomUUID(), randomPrefix = "prefix", sizeInBytes = 15, cardinality = 25, offset)
         case "absolute path" => onDiskWithAbsolutePath(
           testDVAbsPath, sizeInBytes = 15, cardinality = 10, offset)
+        case "unencoded relative path" => createRelativePathDVDescriptor(
+          testDVRelPath, sizeInBytes = 15, cardinality = 7, offset)
       }
       val encoded = dv.serializeToBase64()
       val decoded = DeletionVectorDescriptor.deserializeFromBase64(encoded)
@@ -169,5 +253,6 @@ class DeletionVectorDescriptorSuite extends SparkFunSuite {
 
   private val testTablePath = new Path("s3a://table/test")
   private val testDVAbsPath = "s3a://table/test/dv1.bin"
+  private val testDVRelPath = "data/deletes-abc.puffin"
   private val testDVData: Array[Byte] = Array(1, 2, 3, 4)
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSingleActionSerializerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSingleActionSerializerSuite.scala
@@ -308,7 +308,7 @@ class AMTSingleActionSerializerSuite extends QueryTest with SharedSparkSession {
 
   test("DeletionVector.fromDescriptor maps a UUID-relative DV to an unencoded absolute location") {
     val id = UUID.randomUUID()
-    val dv = DeletionVectorDescriptor.onDiskWithRelativePath(
+    val dv = DeletionVectorDescriptor.onDiskWithUuidRelativePath(
       id = id,
       randomPrefix = "test%dv%prefix-",
       sizeInBytes = 20,
@@ -350,7 +350,7 @@ class AMTSingleActionSerializerSuite extends QueryTest with SharedSparkSession {
   }
 
   test("DeletionVector.fromDescriptor rejects an on-disk DV with no offset") {
-    val dv = DeletionVectorDescriptor.onDiskWithRelativePath(
+    val dv = DeletionVectorDescriptor.onDiskWithUuidRelativePath(
       id = UUID.randomUUID(), sizeInBytes = 10, cardinality = 1L, offset = None)
     val ex = intercept[IllegalArgumentException](DeletionVector.fromDescriptor(dv, tableRoot))
     assert(ex.getMessage.contains("missing an offset"))


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Adds a new deletion vector (DV) storage type, `r`, alongside the existing `u`
(UUID-relative), `p` (absolute path), and `i` (inline) types.

An `r` deletion vector is stored at a path relative to the root of the Delta
table. Unlike `u`, the file name is arbitrary rather than derived from a UUID;
unlike `p`, the path is neither absolute nor URL-encoded. This type is only
permitted when the `adaptiveMetadata` table feature is enabled.

Now that there are two kinds of relative DV, the existing UUID-relative helpers
are renamed to keep the naming unambiguous:

- `isRelative` -> `isUuidRelative`
- `copyWithNewRelativePath` -> `copyWithNewUuidRelativePath`
- `onDiskWithRelativePath` -> `onDiskWithUuidRelativePath`

A new factory `createRelativePathDVDescriptor` builds an `r` descriptor, and
`absolutePath` / `copyWithAbsolutePath` are extended to resolve the new type.

## How was this patch tested?

New unit tests in `DeletionVectorDescriptorSuite`:

- construction, metadata, unique-id, and base64 round-trip of `r` descriptors
- `absolutePath` resolving `p`, `u`, and `r` DVs that contain escaped
  characters to the same unencoded path
- `copyWithAbsolutePath` emitting a correctly URL-encoded absolute path
- rejecting an absolute path passed to an `r` descriptor

Existing suites were updated to use the renamed helpers.

## Does this PR introduce _any_ user-facing changes?

No.
