### PR TITLE
[Kernel-Spark] Unify DeltaV2SnapshotManager on the V1 Snapshot facade

### DIFF
--- a/spark-unified/src/main/scala-shims/spark-4.2/org/apache/spark/sql/delta/catalog/ChangelogSupport.scala
+++ b/spark-unified/src/main/scala-shims/spark-4.2/org/apache/spark/sql/delta/catalog/ChangelogSupport.scala
@@ -99,7 +99,7 @@ trait ChangelogSupport extends TableCatalog {
       deltaV2Table: DeltaV2Table,
       range: org.apache.spark.sql.connector.catalog.ChangelogRange): (Long, Long) = {
     val snapshotManager = deltaV2Table.getSnapshotManager
-    val latestVersion = snapshotManager.loadLatestSnapshot().getVersion
+    val latestVersion = snapshotManager.loadLatestSnapshot().version
     range match {
       case vr: VersionRange =>
         val rawStart = vr.startingVersion().toLong

--- a/spark-unified/src/main/scala/org/apache/spark/sql/delta/v2/interop/DeltaV2OptimisticTransaction.scala
+++ b/spark-unified/src/main/scala/org/apache/spark/sql/delta/v2/interop/DeltaV2OptimisticTransaction.scala
@@ -170,7 +170,7 @@ private[v2] class DeltaV2OptimisticTransaction(
       kernelPostCommitSnapshot.getVersion >= committedVersion,
       s"Kernel reload returned version ${kernelPostCommitSnapshot.getVersion}, older than the " +
         s"just-committed version $committedVersion")
-    new DeltaV2Snapshot(kernelPostCommitSnapshot, spark, kernelEngine)
+    new DeltaV2Snapshot(kernelPostCommitSnapshot)
   }
 
   /**

--- a/spark-unified/src/test/scala-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaV2ChangelogCatalogIntegrationTest.java
+++ b/spark-unified/src/test/scala-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaV2ChangelogCatalogIntegrationTest.java
@@ -108,7 +108,7 @@ class DeltaV2ChangelogCatalogIntegrationTest extends DeltaV2ChangelogTestBase {
     // runs in. tableLocation is resolved by withHistoryTable before STRICT is set.
     DeltaV2SnapshotManager snapshotManager =
         SnapshotManagerFactory.create(tableLocation, defaultEngine, Optional.empty());
-    long millis = snapshotManager.loadSnapshotAt(version).getTimestamp(defaultEngine);
+    long millis = snapshotManager.loadSnapshotAt(version).timestamp();
     return new java.sql.Timestamp(millis);
   }
 

--- a/spark-unified/src/test/scala-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaV2ChangelogDirectBatchExecutionTest.java
+++ b/spark-unified/src/test/scala-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaV2ChangelogDirectBatchExecutionTest.java
@@ -79,7 +79,7 @@ class DeltaV2ChangelogDirectBatchExecutionTest extends DeltaV2ChangelogTestBase 
           DeltaV2SnapshotManager snapshotManager =
               SnapshotManagerFactory.create(tablePath, defaultEngine, Optional.empty());
           StructType dataSchema = spark.table(tableName).schema();
-          long latestVersion = snapshotManager.loadLatestSnapshot().getVersion();
+          long latestVersion = snapshotManager.loadLatestSnapshot().version();
           Map<Long, Long> commitTimestampsMicros = loadCommitTimestampsMicros(tableName);
 
           DeltaV2Changelog changeLog =
@@ -151,7 +151,7 @@ class DeltaV2ChangelogDirectBatchExecutionTest extends DeltaV2ChangelogTestBase 
           DeltaV2SnapshotManager snapshotManager =
               SnapshotManagerFactory.create(tablePath, defaultEngine, Optional.empty());
           StructType dataSchema = spark.table(tableName).schema();
-          long latestVersion = snapshotManager.loadLatestSnapshot().getVersion();
+          long latestVersion = snapshotManager.loadLatestSnapshot().version();
 
           DeltaV2Changelog changeLog =
               new DeltaV2Changelog(
@@ -202,7 +202,7 @@ class DeltaV2ChangelogDirectBatchExecutionTest extends DeltaV2ChangelogTestBase 
           DeltaV2SnapshotManager snapshotManager =
               SnapshotManagerFactory.create(tablePath, defaultEngine, Optional.empty());
           StructType dataSchema = spark.table(tableName).schema();
-          long latestVersion = snapshotManager.loadLatestSnapshot().getVersion();
+          long latestVersion = snapshotManager.loadLatestSnapshot().version();
           Map<Long, Long> commitTimestampsMicros = loadCommitTimestampsMicros(tableName);
 
           DeltaV2Changelog changeLog =
@@ -343,7 +343,7 @@ class DeltaV2ChangelogDirectBatchExecutionTest extends DeltaV2ChangelogTestBase 
 
           DeltaV2SnapshotManager snapshotManager =
               SnapshotManagerFactory.create(tablePath, defaultEngine, Optional.empty());
-          long latestVersion = snapshotManager.loadLatestSnapshot().getVersion();
+          long latestVersion = snapshotManager.loadLatestSnapshot().version();
           Map<Long, Long> commitTimestampsMicros = loadCommitTimestampsMicros(tableName);
 
           DeltaV2Changelog changelog =
@@ -408,7 +408,7 @@ class DeltaV2ChangelogDirectBatchExecutionTest extends DeltaV2ChangelogTestBase 
 
           DeltaV2SnapshotManager snapshotManager =
               SnapshotManagerFactory.create(tablePath, defaultEngine, Optional.empty());
-          long latestVersion = snapshotManager.loadLatestSnapshot().getVersion();
+          long latestVersion = snapshotManager.loadLatestSnapshot().version();
           Map<Long, Long> commitTimestampsMicros = loadCommitTimestampsMicros(tableName);
 
           DeltaV2Changelog changelog =

--- a/spark-unified/src/test/scala/io/delta/internal/ApplyV2ReadOptionsSuite.scala
+++ b/spark-unified/src/test/scala/io/delta/internal/ApplyV2ReadOptionsSuite.scala
@@ -21,14 +21,9 @@ import java.util.{HashMap => JHashMap}
 
 import scala.jdk.CollectionConverters._
 
-import io.delta.kernel.internal.SnapshotImpl
-import io.delta.spark.internal.v2.catalog.DeltaV2Table
-import io.delta.spark.internal.v2.snapshot.PathBasedSnapshotManager
-import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorClient
 import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTable, CatalogTableType}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
-import org.apache.spark.sql.catalyst.catalog.CatalogTable
-import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTableType}
 import org.apache.spark.sql.catalyst.streaming.StreamingRelationV2
 import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
 import org.apache.spark.sql.delta.{DeltaLog, DeltaOptions}
@@ -37,10 +32,14 @@ import org.apache.spark.sql.delta.test.shims.StreamingRelationV2Shim
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
 import org.apache.spark.sql.delta.sources.{DeltaSourceMetadataTrackingLog, DeltaSourceUtils, DeltaSQLConf, PersistedMetadata}
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
-import org.apache.spark.sql.execution.datasources.DataSource
-import org.apache.spark.sql.connector.catalog.Identifier
-import org.apache.spark.sql.types.{StringType, StructType}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
+import io.delta.spark.internal.v2.catalog.DeltaV2Table
+import io.delta.spark.internal.v2.snapshot.PathBasedSnapshotManager
+import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorClient
+
+import org.apache.spark.sql.connector.catalog.Identifier
+import org.apache.spark.sql.execution.datasources.DataSource
+import org.apache.spark.sql.types.{StringType, StructType}
 
 class ApplyV2ReadOptionsSuite extends DeltaSQLCommandTest {
 
@@ -272,8 +271,7 @@ class ApplyV2ReadOptionsSuite extends DeltaSQLCommandTest {
     val deltaLog = DeltaLog.forTable(spark, tablePath)
     val snapshotManager =
       new PathBasedSnapshotManager(tablePath, deltaLog.newDeltaHadoopConf())
-    val tableId =
-      snapshotManager.loadLatestSnapshot.asInstanceOf[SnapshotImpl].getMetadata.getId
+    val tableId = snapshotManager.loadLatestSnapshot.metadata.getId
     val trackingLog = DeltaSourceMetadataTrackingLog.create(
       spark, schemaLogPath, tableId, tablePath, parameters = Map.empty[String, String])
     val customSchemaJson =

--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/v2/interop/DeltaV2OptimisticTransactionSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/v2/interop/DeltaV2OptimisticTransactionSuite.scala
@@ -57,7 +57,7 @@ class DeltaV2OptimisticTransactionSuite
       .forPath(engine, dir.getCanonicalPath)
       .getLatestSnapshot(engine)
       .asInstanceOf[SnapshotImpl]
-    val deltaV2Snapshot = new DeltaV2Snapshot(kernelSnap, spark, engine)
+    val deltaV2Snapshot = new DeltaV2Snapshot(kernelSnap)
     new DeltaV2OptimisticTransaction(catalogTable = None, deltaV2Snapshot, engine)
   }
 
@@ -69,7 +69,7 @@ class DeltaV2OptimisticTransactionSuite
       .forPath(engine, dir.getCanonicalPath)
       .getLatestSnapshot(engine)
       .asInstanceOf[SnapshotImpl]
-    new DeltaV2Snapshot(kernelSnap, spark, engine)
+    new DeltaV2Snapshot(kernelSnap)
   }
 
   /** Seeds a simple (unpartitioned) V1 Delta table at `dir`. */

--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/v2/interop/DeltaV2SnapshotSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/v2/interop/DeltaV2SnapshotSuite.scala
@@ -21,9 +21,9 @@ import org.apache.spark.sql.delta.actions.DomainMetadata
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.stats.FileSizeHistogramUtils
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import io.delta.spark.internal.v2.kernel.KernelEngineFactory
 import org.apache.hadoop.fs.Path
 import io.delta.kernel.TableManager
-import io.delta.kernel.defaults.engine.DefaultEngine
 import io.delta.kernel.engine.Engine
 import io.delta.kernel.internal.{SnapshotImpl => KernelSnapshot}
 
@@ -37,7 +37,8 @@ class DeltaV2SnapshotSuite extends DeltaSQLCommandTest {
 
   // scalastyle:off deltahadoopconfiguration
   // No DeltaLog in this test (the snapshot is loaded via Kernel), so use the session Hadoop conf.
-  private def engine: Engine = DefaultEngine.create(spark.sessionState.newHadoopConf())
+  private def engine: Engine =
+    KernelEngineFactory.createDefaultEngine(spark.sessionState.newHadoopConf())
   // scalastyle:on deltahadoopconfiguration
 
   /** Load the latest snapshot of the Delta table at `path` via Kernel. */
@@ -50,7 +51,7 @@ class DeltaV2SnapshotSuite extends DeltaSQLCommandTest {
       spark.range(5).write.format("delta").save(path) // version 0
 
       val kernelSnapshot0 = loadKernelSnapshot(path)
-      val snapshot0 = new DeltaV2Snapshot(kernelSnapshot0, spark)
+      val snapshot0 = new DeltaV2Snapshot(kernelSnapshot0)
       assert(snapshot0.version === kernelSnapshot0.getVersion)
       assert(snapshot0.version === 0L)
       assert(snapshot0.path === new Path(kernelSnapshot0.getDataPath.toString))
@@ -60,7 +61,7 @@ class DeltaV2SnapshotSuite extends DeltaSQLCommandTest {
       spark.range(1).write.format("delta").mode("append").save(path) // version 2
 
       val kernelSnapshot2 = loadKernelSnapshot(path)
-      val snapshot2 = new DeltaV2Snapshot(kernelSnapshot2, spark)
+      val snapshot2 = new DeltaV2Snapshot(kernelSnapshot2)
       assert(snapshot2.version === 2L)
       assert(snapshot2.version === kernelSnapshot2.getVersion)
     }
@@ -72,7 +73,7 @@ class DeltaV2SnapshotSuite extends DeltaSQLCommandTest {
    */
   private def assertMatchesV1(path: String): Unit = {
     val v1 = DeltaLog.forTable(spark, path).update()
-    val v2 = new DeltaV2Snapshot(loadKernelSnapshot(path), spark)
+    val v2 = new DeltaV2Snapshot(loadKernelSnapshot(path))
 
     assert(v2.version === v1.version)
     assert(v2.metadata.id === v1.metadata.id)
@@ -159,7 +160,7 @@ class DeltaV2SnapshotSuite extends DeltaSQLCommandTest {
       val path = dir.getCanonicalPath
       spark.range(1).write.format("delta").save(path)
 
-      val snapshot = new DeltaV2Snapshot(loadKernelSnapshot(path), spark)
+      val snapshot = new DeltaV2Snapshot(loadKernelSnapshot(path))
 
       // These still fail loudly so an unmigrated caller cannot silently read empty V1 state.
       intercept[UnsupportedOperationException](snapshot.stateDF)
@@ -186,7 +187,7 @@ class DeltaV2SnapshotSuite extends DeltaSQLCommandTest {
         DomainMetadata("test.userDomain", """{"key":"value"}""", removed = false) :: Nil,
         DeltaOperations.ManualUpdate)
 
-      val snapshot = new DeltaV2Snapshot(loadKernelSnapshot(path), spark)
+      val snapshot = new DeltaV2Snapshot(loadKernelSnapshot(path))
 
       val userDomain = snapshot.domainMetadata.find(_.domain == "test.userDomain")
         .getOrElse(fail("expected the test.userDomain domain"))
@@ -205,7 +206,7 @@ class DeltaV2SnapshotSuite extends DeltaSQLCommandTest {
       spark.range(0, 5).write.format("delta").mode("append").save(path)
       val kernelSnapshot = loadKernelSnapshot(path)
       assert(kernelSnapshot.getCurrentCrcInfo.get().getFileSizeHistogram.isPresent)
-      val snapshot = new DeltaV2Snapshot(kernelSnapshot, spark)
+      val snapshot = new DeltaV2Snapshot(kernelSnapshot)
 
       assert(snapshot.fileSizeHistogram.nonEmpty)
       assert(
@@ -226,7 +227,7 @@ class DeltaV2SnapshotSuite extends DeltaSQLCommandTest {
       withSQLConf(DeltaSQLConf.DELTA_WRITE_CHECKSUM_ENABLED.key -> "false") {
         spark.range(0, 1000).write.format("delta").save(path)
       }
-      val snapshot = new DeltaV2Snapshot(loadKernelSnapshot(path), spark)
+      val snapshot = new DeltaV2Snapshot(loadKernelSnapshot(path))
       assert(snapshot.fileSizeHistogram.isEmpty)
     }
   }
@@ -239,7 +240,7 @@ class DeltaV2SnapshotSuite extends DeltaSQLCommandTest {
       val kernelSnapshot = loadKernelSnapshot(path)
       assert(kernelSnapshot.getCurrentCrcInfo.isPresent)
 
-      val snapshot = new DeltaV2Snapshot(kernelSnapshot, spark)
+      val snapshot = new DeltaV2Snapshot(kernelSnapshot)
       assert(snapshot.sizeInBytesIfKnown.nonEmpty)
       assert(
         snapshot.sizeInBytes === snapshot.allFiles.collect().map(_.size).sum
@@ -254,7 +255,7 @@ class DeltaV2SnapshotSuite extends DeltaSQLCommandTest {
         spark.range(0, 1000).write.format("delta").save(path)
       }
 
-      val snapshot = new DeltaV2Snapshot(loadKernelSnapshot(path), spark)
+      val snapshot = new DeltaV2Snapshot(loadKernelSnapshot(path))
       assert(snapshot.sizeInBytesIfKnown.isEmpty)
       assert(snapshot.sizeInBytes === -1L)
     }
@@ -266,7 +267,7 @@ class DeltaV2SnapshotSuite extends DeltaSQLCommandTest {
       spark.range(5).write.format("delta").save(path)
 
       withSQLConf(DeltaSQLConf.DELTA_FILE_SIZE_HISTOGRAM_ENABLED.key -> "false") {
-        assert(new DeltaV2Snapshot(loadKernelSnapshot(path), spark).fileSizeHistogram.isEmpty)
+        assert(new DeltaV2Snapshot(loadKernelSnapshot(path)).fileSizeHistogram.isEmpty)
       }
     }
   }
@@ -276,9 +277,55 @@ class DeltaV2SnapshotSuite extends DeltaSQLCommandTest {
       val path = dir.getCanonicalPath
       spark.range(1).write.format("delta").save(path)
 
-      val snapshot = new DeltaV2Snapshot(loadKernelSnapshot(path), spark)
+      val snapshot = new DeltaV2Snapshot(loadKernelSnapshot(path))
       assert(snapshot.domainMetadata.isEmpty)
     }
+  }
+
+  test("allFiles uses the active Spark session instead of storing a construction session") {
+    withTempDir { dir =>
+      val path = dir.getCanonicalPath
+      spark.range(1).write.format("delta").save(path)
+      val snapshot = new DeltaV2Snapshot(loadKernelSnapshot(path))
+      val activeSession = spark.newSession()
+
+      activeSession.withActive {
+        assert(snapshot.allFiles.sparkSession eq activeSession)
+        assert(snapshot.allFiles.count() === 1L)
+      }
+    }
+  }
+
+  test("getKernelSnapshot returns the wrapped Kernel snapshot") {
+    withTempDir { dir =>
+      val path = dir.getCanonicalPath
+      spark.range(1).write.format("delta").save(path)
+      val kernelSnapshot = loadKernelSnapshot(path)
+      val snapshot = new DeltaV2Snapshot(kernelSnapshot)
+
+      assert(DeltaV2Snapshot.getKernelSnapshot(snapshot) eq kernelSnapshot)
+    }
+  }
+
+  test("getKernelSnapshot rejects a non-Kernel-backed V1 snapshot") {
+    withTempDir { dir =>
+      val path = dir.getCanonicalPath
+      spark.range(1).write.format("delta").save(path)
+      val snapshot = DeltaLog.forTable(spark, path).update()
+
+      val error = intercept[IllegalStateException] {
+        DeltaV2Snapshot.getKernelSnapshot(snapshot)
+      }
+      assert(error.getMessage.contains("Expected a DeltaV2Snapshot"))
+      assert(error.getMessage.contains(snapshot.getClass.getName))
+    }
+  }
+
+  test("getKernelSnapshot rejects null") {
+    val error = intercept[NullPointerException] {
+      DeltaV2Snapshot.getKernelSnapshot(null)
+    }
+    assert(error.getMessage === "snapshot is null")
   }
 
 }

--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/v2/interop/KernelSnapshotUtilsSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/v2/interop/KernelSnapshotUtilsSuite.scala
@@ -171,7 +171,7 @@ class KernelSnapshotUtilsSuite extends DeltaSQLCommandTest {
         KernelSnapshotUtils.buildAllFiles(kernelSnapshot, spark, kernelEngine).collect()
       assert(kernelFiles.find(_.path == taggedPath).map(_.tags).contains(expectedTags))
 
-      val snapshot = new DeltaV2Snapshot(kernelSnapshot, spark)
+      val snapshot = new DeltaV2Snapshot(kernelSnapshot)
       val selectedFiles = snapshot.filesForScan(Nil).files
       assert(selectedFiles.find(_.path == taggedPath).map(_.tags).contains(expectedTags))
     }

--- a/spark/v2/src/main/java-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaV2Changelog.java
+++ b/spark/v2/src/main/java-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaV2Changelog.java
@@ -1,6 +1,6 @@
 package io.delta.spark.internal.v2.read.changelog;
 
-import io.delta.kernel.Snapshot;
+import org.apache.spark.sql.delta.Snapshot;
 import io.delta.spark.internal.v2.catalog.DeltaV2Table;
 import io.delta.spark.internal.v2.shims.CatalogV2UtilShims;
 import io.delta.spark.internal.v2.utils.SchemaUtils;
@@ -63,7 +63,7 @@ public class DeltaV2Changelog implements Changelog {
     // Resolve lazily so catalog construction stays side-effect free. The scan path validates
     // each per-commit Metadata against this same end-version schema.
     Snapshot endSnapshot = deltaV2Table.getSnapshotManager().loadSnapshotAt(endVersion);
-    StructType endSchema = SchemaUtils.convertKernelSchemaToSparkSchema(endSnapshot.getSchema());
+    StructType endSchema = endSnapshot.schema();
     StructType cdcSchema =
         endSchema
             .add(METADATA_COLUMN, METADATA_STRUCT, false)

--- a/spark/v2/src/main/java-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaV2ChangelogScanBuilder.java
+++ b/spark/v2/src/main/java-shims/spark-4.2/io/delta/spark/internal/v2/read/changelog/DeltaV2ChangelogScanBuilder.java
@@ -1,12 +1,13 @@
 package io.delta.spark.internal.v2.read.changelog;
 
 import io.delta.kernel.CommitRange;
-import io.delta.kernel.Snapshot;
+import org.apache.spark.sql.delta.Snapshot;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.internal.SnapshotImpl;
-import io.delta.kernel.internal.rowtracking.RowTracking;
+import org.apache.spark.sql.delta.RowTracking$;
 import io.delta.spark.internal.v2.catalog.DeltaV2Table;
 import io.delta.spark.internal.v2.kernel.KernelEngineFactory;
+import org.apache.spark.sql.delta.v2.interop.DeltaV2Snapshot$;
 import org.apache.spark.sql.delta.v2.interop.DeltaV2SnapshotManager;
 import io.delta.spark.internal.v2.utils.SchemaUtils;
 import java.util.Objects;
@@ -63,14 +64,13 @@ class DeltaV2ChangelogScanBuilder implements ScanBuilder {
     // but the start does not, the toggle happened within the range -- emit
     // DELTA_CHANGELOG_ROW_TRACKING_DISABLED_IN_RANGE with the offending start version.
     Snapshot startSnapshot = snapshotManager.loadSnapshotAt(startVersion);
-    SnapshotImpl startSnapshotImpl = (SnapshotImpl) startSnapshot;
+    SnapshotImpl startSnapshotImpl = DeltaV2Snapshot$.MODULE$.getKernelSnapshot(startSnapshot);
     Snapshot endSnapshot = snapshotManager.loadSnapshotAt(endVersion);
-    SnapshotImpl endSnapshotImpl = (SnapshotImpl) endSnapshot;
-    StructType endSchema = SchemaUtils.convertKernelSchemaToSparkSchema(endSnapshot.getSchema());
-    if (!RowTracking.isEnabled(endSnapshotImpl.getProtocol(), endSnapshotImpl.getMetadata())) {
+    StructType endSchema = endSnapshot.schema();
+    if (!RowTracking$.MODULE$.isEnabled(endSnapshot.protocol(), endSnapshot.metadata())) {
       DeltaErrors.throwChangelogRequiresRowTracking(deltaV2Table.name());
     }
-    if (!RowTracking.isEnabled(startSnapshotImpl.getProtocol(), startSnapshotImpl.getMetadata())) {
+    if (!RowTracking$.MODULE$.isEnabled(startSnapshot.protocol(), startSnapshot.metadata())) {
       DeltaErrors.throwChangelogRowTrackingDisabledInRange(startVersion);
     }
 
@@ -85,7 +85,7 @@ class DeltaV2ChangelogScanBuilder implements ScanBuilder {
         commitRange,
         engine,
         endSchema,
-        startSnapshot,
+        startSnapshotImpl,
         startVersion,
         endVersion,
         hadoopConf);

--- a/spark/v2/src/main/java-shims/spark-4.2/io/delta/spark/internal/v2/write/DeltaMetadataOnlyDeleteExecutor.java
+++ b/spark/v2/src/main/java-shims/spark-4.2/io/delta/spark/internal/v2/write/DeltaMetadataOnlyDeleteExecutor.java
@@ -41,7 +41,6 @@ import io.delta.spark.internal.v2.utils.SchemaUtils;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.catalog.CatalogTable;
 import org.apache.spark.sql.catalyst.expressions.Expression;
 import org.apache.spark.sql.catalyst.expressions.V2ExpressionUtils;
@@ -92,7 +91,7 @@ public final class DeltaMetadataOnlyDeleteExecutor {
       Optional<CatalogTable> catalogTable,
       Predicate[] predicates) {
     DeltaV2Snapshot snapshot =
-        new DeltaV2Snapshot(initialSnapshot, SparkSession.active(), engine);
+        new DeltaV2Snapshot(initialSnapshot);
 
     List<Expression> catalystFilters = new ArrayList<>(predicates.length);
     for (Predicate predicate : predicates) {

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
@@ -20,13 +20,9 @@ import static io.delta.spark.internal.v2.utils.ScalaUtils.toScalaMap;
 import static io.delta.spark.internal.v2.utils.StatsUtils.toV2Statistics;
 import static java.util.Objects.requireNonNull;
 
-import io.delta.kernel.Snapshot;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.internal.DeltaHistoryManager;
 import io.delta.kernel.internal.SnapshotImpl;
-import io.delta.kernel.internal.rowtracking.RowTracking;
-import io.delta.spark.internal.v2.adapters.KernelMetadataAdapter;
-import io.delta.spark.internal.v2.adapters.KernelProtocolAdapter;
 import io.delta.spark.internal.v2.exception.NoRecreatableHistoryException;
 import io.delta.spark.internal.v2.exception.TableNotFoundException;
 import io.delta.spark.internal.v2.exception.TimestampOutOfRangeException;
@@ -36,7 +32,6 @@ import io.delta.spark.internal.v2.read.MetadataEvolutionHandler;
 import io.delta.spark.internal.v2.read.cdc.CDCSchemaContext;
 import io.delta.spark.internal.v2.shims.CatalogV2UtilShims;
 import io.delta.spark.internal.v2.snapshot.SnapshotManagerFactory;
-import io.delta.spark.internal.v2.utils.SchemaUtils;
 import io.delta.spark.internal.v2.write.DeltaRowLevelOperationBuilder;
 import io.delta.spark.internal.v2.write.DeltaV2WriteBuilder;
 import java.util.ArrayList;
@@ -75,11 +70,14 @@ import org.apache.spark.sql.connector.write.WriteBuilder;
 import org.apache.spark.sql.delta.DeltaTableUtils;
 import org.apache.spark.sql.delta.RowCommitVersion$;
 import org.apache.spark.sql.delta.RowId$;
+import org.apache.spark.sql.delta.RowTracking$;
+import org.apache.spark.sql.delta.Snapshot;
 import org.apache.spark.sql.delta.catalog.DeltaV2TableMarker;
 import org.apache.spark.sql.delta.commands.cdc.CDCReader;
 import org.apache.spark.sql.delta.sources.PersistedMetadata;
 import org.apache.spark.sql.delta.v2.interop.AbstractMetadata;
 import org.apache.spark.sql.delta.v2.interop.AbstractProtocol;
+import org.apache.spark.sql.delta.v2.interop.DeltaV2Snapshot$;
 import org.apache.spark.sql.delta.v2.interop.DeltaV2SnapshotManager;
 import org.apache.spark.sql.execution.datasources.FileFormat$;
 import org.apache.spark.sql.types.DataType;
@@ -255,14 +253,10 @@ public class DeltaV2Table extends DeltaV2TableLogging
     this.kernelEngine = KernelEngineFactory.createDefaultEngine(this.hadoopConf);
     this.snapshotManager = SnapshotManagerFactory.create(tablePath, kernelEngine, catalogTable);
     try {
-      if (timeTravelVersion.isPresent()) {
-        this.initialSnapshot =
-            loadSnapshotAtCheckedVersion(snapshotManager, timeTravelVersion.getAsLong());
-      } else {
-        this.initialSnapshot =
-            recordFrameProfileValue(
-                "Delta", "DeltaV2.snapshot.loadLatest", snapshotManager::loadLatestSnapshot);
-      }
+      this.initialSnapshot =
+          timeTravelVersion.isPresent()
+              ? loadSnapshotAtCheckedVersion(snapshotManager, timeTravelVersion.getAsLong())
+              : snapshotManager.loadLatestSnapshot();
     } catch (io.delta.kernel.exceptions.TableNotFoundException e) {
       // Rethrow as the Delta-module wrapper so catalog/interop layer never names a Kernel type.
       throw new TableNotFoundException(tablePath);
@@ -280,11 +274,7 @@ public class DeltaV2Table extends DeltaV2TableLogging
 
     Optional<PersistedMetadata> persistedMetadata =
         MetadataEvolutionHandler.getPersistedMetadataForMicroBatchStream(
-            SparkSession.active(),
-            (SnapshotImpl) initialSnapshot,
-            options,
-            snapshotManager,
-            kernelEngine);
+            SparkSession.active(), initialSnapshot, options, snapshotManager, kernelEngine);
 
     StructType rawSchema;
     List<String> partitionColumnNames;
@@ -293,8 +283,8 @@ public class DeltaV2Table extends DeltaV2TableLogging
       rawSchema = persisted.dataSchema();
       partitionColumnNames = Arrays.asList(persisted.partitionSchema().fieldNames());
     } else {
-      rawSchema = SchemaUtils.convertKernelSchemaToSparkSchema(initialSnapshot.getSchema());
-      partitionColumnNames = new ArrayList<>(initialSnapshot.getPartitionColumnNames());
+      rawSchema = initialSnapshot.schema();
+      partitionColumnNames = new ArrayList<>(initialSnapshot.metadata().getPartitionColumns());
     }
     // Schema-related metadata is lazily computed on first access within SchemaProvider
     this.schemaProvider =
@@ -366,12 +356,12 @@ public class DeltaV2Table extends DeltaV2TableLogging
 
   /** The table protocol from the initial snapshot. */
   protected AbstractProtocol protocol() {
-    return new KernelProtocolAdapter(((SnapshotImpl) initialSnapshot).getProtocol());
+    return initialSnapshot.protocol();
   }
 
   /** The table metadata from the initial snapshot. */
   protected AbstractMetadata metadata() {
-    return new KernelMetadataAdapter(((SnapshotImpl) initialSnapshot).getMetadata());
+    return initialSnapshot.metadata();
   }
 
   /** Inputs exposed to the Spark-version shim for metadata-only DELETE. */
@@ -380,7 +370,7 @@ public class DeltaV2Table extends DeltaV2TableLogging
   }
 
   protected SnapshotImpl initialSnapshot() {
-    return (SnapshotImpl) initialSnapshot;
+    return DeltaV2Snapshot$.MODULE$.getKernelSnapshot(initialSnapshot);
   }
 
   protected Optional<CatalogTable> catalogTable() {
@@ -415,7 +405,7 @@ public class DeltaV2Table extends DeltaV2TableLogging
             /* canReturnLastCommit = */ true,
             /* mustBeRecreatable = */ true,
             /* canReturnEarliestCommit = */ true);
-    long latestVersion = manager.loadLatestSnapshot().getVersion();
+    long latestVersion = manager.loadLatestSnapshot().version();
     if (commit.getTimestamp() > timeMillis) {
       // The earliest available commit is younger than the requested time.
       throw new TimestampOutOfRangeException(timeMillis, commit.getTimestamp(), false);
@@ -460,7 +450,7 @@ public class DeltaV2Table extends DeltaV2TableLogging
 
   @Override
   public Map<String, String> properties() {
-    Map<String, String> props = new HashMap<>(initialSnapshot.getTableProperties());
+    Map<String, String> props = new HashMap<>(initialSnapshot.metadata().getConfiguration());
     return Collections.unmodifiableMap(props);
   }
 
@@ -477,7 +467,7 @@ public class DeltaV2Table extends DeltaV2TableLogging
    * <p>Add {@code @Override} annotation eventually: TODO(#7128)
    */
   public String version() {
-    return Long.toString(initialSnapshot.getVersion());
+    return Long.toString(initialSnapshot.version());
   }
 
   /**
@@ -497,9 +487,8 @@ public class DeltaV2Table extends DeltaV2TableLogging
    */
   @Override
   public MetadataColumn[] metadataColumns() {
-    SnapshotImpl snapshotImpl = (SnapshotImpl) initialSnapshot;
     boolean rowTrackingEnabled =
-        RowTracking.isEnabled(snapshotImpl.getProtocol(), snapshotImpl.getMetadata());
+        RowTracking$.MODULE$.isEnabled(initialSnapshot.protocol(), initialSnapshot.metadata());
 
     StructType metadataType = new StructType();
     for (StructField field :
@@ -595,7 +584,12 @@ public class DeltaV2Table extends DeltaV2TableLogging
   @Override
   public RowLevelOperationBuilder newRowLevelOperationBuilder(RowLevelOperationInfo info) {
     requireNonNull(info, "row-level operation info is null");
-    return new DeltaRowLevelOperationBuilder(this, kernelEngine, hadoopConf, initialSnapshot, info);
+    return new DeltaRowLevelOperationBuilder(
+        this,
+        kernelEngine,
+        hadoopConf,
+        DeltaV2Snapshot$.MODULE$.getKernelSnapshot(initialSnapshot),
+        info);
   }
 
   @Override
@@ -616,8 +610,11 @@ public class DeltaV2Table extends DeltaV2TableLogging
         && Objects.equals(tablePath, that.tablePath)
         && Objects.equals(options, that.options)
         && Objects.equals(catalogTable, that.catalogTable)
-        && Objects.equals(initialSnapshot.getPath(), that.initialSnapshot.getPath())
-        && initialSnapshot.getVersion() == that.initialSnapshot.getVersion();
+        && Objects.equals(
+            initialSnapshot.dataPath().toString(), that.initialSnapshot.dataPath().toString())
+        && initialSnapshot.version() == that.initialSnapshot.version()
+        && Objects.equals(
+            initialSnapshot.metadata().getId(), that.initialSnapshot.metadata().getId());
   }
 
   @Override
@@ -627,8 +624,9 @@ public class DeltaV2Table extends DeltaV2TableLogging
         tablePath,
         options,
         catalogTable,
-        initialSnapshot.getPath(),
-        initialSnapshot.getVersion());
+        initialSnapshot.dataPath().toString(),
+        initialSnapshot.version(),
+        initialSnapshot.metadata().getId());
   }
 
   /**

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2MicroBatchStream.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2MicroBatchStream.java
@@ -23,7 +23,6 @@ import com.google.common.collect.ImmutableSet;
 import io.delta.kernel.CommitActions;
 import io.delta.kernel.CommitRange;
 import io.delta.kernel.Scan;
-import io.delta.kernel.Snapshot;
 import io.delta.kernel.data.ColumnarBatch;
 import io.delta.kernel.data.FilteredColumnarBatch;
 import io.delta.kernel.engine.Engine;
@@ -75,6 +74,7 @@ import org.apache.spark.sql.delta.DeltaErrors;
 import org.apache.spark.sql.delta.DeltaOptions;
 import org.apache.spark.sql.delta.DeltaStartingVersion;
 import org.apache.spark.sql.delta.DeltaTimeTravelSpec;
+import org.apache.spark.sql.delta.Snapshot;
 import org.apache.spark.sql.delta.StartingVersion;
 import org.apache.spark.sql.delta.StartingVersionLatest$;
 import org.apache.spark.sql.delta.TypeWidening;
@@ -87,6 +87,7 @@ import org.apache.spark.sql.delta.sources.DeltaSourceOffset$;
 import org.apache.spark.sql.delta.sources.DeltaStreamUtils;
 import org.apache.spark.sql.delta.sources.PersistedMetadata;
 import org.apache.spark.sql.delta.v2.CDCDeletionVectorHelper;
+import org.apache.spark.sql.delta.v2.interop.DeltaV2Snapshot$;
 import org.apache.spark.sql.delta.v2.interop.DeltaV2SnapshotManager;
 import org.apache.spark.sql.execution.datasources.PartitionedFile;
 import org.apache.spark.sql.functions;
@@ -273,7 +274,7 @@ class DeltaV2MicroBatchStream
     this.sqlConf = SQLConf.get();
     this.scalaOptions = Objects.requireNonNull(scalaOptions, "scalaOptions is null");
 
-    this.snapshotAtSourceInit = (SnapshotImpl) snapshotAtSourceInit;
+    this.snapshotAtSourceInit = DeltaV2Snapshot$.MODULE$.getKernelSnapshot(snapshotAtSourceInit);
     this.tableId = this.snapshotAtSourceInit.getMetadata().getId();
 
     // The effective snapshot for reading, mirroring v1's readSnapshotDescriptor. When schema
@@ -809,7 +810,7 @@ class DeltaV2MicroBatchStream
       if (startingVersion instanceof StartingVersionLatest$) {
         Snapshot latestSnapshot = snapshotManager.loadLatestSnapshot();
         // "latest": start reading from the next commit
-        cachedStartingVersion = Optional.of(latestSnapshot.getVersion() + 1);
+        cachedStartingVersion = Optional.of(latestSnapshot.version() + 1);
         return cachedStartingVersion;
       } else if (startingVersion instanceof StartingVersion) {
         long version = ((StartingVersion) startingVersion).version();
@@ -865,7 +866,7 @@ class DeltaV2MicroBatchStream
             /* canReturnLastCommit= */ true,
             /* mustBeRecreatable= */ false,
             /* canReturnEarliestCommit= */ true);
-    long latestVersion = snapshotManager.loadLatestSnapshot().getVersion();
+    long latestVersion = snapshotManager.loadLatestSnapshot().version();
     long startingVersion =
         DeltaStreamUtils.getStartingVersionFromCommitAtTimestamp(
             /* timeZone= */ spark.sessionState().conf().sessionLocalTimeZone(),
@@ -1130,7 +1131,9 @@ class DeltaV2MicroBatchStream
       startSnapshot = snapshotAtSourceInit;
     } else {
       try {
-        startSnapshot = (SnapshotImpl) snapshotManager.loadSnapshotAt(startVersion);
+        startSnapshot =
+            DeltaV2Snapshot$.MODULE$.getKernelSnapshot(
+                snapshotManager.loadSnapshotAt(startVersion));
       } catch (io.delta.kernel.exceptions.KernelException e) {
         // startVersion may not yet exist (e.g. startingVersion=latest resolves to latest+1).
         // TODO(#6745): narrow this catch once kernel exposes a specific exception subclass
@@ -1192,7 +1195,7 @@ class DeltaV2MicroBatchStream
         // 2. buildOffsetFromIndexedFile bumps the version up by one when we hit the END_INDEX.
         // TODO(#5318): consider caching the latest version to avoid loading a new snapshot.
         // TODO(#5318): kernel should ideally relax this constraint.
-        endVersionOpt = Optional.of(snapshotManager.loadLatestSnapshot().getVersion());
+        endVersionOpt = Optional.of(snapshotManager.loadLatestSnapshot().version());
       }
 
       // After capping, check if startVersion is beyond the endVersion.
@@ -1205,7 +1208,7 @@ class DeltaV2MicroBatchStream
       // When endOffset is empty (offset discovery), check if startVersion exceeds the current
       // latest version. We must load the current latest (not snapshotAtSourceInit) because new
       // commits may have arrived since stream initialization.
-      long currentLatestVersion = snapshotManager.loadLatestSnapshot().getVersion();
+      long currentLatestVersion = snapshotManager.loadLatestSnapshot().version();
       if (startVersion > currentLatestVersion) {
         return Utils.toCloseableIterator(Collections.emptyIterator());
       }
@@ -1698,7 +1701,9 @@ class DeltaV2MicroBatchStream
     SnapshotImpl startVersionSnapshot = null;
     Exception err = null;
     try {
-      startVersionSnapshot = (SnapshotImpl) snapshotManager.loadSnapshotAt(batchStartVersion);
+      startVersionSnapshot =
+          DeltaV2Snapshot$.MODULE$.getKernelSnapshot(
+              snapshotManager.loadSnapshotAt(batchStartVersion));
     } catch (Exception e) {
       err = e;
     }
@@ -1870,7 +1875,8 @@ class DeltaV2MicroBatchStream
   private DataFrameSnapshotCache buildDataFrameSnapshotCache(long version) {
     // May differ from snapshotAtSourceInit on checkpoint restart. loadSnapshotAt is
     // metadata-only on driver; log replay runs on executors via ScanFileRDD.
-    SnapshotImpl snapshot = (SnapshotImpl) snapshotManager.loadSnapshotAt(version);
+    SnapshotImpl snapshot =
+        DeltaV2Snapshot$.MODULE$.getKernelSnapshot(snapshotManager.loadSnapshotAt(version));
     SerializableReadOnlySnapshot serSnapshot =
         SerializableReadOnlySnapshot.fromSnapshot(snapshot, hadoopConf);
 
@@ -1951,7 +1957,8 @@ class DeltaV2MicroBatchStream
 
   /** Loads snapshot files at the specified version. */
   private InitialSnapshotCache loadAndValidateSnapshot(long version) {
-    SnapshotImpl snapshot = (SnapshotImpl) snapshotManager.loadSnapshotAt(version);
+    SnapshotImpl snapshot =
+        DeltaV2Snapshot$.MODULE$.getKernelSnapshot(snapshotManager.loadSnapshotAt(version));
     // If schema tracking is already active and the initial snapshot has advanced since the tracked
     // read snapshot, replace the tracked metadata/protocol before reading snapshot files.
     if (metadataEvolutionHandler.shouldTrackMetadataChange()

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2Scan.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2Scan.java
@@ -17,7 +17,6 @@ package io.delta.spark.internal.v2.read;
 
 import static io.delta.spark.internal.v2.utils.ExpressionUtils.dsv2PredicateToCatalystExpression;
 
-import io.delta.kernel.Snapshot;
 import io.delta.kernel.expressions.Predicate;
 import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.spark.internal.v2.kernel.KernelEngineFactory;
@@ -42,6 +41,7 @@ import org.apache.spark.sql.connector.read.*;
 import org.apache.spark.sql.connector.read.colstats.ColumnStatistics;
 import org.apache.spark.sql.connector.read.streaming.MicroBatchStream;
 import org.apache.spark.sql.delta.DeltaOptions;
+import org.apache.spark.sql.delta.Snapshot;
 import org.apache.spark.sql.delta.sources.DeltaSourceMetadataTrackingLog;
 import org.apache.spark.sql.delta.stats.DeltaScan;
 import org.apache.spark.sql.delta.v2.interop.DeltaV2SnapshotManager;
@@ -63,7 +63,7 @@ import scala.Option;
 class DeltaV2Scan implements Scan, SupportsReportStatistics, SupportsRuntimeV2Filtering {
 
   private final DeltaV2SnapshotManager snapshotManager;
-  private final Snapshot initialSnapshot;
+  private final io.delta.kernel.Snapshot initialSnapshot;
   private final StructType readDataSchema;
   private final StructType dataSchema;
   private final StructType partitionSchema;
@@ -112,7 +112,7 @@ class DeltaV2Scan implements Scan, SupportsReportStatistics, SupportsRuntimeV2Fi
   // TODO(#6743): bundle scan-level schemas into a single ScanSchemaContext.
   public DeltaV2Scan(
       DeltaV2SnapshotManager snapshotManager,
-      Snapshot initialSnapshot,
+      io.delta.kernel.Snapshot initialSnapshot,
       StructType tableSchema,
       StructType dataSchema,
       StructType partitionSchema,
@@ -256,7 +256,7 @@ class DeltaV2Scan implements Scan, SupportsReportStatistics, SupportsRuntimeV2Fi
     Option<DeltaSourceMetadataTrackingLog> metadataTrackingLog =
         MetadataEvolutionHandler.getMetadataTrackingLogForMicroBatchStream(
             spark,
-            (io.delta.kernel.internal.SnapshotImpl) latestSnapshot,
+            latestSnapshot,
             options,
             snapshotManager,
             KernelEngineFactory.createDefaultEngine(hadoopConf),

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2ScanUtils.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2ScanUtils.java
@@ -15,7 +15,6 @@
  */
 package io.delta.spark.internal.v2.read;
 
-import io.delta.kernel.Snapshot;
 import io.delta.kernel.engine.Engine;
 import java.util.Optional;
 import org.apache.spark.sql.catalyst.InternalRow;
@@ -23,6 +22,7 @@ import org.apache.spark.sql.catalyst.catalog.CatalogTable;
 import org.apache.spark.sql.connector.read.PartitionReaderFactory;
 import org.apache.spark.sql.connector.read.ScanBuilder;
 import org.apache.spark.sql.connector.read.Statistics;
+import org.apache.spark.sql.delta.Snapshot;
 import org.apache.spark.sql.delta.v2.interop.DeltaV2SnapshotManager;
 import org.apache.spark.sql.execution.datasources.PartitionedFile;
 import org.apache.spark.sql.types.StructType;

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/MetadataEvolutionHandler.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/MetadataEvolutionHandler.java
@@ -66,6 +66,7 @@ import org.apache.spark.sql.delta.sources.DeltaStreamUtils;
 import org.apache.spark.sql.delta.sources.PersistedMetadata;
 import org.apache.spark.sql.delta.v2.interop.AbstractMetadata;
 import org.apache.spark.sql.delta.v2.interop.AbstractProtocol;
+import org.apache.spark.sql.delta.v2.interop.DeltaV2Snapshot$;
 import org.apache.spark.sql.delta.v2.interop.DeltaV2SnapshotManager;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 import org.slf4j.Logger;
@@ -340,7 +341,9 @@ public class MetadataEvolutionHandler {
       metadata = validated.metadata;
       protocol = validated.protocol;
     } else {
-      SnapshotImpl snapshot = (SnapshotImpl) snapshotManager.loadSnapshotAt(batchStartVersion);
+      SnapshotImpl snapshot =
+          DeltaV2Snapshot$.MODULE$.getKernelSnapshot(
+              snapshotManager.loadSnapshotAt(batchStartVersion));
       version = snapshot.getVersion();
       metadata = snapshot.getMetadata();
       protocol = snapshot.getProtocol();
@@ -425,11 +428,14 @@ public class MetadataEvolutionHandler {
    * <p>V2 port of V1's {@code
    * DeltaSourceMetadataEvolutionSupport.validateAndResolveMetadataForLogInitialization}.
    */
+  // TODO(kernel-table-manager): Remove getKernelSnapshot here once collectMetadataActions
+  // and collectProtocolActions return AbstractMetadata/AbstractProtocol instead of Kernel types.
   private ValidatedMetadataAndProtocol validateAndResolveMetadataForLogInitialization(
       long startVersion, long endVersion) {
     List<Metadata> metadataChanges =
         new ArrayList<>(collectMetadataActions(startVersion, endVersion).values());
-    SnapshotImpl startSnapshot = (SnapshotImpl) snapshotManager.loadSnapshotAt(startVersion);
+    SnapshotImpl startSnapshot =
+        DeltaV2Snapshot$.MODULE$.getKernelSnapshot(snapshotManager.loadSnapshotAt(startVersion));
     Metadata startMetadata = startSnapshot.getMetadata();
 
     // Try to find rename or drop columns in between, or nullability/datatype changes by using
@@ -510,7 +516,7 @@ public class MetadataEvolutionHandler {
    */
   public static Optional<PersistedMetadata> getPersistedMetadataForMicroBatchStream(
       SparkSession spark,
-      SnapshotImpl snapshot,
+      org.apache.spark.sql.delta.Snapshot snapshot,
       Map<String, String> options,
       DeltaV2SnapshotManager snapshotManager,
       Engine engine) {
@@ -663,7 +669,7 @@ public class MetadataEvolutionHandler {
    */
   public static Option<DeltaSourceMetadataTrackingLog> getMetadataTrackingLogForMicroBatchStream(
       SparkSession spark,
-      SnapshotImpl snapshot,
+      org.apache.spark.sql.delta.Snapshot snapshot,
       Map<String, String> options,
       DeltaV2SnapshotManager snapshotManager,
       Engine engine,
@@ -685,12 +691,12 @@ public class MetadataEvolutionHandler {
           "Schema tracking location is not supported for Delta streaming source");
     }
 
-    String tablePath = snapshot.getPath();
+    String tablePath = snapshot.dataPath().toString();
     return Option.apply(
         DeltaSourceMetadataTrackingLog.create(
             spark,
             location,
-            snapshot.getMetadata().getId(),
+            snapshot.metadata().getId(),
             tablePath,
             ScalaUtils.toScalaMap(options),
             sourceMetadataPathOpt,

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/snapshot/PathBasedSnapshotManager.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/snapshot/PathBasedSnapshotManager.java
@@ -19,7 +19,6 @@ import static java.util.Objects.requireNonNull;
 
 import io.delta.kernel.CommitRange;
 import io.delta.kernel.CommitRangeBuilder;
-import io.delta.kernel.Snapshot;
 import io.delta.kernel.TableManager;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.internal.DeltaHistoryManager;
@@ -30,7 +29,9 @@ import java.util.ArrayList;
 import java.util.Optional;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.spark.annotation.Experimental;
+import org.apache.spark.sql.delta.Snapshot;
 import org.apache.spark.sql.delta.v2.interop.DeltaV2SnapshotManager;
+import org.apache.spark.sql.delta.v2.interop.DeltaV2SnapshotManager$;
 
 /** Implementation of DeltaV2SnapshotManager for managing Delta snapshots for Path-based Table. */
 @Experimental
@@ -57,7 +58,8 @@ public class PathBasedSnapshotManager implements DeltaV2SnapshotManager {
    */
   @Override
   public Snapshot loadLatestSnapshot() {
-    return TableManager.loadSnapshot(tablePath).build(kernelEngine);
+    return DeltaV2SnapshotManager$.MODULE$.wrapKernelSnapshot(
+        loadLatestKernelSnapshot(), tablePath);
   }
 
   /**
@@ -68,7 +70,17 @@ public class PathBasedSnapshotManager implements DeltaV2SnapshotManager {
    */
   @Override
   public Snapshot loadSnapshotAt(long version) {
-    return TableManager.loadSnapshot(tablePath).atVersion(version).build(kernelEngine);
+    return DeltaV2SnapshotManager$.MODULE$.wrapKernelSnapshot(
+        loadKernelSnapshotAt(version), tablePath);
+  }
+
+  private SnapshotImpl loadLatestKernelSnapshot() {
+    return (SnapshotImpl) TableManager.loadSnapshot(tablePath).build(kernelEngine);
+  }
+
+  private SnapshotImpl loadKernelSnapshotAt(long version) {
+    return (SnapshotImpl)
+        TableManager.loadSnapshot(tablePath).atVersion(version).build(kernelEngine);
   }
 
   /**
@@ -92,7 +104,7 @@ public class PathBasedSnapshotManager implements DeltaV2SnapshotManager {
       boolean canReturnLastCommit,
       boolean mustBeRecreatable,
       boolean canReturnEarliestCommit) {
-    SnapshotImpl snapshot = (SnapshotImpl) loadLatestSnapshot();
+    SnapshotImpl snapshot = loadLatestKernelSnapshot();
     return DeltaHistoryManager.getActiveCommitAtTimestamp(
         kernelEngine,
         snapshot,
@@ -117,7 +129,7 @@ public class PathBasedSnapshotManager implements DeltaV2SnapshotManager {
   @Override
   public void checkVersionExists(long version, boolean mustBeRecreatable, boolean allowOutOfRange)
       throws VersionNotFoundException {
-    SnapshotImpl snapshot = (SnapshotImpl) loadLatestSnapshot();
+    SnapshotImpl snapshot = loadLatestKernelSnapshot();
     long earliest =
         mustBeRecreatable
             ? DeltaHistoryManager.getEarliestRecreatableCommit(

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/snapshot/unitycatalog/UCManagedTableSnapshotManager.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/snapshot/unitycatalog/UCManagedTableSnapshotManager.java
@@ -18,7 +18,6 @@ package io.delta.spark.internal.v2.snapshot.unitycatalog;
 import static java.util.Objects.requireNonNull;
 
 import io.delta.kernel.CommitRange;
-import io.delta.kernel.Snapshot;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.internal.DeltaHistoryManager;
 import io.delta.kernel.internal.SnapshotImpl;
@@ -28,7 +27,9 @@ import io.delta.kernel.unitycatalog.UCTableIdentifier;
 import io.delta.spark.internal.v2.exception.VersionNotFoundException;
 import java.util.List;
 import java.util.Optional;
+import org.apache.spark.sql.delta.Snapshot;
 import org.apache.spark.sql.delta.v2.interop.DeltaV2SnapshotManager;
+import org.apache.spark.sql.delta.v2.interop.DeltaV2SnapshotManager$;
 
 /**
  * Snapshot manager for Unity Catalog managed tables.
@@ -69,22 +70,25 @@ public class UCManagedTableSnapshotManager implements DeltaV2SnapshotManager {
    */
   @Override
   public Snapshot loadLatestSnapshot() {
-    return loadSnapshot(Optional.empty() /* versionOpt */);
+    return DeltaV2SnapshotManager$.MODULE$.wrapKernelSnapshot(
+        loadKernelSnapshot(Optional.empty()), tablePath);
   }
 
   @Override
   public Snapshot loadSnapshotAt(long version) {
-    return loadSnapshot(Optional.of(version));
+    return DeltaV2SnapshotManager$.MODULE$.wrapKernelSnapshot(
+        loadKernelSnapshot(Optional.of(version)), tablePath);
   }
 
-  private Snapshot loadSnapshot(Optional<Long> versionOpt) {
-    return ucCatalogManagedClient.loadSnapshot(
-        engine,
-        tableId,
-        tablePath,
-        tableIdentifier,
-        versionOpt,
-        Optional.empty() /* timestampOpt */);
+  private SnapshotImpl loadKernelSnapshot(Optional<Long> versionOpt) {
+    return (SnapshotImpl)
+        ucCatalogManagedClient.loadSnapshot(
+            engine,
+            tableId,
+            tablePath,
+            tableIdentifier,
+            versionOpt,
+            Optional.empty() /* timestampOpt */);
   }
 
   /**
@@ -108,7 +112,7 @@ public class UCManagedTableSnapshotManager implements DeltaV2SnapshotManager {
       boolean canReturnLastCommit,
       boolean mustBeRecreatable,
       boolean canReturnEarliestCommit) {
-    SnapshotImpl snapshot = (SnapshotImpl) loadLatestSnapshot();
+    SnapshotImpl snapshot = loadKernelSnapshot(Optional.empty());
     List<ParsedCatalogCommitData> catalogCommits = snapshot.getLogSegment().getAllCatalogCommits();
     return DeltaHistoryManager.getActiveCommitAtTimestamp(
         engine,
@@ -138,7 +142,7 @@ public class UCManagedTableSnapshotManager implements DeltaV2SnapshotManager {
   public void checkVersionExists(long version, boolean mustBeRecreatable, boolean allowOutOfRange)
       throws VersionNotFoundException {
     // Load latest to get the current version bounds
-    SnapshotImpl snapshot = (SnapshotImpl) loadLatestSnapshot();
+    SnapshotImpl snapshot = loadKernelSnapshot(Optional.empty());
     // Latest version visible in this UC-managed snapshot.
     long latestSnapshotVersion = snapshot.getVersion();
 

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2StreamingWrite.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2StreamingWrite.java
@@ -32,6 +32,7 @@ import org.apache.spark.sql.connector.write.PhysicalWriteInfo;
 import org.apache.spark.sql.connector.write.WriterCommitMessage;
 import org.apache.spark.sql.connector.write.streaming.StreamingDataWriterFactory;
 import org.apache.spark.sql.connector.write.streaming.StreamingWrite;
+import org.apache.spark.sql.delta.v2.interop.DeltaV2Snapshot$;
 import org.apache.spark.sql.delta.v2.interop.DeltaV2SnapshotManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -110,8 +111,13 @@ class DeltaV2StreamingWrite implements StreamingWrite {
 
   @Override
   public void commit(long epochId, WriterCommitMessage[] messages) {
-    // Refresh so this epoch commits at latest+1.
-    Snapshot latestSnapshot = snapshotManager.loadLatestSnapshot();
+    // TODO: Expose streaming transaction construction and latest transaction-version lookup
+    // through the snapshot facade so this path does not depend on SnapshotImpl.
+    // Kernel-only: needs SnapshotImpl.buildUpdateTableTransaction
+    // (TransactionBuilder) for the streaming commit, and
+    // getLatestTransactionVersion for the epoch-skip check.
+    SnapshotImpl latestSnapshot =
+        DeltaV2Snapshot$.MODULE$.getKernelSnapshot(snapshotManager.loadLatestSnapshot());
 
     // TODO(#7140): no implicit type cast and mergeSchema. Fail loudly on a concurrent
     // schema/protocol change.

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2WriteBuilder.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/write/DeltaV2WriteBuilder.java
@@ -17,20 +17,17 @@ package io.delta.spark.internal.v2.write;
 
 import static java.util.Objects.requireNonNull;
 
-import io.delta.kernel.Snapshot;
 import io.delta.kernel.engine.Engine;
-import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.internal.TableConfig;
-import io.delta.kernel.internal.actions.Metadata;
-import io.delta.kernel.internal.actions.Protocol;
-import io.delta.spark.internal.v2.utils.SchemaUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.spark.sql.connector.write.LogicalWriteInfo;
 import org.apache.spark.sql.connector.write.Write;
 import org.apache.spark.sql.connector.write.WriteBuilder;
 import org.apache.spark.sql.delta.DeltaColumnMapping;
+import org.apache.spark.sql.delta.Snapshot;
 import org.apache.spark.sql.delta.TypeWideningMode;
 import org.apache.spark.sql.delta.schema.SchemaMergingUtils;
+import org.apache.spark.sql.delta.v2.interop.DeltaV2Snapshot$;
 import org.apache.spark.sql.delta.v2.interop.DeltaV2SnapshotManager;
 import org.apache.spark.sql.types.StructType;
 
@@ -91,15 +88,18 @@ public class DeltaV2WriteBuilder implements WriteBuilder {
 
     // TODO: support partitioned IcebergCompat / materializePartitionColumns writes.
     if (!partitionSchema.isEmpty()) {
-      SnapshotImpl snapshotImpl = (SnapshotImpl) initialSnapshot;
-      Metadata metadata = snapshotImpl.getMetadata();
-      Protocol protocol = snapshotImpl.getProtocol();
       boolean icebergCompat =
-          TableConfig.ICEBERG_COMPAT_V2_ENABLED.fromMetadata(metadata)
-              || TableConfig.ICEBERG_COMPAT_V3_ENABLED.fromMetadata(metadata);
+          TableConfig.ICEBERG_COMPAT_V2_ENABLED.fromMetadata(
+                  initialSnapshot.metadata().getConfiguration())
+              || TableConfig.ICEBERG_COMPAT_V3_ENABLED.fromMetadata(
+                  initialSnapshot.metadata().getConfiguration());
       // Detect the materializePartitionColumns writer feature by its protocol name.
       boolean materializePartitionColumns =
-          protocol.getWriterFeatures().contains("materializePartitionColumns");
+          initialSnapshot.protocol().getWriterFeatures() != null
+              && initialSnapshot
+                  .protocol()
+                  .getWriterFeatures()
+                  .contains("materializePartitionColumns");
       if (icebergCompat || materializePartitionColumns) {
         throw new UnsupportedOperationException(
             "DSv2 partitioned writes are not supported on tables that materialize partition "
@@ -115,7 +115,7 @@ public class DeltaV2WriteBuilder implements WriteBuilder {
         engine,
         hadoopConf,
         tablePath,
-        initialSnapshot,
+        DeltaV2Snapshot$.MODULE$.getKernelSnapshot(initialSnapshot),
         snapshotManager,
         dataSchema,
         partitionSchema,
@@ -125,8 +125,7 @@ public class DeltaV2WriteBuilder implements WriteBuilder {
   static void validateDataSchema(Snapshot initialSnapshot, StructType dataSchema) {
     // Validate data schema against table schema using the same utility as V1
     // (ImplicitMetadataOperation.updateMetadata -> SchemaMergingUtils.mergeSchemas).
-    StructType tableSchema =
-        SchemaUtils.convertKernelSchemaToSparkSchema(initialSnapshot.getSchema());
+    StructType tableSchema = initialSnapshot.schema();
     // Strip column mapping metadata (physical names, IDs) so mergeSchemas compares
     // only logical types - matches V1's dropColumnMappingMetadata call.
     StructType cleanTableSchema =

--- a/spark/v2/src/main/scala/io/delta/spark/internal/v2/read/DeltaV2ScanBuilder.scala
+++ b/spark/v2/src/main/scala/io/delta/spark/internal/v2/read/DeltaV2ScanBuilder.scala
@@ -19,17 +19,15 @@ package io.delta.spark.internal.v2.read
 import java.util.{Locale, Objects, Optional, OptionalInt}
 import java.util.function.Supplier
 
-import io.delta.kernel.Snapshot
 import io.delta.kernel.engine.Engine
-import io.delta.kernel.internal.SnapshotImpl
 import io.delta.spark.internal.v2.read.cdc.CDCSchemaContext
 
+import org.apache.spark.sql.delta.Snapshot
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.stats.DeltaScan
 import org.apache.spark.sql.delta.v2.interop.DeltaV2Snapshot
 import org.apache.spark.sql.delta.v2.interop.DeltaV2SnapshotManager
 
-import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression, ExprId}
 import org.apache.spark.sql.connector.expressions.filter.Predicate
@@ -157,66 +155,65 @@ private[read] class DeltaV2ScanBuilder(
 
   override def build(): Scan =
     recordFrameProfile("Delta", "DeltaV2.scanBuilder.build") {
-    // Capture the planning inputs here, but defer constructing the Kernel-backed V1 snapshot and
-    // running filesForScan until DeltaV2Scan actually plans a batch. A MicroBatchStream performs
-    // its own snapshot and commit-range reads and never consumes batch-selected files.
-    //
-    // Ask for per-file record counts exactly when DeltaV2Scan will consume them for scan metadata.
-    // This must stay in sync with DeltaV2Scan.arePlanStatsEnabled, which gates the reading side.
-    // Note this only affects the no-limit branch below -- V1's limit-aware filesForScan takes no
-    // keepNumRecords and always drops per-file stats, so DeltaV2Scan falls back to
-    // DeltaScan.scanned.rows there.
-    val sparkSession = SparkSession.active
-    val sqlConf = SQLConf.get
-    val keepNumRecords = sqlConf.cboEnabled || sqlConf.planStatsEnabled
-    val partitionFiltersForScan = partitionCatalystFilters.toIndexedSeq
-    val catalystFilters = partitionFiltersForScan ++ dataCatalystFilters
+      // Capture the planning inputs here, but defer constructing the Kernel-backed V1 snapshot and
+      // running filesForScan until DeltaV2Scan actually plans a batch. A MicroBatchStream performs
+      // its own snapshot and commit-range reads and never consumes batch-selected files.
+      //
+      // Ask for per-file record counts exactly when DeltaV2Scan will consume them for scan
+      // metadata.
+      // This must stay in sync with DeltaV2Scan.arePlanStatsEnabled, which gates the reading side.
+      // Note this only affects the no-limit branch below -- V1's limit-aware filesForScan takes no
+      // keepNumRecords and always drops per-file stats, so DeltaV2Scan falls back to
+      // DeltaScan.scanned.rows there.
+      val sqlConf = SQLConf.get
+      val keepNumRecords = sqlConf.cboEnabled || sqlConf.planStatsEnabled
+      val partitionFiltersForScan = partitionCatalystFilters.toIndexedSeq
+      val catalystFilters = partitionFiltersForScan ++ dataCatalystFilters
 
-    // Spark's V2ScanRelationPushDown only pushes a limit when no post-scan residual remains (it
-    // matches PhysicalOperation(_, Nil, sHolder)), so an effective limit implies only exact
-    // partition filters are present. Retain this residual check for direct callers that may invoke
-    // the ScanBuilder methods in a different order.
-    val effectiveLimit = if (hasPostScanResidualFilters) OptionalInt.empty() else pushedLimit
+      // Spark's V2ScanRelationPushDown only pushes a limit when no post-scan residual remains (it
+      // matches PhysicalOperation(_, Nil, sHolder)), so an effective limit implies only exact
+      // partition filters are present. Retain this residual check for direct callers that may
+      // invoke the ScanBuilder methods in a different order.
+      val effectiveLimit = if (hasPostScanResidualFilters) OptionalInt.empty() else pushedLimit
 
-    val deltaScanSupplier = new Supplier[DeltaScan] {
-      override def get(): DeltaScan = {
-        val snapshot =
-          new DeltaV2Snapshot(
-            initialSnapshot.asInstanceOf[SnapshotImpl],
-            sparkSession,
-            kernelEngine)
+      val deltaScanSupplier = new Supplier[DeltaScan] {
+        override def get(): DeltaScan = {
+          val snapshot = initialSnapshot.asInstanceOf[DeltaV2Snapshot]
 
-        // When a limit is pushed, route selection through V1's limit-aware filesForScan. It
-        // requires partition-only filters (guaranteed above) and prunes files by accumulating
-        // record counts until the limit is satisfied.
-        def selectFiles(): DeltaScan =
-          if (effectiveLimit.isPresent) {
-            snapshot.filesForScan(
-              effectiveLimit.getAsInt.toLong,
-              partitionFiltersForScan)
-          } else {
-            snapshot.filesForScan(catalystFilters, keepNumRecords)
-          }
+          // When a limit is pushed, route selection through V1's limit-aware filesForScan. It
+          // requires partition-only filters (guaranteed above) and prunes files by accumulating
+          // record counts until the limit is satisfied.
+          def selectFiles(): DeltaScan =
+            if (effectiveLimit.isPresent) {
+              snapshot.filesForScan(
+                effectiveLimit.getAsInt.toLong,
+                partitionFiltersForScan)
+            } else {
+              snapshot.filesForScan(catalystFilters, keepNumRecords)
+            }
 
-        // Select files inline on this path.
-        selectFiles()
+          // Select files inline on this path.
+          selectFiles()
+        }
       }
-    }
 
-    new DeltaV2Scan(
-      snapshotManager,
-      initialSnapshot,
-      tableSchema,
-      dataSchema,
-      partitionSchema,
-      requiredDataSchema,
-      deltaScanSupplier,
-      dataCatalystFilters,
-      partitionCatalystFilters,
-      catalogStats,
-      options,
-      effectiveLimit)
-  }
+      val kernelSnapshot =
+        DeltaV2Snapshot.getKernelSnapshot(initialSnapshot)
+      val scan = new DeltaV2Scan(
+        snapshotManager,
+        kernelSnapshot,
+        tableSchema,
+        dataSchema,
+        partitionSchema,
+        requiredDataSchema,
+        deltaScanSupplier,
+        dataCatalystFilters,
+        partitionCatalystFilters,
+        catalogStats,
+        options,
+        effectiveLimit)
+      scan
+    }
 
   private[read] def getOptions: CaseInsensitiveStringMap = options
 

--- a/spark/v2/src/main/scala/org/apache/spark/sql/delta/v2/interop/DeltaV2Snapshot.scala
+++ b/spark/v2/src/main/scala/org/apache/spark/sql/delta/v2/interop/DeltaV2Snapshot.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.delta.stats.{DeltaStatsColumnSpec, FileSizeHistogram
 
 import com.databricks.spark.util.TagDefinition
 import org.apache.hadoop.fs.Path
-import org.apache.spark.sql.{DataFrame, Dataset, SparkSession}
+import org.apache.spark.sql.{DataFrame, Dataset}
 
 /**
  * A [[Snapshot]] backed by a Delta Kernel snapshot, for the v2 Connector. It extends the V1
@@ -46,15 +46,7 @@ class DeltaV2Snapshot(
     // `Snapshot` interface: the decoded data path is only exposed on SnapshotImpl in the
     // OSS-published Kernel. The public io.delta.kernel.Snapshot has no `getDataPath`, and its
     // `getPath` is URL-encoded, which breaks Hadoop `Path` for table roots containing spaces.
-    kernelSnapshot: KernelSnapshot,
-    sparkSession: SparkSession,
-    // Kernel engine for reading scan files and the commit timestamp -- owned and passed by the
-    // connector. The secondary constructor below builds a default one for callers without a Kernel
-    // engine of their own.
-    // The separating comma lives inside the edge block: it is only needed when the edge-only
-    // catalogTableOpt parameter follows. Without it, the OSS export would strip catalogTableOpt and
-    // leave a trailing comma that scalac accepts but scalastyle's parser rejects.
-    kernelEngine: Engine)
+    private val kernelSnapshot: KernelSnapshot)
     extends Snapshot(
       // toString keeps this compiling across Kernel versions: getDataPath returns String in the
       // currently pinned Kernel and io.delta.kernel.internal.fs.Path in newer Kernels.
@@ -67,16 +59,9 @@ class DeltaV2Snapshot(
       deltaLog = null,
       checksumOpt = None) {
 
-  override protected def spark: SparkSession = sparkSession
-
-  /** Convenience for callers without their own Kernel engine: builds a fresh DefaultEngine. */
   // scalastyle:off deltahadoopconfiguration
-  // No DeltaLog to source a Hadoop conf from, so use the session Hadoop conf for the engine.
-  def this(kernelSnapshot: KernelSnapshot, sparkSession: SparkSession) =
-    this(
-      kernelSnapshot,
-      sparkSession,
-      KernelEngineFactory.createDefaultEngine(sparkSession.sessionState.newHadoopConf()))
+  private def kernelEngine: Engine =
+    KernelEngineFactory.createDefaultEngine(spark.sessionState.newHadoopConf())
   // scalastyle:on deltahadoopconfiguration
 
   // --- logSegment/deltaLog = null guardrail: construction-path overrides ----------------------
@@ -171,10 +156,21 @@ class DeltaV2Snapshot(
   // which a DeltaV2Snapshot cannot use directly because it has no V1 LogSegment.
   override def timestamp: Long = kernelSnapshot.getTimestamp(kernelEngine)
 
+  def getLatestTransactionVersion(
+      appId: String): java.util.OptionalLong = {
+    val result = kernelSnapshot
+      .getLatestTransactionVersion(kernelEngine, appId)
+    if (result.isPresent) {
+      java.util.OptionalLong.of(result.get)
+    } else {
+      java.util.OptionalLong.empty()
+    }
+  }
+
   // --- Files surfaced via Kernel scan ---------------------------------------------------------
 
   override lazy val allFiles: Dataset[AddFile] =
-    KernelSnapshotUtils.buildAllFiles(kernelSnapshot, sparkSession, kernelEngine)
+    KernelSnapshotUtils.buildAllFiles(kernelSnapshot, spark, kernelEngine)
 
   // --- StatisticsCollection ------------------------------------------------------------------
 
@@ -228,4 +224,26 @@ class DeltaV2Snapshot(
   private def unimplemented: Nothing =
     throw new UnsupportedOperationException(
       "This member is not yet supported on a Kernel-backed DeltaV2Snapshot")
+}
+
+object DeltaV2Snapshot {
+
+  /**
+   * Returns the Kernel snapshot wrapped by a Kernel-backed V1 snapshot facade.
+   *
+   * Temporary: this accessor exists for code paths that still consume Kernel's SnapshotImpl
+   * directly and will be removed once those consumers are migrated to DSv1-level APIs.
+   */
+  def getKernelSnapshot(snapshot: Snapshot): KernelSnapshot = {
+    if (snapshot == null) {
+      throw new NullPointerException("snapshot is null")
+    }
+    snapshot match {
+      case deltaV2Snapshot: DeltaV2Snapshot => deltaV2Snapshot.kernelSnapshot
+      case other =>
+        throw new IllegalStateException(
+          s"Expected a DeltaV2Snapshot, but found ${other.getClass.getName}")
+    }
+  }
+
 }

--- a/spark/v2/src/main/scala/org/apache/spark/sql/delta/v2/interop/DeltaV2SnapshotManager.scala
+++ b/spark/v2/src/main/scala/org/apache/spark/sql/delta/v2/interop/DeltaV2SnapshotManager.scala
@@ -16,21 +16,24 @@
 
 package org.apache.spark.sql.delta.v2.interop
 
-import java.util.Optional
+import java.util.{Objects, Optional}
 
-import io.delta.kernel.{CommitRange, Snapshot}
+import io.delta.kernel.CommitRange
 import io.delta.kernel.engine.Engine
 import io.delta.kernel.internal.DeltaHistoryManager
+import io.delta.kernel.internal.SnapshotImpl
 import io.delta.spark.internal.v2.exception.VersionNotFoundException
+
+import org.apache.spark.sql.delta.Snapshot
 
 import org.apache.spark.annotation.Experimental
 
 /**
  * Contract for managing Delta table snapshots in the DSv2 connector.
  *
- * Provides methods for loading, caching, and querying Delta table
- * snapshots. Implementations manage snapshot lifecycle including loading
- * from storage and maintaining any necessary caching.
+ * This connector exposes loaded state through the V1 snapshot facade so callers use the same
+ * metadata, protocol, schema, timestamp, column-mapping, and file-access surface as V1. Kernel
+ * execution details remain confined to the connector's execution seams.
  */
 @Experimental
 trait DeltaV2SnapshotManager {
@@ -89,4 +92,20 @@ trait DeltaV2SnapshotManager {
       engine: Engine,
       startVersion: Long,
       endVersion: Optional[java.lang.Long]): CommitRange
+}
+
+object DeltaV2SnapshotManager {
+
+  /**
+   * Wraps a Kernel snapshot in the V1 [[Snapshot]] facade returned by manager load APIs.
+   *
+   * @param kernelSnapshot the Kernel snapshot to wrap
+   * @param tablePath table path used in construction-error messages
+   * @return the V1 snapshot facade
+   */
+  def wrapKernelSnapshot(kernelSnapshot: SnapshotImpl, tablePath: String): Snapshot = {
+    Objects.requireNonNull(kernelSnapshot, "kernelSnapshot is null")
+    Objects.requireNonNull(tablePath, "tablePath is null")
+    new DeltaV2Snapshot(kernelSnapshot)
+  }
 }

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/catalog/DeltaV2TableTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/catalog/DeltaV2TableTest.java
@@ -62,6 +62,7 @@ import org.apache.spark.sql.delta.catalog.DeltaTableV2;
 import org.apache.spark.sql.delta.sources.DeltaSQLConf;
 import org.apache.spark.sql.delta.sources.DeltaSourceMetadataTrackingLog;
 import org.apache.spark.sql.delta.sources.PersistedMetadata;
+import org.apache.spark.sql.delta.v2.interop.DeltaV2Snapshot$;
 import org.apache.spark.sql.execution.datasources.FileFormat$;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
@@ -787,7 +788,8 @@ public class DeltaV2TableTest extends DeltaV2TestBase {
     // Capture v0 metadata BEFORE evolving the table.
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(tablePath, spark.sessionState().newHadoopConf());
-    SnapshotImpl snapshotV0 = (SnapshotImpl) snapshotManager.loadSnapshotAt(0L);
+    SnapshotImpl snapshotV0 =
+        DeltaV2Snapshot$.MODULE$.getKernelSnapshot(snapshotManager.loadSnapshotAt(0L));
     Metadata metadataV0 = snapshotV0.getMetadata();
     Protocol protocolV0 = snapshotV0.getProtocol();
     String tableId = metadataV0.getId();

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2MicroBatchStreamCDCTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2MicroBatchStreamCDCTest.java
@@ -46,6 +46,7 @@ import org.apache.spark.sql.delta.sources.DeltaSource;
 import org.apache.spark.sql.delta.sources.DeltaSourceOffset;
 import org.apache.spark.sql.delta.sources.DeltaSourceOffset$;
 import org.apache.spark.sql.delta.storage.ClosableIterator;
+import org.apache.spark.sql.delta.v2.interop.DeltaV2Snapshot$;
 import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -111,7 +112,7 @@ class DeltaV2MicroBatchStreamCDCTest extends DeltaV2TestBase {
     DeltaV2MicroBatchStream stream =
         createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
 
-    long initVersion = snapshotManager.loadLatestSnapshot().getVersion();
+    long initVersion = snapshotManager.loadLatestSnapshot().version();
     assertDoesNotThrow(() -> stream.validateCDFEnabledOnTable(initVersion));
   }
 
@@ -152,7 +153,7 @@ class DeltaV2MicroBatchStreamCDCTest extends DeltaV2TestBase {
     PathBasedSnapshotManager snapshotManager = new PathBasedSnapshotManager(tablePath, hadoopConf);
     DeltaV2MicroBatchStream stream =
         createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
-    long latestVersion = snapshotManager.loadLatestSnapshot().getVersion();
+    long latestVersion = snapshotManager.loadLatestSnapshot().version();
 
     // startingVersion=latest resolves to latest+1, which is not materialized. The KernelException
     // is swallowed and the validator returns without throwing.
@@ -1035,10 +1036,9 @@ class DeltaV2MicroBatchStreamCDCTest extends DeltaV2TestBase {
         ScalaUtils.toScalaMap(javaOptions);
     DeltaOptions deltaOptions = new DeltaOptions(scalaOptions, spark.sessionState().conf());
 
-    io.delta.kernel.internal.SnapshotImpl latestSnapshot =
-        (io.delta.kernel.internal.SnapshotImpl) snapshotManager.loadLatestSnapshot();
+    Snapshot latestSnapshot = snapshotManager.loadLatestSnapshot();
     io.delta.kernel.internal.SnapshotImpl seededSnapshot =
-        (io.delta.kernel.internal.SnapshotImpl) snapshotManager.loadSnapshotAt(seededVersion);
+        DeltaV2Snapshot$.MODULE$.getKernelSnapshot(snapshotManager.loadSnapshotAt(seededVersion));
 
     org.apache.spark.sql.delta.sources.DeltaSourceMetadataTrackingLog trackingLog =
         MetadataEvolutionHandler.getMetadataTrackingLogForMicroBatchStream(
@@ -1182,10 +1182,8 @@ class DeltaV2MicroBatchStreamCDCTest extends DeltaV2TestBase {
 
   private DeltaV2MicroBatchStream createTestStreamWithDefaults(
       PathBasedSnapshotManager snapshotManager, Configuration hadoopConf, DeltaOptions options) {
-    io.delta.kernel.Snapshot snapshot = snapshotManager.loadLatestSnapshot();
-    StructType tableSchema =
-        io.delta.spark.internal.v2.utils.SchemaUtils.convertKernelSchemaToSparkSchema(
-            snapshot.getSchema());
+    Snapshot snapshot = snapshotManager.loadLatestSnapshot();
+    StructType tableSchema = snapshot.schema();
     return new DeltaV2MicroBatchStream(
         snapshotManager,
         snapshot,

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2MicroBatchStreamTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2MicroBatchStreamTest.java
@@ -2060,10 +2060,7 @@ public class DeltaV2MicroBatchStreamTest extends DeltaV2TestBase {
             partitionSchema,
             dataSchema,
             SchemaUtils.ddlOrderedOutputSchema(
-                io.delta.spark.internal.v2.utils.SchemaUtils.convertKernelSchemaToSparkSchema(
-                    snapshotManager.loadLatestSnapshot().getSchema()),
-                dataSchema,
-                partitionSchema),
+                snapshotManager.loadLatestSnapshot().schema(), dataSchema, partitionSchema),
             new org.apache.spark.sql.sources.Filter[0],
             Map$.MODULE$.empty(),
             Option.empty(),
@@ -2248,10 +2245,7 @@ public class DeltaV2MicroBatchStreamTest extends DeltaV2TestBase {
             partitionSchema,
             dataSchema,
             SchemaUtils.ddlOrderedOutputSchema(
-                io.delta.spark.internal.v2.utils.SchemaUtils.convertKernelSchemaToSparkSchema(
-                    snapshotManager.loadLatestSnapshot().getSchema()),
-                dataSchema,
-                partitionSchema),
+                snapshotManager.loadLatestSnapshot().schema(), dataSchema, partitionSchema),
             new org.apache.spark.sql.sources.Filter[0],
             Map$.MODULE$.empty(),
             Option.empty(),
@@ -3362,9 +3356,7 @@ public class DeltaV2MicroBatchStreamTest extends DeltaV2TestBase {
       assertPostChangeSchema.accept(evolved.dataSchema());
 
       // Restart with the post-change schema (same trackingLog: it now carries the evolved entry).
-      StructType postChangeSchema =
-          io.delta.spark.internal.v2.utils.SchemaUtils.convertKernelSchemaToSparkSchema(
-              snapshotManager.loadLatestSnapshot().getSchema());
+      StructType postChangeSchema = snapshotManager.loadLatestSnapshot().schema();
       DeltaV2MicroBatchStream streamPostChange =
           createSchemaTrackingTestStream(
               snapshotManager,
@@ -3458,9 +3450,7 @@ public class DeltaV2MicroBatchStreamTest extends DeltaV2TestBase {
           createTrackingLog(snapshotManager, schemaTrackingLocation, checkpointLocation, optionMap);
 
       StructType preChangeSchema = loadSparkSchemaAtVersion(snapshotManager, startVersion);
-      StructType postChangeSchema =
-          io.delta.spark.internal.v2.utils.SchemaUtils.convertKernelSchemaToSparkSchema(
-              snapshotManager.loadLatestSnapshot().getSchema());
+      StructType postChangeSchema = snapshotManager.loadLatestSnapshot().schema();
 
       // Round 1: post-change schema (analysis would bind to the latest snapshot since the log
       // is empty). First latestOffset runs eager-init and throws.
@@ -3575,8 +3565,7 @@ public class DeltaV2MicroBatchStreamTest extends DeltaV2TestBase {
     String schemaTrackingLocation = new File(tempDir, "schema_tracking").getAbsolutePath();
     String checkpointLocation = new File(tempDir, "checkpoint").getAbsolutePath();
     StructType schema =
-        loadSparkSchemaAtVersion(
-            snapshotManager, snapshotManager.loadLatestSnapshot().getVersion());
+        loadSparkSchemaAtVersion(snapshotManager, snapshotManager.loadLatestSnapshot().version());
     DeltaSourceMetadataTrackingLog trackingLog =
         createTrackingLog(
             snapshotManager, schemaTrackingLocation, checkpointLocation, Collections.emptyMap());
@@ -4292,11 +4281,9 @@ public class DeltaV2MicroBatchStreamTest extends DeltaV2TestBase {
   /** Helper method to create a DeltaV2MicroBatchStream with default values for testing. */
   private DeltaV2MicroBatchStream createTestStreamWithDefaults(
       PathBasedSnapshotManager snapshotManager, Configuration hadoopConf, DeltaOptions options) {
-    io.delta.kernel.Snapshot snapshot = snapshotManager.loadLatestSnapshot();
-    String tablePath = ((io.delta.kernel.internal.SnapshotImpl) snapshot).getPath();
-    StructType tableSchema =
-        io.delta.spark.internal.v2.utils.SchemaUtils.convertKernelSchemaToSparkSchema(
-            snapshot.getSchema());
+    Snapshot snapshot = snapshotManager.loadLatestSnapshot();
+    String tablePath = snapshot.dataPath().toString();
+    StructType tableSchema = snapshot.schema();
     return new DeltaV2MicroBatchStream(
         snapshotManager,
         snapshot,
@@ -4322,7 +4309,7 @@ public class DeltaV2MicroBatchStreamTest extends DeltaV2TestBase {
       StructType dataSchema,
       Option<DeltaSourceMetadataTrackingLog> metadataTrackingLog,
       String metadataPath) {
-    io.delta.kernel.Snapshot snapshot = snapshotManager.loadLatestSnapshot();
+    Snapshot snapshot = snapshotManager.loadLatestSnapshot();
     return new DeltaV2MicroBatchStream(
         snapshotManager,
         snapshot,
@@ -4334,10 +4321,7 @@ public class DeltaV2MicroBatchStreamTest extends DeltaV2TestBase {
         /* partitionSchema= */ new StructType(),
         /* readDataSchema= */ dataSchema,
         SchemaUtils.ddlOrderedOutputSchema(
-            io.delta.spark.internal.v2.utils.SchemaUtils.convertKernelSchemaToSparkSchema(
-                snapshotManager.loadLatestSnapshot().getSchema()),
-            dataSchema,
-            new StructType()),
+            snapshotManager.loadLatestSnapshot().schema(), dataSchema, new StructType()),
         /* dataFilters= */ new org.apache.spark.sql.sources.Filter[0],
         /* scalaOptions= */ scala.collection.immutable.Map$.MODULE$.empty(),
         metadataTrackingLog,
@@ -4349,13 +4333,12 @@ public class DeltaV2MicroBatchStreamTest extends DeltaV2TestBase {
       String schemaTrackingLocation,
       String checkpointLocation,
       java.util.Map<String, String> optionMap) {
-    io.delta.kernel.internal.SnapshotImpl snapshot =
-        (io.delta.kernel.internal.SnapshotImpl) snapshotManager.loadLatestSnapshot();
+    Snapshot snapshot = snapshotManager.loadLatestSnapshot();
     return DeltaSourceMetadataTrackingLog.create(
         spark,
         schemaTrackingLocation,
-        snapshot.getMetadata().getId(),
-        snapshot.getPath(),
+        snapshot.metadata().getId(),
+        snapshot.dataPath().toString(),
         ScalaUtils.toScalaMap(optionMap),
         Option.apply(checkpointLocation),
         /* mergeConsecutiveSchemaChanges= */ false,
@@ -4365,8 +4348,7 @@ public class DeltaV2MicroBatchStreamTest extends DeltaV2TestBase {
 
   private StructType loadSparkSchemaAtVersion(
       PathBasedSnapshotManager snapshotManager, long version) {
-    return io.delta.spark.internal.v2.utils.SchemaUtils.convertKernelSchemaToSparkSchema(
-        snapshotManager.loadSnapshotAt(version).getSchema());
+    return snapshotManager.loadSnapshotAt(version).schema();
   }
 
   private List<Integer> readIdsBetweenOffsets(
@@ -4942,7 +4924,7 @@ public class DeltaV2MicroBatchStreamTest extends DeltaV2TestBase {
       DeltaV2MicroBatchStream stream =
           createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
 
-      long version = snapshotManager.loadLatestSnapshot().getVersion();
+      long version = snapshotManager.loadLatestSnapshot().version();
       long fromIndex = DeltaSourceOffset.BASE_INDEX();
       boolean isInitialSnapshot = true;
 
@@ -5004,7 +4986,7 @@ public class DeltaV2MicroBatchStreamTest extends DeltaV2TestBase {
       DeltaV2MicroBatchStream stream =
           createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
 
-      long version = snapshotManager.loadLatestSnapshot().getVersion();
+      long version = snapshotManager.loadLatestSnapshot().version();
       long fromIndex = DeltaSourceOffset.BASE_INDEX();
       boolean isInitialSnapshot = true;
 
@@ -5084,7 +5066,7 @@ public class DeltaV2MicroBatchStreamTest extends DeltaV2TestBase {
       DeltaV2MicroBatchStream stream =
           createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
 
-      long version = snapshotManager.loadLatestSnapshot().getVersion();
+      long version = snapshotManager.loadLatestSnapshot().version();
 
       // Access the internal AtomicReference via reflection
       java.lang.reflect.Field cacheField =
@@ -5137,7 +5119,7 @@ public class DeltaV2MicroBatchStreamTest extends DeltaV2TestBase {
       DeltaV2MicroBatchStream stream =
           createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
 
-      long version = snapshotManager.loadLatestSnapshot().getVersion();
+      long version = snapshotManager.loadLatestSnapshot().version();
       long fromIndex = DeltaSourceOffset.BASE_INDEX();
       boolean isInitialSnapshot = true;
 

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2ScanBuilderTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2ScanBuilderTest.java
@@ -20,7 +20,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.delta.kernel.Snapshot;
 import io.delta.kernel.defaults.engine.DefaultEngine;
 import io.delta.kernel.engine.Engine;
 import io.delta.spark.internal.v2.DeltaV2TestBase;
@@ -33,6 +32,7 @@ import java.util.OptionalInt;
 import org.apache.spark.sql.catalyst.expressions.Expression;
 import org.apache.spark.sql.connector.read.Scan;
 import org.apache.spark.sql.connector.read.streaming.MicroBatchStream;
+import org.apache.spark.sql.delta.Snapshot;
 import org.apache.spark.sql.sources.And;
 import org.apache.spark.sql.sources.EqualTo;
 import org.apache.spark.sql.sources.Filter;

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/MetadataEvolutionHandlerTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/MetadataEvolutionHandlerTest.java
@@ -18,7 +18,6 @@ package io.delta.spark.internal.v2.read;
 import static org.junit.jupiter.api.Assertions.*;
 
 import io.delta.kernel.CommitRange;
-import io.delta.kernel.Snapshot;
 import io.delta.kernel.data.ArrayValue;
 import io.delta.kernel.data.ColumnVector;
 import io.delta.kernel.engine.Engine;
@@ -44,11 +43,13 @@ import java.util.*;
 import java.util.stream.Stream;
 import org.apache.spark.sql.delta.DeltaOptions;
 import org.apache.spark.sql.delta.DeltaRuntimeException;
+import org.apache.spark.sql.delta.Snapshot;
 import org.apache.spark.sql.delta.sources.DeltaSQLConf;
 import org.apache.spark.sql.delta.sources.DeltaSourceMetadataTrackingLog;
 import org.apache.spark.sql.delta.sources.DeltaSourceOffset;
 import org.apache.spark.sql.delta.sources.DeltaStreamUtils;
 import org.apache.spark.sql.delta.sources.PersistedMetadata;
+import org.apache.spark.sql.delta.v2.interop.DeltaV2Snapshot$;
 import org.apache.spark.sql.delta.v2.interop.DeltaV2SnapshotManager;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 import org.junit.jupiter.api.Test;
@@ -197,7 +198,8 @@ public class MetadataEvolutionHandlerTest extends DeltaV2TestBase {
       String tablePath, long initVersion, boolean seedLogWithInitEntry) {
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(tablePath, spark.sessionState().newHadoopConf());
-    SnapshotImpl snapshot = (SnapshotImpl) snapshotManager.loadSnapshotAt(initVersion);
+    SnapshotImpl snapshot =
+        DeltaV2Snapshot$.MODULE$.getKernelSnapshot(snapshotManager.loadSnapshotAt(initVersion));
     Metadata tableMetadata = snapshot.getMetadata();
     Protocol tableProtocol = snapshot.getProtocol();
     KernelMetadataAdapter adapter = new KernelMetadataAdapter(tableMetadata);
@@ -996,7 +998,7 @@ public class MetadataEvolutionHandlerTest extends DeltaV2TestBase {
     createEmptyTestTable(tablePath, tableName);
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(tablePath, spark.sessionState().newHadoopConf());
-    SnapshotImpl snapshot = (SnapshotImpl) snapshotManager.loadLatestSnapshot();
+    Snapshot snapshot = snapshotManager.loadLatestSnapshot();
     return MetadataEvolutionHandler.getMetadataTrackingLogForMicroBatchStream(
         spark,
         snapshot,
@@ -1136,7 +1138,7 @@ public class MetadataEvolutionHandlerTest extends DeltaV2TestBase {
     createEmptyTestTable(tablePath, tableName);
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(tablePath, spark.sessionState().newHadoopConf());
-    SnapshotImpl snapshot = (SnapshotImpl) snapshotManager.loadLatestSnapshot();
+    Snapshot snapshot = snapshotManager.loadLatestSnapshot();
     return MetadataEvolutionHandler.getPersistedMetadataForMicroBatchStream(
         spark, snapshot, options, snapshotManager, defaultEngine);
   }
@@ -1158,7 +1160,8 @@ public class MetadataEvolutionHandlerTest extends DeltaV2TestBase {
     createEmptyTestTable(tablePath, tableName);
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(tablePath, spark.sessionState().newHadoopConf());
-    SnapshotImpl snapshot = (SnapshotImpl) snapshotManager.loadLatestSnapshot();
+    Snapshot dsv1Snapshot = snapshotManager.loadLatestSnapshot();
+    SnapshotImpl snapshot = DeltaV2Snapshot$.MODULE$.getKernelSnapshot(dsv1Snapshot);
 
     String schemaLogPath = new File(tempDir, "schema_log").getAbsolutePath();
     Map<String, String> options = new HashMap<>();
@@ -1175,7 +1178,7 @@ public class MetadataEvolutionHandlerTest extends DeltaV2TestBase {
           DeltaSourceMetadataTrackingLog trackingLog =
               MetadataEvolutionHandler.getMetadataTrackingLogForMicroBatchStream(
                       spark,
-                      snapshot,
+                      dsv1Snapshot,
                       options,
                       snapshotManager,
                       defaultEngine,
@@ -1195,7 +1198,7 @@ public class MetadataEvolutionHandlerTest extends DeltaV2TestBase {
 
           Optional<PersistedMetadata> result =
               MetadataEvolutionHandler.getPersistedMetadataForMicroBatchStream(
-                  spark, snapshot, options, snapshotManager, defaultEngine);
+                  spark, dsv1Snapshot, options, snapshotManager, defaultEngine);
           assertTrue(result.isPresent());
           assertEquals(seededVersion, result.get().deltaCommitVersion());
         });
@@ -1212,7 +1215,7 @@ public class MetadataEvolutionHandlerTest extends DeltaV2TestBase {
     createEmptyTestTable(tablePath, tableName);
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(tablePath, spark.sessionState().newHadoopConf());
-    return (SnapshotImpl) snapshotManager.loadLatestSnapshot();
+    return DeltaV2Snapshot$.MODULE$.getKernelSnapshot(snapshotManager.loadLatestSnapshot());
   }
 
   /** Persisted metadata with schema, protocol, and configuration distinct from the source. */
@@ -1348,7 +1351,8 @@ public class MetadataEvolutionHandlerTest extends DeltaV2TestBase {
   /** Builds a {@link PersistedMetadata} snapshot of the table state at v0. */
   private PersistedMetadata buildCurrentMetadataAtV0(
       String tablePath, PathBasedSnapshotManager snapshotManager) {
-    SnapshotImpl v0 = (SnapshotImpl) snapshotManager.loadSnapshotAt(0L);
+    SnapshotImpl v0 =
+        DeltaV2Snapshot$.MODULE$.getKernelSnapshot(snapshotManager.loadSnapshotAt(0L));
     return PersistedMetadata.apply(
         "test-table-id",
         0L,
@@ -1440,7 +1444,8 @@ public class MetadataEvolutionHandlerTest extends DeltaV2TestBase {
     // version — if the merger captured the right metadata/protocol actions, the JSONs will match.
     assertTrue(result.isDefined());
     SnapshotImpl mergedSnapshot =
-        (SnapshotImpl) snapshotManager.loadSnapshotAt(expectedMergedVersion);
+        DeltaV2Snapshot$.MODULE$.getKernelSnapshot(
+            snapshotManager.loadSnapshotAt(expectedMergedVersion));
     PersistedMetadata expected =
         PersistedMetadata.apply(
             "test-table-id",
@@ -1481,7 +1486,8 @@ public class MetadataEvolutionHandlerTest extends DeltaV2TestBase {
         new PathBasedSnapshotManager(tablePath, spark.sessionState().newHadoopConf());
 
     // current = v2 (the ALTER ADD COLUMN). Merger walks forward from here.
-    SnapshotImpl v2Snapshot = (SnapshotImpl) snapshotManager.loadSnapshotAt(2L);
+    SnapshotImpl v2Snapshot =
+        DeltaV2Snapshot$.MODULE$.getKernelSnapshot(snapshotManager.loadSnapshotAt(2L));
     PersistedMetadata current =
         PersistedMetadata.apply(
             "test-table-id",
@@ -1498,7 +1504,8 @@ public class MetadataEvolutionHandlerTest extends DeltaV2TestBase {
     assertTrue(result.isDefined());
     assertEquals(3L, result.get().deltaCommitVersion());
 
-    SnapshotImpl v3Snapshot = (SnapshotImpl) snapshotManager.loadSnapshotAt(3L);
+    SnapshotImpl v3Snapshot =
+        DeltaV2Snapshot$.MODULE$.getKernelSnapshot(snapshotManager.loadSnapshotAt(3L));
     assertEquals(v3Snapshot.getMetadata().getSchemaString(), result.get().dataSchemaJson());
   }
 }

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/ScanFileRDDTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/ScanFileRDDTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
+import org.apache.spark.sql.delta.v2.interop.DeltaV2Snapshot$;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -42,7 +43,7 @@ public class ScanFileRDDTest extends DeltaV2TestBase {
 
     Configuration hadoopConf = spark.sessionState().newHadoopConf();
     PathBasedSnapshotManager mgr = new PathBasedSnapshotManager(tablePath, hadoopConf);
-    SnapshotImpl snapshot = (SnapshotImpl) mgr.loadLatestSnapshot();
+    SnapshotImpl snapshot = DeltaV2Snapshot$.MODULE$.getKernelSnapshot(mgr.loadLatestSnapshot());
 
     SerializableReadOnlySnapshot serializable =
         SerializableReadOnlySnapshot.fromSnapshot(snapshot, hadoopConf);
@@ -67,7 +68,7 @@ public class ScanFileRDDTest extends DeltaV2TestBase {
 
     Configuration hadoopConf = spark.sessionState().newHadoopConf();
     PathBasedSnapshotManager mgr = new PathBasedSnapshotManager(tablePath, hadoopConf);
-    SnapshotImpl snapshot = (SnapshotImpl) mgr.loadLatestSnapshot();
+    SnapshotImpl snapshot = DeltaV2Snapshot$.MODULE$.getKernelSnapshot(mgr.loadLatestSnapshot());
 
     SerializableReadOnlySnapshot serializable =
         SerializableReadOnlySnapshot.fromSnapshot(snapshot, hadoopConf);

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/snapshot/PathBasedSnapshotManagerTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/snapshot/PathBasedSnapshotManagerTest.java
@@ -17,10 +17,10 @@ package io.delta.spark.internal.v2.snapshot;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.delta.kernel.Snapshot;
 import io.delta.kernel.internal.DeltaHistoryManager;
 import io.delta.spark.internal.v2.DeltaV2TestBase;
 import io.delta.spark.internal.v2.exception.VersionNotFoundException;
@@ -29,6 +29,7 @@ import java.sql.Timestamp;
 import java.util.stream.Stream;
 import org.apache.hadoop.fs.Path;
 import org.apache.spark.sql.delta.DeltaLog;
+import org.apache.spark.sql.delta.Snapshot;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -54,7 +55,7 @@ public class PathBasedSnapshotManagerTest extends DeltaV2TestBase {
     spark.sql(String.format("INSERT INTO %s VALUES (4, 'David')", testTableName));
 
     assertEquals(0L, deltaSnapshot.version());
-    assertEquals(deltaSnapshot.version(), kernelSnapshot.getVersion());
+    assertEquals(deltaSnapshot.version(), kernelSnapshot.version());
   }
 
   @Test
@@ -67,7 +68,7 @@ public class PathBasedSnapshotManagerTest extends DeltaV2TestBase {
     DeltaLog deltaLog = DeltaLog.forTable(spark, new Path(testTablePath));
 
     Snapshot initialSnapshot = snapshotManager.loadLatestSnapshot();
-    assertEquals(0L, initialSnapshot.getVersion());
+    assertEquals(0L, initialSnapshot.version());
 
     spark.sql(String.format("INSERT INTO %s VALUES (4, 'David')", testTableName));
 
@@ -77,10 +78,11 @@ public class PathBasedSnapshotManagerTest extends DeltaV2TestBase {
     org.apache.spark.sql.delta.Snapshot cachedSnapshot = deltaLog.unsafeVolatileSnapshot();
     Snapshot kernelcachedSnapshot = snapshotManager.loadLatestSnapshot();
 
-    assertEquals(1L, updatedSnapshot.getVersion());
-    assertEquals(deltaSnapshot.version(), updatedSnapshot.getVersion());
-    assertEquals(1L, kernelcachedSnapshot.getVersion());
-    assertEquals(cachedSnapshot.version(), kernelcachedSnapshot.getVersion());
+    assertEquals(1L, updatedSnapshot.version());
+    assertEquals(deltaSnapshot.version(), updatedSnapshot.version());
+    assertEquals(1L, kernelcachedSnapshot.version());
+    assertEquals(cachedSnapshot.version(), kernelcachedSnapshot.version());
+    assertNotSame(updatedSnapshot, kernelcachedSnapshot);
   }
 
   @Test
@@ -93,7 +95,7 @@ public class PathBasedSnapshotManagerTest extends DeltaV2TestBase {
 
     DeltaLog deltaLog = DeltaLog.forTable(spark, new Path(testTablePath));
 
-    assertEquals(0L, snapshotManager.loadLatestSnapshot().getVersion());
+    assertEquals(0L, snapshotManager.loadLatestSnapshot().version());
 
     for (int i = 0; i < 3; i++) {
       spark.sql(
@@ -105,7 +107,7 @@ public class PathBasedSnapshotManagerTest extends DeltaV2TestBase {
 
       long expectedVersion = i + 1;
       assertEquals(expectedVersion, deltaSnapshot.version());
-      assertEquals(expectedVersion, kernelSnapshot.getVersion());
+      assertEquals(expectedVersion, kernelSnapshot.version());
     }
   }
 
@@ -125,16 +127,16 @@ public class PathBasedSnapshotManagerTest extends DeltaV2TestBase {
 
     // Load specific versions
     Snapshot snapshot0 = snapshotManager.loadSnapshotAt(0L);
-    assertEquals(0L, snapshot0.getVersion());
+    assertEquals(0L, snapshot0.version());
 
     Snapshot snapshot1 = snapshotManager.loadSnapshotAt(1L);
-    assertEquals(1L, snapshot1.getVersion());
+    assertEquals(1L, snapshot1.version());
 
     Snapshot snapshot2 = snapshotManager.loadSnapshotAt(2L);
-    assertEquals(2L, snapshot2.getVersion());
+    assertEquals(2L, snapshot2.version());
 
     Snapshot snapshot3 = snapshotManager.loadSnapshotAt(3L);
-    assertEquals(3L, snapshot3.getVersion());
+    assertEquals(3L, snapshot3.version());
 
     // Note: loadSnapshotAt does not update the cached snapshot
   }

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/SerializableReadOnlySnapshotTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/SerializableReadOnlySnapshotTest.java
@@ -34,6 +34,7 @@ import java.io.ObjectOutputStream;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.spark.sql.delta.v2.interop.DeltaV2Snapshot$;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -48,7 +49,7 @@ public class SerializableReadOnlySnapshotTest extends DeltaV2TestBase {
 
     Configuration hadoopConf = spark.sessionState().newHadoopConf();
     PathBasedSnapshotManager mgr = new PathBasedSnapshotManager(tablePath, hadoopConf);
-    SnapshotImpl snapshot = (SnapshotImpl) mgr.loadLatestSnapshot();
+    SnapshotImpl snapshot = DeltaV2Snapshot$.MODULE$.getKernelSnapshot(mgr.loadLatestSnapshot());
 
     SerializableReadOnlySnapshot original =
         SerializableReadOnlySnapshot.fromSnapshot(snapshot, hadoopConf);
@@ -88,7 +89,7 @@ public class SerializableReadOnlySnapshotTest extends DeltaV2TestBase {
 
     Configuration hadoopConf = spark.sessionState().newHadoopConf();
     PathBasedSnapshotManager mgr = new PathBasedSnapshotManager(tablePath, hadoopConf);
-    SnapshotImpl snapshot = (SnapshotImpl) mgr.loadLatestSnapshot();
+    SnapshotImpl snapshot = DeltaV2Snapshot$.MODULE$.getKernelSnapshot(mgr.loadLatestSnapshot());
 
     SerializableReadOnlySnapshot serializable =
         SerializableReadOnlySnapshot.fromSnapshot(snapshot, hadoopConf);

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/StreamingHelperTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/utils/StreamingHelperTest.java
@@ -20,7 +20,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.delta.kernel.Snapshot;
 import io.delta.kernel.internal.DeltaHistoryManager;
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.actions.Protocol;
@@ -38,6 +37,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 import org.apache.hadoop.fs.Path;
 import org.apache.spark.sql.delta.DeltaLog;
+import org.apache.spark.sql.delta.Snapshot;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -63,7 +63,7 @@ public class StreamingHelperTest extends DeltaV2TestBase {
     spark.sql(String.format("INSERT INTO %s VALUES (4, 'David')", testTableName));
 
     assertEquals(0L, deltaSnapshot.version());
-    assertEquals(deltaSnapshot.version(), kernelSnapshot.getVersion());
+    assertEquals(deltaSnapshot.version(), kernelSnapshot.version());
   }
 
   @Test
@@ -76,7 +76,7 @@ public class StreamingHelperTest extends DeltaV2TestBase {
     DeltaLog deltaLog = DeltaLog.forTable(spark, new Path(testTablePath));
 
     Snapshot initialSnapshot = snapshotManager.loadLatestSnapshot();
-    assertEquals(0L, initialSnapshot.getVersion());
+    assertEquals(0L, initialSnapshot.version());
 
     spark.sql(String.format("INSERT INTO %s VALUES (4, 'David')", testTableName));
 
@@ -86,10 +86,10 @@ public class StreamingHelperTest extends DeltaV2TestBase {
     org.apache.spark.sql.delta.Snapshot cachedSnapshot = deltaLog.unsafeVolatileSnapshot();
     Snapshot kernelcachedSnapshot = snapshotManager.loadLatestSnapshot();
 
-    assertEquals(1L, updatedSnapshot.getVersion());
-    assertEquals(deltaSnapshot.version(), updatedSnapshot.getVersion());
-    assertEquals(1L, kernelcachedSnapshot.getVersion());
-    assertEquals(cachedSnapshot.version(), kernelcachedSnapshot.getVersion());
+    assertEquals(1L, updatedSnapshot.version());
+    assertEquals(deltaSnapshot.version(), updatedSnapshot.version());
+    assertEquals(1L, kernelcachedSnapshot.version());
+    assertEquals(cachedSnapshot.version(), kernelcachedSnapshot.version());
   }
 
   @Test
@@ -102,7 +102,7 @@ public class StreamingHelperTest extends DeltaV2TestBase {
 
     DeltaLog deltaLog = DeltaLog.forTable(spark, new Path(testTablePath));
 
-    assertEquals(0L, snapshotManager.loadLatestSnapshot().getVersion());
+    assertEquals(0L, snapshotManager.loadLatestSnapshot().version());
 
     for (int i = 0; i < 3; i++) {
       spark.sql(
@@ -114,7 +114,7 @@ public class StreamingHelperTest extends DeltaV2TestBase {
 
       long expectedVersion = i + 1;
       assertEquals(expectedVersion, deltaSnapshot.version());
-      assertEquals(expectedVersion, kernelSnapshot.getVersion());
+      assertEquals(expectedVersion, kernelSnapshot.version());
     }
   }
 

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/write/DeltaRowLevelOperationBuilderTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/write/DeltaRowLevelOperationBuilderTest.java
@@ -35,6 +35,7 @@ import org.apache.spark.sql.connector.write.LogicalWriteInfo;
 import org.apache.spark.sql.connector.write.RowLevelOperation;
 import org.apache.spark.sql.connector.write.RowLevelOperationBuilder;
 import org.apache.spark.sql.connector.write.RowLevelOperationInfo;
+import org.apache.spark.sql.delta.v2.interop.DeltaV2Snapshot$;
 import org.apache.spark.sql.execution.datasources.FileFormat$;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
@@ -107,7 +108,8 @@ public class DeltaRowLevelOperationBuilderTest extends DeltaV2TestBase {
     Configuration hadoopConf = spark.sessionState().newHadoopConf();
     Engine engine = DefaultEngine.create(hadoopConf);
     Snapshot snapshot =
-        new PathBasedSnapshotManager(tempDir.getAbsolutePath(), engine).loadLatestSnapshot();
+        DeltaV2Snapshot$.MODULE$.getKernelSnapshot(
+            new PathBasedSnapshotManager(tempDir.getAbsolutePath(), engine).loadLatestSnapshot());
 
     assertThrows(
         NullPointerException.class,
@@ -139,7 +141,9 @@ public class DeltaRowLevelOperationBuilderTest extends DeltaV2TestBase {
     Configuration hadoopConf = spark.sessionState().newHadoopConf();
     Engine engine = DefaultEngine.create(hadoopConf);
     Snapshot snapshot =
-        new PathBasedSnapshotManager(table.getTablePath().toString(), engine).loadLatestSnapshot();
+        DeltaV2Snapshot$.MODULE$.getKernelSnapshot(
+            new PathBasedSnapshotManager(table.getTablePath().toString(), engine)
+                .loadLatestSnapshot());
     return new DeltaRowLevelOperationBuilder(
         table, engine, hadoopConf, snapshot, testInfo(command));
   }

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/write/DeltaV2BatchWriteTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/write/DeltaV2BatchWriteTest.java
@@ -39,6 +39,7 @@ import org.apache.spark.sql.connector.write.DataWriter;
 import org.apache.spark.sql.connector.write.DataWriterFactory;
 import org.apache.spark.sql.connector.write.LogicalWriteInfo;
 import org.apache.spark.sql.connector.write.WriterCommitMessage;
+import org.apache.spark.sql.delta.v2.interop.DeltaV2Snapshot$;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
@@ -408,7 +409,7 @@ public class DeltaV2BatchWriteTest extends DeltaV2TestBase {
                     defaultEngine,
                     spark.sessionState().newHadoopConf(),
                     path,
-                    mgr.loadLatestSnapshot(),
+                    DeltaV2Snapshot$.MODULE$.getKernelSnapshot(mgr.loadLatestSnapshot()),
                     mgr,
                     data,
                     part,
@@ -501,7 +502,7 @@ public class DeltaV2BatchWriteTest extends DeltaV2TestBase {
                 defaultEngine,
                 spark.sessionState().newHadoopConf(),
                 path,
-                mgr.loadLatestSnapshot(),
+                DeltaV2Snapshot$.MODULE$.getKernelSnapshot(mgr.loadLatestSnapshot()),
                 mgr,
                 data,
                 part,
@@ -543,7 +544,7 @@ public class DeltaV2BatchWriteTest extends DeltaV2TestBase {
                 defaultEngine,
                 spark.sessionState().newHadoopConf(),
                 path,
-                mgr.loadLatestSnapshot(),
+                DeltaV2Snapshot$.MODULE$.getKernelSnapshot(mgr.loadLatestSnapshot()),
                 mgr,
                 data,
                 part,
@@ -564,7 +565,8 @@ public class DeltaV2BatchWriteTest extends DeltaV2TestBase {
   private DeltaV2BatchWrite newPartitionedWrite(String path) {
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(path, spark.sessionState().newHadoopConf());
-    Snapshot snapshot = snapshotManager.loadLatestSnapshot();
+    Snapshot snapshot =
+        DeltaV2Snapshot$.MODULE$.getKernelSnapshot(snapshotManager.loadLatestSnapshot());
     LogicalWriteInfo info =
         WriteTestUtils.logicalWriteInfo(PARTITIONED_FULL_SCHEMA, CaseInsensitiveStringMap.empty());
     DeltaV2Write write =
@@ -663,8 +665,9 @@ public class DeltaV2BatchWriteTest extends DeltaV2TestBase {
 
   private DeltaV2BatchWrite newWrite(String path) {
     Snapshot snapshot =
-        new PathBasedSnapshotManager(path, spark.sessionState().newHadoopConf())
-            .loadLatestSnapshot();
+        DeltaV2Snapshot$.MODULE$.getKernelSnapshot(
+            new PathBasedSnapshotManager(path, spark.sessionState().newHadoopConf())
+                .loadLatestSnapshot());
     LogicalWriteInfo info =
         WriteTestUtils.logicalWriteInfo(TABLE_SCHEMA, CaseInsensitiveStringMap.empty());
     return new DeltaV2BatchWrite(

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/write/DeltaV2StreamingWriteTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/write/DeltaV2StreamingWriteTest.java
@@ -32,6 +32,7 @@ import org.apache.spark.sql.connector.write.DataWriter;
 import org.apache.spark.sql.connector.write.LogicalWriteInfo;
 import org.apache.spark.sql.connector.write.WriterCommitMessage;
 import org.apache.spark.sql.connector.write.streaming.StreamingDataWriterFactory;
+import org.apache.spark.sql.delta.v2.interop.DeltaV2Snapshot$;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
@@ -406,7 +407,8 @@ public class DeltaV2StreamingWriteTest extends DeltaV2TestBase {
   private DeltaV2StreamingWrite newWrite(String path) {
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(path, spark.sessionState().newHadoopConf());
-    Snapshot snapshot = snapshotManager.loadLatestSnapshot();
+    Snapshot snapshot =
+        DeltaV2Snapshot$.MODULE$.getKernelSnapshot(snapshotManager.loadLatestSnapshot());
     LogicalWriteInfo info =
         WriteTestUtils.logicalWriteInfo(TABLE_SCHEMA, CaseInsensitiveStringMap.empty());
     DeltaV2Write write =
@@ -435,7 +437,8 @@ public class DeltaV2StreamingWriteTest extends DeltaV2TestBase {
   private DeltaV2StreamingWrite newPartitionedWrite(String path) {
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(path, spark.sessionState().newHadoopConf());
-    Snapshot snapshot = snapshotManager.loadLatestSnapshot();
+    Snapshot snapshot =
+        DeltaV2Snapshot$.MODULE$.getKernelSnapshot(snapshotManager.loadLatestSnapshot());
     LogicalWriteInfo info =
         WriteTestUtils.logicalWriteInfo(PARTITIONED_FULL_SCHEMA, CaseInsensitiveStringMap.empty());
     DeltaV2Write write =

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/write/DeltaV2WriteTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/write/DeltaV2WriteTest.java
@@ -30,6 +30,7 @@ import org.apache.spark.sql.connector.distributions.UnspecifiedDistribution;
 import org.apache.spark.sql.connector.expressions.NamedReference;
 import org.apache.spark.sql.connector.expressions.SortOrder;
 import org.apache.spark.sql.connector.write.LogicalWriteInfo;
+import org.apache.spark.sql.delta.v2.interop.DeltaV2Snapshot$;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
@@ -113,7 +114,7 @@ public class DeltaV2WriteTest extends DeltaV2TestBase {
             defaultEngine,
             spark.sessionState().newHadoopConf(),
             path,
-            mgr.loadLatestSnapshot(),
+            DeltaV2Snapshot$.MODULE$.getKernelSnapshot(mgr.loadLatestSnapshot()),
             mgr,
             dataSchema,
             partitionSchema,
@@ -159,7 +160,7 @@ public class DeltaV2WriteTest extends DeltaV2TestBase {
             defaultEngine,
             spark.sessionState().newHadoopConf(),
             path,
-            mgr.loadLatestSnapshot(),
+            DeltaV2Snapshot$.MODULE$.getKernelSnapshot(mgr.loadLatestSnapshot()),
             mgr,
             dataSchema,
             partitionSchema,
@@ -185,7 +186,8 @@ public class DeltaV2WriteTest extends DeltaV2TestBase {
   private DeltaV2Write newWrite(String path, CaseInsensitiveStringMap options) {
     PathBasedSnapshotManager snapshotManager =
         new PathBasedSnapshotManager(path, spark.sessionState().newHadoopConf());
-    Snapshot snapshot = snapshotManager.loadLatestSnapshot();
+    Snapshot snapshot =
+        DeltaV2Snapshot$.MODULE$.getKernelSnapshot(snapshotManager.loadLatestSnapshot());
     LogicalWriteInfo info = WriteTestUtils.logicalWriteInfo(TABLE_SCHEMA, options);
     return new DeltaV2Write(
         defaultEngine,

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/write/DeltaV2WriterCommitMessageTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/write/DeltaV2WriterCommitMessageTest.java
@@ -28,6 +28,7 @@ import java.io.File;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.write.DataWriter;
 import org.apache.spark.sql.connector.write.WriterCommitMessage;
+import org.apache.spark.sql.delta.v2.interop.DeltaV2Snapshot$;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
@@ -120,8 +121,9 @@ public class DeltaV2WriterCommitMessageTest extends DeltaV2TestBase {
 
   private DeltaV2DataWriterFactory dataWriterFactory(String path) {
     Snapshot snapshot =
-        new PathBasedSnapshotManager(path, spark.sessionState().newHadoopConf())
-            .loadLatestSnapshot();
+        DeltaV2Snapshot$.MODULE$.getKernelSnapshot(
+            new PathBasedSnapshotManager(path, spark.sessionState().newHadoopConf())
+                .loadLatestSnapshot());
     DeltaV2BatchWrite write =
         new DeltaV2BatchWrite(
             defaultEngine,

--- a/spark/v2/src/test/scala/io/delta/spark/internal/v2/snapshot/unitycatalog/UCManagedTableSnapshotManagerSuite.scala
+++ b/spark/v2/src/test/scala/io/delta/spark/internal/v2/snapshot/unitycatalog/UCManagedTableSnapshotManagerSuite.scala
@@ -24,12 +24,16 @@ import io.delta.kernel.unitycatalog.{InMemoryUCClient, UCCatalogManagedClient, U
 import io.delta.spark.internal.v2.exception.VersionNotFoundException
 import io.delta.storage.commit.uccommitcoordinator.InvalidTargetTableException
 
+import org.scalatest.Outcome
 import org.scalatest.funsuite.AnyFunSuite
 
 /** Integration tests for [[UCManagedTableSnapshotManager]]. */
 class UCManagedTableSnapshotManagerSuite
     extends AnyFunSuite
     with UCCatalogManagedTestUtils {
+
+  override protected def withFixture(test: NoArgTest): Outcome =
+    spark.withActive(super.withFixture(test))
 
   private val testUcTableId = "testUcTableId"
   private val testTableIdentifier = new UCTableIdentifier("cat", "sch", "tbl")
@@ -83,7 +87,7 @@ class UCManagedTableSnapshotManagerSuite
 
       val snapshot = manager.loadLatestSnapshot()
 
-      assert(snapshot.getVersion == maxRatifiedVersion)
+      assert(snapshot.version == maxRatifiedVersion)
       assert(ucClient.getLastGetCommitsTableIdentifier.getNamespace.toSeq == Seq("cat", "sch"))
       assert(ucClient.getLastGetCommitsTableIdentifier.getName == "tbl")
     }
@@ -112,8 +116,8 @@ class UCManagedTableSnapshotManagerSuite
     withUCClientAndTestTable { (ucClient, tablePath, maxRatifiedVersion) =>
       val manager = createManager(ucClient, tablePath)
 
-      assert(manager.loadSnapshotAt(0L).getVersion == 0L)
-      assert(manager.loadSnapshotAt(1L).getVersion == 1L)
+      assert(manager.loadSnapshotAt(0L).version == 0L)
+      assert(manager.loadSnapshotAt(1L).version == 1L)
 
       intercept[IllegalArgumentException] { manager.loadSnapshotAt(-1L) }
       intercept[IllegalArgumentException] { manager.loadSnapshotAt(maxRatifiedVersion + 10) }


### PR DESCRIPTION
## What changes were proposed in this pull request?

`DeltaV2SnapshotManager.loadLatestSnapshot()` and `loadSnapshotAt()` now return the V1 `Snapshot` facade (`DeltaV2Snapshot`, a Kernel-backed `Snapshot` subclass) instead of exposing a raw Kernel `Snapshot` to every connector consumer.

The snapshot managers still load through Kernel, but the facade centralizes the translation into Delta Spark concepts. Most consumers can therefore use the established V1 snapshot surface, while the small number of genuinely Kernel-only execution paths borrow the underlying Kernel snapshot at the latest possible boundary.

```mermaid
flowchart LR
    subgraph Before
        M1[Snapshot manager] --> K1[Kernel SnapshotImpl]
        K1 --> C1[Connector consumers]
        C1 --> U1[Repeated conversion helpers]
        C1 --> E1[Engine-aware Kernel calls]
    end
    subgraph After
        M2[Snapshot manager] --> F[DeltaV2Snapshot facade]
        F --> V[V1 Snapshot API]
        V --> C2[Most connector consumers]
        F -. narrow escape hatch .-> K2[Borrowed Kernel snapshot]
        K2 --> S[Kernel-only execution seams]
    end
```

### Expected consumer transformations

| Concern | Before | After |
|---|---|---|
| Schema | `SchemaUtils.convertKernelSchemaToSparkSchema(kernelSnapshot.getSchema())` | `snapshot.schema()` returns a Spark `StructType` |
| Metadata | Read Kernel metadata and adapt it at the call site | `snapshot.getMetadata()` returns Delta Spark `Metadata` |
| Protocol | Read Kernel protocol and adapt it at the call site | `snapshot.protocol()` returns Delta Spark `Protocol` |
| Timestamp | `kernelSnapshot.getTimestamp(engine)` | `snapshot.timestamp()`; the facade owns the engine-aware delegation |
| Version | `kernelSnapshot.getVersion()` | `snapshot.getVersion()` |
| Partition columns and table properties | Derive them from Kernel metadata | `getPartitionColumnNames()` and `getTableProperties()` |
| Table path | Carry a separate path or reach into the manager | `snapshot.getTablePath()` |
| Application transaction version | Pass both `Engine` and application ID to Kernel | `snapshot.getLatestTransactionVersion(appId)` |
| Known file count | Query the Kernel snapshot directly | `snapshot.getNumOfFilesIfKnown()` |

The Java-friendly `get...` methods are deliberately limited to common Kernel-shaped access patterns where aliases keep the migration small. We do not add parallel `getSchema`, `getProtocol`, or `getTimestamp` methods: Java callers use the existing V1 `schema()`, `protocol()`, and `timestamp()` APIs for those values.

`DeltaV2Snapshot` performs Kernel-to-Delta conversion once for metadata and protocol, and its V1 `schema()` derives the Spark schema from the converted metadata. This removes repeated schema conversion utilities from ordinary consumers without changing the underlying Kernel-backed snapshot semantics.

The underlying Kernel snapshot remains available through `DeltaV2Snapshot.borrowKernelSnapshot(...)`, but only at narrow boundaries such as constructing a Kernel write transaction or physical scan. Consumers should otherwise stay on the V1 facade so future snapshot-manager implementations can change without spreading Kernel implementation types through the connector.

Other changes in this PR:

- `PathBasedSnapshotManager` and `UCManagedTableSnapshotManager` wrap loaded Kernel snapshots before returning them.
- `DeltaV2Snapshot` gains a one-argument constructor for callers without catalog-table context.
- Existing connector consumers and tests are migrated to the facade with behavior-preserving accessor changes.

## How was this patch tested?

- Existing V2 connector unit tests were updated for the facade return type.
- The Spark V2 Java formatter and formatter check pass.
- The Spark V2 compile passes on JDK 17.
- The paired snapshot-manager export and consumer projection are continuously validated in CI.
