### PR TITLE
[4.4][Flink] Copy rows before buffering sink writes

### DIFF
--- a/flink/src/main/java/io/delta/flink/sink/DeltaSink.java
+++ b/flink/src/main/java/io/delta/flink/sink/DeltaSink.java
@@ -109,6 +109,7 @@ public class DeltaSink
         .withAttemptNumber(context.getTaskInfo().getAttemptNumber())
         .withDeltaTable(deltaTable)
         .withConf(conf)
+        .withInputSerializer(context.createInputSerializer())
         .withMetricGroup(context.metricGroup())
         .build();
   }

--- a/flink/src/main/java/io/delta/flink/sink/DeltaSinkWriter.java
+++ b/flink/src/main/java/io/delta/flink/sink/DeltaSinkWriter.java
@@ -23,6 +23,7 @@ import io.delta.kernel.types.StructType;
 import java.io.IOException;
 import java.util.*;
 import org.apache.flink.api.common.eventtime.Watermark;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.connector.sink2.CommittingSinkWriter;
 import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
 import org.apache.flink.streaming.api.connector.sink2.SupportsPreWriteTopology;
@@ -65,6 +66,7 @@ public class DeltaSinkWriter implements CommittingSinkWriter<RowData, DeltaWrite
 
   private final DeltaTable deltaTable;
   private final DeltaSinkConf conf;
+  private final TypeSerializer<RowData> inputSerializer;
 
   private final SinkWriterMetricGroup metricGroup;
   private volatile long lastSendTimeMs;
@@ -81,6 +83,7 @@ public class DeltaSinkWriter implements CommittingSinkWriter<RowData, DeltaWrite
       int attemptNumber,
       DeltaTable deltaTable,
       DeltaSinkConf conf,
+      TypeSerializer<RowData> inputSerializer,
       SinkWriterMetricGroup metricGroup) {
     this.jobId = jobId;
     this.subtaskId = subtaskId;
@@ -88,6 +91,7 @@ public class DeltaSinkWriter implements CommittingSinkWriter<RowData, DeltaWrite
 
     this.deltaTable = deltaTable;
     this.conf = conf;
+    this.inputSerializer = inputSerializer;
 
     this.metricGroup = metricGroup;
     metricGroup.setCurrentSendTimeGauge(() -> lastSendTimeMs);
@@ -129,10 +133,13 @@ public class DeltaSinkWriter implements CommittingSinkWriter<RowData, DeltaWrite
     //     without appending a row.
     switch (element.getRowKind()) {
       case INSERT:
-        mergeStrategy.insert(extractPrimaryKey(element), partitionValues, element, context);
+        // Writer tasks buffer rows, so take ownership before Flink can reuse the input object.
+        mergeStrategy.insert(
+            extractPrimaryKey(element), partitionValues, inputSerializer.copy(element), context);
         break;
       case UPDATE_AFTER:
-        mergeStrategy.upsert(extractPrimaryKey(element), partitionValues, element, context);
+        mergeStrategy.upsert(
+            extractPrimaryKey(element), partitionValues, inputSerializer.copy(element), context);
         break;
       case UPDATE_BEFORE:
         // Dropped — see policy comment above.
@@ -238,6 +245,7 @@ public class DeltaSinkWriter implements CommittingSinkWriter<RowData, DeltaWrite
 
     private DeltaTable deltaTable;
     private DeltaSinkConf conf;
+    private TypeSerializer<RowData> inputSerializer;
 
     private SinkWriterMetricGroup metricGroup;
 
@@ -268,6 +276,11 @@ public class DeltaSinkWriter implements CommittingSinkWriter<RowData, DeltaWrite
       return this;
     }
 
+    public Builder withInputSerializer(TypeSerializer<RowData> inputSerializer) {
+      this.inputSerializer = inputSerializer;
+      return this;
+    }
+
     public Builder withMetricGroup(SinkWriterMetricGroup metricGroup) {
       this.metricGroup = metricGroup;
       return this;
@@ -279,8 +292,10 @@ public class DeltaSinkWriter implements CommittingSinkWriter<RowData, DeltaWrite
       Objects.requireNonNull(deltaTable, "deltaTable must not be null");
       Objects.requireNonNull(metricGroup, "metricGroup must not be null");
       Objects.requireNonNull(conf, "conf must not be null");
+      Objects.requireNonNull(inputSerializer, "inputSerializer must not be null");
 
-      return new DeltaSinkWriter(jobId, subtaskId, attemptNumber, deltaTable, conf, metricGroup);
+      return new DeltaSinkWriter(
+          jobId, subtaskId, attemptNumber, deltaTable, conf, inputSerializer, metricGroup);
     }
   }
 }

