### PR TITLE
Revert "[Kernel] Promote Snapshot/Scan/CommitRange accessors used by Delta Spark (#7269)"

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/CommitRange.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/CommitRange.java
@@ -22,8 +22,6 @@ import io.delta.kernel.engine.Engine;
 import io.delta.kernel.exceptions.KernelException;
 import io.delta.kernel.internal.DeltaLogActionUtils;
 import io.delta.kernel.utils.CloseableIterator;
-import io.delta.kernel.utils.FileStatus;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -54,15 +52,6 @@ public interface CommitRange {
    * @return the ending version number of the commit range
    */
   long getEndVersion();
-
-  /**
-   * Returns the delta commit files that make up this commit range, one per version in {@code
-   * [getStartVersion(), getEndVersion()]}, in increasing version order.
-   *
-   * @return the list of {@link FileStatus}es for the delta commit files in this range
-   * @since 4.4.0
-   */
-  List<FileStatus> getDeltaFiles();
 
   /**
    * Returns the original query boundary used to define the start boundary of this commit range.

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Scan.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Scan.java
@@ -107,25 +107,6 @@ public interface Scan {
   CloseableIterator<FilteredColumnarBatch> getScanFiles(Engine engine);
 
   /**
-   * Get an iterator of data files to scan, optionally including the file statistics.
-   *
-   * <p>Behaves like {@link #getScanFiles(Engine)}, but when {@code includeStats} is {@code true}
-   * the returned scan-file rows are guaranteed to include the JSON file statistics read from the
-   * log (schema {@code add.stats}). When {@code includeStats} is {@code false} the statistics may
-   * or may not be present, depending on whether they were needed internally (e.g. for data
-   * skipping); callers must not rely on their presence.
-   *
-   * @param engine {@link Engine} instance to use in Delta Kernel.
-   * @param includeStats whether to guarantee the JSON file statistics are included in the scan-file
-   *     rows.
-   * @return iterator of {@link FilteredColumnarBatch}s, one selected row per scan file, with the
-   *     schema described in {@link #getScanFiles(Engine)} (plus {@code stats} when {@code
-   *     includeStats} is {@code true}).
-   * @since 4.4.0
-   */
-  CloseableIterator<FilteredColumnarBatch> getScanFiles(Engine engine, boolean includeStats);
-
-  /**
    * Get the remaining filter that is not guaranteed to be satisfied for the data Delta Kernel
    * returns. This filter is used by Delta Kernel to do data skipping when possible.
    *

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Snapshot.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Snapshot.java
@@ -18,17 +18,10 @@ package io.delta.kernel;
 
 import io.delta.kernel.annotation.Evolving;
 import io.delta.kernel.clustering.ClusteringColumnInfo;
-import io.delta.kernel.commit.Committer;
 import io.delta.kernel.commit.PublishFailedException;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.exceptions.CheckpointAlreadyExistsException;
 import io.delta.kernel.exceptions.KernelException;
-import io.delta.kernel.internal.actions.Metadata;
-import io.delta.kernel.internal.actions.Protocol;
-import io.delta.kernel.internal.checksum.CRCInfo;
-import io.delta.kernel.internal.fs.Path;
-import io.delta.kernel.internal.replay.CreateCheckpointIterator;
-import io.delta.kernel.internal.snapshot.LogSegment;
 import io.delta.kernel.statistics.SnapshotStatistics;
 import io.delta.kernel.transaction.UpdateTableTransactionBuilder;
 import io.delta.kernel.types.StructType;
@@ -126,99 +119,6 @@ public interface Snapshot {
 
   /** @return statistics about this snapshot */
   SnapshotStatistics getStatistics();
-
-  /**
-   * Returns the table protocol at this snapshot.
-   *
-   * @return the {@link Protocol} for this snapshot
-   * @since 4.4.0
-   */
-  Protocol getProtocol();
-
-  /**
-   * Returns the table metadata at this snapshot.
-   *
-   * @return the {@link Metadata} for this snapshot
-   * @since 4.4.0
-   */
-  Metadata getMetadata();
-
-  /**
-   * Returns the {@link Committer} used to commit transactions against this snapshot's table.
-   *
-   * @return the committer for this snapshot
-   * @since 4.4.0
-   */
-  Committer getCommitter();
-
-  /**
-   * Returns the table data path, i.e. the same location as {@link #getPath()} in {@link Path} form.
-   *
-   * <p>When turning the result back into a string for file paths, use {@link Path#toString()}
-   * rather than {@code toUri().toString()}: the latter percent-encodes special characters, which
-   * breaks resolution for table roots containing e.g. spaces.
-   *
-   * @return the table data path
-   * @since 4.4.0
-   */
-  default Path getDataPath() {
-    return new Path(getPath());
-  }
-
-  /**
-   * Returns the path to this table's {@code _delta_log} directory.
-   *
-   * @return the {@code _delta_log} path
-   * @since 4.4.0
-   */
-  default Path getLogPath() {
-    return new Path(getDataPath(), "_delta_log");
-  }
-
-  /**
-   * Returns the latest transaction version recorded in the Delta log for the given application id,
-   * or empty if none exists.
-   *
-   * @param engine the engine to use for IO operations
-   * @param applicationId identifier of the application that wrote transaction identifiers into the
-   *     Delta log
-   * @return the last transaction version for {@code applicationId}, or empty if none
-   * @since 4.4.0
-   */
-  default Optional<Long> getLatestTransactionVersion(Engine engine, String applicationId) {
-    return Optional.empty();
-  }
-
-  /**
-   * Returns the checksum ({@code CRC}) information for this snapshot if it was loaded from a
-   * checksum file, otherwise empty.
-   *
-   * <p>An empty result means no checksum was read, not that the table has no checksum file.
-   *
-   * @return the {@link CRCInfo} for this snapshot, or empty if no checksum was loaded
-   * @since 4.4.0
-   */
-  default Optional<CRCInfo> getCurrentCrcInfo() {
-    return Optional.empty();
-  }
-
-  /**
-   * Returns the log segment that backs this snapshot.
-   *
-   * @return the {@link LogSegment} for this snapshot
-   * @since 4.4.0
-   */
-  LogSegment getLogSegment();
-
-  /**
-   * Returns an iterator over the actions that should be written into a checkpoint for this
-   * snapshot.
-   *
-   * @param engine the engine to use for IO operations
-   * @return iterator of filtered columnar batches for checkpoint writing
-   * @since 4.4.0
-   */
-  CreateCheckpointIterator getCreateCheckpointIterator(Engine engine);
 
   /**
    * Get per-clustering-column descriptors with the physical column reference (as stored in the

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaHistoryManager.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaHistoryManager.java
@@ -20,7 +20,6 @@ import static io.delta.kernel.internal.TableConfig.*;
 import static io.delta.kernel.internal.fs.Path.getName;
 import static io.delta.kernel.internal.util.Preconditions.checkArgument;
 
-import io.delta.kernel.Snapshot;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.exceptions.KernelException;
 import io.delta.kernel.exceptions.TableNotFoundException;
@@ -73,7 +72,7 @@ public final class DeltaHistoryManager {
       Engine engine,
       Path logPath,
       long millisSinceEpochUTC,
-      Snapshot latestSnapshot,
+      SnapshotImpl latestSnapshot,
       List<ParsedCatalogCommitData> catalogCommits) {
     DeltaHistoryManager.Commit commit =
         DeltaHistoryManager.getActiveCommitAtTimestamp(
@@ -123,7 +122,7 @@ public final class DeltaHistoryManager {
       Engine engine,
       Path logPath,
       long millisSinceEpochUTC,
-      Snapshot latestSnapshot,
+      SnapshotImpl latestSnapshot,
       List<ParsedCatalogCommitData> catalogCommits) {
     return DeltaHistoryManager.getActiveCommitAtTimestamp(
             engine,
@@ -164,7 +163,7 @@ public final class DeltaHistoryManager {
    */
   public static Commit getActiveCommitAtTimestamp(
       Engine engine,
-      Snapshot latestSnapshot,
+      SnapshotImpl latestSnapshot,
       Path logPath,
       long timestamp,
       boolean mustBeRecreatable,
@@ -335,7 +334,7 @@ public final class DeltaHistoryManager {
    *     timestamps enabled, this will be the commit after the latest version. If in-commit
    *     timestamps were enabled for the entire history, this will be `earliestCommit`.
    */
-  private static Commit getICTEnablementCommit(Snapshot snapshot, Commit earliestCommit) {
+  private static Commit getICTEnablementCommit(SnapshotImpl snapshot, Commit earliestCommit) {
     Metadata metadata = snapshot.getMetadata();
     if (!IN_COMMIT_TIMESTAMPS_ENABLED.fromMetadata(metadata)) {
       // Pretend ICT will be enabled after the latest version and requested timestamp.

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/PaginatedScanImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/PaginatedScanImpl.java
@@ -84,7 +84,6 @@ public class PaginatedScanImpl implements PaginatedScan {
     return this.getScanFiles(engine, false /* include stats */);
   }
 
-  @Override
   public PaginatedScanFilesIterator getScanFiles(Engine engine, boolean includeStates) {
     CloseableIterator<FilteredColumnarBatch> filteredScanFilesIter =
         baseScan.getScanFiles(engine, includeStates, Optional.of(paginationContext));

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
@@ -119,7 +119,6 @@ public class ScanImpl implements Scan {
    *
    * @return data in {@link ColumnarBatch} batch format. Each row correspond to one survived file.
    */
-  @Override
   public CloseableIterator<FilteredColumnarBatch> getScanFiles(
       Engine engine, boolean includeStats) {
     return getScanFiles(engine, includeStats, Optional.empty() /* paginationContextOpt */);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
@@ -351,17 +351,14 @@ public class SnapshotImpl implements Snapshot {
     return new ReplaceTableTransactionBuilderV2Impl(this, schema, engineInfo);
   }
 
-  @Override
   public Committer getCommitter() {
     return committer;
   }
 
-  @Override
   public Path getLogPath() {
     return logPath;
   }
 
-  @Override
   public Path getDataPath() {
     return dataPath;
   }
@@ -375,7 +372,6 @@ public class SnapshotImpl implements Snapshot {
     return wasBuiltAsLatest;
   }
 
-  @Override
   public Protocol getProtocol() {
     return protocol;
   }
@@ -423,17 +419,14 @@ public class SnapshotImpl implements Snapshot {
   }
 
   /** Returns the crc info for the current snapshot if the checksum file is read */
-  @Override
   public Optional<CRCInfo> getCurrentCrcInfo() {
     return logReplay.getCrcInfoAtSnapshotVersion();
   }
 
-  @Override
   public Metadata getMetadata() {
     return metadata;
   }
 
-  @Override
   public LogSegment getLogSegment() {
     return lazyLogSegment.get();
   }
@@ -443,7 +436,6 @@ public class SnapshotImpl implements Snapshot {
     return lazyLogSegment;
   }
 
-  @Override
   public CreateCheckpointIterator getCreateCheckpointIterator(Engine engine) {
     long minFileRetentionTimestampMillis =
         System.currentTimeMillis() - TOMBSTONE_RETENTION.fromMetadata(metadata);
@@ -452,14 +444,14 @@ public class SnapshotImpl implements Snapshot {
 
   /**
    * Get the latest transaction version for given <i>applicationId</i>. This information comes from
-   * the transactions identifiers stored in Delta transaction log.
+   * the transactions identifiers stored in Delta transaction log. This API is not a public API. For
+   * now keep this internal to enable Flink upgrade to use Kernel.
    *
    * @param applicationId Identifier of the application that put transaction identifiers in Delta
    *     transaction log
    * @return Last transaction version or {@link Optional#empty()} if no transaction identifier
    *     exists for this application.
    */
-  @Override
   public Optional<Long> getLatestTransactionVersion(Engine engine, String applicationId) {
     return logReplay.getLatestTransactionIdentifier(engine, applicationId);
   }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/commitrange/CommitRangeImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/commitrange/CommitRangeImpl.java
@@ -27,6 +27,7 @@ import io.delta.kernel.data.ColumnarBatch;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.internal.DeltaLogActionUtils;
 import io.delta.kernel.internal.TableChangesUtils;
+import io.delta.kernel.internal.annotation.VisibleForTesting;
 import io.delta.kernel.internal.files.ParsedDeltaData;
 import io.delta.kernel.internal.fs.Path;
 import io.delta.kernel.utils.CloseableIterator;
@@ -89,7 +90,7 @@ public class CommitRangeImpl implements CommitRange {
     return endBoundaryOpt;
   }
 
-  @Override
+  @VisibleForTesting
   public List<FileStatus> getDeltaFiles() {
     return deltas.stream().map(ParsedDeltaData::getFileStatus).collect(Collectors.toList());
   }


### PR DESCRIPTION
## Description

Reverts #7269 now that the promoted Kernel accessors are no longer needed.

## How was this patch tested?

Attempted:

```
build/sbt kernelApi/compile
```

This could not complete locally because dependency resolution failed with DNS errors while reaching Maven repositories.
