### PR TITLE
[SPARK] test refactor: Resolve delta._ imports in typewidening tests

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningAlterTableSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningAlterTableSuite.scala
@@ -17,7 +17,11 @@
 package org.apache.spark.sql.delta.typewidening
 
 import com.databricks.spark.util.Log4jUsageLogger
-import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.DeltaAnalysisException
+import org.apache.spark.sql.delta.DeltaDMLTestUtilsNameBased
+import org.apache.spark.sql.delta.DeltaTableFeatureException
+import org.apache.spark.sql.delta.TimestampNTZTableFeature
+import org.apache.spark.sql.delta.TypeWidening
 import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils
 import org.apache.spark.sql.delta.util.JsonUtils
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningConstraintsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningConstraintsSuite.scala
@@ -16,7 +16,8 @@
 
 package org.apache.spark.sql.delta.typewidening
 
-import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.DeltaAnalysisException
+import org.apache.spark.sql.delta.DeltaDMLTestUtilsNameBased
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 
 import org.apache.spark.sql.{QueryTest, Row}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningFeatureCompatibilitySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningFeatureCompatibilitySuite.scala
@@ -16,7 +16,11 @@
 
 package org.apache.spark.sql.delta.typewidening
 
-import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.DeltaConfigs
+import org.apache.spark.sql.delta.DeltaDMLTestUtils
+import org.apache.spark.sql.delta.DeltaUnsupportedOperationException
+import org.apache.spark.sql.delta.IdMapping
+import org.apache.spark.sql.delta.NameMapping
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningGeneratedColumnsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningGeneratedColumnsSuite.scala
@@ -16,7 +16,9 @@
 
 package org.apache.spark.sql.delta.typewidening
 
-import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.DeltaAnalysisException
+import org.apache.spark.sql.delta.DeltaDMLTestUtilsNameBased
+import org.apache.spark.sql.delta.GeneratedColumnTest
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 
 import org.apache.spark.sql.{QueryTest, Row}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningInsertSchemaEvolutionBasicSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningInsertSchemaEvolutionBasicSuite.scala
@@ -17,7 +17,13 @@
 package org.apache.spark.sql.delta.typewidening
 
 import com.databricks.spark.util.Log4jUsageLogger
-import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.DataFrameUtils
+import org.apache.spark.sql.delta.DeltaAnalysisException
+import org.apache.spark.sql.delta.DeltaDMLTestUtils
+import org.apache.spark.sql.delta.DeltaInsertIntoTest
+import org.apache.spark.sql.delta.DSv2TemporarilyIncompatible
+import org.apache.spark.sql.delta.NameBasedAccessIncompatible
+import org.apache.spark.sql.delta.TypeWideningMode
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.hadoop.fs.Path

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningInsertSchemaEvolutionExtendedSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningInsertSchemaEvolutionExtendedSuite.scala
@@ -16,7 +16,9 @@
 
 package org.apache.spark.sql.delta.typewidening
 
-import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.DeltaDMLTestUtils
+import org.apache.spark.sql.delta.DeltaDMLTestUtilsNameBased
+import org.apache.spark.sql.delta.DeltaInsertIntoTest
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 
 import org.apache.spark.SparkConf

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningMergeIntoSchemaEvolutionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningMergeIntoSchemaEvolutionSuite.scala
@@ -16,7 +16,12 @@
 
 package org.apache.spark.sql.delta.typewidening
 
-import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.DeltaDMLTestUtils
+import org.apache.spark.sql.delta.DeltaTable
+import org.apache.spark.sql.delta.MergeIntoSchemaEvolutionMixin
+import org.apache.spark.sql.delta.MergeIntoSQLTestUtils
+import org.apache.spark.sql.delta.MetadataChangedException
+import org.apache.spark.sql.delta.NameBasedAccessIncompatible
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 
 import org.apache.spark.SparkConf

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningMetadataSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningMetadataSuite.scala
@@ -18,7 +18,13 @@ package org.apache.spark.sql.delta.typewidening
 
 import java.io.File
 
