### PR TITLE
Add DeltaTableProvider test trait to parameterize table format in test suites

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeleteSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeleteSuiteBase.scala
@@ -53,7 +53,7 @@ trait DeleteBaseMixin
       expectedErrorClassForDataSetTempView: String = null): Unit = {
     testWithTempView(s"test delete on temp view - $name") { isSQLTempView =>
       withTable("tab") {
-        Seq((0, 3), (1, 2)).toDF("key", "value").write.format("delta").saveAsTable("tab")
+        Seq((0, 3), (1, 2)).toDF("key", "value").write.format(writeFormat).saveAsTable("tab")
         if (isSQLTempView) {
           sql(s"CREATE TEMP VIEW v AS $text")
         } else {
@@ -91,13 +91,13 @@ trait DeleteBaseMixin
       expectResult: Seq[Row]): Unit = {
     testWithTempView(s"test delete on temp view - $name") { isSQLTempView =>
         withTable("tab") {
-          Seq((0, 3), (1, 2)).toDF("key", "value").write.format("delta").saveAsTable("tab")
+          Seq((0, 3), (1, 2)).toDF("key", "value").write.format(writeFormat).saveAsTable("tab")
           createTempViewFromSelect(text, isSQLTempView)
           executeDelete(
             "v",
             "key >= 1 and value < 3"
           )
-          checkAnswer(spark.read.format("delta").table("v"), expectResult)
+          checkAnswer(spark.read.format(writeFormat).table("v"), expectResult)
         }
     }
   }
@@ -307,7 +307,7 @@ trait DeleteBaseTests extends DeleteBaseMixin {
     withTempPath { tempDir =>
       val tempPath = tempDir.getCanonicalPath
       val df = Seq((2, 2), (3, 2)).toDF("key", "value")
-      df.write.format("delta").partitionBy("key").save(tempPath)
+      df.write.format(writeFormat).partitionBy("key").save(tempPath)
 
       val e = intercept[AnalysisException] {
         executeDelete(target = s"delta.`$tempPath/key=2`", where = "value = 2")
@@ -319,7 +319,7 @@ trait DeleteBaseTests extends DeleteBaseMixin {
   test("delete cached table by name") {
     withTable("cached_delta_table") {
       Seq((2, 2), (1, 4)).toDF("key", "value")
-        .write.format("delta").saveAsTable("cached_delta_table")
+        .write.format(writeFormat).saveAsTable("cached_delta_table")
 
       spark.table("cached_delta_table").cache()
       spark.table("cached_delta_table").collect()
@@ -552,7 +552,7 @@ trait DeleteBaseTests extends DeleteBaseMixin {
       customErrorRegex: Option[String] = None) {
     test(s"$functionType functions in delete - expect exception: $expectException") {
       withTable("deltaTable") {
-        data.write.format("delta").saveAsTable("deltaTable")
+        data.write.format(writeFormat).saveAsTable("deltaTable")
 
         val expectedErrorRegex = "(?s).*(?i)unsupported.*(?i).*Invalid expressions.*"
 
@@ -575,7 +575,7 @@ trait DeleteBaseTests extends DeleteBaseMixin {
 
 
         if (catchException) {
-          val dataBeforeException = spark.read.format("delta").table("deltaTable").collect()
+          val dataBeforeException = spark.read.format(writeFormat).table("deltaTable").collect()
           val e = intercept[Exception] {
             executeDelete(target = "deltaTable", where = where)
           }
@@ -584,7 +584,7 @@ trait DeleteBaseTests extends DeleteBaseMixin {
           } else e.getMessage
           assert(message.matches(errorRegex),
             s"unexpected error in $functionType case: ${e.getClass.getName}: $message")
-          checkAnswer(spark.read.format("delta").table("deltaTable"), dataBeforeException)
+          checkAnswer(spark.read.format(writeFormat).table("deltaTable"), dataBeforeException)
         } else {
           executeDelete(target = "deltaTable", where = where)
         }
@@ -678,7 +678,7 @@ trait DeleteSubqueryBaseMixin extends DeleteBaseMixin {
         .toDF("c", "t1")
         .coalesce(1)
         .write
-        .format("delta")
+        .format(writeFormat)
         .mode("overwrite")
         .saveAsTable("target")
       if (source.nonEmpty) {
@@ -707,7 +707,7 @@ trait DeleteSubqueryBaseMixin extends DeleteBaseMixin {
       val partSpec = if (isPartitioned) "partitioned by (c)" else ""
       test(name + s" isPartitioned=$isPartitioned") {
         withTable("target") {
-          sql(s"CREATE TABLE target(c int, t1 string) USING delta $partSpec")
+          sql(s"CREATE TABLE target(c int, t1 string) USING $tableProvider $partSpec")
           body
         }
       }
@@ -833,7 +833,7 @@ trait DeleteSubqueryExistsTests extends DeleteSubqueryBaseMixin {
       .toDF("c", "t1")
       .coalesce(1)
       .write
-      .format("delta")
+      .format(writeFormat)
       .mode("overwrite")
       .saveAsTable("target")
     // Create an empty source view with the correct schema
@@ -859,7 +859,7 @@ trait DeleteSubqueryExistsTests extends DeleteSubqueryBaseMixin {
       .toDF("c", "t1")
       .repartition(4)
       .write
-      .format("delta")
+      .format(writeFormat)
       .mode("overwrite")
       .saveAsTable("target")
     Seq((3, "x"), (7, "y"), (15, "z"))

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaDataFrameWriterV2Suite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaDataFrameWriterV2Suite.scala
@@ -41,7 +41,8 @@ import org.apache.spark.util.Utils
 trait OpenSourceDataFrameWriterV2Tests
     extends QueryTest
     with SharedSparkSession
-    with BeforeAndAfter {
+    with BeforeAndAfter
+    with DeltaTableProvider {
 
   import testImplicits._
 
@@ -74,7 +75,7 @@ trait OpenSourceDataFrameWriterV2Tests
   }
 
   test("Append: basic append") {
-    spark.sql("CREATE TABLE table_name (id bigint, data string) USING delta")
+    spark.sql(createTableSQL("table_name", "id bigint, data string"))
 
     checkAnswer(spark.table("table_name"), Seq.empty)
 
@@ -92,7 +93,7 @@ trait OpenSourceDataFrameWriterV2Tests
   }
 
   test("Append: by name not position") {
-    spark.sql("CREATE TABLE table_name (id bigint, data string) USING delta")
+    spark.sql(createTableSQL("table_name", "id bigint, data string"))
 
     checkAnswer(spark.table("table_name"), Seq.empty)
 
@@ -117,7 +118,7 @@ trait OpenSourceDataFrameWriterV2Tests
 
   test("Overwrite: overwrite by expression: true") {
     spark.sql(
-      "CREATE TABLE table_name (id bigint, data string) USING delta PARTITIONED BY (id)")
+      createTableSQL("table_name", "id bigint, data string", partitionBy = "PARTITIONED BY (id)"))
 
     checkAnswer(spark.table("table_name"), Seq.empty)
 
@@ -136,7 +137,7 @@ trait OpenSourceDataFrameWriterV2Tests
 
   test("Overwrite: overwrite by expression: id = 3") {
     spark.sql(
-      "CREATE TABLE table_name (id bigint, data string) USING delta PARTITIONED BY (id)")
+      createTableSQL("table_name", "id bigint, data string", partitionBy = "PARTITIONED BY (id)"))
 
     checkAnswer(spark.table("table_name"), Seq.empty)
 
@@ -160,7 +161,7 @@ trait OpenSourceDataFrameWriterV2Tests
   }
 
   test("Overwrite: by name not position") {
-    spark.sql("CREATE TABLE table_name (id bigint, data string) USING delta")
+    spark.sql(createTableSQL("table_name", "id bigint, data string"))
 
     checkAnswer(spark.table("table_name"), Seq.empty)
 
@@ -186,7 +187,7 @@ trait OpenSourceDataFrameWriterV2Tests
 
   test("OverwritePartitions: overwrite conflicting partitions") {
     spark.sql(
-      "CREATE TABLE table_name (id bigint, data string) USING delta PARTITIONED BY (id)")
+      createTableSQL("table_name", "id bigint, data string", partitionBy = "PARTITIONED BY (id)"))
 
     checkAnswer(spark.table("table_name"), Seq.empty)
 
@@ -205,7 +206,7 @@ trait OpenSourceDataFrameWriterV2Tests
   }
 
   test("OverwritePartitions: overwrite all rows if not partitioned") {
-    spark.sql("CREATE TABLE table_name (id bigint, data string) USING delta")
+    spark.sql(createTableSQL("table_name", "id bigint, data string"))
 
     checkAnswer(spark.table("table_name"), Seq.empty)
 
@@ -223,7 +224,7 @@ trait OpenSourceDataFrameWriterV2Tests
   }
 
   test("OverwritePartitions: by name not position") {
-    spark.sql("CREATE TABLE table_name (id bigint, data string) USING delta")
+    spark.sql(createTableSQL("table_name", "id bigint, data string"))
 
     checkAnswer(spark.table("table_name"), Seq.empty)
 
@@ -248,7 +249,7 @@ trait OpenSourceDataFrameWriterV2Tests
   }
 
   test("Create: basic behavior") {
-    spark.table("source").writeTo("table_name").using("delta").create()
+    spark.table("source").writeTo("table_name").using(tableProvider).create()
 
     checkAnswer(
       spark.table("table_name"),
@@ -263,7 +264,7 @@ trait OpenSourceDataFrameWriterV2Tests
   }
 
   test("Create: with using") {
-    spark.table("source").writeTo("table_name").using("delta").create()
+    spark.table("source").writeTo("table_name").using(tableProvider).create()
 
     checkAnswer(
       spark.table("table_name"),
@@ -279,7 +280,7 @@ trait OpenSourceDataFrameWriterV2Tests
 
   test("Create: with property") {
     spark.table("source").writeTo("table_name")
-      .tableProperty("prop", "value").using("delta").create()
+      .tableProperty("prop", "value").using(tableProvider).create()
 
     checkAnswer(
       spark.table("table_name"),
@@ -294,7 +295,7 @@ trait OpenSourceDataFrameWriterV2Tests
   }
 
   test("Create: identity partitioned table") {
-    spark.table("source").writeTo("table_name").using("delta").partitionedBy($"id").create()
+    spark.table("source").writeTo("table_name").using(tableProvider).partitionedBy($"id").create()
 
     checkAnswer(
       spark.table("table_name"),
@@ -310,10 +311,10 @@ trait OpenSourceDataFrameWriterV2Tests
 
   test("Create: fail if table already exists") {
     spark.sql(
-      "CREATE TABLE table_name (id bigint, data string) USING delta PARTITIONED BY (id)")
+      createTableSQL("table_name", "id bigint, data string", partitionBy = "PARTITIONED BY (id)"))
 
     val exc = intercept[TableAlreadyExistsException] {
-      spark.table("source").writeTo("table_name").using("delta").create()
+      spark.table("source").writeTo("table_name").using(tableProvider).create()
     }
 
     assert(exc.getMessage.contains("table_name"))
@@ -329,7 +330,7 @@ trait OpenSourceDataFrameWriterV2Tests
 
   test("Replace: basic behavior") {
     spark.sql(
-      "CREATE TABLE table_name (id bigint, data string) USING delta PARTITIONED BY (id)")
+      createTableSQL("table_name", "id bigint, data string", partitionBy = "PARTITIONED BY (id)"))
     spark.sql("INSERT INTO TABLE table_name SELECT * FROM source")
 
     checkAnswer(
@@ -346,7 +347,7 @@ trait OpenSourceDataFrameWriterV2Tests
 
     spark.table("source2")
       .withColumn("even_or_odd", when(($"id" % 2) === 0, "even").otherwise("odd"))
-      .writeTo("table_name").using("delta")
+      .writeTo("table_name").using(tableProvider)
       .tableProperty("deLta.aPpeNdonly", "true").replace()
 
     checkAnswer(
@@ -366,7 +367,7 @@ trait OpenSourceDataFrameWriterV2Tests
   }
 
   test("Replace: partitioned table") {
-    spark.sql("CREATE TABLE table_name (id bigint, data string) USING delta")
+    spark.sql(createTableSQL("table_name", "id bigint, data string"))
     spark.sql("INSERT INTO TABLE table_name SELECT * FROM source")
 
     checkAnswer(
@@ -383,7 +384,7 @@ trait OpenSourceDataFrameWriterV2Tests
 
     spark.table("source2")
       .withColumn("even_or_odd", when(($"id" % 2) === 0, "even").otherwise("odd"))
-      .writeTo("table_name").using("delta")
+      .writeTo("table_name").using(tableProvider)
       .partitionedBy($"id")
       .replace()
 
@@ -405,7 +406,7 @@ trait OpenSourceDataFrameWriterV2Tests
 
   test("Replace: fail if table does not exist") {
     val exc = intercept[AnalysisException] {
-      spark.table("source").writeTo("table_name").using("delta").replace()
+      spark.table("source").writeTo("table_name").using(tableProvider).replace()
     }
 
     checkError(exc, "TABLE_OR_VIEW_NOT_FOUND", Some("42P01"),
@@ -413,7 +414,7 @@ trait OpenSourceDataFrameWriterV2Tests
   }
 
   test("CreateOrReplace: table does not exist") {
-    spark.table("source2").writeTo("table_name").using("delta").createOrReplace()
+    spark.table("source2").writeTo("table_name").using(tableProvider).createOrReplace()
 
     checkAnswer(
       spark.table("table_name"),
@@ -430,7 +431,7 @@ trait OpenSourceDataFrameWriterV2Tests
 
   test("CreateOrReplace: table exists") {
     spark.sql(
-      "CREATE TABLE table_name (id bigint, data string) USING delta PARTITIONED BY (id)")
+      createTableSQL("table_name", "id bigint, data string", partitionBy = "PARTITIONED BY (id)"))
     spark.sql("INSERT INTO TABLE table_name SELECT * FROM source")
 
     checkAnswer(
@@ -447,7 +448,7 @@ trait OpenSourceDataFrameWriterV2Tests
 
     spark.table("source2")
       .withColumn("even_or_odd", when(($"id" % 2) === 0, "even").otherwise("odd"))
-      .writeTo("table_name").using("delta").createOrReplace()
+      .writeTo("table_name").using(tableProvider).createOrReplace()
 
     checkAnswer(
       spark.table("table_name"),
@@ -471,7 +472,7 @@ trait OpenSourceDataFrameWriterV2Tests
         .withColumn("ts", lit("2019-06-01 10:00:00.000000").cast("timestamp"))
         .writeTo("table_name")
         .partitionedBy(years($"ts"))
-        .using("delta")
+        .using(tableProvider)
         .create()
     }
     assert(e.getMessage.contains("Partitioning by expressions"))
@@ -483,7 +484,7 @@ trait OpenSourceDataFrameWriterV2Tests
         .withColumn("ts", lit("2019-06-01 10:00:00.000000").cast("timestamp"))
         .writeTo("table_name")
         .partitionedBy(months($"ts"))
-        .using("delta")
+        .using(tableProvider)
         .create()
     }
     assert(e.getMessage.contains("Partitioning by expressions"))
@@ -495,7 +496,7 @@ trait OpenSourceDataFrameWriterV2Tests
         .withColumn("ts", lit("2019-06-01 10:00:00.000000").cast("timestamp"))
         .writeTo("table_name")
         .partitionedBy(days($"ts"))
-        .using("delta")
+        .using(tableProvider)
         .create()
     }
     assert(e.getMessage.contains("Partitioning by expressions"))
@@ -507,7 +508,7 @@ trait OpenSourceDataFrameWriterV2Tests
         .withColumn("ts", lit("2019-06-01 10:00:00.000000").cast("timestamp"))
         .writeTo("table_name")
         .partitionedBy(hours($"ts"))
-        .using("delta")
+        .using(tableProvider)
         .create()
     }
     assert(e.getMessage.contains("Partitioning by expressions"))
@@ -518,7 +519,7 @@ trait OpenSourceDataFrameWriterV2Tests
       spark.table("source")
         .writeTo("table_name")
         .partitionedBy(bucket(4, $"id"))
-        .using("delta")
+        .using(tableProvider)
         .create()
     }
     assert(e.getMessage.contains("is not supported for Delta tables"))
@@ -532,7 +533,7 @@ class DeltaDataFrameWriterV2Suite
   import testImplicits._
 
   test("Append: basic append by path") {
-    spark.sql("CREATE TABLE table_name (id bigint, data string) USING delta")
+    spark.sql(createTableSQL("table_name", "id bigint, data string"))
 
     checkAnswer(spark.table("table_name"), Seq.empty)
     val location = catalog.loadTable(Identifier.of(Array("default"), "table_name"))
@@ -554,10 +555,10 @@ class DeltaDataFrameWriterV2Suite
   test("Create: basic behavior by path") {
     withTempDir { tempDir =>
       val dir = tempDir.getCanonicalPath
-      spark.table("source").writeTo(s"delta.`$dir`").using("delta").create()
+      spark.table("source").writeTo(s"delta.`$dir`").using(tableProvider).create()
 
       checkAnswer(
-        spark.read.format("delta").load(dir),
+        spark.read.format(writeFormat).load(dir),
         Seq(Row(1L, "a"), Row(2L, "b"), Row(3L, "c")))
 
       val table = catalog.loadTable(Identifier.of(Array("delta"), dir))
@@ -571,7 +572,7 @@ class DeltaDataFrameWriterV2Suite
 
   test("Create: using empty dataframe") {
     spark.table("source").where("false")
-      .writeTo("table_name").using("delta")
+      .writeTo("table_name").using(tableProvider)
       .tableProperty("delta.appendOnly", "true")
       .partitionedBy($"id").create()
 
@@ -587,7 +588,7 @@ class DeltaDataFrameWriterV2Suite
 
   test("Replace: basic behavior using empty df") {
     spark.sql(
-      "CREATE TABLE table_name (id bigint, data string) USING delta PARTITIONED BY (id)")
+      createTableSQL("table_name", "id bigint, data string", partitionBy = "PARTITIONED BY (id)"))
     spark.sql("INSERT INTO TABLE table_name SELECT * FROM source")
 
     checkAnswer(
@@ -604,7 +605,7 @@ class DeltaDataFrameWriterV2Suite
 
     spark.table("source2").where("false")
       .withColumn("even_or_odd", when(($"id" % 2) === 0, "even").otherwise("odd"))
-      .writeTo("table_name").using("delta")
+      .writeTo("table_name").using(tableProvider)
       .tableProperty("deLta.aPpeNdonly", "true").replace()
 
     checkAnswer(
@@ -625,7 +626,7 @@ class DeltaDataFrameWriterV2Suite
 
   test("throw error with createOrReplace and Replace if overwriteSchema=false") {
     spark.sql(
-      "CREATE TABLE table_name (id bigint, data string) USING delta PARTITIONED BY (id)")
+      createTableSQL("table_name", "id bigint, data string", partitionBy = "PARTITIONED BY (id)"))
     spark.sql("INSERT INTO TABLE table_name SELECT * FROM source")
 
     checkAnswer(
@@ -638,7 +639,7 @@ class DeltaDataFrameWriterV2Suite
         f: CreateTableWriter[_] => CreateTableWriter[_]): Unit = {
       val e = intercept[IllegalArgumentException] {
         val dfwV2 = df.writeTo("table_name")
-          .using("delta")
+          .using(tableProvider)
           .option("overwriteSchema", "false")
         f(dfwV2).replace()
       }
@@ -646,7 +647,7 @@ class DeltaDataFrameWriterV2Suite
 
       val e2 = intercept[IllegalArgumentException] {
         val dfwV2 = df.writeTo("table_name")
-            .using("delta")
+            .using(tableProvider)
             .option("overwriteSchema", "false")
         f(dfwV2).createOrReplace()
       }
@@ -675,9 +676,9 @@ class DeltaDataFrameWriterV2Suite
   test("saveAsTable overwrite mode should not do implicit casting") {
     val table = "not_implicit_casting"
     withTable(table) {
-      spark.sql(s"CREATE TABLE $table(id bigint, p int) USING delta PARTITIONED BY (p)")
+      spark.sql(s"CREATE TABLE $table(id bigint, p int) USING $tableProvider PARTITIONED BY (p)")
       val e = intercept[DeltaAnalysisException] {
-        Seq(1 -> 1).toDF("id", "p").write.mode("overwrite").format("delta").saveAsTable(table)
+        Seq(1 -> 1).toDF("id", "p").write.mode("overwrite").format(writeFormat).saveAsTable(table)
       }
       checkError(
         e.getCause.asInstanceOf[DeltaAnalysisException],
@@ -689,9 +690,9 @@ class DeltaDataFrameWriterV2Suite
   test("implicit casting supported for saveAsTable append and writeTo operations") {
     val table = "implicit_casting"
     withTable(table) {
-      spark.sql(s"CREATE TABLE $table(id bigint, p int) USING delta PARTITIONED BY (p)")
+      spark.sql(s"CREATE TABLE $table(id bigint, p int) USING $tableProvider PARTITIONED BY (p)")
       // All of these should succeed with implicit casting (int -> bigint)
-      Seq(1 -> 1).toDF("id", "p").write.mode("append").format("delta").saveAsTable(table)
+      Seq(1 -> 1).toDF("id", "p").write.mode("append").format(writeFormat).saveAsTable(table)
       Seq(1 -> 1).toDF("id", "p").writeTo(table).append()
       Seq(1 -> 1).toDF("id", "p").writeTo(table).overwrite($"p" === 1)
       Seq(1 -> 1).toDF("id", "p").writeTo(table).overwritePartitions()
@@ -702,7 +703,8 @@ class DeltaDataFrameWriterV2Suite
     val table = "allow_missing_columns"
     withTable(table) {
       spark.sql(
-        s"CREATE TABLE $table(col1 int, col2 int, col3 int) USING delta PARTITIONED BY (col3)")
+        s"CREATE TABLE $table(col1 int, col2 int, col3 int) USING $tableProvider " +
+          "PARTITIONED BY (col3)")
 
       // append
       Seq((0, 10)).toDF("col1", "col3").writeTo(table).append()
@@ -731,7 +733,7 @@ class DeltaDataFrameWriterV2Suite
   test("Append: writeTo with replaceUsing option just appends") {
     withSQLConf(
         DeltaSQLConf.REPLACE_USING_OPTION_IN_DATAFRAME_WRITER_ENABLED.key -> "true") {
-      spark.sql("CREATE TABLE table_name (id bigint, data string) USING delta")
+      spark.sql(createTableSQL("table_name", "id bigint, data string"))
 
       spark.table("source").writeTo("table_name").append()
 
@@ -758,7 +760,7 @@ class DeltaDataFrameWriterV2Suite
   test("Append: writeTo with replaceOn and targetAlias option just appends") {
     withSQLConf(
         DeltaSQLConf.REPLACE_ON_OPTION_IN_DATAFRAME_WRITER_ENABLED.key -> "true") {
-      spark.sql("CREATE TABLE table_name (id bigint, data string) USING delta")
+      spark.sql(createTableSQL("table_name", "id bigint, data string"))
 
       spark.table("source").writeTo("table_name").append()
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoSchemaEvolutionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoSchemaEvolutionSuite.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.SaveMode
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 
-trait DeltaInsertIntoEvolutionSuiteBase extends DeltaInsertIntoTest {
+trait DeltaInsertIntoEvolutionSuiteBase extends DeltaInsertIntoTest with DeltaTableProvider {
 
   override def beforeAll(): Unit = {
     super.beforeAll()
@@ -295,7 +295,7 @@ class DeltaInsertIntoSchemaEvolutionSuite extends DeltaInsertIntoEvolutionSuiteB
   test("insert by name with extra top-level column and implicit cast fails " +
       "when byNameSchemaEvolution is disabled") {
     withTable("target") {
-      sql("CREATE TABLE target (a INT, b INT) USING DELTA")
+      sql(createTableSQL("target", "a INT, b INT"))
       withSQLConf(
           DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> "true",
           DeltaSQLConf.DELTA_INSERT_BY_NAME_SCHEMA_EVOLUTION_ENABLED.key -> "false") {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaNotSupportedDDLSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaNotSupportedDDLSuite.scala
@@ -35,9 +35,10 @@ class DeltaNotSupportedDDLSuite
 
 
 abstract class DeltaNotSupportedDDLBase extends QueryTest
-    with DeltaSQLTestUtils {
+    with DeltaSQLTestUtils
+    with DeltaTableProvider {
 
-  val format = "delta"
+  val format = tableProvider
 
   val nonPartitionedTableName = "deltaTbl"
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableProvider.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableProvider.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+/**
+ * Indirection over the table format used by a test suite so that a single suite body can run
+ * against different table formats.
+ *
+ * A suite mixes this in (directly or transitively) and uses [[tableProvider]] / [[writeFormat]]
+ * instead of hard-coded `"delta"` literals in `USING <provider>` clauses and
+ * `df.write.format(...)` calls. A variant of the suite can override these to target another
+ * format. Because the defaults here are `"delta"`, mixing this into an existing Delta suite is
+ * behavior-preserving.
+ */
+trait DeltaTableProvider {
+  /** Provider name for `USING <provider>` in CREATE TABLE statements. Defaults to Delta. */
+  protected def tableProvider: String = "delta"
+
+  /**
+   * Format name for `df.write.format(...)` / `spark.read.format(...)`. Defaults to
+   * [[tableProvider]].
+   */
+  protected def writeFormat: String = tableProvider
+
+  /**
+   * Table properties applied to every table created via [[createTableSQL]]. Empty by default; a
+   * variant can override this to add format-specific properties.
+   */
+  protected def defaultTableProperties: Map[String, String] = Map.empty
+
+  /**
+   * Build a `CREATE TABLE` statement for the table format under test. Merges
+   * [[defaultTableProperties]] with any per-call `props` (the latter win on key conflicts).
+   *
+   * @param partitionBy passed through verbatim when non-empty, so it must already include its
+   *                    keyword, e.g. `"PARTITIONED BY (p)"`.
+   * @param clusterBy   passed through verbatim when non-empty, so it must already include its
+   *                    keyword, e.g. `"CLUSTER BY (c)"`.
+   * @param location    a bare path (no keyword); it is wrapped as `LOCATION '<location>'`.
+   */
+  protected def createTableSQL(
+      name: String,
+      schema: String,
+      partitionBy: String = "",
+      clusterBy: String = "",
+      location: String = "",
+      props: Map[String, String] = Map.empty): String = {
+    val allProps = defaultTableProperties ++ props
+    val propStr =
+      if (allProps.isEmpty) ""
+      else s"TBLPROPERTIES (${allProps.map { case (k, v) => s"'$k'='$v'" }.mkString(",")})"
+    val locStr = if (location.isEmpty) "" else s"LOCATION '$location'"
+    s"CREATE TABLE $name ($schema) USING $tableProvider $partitionBy $clusterBy $locStr $propStr"
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTestUtils.scala
@@ -809,6 +809,7 @@ trait DeltaSQLInMemoryTestUtils
 trait DeltaDMLTestUtils
   extends DeltaSQLTestUtils
   with DeltaTestUtilsBase
+  with DeltaTableProvider
   with BeforeAndAfterEach
   with CDCTestMixin {
   self: SharedSparkSession =>
@@ -868,7 +869,7 @@ trait DeltaDMLTestUtils
   }
 
   protected def append(df: DataFrame, partitionBy: Seq[String] = Nil): Unit = {
-    val dfw = df.write.format("delta").mode("append")
+    val dfw = df.write.format(writeFormat).mode("append")
     if (partitionBy.nonEmpty) {
       dfw.partitionBy(partitionBy: _*)
     }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/TruncateTableSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/TruncateTableSuite.scala
@@ -23,12 +23,13 @@ import org.apache.spark.sql.test.SharedSparkSession
 class TruncateTableSuite extends QueryTest
   with SharedSparkSession
   with DeltaSQLCommandTest
-  with DeltaTestUtilsForTempViews {
+  with DeltaTestUtilsForTempViews
+  with DeltaTableProvider {
 
 
   test("non-partitioned table") {
     withTable("t1") {
-      sql("CREATE TABLE t1 (a int) USING delta")
+      sql(createTableSQL("t1", "a int"))
       sql("INSERT into t1 VALUES (3)")
       sql("INSERT into t1 VALUES (4)")
 
@@ -44,7 +45,7 @@ class TruncateTableSuite extends QueryTest
 
   test("partitioned table") {
     withTable("t1") {
-      sql("CREATE TABLE t1 (a int, b int) USING delta partitioned by (b)")
+      sql(createTableSQL("t1", "a int, b int", partitionBy = "partitioned by (b)"))
       sql("INSERT into t1 VALUES (1, 1)")
       sql("INSERT into t1 VALUES (2, 2)")
 
@@ -63,7 +64,7 @@ class TruncateTableSuite extends QueryTest
       import testImplicits._
       val path = dir.getCanonicalPath
       Seq((1, 2)).toDF("key", "value")
-        .write.format("delta").partitionBy("key").save(path)
+        .write.format(writeFormat).partitionBy("key").save(path)
       sql(s"TRUNCATE TABLE delta.`$path`")
       checkAnswer(sql(s"select * from delta.`$path`"), Nil)
       val ae = intercept[AnalysisException] {
@@ -75,7 +76,7 @@ class TruncateTableSuite extends QueryTest
 
   test("truncate should refresh DF cache - table") {
     withTable("t1") {
-      sql("CREATE TABLE t1 (a int, b int) USING delta partitioned by (b)")
+      sql(createTableSQL("t1", "a int, b int", partitionBy = "partitioned by (b)"))
       sql("INSERT into t1 VALUES (1, 1)")
       sql("INSERT into t1 VALUES (2, 2)")
 
@@ -91,7 +92,7 @@ class TruncateTableSuite extends QueryTest
       import testImplicits._
       val path = dir.getCanonicalPath
       Seq((1, 2)).toDF("key", "value")
-        .write.format("delta").partitionBy("key").save(path)
+        .write.format(writeFormat).partitionBy("key").save(path)
       val df = sql(s"select * from delta.`$path`").cache()
       sql(s"TRUNCATE TABLE delta.`$path`")
       checkAnswer(df, Nil)
@@ -101,7 +102,7 @@ class TruncateTableSuite extends QueryTest
 
   testWithTempView("truncate on temp views") { isSQLTempView =>
     withTable("t1") {
-      sql("CREATE TABLE t1 (a int) USING delta")
+      sql(createTableSQL("t1", "a int"))
       sql("INSERT into t1 VALUES (3)")
       sql("INSERT into t1 VALUES (4)")
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/UpdateSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/UpdateSuiteBase.scala
@@ -140,7 +140,7 @@ trait UpdateBaseTempViewTests extends UpdateBaseMixin {
       expectedErrorClassForDataSetTempView: String = null): Unit = {
     testWithTempView(s"test update on temp view - $name") { isSQLTempView =>
       withTable("tab") {
-        Seq((0, 3), (1, 2)).toDF("key", "value").write.format("delta").saveAsTable("tab")
+        Seq((0, 3), (1, 2)).toDF("key", "value").write.format(writeFormat).saveAsTable("tab")
         createTempViewFromSelect(text, isSQLTempView)
         val ex = intercept[AnalysisException] {
           executeUpdate(
@@ -176,14 +176,14 @@ trait UpdateBaseTempViewTests extends UpdateBaseMixin {
   private def testComplexTempViews(name: String)(text: String, expectedResult: Seq[Row]) = {
     testWithTempView(s"test update on temp view - $name") { isSQLTempView =>
         withTable("tab") {
-          Seq((0, 3), (1, 2)).toDF("key", "value").write.format("delta").saveAsTable("tab")
+          Seq((0, 3), (1, 2)).toDF("key", "value").write.format(writeFormat).saveAsTable("tab")
           createTempViewFromSelect(text, isSQLTempView)
           executeUpdate(
             "v",
             where = "key >= 1 and value < 3",
             set = "value = key + value, key = key + 1"
           )
-          checkAnswer(spark.read.format("delta").table("v"), expectedResult)
+          checkAnswer(spark.read.format(writeFormat).table("v"), expectedResult)
         }
       }
   }
@@ -226,14 +226,14 @@ trait UpdateBaseMiscTests extends UpdateBaseMixin {
     test(s"basic update - Delta table by name - Partition=$isPartitioned") {
       withTable("delta_table") {
         val partitionByClause = if (isPartitioned) "PARTITIONED BY (key)" else ""
-        sql(s"""
-             |CREATE TABLE delta_table(key INT, value INT) USING delta
-             |$partitionByClause
-           """.stripMargin)
+        sql(createTableSQL(
+          "delta_table",
+          "key INT, value INT",
+          partitionBy = partitionByClause))
 
         Seq((2, 2), (1, 4), (1, 1), (0, 3)).toDF("key", "value")
           .write
-          .format("delta")
+          .format(writeFormat)
           .mode("append")
           .saveAsTable("delta_table")
 
@@ -513,7 +513,7 @@ trait UpdateBaseMiscTests extends UpdateBaseMixin {
       spark.read.json("""
           {"a": {"b.1": 1, "c.e": 'random'}, "d": 1}
           {"a": {"b.1": 3, "c.e": 'string'}, "d": 2}"""
-        .split("\n").toSeq.toDS()).write.format("delta").saveAsTable("`target`")
+        .split("\n").toSeq.toDS()).write.format(writeFormat).saveAsTable("`target`")
 
       executeUpdate(
         target = "target",
@@ -556,7 +556,7 @@ trait UpdateBaseMiscTests extends UpdateBaseMixin {
 
   test("Negative case - check target columns during analysis") {
     withTable("table") {
-      sql("CREATE TABLE table (s int, t string) USING delta PARTITIONED BY (s)")
+      sql(createTableSQL("table", "s int, t string", partitionBy = "PARTITIONED BY (s)"))
       var ae = intercept[AnalysisException] {
         executeUpdate("table", set = "column_doesnt_exist = 'San Francisco'", where = "t = 'a'")
       }
@@ -603,7 +603,7 @@ trait UpdateBaseMiscTests extends UpdateBaseMixin {
     withTempDir { dir =>
       val tempPath = dir.getCanonicalPath
       val df = Seq((2, 2), (3, 2)).toDF("key", "value")
-      df.write.format("delta").partitionBy("key").save(tempPath)
+      df.write.format(writeFormat).partitionBy("key").save(tempPath)
 
       val e = intercept[AnalysisException] {
         executeUpdate(
@@ -925,7 +925,7 @@ trait UpdateBaseMiscTests extends UpdateBaseMixin {
       customErrorRegex: Option[String] = None) {
     test(s"$functionType functions in update - expect exception: $expectException") {
       withTable("deltaTable") {
-        data.write.format("delta").saveAsTable("deltaTable")
+        data.write.format(writeFormat).saveAsTable("deltaTable")
 
         val expectedErrorRegex = "(?s).*(?i)unsupported.*(?i).*Invalid expressions.*"
 
@@ -942,7 +942,7 @@ trait UpdateBaseMiscTests extends UpdateBaseMixin {
 
 
           if (catchException) {
-            val dataBeforeException = spark.read.format("delta").table("deltaTable").collect()
+            val dataBeforeException = spark.read.format(writeFormat).table("deltaTable").collect()
             val e = intercept[Exception] {
               executeUpdate(
                 "deltaTable",
@@ -953,7 +953,7 @@ trait UpdateBaseMiscTests extends UpdateBaseMixin {
               e.getCause.getMessage
             } else e.getMessage
             assert(message.matches(errorRegex))
-            checkAnswer(spark.read.format("delta").table("deltaTable"), dataBeforeException)
+            checkAnswer(spark.read.format(writeFormat).table("deltaTable"), dataBeforeException)
           } else {
             executeUpdate(
               "deltaTable",

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowtracking/RowTrackingReadWriteSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowtracking/RowTrackingReadWriteSuite.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.delta.rowtracking
 
 import scala.collection.JavaConverters._
 
-import org.apache.spark.sql.delta.{DeltaConfigs, DeltaLog, RowCommitVersion, RowId}
+import org.apache.spark.sql.delta.{DeltaConfigs, DeltaLog, DeltaTableProvider, RowCommitVersion, RowId}
 import org.apache.spark.sql.delta.actions.AddFile
 import org.apache.spark.sql.delta.rowid.RowIdTestUtils
 
@@ -31,7 +31,8 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{LongType, StructType}
 
 class RowTrackingReadWriteSuite extends RowIdTestUtils
-  with ParquetTest {
+  with ParquetTest
+  with DeltaTableProvider {
 
   private val testTableName = "target"
 
@@ -59,7 +60,7 @@ class RowTrackingReadWriteSuite extends RowIdTestUtils
       withRowTrackingEnabled(enabled = true) {
         val numRows = 5L
         spark.range(numRows).toDF(testDataColumnName)
-          .write.format("delta").saveAsTable(testTableName)
+          .write.format(writeFormat).saveAsTable(testTableName)
 
         try {
           // Confirm that the materialized columns are not present in the Parquet file(s).
@@ -279,7 +280,7 @@ class RowTrackingReadWriteSuite extends RowIdTestUtils
           .toDF(testDataColumnName)
           .withMaterializedRowIdColumn(columnName, lit(1L))
           .write
-          .format("delta")
+          .format(writeFormat)
           .mode("append")
           .saveAsTable(testTableName)
       }
@@ -297,7 +298,7 @@ class RowTrackingReadWriteSuite extends RowIdTestUtils
           .toDF(testDataColumnName)
           .withMaterializedRowCommitVersionColumn(columnName, lit(2L))
           .write
-          .format("delta")
+          .format(writeFormat)
           .mode("append")
           .saveAsTable(testTableName)
       }
@@ -371,7 +372,7 @@ class RowTrackingReadWriteSuite extends RowIdTestUtils
     withRowTrackingEnabled(enabled = true) {
       // Create the table if it does not exist already.
       df.limit(n = 0)
-        .write.format("delta").mode("append").saveAsTable(testTableName)
+        .write.format(writeFormat).mode("append").saveAsTable(testTableName)
 
       val deltaLog = DeltaLog.forTable(spark, TableIdentifier(testTableName))
       val materializedRowIdColumnName =
@@ -385,7 +386,7 @@ class RowTrackingReadWriteSuite extends RowIdTestUtils
           materializedRowCommitVersionName, rowCommitVersionColumn)
         .write
         .mode("append")
-        .format("delta")
+        .format(writeFormat)
         .saveAsTable(testTableName)
     }
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/schema/CheckConstraintsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/schema/CheckConstraintsSuite.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.delta.schema
 
 import scala.collection.JavaConverters._
 
-import org.apache.spark.sql.delta.{AllowedUserProvidedExpressions, DeltaConfigs, DeltaLog}
+import org.apache.spark.sql.delta.{AllowedUserProvidedExpressions, DeltaConfigs, DeltaLog, DeltaTableProvider}
 import org.apache.spark.sql.delta.constraints.CharVarcharConstraint
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.sources.DeltaSQLConf.ValidateCheckConstraintsMode
@@ -36,7 +36,8 @@ import org.apache.spark.sql.types.{ArrayType, BooleanType, IntegerType, MapType,
 class CheckConstraintsSuite extends QueryTest
     with SharedSparkSession
     with DeltaSQLCommandTest
-    with DeltaSQLTestUtils {
+    with DeltaSQLTestUtils
+    with DeltaTableProvider {
 
 
   import testImplicits._
@@ -49,7 +50,7 @@ class CheckConstraintsSuite extends QueryTest
         Seq(
           (1, "a"), (2, "b"), (3, "c"),
           (4, "d"), (5, "e"), (6, "f")
-        ).toDF("num", "text").write.format("delta").saveAsTable("checkConstraintsTest")
+        ).toDF("num", "text").write.format(writeFormat).saveAsTable("checkConstraintsTest")
         thunk("checkConstraintsTest")
       }
     }
@@ -79,13 +80,10 @@ class CheckConstraintsSuite extends QueryTest
   test("Checking incorrect constraints added through table property in CREATE TABLE errors out") {
     val tableName = "test_tbl"
     withTable(tableName) {
-      sql(
-        s"""
-           |CREATE TABLE $tableName (
-           |id INT,
-           |event_date DATE
-           |) USING DELTA
-           |TBLPROPERTIES('delta.constraints.ch' = 'event_date < 2025-06-12');""".stripMargin)
+      sql(createTableSQL(
+        tableName,
+        "id INT, event_date DATE",
+        props = Map("delta.constraints.ch" -> "event_date < 2025-06-12")))
 
       val e = intercept[AnalysisException] {
         sql(s"INSERT INTO $tableName VALUES(1, '2025-06-11')")
@@ -102,14 +100,10 @@ class CheckConstraintsSuite extends QueryTest
       withTable(tableName) {
         checkError(
           exception = intercept[AnalysisException] {
-            sql(
-              s"""
-                 |CREATE TABLE $tableName (
-                 |id INT,
-                 |value STRING
-                 |) USING DELTA
-                 |TBLPROPERTIES('delta.constraints.invalid' = 'non_existent_column > 0')
-                 |""".stripMargin)
+            sql(createTableSQL(
+              tableName,
+              "id INT, value STRING",
+              props = Map("delta.constraints.invalid" -> "non_existent_column > 0")))
           },
           "DELTA_INVALID_CHECK_CONSTRAINT_REFERENCES",
           parameters = Map("colName" -> "`non_existent_column`")
@@ -125,14 +119,10 @@ class CheckConstraintsSuite extends QueryTest
       withTable(tableName) {
         checkError(
           exception = intercept[AnalysisException] {
-            sql(
-              s"""
-                 |CREATE TABLE $tableName (
-                 |id INT,
-                 |value STRING
-                 |) USING DELTA
-                 |TBLPROPERTIES('delta.constraints.nonbool' = 'id + 1')
-                 |""".stripMargin)
+            sql(createTableSQL(
+              tableName,
+              "id INT, value STRING",
+              props = Map("delta.constraints.nonbool" -> "id + 1")))
           },
           "DELTA_NON_BOOLEAN_CHECK_CONSTRAINT",
           parameters = Map(
@@ -149,14 +139,10 @@ class CheckConstraintsSuite extends QueryTest
         ValidateCheckConstraintsMode.ASSERT.toString) {
       val tableName = "test_create_valid_constraint"
       withTable(tableName) {
-        sql(
-          s"""
-             |CREATE TABLE $tableName (
-             |id INT,
-             |value STRING
-             |) USING DELTA
-             |TBLPROPERTIES('delta.constraints.positive_id' = 'id > 0')
-             |""".stripMargin)
+        sql(createTableSQL(
+          tableName,
+          "id INT, value STRING",
+          props = Map("delta.constraints.positive_id" -> "id > 0")))
       }
     }
   }
@@ -425,7 +411,7 @@ class CheckConstraintsSuite extends QueryTest
             StructField("m", MapType(IntegerType, IntegerType, valueContainsNull = true)),
             StructField("arr", ArrayType(IntegerType, containsNull = true)))))))
         spark.createDataFrame(rows.toList.asJava, schema)
-          .write.format("delta").saveAsTable("checkConstraintsTest")
+          .write.format(writeFormat).saveAsTable("checkConstraintsTest")
 
         // Constraints checking for a null value should work.
         sql("ALTER TABLE checkConstraintsTest ADD CONSTRAINT textNull CHECK (text IS NULL)")
@@ -453,7 +439,7 @@ class CheckConstraintsSuite extends QueryTest
         newRows.foreach { r =>
           e = intercept[InvariantViolationException] {
             spark.createDataFrame(List(r).asJava, schema)
-              .write.format("delta").mode("append").saveAsTable("checkConstraintsTest")
+              .write.format(writeFormat).mode("append").saveAsTable("checkConstraintsTest")
           }
           errorContains(e.getMessage,
             "CHECK constraint arr0 (nested.arr[0] < 100) violated by row")
@@ -464,10 +450,10 @@ class CheckConstraintsSuite extends QueryTest
         sql("ALTER TABLE checkConstraintsTest DROP CONSTRAINT arr0")
         newRows.foreach { r =>
           spark.createDataFrame(List(r).asJava, schema)
-            .write.format("delta").mode("append").saveAsTable("checkConstraintsTest")
+            .write.format(writeFormat).mode("append").saveAsTable("checkConstraintsTest")
         }
         checkAnswer(
-          spark.read.format("delta").table("checkConstraintsTest").select("id"),
+          spark.read.format(writeFormat).table("checkConstraintsTest").select("id"),
           (0 to 12).toDF("id"))
       }
     }
@@ -492,7 +478,7 @@ class CheckConstraintsSuite extends QueryTest
             StructField("m", MapType(IntegerType, IntegerType, valueContainsNull = false)),
             StructField("arr", ArrayType(IntegerType, containsNull = false)))))))
         spark.createDataFrame(rows.toList.asJava, schema)
-          .write.format("delta").saveAsTable("checkConstraintsTest")
+          .write.format(writeFormat).saveAsTable("checkConstraintsTest")
         sql("ALTER TABLE checkConstraintsTest ADD CONSTRAINT arrLen CHECK (SIZE(nested.arr) = 3)")
         sql("ALTER TABLE checkConstraintsTest ADD CONSTRAINT mapIntegrity " +
           "CHECK (nested.m[id] = id)")
@@ -510,7 +496,7 @@ class CheckConstraintsSuite extends QueryTest
   // TODO: https://github.com/delta-io/delta/issues/831
   test("SET NOT NULL constraint fails") {
     withTable("my_table") {
-      sql("CREATE TABLE my_table (id INT) USING DELTA;")
+      sql(createTableSQL("my_table", "id INT"))
       sql("INSERT INTO my_table VALUES (1);")
       val e = intercept[AnalysisException] {
         sql("ALTER TABLE my_table CHANGE COLUMN id SET NOT NULL;")
@@ -521,7 +507,7 @@ class CheckConstraintsSuite extends QueryTest
 
   testQuietly("ending semi-colons no longer makes ADD, DROP constraint commands fail") {
     withTable("my_table") {
-      sql("CREATE TABLE my_table (birthday DATE) USING DELTA;")
+      sql(createTableSQL("my_table", "birthday DATE"))
       sql("INSERT INTO my_table VALUES ('2021-11-11');")
 
       sql("ALTER TABLE my_table ADD CONSTRAINT aaa CHECK (birthday > '1900-01-01')")
@@ -538,14 +524,10 @@ class CheckConstraintsSuite extends QueryTest
         ValidateCheckConstraintsMode.ASSERT.toString,
       SQLConf.READ_SIDE_CHAR_PADDING.key -> "true") {
       withTable("charVarcharConstraintTest") {
-        sql(
-          """CREATE TABLE charVarcharConstraintTest (
-            |  id INT,
-            |  name VARCHAR(50),
-            |  code CHAR(10)
-            |) USING DELTA
-            |TBLPROPERTIES('delta.constraints.positive_id' = 'id > 0')
-            |""".stripMargin)
+        sql(createTableSQL(
+          "charVarcharConstraintTest",
+          "id INT, name VARCHAR(50), code CHAR(10)",
+          props = Map("delta.constraints.positive_id" -> "id > 0")))
         sql("INSERT INTO charVarcharConstraintTest VALUES (1, 'test', 'ABC')")
         checkAnswer(
           sql("SELECT id, name, code FROM charVarcharConstraintTest"),
@@ -556,7 +538,7 @@ class CheckConstraintsSuite extends QueryTest
 
   test("constraint induced by varchar") {
     withTable("table") {
-      sql("CREATE TABLE table (id INT, value VARCHAR(12)) USING DELTA")
+      sql(createTableSQL("table", "id INT, value VARCHAR(12)"))
       sql("INSERT INTO table VALUES (1, 'short string')")
       val exception = intercept[DeltaInvariantViolationException] {
         sql("INSERT INTO table VALUES (2, 'a very long string')")
@@ -576,8 +558,8 @@ class CheckConstraintsSuite extends QueryTest
     withSQLConf(
         DeltaConfigs.ENABLE_DELETION_VECTORS_CREATION.defaultTablePropertyKey -> false.toString) {
       withTable("table") {
-        sql("CREATE TABLE table (a INT, b INT) USING DELTA " +
-          "TBLPROPERTIES ('delta.feature.checkConstraints' = 'supported')")
+        sql(createTableSQL("table", "a INT, b INT",
+          props = Map("delta.feature.checkConstraints" -> "supported")))
         sql("ALTER TABLE table ADD CONSTRAINT c1 CHECK (a > 0)")
         sql("ALTER TABLE table ADD CONSTRAINT c2 CHECK (b > 0)")
 
@@ -622,8 +604,8 @@ class CheckConstraintsSuite extends QueryTest
         ValidateCheckConstraintsMode.ASSERT.toString) {
         val testTable = "tbl"
         withTable(testTable) {
-          sql(s"CREATE TABLE $testTable (id STRING, value BOOLEAN) USING DELTA " +
-            "TBLPROPERTIES ('delta.feature.checkConstraints' = 'supported')")
+          sql(createTableSQL(testTable, "id STRING, value BOOLEAN",
+            props = Map("delta.feature.checkConstraints" -> "supported")))
           sql(s"ALTER TABLE $testTable ADD CONSTRAINT c1 CHECK (value == $expression(id, 'A'))")
           sql(s"INSERT INTO $testTable VALUES ('ABA', true), ('DEF', false)")
         }
@@ -636,8 +618,8 @@ class CheckConstraintsSuite extends QueryTest
       ValidateCheckConstraintsMode.ASSERT.toString) {
       val testTable = "like_any_all_test"
       withTable(testTable) {
-        sql(s"CREATE TABLE $testTable (id INT, name STRING, code STRING) USING DELTA " +
-          "TBLPROPERTIES ('delta.feature.checkConstraints' = 'supported')")
+        sql(createTableSQL(testTable, "id INT, name STRING, code STRING",
+          props = Map("delta.feature.checkConstraints" -> "supported")))
         sql(s"ALTER TABLE $testTable ADD CONSTRAINT c_like_any " +
           "CHECK (name LIKE ANY ('%test%', '%prod%'))")
         sql(s"ALTER TABLE $testTable ADD CONSTRAINT c_not_like_any " +
@@ -659,8 +641,8 @@ class CheckConstraintsSuite extends QueryTest
       ValidateCheckConstraintsMode.ASSERT.toString) {
       val testTable = "array_funcs_test"
       withTable(testTable) {
-        sql(s"CREATE TABLE $testTable (id INT, tags ARRAY<STRING>) USING DELTA " +
-          "TBLPROPERTIES ('delta.feature.checkConstraints' = 'supported')")
+        sql(createTableSQL(testTable, "id INT, tags ARRAY<STRING>",
+          props = Map("delta.feature.checkConstraints" -> "supported")))
         sql(s"ALTER TABLE $testTable ADD CONSTRAINT c_array_size " +
           "CHECK (array_size(tags) > 0)")
         sql(s"ALTER TABLE $testTable ADD CONSTRAINT c_array_compact " +
@@ -678,8 +660,8 @@ class CheckConstraintsSuite extends QueryTest
       ValidateCheckConstraintsMode.ASSERT.toString) {
       val testTable = "array_modify_funcs_test"
       withTable(testTable) {
-        sql(s"CREATE TABLE $testTable (id INT, tags ARRAY<STRING>) USING DELTA " +
-          "TBLPROPERTIES ('delta.feature.checkConstraints' = 'supported')")
+        sql(createTableSQL(testTable, "id INT, tags ARRAY<STRING>",
+          props = Map("delta.feature.checkConstraints" -> "supported")))
         sql(s"ALTER TABLE $testTable ADD CONSTRAINT c_array_append " +
           "CHECK (array_size(array_append(tags, 'x')) > 1)")
         sql(s"ALTER TABLE $testTable ADD CONSTRAINT c_array_prepend " +
@@ -699,8 +681,8 @@ class CheckConstraintsSuite extends QueryTest
       ValidateCheckConstraintsMode.ASSERT.toString) {
       val testTable = "tbl"
       withTable(testTable) {
-        sql(s"CREATE TABLE $testTable (id INT) USING DELTA " +
-          "TBLPROPERTIES ('delta.feature.checkConstraints' = 'supported')")
+        sql(createTableSQL(testTable, "id INT",
+          props = Map("delta.feature.checkConstraints" -> "supported")))
         checkError(
           exception = intercept[AnalysisException] {
             sql(s"ALTER TABLE $testTable ADD CONSTRAINT c1 " +
@@ -719,8 +701,8 @@ class CheckConstraintsSuite extends QueryTest
         val testTable = "check_external_udf_test"
         withTable(testTable) {
           withUserDefinedFunction("external_udf" -> true) {
-            sql(s"CREATE TABLE $testTable (id INT, value INT) USING DELTA " +
-              "TBLPROPERTIES ('delta.feature.checkConstraints' = 'supported')")
+            sql(createTableSQL(testTable, "id INT, value INT",
+              props = Map("delta.feature.checkConstraints" -> "supported")))
 
             spark.udf.register("external_udf", (x: Int) => x > 0)
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningAlterTableSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningAlterTableSuite.scala
@@ -39,7 +39,8 @@ class TypeWideningAlterTableSuite
 
 trait TypeWideningAlterTableTests extends QueryTest
     with QueryErrorsBase
-    with TypeWideningTestCases {
+    with TypeWideningTestCases
+    with DeltaTableProvider {
   self: QueryTest with ParquetTest with TypeWideningTestMixin =>
 
   import testImplicits._
@@ -157,7 +158,7 @@ trait TypeWideningAlterTableTests extends QueryTest
   test(
     "widening Date -> TimestampNTZ rejected when TimestampNTZ feature isn't supported") {
     withTimestampNTZDisabled {
-      sql(s"CREATE TABLE $tableSQLIdentifier (a date) USING DELTA")
+      sql(createTableSQL(tableSQLIdentifier, "a date"))
       val currentProtocol = deltaLog.unsafeVolatileSnapshot.protocol
       val currentFeatures = currentProtocol.implicitlyAndExplicitlySupportedFeatures
         .map(_.name)
@@ -179,7 +180,7 @@ trait TypeWideningAlterTableTests extends QueryTest
   }
 
   test("type widening type change metrics") {
-    sql(s"CREATE TABLE $tableSQLIdentifier (a byte) USING DELTA")
+    sql(createTableSQL(tableSQLIdentifier, "a byte"))
     val usageLogs = Log4jUsageLogger.track {
       sql(s"ALTER TABLE $tableSQLIdentifier CHANGE COLUMN a TYPE int")
     }
@@ -204,7 +205,7 @@ trait TypeWideningAlterTableTests extends QueryTest
   }
 
   test("type widening with null type in table") {
-    sql(s"CREATE TABLE $tableSQLIdentifier (a byte, n VOID) USING DELTA")
+    sql(createTableSQL(tableSQLIdentifier, "a byte, n VOID"))
     sql(s"ALTER TABLE $tableSQLIdentifier CHANGE COLUMN a TYPE int")
   }
 }


### PR DESCRIPTION
## Description

Introduces `DeltaTableProvider`, a test-only trait that lets Delta test suites parameterize the table format they exercise — via `tableProvider` (for `USING <provider>`), `writeFormat` (for `df.write.format(...)` / `spark.read.format(...)`), and a `createTableSQL(...)` helper — instead of hard-coding `USING delta` / `format("delta")`. All defaults resolve to `"delta"`, so existing suites are behavior-preserving.

Several suites and shared DML test bases are migrated to the indirection: `DeltaInsertIntoSchemaEvolutionSuite`, `DeltaDataFrameWriterV2Suite`, `DeltaNotSupportedDDLSuite`, `TruncateTableSuite`, `RowTrackingReadWriteSuite`, `CheckConstraintsSuite`, `TypeWideningAlterTableSuite`, and `UpdateSuiteBase` / `DeleteSuiteBase`.

## How was this patch tested?

Existing test suites; behavior is unchanged because the provider defaults to Delta.

## Does this PR introduce any user-facing changes?

No — test-only.