### PR TITLE
[Flink] Fix V2 checkpoint state tracking

### DIFF
--- a/flink/src/main/java/io/delta/flink/kernel/CheckpointWriter.java
+++ b/flink/src/main/java/io/delta/flink/kernel/CheckpointWriter.java
@@ -124,7 +124,8 @@ public class CheckpointWriter {
 
   private final CheckpointMetaData lastCheckpointMeta;
   private final boolean lastCheckpointByMe;
-  private int lastSidecarCount;
+  private final int lastCheckpointSidecarCount;
+  private int carriedSidecarCount;
   /** Guard to prevent reusing a single writer instance. */
   private boolean used = false;
 
@@ -162,12 +163,14 @@ public class CheckpointWriter {
     lastCheckpointByMe =
         Boolean.parseBoolean(
             lastCheckpointMeta.tags.getOrDefault(TAG_DELTASINK_CHECKPOINT, "false"));
-    lastSidecarCount = 0;
+    int parsedSidecarCount = 0;
     try {
-      lastSidecarCount =
+      parsedSidecarCount =
           Integer.parseInt(lastCheckpointMeta.tags.getOrDefault(TAG_SIDECAR_COUNT, "0"));
     } catch (Exception ignore) {
     }
+    lastCheckpointSidecarCount = parsedSidecarCount;
+    carriedSidecarCount = 0;
   }
 
   public CheckpointWriter(Engine engine, Snapshot snapshot) {
@@ -241,7 +244,18 @@ public class CheckpointWriter {
     // including AddFiles. It also checks if remove file exists.
     SidecarFile newSidecar;
     CloseableIterator<FilteredColumnarBatch> existingSidecars = EMPTY_ITERATOR();
+    if (baseCheckpointMeta.isPresent()) {
+      // When there's no remove files, read existing sidecars from the base checkpoint if it
+      // exists. Materialize existing sidecars and their selection vectors before scanning
+      // incremental actions, so it triggers the computation of txnId/domainMetadata from the base
+      // checkpoint first.
+      existingSidecars = materialize(sidecarsFromCheckpoint(baseCheckpointPath));
+    }
+    int prevTxnCount = transactionIds.size();
+    int prevDomainMetadataCount = domainMetadatas.size();
 
+    boolean fallbackToFullSnapshot = false;
+    AtomicInteger snapshotAddFileCounter = new AtomicInteger();
     try (CloseableIterator<FilteredColumnarBatch> actions =
         DeltaLogActionUtils.getActionsFromCommitFilesWithProtocolValidation(
                 engine,
@@ -257,14 +271,14 @@ public class CheckpointWriter {
       newSidecar = sidecarFromAddFiles(actions);
       // If remove file exists, fallback to generating a new sidecar including everything.
       if (removeFileCounter.get() > 0) {
+        fallbackToFullSnapshot = true;
+        existingSidecars = EMPTY_ITERATOR();
         try (CloseableIterator<FilteredColumnarBatch> allActions =
-            snapshot.getCreateCheckpointIterator(engine).map(filterAddFiles())) {
+            snapshot
+                .getCreateCheckpointIterator(engine)
+                .map(filterAddFiles(snapshotAddFileCounter))) {
           newSidecar = sidecarFromAddFiles(allActions);
         }
-      } else if (baseCheckpointMeta.isPresent()) {
-        // When there's no remove files, read existing sidecars from the base checkpoint if it
-        // exists
-        existingSidecars = sidecarsFromCheckpoint(baseCheckpointPath);
       }
     }
     // ==========
@@ -297,6 +311,16 @@ public class CheckpointWriter {
     // ==========
     // Write _last_checkpoint file with our tag, so we can recognize our own checkpoints later.
     if (version > lastCheckpointMeta.version) {
+      int newSidecarCount = fallbackToFullSnapshot ? 1 : carriedSidecarCount + 1;
+      long checkpointActionCount =
+          checkpointActionCount(
+              baseCheckpointMeta.isPresent(),
+              fallbackToFullSnapshot,
+              addFileCounter.get(),
+              snapshotAddFileCounter.get(),
+              prevTxnCount,
+              prevDomainMetadataCount,
+              newSidecarCount);
       engine
           .getJsonHandler()
           .writeJsonFileAtomically(
@@ -304,16 +328,45 @@ public class CheckpointWriter {
               singletonCloseableIterator(
                   new CheckpointMetaData(
                           version,
-                          lastCheckpointMeta.size + addFileCounter.get() - removeFileCounter.get(),
+                          checkpointActionCount,
                           Optional.empty(),
                           Map.of(
                               TAG_DELTASINK_CHECKPOINT,
                               "true",
                               TAG_SIDECAR_COUNT,
-                              String.valueOf(lastSidecarCount + 1)))
+                              String.valueOf(newSidecarCount)))
                       .toRow()),
               true /* overwrite */);
     }
+  }
+
+  /**
+   * Computes {@code _last_checkpoint.size}, defined by the protocol as the number of actions stored
+   * in the checkpoint. Keep append-only checkpoints incremental to avoid reading old sidecars;
+   * fallback checkpoints count actions while rebuilding from the full snapshot.
+   */
+  private long checkpointActionCount(
+      boolean hasBaseCheckpoint,
+      boolean fallbackToFullSnapshot,
+      int addFileCount,
+      int snapshotAddFileCount,
+      int prevTxnCount,
+      int prevDomainMetadataCount,
+      int newSidecarCount) {
+    if (fallbackToFullSnapshot || !hasBaseCheckpoint) {
+      int sidecarAddFileCount = fallbackToFullSnapshot ? snapshotAddFileCount : addFileCount;
+      return sidecarAddFileCount
+          + 3 // protocol, metadata, checkpointMetadata
+          + newSidecarCount
+          + transactionIds.size()
+          + domainMetadatas.size();
+    }
+
+    return lastCheckpointMeta.size
+        + addFileCount
+        + (newSidecarCount - lastCheckpointSidecarCount)
+        + (transactionIds.size() - prevTxnCount)
+        + (domainMetadatas.size() - prevDomainMetadataCount);
   }
 
   /**
@@ -338,7 +391,8 @@ public class CheckpointWriter {
             .map(FileReadResult::getData)
             .map(filterActions(Map.of("sidecar", sidecarCounter)));
 
-    if (sidecarMergeThreshold > 0 && lastSidecarCount >= sidecarMergeThreshold - 1) {
+    carriedSidecarCount = lastCheckpointSidecarCount;
+    if (sidecarMergeThreshold > 0 && lastCheckpointSidecarCount >= sidecarMergeThreshold - 1) {
       // Too many existing sidecars. Merge them into one.
       try (CloseableIterator<FileStatus> sidecarFiles =
               existingSidecars
@@ -357,27 +411,65 @@ public class CheckpointWriter {
                   .map(FileReadResult::getData)
                   .map(ColumnVectorUtils::wrap)) {
         existingSidecars = rowsToBatch(Stream.of(sidecarFromAddFiles(addFileRows)));
-        lastSidecarCount = 1;
+        carriedSidecarCount = 1;
       }
     }
     return existingSidecars;
   }
 
-  /**
-   * Return a mapping function that further filter add files from a filtered column batch
-   *
-   * @return a mapping function that applies to a filtered column batch
-   */
-  private Function<FilteredColumnarBatch, FilteredColumnarBatch> filterAddFiles() {
+  private CloseableIterator<FilteredColumnarBatch> materialize(
+      CloseableIterator<FilteredColumnarBatch> iterator) {
+    List<FilteredColumnarBatch> batches = iterator.toInMemoryList();
+    for (FilteredColumnarBatch batch : batches) {
+      batch.getRows().toInMemoryList();
+    }
+    return toCloseableIterator(batches.iterator());
+  }
+
+  private void accumulateNonFileActions(ColumnarBatch columnarBatch, int rowId) {
+    int txnOrdinal = columnarBatch.getSchema().indexOf("txn");
+    int dmOrdinal = columnarBatch.getSchema().indexOf("domainMetadata");
+
+    ColumnVector txnVector = columnarBatch.getColumnVector(txnOrdinal);
+    if (!txnVector.isNullAt(rowId)) {
+      String appId = txnVector.getChild(0).getString(rowId);
+      long txnVersion = txnVector.getChild(1).getLong(rowId);
+      transactionIds.merge(appId, txnVersion, Math::max);
+    }
+    ColumnVector dmVector = columnarBatch.getColumnVector(dmOrdinal);
+    if (!dmVector.isNullAt(rowId)) {
+      String domain = dmVector.getChild(0).getString(rowId);
+      String configuration = dmVector.getChild(1).getString(rowId);
+      boolean removed = dmVector.getChild(2).getBoolean(rowId);
+      if (removed) {
+        domainMetadatas.remove(domain);
+      } else {
+        domainMetadatas.put(domain, configuration);
+      }
+    }
+  }
+
+  private Function<FilteredColumnarBatch, FilteredColumnarBatch> filterAddFiles(
+      AtomicInteger addFileCounter) {
     return (input) -> {
       int addOrdinal = input.getData().getSchema().indexOf("add");
       return new FilteredColumnarBatch(
           input.getData(),
           ColumnVectorUtils.filter(
               input.getData().getSize(),
-              (rowId) ->
-                  input.getSelectionVector().map(cv -> cv.getBoolean(rowId)).orElse(true)
-                      && !input.getData().getColumnVector(addOrdinal).isNullAt(rowId)));
+              (rowId) -> {
+                boolean selected =
+                    input.getSelectionVector().map(cv -> cv.getBoolean(rowId)).orElse(true);
+                if (!selected) {
+                  return false;
+                }
+
+                if (!input.getData().getColumnVector(addOrdinal).isNullAt(rowId)) {
+                  addFileCounter.incrementAndGet();
+                  return true;
+                }
+                return false;
+              }));
     };
   }
 
@@ -386,6 +478,7 @@ public class CheckpointWriter {
    *
    * <ul>
    *   <li>Aggregates {@code txn} actions into {@link #transactionIds} (max version per appId)
+   *   <li>Aggregates {@code domainMetadata} actions into {@link #domainMetadatas}
    *   <li>Filters rows where {@code notNullName} is non-null
    *   <li>Optionally increments {@code counter} for each retained row
    * </ul>
@@ -400,9 +493,6 @@ public class CheckpointWriter {
   private Function<ColumnarBatch, FilteredColumnarBatch> filterActions(
       Map<String, AtomicInteger> nameToCounters) {
     return (columnarBatch) -> {
-      int txnOrdinal = columnarBatch.getSchema().indexOf("txn");
-      int dmOrdinal = columnarBatch.getSchema().indexOf("domainMetadata");
-
       var entries = new ArrayList<>(nameToCounters.entrySet());
       Integer[] ordinals = new Integer[nameToCounters.size()];
       AtomicInteger[] counters = new AtomicInteger[nameToCounters.size()];
@@ -416,23 +506,7 @@ public class CheckpointWriter {
           ColumnVectorUtils.filter(
               columnarBatch.getSize(),
               (rowId) -> {
-                ColumnVector txnVector = columnarBatch.getColumnVector(txnOrdinal);
-                if (!txnVector.isNullAt(rowId)) {
-                  String appId = txnVector.getChild(0).getString(rowId);
-                  long txnVersion = txnVector.getChild(1).getLong(rowId);
-                  transactionIds.merge(appId, txnVersion, Math::max);
-                }
-                ColumnVector dmVector = columnarBatch.getColumnVector(dmOrdinal);
-                if (!dmVector.isNullAt(rowId)) {
-                  String domain = dmVector.getChild(0).getString(rowId);
-                  String configuration = dmVector.getChild(1).getString(rowId);
-                  boolean removed = dmVector.getChild(2).getBoolean(rowId);
-                  if (removed) {
-                    domainMetadatas.remove(domain);
-                  } else {
-                    domainMetadatas.put(domain, configuration);
-                  }
-                }
+                accumulateNonFileActions(columnarBatch, rowId);
                 for (int i = 0; i < ordinals.length; i++) {
                   if (!columnarBatch.getColumnVector(ordinals[i]).isNullAt(rowId)) {
                     counters[i].incrementAndGet();

--- a/flink/src/main/java/io/delta/flink/kernel/CheckpointWriter.java
+++ b/flink/src/main/java/io/delta/flink/kernel/CheckpointWriter.java
@@ -66,16 +66,15 @@ import org.slf4j.LoggerFactory;
  * most efficient when used for incremental checkpoint creation on Flink sink tables.
  *
  * <p>Because the Flink sink performs blind appends, the writer generates a new sidecar file
- * containing all {@code AddFile} and {@code SetTransaction} actions in the range {@code
- * (previousCheckpointVersion + 1, currentSnapshotVersion]}. It then writes a new singular v2
- * checkpoint that includes:
+ * containing all {@code AddFile} actions in the range {@code (previousCheckpointVersion + 1,
+ * currentSnapshotVersion]}. It then writes a new singular v2 checkpoint that includes:
  *
  * <ul>
  *   <li>protocol, metadata, and checkpointMetadata actions
  *   <li>the newly generated sidecar file
  *   <li>all sidecars referenced by the previous checkpoint, if that checkpoint was written by this
  *       class
- *   <li>aggregated {@code SetTransaction} actions computed from commits in the version range
+ *   <li>reconciled {@code SetTransaction} and {@code DomainMetadata} actions
  * </ul>
  *
  * If the writer detects that the number of existing sidecar files exceeds a threshold, it will
@@ -94,9 +93,6 @@ import org.slf4j.LoggerFactory;
  *
  * We choose to not support reading checkpoints written by other writers assuming that the case is
  * rare. The support can be added in the future if being requested.
- *
- * <p>## Limitations This writer does not support tables with domain metadata feature. The support
- * will be added in the future.
  */
 public class CheckpointWriter {
 
@@ -106,6 +102,9 @@ public class CheckpointWriter {
   public static final String TAG_DELTASINK_CHECKPOINT = "io.delta.flink.sink.checkpoint";
 
   public static final String TAG_SIDECAR_COUNT = "io.delta.flink.num_sidecar";
+
+  public static final String TAG_LAST_CHECKPOINT_SIZE_IN_ACTIONS =
+      "io.delta.flink.lastCheckpointSizeInActions";
 
   private static final Logger LOG = LoggerFactory.getLogger(CheckpointWriter.class);
 
@@ -124,6 +123,7 @@ public class CheckpointWriter {
 
   private final CheckpointMetaData lastCheckpointMeta;
   private final boolean lastCheckpointByMe;
+  private final boolean lastCheckpointSizeInActions;
   private final int lastCheckpointSidecarCount;
   private int carriedSidecarCount;
   /** Guard to prevent reusing a single writer instance. */
@@ -163,6 +163,9 @@ public class CheckpointWriter {
     lastCheckpointByMe =
         Boolean.parseBoolean(
             lastCheckpointMeta.tags.getOrDefault(TAG_DELTASINK_CHECKPOINT, "false"));
+    lastCheckpointSizeInActions =
+        Boolean.parseBoolean(
+            lastCheckpointMeta.tags.getOrDefault(TAG_LAST_CHECKPOINT_SIZE_IN_ACTIONS, "false"));
     int parsedSidecarCount = 0;
     try {
       parsedSidecarCount =
@@ -212,11 +215,13 @@ public class CheckpointWriter {
     // ===========
     // Use _last_checkpoint as baseCheckpoint when
     // 1. It is written by this writer
-    // 2. _last_checkpoint version is smaller than this snapshot version
-    // Otherwise assume there's no baseCheckpoint
+    // 2. _last_checkpoint uses the protocol-defined action count for size
+    // 3. _last_checkpoint version is smaller than this snapshot version
+    // Otherwise assume there's no baseCheckpoint. Checkpoints from older versions of this writer
+    // did not use the action-count semantics, so rebuild them once before resuming incrementally.
     // ====================================================================
     Optional<CheckpointMetaData> baseCheckpointMeta =
-        (lastCheckpointByMe && lastCheckpointMeta.version < version)
+        (lastCheckpointByMe && lastCheckpointSizeInActions && lastCheckpointMeta.version < version)
             ? Optional.of(lastCheckpointMeta)
             : Optional.empty();
     long baseVersion = baseCheckpointMeta.map(m -> m.version).orElse(-1L);
@@ -245,11 +250,10 @@ public class CheckpointWriter {
     SidecarFile newSidecar;
     CloseableIterator<FilteredColumnarBatch> existingSidecars = EMPTY_ITERATOR();
     if (baseCheckpointMeta.isPresent()) {
-      // When there's no remove files, read existing sidecars from the base checkpoint if it
-      // exists. Materialize existing sidecars and their selection vectors before scanning
-      // incremental actions, so it triggers the computation of txnId/domainMetadata from the base
-      // checkpoint first.
-      existingSidecars = materialize(sidecarsFromCheckpoint(baseCheckpointPath));
+      // Materialize the selected sidecar rows before scanning incremental actions. This both
+      // collects the base txn/domainMetadata state and prevents those side effects from being
+      // replayed when the sidecar rows are written to the new checkpoint.
+      existingSidecars = materializeSelectedRows(sidecarsFromCheckpoint(baseCheckpointPath));
     }
     int prevTxnCount = transactionIds.size();
     int prevDomainMetadataCount = domainMetadatas.size();
@@ -334,7 +338,9 @@ public class CheckpointWriter {
                               TAG_DELTASINK_CHECKPOINT,
                               "true",
                               TAG_SIDECAR_COUNT,
-                              String.valueOf(newSidecarCount)))
+                              String.valueOf(newSidecarCount),
+                              TAG_LAST_CHECKPOINT_SIZE_IN_ACTIONS,
+                              "true"))
                       .toRow()),
               true /* overwrite */);
     }
@@ -417,13 +423,12 @@ public class CheckpointWriter {
     return existingSidecars;
   }
 
-  private CloseableIterator<FilteredColumnarBatch> materialize(
+  private CloseableIterator<FilteredColumnarBatch> materializeSelectedRows(
       CloseableIterator<FilteredColumnarBatch> iterator) {
-    List<FilteredColumnarBatch> batches = iterator.toInMemoryList();
-    for (FilteredColumnarBatch batch : batches) {
-      batch.getRows().toInMemoryList();
-    }
-    return toCloseableIterator(batches.iterator());
+    List<Row> rows = iterator.flatMap(FilteredColumnarBatch::getRows).toInMemoryList();
+    return singletonCloseableIterator(
+        new FilteredColumnarBatch(
+            new DefaultRowBasedColumnarBatch(CHECKPOINT_SCHEMA, rows), Optional.empty()));
   }
 
   private void accumulateNonFileActions(ColumnarBatch columnarBatch, int rowId) {

--- a/flink/src/test/java/io/delta/flink/kernel/CheckpointWriterTest.java
+++ b/flink/src/test/java/io/delta/flink/kernel/CheckpointWriterTest.java
@@ -151,6 +151,39 @@ class CheckpointWriterTest extends TestHelper {
         .getPostCommitSnapshot();
   }
 
+  private Optional<Snapshot> writeTableWithTransactionId(
+      Engine engine,
+      String tablePath,
+      StructType schema,
+      String applicationId,
+      long transactionVersion) {
+    AddFile dummyAddFile =
+        AddFile.convertDataFileStatus(
+            schema,
+            URI.create(tablePath),
+            new DataFileStatus(UUID.randomUUID().toString(), 1000L, 2000L, Optional.empty()),
+            Collections.emptyMap(),
+            true,
+            Collections.emptyMap(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty());
+
+    var txn =
+        TableManager.loadSnapshot(tablePath)
+            .build(engine)
+            .buildUpdateTableTransaction("dummy", Operation.WRITE)
+            .withTransactionId(applicationId, transactionVersion)
+            .build(engine);
+
+    return txn.commit(
+            engine,
+            CloseableIterable.inMemoryIterable(
+                Utils.singletonCloseableIterator(
+                    SingleAction.createAddFileSingleAction(dummyAddFile.toRow()))))
+        .getPostCommitSnapshot();
+  }
+
   private void assertSnapshotRead(
       Engine engine, String tablePath, long version, int numSidecars, int numActions) {
     SnapshotImpl latest = (SnapshotImpl) TableManager.loadSnapshot(tablePath).build(engine);
@@ -209,6 +242,16 @@ class CheckpointWriterTest extends TestHelper {
    */
   private void assertLastCheckpointFile(
       Engine engine, Snapshot snapshot, int expectedVersion, int expectedNumSidecars) {
+    assertLastCheckpointFile(
+        engine, snapshot, expectedVersion, expectedNumSidecars, -1 /* expectedSize */);
+  }
+
+  private void assertLastCheckpointFile(
+      Engine engine,
+      Snapshot snapshot,
+      int expectedVersion,
+      int expectedNumSidecars,
+      int expectedSize) {
     String tablePath = snapshot.getPath();
     String lastCheckpointPath = tablePath + "/_delta_log/_last_checkpoint";
 
@@ -231,14 +274,18 @@ class CheckpointWriterTest extends TestHelper {
         assertEquals(expectedVersion, metadata.version, "Checkpoint version mismatch");
       }
 
+      if (expectedSize >= 0) {
+        assertEquals(expectedSize, metadata.size, "Checkpoint size mismatch");
+      }
+
       // Verify tags contain TAG_FLINK_DELTASINK_CHECKPOINT
       assertTrue(
           Boolean.parseBoolean(
               metadata.tags.getOrDefault(CheckpointWriter.TAG_DELTASINK_CHECKPOINT, "false")),
           "Expected TAG_DELTASINK_CHECKPOINT to be true in _last_checkpoint");
 
-      // Verify number of sidecars if parts are present
-      if (expectedNumSidecars >= 0 && metadata.parts.isPresent()) {
+      // Verify number of sidecars tracked by the Flink checkpoint writer.
+      if (expectedNumSidecars >= 0) {
         assertEquals(
             expectedNumSidecars,
             Integer.parseInt(metadata.tags.getOrDefault(TAG_SIDECAR_COUNT, "0")),
@@ -375,6 +422,10 @@ class CheckpointWriterTest extends TestHelper {
           s.ifPresent(wrap(sn -> new CheckpointWriter(engine, sn).write()));
 
           assertSnapshotRead(engine, tablePath, 27, 1, 26);
+          s.ifPresent(
+              snapshot ->
+                  assertLastCheckpointFile(
+                      engine, snapshot, /* version */ 27, /* numSidecar */ 1, /* size */ 30));
         });
   }
 
@@ -413,6 +464,8 @@ class CheckpointWriterTest extends TestHelper {
               (SnapshotImpl) TableManager.loadSnapshot(tablePath).build(engine);
 
           assertSnapshotRead(engine, snapshotAfter, -1, 2, 41);
+          assertLastCheckpointFile(
+              engine, finalSnapshot, /* version */ 40, /* numSidecar */ 2, /* size */ 46);
         });
   }
 
@@ -432,15 +485,27 @@ class CheckpointWriterTest extends TestHelper {
 
           writeDomainMetadata(engine, tablePath, "domain1", "conf1");
           writeDomainMetadata(engine, tablePath, "domain2", "conf2");
-          snapshot = writeDomainMetadata(engine, tablePath, "domain1", "conf2");
+          writeDomainMetadata(engine, tablePath, "domain1", "conf2");
+          snapshot = writeTableWithTransactionId(engine, tablePath, schema, "app1", 5L);
 
           new CheckpointWriter(engine, snapshot.get()).write();
-          // Write a new commit then read the table
-          writeTable(engine, tablePath, schema).get();
+
+          // Write a plain data commit and create an incremental checkpoint. Live non-file actions
+          // from the base checkpoint must be carried forward even when not updated in the
+          // incremental range.
+          snapshot = writeTable(engine, tablePath, schema);
+          new CheckpointWriter(engine, snapshot.get()).write();
+
           SnapshotImpl snapshotAfter =
               (SnapshotImpl) TableManager.loadSnapshot(tablePath).build(engine);
           assertSnapshotRead(
-              engine, snapshotAfter, 3, 1, 2, Map.of("domain1", "conf2", "domain2", "conf2"));
+              engine, snapshotAfter, 5, 2, 3, Map.of("domain1", "conf2", "domain2", "conf2"));
+          assertEquals(Optional.of(5L), snapshotAfter.getLatestTransactionVersion(engine, "app1"));
+
+          // 3 AddFiles in sidecars + protocol + metadata + checkpointMetadata + 2 sidecars
+          // + carried txn + 2 carried domainMetadata actions.
+          assertLastCheckpointFile(
+              engine, snapshot.get(), /* version */ 5, /* numSidecar */ 2, /* size */ 11);
         });
   }
 }

--- a/flink/src/test/java/io/delta/flink/kernel/CheckpointWriterTest.java
+++ b/flink/src/test/java/io/delta/flink/kernel/CheckpointWriterTest.java
@@ -40,6 +40,7 @@ import io.delta.kernel.types.StructType;
 import io.delta.kernel.utils.CloseableIterable;
 import io.delta.kernel.utils.DataFileStatus;
 import io.delta.kernel.utils.FileStatus;
+import java.io.IOException;
 import java.net.URI;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -133,9 +134,12 @@ class CheckpointWriterTest extends TestHelper {
 
   private Optional<Snapshot> writeDomainMetadata(
       Engine engine, String tablePath, String domain, String conf) {
+    return writeDomainMetadata(engine, tablePath, domain, conf, false);
+  }
 
-    // Prepare some dummy AddFile
-    DomainMetadata dm = new DomainMetadata(domain, conf, false);
+  private Optional<Snapshot> writeDomainMetadata(
+      Engine engine, String tablePath, String domain, String conf, boolean removed) {
+    DomainMetadata dm = new DomainMetadata(domain, conf, removed);
 
     var txn =
         TableManager.loadSnapshot(tablePath)
@@ -283,6 +287,11 @@ class CheckpointWriterTest extends TestHelper {
           Boolean.parseBoolean(
               metadata.tags.getOrDefault(CheckpointWriter.TAG_DELTASINK_CHECKPOINT, "false")),
           "Expected TAG_DELTASINK_CHECKPOINT to be true in _last_checkpoint");
+      assertTrue(
+          Boolean.parseBoolean(
+              metadata.tags.getOrDefault(
+                  CheckpointWriter.TAG_LAST_CHECKPOINT_SIZE_IN_ACTIONS, "false")),
+          "Expected _last_checkpoint.size to use action-count semantics");
 
       // Verify number of sidecars tracked by the Flink checkpoint writer.
       if (expectedNumSidecars >= 0) {
@@ -294,6 +303,27 @@ class CheckpointWriterTest extends TestHelper {
     } catch (Exception e) {
       throw new AssertionError("Failed to read or verify _last_checkpoint", e);
     }
+  }
+
+  private void writeLegacyLastCheckpointFile(
+      Engine engine, Snapshot snapshot, int size, int numSidecars) throws IOException {
+    String lastCheckpointPath = snapshot.getPath() + "/_delta_log/_last_checkpoint";
+    engine
+        .getJsonHandler()
+        .writeJsonFileAtomically(
+            lastCheckpointPath,
+            singletonCloseableIterator(
+                new CheckpointMetaData(
+                        snapshot.getVersion(),
+                        size,
+                        Optional.empty(),
+                        Map.of(
+                            CheckpointWriter.TAG_DELTASINK_CHECKPOINT,
+                            "true",
+                            TAG_SIDECAR_COUNT,
+                            String.valueOf(numSidecars)))
+                    .toRow()),
+            true /* overwrite */);
   }
 
   @Test
@@ -506,6 +536,59 @@ class CheckpointWriterTest extends TestHelper {
           // + carried txn + 2 carried domainMetadata actions.
           assertLastCheckpointFile(
               engine, snapshot.get(), /* version */ 5, /* numSidecar */ 2, /* size */ 11);
+        });
+  }
+
+  @Test
+  void testIncrementalCheckpointPreservesDomainMetadataRemoval() {
+    withTempDir(
+        dir -> {
+          String tablePath = dir.getAbsolutePath();
+          Engine engine = DefaultEngine.create(new Configuration());
+          StructType schema = new StructType().add("id", IntegerType.INTEGER);
+          Map<String, String> properties =
+              Map.of(
+                  "delta.feature.v2Checkpoint", "supported",
+                  "delta.feature.domainMetadata", "supported");
+          createNonEmptyTable(engine, tablePath, schema, List.of(), properties);
+
+          Optional<Snapshot> snapshot = writeDomainMetadata(engine, tablePath, "domain1", "conf1");
+          new CheckpointWriter(engine, snapshot.get()).write();
+
+          snapshot = writeDomainMetadata(engine, tablePath, "domain1", "", true);
+          new CheckpointWriter(engine, snapshot.get()).write();
+
+          SnapshotImpl snapshotAfter =
+              (SnapshotImpl) TableManager.loadSnapshot(tablePath).build(engine);
+          assertTrue(snapshotAfter.getDomainMetadata("domain1").isEmpty());
+
+          // 1 AddFile in a sidecar + protocol + metadata + checkpointMetadata + 2 sidecars.
+          assertLastCheckpointFile(
+              engine, snapshot.get(), /* version */ 2, /* numSidecar */ 2, /* size */ 6);
+        });
+  }
+
+  @Test
+  void testRebuildsLegacyCheckpointWithFileCountSize() {
+    withTempDir(
+        dir -> {
+          String tablePath = dir.getAbsolutePath();
+          Engine engine = DefaultEngine.create(new Configuration());
+          StructType schema = new StructType().add("id", IntegerType.INTEGER);
+          Map<String, String> properties = Map.of("delta.feature.v2Checkpoint", "supported");
+          Snapshot initialSnapshot =
+              createNonEmptyTable(engine, tablePath, schema, List.of(), properties).get();
+
+          new CheckpointWriter(engine, initialSnapshot).write();
+          writeLegacyLastCheckpointFile(engine, initialSnapshot, /* size */ 1, /* numSidecars */ 1);
+
+          Snapshot latestSnapshot = writeTable(engine, tablePath, schema).get();
+          new CheckpointWriter(engine, latestSnapshot).write();
+
+          assertSnapshotRead(engine, tablePath, /* version */ 1, /* numSidecars */ 1, 2);
+          // 2 AddFiles in one sidecar + protocol + metadata + checkpointMetadata + the sidecar.
+          assertLastCheckpointFile(
+              engine, latestSnapshot, /* version */ 1, /* numSidecars */ 1, /* size */ 6);
         });
   }
 }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [x] Flink
- [ ] Kernel
- [ ] Other

## Description

Supersedes #7260. The first commit preserves the original implementation and authorship from @harperjiang; the follow-up commit completes the correctness and upgrade handling.

This PR fixes state tracking in the Flink-specialized V2 checkpoint writer:

- Carries reconciled `SetTransaction` and `DomainMetadata` actions forward from the base checkpoint.
- Computes `_last_checkpoint.size` as the protocol-defined number of checkpoint actions.
- Materializes selected base-checkpoint rows into a row-backed batch so lazy selection-vector side effects execute exactly once. This prevents an incremental domain removal from being replayed back into the in-memory state while the new checkpoint is written.
- Marks checkpoints that use action-count size semantics. Checkpoints produced by released older versions used live AddFile count instead, so the first checkpoint after upgrade performs a one-time full rebuild before incremental checkpointing resumes.
- Updates the CheckpointWriter documentation to match the supported actions.

## How was this patch tested?

- `flink/testOnly io.delta.flink.kernel.CheckpointWriterTest`: 8 passed, including new domain-removal and legacy-upgrade regressions.
- `flink/test`: 268 total, 264 passed, 4 existing tests skipped, 0 failed.
- Java formatting, Checkstyle, compilation, and `git diff --check` passed.

## Does this PR introduce any user-facing changes?

Yes. Flink V2 checkpoints retain live transaction/domain metadata state and publish a protocol-correct `_last_checkpoint.size`. Tables with a legacy Flink checkpoint perform one full checkpoint rebuild on the first post-upgrade checkpoint, then return to the incremental path.