### PR TITLE
[RLC] Case 1 — conflict-time data skipping (value-exact tier)

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
@@ -994,14 +994,41 @@ private[delta] class ConflictChecker(
       return None
     }
 
+    // Reader-side data skipping: narrow the candidate files using the read snapshot's column-stats
+    // skipping. A concurrently-added file whose stats prove it cannot match the read predicates is
+    // not a conflict -- this is what lets unpartitioned / liquid-clustered tables avoid conflicting
+    // on every added file below. Data predicates are applied *per read predicate* and the survivors
+    // unioned (OR across reads), because independent reads have OR, not AND, semantics: a file is a
+    // candidate if it could match ANY read; it is dropped only if its stats prove it fails EVERY
+    // read. Skipping is not applied for a whole-table read, where every added file must conflict.
+    val candidateFiles =
+      if (spark.conf.get(DeltaSQLConf.DELTA_CONFLICT_DETECTION_DATA_SKIPPING_ENABLED) &&
+          !currentTransactionInfo.readWholeTable) {
+        val readSnapshot = currentTransactionInfo.readSnapshot
+        val survivingPaths = currentTransactionInfo.readPredicates.iterator.flatMap { rp =>
+          readSnapshot.filterFilesByDataSkipping(files, rp.dataPredicates)
+        }.map(_.path).toSet
+        val remaining = files.filter(f => survivingPaths.contains(f.path))
+        if (remaining.size < files.size) {
+          recordDeltaEvent(deltaLog,
+            opType = "delta.conflictDetection.dataSkipping.filesSkipped",
+            data = Map(
+              "candidateFiles" -> files.size,
+              "skippedFiles" -> (files.size - remaining.size)))
+        }
+        remaining
+      } else {
+        files
+      }
+
     // There is no reason to filter files if the table is not partitioned.
     if (currentTransactionInfo.readWholeTable ||
         currentTransactionInfo.readSnapshot.metadata.partitionColumns.isEmpty) {
-      return files.headOption
+      return candidateFiles.headOption
     }
 
     import org.apache.spark.sql.delta.implicits._
