### PR TITLE
Add withCheckpointDir hook to CatalogManagedStreamingSuite for configurable checkpoint storage

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogManagedStreamingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogManagedStreamingSuite.scala
@@ -64,37 +64,47 @@ trait CatalogManagedStreamingSuiteBase
     getTrackingClient.foreach(_.reset())
   }
 
+  /**
+   * Provides a checkpoint location for streaming tests. Defaults to a local temp dir; subclasses
+   * can override it to run the same test bodies against a different storage backend.
+   */
+  protected def withCheckpointDir(f: String => Unit): Unit =
+    withTempDir(dir => f(dir.getAbsolutePath))
+
   protected override def beforeEach(): Unit = {
     super.beforeEach()
     resetTrackingClient()
   }
 
   test("stream from delta source") {
-    withTempTable(createTable = false) { sourceTableName =>
-      sql(s"CREATE TABLE $sourceTableName (value INT) USING delta")
+    withCheckpointDir { checkpointPath =>
+      withTempTable(createTable = false) { sourceTableName =>
+        sql(s"CREATE TABLE $sourceTableName (value INT) USING delta")
 
-      val df = spark.readStream
-        .format("delta")
-        .table(sourceTableName)
+        val df = spark.readStream
+          .format("delta")
+          .table(sourceTableName)
 
-      resetTrackingClient()
+        resetTrackingClient()
 
-      testStream(df)(
-        Execute{ _ =>
-          Seq(1, 2).toDF().write.format("delta").mode("append").saveAsTable(sourceTableName)
-        },
-        ProcessAllAvailable(),
-        CheckAnswer(1, 2),
-        Execute { _ => assertNumCommitsCalled(1) },
-        // At least one read from the commit and one from checking the result
-        Execute { _ => assertNumGetCommitsCalled(2) }
-      )
+        testStream(df)(
+          StartStream(checkpointLocation = checkpointPath),
+          Execute{ _ =>
+            Seq(1, 2).toDF().write.format("delta").mode("append").saveAsTable(sourceTableName)
+          },
+          ProcessAllAvailable(),
+          CheckAnswer(1, 2),
+          Execute { _ => assertNumCommitsCalled(1) },
+          // At least one read from the commit and one from checking the result
+          Execute { _ => assertNumGetCommitsCalled(2) }
+        )
+      }
     }
   }
 
   test("stream to delta sink") {
     // The dir is only used as the checkpoint location and doesn't imply a path-based access.
-    withTempDir { tempDir =>
+    withCheckpointDir { checkpointPath =>
       withTempTable(createTable = false) { sinkTableName =>
         var expectedNumCommits = 0
         var expectedNumGetCommits = 0
@@ -104,7 +114,7 @@ trait CatalogManagedStreamingSuiteBase
           .toDF()
           .writeStream
           .format("delta")
-          .option("checkpointLocation", tempDir.getAbsolutePath)
+          .option("checkpointLocation", checkpointPath)
           .toTable(sinkTableName)
         query.processAllAvailable()
 
@@ -138,7 +148,7 @@ trait CatalogManagedStreamingSuiteBase
   }
 
   test("stream from delta source to delta sink with shared commit coordinator") {
-    withTempDir { tempDir =>
+    withCheckpointDir { checkpointPath =>
       withTempTable(createTable = false) { sourceTableName =>
         withTempTable(createTable = false) { sinkTableName =>
           var expectedNumCommits = 0
@@ -154,7 +164,7 @@ trait CatalogManagedStreamingSuiteBase
             .toDF()
             .writeStream
             .format("delta")
-            .option("checkpointLocation", tempDir.getAbsolutePath)
+            .option("checkpointLocation", checkpointPath)
             .toTable(sinkTableName)
           query.processAllAvailable()
           expectedNumCommits += 1


### PR DESCRIPTION
Introduces a withCheckpointDir hook in CatalogManagedStreamingSuiteBase that supplies the streaming checkpoint location (defaulting to a local temp dir), so subclasses can run the same streaming test bodies against a different storage backend. Existing tests are updated to route their checkpoint through the hook, and the "stream from delta source" test now sets the checkpoint explicitly via StartStream(checkpointLocation = ...).