### PR TITLE
[Spark] Introduce the "r" relative-path deletion vector storage type

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/DeletionVectorDescriptor.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/DeletionVectorDescriptor.scala
@@ -33,6 +33,7 @@ import org.apache.spark.sql.{Column, Encoder}
 import org.apache.spark.sql.functions.{concat, lit, when}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
+import org.apache.spark.util.Utils
 
 /** Information about a deletion vector attached to a file action. */
 case class DeletionVectorDescriptor(
@@ -45,7 +46,7 @@ case class DeletionVectorDescriptor(
     /**
      * Contains the actual data that allows accessing the DV.
      *
-     * Three options are currently supported:
+     * Four options are currently supported:
      * - `storageType="u"` format: `<random prefix - optional><base85 encoded uuid>`
      *                            The deletion vector is stored in a file with a path relative to
      *                            the data directory of this Delta Table, and the file name can be
@@ -57,6 +58,12 @@ case class DeletionVectorDescriptor(
      * - `storageType="p"` format: `<absolute path>`
      *                             The DV is stored in a file with an absolute path given by this
      *                             url. Special characters in this path must be escaped.
+     * - `storageType="r"` format: `<relative path>`
+     *                             The DV is stored in a file at this path, relative to the root of
+     *                             this Delta Table. Unlike `u`, the file name is arbitrary rather
+     *                             than derived from a UUID; unlike `p`, the path is neither
+     *                             absolute nor URL-encoded. Only permitted when the
+     *                             `adaptiveMetadata` table feature is enabled.
      */
     pathOrInlineDv: String,
     /**
@@ -103,6 +110,9 @@ case class DeletionVectorDescriptor(
   protected[delta] def isRelative: Boolean = storageType == UUID_DV_MARKER
 
   @JsonIgnore
+  protected[delta] def isUnencodedRelative: Boolean = storageType == RELATIVE_DV_MARKER
+
+  @JsonIgnore
   protected[delta] def isAbsolute: Boolean = storageType == PATH_DV_MARKER
 
   @JsonIgnore
@@ -115,11 +125,12 @@ case class DeletionVectorDescriptor(
         val (randomPrefix, uuid) = getRandomPrefixAndUuid.get
         assembleDeletionVectorPath(tableLocation, uuid, randomPrefix)
       case PATH_DV_MARKER =>
-        // Since there is no need for legacy support for relative paths for DVs,
-        // relative DVs should *always* use the UUID variant.
         val parsedUri = new URI(pathOrInlineDv)
         assert(parsedUri.isAbsolute, "Relative URIs are not supported for DVs")
         new Path(parsedUri)
+      case RELATIVE_DV_MARKER =>
+        val path = new Path(pathOrInlineDv)
+        new Path(tableLocation, path)
       case _ => throw DeltaErrors.cannotReconstructPathFromURI(pathOrInlineDv)
     }
   }
@@ -149,7 +160,7 @@ case class DeletionVectorDescriptor(
   }
 
   /**
-   * Parse the prefix and UUID of a relative DV. Returns None if the DV is not relative.
+   * Parse the prefix and UUID of a u DV. Returns None if the DV is not of type u.
    */
   @JsonIgnore
   def getRandomPrefixAndUuid: Option[(String, UUID)] = storageType match {
@@ -169,7 +180,7 @@ case class DeletionVectorDescriptor(
    */
   def copyWithAbsolutePath(tableLocation: Path): DeletionVectorDescriptor = {
     storageType match {
-      case UUID_DV_MARKER =>
+      case UUID_DV_MARKER | RELATIVE_DV_MARKER =>
         this.copy(
           storageType = PATH_DV_MARKER,
           pathOrInlineDv = urlEncodedPath(tableLocation))
@@ -187,9 +198,10 @@ case class DeletionVectorDescriptor(
     storageType match {
       case PATH_DV_MARKER =>
         this.copy(storageType = UUID_DV_MARKER, pathOrInlineDv = encodeUUID(id, randomPrefix))
-      case UUID_DV_MARKER | INLINE_DV_MARKER => this.copy()
+      case UUID_DV_MARKER | RELATIVE_DV_MARKER | INLINE_DV_MARKER => this.copy()
     }
   }
+
 
   @JsonIgnore
   def inlineData: Array[Byte] = {
@@ -256,6 +268,7 @@ object DeletionVectorDescriptor {
   final val PATH_DV_MARKER: String = "p"
   final val INLINE_DV_MARKER: String = "i"
   final val UUID_DV_MARKER: String = "u"
+  final val RELATIVE_DV_MARKER: String = "r"
 
   private final val deletionVectorFileNameRegex =
     raw"${new Path(DELETION_VECTOR_FILE_NAME_CORE).toUri}_([^.]+)\.bin".r
@@ -297,6 +310,30 @@ object DeletionVectorDescriptor {
       sizeInBytes = sizeInBytes,
       cardinality = cardinality,
       maxRowIndex = maxRowIndex)
+
+  /**
+   * Utility method to create a [[DeletionVectorDescriptor]] for an unencoded path relative to the
+   * table root. Callers are responsible for relativizing the path before invoking this method.
+   */
+  def createRelativePathDVDescriptor(
+      relativePath: String,
+      sizeInBytes: Int,
+      cardinality: Long,
+      offset: Option[Int] = None,
+      maxRowIndex: Option[Long] = None): DeletionVectorDescriptor = {
+    if (Utils.isTesting) {
+      require(!new Path(relativePath).isAbsolute,
+        s"A '$RELATIVE_DV_MARKER' deletion vector must have a relative path, " +
+          s"but got: $relativePath")
+    }
+    DeletionVectorDescriptor(
+      storageType = RELATIVE_DV_MARKER,
+      pathOrInlineDv = relativePath,
+      offset = offset,
+      sizeInBytes = sizeInBytes,
+      cardinality = cardinality,
+      maxRowIndex = maxRowIndex)
+  }
 
   /** Utility method to create an inline [[DeletionVectorDescriptor]] */
   def inlineInLog(

--- a/spark/src/test/scala/org/apache/spark/sql/delta/actions/DeletionVectorDescriptorSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/actions/DeletionVectorDescriptorSuite.scala
@@ -135,6 +135,88 @@ class DeletionVectorDescriptorSuite extends SparkFunSuite {
     }
   }
 
+  for (offset <- Seq(None, Some(25))) {
+    test(s"On-disk DV with un-encoded relative path with offset=$offset") {
+      val dv = createRelativePathDVDescriptor(
+        testDVRelPath, sizeInBytes = 15, cardinality = 7, offset)
+
+      // Make sure the metadata (type, size etc.) in the DV is as expected
+      assert(dv.isOnDisk && !dv.isInline, s"Incorrect DV storage type: $dv")
+      assertCardinality(dv, 7)
+
+      assert(dv.isUnencodedRelative)
+      assert(!dv.isRelative)
+      assert(!dv.isAbsolute)
+      // It carries no UUID, so there is no prefix/UUID pair to recover.
+      assert(dv.getRandomPrefixAndUuid.isEmpty)
+
+      assert(dv.pathOrInlineDv === testDVRelPath)
+      assert(dv.sizeInBytes === 15)
+      intercept[Exception] { dv.inlineData }
+      assert(dv.offset === offset)
+
+      // Unique id to identify the DV
+      val offsetSuffix = offset.map(o => s"@$o").getOrElse("")
+      assert(dv.uniqueId === s"r$testDVRelPath$offsetSuffix")
+      assert(dv.uniqueFileId === s"r$testDVRelPath")
+
+      // Expect the DV path to resolve under the given table path.
+      assert(dv.absolutePath(testTablePath) === new Path(s"$testTablePath/$testDVRelPath"))
+      // And to relativize back to exactly what we started with.
+      assert(dv.urlEncodedRelativePathIfExists(testTablePath).contains(testDVRelPath))
+
+      val dvCopyWithAbsPath = dv.copyWithAbsolutePath(testTablePath)
+      assert(dvCopyWithAbsPath.isAbsolute)
+      assert(dvCopyWithAbsPath.isOnDisk)
+      assert(dvCopyWithAbsPath.pathOrInlineDv ===
+        SparkPath.fromPath(dv.absolutePath(testTablePath)).urlEncoded)
+      assert(dvCopyWithAbsPath.absolutePath(testTablePath) === dv.absolutePath(testTablePath))
+      assert(dvCopyWithAbsPath.sizeInBytes === dv.sizeInBytes)
+      assert(dvCopyWithAbsPath.cardinality === dv.cardinality)
+      assert(dvCopyWithAbsPath.offset === dv.offset)
+    }
+  }
+
+  test("absolutePath() resolves p, u, r DVs with space (%20) to the same unencoded path") {
+    // Following paths are all equivalent and follow Delta's path encoding rules.
+    val uuid = UUID.fromString("f92b8939-98dc-41c0-ae52-ffb7df72a37f")
+    val fileName = assembleDeletionVectorFileName(uuid)
+    val relativePath = s"dv dir/$fileName"
+    val absolutePath = s"s3a://table/test/dv%20dir/${fileName.replace("%", "%25")}"
+    val expectedPath = s"s3a://table/test/dv dir/$fileName"
+
+    val testCases = Seq(
+      (PATH_DV_MARKER,
+        onDiskWithAbsolutePath(absolutePath, sizeInBytes = 15, cardinality = 10)),
+      (UUID_DV_MARKER,
+        onDiskWithRelativePath(uuid, randomPrefix = "dv dir", sizeInBytes = 15, cardinality = 10)),
+      (RELATIVE_DV_MARKER,
+        createRelativePathDVDescriptor(relativePath, sizeInBytes = 15, cardinality = 10)))
+
+    for ((storageType, dv) <- testCases) {
+      withClue(s"$storageType DV: ") {
+        assert(dv.absolutePath(testTablePath).toString === expectedPath)
+      }
+    }
+  }
+
+  test("r DV copyWithAbsolutePath emits URL-encoded path") {
+    val path = "data/test%dv%prefix-deletes file.puffin"
+    val dv = createRelativePathDVDescriptor(path, sizeInBytes = 15, cardinality = 7)
+    val dvCopyWithAbsPath = dv.copyWithAbsolutePath(testTablePath)
+
+    assert(dvCopyWithAbsPath.isAbsolute)
+    assert(dvCopyWithAbsPath.pathOrInlineDv.contains("test%25dv%25prefix-deletes%20file"))
+    assert(dvCopyWithAbsPath.absolutePath(testTablePath) === dv.absolutePath(testTablePath))
+  }
+
+  test("r DV rejects an absolute path") {
+    intercept[IllegalArgumentException] {
+      createRelativePathDVDescriptor(
+        "s3a://other/dv.bin", sizeInBytes = 15, cardinality = 7)
+    }
+  }
+
   test("base64 round-trip for inline DV") {
     val dv = inlineInLog(testDVData, cardinality = 3)
     val encoded = dv.serializeToBase64()
@@ -144,14 +226,16 @@ class DeletionVectorDescriptorSuite extends SparkFunSuite {
 
   for {
     offset <- Seq(None, Some(0), Some(25))
-    label <- Seq("relative path", "absolute path")
+    label <- Seq("uuid relative path", "absolute path", "unencoded relative path")
   } {
     test(s"base64 round-trip for $label DV with offset=$offset") {
       val dv = label match {
-        case "relative path" => onDiskWithRelativePath(
+        case "uuid relative path" => onDiskWithRelativePath(
           UUID.randomUUID(), randomPrefix = "prefix", sizeInBytes = 15, cardinality = 25, offset)
         case "absolute path" => onDiskWithAbsolutePath(
           testDVAbsPath, sizeInBytes = 15, cardinality = 10, offset)
+        case "unencoded relative path" => createRelativePathDVDescriptor(
+          testDVRelPath, sizeInBytes = 15, cardinality = 7, offset)
       }
       val encoded = dv.serializeToBase64()
       val decoded = DeletionVectorDescriptor.deserializeFromBase64(encoded)
@@ -169,5 +253,6 @@ class DeletionVectorDescriptorSuite extends SparkFunSuite {
 
   private val testTablePath = new Path("s3a://table/test")
   private val testDVAbsPath = "s3a://table/test/dv1.bin"
+  private val testDVRelPath = "data/deletes-abc.puffin"
   private val testDVData: Array[Byte] = Array(1, 2, 3, 4)
 }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Adds a new deletion vector (DV) storage type, `r`, alongside the existing `u`
(UUID-relative), `p` (absolute path), and `i` (inline) types.

An `r` deletion vector is stored at a path relative to the root of the Delta
table. Unlike `u`, the file name is arbitrary rather than derived from a UUID;
unlike `p`, the path is neither absolute nor URL-encoded. This type is only
permitted when the `adaptiveMetadata` table feature is enabled.

This change adds `RELATIVE_DV_MARKER` and an `isUnencodedRelative` predicate, a
`createRelativePathDVDescriptor` factory that rejects absolute paths, and
extends `absolutePath` / `copyWithAbsolutePath` to resolve the new type, so an
`r` DV resolves under the table root and re-encodes correctly when converted to
an absolute path.

## How was this patch tested?

New unit tests in `DeletionVectorDescriptorSuite`:

- construction, metadata, unique-id, and base64 round-trip of `r` descriptors
- `absolutePath` resolving `p`, `u`, and `r` DVs that contain escaped
  characters to the same unencoded path
- `copyWithAbsolutePath` emitting a correctly URL-encoded absolute path
- rejecting an absolute path passed to an `r` descriptor

## Does this PR introduce _any_ user-facing changes?

No.
