### PR TITLE
[AMT] Clear backReference on superseding AddFile in removeRows

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -966,8 +966,10 @@ case class AddFile(
       case Some(_) => deletionVector.copy(maxRowIndex = None)
       case _ => deletionVector
     }
-    var addFileWithNewDv =
-      this.copy(deletionVector = dvDescriptorWithoutMaxRowIndex, dataChange = dataChange)
+    var addFileWithNewDv = this.copy(
+      deletionVector = dvDescriptorWithoutMaxRowIndex,
+      dataChange = dataChange,
+      backReference = None)
     if (updateStats) {
       addFileWithNewDv = addFileWithNewDv.withoutTightBoundStats
     }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTCheckpointProvider.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTCheckpointProvider.scala
@@ -200,17 +200,25 @@ final class AMTCheckpointProvider(
       spark: SparkSession,
       deltaLog: DeltaLog,
       committedActions: Seq[Action]): Unit = {
-    val committedFiles: Seq[(String, Option[BackReference])] = committedActions.collect {
-      case a: AddFile => a.path -> a.backReference
-      case r: RemoveFile => r.path -> r.backReference
-    }
-    if (committedFiles.isEmpty) return
+    val committedAdds = committedActions.collect { case a: AddFile => a }
+    val committedRemoves = committedActions.collect { case r: RemoveFile => r }
+    if (committedAdds.isEmpty && committedRemoves.isEmpty) return
 
     val expectedPathToBackreferenceMap: Map[String, Option[BackReference]] =
       liveAddSingleActions(spark, deltaLog)
         .collect()
         .map(sa => sa.add.path -> sa.add.backReference)
         .toMap
+
+    // A file superseded within this commit (by DV update for example) has its leaf entry masked
+    // by the RemoveFile's back reference, so the superseding AddFile is a net-new entry with
+    // a different DV and legitimately carries no back reference.
+    val supersededPaths = committedRemoves.filter(_.backReference.isDefined).map(_.path).toSet
+    val committedFiles: Seq[(String, Option[BackReference])] =
+      committedRemoves.map(r => r.path -> r.backReference) ++
+        committedAdds
+          .filterNot(a => a.backReference.isEmpty && supersededPaths.contains(a.path))
+          .map(a => a.path -> a.backReference)
 
     committedFiles.foreach { case (path, actual) =>
       expectedPathToBackreferenceMap.get(path) match {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTBackReferenceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTBackReferenceSuite.scala
@@ -89,23 +89,32 @@ class AMTBackReferenceSuite extends AMTCheckpointTestBase with DeletionVectorsTe
 
   /**
    * Asserts that every file action committed after `afterVersion` that reuses a pre-command
-   * leaf-derived file's path carries exactly that file's back reference.
+   * leaf-derived file's path carries exactly that file's back reference. A file superseded under
+   * the same path with a new DV is the one exception: the RemoveFile keeps the back reference
+   * and the superseding AddFile must carry none.
    */
   private def assertBackRefsPropagated(
       deltaLog: DeltaLog,
       afterVersion: Long,
       backRefByPath: Map[String, Option[BackReference]]): Int = {
+    val actions = actionsAfter(deltaLog, afterVersion)
+    val supersededPaths = actions.collect {
+      case r: RemoveFile if r.backReference.isDefined => r.path
+    }.toSet
     var matched = 0
-    actionsAfter(deltaLog, afterVersion).foreach {
+    actions.foreach {
       case r: RemoveFile if backRefByPath.contains(r.path) =>
         val expected = backRefByPath(r.path)
         assert(r.backReference == expected,
           s"RemoveFile ${r.path} back-ref ${r.backReference} must equal source $expected.")
         matched += 1
+      case a: AddFile if supersededPaths.contains(a.path) =>
+        assert(a.backReference.isEmpty,
+          s"Superseding AddFile ${a.path} must carry no back reference, was ${a.backReference}.")
       case a: AddFile if backRefByPath.contains(a.path) =>
         val expected = backRefByPath(a.path)
         assert(a.backReference == expected,
-          s"Superseding AddFile ${a.path} back-ref ${a.backReference} must equal source $expected.")
+          s"Re-added AddFile ${a.path} back-ref ${a.backReference} must equal source $expected.")
         matched += 1
       case _ => // A freshly written AddFile (new path) or a non-file action: nothing to inherit.
     }
@@ -222,7 +231,7 @@ class AMTBackReferenceSuite extends AMTCheckpointTestBase with DeletionVectorsTe
   }
 
   testAcrossAMTCheckpointScenarios(
-      "removeRows propagates the back reference to the superseding AddFile and the RemoveFile",
+      "removeRows keeps the back reference on the RemoveFile and drops it from the AddFile",
       "amt_back_ref_remove_rows",
       sqlConfs = leafPackingConfs)(
       setup = name => {
@@ -244,8 +253,8 @@ class AMTBackReferenceSuite extends AMTCheckpointTestBase with DeletionVectorsTe
       twoRowFile.removeRows(
         deletionVector = dv, updateStats = false)
 
-    assert(supersedingAdd.backReference == twoRowFile.backReference,
-      "The superseding AddFile (new DV) must inherit the source file's back reference.")
+    assert(supersedingAdd.backReference.isEmpty,
+      "The superseding AddFile (new DV) is a net-new root entry and must carry no back reference.")
     assert(removeFile.backReference == twoRowFile.backReference,
       "The paired RemoveFile must inherit the source file's back reference.")
   }
@@ -279,8 +288,8 @@ class AMTBackReferenceSuite extends AMTCheckpointTestBase with DeletionVectorsTe
       case r: RemoveFile if r.path == twoRowPath => r
     }.getOrElse(fail("expected a paired RemoveFile for the two-row file."))
     assert(supersedingAdd.deletionVector != null, "the superseding AddFile must carry the DV.")
-    assert(supersedingAdd.backReference == backRefByPath(twoRowPath),
-      "the superseding AddFile must inherit the source file's back reference.")
+    assert(supersedingAdd.backReference.isEmpty,
+      "the superseding AddFile must not claim the source file's leaf position.")
     assert(removed.backReference == backRefByPath(twoRowPath),
       "the paired RemoveFile must inherit the source file's back reference.")
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixes the AMT (Adaptive Metadata Tree) `backReference` stamp on the **superseding
`AddFile`** produced when `removeRows` rewrites a file's deletion vector.

When `removeRows` supersedes a file in place (e.g. a DV update), the commit emits a
`RemoveFile` for the old file plus a new `AddFile` for the superseding one. The old
file's leaf entry is masked by the `RemoveFile`'s `backReference`, so the superseding
`AddFile` is effectively a **net-new entry with a different deletion vector** and must
carry **no** `backReference`. Previously `AddFile.copy(...)` in the DV-rewrite path
retained the source file's stale `backReference`.

- **`actions.scala`** — the DV-rewrite copy now sets `backReference = None`, so the
  superseding `AddFile` no longer inherits a stale stamp.
- **`AMTCheckpointProvider.scala`** — the per-commit back-reference verification now
  splits committed `AddFile`s and `RemoveFile`s, and excludes a superseding `AddFile`
  (empty back reference whose path was just removed with a back reference in the same
  commit) from the expected-map comparison, since that file is legitimately a fresh,
  unstamped entry.

## How was this patch tested?

Extended `AMTBackReferenceSuite` to cover the `removeRows` supersede path: it asserts the
superseding `AddFile` carries no `backReference` while the `RemoveFile` for the old file
keeps its stamped back reference, and that per-commit verification stays green.

All tests pass locally.