-    val filesDf = files.toDF(spark)
+    val filesDf = candidateFiles.toDF(spark)
 
     spark.conf.get(DeltaSQLConf.DELTA_CONFLICT_DETECTION_WIDEN_NONDETERMINISTIC_PREDICATES) match {
       case DeltaSQLConf.NonDeterministicPredicateWidening.OFF =>

--- a/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
@@ -1000,10 +1000,15 @@ private[delta] class ConflictChecker(
     // on every added file below. Data predicates are applied *per read predicate* and the survivors
     // unioned (OR across reads), because independent reads have OR, not AND, semantics: a file is a
     // candidate if it could match ANY read; it is dropped only if its stats prove it fails EVERY
-    // read. Skipping is not applied for a whole-table read, where every added file must conflict.
+    // read. Skipping is not applied for a whole-table read, nor when there are no read predicates
+    // at all: a transaction can be a non-blind-append (e.g. it removed files) yet have no read
+    // predicates, and in that case every added file must remain a conflict candidate, exactly as
+    // when the feature is disabled. Guarding on non-empty read predicates avoids an empty survivor
+    // set silently suppressing a real conflict.
     val candidateFiles =
       if (spark.conf.get(DeltaSQLConf.DELTA_CONFLICT_DETECTION_DATA_SKIPPING_ENABLED) &&
-          !currentTransactionInfo.readWholeTable) {
+          !currentTransactionInfo.readWholeTable &&
+          currentTransactionInfo.readPredicates.nonEmpty) {
         val readSnapshot = currentTransactionInfo.readSnapshot
         val survivingPaths = currentTransactionInfo.readPredicates.iterator.flatMap { rp =>
           readSnapshot.filterFilesByDataSkipping(files, rp.dataPredicates)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
@@ -998,22 +998,21 @@ private[delta] class ConflictChecker(
     // skipping. A concurrently-added file whose stats prove it cannot match the read predicates is
     // not a conflict -- this is what lets unpartitioned / liquid-clustered tables avoid conflicting
     // on every added file below. Data predicates are applied *per read predicate* and the survivors
-    // unioned (OR across reads), because independent reads have OR, not AND, semantics: a file is a
-    // candidate if it could match ANY read; it is dropped only if its stats prove it fails EVERY
-    // read. Skipping is not applied for a whole-table read, nor when there are no read predicates
-    // at all: a transaction can be a non-blind-append (e.g. it removed files) yet have no read
-    // predicates, and in that case every added file must remain a conflict candidate, exactly as
-    // when the feature is disabled. Guarding on non-empty read predicates avoids an empty survivor
-    // set silently suppressing a real conflict.
+    // OR-combined, because independent reads have OR, not AND, semantics: a file is a candidate if
+    // it could match ANY read; it is dropped only if its stats prove it fails EVERY read. All reads
+    // are evaluated in a single Spark job by filterFilesMatchingAnyReadPredicate. Skipping is not
+    // applied for a whole-table read, nor when there are no read predicates at all: a transaction
+    // can be a non-blind-append (e.g. it removed files) yet have no read predicates, and in that
+    // case every added file must remain a conflict candidate, exactly as when the feature is
+    // disabled. Guarding on non-empty read predicates avoids an empty survivor set silently
+    // suppressing a real conflict.
     val candidateFiles =
       if (spark.conf.get(DeltaSQLConf.DELTA_CONFLICT_DETECTION_DATA_SKIPPING_ENABLED) &&
           !currentTransactionInfo.readWholeTable &&
           currentTransactionInfo.readPredicates.nonEmpty) {
         val readSnapshot = currentTransactionInfo.readSnapshot
-        val survivingPaths = currentTransactionInfo.readPredicates.iterator.flatMap { rp =>
-          readSnapshot.filterFilesByDataSkipping(files, rp.dataPredicates)
-        }.map(_.path).toSet
-        val remaining = files.filter(f => survivingPaths.contains(f.path))
+        val remaining = readSnapshot.filterFilesMatchingAnyReadPredicate(
+          files, currentTransactionInfo.readPredicates.map(_.dataPredicates).toSeq)
         if (remaining.size < files.size) {
           recordDeltaEvent(deltaLog,
             opType = "delta.conflictDetection.dataSkipping.filesSkipped",

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -534,6 +534,17 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .booleanConf
       .createWithDefault(true)
 
+  val DELTA_CONFLICT_DETECTION_DATA_SKIPPING_ENABLED =
+    buildConf("conflictDetection.dataSkipping.enabled")
+      .internal()
+      .doc(
+        """When enabled, conflict detection uses column-statistics data skipping to exclude
+          |concurrently-added files whose stats prove they cannot match the current transaction's
+          |read predicates, reducing unnecessary conflicts (especially on unpartitioned tables).
+          |One-way safe: a file is excluded only when its stats prove no match.""".stripMargin)
+      .booleanConf
+      .createWithDefault(false)
+
   val DELTA_PROTOCOL_DEFAULT_WRITER_VERSION =
     buildConf("properties.defaults.minWriterVersion")
       .doc("The default writer protocol version to create new tables with, unless a feature " +

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -554,10 +554,26 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
           |not rule out, and excludes those whose rows do not actually match the current
           |transaction's read predicates. This resolves predicates min/max stats cannot skip (e.g.
           |modulo or other non-range expressions), at the cost of reading the (already stats-
-          |narrowed) added files during commit. One-way safe: a file is excluded only when an actual
-          |scan proves no row matches.""".stripMargin)
+          |narrowed) added files during commit. The scan runs synchronously on the committing thread
+          |inside the conflict-retry loop and is bounded by
+          |conflictDetection.dataSkipping.valueExact.maxBytes. One-way safe: a file is excluded only
+          |when an actual scan proves no row matches.""".stripMargin)
       .booleanConf
       .createWithDefault(false)
+
+  val DELTA_CONFLICT_DETECTION_DATA_SKIPPING_VALUE_EXACT_MAX_BYTES =
+    buildConf("conflictDetection.dataSkipping.valueExact.maxBytes")
+      .internal()
+      .doc(
+        """The maximum total size, in bytes, of the stats-narrowed added files that value-exact
+          |conflict-time data skipping (conflictDetection.dataSkipping.valueExact.enabled) will scan
+          |during a commit. Because the scan runs synchronously on the committing thread inside the
+          |conflict-retry loop, this bounds the commit-time I/O it can add: when the candidate files
+          |exceed this size the scan is skipped and every candidate is kept as a conflict candidate
+          |(the same one-way-safe fallback as when the feature is off). Set to a non-positive value
+          |to disable the bound.""".stripMargin)
+      .longConf
+      .createWithDefault(1L << 30) // 1 GiB
 
   val DELTA_PROTOCOL_DEFAULT_WRITER_VERSION =
     buildConf("properties.defaults.minWriterVersion")

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -545,6 +545,20 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .booleanConf
       .createWithDefault(false)
 
+  val DELTA_CONFLICT_DETECTION_DATA_SKIPPING_VALUE_EXACT_ENABLED =
+    buildConf("conflictDetection.dataSkipping.valueExact.enabled")
+      .internal()
+      .doc(
+        """When enabled (together with conflictDetection.dataSkipping.enabled), conflict detection
+          |reads the actual data of concurrently-added files that column-statistics skipping could
+          |not rule out, and excludes those whose rows do not actually match the current
+          |transaction's read predicates. This resolves predicates min/max stats cannot skip (e.g.
+          |modulo or other non-range expressions), at the cost of reading the (already stats-
+          |narrowed) added files during commit. One-way safe: a file is excluded only when an actual
+          |scan proves no row matches.""".stripMargin)
+      .booleanConf
+      .createWithDefault(false)
+
   val DELTA_PROTOCOL_DEFAULT_WRITER_VERSION =
     buildConf("properties.defaults.minWriterVersion")
       .doc("The default writer protocol version to create new tables with, unless a feature " +

--- a/spark/src/main/scala/org/apache/spark/sql/delta/stats/ConflictDataSkippingReader.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/stats/ConflictDataSkippingReader.scala
@@ -68,7 +68,7 @@ trait ConflictDataSkippingReader extends DeltaLogging { self: DataSkippingReader
    * deterministic, no metadata attributes. Mirrors [[filesForScan]] eligibility so we never build a
    * predicate (stats or value-exact) that could wrongly exclude a matching file. Shared by the
    * stats tier ([[buildDataSkippingPredicate]]) and the value-exact tier
-   * ([[filterFilesByValueExactScan]]).
+   * ([[anyAddedRowMatchesReadPredicate]]).
    */
   private def eligibleSkippingFilters(dataFilters: Seq[Expression]): Seq[Expression] = {
     import DeltaTableUtils._
@@ -131,25 +131,29 @@ trait ConflictDataSkippingReader extends DeltaLogging { self: DataSkippingReader
    * all `files`, since skipping is a pure optimization over correct conservative detection):
    *   1. [[filterFilesByStatsSkipping]] -- column min/max stats, no data I/O (always on with the
    *      feature). Cannot resolve predicates min/max does not model (modulo, non-range exprs).
-   *   2. [[filterFilesByValueExactScan]] -- opt-in via
+   *   2. [[anyAddedRowMatchesReadPredicate]] -- opt-in via
    *      [[DeltaSQLConf.DELTA_CONFLICT_DETECTION_DATA_SKIPPING_VALUE_EXACT_ENABLED]]: for the files
-   *      tier 1 could not rule out, reads their actual rows and evaluates the real predicates,
-   *      dropping any file with zero matching rows. Resolves the stats-inconclusive cases at the
-   *      cost of reading the (already narrowed) added files during commit.
+   *      tier 1 could not rule out, reads their actual rows and evaluates the real predicates; when
+   *      none of them matches, all candidates are dropped. Resolves the stats-inconclusive cases at
+   *      the cost of reading the (already narrowed) added files during commit.
    */
   private[delta] def filterFilesMatchingAnyReadPredicate(
       files: Seq[AddFile],
       dataFiltersPerRead: Seq[Seq[Expression]]): Seq[AddFile] = {
     // Tier 1 (cheap, no data I/O): column min/max stats skipping.
     val statsSurvivors = filterFilesByStatsSkipping(files, dataFiltersPerRead)
-    // Tier 2 (opt-in, reads data): for files stats could NOT rule out, evaluate the real read
-    // predicates against their actual rows. Resolves predicates min/max cannot skip (e.g. modulo).
+    // Tier 2 (opt-in, reads data): a SECOND Spark job, so only run it when tier 1 left survivors
+    // and the feature is enabled. For the files stats could NOT rule out, evaluate the real read
+    // predicates against their actual rows (resolves predicates min/max cannot skip, e.g. modulo):
+    // if no surviving file holds a matching row, none can conflict, so drop them all.
     if (statsSurvivors.isEmpty ||
         !spark.sessionState.conf.getConf(
           DeltaSQLConf.DELTA_CONFLICT_DETECTION_DATA_SKIPPING_VALUE_EXACT_ENABLED)) {
       statsSurvivors
+    } else if (anyAddedRowMatchesReadPredicate(statsSurvivors, dataFiltersPerRead)) {
+      statsSurvivors
     } else {
-      filterFilesByValueExactScan(statsSurvivors, dataFiltersPerRead)
+      Nil
     }
   }
 
@@ -210,77 +214,139 @@ trait ConflictDataSkippingReader extends DeltaLogging { self: DataSkippingReader
   /**
    * Tier 2 -- value-exact scan (see [[filterFilesMatchingAnyReadPredicate]]). For the `files` that
    * tier 1 stats skipping could not rule out, read their ACTUAL data and evaluate the real read
-   * predicates, keeping only files that genuinely have >= 1 matching row. This resolves predicates
+   * predicates, returning whether ANY of them still holds a matching row. This resolves predicates
    * column min/max cannot skip (e.g. `a % 2 = 1`, other non-range expressions): a file whose stats
-   * range spans the predicate but whose values never satisfy it is dropped here, avoiding an
-   * unnecessary conflict.
+   * range spans the predicate but whose values never satisfy it contributes no match, so when
+   * nothing matches the caller can drop every candidate and avoid an unnecessary conflict.
    *
    * Reads are OR-combined, AND within a read -- the same semantics tier 1 approximates. A read with
    * no eligible (deterministic, subquery-free, non-metadata) filter matches everything, so we
-   * cannot prove non-match and keep all `files`. Using only the eligible filters is a sound
+   * cannot prove non-match and return true. Using only the eligible filters is a sound
    * over-approximation of the true read predicate (dropping a conjunct only makes it match more),
    * so a real conflict is never a false negative.
    *
    * Runs a SINGLE, short-circuiting Spark job over the (already stats-narrowed) files: does ANY of
-   * them still hold a row matching the read predicates? If so, keep them ALL as conflict
-   * candidates; if not, drop them all. That is exactly what the caller
+   * them still hold a row matching the read predicates? That boolean is exactly what the caller
    * ([[org.apache.spark.sql.delta.ConflictChecker]]) consumes -- an unpartitioned table collapses
-   * the survivors to `headOption`, and a partitioned table runs this before its partition filter,
-   * so in both cases only "can anything still match?" matters, never which file. Deliberately an
-   * existence check rather than per-file attribution: we never map a scanned row back to its
-   * [[AddFile]], so there is no `_metadata.file_path` distinct/collect and no chance that a
-   * path-canonicalization mismatch drops a genuinely-matching file (which would be a missed
-   * conflict). One-way safe: dropping all files is sound only because the scan proved no candidate
-   * has a matching row. Any failure falls back to keeping all `files`.
+   * its survivors to `headOption`, and a partitioned table runs this before its partition filter,
+   * so only "can anything still match?" matters, never which file. NOTE the flip side on a
+   * partitioned table: a match in ANY partition returns true and keeps EVERY candidate, so the
+   * cross-partition skip is left entirely to the downstream partition filter; tier 2 only helps
+   * when no file in any partition matches. Deliberately an existence check rather than per-file
+   * attribution: we never map a scanned row back to its [[AddFile]], so there is no
+   * `_metadata.file_path` distinct/collect and no chance that a path-canonicalization mismatch
+   * drops a genuinely-matching file (which would be a missed conflict).
+   *
+   * One-way safe: returns false (no conflict) only when the scan PROVES no candidate has a matching
+   * row. It returns true whenever it cannot prove that -- an ineligible read, a scan skipped
+   * because the candidates exceed
+   * [[DeltaSQLConf.DELTA_CONFLICT_DETECTION_DATA_SKIPPING_VALUE_EXACT_MAX_BYTES]], or any error --
+   * so a real conflict is never a false negative.
    */
-  private[delta] def filterFilesByValueExactScan(
+  private[delta] def anyAddedRowMatchesReadPredicate(
       files: Seq[AddFile],
-      dataFiltersPerRead: Seq[Seq[Expression]]): Seq[AddFile] = {
-    if (files.isEmpty || dataFiltersPerRead.isEmpty || schema.isEmpty) return files
+      dataFiltersPerRead: Seq[Seq[Expression]]): Boolean = {
+    if (files.isEmpty) return false
+    if (dataFiltersPerRead.isEmpty || schema.isEmpty) return true
     try {
       // AND within a read over its eligible filters; a read with none matches everything, so we
-      // cannot prove any file fails it -> keep all files (no job).
+      // cannot prove any file fails it -> conservative match (keep all candidates, no job).
       val perReadEligible = dataFiltersPerRead.map(eligibleSkippingFilters)
-      if (perReadEligible.exists(_.isEmpty)) return files
+      if (perReadEligible.exists(_.isEmpty)) return true
+      // Bound the commit-time I/O: the scan runs synchronously on the committing thread inside the
+      // conflict-retry loop, so above the configured size skip it and conservatively report a match
+      // (keeping every candidate), the same one-way-safe fallback as the feature being off.
+      val maxBytes = spark.sessionState.conf.getConf(
+        DeltaSQLConf.DELTA_CONFLICT_DETECTION_DATA_SKIPPING_VALUE_EXACT_MAX_BYTES)
+      if (maxBytes > 0 && files.map(_.size).sum > maxBytes) {
+        logWarning(log"Conflict-time value-exact scan skipped: candidate files exceed the " +
+          log"configured value-exact scan byte bound; keeping all as conflict candidates")
+        return true
+      }
       val snapshot = snapshotToScan
+      // Reads the winner's already-committed added files under the current transaction's snapshot
+      // schema. A concurrent schema change is caught earlier as a metadata conflict, so the
+      // winner's files and this schema agree by the time we get here.
       val df = snapshot.deltaLog.createDataFrame(
-        snapshot, files, actionTypeOpt = Some("conflictDetectionValueExact"))
+        snapshot, files, actionTypeOpt = Some(ConflictDataSkippingReader.VALUE_EXACT_ACTION_TYPE))
       // Rebind each filter's attributes to the fresh DataFrame's columns by name, AND within a
       // read, OR across reads -- a file matches if any read's predicate matches any of its rows.
       val condition = perReadEligible
         .map(filters => filters.map(f => rebindToDataFrame(f, df)).reduce(_ && _))
         .reduce(_ || _)
       // The caller only needs a boolean (see the scaladoc), so run one short-circuiting existence
-      // check instead of attributing rows back to files: keep all candidates if any row matches,
-      // else drop them all.
+      // check instead of attributing rows back to files.
       val sc = spark.sparkContext
       val prevJobDesc = sc.getLocalProperty(SparkContext.SPARK_JOB_DESCRIPTION)
-      val anyRowMatches =
-        try {
-          sc.setJobDescription("Delta conflict detection: value-exact data skipping")
-          recordFrameProfile("Delta", "DataSkippingReader.filterFilesByValueExactScan") {
-            !df.where(condition).isEmpty
-          }
-        } finally {
-          sc.setJobDescription(prevJobDesc)
+      try {
+        sc.setJobDescription("Delta conflict detection: value-exact data skipping")
+        recordFrameProfile("Delta", "DataSkippingReader.anyAddedRowMatchesReadPredicate") {
+          !df.where(condition).isEmpty
         }
-      if (anyRowMatches) files else Nil
+      } finally {
+        sc.setJobDescription(prevJobDesc)
+      }
     } catch {
       case NonFatal(e) =>
         // Optimization only: never let a value-exact scan failure abort a commit. Fall back to
-        // keeping every stats-surviving file as a conflict candidate.
+        // treating every stats-surviving file as a conflict candidate.
         logWarning(log"Conflict-time value-exact scan failed to evaluate; falling back to " +
           log"keeping all stats-surviving files as conflict candidates", e)
-        files
+        true
     }
   }
 
   /**
-   * Rebinds `e`'s attribute references to `df`'s output columns by name, so a read predicate
+   * Rebinds `e`'s attribute references to `df`'s output columns BY NAME, so a read predicate
    * resolved against the transaction's plan can be evaluated on a freshly built DataFrame. Nested
-   * accesses (`GetStructField` over a top-level struct column) are preserved. If a referenced name
-   * is not a column of `df`, `df.col` throws and the caller's fail-safe keeps all files.
+   * struct accesses are resolved by their field NAMES too (via a back-tick-quoted dotted path), not
+   * by the resolved plan's ordinals, so a struct whose fields are laid out in a different order in
+   * `df` is still read correctly rather than silently reading the wrong field (which could drop a
+   * genuinely-matching file). A `GetStructField` without a field name falls back to preserving its
+   * ordinal over the rebound leaf attribute; any referenced name that is not a column of `df` makes
+   * `df.col` throw, and the caller's fail-safe keeps all files.
    */
-  private def rebindToDataFrame(e: Expression, df: DataFrame): Column =
-    Column(e.transform { case a: AttributeReference => df.col(a.name).expr })
+  private def rebindToDataFrame(e: Expression, df: DataFrame): Column = {
+    // transformUp, not transformDown: a matched node is rewritten to a resolved `df` column, which
+    // is itself a `GetStructField`/`AttributeReference`. transformDown would re-descend into that
+    // replacement and re-match forever; transformUp rewrites children first and never revisits the
+    // rule's own output, so a replacement that looks like its input cannot loop.
+    Column(e.transformUp {
+      case g: GetStructField => rebindStructField(g, df)
+      case a: AttributeReference => df.col(quoteColumnName(a.name)).expr
+    })
+  }
+
+  /**
+   * Resolves a `GetStructField`'s whole nested access by name; if it is not a pure named chain,
+   * leaves the node in place (its leaf attribute is still rebound by [[rebindToDataFrame]],
+   * preserving the ordinal fallback). Kept a named method rather than an inline `case` body so the
+   * pattern-bound path does not close over the enclosing `transformUp` function.
+   */
+  private def rebindStructField(g: GetStructField, df: DataFrame): Expression =
+    columnPathOf(g) match {
+      case Some(path) => df.col(path.mkString(".")).expr
+      case None => g
+    }
+
+  /**
+   * Back-tick-quotes a column-path segment so names containing dots/backticks resolve literally.
+   */
+  private def quoteColumnName(name: String): String = "`" + name.replace("`", "``") + "`"
+
+  /**
+   * The dotted, back-tick-quoted column path of a pure attribute / named-`GetStructField` chain
+   * (e.g. `` `s`.`v` ``), or None when `e` is not such a chain.
+   */
+  private def columnPathOf(e: Expression): Option[Seq[String]] = e match {
+    case a: AttributeReference => Some(Seq(quoteColumnName(a.name)))
+    case GetStructField(child, _, Some(fieldName)) =>
+      columnPathOf(child).map(parent => parent :+ quoteColumnName(fieldName))
+    case _ => None
+  }
+}
+
+object ConflictDataSkippingReader {
+  /** `TahoeFileIndex` action-type tag for the conflict-time value-exact scan (metrics only). */
+  private[delta] val VALUE_EXACT_ACTION_TYPE = "conflictDetectionValueExact"
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/stats/ConflictDataSkippingReader.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/stats/ConflictDataSkippingReader.scala
@@ -26,7 +26,8 @@ import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.schema.SchemaUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 
-import org.apache.spark.sql.Column
+import org.apache.spark.SparkContext
+import org.apache.spark.sql.{Column, DataFrame}
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.functions.{col, from_json}
 
@@ -63,6 +64,23 @@ trait ConflictDataSkippingReader extends DeltaLogging { self: DataSkippingReader
   }
 
   /**
+   * Filters `dataFilters` to those safe to use for conflict-time skipping: no subqueries, fully
+   * deterministic, no metadata attributes. Mirrors [[filesForScan]] eligibility so we never build a
+   * predicate (stats or value-exact) that could wrongly exclude a matching file. Shared by the
+   * stats tier ([[buildDataSkippingPredicate]]) and the value-exact tier
+   * ([[filterFilesByValueExactScan]]).
+   */
+  private def eligibleSkippingFilters(dataFilters: Seq[Expression]): Seq[Expression] = {
+    import DeltaTableUtils._
+    dataFilters.filterNot { f =>
+      containsSubquery(f) || !f.deterministic || f.exists {
+        case MetadataAttribute(_) => true
+        case _ => false
+      }
+    }
+  }
+
+  /**
    * Builds a single [[DataSkippingPredicate]] (skipping expression + the stats it references) from
    * `dataFilters`, mirroring [[filesForScan]]'s eligibility filtering, per-filter construction and
    * conjunction fold. Returns None when stats skipping is unavailable or no eligible filter yields
@@ -71,18 +89,10 @@ trait ConflictDataSkippingReader extends DeltaLogging { self: DataSkippingReader
    */
   private[delta] def buildDataSkippingPredicate(
       dataFilters: Seq[Expression]): Option[DataSkippingPredicate] = {
-    import DeltaTableUtils._
     // Stats-skipping conf, inlined from DataSkippingReaderBase.useStats (file-private, so not
     // visible here). Reading it inline avoids widening that member's visibility.
     if (!spark.sessionState.conf.getConf(DeltaSQLConf.DELTA_STATS_SKIPPING)) return None
-    // Mirror filesForScan eligibility: drop subquery / non-deterministic / metadata filters, so we
-    // never build a skipping predicate that could wrongly exclude a matching file.
-    val eligibleFilters = dataFilters.filterNot { f =>
-      containsSubquery(f) || !f.deterministic || f.exists {
-        case MetadataAttribute(_) => true
-        case _ => false
-      }
-    }
+    val eligibleFilters = eligibleSkippingFilters(dataFilters)
     val constructDataFilters = new DataFiltersBuilder(
       spark = spark,
       dataSkippingType = DeltaDataSkippingType.dataSkippingOnlyV1,
@@ -112,9 +122,40 @@ trait ConflictDataSkippingReader extends DeltaLogging { self: DataSkippingReader
   /**
    * Conflict-detection helper (reader-side data skipping) over several INDEPENDENT reads: returns
    * the subset of `files` that could still match ANY read and therefore must be treated as
-   * conflicts. Each inner `Seq[Expression]` is one logical read's data filters (AND-combined via
-   * [[buildDataSkippingPredicate]]); the reads are OR-combined, matching read semantics -- a file
-   * is a candidate if it could match any one of them.
+   * conflicts. Each inner `Seq[Expression]` is one logical read's data filters (AND-combined); the
+   * reads are OR-combined, matching read semantics -- a file is a candidate if it could match any
+   * one of them.
+   *
+   * Two tiers, both one-way safe (a file is dropped only when it is *proven* to fail EVERY read, so
+   * a real conflict is never a false negative) and both fail-safe (any error falls back to keeping
+   * all `files`, since skipping is a pure optimization over correct conservative detection):
+   *   1. [[filterFilesByStatsSkipping]] -- column min/max stats, no data I/O (always on with the
+   *      feature). Cannot resolve predicates min/max does not model (modulo, non-range exprs).
+   *   2. [[filterFilesByValueExactScan]] -- opt-in via
+   *      [[DeltaSQLConf.DELTA_CONFLICT_DETECTION_DATA_SKIPPING_VALUE_EXACT_ENABLED]]: for the files
+   *      tier 1 could not rule out, reads their actual rows and evaluates the real predicates,
+   *      dropping any file with zero matching rows. Resolves the stats-inconclusive cases at the
+   *      cost of reading the (already narrowed) added files during commit.
+   */
+  private[delta] def filterFilesMatchingAnyReadPredicate(
+      files: Seq[AddFile],
+      dataFiltersPerRead: Seq[Seq[Expression]]): Seq[AddFile] = {
+    // Tier 1 (cheap, no data I/O): column min/max stats skipping.
+    val statsSurvivors = filterFilesByStatsSkipping(files, dataFiltersPerRead)
+    // Tier 2 (opt-in, reads data): for files stats could NOT rule out, evaluate the real read
+    // predicates against their actual rows. Resolves predicates min/max cannot skip (e.g. modulo).
+    if (statsSurvivors.isEmpty ||
+        !spark.sessionState.conf.getConf(
+          DeltaSQLConf.DELTA_CONFLICT_DETECTION_DATA_SKIPPING_VALUE_EXACT_ENABLED)) {
+      statsSurvivors
+    } else {
+      filterFilesByValueExactScan(statsSurvivors, dataFiltersPerRead)
+    }
+  }
+
+  /**
+   * Tier 1 -- column min/max stats skipping (see [[filterFilesMatchingAnyReadPredicate]]). Returns
+   * the subset of `files` whose stats do NOT prove they fail every read.
    *
    * All reads are evaluated in a SINGLE Spark job: the per-read skipping predicates are OR-ed
    * together into one `where` clause, rather than filtering per read and unioning the survivors
@@ -122,16 +163,12 @@ trait ConflictDataSkippingReader extends DeltaLogging { self: DataSkippingReader
    * predicate -- that would AND them (read1 AND read2), the opposite of the OR we need.
    *
    * One-way safe: each read contributes `expr || !verifyStatsForFilter(...)` exactly as
-   * [[getDataSkippedFiles]], so a file is dropped only when its stats *prove* it fails EVERY read
-   * -- a real conflict is never a false negative. Files with missing/insufficient stats, a
-   * read with no usable skipping predicate (empty / ineligible filters -> matches everything), or a
-   * table without stats are all kept. Returns the original [[AddFile]]s (matched by path).
-   *
-   * Fail-safe: skipping here is a pure optimization over correct (conservative) conflict detection,
-   * so if building or evaluating the predicate throws we fall back to the default behavior of
-   * keeping all `files` as conflict candidates rather than failing the commit.
+   * [[getDataSkippedFiles]], so a file is dropped only when its stats *prove* it fails EVERY read.
+   * Files with missing/insufficient stats, a read with no usable skipping predicate (empty /
+   * ineligible filters -> matches everything), or a table without stats are all kept. Returns the
+   * original [[AddFile]]s (matched by path). Any failure falls back to keeping all `files`.
    */
-  private[delta] def filterFilesMatchingAnyReadPredicate(
+  private def filterFilesByStatsSkipping(
       files: Seq[AddFile],
       dataFiltersPerRead: Seq[Seq[Expression]]): Seq[AddFile] = {
     import org.apache.spark.sql.delta.implicits._
@@ -169,4 +206,81 @@ trait ConflictDataSkippingReader extends DeltaLogging { self: DataSkippingReader
         files
     }
   }
+
+  /**
+   * Tier 2 -- value-exact scan (see [[filterFilesMatchingAnyReadPredicate]]). For the `files` that
+   * tier 1 stats skipping could not rule out, read their ACTUAL data and evaluate the real read
+   * predicates, keeping only files that genuinely have >= 1 matching row. This resolves predicates
+   * column min/max cannot skip (e.g. `a % 2 = 1`, other non-range expressions): a file whose stats
+   * range spans the predicate but whose values never satisfy it is dropped here, avoiding an
+   * unnecessary conflict.
+   *
+   * Reads are OR-combined, AND within a read -- the same semantics tier 1 approximates. A read with
+   * no eligible (deterministic, subquery-free, non-metadata) filter matches everything, so we
+   * cannot prove non-match and keep all `files`. Using only the eligible filters is a sound
+   * over-approximation of the true read predicate (dropping a conjunct only makes it match more),
+   * so a real conflict is never a false negative.
+   *
+   * Runs a SINGLE, short-circuiting Spark job over the (already stats-narrowed) files: does ANY of
+   * them still hold a row matching the read predicates? If so, keep them ALL as conflict
+   * candidates; if not, drop them all. That is exactly what the caller
+   * ([[org.apache.spark.sql.delta.ConflictChecker]]) consumes -- an unpartitioned table collapses
+   * the survivors to `headOption`, and a partitioned table runs this before its partition filter,
+   * so in both cases only "can anything still match?" matters, never which file. Deliberately an
+   * existence check rather than per-file attribution: we never map a scanned row back to its
+   * [[AddFile]], so there is no `_metadata.file_path` distinct/collect and no chance that a
+   * path-canonicalization mismatch drops a genuinely-matching file (which would be a missed
+   * conflict). One-way safe: dropping all files is sound only because the scan proved no candidate
+   * has a matching row. Any failure falls back to keeping all `files`.
+   */
+  private[delta] def filterFilesByValueExactScan(
+      files: Seq[AddFile],
+      dataFiltersPerRead: Seq[Seq[Expression]]): Seq[AddFile] = {
+    if (files.isEmpty || dataFiltersPerRead.isEmpty || schema.isEmpty) return files
+    try {
+      // AND within a read over its eligible filters; a read with none matches everything, so we
+      // cannot prove any file fails it -> keep all files (no job).
+      val perReadEligible = dataFiltersPerRead.map(eligibleSkippingFilters)
+      if (perReadEligible.exists(_.isEmpty)) return files
+      val snapshot = snapshotToScan
+      val df = snapshot.deltaLog.createDataFrame(
+        snapshot, files, actionTypeOpt = Some("conflictDetectionValueExact"))
+      // Rebind each filter's attributes to the fresh DataFrame's columns by name, AND within a
+      // read, OR across reads -- a file matches if any read's predicate matches any of its rows.
+      val condition = perReadEligible
+        .map(filters => filters.map(f => rebindToDataFrame(f, df)).reduce(_ && _))
+        .reduce(_ || _)
+      // The caller only needs a boolean (see the scaladoc), so run one short-circuiting existence
+      // check instead of attributing rows back to files: keep all candidates if any row matches,
+      // else drop them all.
+      val sc = spark.sparkContext
+      val prevJobDesc = sc.getLocalProperty(SparkContext.SPARK_JOB_DESCRIPTION)
+      val anyRowMatches =
+        try {
+          sc.setJobDescription("Delta conflict detection: value-exact data skipping")
+          recordFrameProfile("Delta", "DataSkippingReader.filterFilesByValueExactScan") {
+            !df.where(condition).isEmpty
+          }
+        } finally {
+          sc.setJobDescription(prevJobDesc)
+        }
+      if (anyRowMatches) files else Nil
+    } catch {
+      case NonFatal(e) =>
+        // Optimization only: never let a value-exact scan failure abort a commit. Fall back to
+        // keeping every stats-surviving file as a conflict candidate.
+        logWarning(log"Conflict-time value-exact scan failed to evaluate; falling back to " +
+          log"keeping all stats-surviving files as conflict candidates", e)
+        files
+    }
+  }
+
+  /**
+   * Rebinds `e`'s attribute references to `df`'s output columns by name, so a read predicate
+   * resolved against the transaction's plan can be evaluated on a freshly built DataFrame. Nested
+   * accesses (`GetStructField` over a top-level struct column) are preserved. If a referenced name
+   * is not a column of `df`, `df.col` throws and the caller's fail-safe keeps all files.
+   */
+  private def rebindToDataFrame(e: Expression, df: DataFrame): Column =
+    Column(e.transform { case a: AttributeReference => df.col(a.name).expr })
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/stats/ConflictDataSkippingReader.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/stats/ConflictDataSkippingReader.scala
@@ -1,0 +1,172 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.stats
+
+import scala.util.control.NonFatal
+
+import org.apache.spark.sql.delta.ClassicColumnConversions._
+import org.apache.spark.sql.delta.DeltaTableUtils
+import org.apache.spark.sql.delta.actions.AddFile
+import org.apache.spark.sql.delta.expressions.DecodeNestedZ85EncodedVariant
+import org.apache.spark.sql.delta.metering.DeltaLogging
+import org.apache.spark.sql.delta.schema.SchemaUtils
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+
+import org.apache.spark.sql.Column
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.functions.{col, from_json}
+
+/**
+ * Reader-side data skipping used during conflict detection (row-level concurrency Case 1: writers
+ * touching disjoint data ranges).
+ *
+ * Mixed into [[DataSkippingReaderBase]] as a self-typed trait so this feature is a single isolated
+ * unit that only ADDS methods -- it does not modify any existing data-skipping code. It is opt-in:
+ * the caller ([[org.apache.spark.sql.delta.ConflictChecker]]) invokes these methods only behind
+ * `DeltaSQLConf.DELTA_CONFLICT_DETECTION_DATA_SKIPPING_ENABLED`, and each is one-way safe -- a file
+ * is dropped only when its stats *prove* it cannot match, so a real conflict is never a false
+ * negative.
+ */
+trait ConflictDataSkippingReader extends DeltaLogging { self: DataSkippingReaderBase =>
+
+  /**
+   * Parses (and, when the schema contains VariantType, Z85-decodes) the JSON `statsCol` into the
+   * `statsSchema` struct, mirroring [[withStatsInternal0]]. Deliberately kept private to this trait
+   * rather than shared with `withStatsInternal0`, so the existing stats path stays untouched.
+   */
+  private def parseAndDecodeStats(statsCol: Column): Column = {
+    val parsedStats = from_json(statsCol, statsSchema)
+    // Only use DecodeNestedZ85EncodedVariant if the schema contains VariantType.
+    // This avoids performance overhead for tables without variant columns.
+    // `DecodeNestedZ85EncodedVariant` is a temporary workaround since the Spark 4.1 from_json
+    // expression has no way to decode a VariantVal from an encoded Z85 string.
+    // TODO: Add Z85 decoding to Variant in Spark 4.2 and use that from_json option here.
+    if (SchemaUtils.checkForVariantTypeColumnsRecursively(statsSchema)) {
+      Column(DecodeNestedZ85EncodedVariant(parsedStats.expr))
+    } else {
+      parsedStats
+    }
+  }
+
+  /**
+   * Builds a single [[DataSkippingPredicate]] (skipping expression + the stats it references) from
+   * `dataFilters`, mirroring [[filesForScan]]'s eligibility filtering, per-filter construction and
+   * conjunction fold. Returns None when stats skipping is unavailable or no eligible filter yields
+   * a predicate. The filters are AND-combined, so callers must pass filters from a single logical
+   * read (predicates from independent reads have OR, not AND, semantics).
+   */
+  private[delta] def buildDataSkippingPredicate(
+      dataFilters: Seq[Expression]): Option[DataSkippingPredicate] = {
+    import DeltaTableUtils._
+    // Stats-skipping conf, inlined from DataSkippingReaderBase.useStats (file-private, so not
+    // visible here). Reading it inline avoids widening that member's visibility.
+    if (!spark.sessionState.conf.getConf(DeltaSQLConf.DELTA_STATS_SKIPPING)) return None
+    // Mirror filesForScan eligibility: drop subquery / non-deterministic / metadata filters, so we
+    // never build a skipping predicate that could wrongly exclude a matching file.
+    val eligibleFilters = dataFilters.filterNot { f =>
+      containsSubquery(f) || !f.deterministic || f.exists {
+        case MetadataAttribute(_) => true
+        case _ => false
+      }
+    }
+    val constructDataFilters = new DataFiltersBuilder(
+      spark = spark,
+      dataSkippingType = DeltaDataSkippingType.dataSkippingOnlyV1,
+      getStatsColumnOpt = (s: StatsColumn) => getStatsColumnOpt(s))
+    eligibleFilters
+      .flatMap(f => constructDataFilters(f))
+      .reduceOption((skip1, skip2) => DataSkippingPredicate(
+        skip1.expr && skip2.expr, skip1.referencedStats ++ skip2.referencedStats))
+  }
+
+  /**
+   * Conflict-detection helper (reader-side data skipping): returns the subset of `files` whose
+   * statistics do NOT prove they fail `dataFilters` -- i.e. the files that could still match and
+   * therefore must be treated as conflicts. Files with missing/insufficient stats (or when skipping
+   * is unavailable) are kept.
+   *
+   * `dataFilters` must come from a single logical read: they are AND-combined via
+   * [[buildDataSkippingPredicate]]. This is the one-read case of
+   * [[filterFilesMatchingAnyReadPredicate]]; callers with multiple independent reads should use
+   * that method so all reads are evaluated in a single Spark job.
+   */
+  private[delta] def filterFilesByDataSkipping(
+      files: Seq[AddFile],
+      dataFilters: Seq[Expression]): Seq[AddFile] =
+    filterFilesMatchingAnyReadPredicate(files, Seq(dataFilters))
+
+  /**
+   * Conflict-detection helper (reader-side data skipping) over several INDEPENDENT reads: returns
+   * the subset of `files` that could still match ANY read and therefore must be treated as
+   * conflicts. Each inner `Seq[Expression]` is one logical read's data filters (AND-combined via
+   * [[buildDataSkippingPredicate]]); the reads are OR-combined, matching read semantics -- a file
+   * is a candidate if it could match any one of them.
+   *
+   * All reads are evaluated in a SINGLE Spark job: the per-read skipping predicates are OR-ed
+   * together into one `where` clause, rather than filtering per read and unioning the survivors
+   * (which launched one job per read). Note we cannot instead flatten every read's filters into one
+   * predicate -- that would AND them (read1 AND read2), the opposite of the OR we need.
+   *
+   * One-way safe: each read contributes `expr || !verifyStatsForFilter(...)` exactly as
+   * [[getDataSkippedFiles]], so a file is dropped only when its stats *prove* it fails EVERY read
+   * -- a real conflict is never a false negative. Files with missing/insufficient stats, a
+   * read with no usable skipping predicate (empty / ineligible filters -> matches everything), or a
+   * table without stats are all kept. Returns the original [[AddFile]]s (matched by path).
+   *
+   * Fail-safe: skipping here is a pure optimization over correct (conservative) conflict detection,
+   * so if building or evaluating the predicate throws we fall back to the default behavior of
+   * keeping all `files` as conflict candidates rather than failing the commit.
+   */
+  private[delta] def filterFilesMatchingAnyReadPredicate(
+      files: Seq[AddFile],
+      dataFiltersPerRead: Seq[Seq[Expression]]): Seq[AddFile] = {
+    import org.apache.spark.sql.delta.implicits._
+    if (files.isEmpty || dataFiltersPerRead.isEmpty || schema.isEmpty) return files
+    try {
+      // One skipping predicate per read. A read with no usable predicate (empty or ineligible
+      // filters) matches every file -> nothing can be skipped, so keep all files without a job.
+      val perReadPredicates = dataFiltersPerRead.map { dataFilters =>
+        if (dataFilters.isEmpty) None else buildDataSkippingPredicate(dataFilters)
+      }
+      if (perReadPredicates.exists(_.isEmpty)) return files
+      // Survive if the file could match ANY read. Per read, `expr || !verifyStatsForFilter(...)`
+      // keeps any file whose referenced stats are missing/NULL (mirrors getDataSkippedFiles): only
+      // skip when stats prove no match. OR the reads so a match against any one keeps the file.
+      val survivorCondition = perReadPredicates.flatten
+        .map(pred => pred.expr || !verifyStatsForFilter(pred.referencedStats))
+        .reduce(_ || _)
+      val survivingPaths = recordFrameProfile(
+          "Delta", "DataSkippingReader.filterFilesMatchingAnyReadPredicate") {
+        files.toDF(spark)
+          .withColumn("stats", parseAndDecodeStats(col("stats")))
+          .where(survivorCondition)
+          .select("path")
+          .collect()
+          .map(_.getString(0))
+          .toSet
+      }
+      files.filter(f => survivingPaths.contains(f.path))
+    } catch {
+      case NonFatal(e) =>
+        // Optimization only: never let a skipping failure abort a commit. Fall back to the default
+        // (feature-off) behavior of treating every added file as a conflict candidate.
+        logWarning(log"Conflict-time data skipping failed to evaluate; falling back to treating " +
+          log"all added files as conflict candidates", e)
+        files
+    }
+  }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/stats/DataSkippingReader.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/stats/DataSkippingReader.scala
@@ -286,21 +286,28 @@ trait DataSkippingReaderBase
         DeltaSQLConf.DELTA_DATASKIPPING_PARTITION_LIKE_FILTERS_ADDITIONAL_SUPPORTED_EXPRESSIONS)
       .toSet.flatMap((exprs: String) => exprs.split(","))
 
-  /** Returns a DataFrame expression to obtain a list of files with parsed statistics. */
-  private def withStatsInternal0: DataFrame = {
-    val parsedStats = from_json(col("stats"), statsSchema)
+  /**
+   * Parses (and, when the schema contains VariantType, Z85-decodes) the JSON `statsCol` into the
+   * `statsSchema` struct. Shared by [[withStatsInternal0]] and conflict-detection data skipping
+   * ([[filterFilesByDataSkipping]]) so both parse stats the same way.
+   */
+  private def parseAndDecodeStats(statsCol: Column): Column = {
+    val parsedStats = from_json(statsCol, statsSchema)
     // Only use DecodeNestedZ85EncodedVariant if the schema contains VariantType.
     // This avoids performance overhead for tables without variant columns.
     // `DecodeNestedZ85EncodedVariant` is a temporary workaround since the Spark 4.1 from_json
     // expression has no way to decode a VariantVal from an encoded Z85 string.
     // TODO: Add Z85 decoding to Variant in Spark 4.2 and use that from_json option here.
-    val decodedStats = if (SchemaUtils.checkForVariantTypeColumnsRecursively(statsSchema)) {
+    if (SchemaUtils.checkForVariantTypeColumnsRecursively(statsSchema)) {
       Column(DecodeNestedZ85EncodedVariant(parsedStats.expr))
     } else {
       parsedStats
     }
-    allFiles.withColumn("stats", decodedStats)
   }
+
+  /** Returns a DataFrame expression to obtain a list of files with parsed statistics. */
+  private def withStatsInternal0: DataFrame =
+    allFiles.withColumn("stats", parseAndDecodeStats(col("stats")))
 
   private lazy val withStatsCache =
     cacheDS(withStatsInternal0, s"Delta Table State with Stats #$version - $redactedPath")
@@ -639,6 +646,75 @@ trait DataSkippingReaderBase
       convertDataFrameToAddFiles(df)
     }
     files.toSeq -> Seq(DataSize(totalSize), DataSize(partitionSize), DataSize(scanSize))
+  }
+
+  /**
+   * Builds a single [[DataSkippingPredicate]] (skipping expression + the stats it references) from
+   * `dataFilters`, mirroring [[filesForScan]]'s eligibility filtering, per-filter construction and
+   * conjunction fold. Returns None when stats skipping is unavailable or no eligible filter yields
+   * a predicate. The filters are AND-combined, so callers must pass filters from a single logical
+   * read (predicates from independent reads have OR, not AND, semantics).
+   */
+  private[delta] def buildDataSkippingPredicate(
+      dataFilters: Seq[Expression]): Option[DataSkippingPredicate] = {
+    import DeltaTableUtils._
+    if (!useStats) return None
+    // Mirror filesForScan eligibility: drop subquery / non-deterministic / metadata filters, so we
+    // never build a skipping predicate that could wrongly exclude a matching file.
+    val eligibleFilters = dataFilters.filterNot { f =>
+      containsSubquery(f) || !f.deterministic || f.exists {
+        case MetadataAttribute(_) => true
+        case _ => false
+      }
+    }
+    val constructDataFilters = new DataFiltersBuilder(
+      spark = spark,
+      dataSkippingType = DeltaDataSkippingType.dataSkippingOnlyV1,
+      getStatsColumnOpt = (s: StatsColumn) => getStatsColumnOpt(s))
+    eligibleFilters
+      .flatMap(f => constructDataFilters(f))
+      .reduceOption((skip1, skip2) => DataSkippingPredicate(
+        skip1.expr && skip2.expr, skip1.referencedStats ++ skip2.referencedStats))
+  }
+
+  /**
+   * Conflict-detection helper (reader-side data skipping): returns the subset of `files` whose
+   * statistics do NOT prove they fail `dataFilters` -- i.e. the files that could still match and
+   * therefore must be treated as conflicts. Files with missing/insufficient stats (or when skipping
+   * is unavailable) are kept.
+   *
+   * `dataFilters` must come from a single logical read: they are AND-combined via
+   * [[buildDataSkippingPredicate]]. Callers with multiple independent reads must invoke this per
+   * read and union the survivors (OR semantics).
+   *
+   * One-way safe: it applies `expr || !verifyStatsForFilter(...)` exactly as
+   * [[getDataSkippedFiles]], so a file is dropped only when its stats *prove* it cannot match -- a
+   * real conflict is never turned into a false negative. Returns the original [[AddFile]]s (matched
+   * by path), stats untouched.
+   */
+  private[delta] def filterFilesByDataSkipping(
+      files: Seq[AddFile],
+      dataFilters: Seq[Expression]): Seq[AddFile] = {
+    import org.apache.spark.sql.delta.implicits._
+    if (files.isEmpty || dataFilters.isEmpty || schema.isEmpty) return files
+    buildDataSkippingPredicate(dataFilters) match {
+      // No usable data-skipping predicate -> keep all files (conservative).
+      case None => files
+      case Some(pred) =>
+        val survivingPaths = recordFrameProfile(
+            "Delta", "DataSkippingReader.filterFilesByDataSkipping") {
+          // `expr || !verifyStatsForFilter(...)` keeps any file whose referenced stats are
+          // missing/NULL (mirrors getDataSkippedFiles): only skip when stats prove no match.
+          files.toDF(spark)
+            .withColumn("stats", parseAndDecodeStats(col("stats")))
+            .where(pred.expr || !verifyStatsForFilter(pred.referencedStats))
+            .select("path")
+            .collect()
+            .map(_.getString(0))
+            .toSet
+        }
+        files.filter(f => survivingPaths.contains(f.path))
+    }
   }
 
   private def getCorrectDataSkippingType(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/stats/DataSkippingReader.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/stats/DataSkippingReader.scala
@@ -20,7 +20,6 @@ package org.apache.spark.sql.delta.stats
 import java.io.Closeable
 
 import scala.collection.mutable.ArrayBuffer
-import scala.util.control.NonFatal
 
 import org.apache.spark.sql.delta.skipping.clustering.{ClusteredTableUtils, ClusteringColumnInfo}
 import org.apache.spark.sql.delta.ClassicColumnConversions._
@@ -265,6 +264,7 @@ trait DataSkippingReaderBase
   with StatisticsCollection
   with ReadsMetadataFields
   with StateCache
+  with ConflictDataSkippingReader
   with DeltaLogging {
 
   import DataSkippingReader._
@@ -287,28 +287,21 @@ trait DataSkippingReaderBase
         DeltaSQLConf.DELTA_DATASKIPPING_PARTITION_LIKE_FILTERS_ADDITIONAL_SUPPORTED_EXPRESSIONS)
       .toSet.flatMap((exprs: String) => exprs.split(","))
 
-  /**
-   * Parses (and, when the schema contains VariantType, Z85-decodes) the JSON `statsCol` into the
-   * `statsSchema` struct. Shared by [[withStatsInternal0]] and conflict-detection data skipping
-   * ([[filterFilesByDataSkipping]]) so both parse stats the same way.
-   */
-  private def parseAndDecodeStats(statsCol: Column): Column = {
-    val parsedStats = from_json(statsCol, statsSchema)
+  /** Returns a DataFrame expression to obtain a list of files with parsed statistics. */
+  private def withStatsInternal0: DataFrame = {
+    val parsedStats = from_json(col("stats"), statsSchema)
     // Only use DecodeNestedZ85EncodedVariant if the schema contains VariantType.
     // This avoids performance overhead for tables without variant columns.
     // `DecodeNestedZ85EncodedVariant` is a temporary workaround since the Spark 4.1 from_json
     // expression has no way to decode a VariantVal from an encoded Z85 string.
     // TODO: Add Z85 decoding to Variant in Spark 4.2 and use that from_json option here.
-    if (SchemaUtils.checkForVariantTypeColumnsRecursively(statsSchema)) {
+    val decodedStats = if (SchemaUtils.checkForVariantTypeColumnsRecursively(statsSchema)) {
       Column(DecodeNestedZ85EncodedVariant(parsedStats.expr))
     } else {
       parsedStats
     }
+    allFiles.withColumn("stats", decodedStats)
   }
-
-  /** Returns a DataFrame expression to obtain a list of files with parsed statistics. */
-  private def withStatsInternal0: DataFrame =
-    allFiles.withColumn("stats", parseAndDecodeStats(col("stats")))
 
   private lazy val withStatsCache =
     cacheDS(withStatsInternal0, s"Delta Table State with Stats #$version - $redactedPath")
@@ -647,112 +640,6 @@ trait DataSkippingReaderBase
       convertDataFrameToAddFiles(df)
     }
     files.toSeq -> Seq(DataSize(totalSize), DataSize(partitionSize), DataSize(scanSize))
-  }
-
-  /**
-   * Builds a single [[DataSkippingPredicate]] (skipping expression + the stats it references) from
-   * `dataFilters`, mirroring [[filesForScan]]'s eligibility filtering, per-filter construction and
-   * conjunction fold. Returns None when stats skipping is unavailable or no eligible filter yields
-   * a predicate. The filters are AND-combined, so callers must pass filters from a single logical
-   * read (predicates from independent reads have OR, not AND, semantics).
-   */
-  private[delta] def buildDataSkippingPredicate(
-      dataFilters: Seq[Expression]): Option[DataSkippingPredicate] = {
-    import DeltaTableUtils._
-    if (!useStats) return None
-    // Mirror filesForScan eligibility: drop subquery / non-deterministic / metadata filters, so we
-    // never build a skipping predicate that could wrongly exclude a matching file.
-    val eligibleFilters = dataFilters.filterNot { f =>
-      containsSubquery(f) || !f.deterministic || f.exists {
-        case MetadataAttribute(_) => true
-        case _ => false
-      }
-    }
-    val constructDataFilters = new DataFiltersBuilder(
-      spark = spark,
-      dataSkippingType = DeltaDataSkippingType.dataSkippingOnlyV1,
-      getStatsColumnOpt = (s: StatsColumn) => getStatsColumnOpt(s))
-    eligibleFilters
-      .flatMap(f => constructDataFilters(f))
-      .reduceOption((skip1, skip2) => DataSkippingPredicate(
-        skip1.expr && skip2.expr, skip1.referencedStats ++ skip2.referencedStats))
-  }
-
-  /**
-   * Conflict-detection helper (reader-side data skipping): returns the subset of `files` whose
-   * statistics do NOT prove they fail `dataFilters` -- i.e. the files that could still match and
-   * therefore must be treated as conflicts. Files with missing/insufficient stats (or when skipping
-   * is unavailable) are kept.
-   *
-   * `dataFilters` must come from a single logical read: they are AND-combined via
-   * [[buildDataSkippingPredicate]]. This is the one-read case of
-   * [[filterFilesMatchingAnyReadPredicate]]; callers with multiple independent reads should use
-   * that method so all reads are evaluated in a single Spark job.
-   */
-  private[delta] def filterFilesByDataSkipping(
-      files: Seq[AddFile],
-      dataFilters: Seq[Expression]): Seq[AddFile] =
-    filterFilesMatchingAnyReadPredicate(files, Seq(dataFilters))
-
-  /**
-   * Conflict-detection helper (reader-side data skipping) over several INDEPENDENT reads: returns
-   * the subset of `files` that could still match ANY read and therefore must be treated as
-   * conflicts. Each inner `Seq[Expression]` is one logical read's data filters (AND-combined via
-   * [[buildDataSkippingPredicate]]); the reads are OR-combined, matching read semantics -- a file
-   * is a candidate if it could match any one of them.
-   *
-   * All reads are evaluated in a SINGLE Spark job: the per-read skipping predicates are OR-ed
-   * together into one `where` clause, rather than filtering per read and unioning the survivors
-   * (which launched one job per read). Note we cannot instead flatten every read's filters into one
-   * predicate -- that would AND them (read1 AND read2), the opposite of the OR we need.
-   *
-   * One-way safe: each read contributes `expr || !verifyStatsForFilter(...)` exactly as
-   * [[getDataSkippedFiles]], so a file is dropped only when its stats *prove* it fails EVERY read
-   * -- a real conflict is never a false negative. Files with missing/insufficient stats, a
-   * read with no usable skipping predicate (empty / ineligible filters -> matches everything), or a
-   * table without stats are all kept. Returns the original [[AddFile]]s (matched by path).
-   *
-   * Fail-safe: skipping here is a pure optimization over correct (conservative) conflict detection,
-   * so if building or evaluating the predicate throws we fall back to the default behavior of
-   * keeping all `files` as conflict candidates rather than failing the commit.
-   */
-  private[delta] def filterFilesMatchingAnyReadPredicate(
-      files: Seq[AddFile],
-      dataFiltersPerRead: Seq[Seq[Expression]]): Seq[AddFile] = {
-    import org.apache.spark.sql.delta.implicits._
-    if (files.isEmpty || dataFiltersPerRead.isEmpty || schema.isEmpty) return files
-    try {
-      // One skipping predicate per read. A read with no usable predicate (empty or ineligible
-      // filters) matches every file -> nothing can be skipped, so keep all files without a job.
-      val perReadPredicates = dataFiltersPerRead.map { dataFilters =>
-        if (dataFilters.isEmpty) None else buildDataSkippingPredicate(dataFilters)
-      }
-      if (perReadPredicates.exists(_.isEmpty)) return files
-      // Survive if the file could match ANY read. Per read, `expr || !verifyStatsForFilter(...)`
-      // keeps any file whose referenced stats are missing/NULL (mirrors getDataSkippedFiles): only
-      // skip when stats prove no match. OR the reads so a match against any one keeps the file.
-      val survivorCondition = perReadPredicates.flatten
-        .map(pred => pred.expr || !verifyStatsForFilter(pred.referencedStats))
-        .reduce(_ || _)
-      val survivingPaths = recordFrameProfile(
-          "Delta", "DataSkippingReader.filterFilesMatchingAnyReadPredicate") {
-        files.toDF(spark)
-          .withColumn("stats", parseAndDecodeStats(col("stats")))
-          .where(survivorCondition)
-          .select("path")
-          .collect()
-          .map(_.getString(0))
-          .toSet
-      }
-      files.filter(f => survivingPaths.contains(f.path))
-    } catch {
-      case NonFatal(e) =>
-        // Optimization only: never let a skipping failure abort a commit. Fall back to the default
-        // (feature-off) behavior of treating every added file as a conflict candidate.
-        logWarning(log"Conflict-time data skipping failed to evaluate; falling back to treating " +
-          log"all added files as conflict candidates", e)
-        files
-    }
   }
 
   private def getCorrectDataSkippingType(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/stats/DataSkippingReader.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/stats/DataSkippingReader.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.delta.stats
 import java.io.Closeable
 
 import scala.collection.mutable.ArrayBuffer
+import scala.util.control.NonFatal
 
 import org.apache.spark.sql.delta.skipping.clustering.{ClusteredTableUtils, ClusteringColumnInfo}
 import org.apache.spark.sql.delta.ClassicColumnConversions._
@@ -684,36 +685,73 @@ trait DataSkippingReaderBase
    * is unavailable) are kept.
    *
    * `dataFilters` must come from a single logical read: they are AND-combined via
-   * [[buildDataSkippingPredicate]]. Callers with multiple independent reads must invoke this per
-   * read and union the survivors (OR semantics).
-   *
-   * One-way safe: it applies `expr || !verifyStatsForFilter(...)` exactly as
-   * [[getDataSkippedFiles]], so a file is dropped only when its stats *prove* it cannot match -- a
-   * real conflict is never turned into a false negative. Returns the original [[AddFile]]s (matched
-   * by path), stats untouched.
+   * [[buildDataSkippingPredicate]]. This is the one-read case of
+   * [[filterFilesMatchingAnyReadPredicate]]; callers with multiple independent reads should use
+   * that method so all reads are evaluated in a single Spark job.
    */
   private[delta] def filterFilesByDataSkipping(
       files: Seq[AddFile],
-      dataFilters: Seq[Expression]): Seq[AddFile] = {
+      dataFilters: Seq[Expression]): Seq[AddFile] =
+    filterFilesMatchingAnyReadPredicate(files, Seq(dataFilters))
+
+  /**
+   * Conflict-detection helper (reader-side data skipping) over several INDEPENDENT reads: returns
+   * the subset of `files` that could still match ANY read and therefore must be treated as
+   * conflicts. Each inner `Seq[Expression]` is one logical read's data filters (AND-combined via
+   * [[buildDataSkippingPredicate]]); the reads are OR-combined, matching read semantics -- a file
+   * is a candidate if it could match any one of them.
+   *
+   * All reads are evaluated in a SINGLE Spark job: the per-read skipping predicates are OR-ed
+   * together into one `where` clause, rather than filtering per read and unioning the survivors
+   * (which launched one job per read). Note we cannot instead flatten every read's filters into one
+   * predicate -- that would AND them (read1 AND read2), the opposite of the OR we need.
+   *
+   * One-way safe: each read contributes `expr || !verifyStatsForFilter(...)` exactly as
+   * [[getDataSkippedFiles]], so a file is dropped only when its stats *prove* it fails EVERY read
+   * -- a real conflict is never a false negative. Files with missing/insufficient stats, a
+   * read with no usable skipping predicate (empty / ineligible filters -> matches everything), or a
+   * table without stats are all kept. Returns the original [[AddFile]]s (matched by path).
+   *
+   * Fail-safe: skipping here is a pure optimization over correct (conservative) conflict detection,
+   * so if building or evaluating the predicate throws we fall back to the default behavior of
+   * keeping all `files` as conflict candidates rather than failing the commit.
+   */
+  private[delta] def filterFilesMatchingAnyReadPredicate(
+      files: Seq[AddFile],
+      dataFiltersPerRead: Seq[Seq[Expression]]): Seq[AddFile] = {
     import org.apache.spark.sql.delta.implicits._
-    if (files.isEmpty || dataFilters.isEmpty || schema.isEmpty) return files
-    buildDataSkippingPredicate(dataFilters) match {
-      // No usable data-skipping predicate -> keep all files (conservative).
-      case None => files
-      case Some(pred) =>
-        val survivingPaths = recordFrameProfile(
-            "Delta", "DataSkippingReader.filterFilesByDataSkipping") {
-          // `expr || !verifyStatsForFilter(...)` keeps any file whose referenced stats are
-          // missing/NULL (mirrors getDataSkippedFiles): only skip when stats prove no match.
-          files.toDF(spark)
-            .withColumn("stats", parseAndDecodeStats(col("stats")))
-            .where(pred.expr || !verifyStatsForFilter(pred.referencedStats))
-            .select("path")
-            .collect()
-            .map(_.getString(0))
-            .toSet
-        }
-        files.filter(f => survivingPaths.contains(f.path))
+    if (files.isEmpty || dataFiltersPerRead.isEmpty || schema.isEmpty) return files
+    try {
+      // One skipping predicate per read. A read with no usable predicate (empty or ineligible
+      // filters) matches every file -> nothing can be skipped, so keep all files without a job.
+      val perReadPredicates = dataFiltersPerRead.map { dataFilters =>
+        if (dataFilters.isEmpty) None else buildDataSkippingPredicate(dataFilters)
+      }
+      if (perReadPredicates.exists(_.isEmpty)) return files
+      // Survive if the file could match ANY read. Per read, `expr || !verifyStatsForFilter(...)`
+      // keeps any file whose referenced stats are missing/NULL (mirrors getDataSkippedFiles): only
+      // skip when stats prove no match. OR the reads so a match against any one keeps the file.
+      val survivorCondition = perReadPredicates.flatten
+        .map(pred => pred.expr || !verifyStatsForFilter(pred.referencedStats))
+        .reduce(_ || _)
+      val survivingPaths = recordFrameProfile(
+          "Delta", "DataSkippingReader.filterFilesMatchingAnyReadPredicate") {
+        files.toDF(spark)
+          .withColumn("stats", parseAndDecodeStats(col("stats")))
+          .where(survivorCondition)
+          .select("path")
+          .collect()
+          .map(_.getString(0))
+          .toSet
+      }
+      files.filter(f => survivingPaths.contains(f.path))
+    } catch {
+      case NonFatal(e) =>
+        // Optimization only: never let a skipping failure abort a commit. Fall back to the default
+        // (feature-off) behavior of treating every added file as a conflict candidate.
+        logWarning(log"Conflict-time data skipping failed to evaluate; falling back to treating " +
+          log"all added files as conflict candidates", e)
+        files
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/ConflictDataSkippingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/ConflictDataSkippingSuite.scala
@@ -1,0 +1,171 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import java.io.File
+
+import scala.concurrent.duration.Duration
+
+import org.apache.spark.sql.delta.concurrency.PhaseLockingTestMixin
+import org.apache.spark.sql.delta.concurrency.TransactionExecutionTestMixin
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+
+import org.apache.spark.SparkException
+import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.functions.lit
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.util.ThreadUtils
+
+/**
+ * Tests for reader-side conflict-time data skipping
+ * ([[DeltaSQLConf.DELTA_CONFLICT_DETECTION_DATA_SKIPPING_ENABLED]]).
+ *
+ * A concurrently-added file whose column stats prove it cannot match the current transaction's read
+ * predicates should NOT cause an append conflict, especially on unpartitioned tables, where the
+ * append check would otherwise conflict on any added file. Skipping must be one-way safe: a file
+ * with missing stats is always kept, so a real conflict is never missed.
+ */
+class ConflictDataSkippingSuite extends QueryTest
+  with SharedSparkSession
+  with DeltaSQLCommandTest
+  with PhaseLockingTestMixin
+  with TransactionExecutionTestMixin {
+
+  private def tableRef(dir: File): String = s"delta.`${dir.getCanonicalPath}`"
+
+  /**
+   * Unpartitioned table with `id` in [0, 1000) across 10 files (file i covers [100i, 100i+100)),
+   * committed at Serializable isolation so that concurrent (blind) appends are conflict-checked.
+   * When `numIndexedCols` is set, stats collection is limited accordingly (0 = no stats).
+   */
+  private def createTable(dir: File, numIndexedCols: Option[Int] = None): Unit = {
+    spark.range(start = 0, end = 1000, step = 1, numPartitions = 10)
+      .write.format("delta").mode("append").save(dir.getAbsolutePath)
+    val extraProps = numIndexedCols
+      .map(n => s", '${DeltaConfigs.DATA_SKIPPING_NUM_INDEXED_COLS.key}' = '$n'")
+      .getOrElse("")
+    sql(s"ALTER TABLE ${tableRef(dir)} SET TBLPROPERTIES " +
+      s"('${DeltaConfigs.ISOLATION_LEVEL.key}' = 'Serializable'$extraProps)")
+  }
+
+  /** A DELETE that runs under the given data-skipping setting (evaluated on its commit thread). */
+  private def deleteTxn(dir: File, condition: String, dataSkipping: Boolean): () => Array[Row] =
+    () => {
+      withSQLConf(
+        DeltaSQLConf.DELTA_CONFLICT_DETECTION_DATA_SKIPPING_ENABLED.key -> dataSkipping.toString) {
+        sql(s"DELETE FROM ${tableRef(dir)} WHERE $condition").collect()
+      }
+      Array.empty[Row]
+    }
+
+  /** A blind append of `id` in [start, end), optionally into partition `p`. */
+  private def appendTxn(
+      dir: File, start: Long, end: Long, partition: Option[Int] = None): () => Array[Row] =
+    () => {
+      var df = spark.range(start, end).toDF()
+      partition.foreach(p => df = df.withColumn("p", lit(p)))
+      df.write.format("delta").mode("append").save(dir.getAbsolutePath)
+      Array.empty[Row]
+    }
+
+  /** Expected surviving ids after deleting id<50 and appending [1000, 1100). */
+  private val disjointExpected: Seq[Row] =
+    ((50L until 1000L) ++ (1000L until 1100L)).map(Row(_))
+
+  private def assertConcurrentAppend(e: SparkException): Unit =
+    assert(e.getCause.isInstanceOf[io.delta.exceptions.ConcurrentAppendException],
+      s"Expected ConcurrentAppendException, got: ${e.getCause}")
+
+  test("disjoint data ranges: added file is skipped, no conflict") {
+    withTempDir { dir =>
+      createTable(dir)
+      // A (loser) deletes id<50; B (winner) appends [1000,1100), disjoint from A's predicate.
+      val txnA = deleteTxn(dir, "id < 50", dataSkipping = true)
+      val txnB = appendTxn(dir, 1000, 1100)
+
+      val (futureA, futureB) = runTxnsWithOrder__A_Start__B__A_End(txnA, txnB)
+      ThreadUtils.awaitResult(futureA, Duration.Inf)
+      ThreadUtils.awaitResult(futureB, Duration.Inf)
+
+      // Both committed: id<50 deleted, [1000,1100) appended.
+      checkAnswer(
+        spark.read.format("delta").load(dir.getAbsolutePath).select("id"), disjointExpected)
+    }
+  }
+
+  test("overlapping data ranges: added file matches the predicate, still conflicts") {
+    withTempDir { dir =>
+      createTable(dir)
+      // A's predicate id>=950 overlaps B's appended [1000,1100) file range -> not skippable.
+      val txnA = deleteTxn(dir, "id >= 950", dataSkipping = true)
+      val txnB = appendTxn(dir, 1000, 1100)
+
+      val (futureA, futureB) = runTxnsWithOrder__A_Start__B__A_End(txnA, txnB)
+      ThreadUtils.awaitResult(futureB, Duration.Inf)
+      val e = intercept[SparkException] { ThreadUtils.awaitResult(futureA, Duration.Inf) }
+      assertConcurrentAppend(e)
+    }
+  }
+
+  test("feature disabled: disjoint data ranges still conflict") {
+    withTempDir { dir =>
+      createTable(dir)
+      val txnA = deleteTxn(dir, "id < 50", dataSkipping = false)
+      val txnB = appendTxn(dir, 1000, 1100)
+
+      val (futureA, futureB) = runTxnsWithOrder__A_Start__B__A_End(txnA, txnB)
+      ThreadUtils.awaitResult(futureB, Duration.Inf)
+      val e = intercept[SparkException] { ThreadUtils.awaitResult(futureA, Duration.Inf) }
+      assertConcurrentAppend(e)
+    }
+  }
+
+  test("missing stats: disjoint ranges still conflict (one-way safety)") {
+    withTempDir { dir =>
+      // No indexed columns -> the appended file has no id stats -> must NOT be skipped.
+      createTable(dir, numIndexedCols = Some(0))
+      val txnA = deleteTxn(dir, "id < 50", dataSkipping = true)
+      val txnB = appendTxn(dir, 1000, 1100)
+
+      val (futureA, futureB) = runTxnsWithOrder__A_Start__B__A_End(txnA, txnB)
+      ThreadUtils.awaitResult(futureB, Duration.Inf)
+      val e = intercept[SparkException] { ThreadUtils.awaitResult(futureA, Duration.Inf) }
+      assertConcurrentAppend(e)
+    }
+  }
+
+  test("partitioned table: data skipping on a non-partition column avoids the conflict") {
+    withTempDir { dir =>
+      // Partitioned by `p`; the appended file shares the partition but its id range is disjoint.
+      spark.range(start = 0, end = 1000, step = 1, numPartitions = 10).withColumn("p", lit(0))
+        .write.partitionBy("p").format("delta").mode("append").save(dir.getAbsolutePath)
+      sql(s"ALTER TABLE ${tableRef(dir)} SET TBLPROPERTIES " +
+        s"('${DeltaConfigs.ISOLATION_LEVEL.key}' = 'Serializable')")
+
+      val txnA = deleteTxn(dir, "id < 50", dataSkipping = true)
+      val txnB = appendTxn(dir, 1000, 1100, partition = Some(0))
+
+      val (futureA, futureB) = runTxnsWithOrder__A_Start__B__A_End(txnA, txnB)
+      ThreadUtils.awaitResult(futureA, Duration.Inf)
+      ThreadUtils.awaitResult(futureB, Duration.Inf)
+
+      checkAnswer(
+        spark.read.format("delta").load(dir.getAbsolutePath).select("id"), disjointExpected)
+    }
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/ConflictDataSkippingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/ConflictDataSkippingSuite.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 
 import org.apache.spark.SparkException
 import org.apache.spark.sql.{QueryTest, Row, SaveMode}
-import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression, GreaterThanOrEqual, LessThan, Literal}
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, EqualTo, Expression, GreaterThanOrEqual, LessThan, Literal, Remainder}
 import org.apache.spark.sql.functions.lit
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.LongType
@@ -66,11 +66,20 @@ class ConflictDataSkippingSuite extends QueryTest
       s"('${DeltaConfigs.ISOLATION_LEVEL.key}' = 'Serializable'$extraProps)")
   }
 
-  /** A DELETE that runs under the given data-skipping setting (evaluated on its commit thread). */
-  private def deleteTxn(dir: File, condition: String, dataSkipping: Boolean): () => Array[Row] =
+  /**
+   * A DELETE that runs under the given conflict-time skipping settings (evaluated on its commit
+   * thread). `valueExact` enables the tier-2 actual-value scan on top of tier-1 stats skipping.
+   */
+  private def deleteTxn(
+      dir: File,
+      condition: String,
+      dataSkipping: Boolean,
+      valueExact: Boolean = false): () => Array[Row] =
     () => {
       withSQLConf(
-        DeltaSQLConf.DELTA_CONFLICT_DETECTION_DATA_SKIPPING_ENABLED.key -> dataSkipping.toString) {
+        DeltaSQLConf.DELTA_CONFLICT_DETECTION_DATA_SKIPPING_ENABLED.key -> dataSkipping.toString,
+        DeltaSQLConf.DELTA_CONFLICT_DETECTION_DATA_SKIPPING_VALUE_EXACT_ENABLED.key ->
+          valueExact.toString) {
         sql(s"DELETE FROM ${tableRef(dir)} WHERE $condition").collect()
       }
       Array.empty[Row]
@@ -81,6 +90,16 @@ class ConflictDataSkippingSuite extends QueryTest
       dir: File, start: Long, end: Long, partition: Option[Int] = None): () => Array[Row] =
     () => {
       var df = spark.range(start, end).toDF()
+      partition.foreach(p => df = df.withColumn("p", lit(p)))
+      df.write.format("delta").mode("append").save(dir.getAbsolutePath)
+      Array.empty[Row]
+    }
+
+  /** A blind append of the EVEN ids in [start, end), optionally into partition `p`. */
+  private def appendEvenTxn(
+      dir: File, start: Long, end: Long, partition: Option[Int] = None): () => Array[Row] =
+    () => {
+      var df = spark.range(start, end, step = 2).toDF()
       partition.foreach(p => df = df.withColumn("p", lit(p)))
       df.write.format("delta").mode("append").save(dir.getAbsolutePath)
       Array.empty[Row]
@@ -275,6 +294,161 @@ class ConflictDataSkippingSuite extends QueryTest
       val allKept = snapshot.filterFilesMatchingAnyReadPredicate(allFiles, Seq(read1, Seq.empty))
       assert(allKept.size == allFiles.size,
         s"a read with no predicate must keep all files, got ${allKept.size}")
+    }
+  }
+
+  test("value-exact: modulo predicate min/max cannot skip is reconciled by actual-value scan") {
+    withTempDir { dir =>
+      createTable(dir)
+      // A (loser) deletes ODD ids; B (winner) appends the all-EVEN ids in [1000,1100). The parities
+      // are disjoint, but the appended file's min/max [1000,1098] spans odd values, so tier-1 stats
+      // cannot prove `id % 2 = 1` unsatisfiable. Tier-2 value-exact reads the rows (all even) and
+      // finds zero matches -> no conflict.
+      val txnA = deleteTxn(dir, "id % 2 = 1", dataSkipping = true, valueExact = true)
+      val txnB = appendEvenTxn(dir, 1000, 1100)
+
+      val (futureA, futureB) = runTxnsWithOrder__A_Start__B__A_End(txnA, txnB)
+      ThreadUtils.awaitResult(futureA, Duration.Inf)
+      ThreadUtils.awaitResult(futureB, Duration.Inf)
+
+      // Both committed: odd ids in [0,1000) deleted; all-even [1000,1100) appended.
+      val expected =
+        ((0L until 1000L).filter(_ % 2 == 0) ++ (1000L until 1100L by 2)).map(Row(_))
+      checkAnswer(
+        spark.read.format("delta").load(dir.getAbsolutePath).select("id"), expected)
+    }
+  }
+
+  test("value-exact disabled: modulo predicate still conflicts (stats cannot skip)") {
+    // The gap value-exact closes: with only tier-1 stats, a modulo predicate the min/max cannot
+    // resolve keeps the added file as a conflict candidate, so the disjoint-parity append
+    // conflicts.
+    withTempDir { dir =>
+      createTable(dir)
+      val txnA = deleteTxn(dir, "id % 2 = 1", dataSkipping = true, valueExact = false)
+      val txnB = appendEvenTxn(dir, 1000, 1100)
+
+      val (futureA, futureB) = runTxnsWithOrder__A_Start__B__A_End(txnA, txnB)
+      ThreadUtils.awaitResult(futureB, Duration.Inf)
+      val e = intercept[SparkException] { ThreadUtils.awaitResult(futureA, Duration.Inf) }
+      assertConcurrentAppend(e)
+    }
+  }
+
+  test("value-exact: a genuinely matching added file still conflicts (no over-skip)") {
+    withTempDir { dir =>
+      createTable(dir)
+      // Loser deletes EVEN ids; winner appends all-even [1000,1100). Every appended row matches
+      // `id % 2 = 0`, so value-exact must KEEP the file and the conflict must still stand.
+      val txnA = deleteTxn(dir, "id % 2 = 0", dataSkipping = true, valueExact = true)
+      val txnB = appendEvenTxn(dir, 1000, 1100)
+
+      val (futureA, futureB) = runTxnsWithOrder__A_Start__B__A_End(txnA, txnB)
+      ThreadUtils.awaitResult(futureB, Duration.Inf)
+      val e = intercept[SparkException] { ThreadUtils.awaitResult(futureA, Duration.Inf) }
+      assertConcurrentAppend(e)
+    }
+  }
+
+  test("filterFilesByValueExactScan drops a file whose rows never match, keeps one that does") {
+    withTempDir { dir =>
+      // A single file of all-even ids in [0,100). min/max = [0,98] spans odd values, so min/max
+      // stats cannot prove `id % 2 = 1` unsatisfiable, but no row actually matches it.
+      spark.range(0, 100, step = 2).repartition(1)
+        .write.format("delta").mode("append").save(dir.getAbsolutePath)
+      val log = DeltaLog.forTable(spark, dir.getCanonicalPath)
+      val snapshot = log.update()
+      val allFiles = snapshot.allFiles.collect().toSeq
+      assert(allFiles.size == 1, s"expected a single file, got ${allFiles.size}")
+
+      val id = AttributeReference("id", LongType)()
+      val odd = EqualTo(Remainder(id, Literal(2L)), Literal(1L))
+      val even = EqualTo(Remainder(id, Literal(2L)), Literal(0L))
+
+      // Value-exact: no row is odd -> file dropped; every row is even -> file kept (no over-drop).
+      assert(snapshot.filterFilesByValueExactScan(allFiles, Seq(Seq(odd))).isEmpty,
+        "all-even file must be dropped for id % 2 = 1")
+      assert(snapshot.filterFilesByValueExactScan(allFiles, Seq(Seq(even))).size == 1,
+        "all-even file must be kept for id % 2 = 0")
+
+      // Contrast tier 1: min/max stats cannot resolve modulo, so it keeps the file regardless.
+      assert(snapshot.filterFilesByDataSkipping(allFiles, Seq(odd)).size == 1,
+        "stats skipping cannot resolve modulo -> keeps the file")
+
+      // A read with no eligible filter matches everything -> keep all (cannot prove non-match).
+      assert(snapshot.filterFilesByValueExactScan(allFiles, Seq(Seq.empty)).size == 1,
+        "a read with no eligible filter must keep all files")
+    }
+  }
+
+  test("filterFilesByValueExactScan keeps all candidates if any matches, drops all if none do") {
+    withTempDir { dir =>
+      // Two single-row-group files: one all-odd, one all-even. The scan is an existence check, not
+      // per-file attribution -- the caller only needs a boolean -- so a predicate matched by EITHER
+      // file keeps BOTH, and a predicate no file matches drops both.
+      spark.range(1, 100, step = 2).repartition(1)
+        .write.format("delta").mode("append").save(dir.getAbsolutePath) // all-odd file
+      spark.range(0, 100, step = 2).repartition(1)
+        .write.format("delta").mode("append").save(dir.getAbsolutePath) // all-even file
+      val log = DeltaLog.forTable(spark, dir.getCanonicalPath)
+      val snapshot = log.update()
+      val allFiles = snapshot.allFiles.collect().toSeq
+      assert(allFiles.size == 2, s"expected two files, got ${allFiles.size}")
+
+      val id = AttributeReference("id", LongType)()
+      val odd = EqualTo(Remainder(id, Literal(2L)), Literal(1L))
+      val even = EqualTo(Remainder(id, Literal(2L)), Literal(0L))
+      val noMatch = EqualTo(Remainder(id, Literal(2L)), Literal(5L)) // id % 2 is 0 or 1, never 5
+
+      // A row in either file matches -> keep every candidate.
+      assert(snapshot.filterFilesByValueExactScan(allFiles, Seq(Seq(odd))).size == 2,
+        "the all-odd file matches -> keep both candidates")
+      assert(snapshot.filterFilesByValueExactScan(allFiles, Seq(Seq(even))).size == 2,
+        "the all-even file matches -> keep both candidates")
+      // No file has a matching row -> drop every candidate (safe: nothing can conflict).
+      assert(snapshot.filterFilesByValueExactScan(allFiles, Seq(Seq(noMatch))).isEmpty,
+        "no candidate matches -> drop all")
+    }
+  }
+
+  test("filterFilesByValueExactScan keeps all files when a predicate is unresolvable (fail-safe)") {
+    withTempDir { dir =>
+      createTable(dir)
+      val log = DeltaLog.forTable(spark, dir.getCanonicalPath)
+      val snapshot = log.update()
+      val allFiles = snapshot.allFiles.collect().toSeq
+      assert(allFiles.size == 10)
+
+      // A predicate on a column that is not in the table: rebinding throws, and the fail-safe must
+      // keep every file as a conflict candidate rather than let the scan failure abort a commit.
+      val ghost = EqualTo(AttributeReference("does_not_exist", LongType)(), Literal(1L))
+      val kept = snapshot.filterFilesByValueExactScan(allFiles, Seq(Seq(ghost)))
+      assert(kept.size == allFiles.size,
+        s"an unresolvable predicate must keep all files (fail-safe), got ${kept.size}")
+    }
+  }
+
+  test("value-exact on a partitioned table: modulo predicate reconciled by actual-value scan") {
+    withTempDir { dir =>
+      // Partitioned by `p`; loser deletes ODD ids, winner appends all-EVEN ids into the same
+      // partition. The data predicate `id % 2 = 1` is non-partition, so stats cannot skip the
+      // appended file, but its rows are all even -> value-exact finds zero matches -> no conflict.
+      spark.range(start = 0, end = 1000, step = 1, numPartitions = 10).withColumn("p", lit(0))
+        .write.partitionBy("p").format("delta").mode("append").save(dir.getAbsolutePath)
+      sql(s"ALTER TABLE ${tableRef(dir)} SET TBLPROPERTIES " +
+        s"('${DeltaConfigs.ISOLATION_LEVEL.key}' = 'Serializable')")
+
+      val txnA = deleteTxn(dir, "id % 2 = 1", dataSkipping = true, valueExact = true)
+      val txnB = appendEvenTxn(dir, 1000, 1100, partition = Some(0))
+
+      val (futureA, futureB) = runTxnsWithOrder__A_Start__B__A_End(txnA, txnB)
+      ThreadUtils.awaitResult(futureA, Duration.Inf)
+      ThreadUtils.awaitResult(futureB, Duration.Inf)
+
+      val expected =
+        ((0L until 1000L).filter(_ % 2 == 0) ++ (1000L until 1100L by 2)).map(Row(_))
+      checkAnswer(
+        spark.read.format("delta").load(dir.getAbsolutePath).select("id"), expected)
     }
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/ConflictDataSkippingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/ConflictDataSkippingSuite.scala
@@ -28,10 +28,10 @@ import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 
 import org.apache.spark.SparkException
 import org.apache.spark.sql.{QueryTest, Row, SaveMode}
-import org.apache.spark.sql.catalyst.expressions.{AttributeReference, EqualTo, Expression, GreaterThanOrEqual, LessThan, Literal, Remainder}
-import org.apache.spark.sql.functions.lit
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, EqualTo, Expression, GetStructField, GreaterThanOrEqual, LessThan, Literal, Remainder}
+import org.apache.spark.sql.functions.{col, lit, struct}
 import org.apache.spark.sql.test.SharedSparkSession
-import org.apache.spark.sql.types.LongType
+import org.apache.spark.sql.types.{LongType, StructField, StructType}
 import org.apache.spark.util.ThreadUtils
 
 /**
@@ -350,7 +350,7 @@ class ConflictDataSkippingSuite extends QueryTest
     }
   }
 
-  test("filterFilesByValueExactScan drops a file whose rows never match, keeps one that does") {
+  test("anyAddedRowMatchesReadPredicate: false when no row matches, true when one does") {
     withTempDir { dir =>
       // A single file of all-even ids in [0,100). min/max = [0,98] spans odd values, so min/max
       // stats cannot prove `id % 2 = 1` unsatisfiable, but no row actually matches it.
@@ -365,27 +365,27 @@ class ConflictDataSkippingSuite extends QueryTest
       val odd = EqualTo(Remainder(id, Literal(2L)), Literal(1L))
       val even = EqualTo(Remainder(id, Literal(2L)), Literal(0L))
 
-      // Value-exact: no row is odd -> file dropped; every row is even -> file kept (no over-drop).
-      assert(snapshot.filterFilesByValueExactScan(allFiles, Seq(Seq(odd))).isEmpty,
-        "all-even file must be dropped for id % 2 = 1")
-      assert(snapshot.filterFilesByValueExactScan(allFiles, Seq(Seq(even))).size == 1,
-        "all-even file must be kept for id % 2 = 0")
+      // Value-exact: no row is odd -> no match; every row is even -> match (no over-drop).
+      assert(!snapshot.anyAddedRowMatchesReadPredicate(allFiles, Seq(Seq(odd))),
+        "all-even file has no odd row -> no match for id % 2 = 1")
+      assert(snapshot.anyAddedRowMatchesReadPredicate(allFiles, Seq(Seq(even))),
+        "all-even file matches id % 2 = 0")
 
       // Contrast tier 1: min/max stats cannot resolve modulo, so it keeps the file regardless.
       assert(snapshot.filterFilesByDataSkipping(allFiles, Seq(odd)).size == 1,
         "stats skipping cannot resolve modulo -> keeps the file")
 
-      // A read with no eligible filter matches everything -> keep all (cannot prove non-match).
-      assert(snapshot.filterFilesByValueExactScan(allFiles, Seq(Seq.empty)).size == 1,
-        "a read with no eligible filter must keep all files")
+      // A read with no eligible filter matches everything -> conservative match (cannot prove not).
+      assert(snapshot.anyAddedRowMatchesReadPredicate(allFiles, Seq(Seq.empty)),
+        "a read with no eligible filter conservatively matches")
     }
   }
 
-  test("filterFilesByValueExactScan keeps all candidates if any matches, drops all if none do") {
+  test("anyAddedRowMatchesReadPredicate: existence check across candidate files") {
     withTempDir { dir =>
       // Two single-row-group files: one all-odd, one all-even. The scan is an existence check, not
       // per-file attribution -- the caller only needs a boolean -- so a predicate matched by EITHER
-      // file keeps BOTH, and a predicate no file matches drops both.
+      // file is a match, and a predicate no file matches is not.
       spark.range(1, 100, step = 2).repartition(1)
         .write.format("delta").mode("append").save(dir.getAbsolutePath) // all-odd file
       spark.range(0, 100, step = 2).repartition(1)
@@ -400,18 +400,152 @@ class ConflictDataSkippingSuite extends QueryTest
       val even = EqualTo(Remainder(id, Literal(2L)), Literal(0L))
       val noMatch = EqualTo(Remainder(id, Literal(2L)), Literal(5L)) // id % 2 is 0 or 1, never 5
 
-      // A row in either file matches -> keep every candidate.
-      assert(snapshot.filterFilesByValueExactScan(allFiles, Seq(Seq(odd))).size == 2,
-        "the all-odd file matches -> keep both candidates")
-      assert(snapshot.filterFilesByValueExactScan(allFiles, Seq(Seq(even))).size == 2,
-        "the all-even file matches -> keep both candidates")
-      // No file has a matching row -> drop every candidate (safe: nothing can conflict).
-      assert(snapshot.filterFilesByValueExactScan(allFiles, Seq(Seq(noMatch))).isEmpty,
-        "no candidate matches -> drop all")
+      // A row in either file matches -> match.
+      assert(snapshot.anyAddedRowMatchesReadPredicate(allFiles, Seq(Seq(odd))),
+        "the all-odd file matches")
+      assert(snapshot.anyAddedRowMatchesReadPredicate(allFiles, Seq(Seq(even))),
+        "the all-even file matches")
+      // No file has a matching row -> no match (safe: caller drops all candidates).
+      assert(!snapshot.anyAddedRowMatchesReadPredicate(allFiles, Seq(Seq(noMatch))),
+        "no candidate matches")
     }
   }
 
-  test("filterFilesByValueExactScan keeps all files when a predicate is unresolvable (fail-safe)") {
+  test("anyAddedRowMatchesReadPredicate OR-combines reads and ANDs within a read") {
+    withTempDir { dir =>
+      // One all-odd file and one all-even file.
+      spark.range(1, 100, step = 2).repartition(1)
+        .write.format("delta").mode("append").save(dir.getAbsolutePath)
+      spark.range(0, 100, step = 2).repartition(1)
+        .write.format("delta").mode("append").save(dir.getAbsolutePath)
+      val log = DeltaLog.forTable(spark, dir.getCanonicalPath)
+      val snapshot = log.update()
+      val allFiles = snapshot.allFiles.collect().toSeq
+      assert(allFiles.size == 2, s"expected two files, got ${allFiles.size}")
+
+      val id = AttributeReference("id", LongType)()
+      val odd = EqualTo(Remainder(id, Literal(2L)), Literal(1L))
+      val even = EqualTo(Remainder(id, Literal(2L)), Literal(0L))
+      val never = EqualTo(Remainder(id, Literal(2L)), Literal(5L))
+      val never2 = EqualTo(Remainder(id, Literal(2L)), Literal(7L))
+
+      // OR across reads: one read unsatisfiable, the other (odd) matches the all-odd file -> match.
+      assert(snapshot.anyAddedRowMatchesReadPredicate(allFiles, Seq(Seq(never), Seq(odd))),
+        "second read matches -> OR across reads is a match")
+      // OR across reads, both unsatisfiable -> no match.
+      assert(!snapshot.anyAddedRowMatchesReadPredicate(allFiles, Seq(Seq(never), Seq(never2))),
+        "neither read matches -> no match")
+      // AND within a read: `odd AND even` cannot hold for any single row -> no match.
+      assert(!snapshot.anyAddedRowMatchesReadPredicate(allFiles, Seq(Seq(odd, even))),
+        "odd AND even cannot hold for any single row -> no match")
+    }
+  }
+
+  test("anyAddedRowMatchesReadPredicate resolves nested struct fields by name, not ordinal") {
+    withTempDir { dir =>
+      // Struct column `s` with fields (a, v): `a` holds odd values, `v` holds even values. A
+      // predicate built with the WRONG ordinal (0 -> `a`) but the RIGHT name (`v`) must read `v`.
+      // Ordinal-based rebinding would read `a` (odd) and wrongly report a match for `s.v % 2 = 1`.
+      spark.range(0, 100, step = 2)
+        .select(struct((col("id") + 1).as("a"), col("id").as("v")).as("s"))
+        .repartition(1)
+        .write.format("delta").mode("append").save(dir.getAbsolutePath)
+      val log = DeltaLog.forTable(spark, dir.getCanonicalPath)
+      val snapshot = log.update()
+      val allFiles = snapshot.allFiles.collect().toSeq
+      assert(allFiles.size == 1, s"expected a single file, got ${allFiles.size}")
+
+      val structType = StructType(Seq(StructField("a", LongType), StructField("v", LongType)))
+      val s = AttributeReference("s", structType)()
+      // Deliberately WRONG ordinal (0 = field `a`), correct name `v`.
+      val sv = GetStructField(s, 0, Some("v"))
+      val svOdd = EqualTo(Remainder(sv, Literal(2L)), Literal(1L))
+      val svEven = EqualTo(Remainder(sv, Literal(2L)), Literal(0L))
+
+      // `v` is all even: `s.v % 2 = 1` must find no match (name-based). Ordinal 0 -> `a` (odd)
+      // would wrongly match.
+      assert(!snapshot.anyAddedRowMatchesReadPredicate(allFiles, Seq(Seq(svOdd))),
+        "s.v holds even values -> no row matches s.v % 2 = 1 (field `v` must resolve by name)")
+      // `s.v % 2 = 0` matches every row.
+      assert(snapshot.anyAddedRowMatchesReadPredicate(allFiles, Seq(Seq(svEven))),
+        "s.v holds even values -> every row matches s.v % 2 = 0")
+    }
+  }
+
+  test("anyAddedRowMatchesReadPredicate: NULLs are non-matches (three-valued logic)") {
+    withTempDir { dir =>
+      // A file whose only rows are NULL id. `id = 5` is UNKNOWN on NULL, i.e. not a match.
+      val nulls = spark.createDataFrame(
+        spark.sparkContext.parallelize(Seq(Row(null), Row(null))),
+        StructType(Seq(StructField("id", LongType))))
+      nulls.repartition(1).write.format("delta").mode("append").save(dir.getAbsolutePath)
+      val log = DeltaLog.forTable(spark, dir.getCanonicalPath)
+      val snapshot = log.update()
+      val allFiles = snapshot.allFiles.collect().toSeq
+      assert(allFiles.size == 1, s"expected a single file, got ${allFiles.size}")
+
+      val id = AttributeReference("id", LongType)()
+      assert(
+        !snapshot.anyAddedRowMatchesReadPredicate(allFiles, Seq(Seq(EqualTo(id, Literal(5L))))),
+        "id = 5 is UNKNOWN on NULL rows -> no match")
+    }
+  }
+
+  test("anyAddedRowMatchesReadPredicate on a partitioned table: a match anywhere -> true") {
+    withTempDir { dir =>
+      // Partitioned by `p`: p=0 all-even ids, p=1 all-odd ids. The scan ignores partitioning, so an
+      // odd predicate matched only in p=1 still returns true across both partitions' files -- the
+      // downstream partition filter, not tier 2, separates partitions.
+      spark.range(0, 100, step = 2).withColumn("p", lit(0)).repartition(1)
+        .write.partitionBy("p").format("delta").mode("append").save(dir.getAbsolutePath)
+      spark.range(1, 100, step = 2).withColumn("p", lit(1)).repartition(1)
+        .write.partitionBy("p").format("delta").mode("append").save(dir.getAbsolutePath)
+      val log = DeltaLog.forTable(spark, dir.getCanonicalPath)
+      val snapshot = log.update()
+      val allFiles = snapshot.allFiles.collect().toSeq
+      assert(allFiles.size == 2, s"expected two partition files, got ${allFiles.size}")
+
+      val id = AttributeReference("id", LongType)()
+      val odd = EqualTo(Remainder(id, Literal(2L)), Literal(1L))
+      val never = EqualTo(Remainder(id, Literal(2L)), Literal(5L))
+
+      // Odd rows exist only in p=1, but the existence check spans all candidate files -> true.
+      assert(snapshot.anyAddedRowMatchesReadPredicate(allFiles, Seq(Seq(odd))),
+        "an odd row exists in the p=1 file -> match across partitions")
+      // No row anywhere matches -> false (the only case tier 2 helps on a partitioned table).
+      assert(!snapshot.anyAddedRowMatchesReadPredicate(allFiles, Seq(Seq(never))),
+        "no row in any partition matches -> no match")
+    }
+  }
+
+  test("anyAddedRowMatchesReadPredicate: over the byte bound is a conservative match") {
+    withTempDir { dir =>
+      // An all-even file: `id % 2 = 1` normally proves no match. With the byte bound set below the
+      // file size, the scan is skipped and the method conservatively reports a match.
+      spark.range(0, 100, step = 2).repartition(1)
+        .write.format("delta").mode("append").save(dir.getAbsolutePath)
+      val log = DeltaLog.forTable(spark, dir.getCanonicalPath)
+      val snapshot = log.update()
+      val allFiles = snapshot.allFiles.collect().toSeq
+      assert(allFiles.size == 1)
+      assert(allFiles.head.size > 1, "the added file must be larger than the 1-byte bound below")
+
+      val id = AttributeReference("id", LongType)()
+      val odd = EqualTo(Remainder(id, Literal(2L)), Literal(1L))
+
+      // Bound above the file size (default): the scan runs and proves no odd row -> no match.
+      assert(!snapshot.anyAddedRowMatchesReadPredicate(allFiles, Seq(Seq(odd))),
+        "under the default bound the scan runs and finds no match")
+      // Bound below the file size: the scan is skipped -> conservative match.
+      withSQLConf(
+          DeltaSQLConf.DELTA_CONFLICT_DETECTION_DATA_SKIPPING_VALUE_EXACT_MAX_BYTES.key -> "1") {
+        assert(snapshot.anyAddedRowMatchesReadPredicate(allFiles, Seq(Seq(odd))),
+          "candidates exceed the 1-byte bound -> scan skipped -> conservative match")
+      }
+    }
+  }
+
+  test("anyAddedRowMatchesReadPredicate: unresolvable predicate is a conservative match") {
     withTempDir { dir =>
       createTable(dir)
       val log = DeltaLog.forTable(spark, dir.getCanonicalPath)
@@ -420,11 +554,11 @@ class ConflictDataSkippingSuite extends QueryTest
       assert(allFiles.size == 10)
 
       // A predicate on a column that is not in the table: rebinding throws, and the fail-safe must
-      // keep every file as a conflict candidate rather than let the scan failure abort a commit.
+      // report a match (keep every file as a conflict candidate) rather than let the scan failure
+      // abort a commit.
       val ghost = EqualTo(AttributeReference("does_not_exist", LongType)(), Literal(1L))
-      val kept = snapshot.filterFilesByValueExactScan(allFiles, Seq(Seq(ghost)))
-      assert(kept.size == allFiles.size,
-        s"an unresolvable predicate must keep all files (fail-safe), got ${kept.size}")
+      assert(snapshot.anyAddedRowMatchesReadPredicate(allFiles, Seq(Seq(ghost))),
+        "an unresolvable predicate must be a conservative match (fail-safe)")
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/ConflictDataSkippingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/ConflictDataSkippingSuite.scala
@@ -20,15 +20,18 @@ import java.io.File
 
 import scala.concurrent.duration.Duration
 
+import org.apache.spark.sql.delta.actions.AddFile
 import org.apache.spark.sql.delta.concurrency.PhaseLockingTestMixin
 import org.apache.spark.sql.delta.concurrency.TransactionExecutionTestMixin
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 
 import org.apache.spark.SparkException
-import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.{QueryTest, Row, SaveMode}
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, GreaterThanOrEqual, LessThan, Literal}
 import org.apache.spark.sql.functions.lit
 import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.LongType
 import org.apache.spark.util.ThreadUtils
 
 /**
@@ -166,6 +169,84 @@ class ConflictDataSkippingSuite extends QueryTest
 
       checkAnswer(
         spark.read.format("delta").load(dir.getAbsolutePath).select("id"), disjointExpected)
+    }
+  }
+
+  private def manufacturedAdd(name: String): AddFile =
+    AddFile(name, Map.empty[String, String], size = 1L, modificationTime = 1L, dataChange = true)
+
+  test("empty read predicates on a non-blind-append txn: added file still conflicts") {
+    // Soundness of the Serializable blind-append case. A transaction can be a NON-blind append
+    // (it removes a file, so onlyAddFiles = false) and yet record no read predicates. With data
+    // skipping enabled such a txn must still conflict-check every concurrently added file, exactly
+    // as it does with the feature disabled. Before the guard on non-empty read predicates, the
+    // empty read set produced an empty survivor set and the conflict was silently suppressed.
+    withTempDir { dir =>
+      createTable(dir)
+      val log = DeltaLog.forTable(spark, dir.getCanonicalPath)
+      // An existing file to remove, which makes the loser a non-blind append with no reads.
+      val existingRemove = log.update().allFiles.collect().head.remove
+      withSQLConf(
+          DeltaSQLConf.DELTA_CONFLICT_DETECTION_DATA_SKIPPING_ENABLED.key -> "true") {
+        val loser = log.startTransaction()
+        // Winner: a blind append committed while the loser is still open.
+        log.startTransaction().commit(
+          Seq(manufacturedAdd("winner.parquet")), DeltaOperations.Write(SaveMode.Append))
+        // Loser adds AND removes without reading -> not a blind append, no read predicates.
+        intercept[io.delta.exceptions.ConcurrentAppendException] {
+          loser.commit(
+            Seq(manufacturedAdd("loser.parquet"), existingRemove),
+            DeltaOperations.Write(SaveMode.Append))
+        }
+      }
+    }
+  }
+
+  test("whole-table read is never skipped: conflicts with a concurrent append") {
+    // A whole-table read must treat every concurrently added file as a conflict, even with data
+    // skipping enabled -- the feature is deliberately bypassed for readWholeTable.
+    withTempDir { dir =>
+      createTable(dir)
+      val log = DeltaLog.forTable(spark, dir.getCanonicalPath)
+      withSQLConf(
+          DeltaSQLConf.DELTA_CONFLICT_DETECTION_DATA_SKIPPING_ENABLED.key -> "true") {
+        val loser = log.startTransaction()
+        loser.readWholeTable()
+        log.startTransaction().commit(
+          Seq(manufacturedAdd("winner.parquet")), DeltaOperations.Write(SaveMode.Append))
+        intercept[io.delta.exceptions.ConcurrentAppendException] {
+          loser.commit(
+            Seq(manufacturedAdd("loser.parquet")), DeltaOperations.Write(SaveMode.Append))
+        }
+      }
+    }
+  }
+
+  test("filterFilesByDataSkipping AND-combines predicates within one read") {
+    // Predicates from a SINGLE read have AND semantics (OR is only across independent reads, which
+    // ConflictChecker unions by construction). This exercises that AND directly.
+    withTempDir { dir =>
+      createTable(dir)
+      val log = DeltaLog.forTable(spark, dir.getCanonicalPath)
+      val snapshot = log.update()
+      val allFiles = snapshot.allFiles.collect().toSeq
+      assert(allFiles.size == 10)
+
+      // Resolved catalyst predicates on the `id` column; built directly so the literal stays a
+      // bare Long (a parsed `id >= 200` would wrap it in a Cast, which is not skipping-eligible).
+      val id = AttributeReference("id", LongType)()
+      val ge200 = GreaterThanOrEqual(id, Literal(200L))
+      val lt300 = LessThan(id, Literal(300L))
+
+      // Only the [200, 300) file can match `id >= 200 AND id < 300`. OR semantics would keep every
+      // file with id >= 200 or id < 300, i.e. all 10.
+      val survivors = snapshot.filterFilesByDataSkipping(allFiles, Seq(ge200, lt300))
+      assert(survivors.size == 1,
+        s"expected exactly the [200,300) file, got ${survivors.map(_.path).sorted}")
+
+      // Sanity: a single predicate keeps its whole matching range (files with max id >= 200).
+      val geOnly = snapshot.filterFilesByDataSkipping(allFiles, Seq(ge200))
+      assert(geOnly.size == 8, s"expected 8 files with id >= 200, got ${geOnly.size}")
     }
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/ConflictDataSkippingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/ConflictDataSkippingSuite.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 
 import org.apache.spark.SparkException
 import org.apache.spark.sql.{QueryTest, Row, SaveMode}
-import org.apache.spark.sql.catalyst.expressions.{AttributeReference, GreaterThanOrEqual, LessThan, Literal}
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression, GreaterThanOrEqual, LessThan, Literal}
 import org.apache.spark.sql.functions.lit
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.LongType
@@ -247,6 +247,34 @@ class ConflictDataSkippingSuite extends QueryTest
       // Sanity: a single predicate keeps its whole matching range (files with max id >= 200).
       val geOnly = snapshot.filterFilesByDataSkipping(allFiles, Seq(ge200))
       assert(geOnly.size == 8, s"expected 8 files with id >= 200, got ${geOnly.size}")
+    }
+  }
+
+  test("filterFilesMatchingAnyReadPredicate OR-combines independent reads in one call") {
+    // Independent reads have OR semantics: a file survives if it could match ANY read. This is the
+    // multi-read path ConflictChecker uses -- all reads are evaluated together in a single job.
+    withTempDir { dir =>
+      createTable(dir)
+      val log = DeltaLog.forTable(spark, dir.getCanonicalPath)
+      val snapshot = log.update()
+      val allFiles = snapshot.allFiles.collect().toSeq
+      assert(allFiles.size == 10)
+
+      val id = AttributeReference("id", LongType)()
+      // Read 1: id in [200, 300) -> the single [200,300) file. Read 2: id >= 800 -> the [800,900)
+      // and [900,1000) files. Their union (OR across reads) is exactly 3 files.
+      val read1 = Seq[Expression](
+        GreaterThanOrEqual(id, Literal(200L)), LessThan(id, Literal(300L)))
+      val read2 = Seq[Expression](GreaterThanOrEqual(id, Literal(800L)))
+      val survivors =
+        snapshot.filterFilesMatchingAnyReadPredicate(allFiles, Seq(read1, read2))
+      assert(survivors.size == 3,
+        s"expected [200,300) + [800,1000), got ${survivors.map(_.path).sorted}")
+
+      // A read with no usable predicate matches everything, so nothing can be skipped -> all kept.
+      val allKept = snapshot.filterFilesMatchingAnyReadPredicate(allFiles, Seq(read1, Seq.empty))
+      assert(allKept.size == allFiles.size,
+        s"a read with no predicate must keep all files, got ${allKept.size}")
     }
   }
 }


### PR DESCRIPTION
## What

Follow-up to #7358 (conflict-time data skipping / row-level concurrency). Adds an opt-in second tier that reads the actual rows of concurrently-added files that column min/max statistics could not rule out, and reports whether any of them still matches the current transaction's read predicates.

**Stacked on #7358.** This branch is based on #7358's branch, so until that PR merges this PR's diff includes its commits. The value-exact change is the single top commit on top of #7358's; please review after #7358.

## Why

Tier-1 min/max skipping cannot model predicates such as `c % 2 = 1` or other non-range expressions. A concurrently-added file whose stats range spans the predicate is therefore kept as a conflict candidate even when none of its rows actually match, producing an unnecessary `ConcurrentAppendException`.

## How

`filterFilesMatchingAnyReadPredicate` now runs two tiers, both one-way safe (candidates are dropped only when proven to fail every read) and fail-safe (any error keeps all files):

1. `filterFilesByStatsSkipping` — column min/max stats, no data I/O (unchanged; always on with the feature).
2. `anyAddedRowMatchesReadPredicate` — new, opt-in via `spark.databricks.delta.conflictDetection.dataSkipping.valueExact.enabled` (default off). For the stats-narrowed files it builds a single DataFrame over exactly those `AddFile`s and evaluates the eligible read predicates (AND within a read, OR across reads), returning a single short-circuiting **existence boolean** — does *any* surviving file still hold a matching row? The orchestrator keeps all survivors when it returns true and drops them all when it returns false. It is deliberately an existence check rather than a per-row→file attribution, so there is no `input_file_name` distinct-collect whose path-canonicalization mismatch could silently drop a genuinely-matching file (a missed conflict).

The scan runs synchronously on the committing thread inside the conflict-retry loop, so it is bounded by `spark.databricks.delta.conflictDetection.dataSkipping.valueExact.maxBytes` (default 1 GiB): when the stats-narrowed candidates exceed it the scan is skipped and every candidate is kept — the same one-way-safe fallback as when the feature is off. Nested struct references in the read predicate are resolved by field **name**, not ordinal. Only eligible filters (deterministic, subquery-free, non-metadata) are used; a read with none matches everything, so all files are kept. Using a subset of a read's conjuncts is a sound over-approximation — it only makes the predicate match more — so a real conflict is never a false negative.

## Tests

`ConflictDataSkippingSuite` (21/21 pass): modulo predicate reconciled end-to-end; value-exact disabled still conflicts; a genuinely-matching added file still conflicts (no over-skip); all-or-nothing existence semantics across multiple added files; OR-across / AND-within reads; nested struct fields resolved by name not ordinal; NULLs treated as non-matches (three-valued logic); partitioned match-anywhere; over-the-byte-bound conservative match; fail-safe on an unresolvable predicate; and single-file unit assertions contrasting tier 1 vs tier 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
