### PR TITLE
[Spark] DSv2 Connector Metadata-only Delete Support for Partitioning Columns

### DIFF
--- a/spark/v2/src/main/java-shims/spark-4.2/io/delta/spark/internal/v2/catalog/DeltaV2TableShims.java
+++ b/spark/v2/src/main/java-shims/spark-4.2/io/delta/spark/internal/v2/catalog/DeltaV2TableShims.java
@@ -16,26 +16,39 @@
 
 package io.delta.spark.internal.v2.catalog;
 
+import io.delta.kernel.engine.Engine;
+import io.delta.kernel.internal.SnapshotImpl;
 import org.apache.spark.sql.delta.ColumnTypeChangeSupport;
 import org.apache.spark.sql.delta.v2.interop.AbstractMetadata;
 import org.apache.spark.sql.delta.v2.interop.AbstractProtocol;
 import io.delta.spark.internal.v2.utils.ScalaUtils;
+import io.delta.spark.internal.v2.write.DeltaMetadataOnlyDeleteExecutor;
+import java.util.Arrays;
 import java.util.Optional;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.catalog.CatalogTable;
+import org.apache.spark.sql.connector.catalog.SupportsDeleteV2;
 import org.apache.spark.sql.connector.catalog.SupportsSchemaEvolution;
 import org.apache.spark.sql.connector.catalog.TableCapability;
 import org.apache.spark.sql.connector.catalog.TableChange;
+import org.apache.spark.sql.connector.expressions.filter.AlwaysTrue;
+import org.apache.spark.sql.connector.expressions.filter.PartitionPredicate;
+import org.apache.spark.sql.connector.expressions.filter.Predicate;
 
 /**
  * Shim to build the DSv2 Delta table connector against different Spark versions.
  * This is the shim for Spark 4.2:
  * - Schema evolution support in DSV2 (add columns, change type) was added in Spark 4.2.
+ * - Partition-aware metadata-only DELETE support depends on Spark 4.2's PartitionPredicate.
  */
