### PR TITLE
[Spark] Rename UUID-relative deletion vector descriptor helpers

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/DeletionVectorDescriptor.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/DeletionVectorDescriptor.scala
@@ -107,7 +107,7 @@ case class DeletionVectorDescriptor(
   protected[delta] def isInline: Boolean = storageType == INLINE_DV_MARKER
 
   @JsonIgnore
-  protected[delta] def isRelative: Boolean = storageType == UUID_DV_MARKER
+  protected[delta] def isUuidRelative: Boolean = storageType == UUID_DV_MARKER
 
   @JsonIgnore
   protected[delta] def isUnencodedRelative: Boolean = storageType == RELATIVE_DV_MARKER
@@ -144,7 +144,7 @@ case class DeletionVectorDescriptor(
    * If the DV path is outside the table directory, returns None.
    */
   def urlEncodedRelativePathIfExists(tablePath: Path): Option[String] = {
-    if (isRelative) {
+    if (isUuidRelative) {
       return Some(SparkPath.fromPath(absolutePath(new Path("."))).urlEncoded)
     }
 
@@ -194,7 +194,7 @@ case class DeletionVectorDescriptor(
    *
    * If the DV already has a relative path or is inline, then this is just a normal copy.
    */
-  def copyWithNewRelativePath(id: UUID, randomPrefix: String): DeletionVectorDescriptor = {
+  def copyWithNewUuidRelativePath(id: UUID, randomPrefix: String): DeletionVectorDescriptor = {
     storageType match {
       case PATH_DV_MARKER =>
         this.copy(storageType = UUID_DV_MARKER, pathOrInlineDv = encodeUUID(id, randomPrefix))
@@ -281,7 +281,7 @@ object DeletionVectorDescriptor {
   implicit def encoder: Encoder[DeletionVectorDescriptor] = _encoder.get
 
   /** Utility method to create an on-disk [[DeletionVectorDescriptor]] */
-  def onDiskWithRelativePath(
+  def onDiskWithUuidRelativePath(
       id: UUID,
       randomPrefix: String = "",
       sizeInBytes: Int,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DMLWithDeletionVectorsHelper.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DMLWithDeletionVectorsHelper.scala
@@ -691,7 +691,7 @@ object DeletionVectorWriter extends DeltaLogging {
       DeletionVectorDescriptor.EMPTY
     } else {
       val dvRange = ctx.writer.write(bitmapData)
-      DeletionVectorDescriptor.onDiskWithRelativePath(
+      DeletionVectorDescriptor.onDiskWithUuidRelativePath(
         id = ctx.fileId,
         randomPrefix = ctx.prefix,
         sizeInBytes = bitmapData.length,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/VacuumCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/VacuumCommand.scala
@@ -744,7 +744,7 @@ trait VacuumCommandImpl extends DeltaCommand {
 
     dv match {
       case Some(dv) if dv.isOnDisk =>
-        if (dv.isRelative) {
+        if (dv.isUuidRelative) {
           // We actually want a relative path here.
           Some((pathToUrlEncodedString(dv.absolutePath(new Path("."))), dv.sizeInBytes))
         } else {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/ActionSerializerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/ActionSerializerSuite.scala
@@ -529,7 +529,7 @@ class ActionSerializerSuite extends QueryTest with SharedSparkSession with Delta
       """"extendedFileMetadata":true,"partitionValues":{"x":"2"},"size":10}}""")
 
   private def deletionVectorWithRelativePath: DeletionVectorDescriptor =
-    DeletionVectorDescriptor.onDiskWithRelativePath(
+    DeletionVectorDescriptor.onDiskWithUuidRelativePath(
       id = UUID.randomUUID(),
       randomPrefix = "a1",
       sizeInBytes = 10,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeletionVectorsTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeletionVectorsTestUtils.scala
@@ -382,7 +382,7 @@ trait DeletionVectorsTestUtils extends QueryTest with SharedSparkSession with De
     withDVWriter(log, dvFileId) { writer =>
       filesWithDVs.flatMap { case (currentFile, dv) =>
         val range = writer.write(serializeRoaringBitmapArrayWithDefaultFormat(dv))
-        val dvData = DeletionVectorDescriptor.onDiskWithRelativePath(
+        val dvData = DeletionVectorDescriptor.onDiskWithUuidRelativePath(
           id = dvFileId,
           sizeInBytes = range.length,
           cardinality = dv.cardinality,
@@ -457,7 +457,7 @@ trait DeletionVectorsTestUtils extends QueryTest with SharedSparkSession with De
     val dvFileId = UUID.randomUUID()
     withDVWriter(log, dvFileId) { writer =>
       val range = writer.write(serializeRoaringBitmapArrayWithDefaultFormat(bitmapArray))
-      DeletionVectorDescriptor.onDiskWithRelativePath(
+      DeletionVectorDescriptor.onDiskWithUuidRelativePath(
         id = dvFileId,
         sizeInBytes = range.length,
         cardinality = bitmapArray.cardinality,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/actions/DeletionVectorDescriptorSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/actions/DeletionVectorDescriptorSuite.scala
@@ -57,7 +57,7 @@ class DeletionVectorDescriptorSuite extends SparkFunSuite {
     // expect the returned DV is same as input, since this is inline
     // so paths are irrelevant.
     assert(dv.copyWithAbsolutePath(testTablePath) === dv)
-    assert(dv.copyWithNewRelativePath(UUID.randomUUID(), "predix2") === dv)
+    assert(dv.copyWithNewUuidRelativePath(UUID.randomUUID(), "predix2") === dv)
   }
 
   for (offset <- Seq(None, Some(25))) {
@@ -87,17 +87,17 @@ class DeletionVectorDescriptorSuite extends SparkFunSuite {
 
       // Copy DV as a relative path DV
       val uuid = UUID.randomUUID()
-      val dvCopyWithRelativePath = dv.copyWithNewRelativePath(uuid, "prefix")
-      assert(dvCopyWithRelativePath.isRelative)
-      assert(dvCopyWithRelativePath.isOnDisk)
-      assert(dvCopyWithRelativePath.pathOrInlineDv === encodeUUID(uuid, "prefix"))
+      val dvCopyWithUuidRelativePath = dv.copyWithNewUuidRelativePath(uuid, "prefix")
+      assert(dvCopyWithUuidRelativePath.isUuidRelative)
+      assert(dvCopyWithUuidRelativePath.isOnDisk)
+      assert(dvCopyWithUuidRelativePath.pathOrInlineDv === encodeUUID(uuid, "prefix"))
     }
   }
 
   for (offset <- Seq(None, Some(25))) {
     test(s"On-disk DV with relative path with offset=$offset") {
       val uuid = UUID.randomUUID()
-      val dv = onDiskWithRelativePath(
+      val dv = onDiskWithUuidRelativePath(
         uuid, randomPrefix = "prefix", sizeInBytes = 15, cardinality = 25, offset)
 
       // Make sure the metadata (type, size etc.) in the DV is as expected
@@ -131,7 +131,7 @@ class DeletionVectorDescriptorSuite extends SparkFunSuite {
 
       // Copy DV as a relative path DV - expect to return the same DV as the current
       // DV already contains relative path.
-      assert(dv.copyWithNewRelativePath(UUID.randomUUID(), "predix2") === dv)
+      assert(dv.copyWithNewUuidRelativePath(UUID.randomUUID(), "predix2") === dv)
     }
   }
 
@@ -145,7 +145,7 @@ class DeletionVectorDescriptorSuite extends SparkFunSuite {
       assertCardinality(dv, 7)
 
       assert(dv.isUnencodedRelative)
-      assert(!dv.isRelative)
+      assert(!dv.isUuidRelative)
       assert(!dv.isAbsolute)
       // It carries no UUID, so there is no prefix/UUID pair to recover.
       assert(dv.getRandomPrefixAndUuid.isEmpty)
@@ -189,7 +189,8 @@ class DeletionVectorDescriptorSuite extends SparkFunSuite {
       (PATH_DV_MARKER,
         onDiskWithAbsolutePath(absolutePath, sizeInBytes = 15, cardinality = 10)),
       (UUID_DV_MARKER,
-        onDiskWithRelativePath(uuid, randomPrefix = "dv dir", sizeInBytes = 15, cardinality = 10)),
+        onDiskWithUuidRelativePath(
+          uuid, randomPrefix = "dv dir", sizeInBytes = 15, cardinality = 10)),
       (RELATIVE_DV_MARKER,
         createRelativePathDVDescriptor(relativePath, sizeInBytes = 15, cardinality = 10)))
 
@@ -230,7 +231,7 @@ class DeletionVectorDescriptorSuite extends SparkFunSuite {
   } {
     test(s"base64 round-trip for $label DV with offset=$offset") {
       val dv = label match {
-        case "uuid relative path" => onDiskWithRelativePath(
+        case "uuid relative path" => onDiskWithUuidRelativePath(
           UUID.randomUUID(), randomPrefix = "prefix", sizeInBytes = 15, cardinality = 25, offset)
         case "absolute path" => onDiskWithAbsolutePath(
           testDVAbsPath, sizeInBytes = 15, cardinality = 10, offset)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSingleActionSerializerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSingleActionSerializerSuite.scala
@@ -308,7 +308,7 @@ class AMTSingleActionSerializerSuite extends QueryTest with SharedSparkSession {
 
   test("DeletionVector.fromDescriptor maps a UUID-relative DV to an unencoded absolute location") {
     val id = UUID.randomUUID()
-    val dv = DeletionVectorDescriptor.onDiskWithRelativePath(
+    val dv = DeletionVectorDescriptor.onDiskWithUuidRelativePath(
       id = id,
       randomPrefix = "test%dv%prefix-",
       sizeInBytes = 20,
@@ -350,7 +350,7 @@ class AMTSingleActionSerializerSuite extends QueryTest with SharedSparkSession {
   }
 
   test("DeletionVector.fromDescriptor rejects an on-disk DV with no offset") {
-    val dv = DeletionVectorDescriptor.onDiskWithRelativePath(
+    val dv = DeletionVectorDescriptor.onDiskWithUuidRelativePath(
       id = UUID.randomUUID(), sizeInBytes = 10, cardinality = 1L, offset = None)
     val ex = intercept[IllegalArgumentException](DeletionVector.fromDescriptor(dv, tableRoot))
     assert(ex.getMessage.contains("missing an offset"))


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

`DeletionVectorDescriptor` now supports two relative storage types: `u`
(UUID-relative) and `r` (an unencoded path relative to the table root). With
both present, the helpers named only after "relative" are ambiguous, so they
are renamed to name the UUID-relative type explicitly:

- `isRelative` -> `isUuidRelative`
- `copyWithNewRelativePath` -> `copyWithNewUuidRelativePath`
- `onDiskWithRelativePath` -> `onDiskWithUuidRelativePath`

This is a pure rename with no behavior change. All call sites and tests are
updated accordingly.

## How was this patch tested?

Existing unit tests, updated to use the renamed helpers.

## Does this PR introduce _any_ user-facing changes?

No.