-import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.DeltaConfigs
+import org.apache.spark.sql.delta.DeltaLog
+import org.apache.spark.sql.delta.OptimisticTransaction
+import org.apache.spark.sql.delta.TypeChange
+import org.apache.spark.sql.delta.TypeWideningMetadata
+import org.apache.spark.sql.delta.TypeWideningPreviewTableFeature
+import org.apache.spark.sql.delta.TypeWideningTableFeature
 import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils.propertyKey
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.util.JsonUtils

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningStatsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningStatsSuite.scala
@@ -16,7 +16,8 @@
 
 package org.apache.spark.sql.delta.typewidening
 
-import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.DeltaConfigs
+import org.apache.spark.sql.delta.LastCheckpointInfo
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 
 import org.apache.spark.sql.{QueryTest, Row}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningStreamingSinkSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningStreamingSinkSuite.scala
@@ -16,7 +16,10 @@
 
 package org.apache.spark.sql.delta.typewidening
 
-import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.DeltaConfigs
+import org.apache.spark.sql.delta.DeltaLog
+import org.apache.spark.sql.delta.DeltaOptions
+import org.apache.spark.sql.delta.DeltaSinkImplicitCastSuiteBase
 import org.apache.spark.sql.delta.Relocated.StreamExecution
 import org.apache.spark.sql.delta.sources.{DeltaSink, DeltaSQLConf}
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningStreamingSourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningStreamingSourceSuite.scala
@@ -19,7 +19,11 @@ package org.apache.spark.sql.delta.typewidening
 import java.io.File
 
 import com.databricks.spark.util.{Log4jUsageLogger, MetricDefinitions}
-import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.DeltaIllegalStateException
+import org.apache.spark.sql.delta.DeltaLog
+import org.apache.spark.sql.delta.DeltaOptions
+import org.apache.spark.sql.delta.DeltaRuntimeException
+import org.apache.spark.sql.delta.DeltaStreamingNonAdditiveSchemaIncompatibleException
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.JsonUtils
 import org.apache.spark.sql.util.ScalaExtensions._

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningTableFeatureSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningTableFeatureSuite.scala
@@ -19,8 +19,15 @@ package org.apache.spark.sql.delta.typewidening
 import java.io.PrintWriter
 
 import com.databricks.spark.util.Log4jUsageLogger
-import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.DeltaConfigs
+import org.apache.spark.sql.delta.DeltaIllegalStateException
+import org.apache.spark.sql.delta.DeltaLog
 import org.apache.spark.sql.delta.DeltaOperations.ManualUpdate
+import org.apache.spark.sql.delta.DeltaTableFeatureException
+import org.apache.spark.sql.delta.TypeWidening
+import org.apache.spark.sql.delta.TypeWideningPreviewTableFeature
+import org.apache.spark.sql.delta.TypeWideningTableFeature
+import org.apache.spark.sql.delta.TypeWideningTableFeatureBase
 import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils.propertyKey
 import org.apache.spark.sql.delta.rowtracking.RowTrackingTestUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningTestMixin.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningTestMixin.scala
@@ -19,7 +19,20 @@ package org.apache.spark.sql.delta.typewidening
 import java.io.File
 import java.util.UUID
 
-import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.DeltaColumnMapping
+import org.apache.spark.sql.delta.DeltaConfigs
+import org.apache.spark.sql.delta.DeltaDMLTestUtils
+import org.apache.spark.sql.delta.DeltaDMLTestUtilsNameBased
+import org.apache.spark.sql.delta.DeltaDMLTestUtilsPathBased
+import org.apache.spark.sql.delta.DeltaDSv2TestMixin
+import org.apache.spark.sql.delta.DeltaTableFeatureException
+import org.apache.spark.sql.delta.DeltaTableIdentifier
+import org.apache.spark.sql.delta.TableFeature
+import org.apache.spark.sql.delta.TimestampNTZTableFeature
+import org.apache.spark.sql.delta.TypeChange
+import org.apache.spark.sql.delta.TypeWidening
+import org.apache.spark.sql.delta.TypeWideningMetadata
+import org.apache.spark.sql.delta.TypeWideningTableFeature
 import org.apache.spark.sql.delta.actions.{RemoveFile, TableFeatureProtocolUtils}
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.commands.AlterTableDropFeatureDeltaCommand


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Resolves `import org.apache.spark.sql.delta._` imports in typewidening tests.
This makes dependencies explicit, which e.g. simplifies refactoring.

## How was this patch tested?

CI

## Does this PR introduce _any_ user-facing changes?

No