-public abstract class DeltaV2TableShims implements SupportsSchemaEvolution {
+public abstract class DeltaV2TableShims implements SupportsSchemaEvolution, SupportsDeleteV2 {
 
   /** Implemented in DeltaV2Table to provide access to the table protocol/metadata. */
   protected abstract AbstractProtocol protocol();
   protected abstract AbstractMetadata metadata();
+  protected abstract Engine kernelEngine();
+  protected abstract SnapshotImpl initialSnapshot();
+  protected abstract Optional<CatalogTable> catalogTable();
 
   /**
    * Whether an analyzer-proposed schema-evolution column change (adding a column or widening a
@@ -62,5 +75,22 @@ public abstract class DeltaV2TableShims implements SupportsSchemaEvolution {
   /** The schema evolution capability to advertise. */
   public static Optional<TableCapability> schemaEvolutionCapability() {
     return Optional.of(TableCapability.AUTOMATIC_SCHEMA_EVOLUTION);
+  }
+
+  /**
+   * A DELETE qualifies for metadata-only execution when every predicate can be evaluated against
+   * partition values alone: either a whole-table {@link AlwaysTrue}, or a
+   * {@link PartitionPredicate} from a partition-column condition.
+   */
+  @Override
+  public boolean canDeleteWhere(Predicate[] predicates) {
+    return Arrays.stream(predicates)
+        .allMatch(p -> p instanceof AlwaysTrue || p instanceof PartitionPredicate);
+  }
+
+  @Override
+  public void deleteWhere(Predicate[] predicates) {
+    DeltaMetadataOnlyDeleteExecutor.deleteWhere(
+        kernelEngine(), initialSnapshot(), catalogTable(), predicates);
   }
 }

--- a/spark/v2/src/main/java-shims/spark-4.2/io/delta/spark/internal/v2/write/DeltaMetadataOnlyDeleteExecutor.java
+++ b/spark/v2/src/main/java-shims/spark-4.2/io/delta/spark/internal/v2/write/DeltaMetadataOnlyDeleteExecutor.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.write;
+
+import static io.delta.spark.internal.v2.utils.ScalaUtils.toJavaMap;
+import static io.delta.spark.internal.v2.utils.ScalaUtils.toScalaList;
+import static java.util.Objects.requireNonNull;
+
+import io.delta.kernel.Operation;
+import io.delta.kernel.Transaction;
+import io.delta.kernel.TransactionCommitResult;
+import io.delta.kernel.data.MapValue;
+import io.delta.kernel.data.Row;
+import io.delta.kernel.engine.Engine;
+import io.delta.kernel.internal.SnapshotImpl;
+import io.delta.kernel.internal.actions.DeletionVectorDescriptor;
+import io.delta.kernel.internal.actions.GenerateIcebergCompatActionUtils;
+import io.delta.kernel.internal.actions.SingleAction;
+import io.delta.kernel.internal.util.Utils;
+import io.delta.kernel.internal.util.VectorUtils;
+import io.delta.kernel.statistics.DataFileStatistics;
+import io.delta.kernel.types.StructType;
+import io.delta.kernel.utils.CloseableIterable;
+import org.apache.spark.sql.delta.DeltaColumnMapping;
+import org.apache.spark.sql.delta.actions.AddFile;
+import org.apache.spark.sql.delta.v2.interop.DeltaV2Snapshot;
+import io.delta.spark.internal.v2.utils.SchemaUtils;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.catalog.CatalogTable;
+import org.apache.spark.sql.catalyst.expressions.Expression;
+import org.apache.spark.sql.catalyst.expressions.V2ExpressionUtils;
+import org.apache.spark.sql.connector.expressions.filter.AlwaysTrue;
+import org.apache.spark.sql.connector.expressions.filter.Predicate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import scala.Option;
+import scala.jdk.javaapi.CollectionConverters;
+
+/**
+ * Executes a metadata-only DELETE on the DSv2 Delta table: the set of files whose rows all match
+ * the delete condition are removed in their entirety by committing {@code RemoveFile} actions,
+ * without scanning or rewriting any data.
+ */
+public final class DeltaMetadataOnlyDeleteExecutor {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(DeltaMetadataOnlyDeleteExecutor.class);
+
+  private DeltaMetadataOnlyDeleteExecutor() {}
+
+  /** Selects and removes every file whose rows match {@code predicates}. */
+  public static void deleteWhere(
+      Engine engine,
+      SnapshotImpl initialSnapshot,
+      Optional<CatalogTable> catalogTable,
+      Predicate[] predicates) {
+    requireNonNull(engine, "engine is null");
+    requireNonNull(initialSnapshot, "initialSnapshot is null");
+    requireNonNull(catalogTable, "catalogTable is null");
+    requireNonNull(predicates, "predicates is null");
+
+    List<AddFile> filesToRemove =
+        selectFilesToRemove(engine, initialSnapshot, catalogTable, predicates);
+
+    if (filesToRemove.isEmpty()) {
+      LOG.info("Metadata-only delete matched no files; nothing to commit");
+      return;
+    }
+
+    deleteFiles(engine, initialSnapshot, filesToRemove);
+  }
+
+  private static List<AddFile> selectFilesToRemove(
+      Engine engine,
+      SnapshotImpl initialSnapshot,
+      Optional<CatalogTable> catalogTable,
+      Predicate[] predicates) {
+    DeltaV2Snapshot snapshot =
+        new DeltaV2Snapshot(initialSnapshot, SparkSession.active(), engine);
+
+    List<Expression> catalystFilters = new ArrayList<>(predicates.length);
+    for (Predicate predicate : predicates) {
+      if (!(predicate instanceof AlwaysTrue)) {
+        catalystFilters.add(toCatalyst(predicate));
+      }
+    }
+
+    return CollectionConverters.asJava(
+        snapshot
+            .filesForScan(
+                toScalaList(catalystFilters.toArray(new Expression[0])),
+                true)
+            .files());
+  }
+
+  private static Expression toCatalyst(Predicate predicate) {
+    // Conversion is all-or-nothing: None means this predicate or one of its children is
+    // unsupported.
+    Option<Expression> expression = V2ExpressionUtils.toCatalyst(predicate);
+    if (expression.isEmpty()) {
+      throw new IllegalStateException("Could not convert " + predicate + " to Catalyst");
+    }
+    return expression.get();
+  }
+
+  private static void deleteFiles(
+      Engine engine, SnapshotImpl initialSnapshot, List<AddFile> filesToRemove) {
+    // The operation is committed as WRITE, not DELETE as Kernel Transactions don't support it.
+    Transaction transaction =
+        initialSnapshot
+            .buildUpdateTableTransaction(DeltaV2BatchWrite.getEngineInfo(), Operation.WRITE)
+            .build(engine);
+
+    org.apache.spark.sql.types.StructType sparkSchema =
+        SchemaUtils.convertKernelSchemaToSparkSchema(initialSnapshot.getSchema());
+    StructType physicalSchema =
+        SchemaUtils.convertSparkSchemaToKernelSchema(
+            DeltaColumnMapping.renameColumns(sparkSchema));
+    long removeTimestamp = System.currentTimeMillis();
+
+    List<Row> removeActionRows = new ArrayList<>(filesToRemove.size());
+    for (AddFile file : filesToRemove) {
+      removeActionRows.add(createRemoveFileActionRow(file, physicalSchema, removeTimestamp));
+    }
+
+    CloseableIterable<Row> dataActions =
+        CloseableIterable.inMemoryIterable(Utils.toCloseableIterator(removeActionRows.iterator()));
+    TransactionCommitResult result = transaction.commit(engine, dataActions);
+    LOG.info(
+        "Metadata-only delete committed at version {}, removed {} files",
+        result.getVersion(),
+        filesToRemove.size());
+  }
+
+  // Kernel's extended-metadata RemoveFile builder does not accept tags, so this conversion drops
+  // them. This conversion code is temporary.
+  private static Row createRemoveFileActionRow(
+      AddFile file, StructType physicalSchema, long removeTimestamp) {
+    MapValue partitionValues =
+        VectorUtils.stringStringMapValue(toJavaMap(file.partitionValues()));
+    Optional<DataFileStatistics> stats =
+        Optional.ofNullable(file.stats())
+            .flatMap(json -> DataFileStatistics.deserializeFromJson(json, physicalSchema));
+    Row removeFileRow =
+        GenerateIcebergCompatActionUtils.createRemoveFileRowWithExtendedFileMetadata(
+            file.path(),
+            removeTimestamp,
+            /* dataChange = */ true,
+            partitionValues,
+            file.size(),
+            stats,
+            physicalSchema,
+            toJavaLong(file.baseRowId()),
+            toJavaLong(file.defaultRowCommitVersion()),
+            toKernelDeletionVector(file));
+    return SingleAction.createRemoveFileSingleAction(removeFileRow);
+  }
+
+  private static Optional<DeletionVectorDescriptor> toKernelDeletionVector(AddFile file) {
+    return Optional.ofNullable(file.deletionVector())
+        .map(
+            deletionVector ->
+                new DeletionVectorDescriptor(
+                    deletionVector.storageType(),
+                    deletionVector.pathOrInlineDv(),
+                    toJavaInt(deletionVector.offset()),
+                    deletionVector.sizeInBytes(),
+                    deletionVector.cardinality()));
+  }
+
+  private static Optional<Long> toJavaLong(scala.Option<Object> value) {
+    return value.isDefined()
+        ? Optional.of(((Number) value.get()).longValue())
+        : Optional.empty();
+  }
+
+  private static Optional<Integer> toJavaInt(scala.Option<Object> value) {
+    return value.isDefined() ? Optional.of((Integer) value.get()) : Optional.empty();
+  }
+}

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
@@ -60,6 +60,7 @@ import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.MetadataColumn;
 import org.apache.spark.sql.connector.catalog.SupportsMetadataColumns;
 import org.apache.spark.sql.connector.catalog.SupportsRead;
+import org.apache.spark.sql.connector.catalog.SupportsRowLevelOperations;
 import org.apache.spark.sql.connector.catalog.SupportsWrite;
 import org.apache.spark.sql.connector.catalog.Table;
 import org.apache.spark.sql.connector.catalog.TableCapability;
@@ -90,7 +91,12 @@ import scala.jdk.javaapi.CollectionConverters;
 
 /** DataSource V2 Table implementation for Delta Lake using the Delta Kernel API. */
 public class DeltaV2Table extends DeltaV2TableShims
-    implements Table, SupportsRead, SupportsWrite, SupportsMetadataColumns, DeltaV2TableMarker {
+    implements Table,
+        SupportsRead,
+        SupportsWrite,
+        SupportsMetadataColumns,
+        SupportsRowLevelOperations,
+        DeltaV2TableMarker {
   private static final String METADATA_COLUMN_NAME = FileFormat$.MODULE$.METADATA_NAME();
   private static final String ROW_ID_METADATA_FIELD_NAME = RowId$.MODULE$.ROW_ID();
   private static final String ROW_COMMIT_VERSION_METADATA_FIELD_NAME =
@@ -364,6 +370,19 @@ public class DeltaV2Table extends DeltaV2TableShims
     return new KernelMetadataAdapter(((SnapshotImpl) initialSnapshot).getMetadata());
   }
 
+  /** Inputs exposed to the Spark-version shim for metadata-only DELETE. */
+  protected Engine kernelEngine() {
+    return kernelEngine;
+  }
+
+  protected SnapshotImpl initialSnapshot() {
+    return (SnapshotImpl) initialSnapshot;
+  }
+
+  protected Optional<CatalogTable> catalogTable() {
+    return catalogTable;
+  }
+
   /** Returns a copy of this table pinned to {@code version}. */
   public DeltaV2Table withVersion(long version) {
     return catalogTable.isPresent()
@@ -569,6 +588,7 @@ public class DeltaV2Table extends DeltaV2TableShims
    * Delta's copy-on-write operation shell; the concrete ReplaceData write path is introduced in a
    * follow-up PR.
    */
+  @Override
   public RowLevelOperationBuilder newRowLevelOperationBuilder(RowLevelOperationInfo info) {
     requireNonNull(info, "row-level operation info is null");
     return new DeltaRowLevelOperationBuilder(this, kernelEngine, hadoopConf, initialSnapshot, info);

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/DeltaV2TestBase.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/DeltaV2TestBase.java
@@ -18,6 +18,7 @@ package io.delta.spark.internal.v2;
 import io.delta.kernel.defaults.engine.DefaultEngine;
 import io.delta.kernel.engine.Engine;
 import io.delta.spark.internal.v2.read.DeltaV2ScanBuilder;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import org.apache.spark.sql.SparkSession;
@@ -64,6 +65,17 @@ public abstract class DeltaV2TestBase {
       spark.stop();
       spark = null;
     }
+  }
+
+  /** Returns a fresh, unique table directory path under the JVM temp dir. */
+  protected static String newTablePath(String prefix) {
+    return Paths.get(System.getProperty("java.io.tmpdir"), prefix + "-" + System.nanoTime())
+        .toString();
+  }
+
+  /** Returns the DSv2-catalog table reference for a path-based Delta table. */
+  protected static String dsv2Table(String tablePath) {
+    return String.format("dsv2.delta.`%s`", tablePath);
   }
 
   protected void createTestTableWithData(String path, String tableName) {

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/V2MetadataReadTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/V2MetadataReadTest.java
@@ -21,7 +21,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
-import java.nio.file.Paths;
 import java.sql.Timestamp;
 import java.util.List;
 import org.apache.spark.sql.Dataset;
@@ -195,10 +194,6 @@ public class V2MetadataReadTest extends DeltaV2TestBase {
   // ---------------------------------------------------------------------------
   // Helpers
   // ---------------------------------------------------------------------------
-
-  private static String newTablePath(String prefix) {
-    return Paths.get(System.getProperty("java.io.tmpdir"), prefix + System.nanoTime()).toString();
-  }
 
   private void createTable(String path, boolean rowTrackingEnabled) {
     spark.sql(

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/write/DeltaRowLevelOperationBuilderTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/write/DeltaRowLevelOperationBuilderTest.java
@@ -28,7 +28,6 @@ import java.util.Collections;
 import java.util.Optional;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.spark.sql.connector.catalog.Identifier;
-import org.apache.spark.sql.connector.catalog.SupportsRowLevelOperations;
 import org.apache.spark.sql.connector.expressions.NamedReference;
 import org.apache.spark.sql.connector.read.Scan;
 import org.apache.spark.sql.connector.read.ScanBuilder;
@@ -46,20 +45,11 @@ import org.junit.jupiter.api.io.TempDir;
 public class DeltaRowLevelOperationBuilderTest extends DeltaV2TestBase {
 
   @Test
-  public void regularTableDoesNotExposeRowLevelOperations(@TempDir File tempDir) {
-    DeltaV2Table table = createBaseTable(tempDir);
-
-    assertFalse(table instanceof SupportsRowLevelOperations);
-  }
-
-  @Test
   public void tableExposesRowLevelOperationBuilder(@TempDir File tempDir) {
     DeltaV2Table table = createRowLevelTable(tempDir);
 
-    assertTrue(table instanceof SupportsRowLevelOperations);
     RowLevelOperationBuilder builder =
-        ((SupportsRowLevelOperations) table)
-            .newRowLevelOperationBuilder(testInfo(RowLevelOperation.Command.DELETE));
+        table.newRowLevelOperationBuilder(testInfo(RowLevelOperation.Command.DELETE));
     assertTrue(builder instanceof DeltaRowLevelOperationBuilder);
   }
 
@@ -136,18 +126,11 @@ public class DeltaRowLevelOperationBuilderTest extends DeltaV2TestBase {
         () -> new DeltaRowLevelOperationBuilder(table, engine, hadoopConf, snapshot, null));
   }
 
-  private DeltaV2Table createBaseTable(File tableDir) {
-    String path = tableDir.getAbsolutePath();
-    String tableName = "delta_row_level_" + System.nanoTime();
-    createEmptyTestTable(path, tableName);
-    return new DeltaV2Table(Identifier.of(new String[] {"default"}, tableName), path);
-  }
-
   private DeltaV2Table createRowLevelTable(File tableDir) {
     String path = tableDir.getAbsolutePath();
     String tableName = "delta_row_level_" + System.nanoTime();
     createEmptyTestTable(path, tableName);
-    return new RowLevelDeltaV2Table(Identifier.of(new String[] {"default"}, tableName), path);
+    return new DeltaV2Table(Identifier.of(new String[] {"default"}, tableName), path);
   }
 
   private DeltaRowLevelOperationBuilder createBuilder(
@@ -159,13 +142,6 @@ public class DeltaRowLevelOperationBuilderTest extends DeltaV2TestBase {
         new PathBasedSnapshotManager(table.getTablePath().toString(), engine).loadLatestSnapshot();
     return new DeltaRowLevelOperationBuilder(
         table, engine, hadoopConf, snapshot, testInfo(command));
-  }
-
-  private static class RowLevelDeltaV2Table extends DeltaV2Table
-      implements SupportsRowLevelOperations {
-    RowLevelDeltaV2Table(Identifier identifier, String tablePath) {
-      super(identifier, tablePath);
-    }
   }
 
   private static StructType tableSchema() {

--- a/spark/v2/src/test/scala-shims/spark-4.2/io/delta/spark/internal/v2/V2MetadataOnlyDeleteTest.java
+++ b/spark/v2/src/test/scala-shims/spark-4.2/io/delta/spark/internal/v2/V2MetadataOnlyDeleteTest.java
@@ -1,0 +1,538 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Arrays;
+import java.util.List;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
+import org.apache.spark.sql.api.java.UDF1;
+import org.apache.spark.sql.execution.SparkPlan;
+import org.apache.spark.sql.execution.QueryExecution;
+import org.apache.spark.sql.execution.datasources.v2.DeleteFromTableExec;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.util.QueryExecutionListener;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end tests for the DSv2 metadata-only DELETE path.
+ */
+public class V2MetadataOnlyDeleteTest extends DeltaV2TestBase {
+
+  private static final String V2_ENABLE_MODE = "spark.databricks.delta.v2.enableMode";
+
+  @Test
+  public void testPartitionPredicateDeleteRemovesMatchingPartition() throws Exception {
+    String tablePath = newTablePath("delta-v2-mod");
+    withTable(
+        tablePath,
+        () -> {
+          createIdPartTable(tablePath);
+          insertRows(tablePath, "(1, 'a'), (2, 'a'), (3, 'b'), (4, 'c')");
+
+          executeAndAssertDsv2MetadataOnlyDeleteAtPath(tablePath, "part = 'a'");
+
+          assertTableRows(
+              tablePath, "id, part", RowFactory.create(3, "b"), RowFactory.create(4, "c"));
+        });
+  }
+
+  @Test
+  public void testMetadataOnlyDeletePreservesNumRecordsInRemoveFile() throws Exception {
+    String tablePath = newTablePath("delta-v2-mod");
+    withTable(
+        tablePath,
+        () -> {
+          createIdPartTable(tablePath);
+          insertRows(tablePath, "(1, 'a'), (2, 'a'), (3, 'b')");
+
+          executeAndAssertDsv2MetadataOnlyDeleteAtPath(tablePath, "part = 'a'");
+
+          Dataset<Row> transactionLog = spark.read().json(tablePath + "/_delta_log/*.json");
+          Dataset<Row> addedFileNumRecords =
+              transactionLog
+                  .where("add IS NOT NULL")
+                  .selectExpr(
+                      "add.path AS path",
+                      "CAST(get_json_object(add.stats, '$.numRecords') AS BIGINT) AS numRecords");
+          Dataset<Row> removedFileNumRecords =
+              transactionLog
+                  .where("remove IS NOT NULL")
+                  .selectExpr(
+                      "remove.path AS path",
+                      "CAST(get_json_object(remove.stats, '$.numRecords') AS BIGINT) "
+                          + "AS numRecords");
+
+          assertFalse(removedFileNumRecords.isEmpty());
+          assertEquals(0, removedFileNumRecords.where("numRecords IS NULL").count());
+          assertTrue(removedFileNumRecords.exceptAll(addedFileNumRecords).isEmpty());
+        });
+  }
+
+  @Test
+  public void testMetadataOnlyDeleteInAutoMode() throws Exception {
+    String tablePath = newTablePath("delta-v2-mod");
+    withTable(
+        tablePath,
+        () -> {
+          createIdPartTable(tablePath);
+          insertRows(tablePath, "(1, 'a'), (2, 'b')");
+
+          withSQLConf(
+              V2_ENABLE_MODE,
+              "AUTO",
+              () -> {
+                String sql =
+                    String.format(
+                        "DELETE FROM %s WHERE part = 'a'", sparkCatalogTable(tablePath));
+                boolean ranAsDsv2Delete =
+                    executeAndCapturePlans(sql).stream()
+                        .anyMatch(plan -> plan.exists(p -> p instanceof DeleteFromTableExec));
+                assertFalse(ranAsDsv2Delete, "AUTO mode should fall back to the V1 DELETE path");
+              });
+
+          assertTableRows(tablePath, "id, part", RowFactory.create(2, "b"));
+        });
+  }
+
+  @Test
+  public void testNonMetadataPredicateDoesNotUseMetadataOnlyDelete() throws Exception {
+    String tablePath = newTablePath("delta-v2-mod");
+    withTable(
+        tablePath,
+        () -> {
+          createIdPartTable(tablePath);
+          insertRows(tablePath, "(1, 'a'), (2, 'b')");
+
+          assertThrows(
+              UnsupportedOperationException.class,
+              () ->
+                  spark.sql(
+                      String.format(
+                          "DELETE FROM %s WHERE part = 'a' OR id = 2", dsv2Table(tablePath))));
+
+          assertTableRows(
+              tablePath, "id, part", RowFactory.create(1, "a"), RowFactory.create(2, "b"));
+        });
+  }
+
+  @Test
+  public void testColumnMappingTableDeleteUsesPhysicalSchema() throws Exception {
+    String tablePath = newTablePath("delta-v2-mod");
+    withTable(
+        tablePath,
+        () -> {
+          spark.sql(
+              String.format(
+                  "CREATE TABLE delta.`%s` (id INT, part STRING) USING delta "
+                      + "PARTITIONED BY (part) "
+                      + "TBLPROPERTIES ('delta.columnMapping.mode' = 'name')",
+                  tablePath));
+          insertRows(tablePath, "(1, 'a'), (2, 'b')");
+
+          executeAndAssertDsv2MetadataOnlyDeleteAtPath(tablePath, "part = 'a'");
+
+          assertTableRows(tablePath, "id, part", RowFactory.create(2, "b"));
+        });
+  }
+
+  @Test
+  public void testWholeTableDeleteRemovesAllRows() throws Exception {
+    String tablePath = newTablePath("delta-v2-mod");
+    withTable(
+        tablePath,
+        () -> {
+          createIdPartTable(tablePath);
+          insertRows(tablePath, "(1, 'a'), (2, 'b')");
+
+          executeAndAssertDsv2MetadataOnlyDeleteAtPath(tablePath, null);
+
+          assertTableRows(tablePath, "id, part");
+        });
+  }
+
+  @Test
+  public void testPartitionPredicateDeleteWithNoMatchIsNoOp() throws Exception {
+    String tablePath = newTablePath("delta-v2-mod");
+    withTable(
+        tablePath,
+        () -> {
+          createIdPartTable(tablePath);
+          insertRows(tablePath, "(1, 'a'), (2, 'b')");
+
+          executeAndAssertDsv2MetadataOnlyDeleteAtPath(tablePath, "part = 'nonExistent'");
+
+          assertTableRows(
+              tablePath, "id, part", RowFactory.create(1, "a"), RowFactory.create(2, "b"));
+        });
+  }
+
+  @Test
+  public void testMetadataOnlyDeleteLeavesUntouchedPartitionFilesStable() throws Exception {
+    String tablePath = newTablePath("delta-v2-mod");
+    withTable(
+        tablePath,
+        () -> {
+          createIdPartTable(tablePath);
+          // Each partition is written as its own file.
+          insertRows(tablePath, "(1, 'a')");
+          insertRows(tablePath, "(2, 'b')");
+
+          List<Row> initialFiles = filePathsById(tablePath);
+          assertEquals(2, initialFiles.size());
+          String deletedFilePath = initialFiles.get(0).getString(1);
+          String untouchedFilePath = initialFiles.get(1).getString(1);
+          assertNotEquals(deletedFilePath, untouchedFilePath);
+
+          executeAndAssertDsv2MetadataOnlyDeleteAtPath(tablePath, "part = 'a'");
+
+          List<Row> remainingFiles = filePathsById(tablePath);
+          assertEquals(1, remainingFiles.size());
+          assertEquals(2, remainingFiles.get(0).getInt(0));
+          // The surviving partition's file is untouched (not rewritten): metadata-only delete only
+          // removes the matching file and never rewrites the others.
+          assertEquals(untouchedFilePath, remainingFiles.get(0).getString(1));
+          assertTableRows(tablePath, "id, part", RowFactory.create(2, "b"));
+        });
+  }
+
+  @Test
+  public void testInListDeleteRemovesMatchingPartitions() throws Exception {
+    String tablePath = newTablePath("delta-v2-mod");
+    withTable(
+        tablePath,
+        () -> {
+          createIdPartTable(tablePath);
+          insertRows(tablePath, "(1, 'a'), (2, 'b'), (3, 'c')");
+
+          executeAndAssertDsv2MetadataOnlyDeleteAtPath(tablePath, "part IN ('a', 'c')");
+
+          assertTableRows(tablePath, "id, part", RowFactory.create(2, "b"));
+        });
+  }
+
+  @Test
+  public void testOrOnSamePartitionColumnRemovesBothPartitions() throws Exception {
+    String tablePath = newTablePath("delta-v2-mod");
+    withTable(
+        tablePath,
+        () -> {
+          createIdPartTable(tablePath);
+          insertRows(tablePath, "(1, 'a'), (2, 'b'), (3, 'c')");
+
+          executeAndAssertDsv2MetadataOnlyDeleteAtPath(
+              tablePath, "part = 'a' OR part = 'c'");
+
+          assertTableRows(tablePath, "id, part", RowFactory.create(2, "b"));
+        });
+  }
+
+  @Test
+  public void testRangeComparisonDeleteRemovesMatchingPartitions() throws Exception {
+    String tablePath = newTablePath("delta-v2-mod");
+    withTable(
+        tablePath,
+        () -> {
+          createIdPartTable(tablePath);
+          insertRows(tablePath, "(1, 'a'), (2, 'b'), (3, 'c')");
+
+          executeAndAssertDsv2MetadataOnlyDeleteAtPath(tablePath, "part >= 'b'");
+
+          assertTableRows(tablePath, "id, part", RowFactory.create(1, "a"));
+        });
+  }
+
+  @Test
+  public void testInequalityDeleteRemovesMatchingPartitions() throws Exception {
+    String tablePath = newTablePath("delta-v2-mod");
+    withTable(
+        tablePath,
+        () -> {
+          createIdPartTable(tablePath);
+          insertRows(tablePath, "(1, 'a'), (2, 'b'), (3, 'c')");
+
+          executeAndAssertDsv2MetadataOnlyDeleteAtPath(tablePath, "part <> 'a'");
+
+          assertTableRows(tablePath, "id, part", RowFactory.create(1, "a"));
+        });
+  }
+
+  @Test
+  public void testLikePrefixDeleteRemovesMatchingPartitions() throws Exception {
+    String tablePath = newTablePath("delta-v2-mod");
+    withTable(
+        tablePath,
+        () -> {
+          createIdPartTable(tablePath);
+          insertRows(tablePath, "(1, 'apple'), (2, 'apricot'), (3, 'banana')");
+
+          executeAndAssertDsv2MetadataOnlyDeleteAtPath(tablePath, "part LIKE 'a%'");
+
+          assertTableRows(tablePath, "id, part", RowFactory.create(3, "banana"));
+        });
+  }
+
+  @Test
+  public void testSubstringOnPartitionColumnDelete() throws Exception {
+    String tablePath = newTablePath("delta-v2-mod");
+    withTable(
+        tablePath,
+        () -> {
+          createIdPartTable(tablePath);
+          insertRows(tablePath, "(1, 'apple'), (2, 'avocado'), (3, 'banana')");
+
+          executeAndAssertDsv2MetadataOnlyDeleteAtPath(
+              tablePath, "substring(part, 1, 1) = 'a'");
+
+          assertTableRows(tablePath, "id, part", RowFactory.create(3, "banana"));
+        });
+  }
+
+  @Test
+  public void testUdfOnPartitionColumnDelete() throws Exception {
+    String tablePath = newTablePath("delta-v2-mod");
+    withTable(
+        tablePath,
+        () -> {
+          spark
+              .udf()
+              .register(
+                  "starts_with_a",
+                  (UDF1<String, Boolean>) s -> s != null && s.startsWith("a"),
+                  DataTypes.BooleanType);
+          createIdPartTable(tablePath);
+          insertRows(tablePath, "(1, 'apple'), (2, 'avocado'), (3, 'banana')");
+
+          executeAndAssertDsv2MetadataOnlyDeleteAtPath(tablePath, "starts_with_a(part)");
+
+          assertTableRows(tablePath, "id, part", RowFactory.create(3, "banana"));
+        });
+  }
+
+  @Test
+  public void testArithmeticOnIntPartitionColumnDelete() throws Exception {
+    String tablePath = newTablePath("delta-v2-mod");
+    withTable(
+        tablePath,
+        () -> {
+          spark.sql(
+              String.format(
+                  "CREATE TABLE delta.`%s` (id INT, pid INT) USING delta PARTITIONED BY (pid)",
+                  tablePath));
+          spark.sql(
+              String.format(
+                  "INSERT INTO delta.`%s` VALUES (1, 1), (2, 2), (3, 3)", tablePath));
+
+          executeAndAssertDsv2MetadataOnlyDeleteAtPath(tablePath, "pid + 1 = 3");
+
+          assertTableRows(
+              tablePath, "id, pid", RowFactory.create(1, 1), RowFactory.create(3, 3));
+        });
+  }
+
+  @Test
+  public void testMixedOrWithUntranslatableAndSimpleLeg() throws Exception {
+    String tablePath = newTablePath("delta-v2-mod");
+    withTable(
+        tablePath,
+        () -> {
+          createIdPartTable(tablePath);
+          insertRows(tablePath, "(1, 'a'), (2, 'b'), (3, 'c')");
+
+          executeAndAssertDsv2MetadataOnlyDeleteAtPath(
+              tablePath, "part = 'a' OR substring(part, 1, 1) = 'c'");
+
+          assertTableRows(tablePath, "id, part", RowFactory.create(2, "b"));
+        });
+  }
+
+  @Test
+  public void testAndAcrossTwoPartitionColumns() throws Exception {
+    String tablePath = newTablePath("delta-v2-mod");
+    withTable(
+        tablePath,
+        () -> {
+          spark.sql(
+              String.format(
+                  "CREATE TABLE delta.`%s` (id INT, p0 STRING, p1 STRING) USING delta "
+                      + "PARTITIONED BY (p0, p1)",
+                  tablePath));
+          spark.sql(
+              String.format(
+                  "INSERT INTO delta.`%s` VALUES "
+                      + "(1, 'a', 'x'), (2, 'a', 'y'), (3, 'b', 'x')",
+                  tablePath));
+
+          executeAndAssertDsv2MetadataOnlyDeleteAtPath(
+              tablePath, "p0 = 'a' AND p1 = 'x'");
+
+          assertTableRows(
+              tablePath,
+              "id, p0, p1",
+              RowFactory.create(2, "a", "y"),
+              RowFactory.create(3, "b", "x"));
+        });
+  }
+
+  @Test
+  public void testAlwaysTrueConditionRemovesAllRows() throws Exception {
+    String tablePath = newTablePath("delta-v2-mod");
+    withTable(
+        tablePath,
+        () -> {
+          createIdPartTable(tablePath);
+          insertRows(tablePath, "(1, 'a'), (2, 'b')");
+
+          executeAndAssertDsv2MetadataOnlyDeleteAtPath(tablePath, "1 = 1");
+
+          assertTableRows(tablePath, "id, part");
+        });
+  }
+
+  @Test
+  public void testIsNullOnPartitionColumnDelete() throws Exception {
+    String tablePath = newTablePath("delta-v2-mod");
+    withTable(
+        tablePath,
+        () -> {
+          createIdPartTable(tablePath);
+          insertRows(tablePath, "(1, 'a'), (2, null), (3, 'b')");
+
+          executeAndAssertDsv2MetadataOnlyDeleteAtPath(tablePath, "part IS NULL");
+
+          assertTableRows(
+              tablePath, "id, part", RowFactory.create(1, "a"), RowFactory.create(3, "b"));
+        });
+  }
+
+  @Test
+  public void testIsNotNullOnPartitionColumnDelete() throws Exception {
+    String tablePath = newTablePath("delta-v2-mod");
+    withTable(
+        tablePath,
+        () -> {
+          createIdPartTable(tablePath);
+          insertRows(tablePath, "(1, 'a'), (2, null), (3, 'b')");
+
+          executeAndAssertDsv2MetadataOnlyDeleteAtPath(tablePath, "part IS NOT NULL");
+
+          assertTableRows(tablePath, "id, part", RowFactory.create(2, null));
+        });
+  }
+
+  private void createIdPartTable(String tablePath) {
+    spark.sql(
+        String.format(
+            "CREATE TABLE delta.`%s` (id INT, part STRING) USING delta PARTITIONED BY (part)",
+            tablePath));
+  }
+
+  private String sparkCatalogTable(String tablePath) {
+    return String.format("delta.`%s`", tablePath);
+  }
+
+  private void insertRows(String tablePath, String valuesSql) {
+    spark.sql(String.format("INSERT INTO delta.`%s` VALUES %s", tablePath, valuesSql));
+  }
+
+  private List<Row> filePathsById(String tablePath) {
+    return spark
+        .sql(
+            String.format(
+                "SELECT id, _metadata.file_path AS file_path FROM delta.`%s` ORDER BY id",
+                tablePath))
+        .collectAsList();
+  }
+
+  private void assertTableRows(String tablePath, String columns, Row... expectedRows) {
+    List<Row> actualRows =
+        spark
+            .sql(String.format("SELECT %s FROM delta.`%s` ORDER BY id", columns, tablePath))
+            .collectAsList();
+    List<Row> expected = Arrays.asList(expectedRows);
+    assertEquals(
+        expected,
+        actualRows,
+        () -> "Unexpected table contents for " + tablePath + ": " + actualRows);
+    assertEquals(
+        spark
+            .sql(String.format("SELECT %s FROM %s ORDER BY id", columns, dsv2Table(tablePath)))
+            .collectAsList(),
+        actualRows,
+        "DSv2 and V1 reads should observe the same committed rows");
+  }
+
+  /**
+   * Runs a DELETE against the {@code dsv2} catalog and asserts that it executed as a DSv2
+   * metadata-only delete: the physical plan is the DSv2 {@link DeleteFromTableExec} node.
+   *
+   * @param tablePath the table's filesystem path
+   * @param whereClause the DELETE predicate without the {@code WHERE} keyword, or {@code null} for
+   *     a whole-table delete
+   */
+  private void executeAndAssertDsv2MetadataOnlyDeleteAtPath(String tablePath, String whereClause) {
+    executeAndAssertDsv2MetadataOnlyDelete(dsv2Table(tablePath), whereClause);
+  }
+
+  private void executeAndAssertDsv2MetadataOnlyDelete(String table, String whereClause) {
+    String sql =
+        whereClause == null
+            ? String.format("DELETE FROM %s", table)
+            : String.format("DELETE FROM %s WHERE %s", table, whereClause);
+
+    boolean ranAsMetadataOnlyDelete =
+        executeAndCapturePlans(sql).stream()
+            .anyMatch(plan -> plan.exists(p -> p instanceof DeleteFromTableExec));
+    assertTrue(
+        ranAsMetadataOnlyDelete,
+        "Expected the DELETE to execute as a DSv2 metadata-only DeleteFromTableExec");
+  }
+
+  /**
+   * Runs {@code sql} and returns every executed physical plan captured via a listener. A DSv2
+   * metadata-only delete selects files via {@code filesForScan}, which runs its own nested Spark
+   * queries (materializing {@code allFiles}). Hence, more than one plan is executed. Callers inspect
+   * the collected plans for the node they care about rather than assuming a single one.
+   */
+  private List<SparkPlan> executeAndCapturePlans(String sql) {
+    List<SparkPlan> captured = java.util.Collections.synchronizedList(new java.util.ArrayList<>());
+    QueryExecutionListener listener = new QueryExecutionListener() {
+      @Override
+      public void onSuccess(String funcName, QueryExecution qe, long durationNs) {
+        captured.add(qe.executedPlan());
+      }
+
+      @Override
+      public void onFailure(String funcName, QueryExecution qe, Exception exception) {}
+    };
+
+    spark.listenerManager().register(listener);
+    try {
+      spark.sql(sql);
+      spark.sparkContext().listenerBus().waitUntilEmpty(60_000L);
+    } catch (java.util.concurrent.TimeoutException e) {
+      throw new RuntimeException("Timed out waiting for the query-execution listener", e);
+    } finally {
+      spark.listenerManager().unregister(listener);
+    }
+    assertFalse(
+        captured.isEmpty(), "QueryExecutionListener did not capture an executed plan for: " + sql);
+    return captured;
+  }
+}


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Adds support for metadata-only DELETEs in DSv2 Delta connector.

## How was this patch tested?

New suite.

## Does this PR introduce _any_ user-facing changes?

No.