--- a/flink/src/test/java/io/delta/flink/sink/DeltaSinkTest.java
+++ b/flink/src/test/java/io/delta/flink/sink/DeltaSinkTest.java
@@ -49,6 +49,7 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.data.*;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
 import org.apache.flink.table.types.logical.*;
 import org.apache.flink.table.types.logical.BinaryType;
 import org.apache.flink.table.types.logical.BooleanType;
@@ -439,7 +440,9 @@ public class DeltaSinkTest extends TestHelper {
                   .withPartitionColNames(List.of("part"))
                   .build();
 
-          assertNotNull(deltaSink.createWriter(new TestWriterInitContext(1, 1, 1)));
+          assertNotNull(
+              deltaSink.createWriter(
+                  new TestWriterInitContext(1, 1, 1, new RowDataSerializer(flinkSchema))));
           assertNotNull(deltaSink.createCommitter(new TestCommitterInitContext(1, 1, 1)));
         });
   }

--- a/flink/src/test/java/io/delta/flink/sink/DeltaSinkWriterTest.java
+++ b/flink/src/test/java/io/delta/flink/sink/DeltaSinkWriterTest.java
@@ -65,7 +65,16 @@ import org.slf4j.LoggerFactory;
 class DeltaSinkWriterTest extends TestHelper {
 
   @Test
-  void testWriteCopiesReusedRowData() {
+  void testWriteCopiesReusedInsertRowData() {
+    assertWriteCopiesReusedRowData(false);
+  }
+
+  @Test
+  void testWriteCopiesReusedUpdateAfterRowData() {
+    assertWriteCopiesReusedRowData(true);
+  }
+
+  private void assertWriteCopiesReusedRowData(boolean upsert) {
     withTempDir(
         dir -> {
           StructType schema =
@@ -78,19 +87,26 @@ class DeltaSinkWriterTest extends TestHelper {
                   Collections.emptyList());
           table.open();
           DeltaSinkWriter sinkWriter =
-              newSinkWriter(table, new DeltaSinkConf(schema, Collections.emptyMap()));
+              newSinkWriter(
+                  table,
+                  upsert
+                      ? upsertConf(schema, new int[] {0})
+                      : new DeltaSinkConf(schema, Collections.emptyMap()));
 
           BinaryRowData reusedRow = new BinaryRowData(2);
+          RowKind rowKind = upsert ? RowKind.UPDATE_AFTER : RowKind.INSERT;
           BinaryRowWriter rowWriter = new BinaryRowWriter(reusedRow);
           rowWriter.writeInt(0, 100);
           rowWriter.writeString(1, StringData.fromString("Alice"));
           rowWriter.complete();
+          reusedRow.setRowKind(rowKind);
           sinkWriter.write(reusedRow, new TestSinkWriterContext(0, 0));
 
           rowWriter.reset();
           rowWriter.writeInt(0, 101);
           rowWriter.writeString(1, StringData.fromString("Bob"));
           rowWriter.complete();
+          reusedRow.setRowKind(rowKind);
           sinkWriter.write(reusedRow, new TestSinkWriterContext(0, 0));
 
           DeltaWriterResult result = sinkWriter.prepareCommit().iterator().next();
@@ -99,10 +115,11 @@ class DeltaSinkWriterTest extends TestHelper {
           List<Row> rows = readParquet(dir.toPath().resolve(addFile.getPath()), schema);
 
           assertEquals(2, rows.size());
-          assertEquals(100, rows.get(0).getInt(0));
-          assertEquals("Alice", rows.get(0).getString(1));
-          assertEquals(101, rows.get(1).getInt(0));
-          assertEquals("Bob", rows.get(1).getString(1));
+          assertEquals(
+              Set.of("100:Alice", "101:Bob"),
+              rows.stream()
+                  .map(row -> row.getInt(0) + ":" + row.getString(1))
+                  .collect(Collectors.toSet()));
         });
   }
 

--- a/flink/src/test/java/io/delta/flink/sink/DeltaSinkWriterTest.java
+++ b/flink/src/test/java/io/delta/flink/sink/DeltaSinkWriterTest.java
@@ -31,6 +31,8 @@ import io.delta.kernel.data.Row;
 import io.delta.kernel.defaults.engine.DefaultEngine;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.internal.InternalScanFileUtils;
+import io.delta.kernel.internal.actions.AddFile;
+import io.delta.kernel.internal.actions.SingleAction;
 import io.delta.kernel.internal.data.ScanStateRow;
 import io.delta.kernel.types.*;
 import io.delta.kernel.utils.CloseableIterable;
@@ -46,6 +48,12 @@ import java.util.stream.IntStream;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.data.writer.BinaryRowWriter;
+import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.types.RowKind;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.jupiter.api.Disabled;
@@ -55,6 +63,48 @@ import org.slf4j.LoggerFactory;
 
 /** JUnit test suite for {@link DeltaSinkWriter}. */
 class DeltaSinkWriterTest extends TestHelper {
+
+  @Test
+  void testWriteCopiesReusedRowData() {
+    withTempDir(
+        dir -> {
+          StructType schema =
+              new StructType().add("id", IntegerType.INTEGER).add("name", StringType.STRING);
+          HadoopTable table =
+              new HadoopTable(
+                  URI.create(dir.getAbsolutePath()),
+                  Collections.emptyMap(),
+                  schema,
+                  Collections.emptyList());
+          table.open();
+          DeltaSinkWriter sinkWriter =
+              newSinkWriter(table, new DeltaSinkConf(schema, Collections.emptyMap()));
+
+          BinaryRowData reusedRow = new BinaryRowData(2);
+          BinaryRowWriter rowWriter = new BinaryRowWriter(reusedRow);
+          rowWriter.writeInt(0, 100);
+          rowWriter.writeString(1, StringData.fromString("Alice"));
+          rowWriter.complete();
+          sinkWriter.write(reusedRow, new TestSinkWriterContext(0, 0));
+
+          rowWriter.reset();
+          rowWriter.writeInt(0, 101);
+          rowWriter.writeString(1, StringData.fromString("Bob"));
+          rowWriter.complete();
+          sinkWriter.write(reusedRow, new TestSinkWriterContext(0, 0));
+
+          DeltaWriterResult result = sinkWriter.prepareCommit().iterator().next();
+          AddFile addFile =
+              new AddFile(result.getDeltaActions().get(0).getStruct(SingleAction.ADD_FILE_ORDINAL));
+          List<Row> rows = readParquet(dir.toPath().resolve(addFile.getPath()), schema);
+
+          assertEquals(2, rows.size());
+          assertEquals(100, rows.get(0).getInt(0));
+          assertEquals("Alice", rows.get(0).getString(1));
+          assertEquals(101, rows.get(1).getInt(0));
+          assertEquals("Bob", rows.get(1).getString(1));
+        });
+  }
 
   @Test
   void testWriteToEmptyTableWithNoPartition() {
@@ -76,6 +126,7 @@ class DeltaSinkWriterTest extends TestHelper {
                   .withAttemptNumber(1)
                   .withDeltaTable(table)
                   .withConf(new DeltaSinkConf(schema, Collections.emptyMap()))
+                  .withInputSerializer(testSerializer(schema))
                   .withMetricGroup(UnregisteredMetricsGroup.createSinkWriterMetricGroup())
                   .build();
 
@@ -182,6 +233,7 @@ class DeltaSinkWriterTest extends TestHelper {
                   .withAttemptNumber(1)
                   .withDeltaTable(table)
                   .withConf(new DeltaSinkConf(schema, Collections.emptyMap()))
+                  .withInputSerializer(testSerializer(schema))
                   .withMetricGroup(UnregisteredMetricsGroup.createSinkWriterMetricGroup())
                   .build();
 
@@ -241,6 +293,7 @@ class DeltaSinkWriterTest extends TestHelper {
                   .withSubtaskId(0)
                   .withAttemptNumber(1)
                   .withConf(new DeltaSinkConf(schema, Collections.emptyMap()))
+                  .withInputSerializer(testSerializer(schema))
                   .withMetricGroup(UnregisteredMetricsGroup.createSinkWriterMetricGroup())
                   .build();
 
@@ -298,6 +351,7 @@ class DeltaSinkWriterTest extends TestHelper {
                   .withAttemptNumber(1)
                   .withDeltaTable(table)
                   .withConf(new DeltaSinkConf(schema, Collections.emptyMap()))
+                  .withInputSerializer(testSerializer(schema))
                   .withMetricGroup(writerMetrics)
                   .build();
 
@@ -341,6 +395,7 @@ class DeltaSinkWriterTest extends TestHelper {
                   .withAttemptNumber(1)
                   .withDeltaTable(table)
                   .withConf(new DeltaSinkConf(schema, Collections.emptyMap()))
+                  .withInputSerializer(testSerializer(schema))
                   .withMetricGroup(writerMetrics)
                   .build();
 
@@ -380,6 +435,7 @@ class DeltaSinkWriterTest extends TestHelper {
                   .withAttemptNumber(1)
                   .withDeltaTable(table)
                   .withConf(new DeltaSinkConf(schema, Collections.emptyMap()))
+                  .withInputSerializer(testSerializer(schema))
                   .withMetricGroup(UnregisteredMetricsGroup.createSinkWriterMetricGroup())
                   .build();
 
@@ -754,14 +810,37 @@ class DeltaSinkWriterTest extends TestHelper {
 
   /** Build a {@link DeltaSinkWriter} with the standard test wiring. */
   private static DeltaSinkWriter newSinkWriter(HadoopTable table, DeltaSinkConf conf) {
+    return newSinkWriter(table, conf, testSerializer(conf.getSinkSchema()));
+  }
+
+  private static DeltaSinkWriter newSinkWriter(
+      HadoopTable table, DeltaSinkConf conf, RowDataSerializer inputSerializer) {
     return new DeltaSinkWriter.Builder()
         .withJobId("test-job")
         .withSubtaskId(0)
         .withAttemptNumber(1)
         .withDeltaTable(table)
         .withConf(conf)
+        .withInputSerializer(inputSerializer)
         .withMetricGroup(UnregisteredMetricsGroup.createSinkWriterMetricGroup())
         .build();
+  }
+
+  private static RowDataSerializer testSerializer(StructType schema) {
+    LogicalType[] types =
+        schema.fields().stream()
+            .map(
+                field -> {
+                  if (field.getDataType() instanceof IntegerType) {
+                    return new IntType();
+                  } else if (field.getDataType() instanceof StringType) {
+                    return new VarCharType(VarCharType.MAX_LENGTH);
+                  }
+                  throw new IllegalArgumentException(
+                      "Unsupported test data type: " + field.getDataType());
+                })
+            .toArray(LogicalType[]::new);
+    return new RowDataSerializer(types);
   }
 
   private void assertPrepareCommitPropagatesWriterFailure(boolean upsert) {
@@ -781,7 +860,11 @@ class DeltaSinkWriterTest extends TestHelper {
               upsert
                   ? upsertConf(schema, new int[] {0})
                   : new DeltaSinkConf(schema, Collections.emptyMap());
-          DeltaSinkWriter sinkWriter = newSinkWriter(table, conf);
+          // Keep this malformed row intact so the test exercises failure propagation from the
+          // asynchronous file writer instead of the input serializer's arity check.
+          RowDataSerializer malformedInputSerializer =
+              testSerializer(new StructType().add("id", IntegerType.INTEGER));
+          DeltaSinkWriter sinkWriter = newSinkWriter(table, conf, malformedInputSerializer);
 
           // The missing string field is detected while the cached writer task is completed.
           sinkWriter.write(GenericRowData.of(1), new TestSinkWriterContext(0, 0));

--- a/flink/src/test/java/io/delta/flink/sink/TestWriterInitContext.java
+++ b/flink/src/test/java/io/delta/flink/sink/TestWriterInitContext.java
@@ -48,11 +48,14 @@ public class TestWriterInitContext implements WriterInitContext {
   private final SinkWriterMetricGroup metricGroup;
   private final JobInfo jobInfo;
   private final TaskInfo taskInfo;
+  private final TypeSerializer<?> inputSerializer;
 
-  public TestWriterInitContext(int subtaskId, int parallelism, int attempt) {
+  public TestWriterInitContext(
+      int subtaskId, int parallelism, int attempt, TypeSerializer<?> inputSerializer) {
     this.subtaskId = subtaskId;
     this.parallelism = parallelism;
     this.attempt = attempt;
+    this.inputSerializer = inputSerializer;
 
     this.mailboxExecutor =
         new MailboxExecutorImpl(
@@ -162,8 +165,9 @@ public class TestWriterInitContext implements WriterInitContext {
   }
 
   @Override
+  @SuppressWarnings("unchecked")
   public <IN> TypeSerializer<IN> createInputSerializer() {
-    return null;
+    return (TypeSerializer<IN>) inputSerializer;
   }
 
   @Override

--- a/flink/src/test/java/io/delta/flink/sink/sql/FlinkSqlTest.java
+++ b/flink/src/test/java/io/delta/flink/sink/sql/FlinkSqlTest.java
@@ -34,6 +34,52 @@ import org.junit.jupiter.api.Test;
 class FlinkSqlTest extends TestHelper {
 
   @Test
+  void testGroupedAggregationPreservesEachRow() {
+    withTempDir(
+        dir -> {
+          TableEnvironment tEnv =
+              TableEnvironment.create(EnvironmentSettings.newInstance().inBatchMode().build());
+          tEnv.executeSql(
+              "CREATE TEMPORARY TABLE sink (\n"
+                  + "  group_id INT,\n"
+                  + "  item_count BIGINT\n"
+                  + ") WITH (\n"
+                  + "  'connector' = 'delta',\n"
+                  + "  'table_path' = '"
+                  + dir.getPath()
+                  + "'\n"
+                  + ")");
+
+          tEnv.executeSql(
+                  "INSERT INTO sink "
+                      + "SELECT group_id, COUNT(*) "
+                      + "FROM (VALUES (1), (2)) AS source(group_id) "
+                      + "GROUP BY group_id")
+              .await();
+
+          StructType schema =
+              new StructType()
+                  .add("group_id", IntegerType.INTEGER)
+                  .add("item_count", LongType.LONG);
+          verifyTableContent(
+              dir.getPath(),
+              (version, addfiles, properties) -> {
+                List<AddFile> actionList = new ArrayList<>();
+                addfiles.iterator().forEachRemaining(actionList::add);
+                Set<String> records =
+                    actionList.stream()
+                        .flatMap(
+                            addFile ->
+                                readParquet(dir.toPath().resolve(addFile.getPath()), schema)
+                                    .stream())
+                        .map(row -> row.getInt(0) + ":" + row.getLong(1))
+                        .collect(Collectors.toSet());
+                assertEquals(Set.of("1:1", "2:1"), records);
+              });
+        });
+  }
+
+  @Test
   void testLoadIntoHadoopTable() {
     withTempDir(
         dir -> {


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [x] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This backports #7474 to `branch-4.4`.

The bug can be reproduced with this Flink query:

```sql
INSERT INTO target
SELECT name, COUNT(*) AS order_count
FROM (VALUES ('Alice'), ('Alice'), ('Bob')) AS orders(name)
GROUP BY name;
```

Reading the Delta table should return:

```text
Alice  2
Bob    1
```

Before this fix, it could return:

```text
Bob    1
Bob    1
```

Flink may use the same row object for more than one result. Its grouped-query code can effectively do this:

```java
row.replace("Alice", 2);
deltaFlink.write(row);

row.replace("Bob", 1); // Same object, new values.
deltaFlink.write(row);
```

This is valid Flink behavior. The `write(...)` method is implemented by the Delta-Flink connector, and the old implementation gave the original object to code that buffers rows:

```java
mergeStrategy.insert(..., element, context);
```

Both buffered entries could therefore point to the same object. When Flink changed that object from Alice to Bob, the earlier buffered entry also appeared to contain Bob.

The crux of the fix is to use Flink's schema-aware input serializer to copy each inserted or updated row before buffering it:

```diff
- mergeStrategy.insert(..., element, context);
+ mergeStrategy.insert(..., inputSerializer.copy(element), context);
```

The copied row belongs to Delta-Flink, so later changes to Flink's original object cannot change a row that Delta-Flink already accepted. The exact implementation is in [`DeltaSink`](https://github.com/delta-io/delta/blob/4edb25fd91d4e356f9437942c80fdabd10ec3890/flink/src/main/java/io/delta/flink/sink/DeltaSink.java#L104-L114) and [`DeltaSinkWriter`](https://github.com/delta-io/delta/blob/4edb25fd91d4e356f9437942c80fdabd10ec3890/flink/src/main/java/io/delta/flink/sink/DeltaSinkWriter.java#L134-L143). The full explanation, including links to the relevant Flink implementation, is in #7474.

## How was this patch tested?

Ran the focused row-copy and SQL regression suites on `branch-4.4`:

```text
DeltaSinkWriterTest: 20 passed, 1 existing test ignored, 0 failed
FlinkSqlTest: 4 passed, 0 failed
```

The build also ran Java formatting and Checkstyle checks successfully.

## Does this PR introduce _any_ user-facing changes?

Yes. Delta-Flink now preserves every row when an upstream Flink operation reuses its row object. Previously, some queries could write a later row's values in place of an earlier row.
