### PR TITLE
Fix DataEntry tracking and CDF on the incremental AMT path

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTCheckpointProvider.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTCheckpointProvider.scala
@@ -194,43 +194,63 @@ final class AMTCheckpointProvider(
   }
 
   /**
-   * Test-only invariant check for AMT back references.
+   * Test-only invariant: verify the AMT back references carried by the current proposed commit's
+   * file actions.
+   *
+   * On an AMT-backed table a leaf-resident file's AddFile / RemoveFile carries a [[BackReference]]
+   * to the (leaf manifest, row position) its entry occupies in the tree, so a later commit can mask
+   * or supersede that leaf slot; a root-resident file carries none. `committedActions` are the
+   * current proposed commit's actions; they are checked against the live set of the AMT checkpoint
+   * this (pre-commit) snapshot is backed by, keyed by (path, dv id):
+   *   - a file whose (path, dv) is live in the AMT checkpoint leaf must carry the back reference;
+   *   - a file whose (path, dv) is absent from the AMT checkpoint leaf must carry none -- a net-new
+   *     file, or the re-added copy of a same-path replace (re-added under a new dv).
+   * A (path, dv) that an intermediate commit (landed after the AMT checkpoint but before this one)
+   * already superseded is relaxed: this commit's later add/remove of it may omit backreference.
+   *
+   * Example: the AMT checkpoint is at version 10 and commits 11/12/13 sit on top of it while this
+   * commit is 14. File f1 lives at leaf-1 / pos-1 in the checkpoint. If commit 12 (say an
+   * ANALYZE TABLE COMPUTE STATS) already re-committed f1 -- carrying its back reference at that
+   * point -- then f1's add/remove in commit 14 need not carry a back reference.
    */
   private[delta] def verifyCommitBackReferences(
       spark: SparkSession,
       deltaLog: DeltaLog,
       committedActions: Seq[Action]): Unit = {
-    val committedAdds = committedActions.collect { case a: AddFile => a }
-    val committedRemoves = committedActions.collect { case r: RemoveFile => r }
-    if (committedAdds.isEmpty && committedRemoves.isEmpty) return
+    // Key by (path, dv) so a same-path replace is handled: the removed (path, oldDv) is checked
+    // against the AMT, while the re-added (path, newDv) is a distinct key absent from the tree.
+    val committedFiles = committedActions.collect {
+      case a: AddFile => (a.path, a.getDeletionVectorUniqueId) -> a.backReference
+      case r: RemoveFile => (r.path, r.getDeletionVectorUniqueId) -> r.backReference
+    }
+    if (committedFiles.isEmpty) return
 
-    val expectedPathToBackreferenceMap: Map[String, Option[BackReference]] =
+    val expectedKeyToBackreferenceMap =
       liveAddSingleActions(spark, deltaLog)
         .collect()
-        .map(sa => sa.add.path -> sa.add.backReference)
+        .map(sa => (sa.add.path, sa.add.getDeletionVectorUniqueId) -> sa.add.backReference)
         .toMap
 
-    // A file superseded within this commit (by DV update for example) has its leaf entry masked
-    // by the RemoveFile's back reference, so the superseding AddFile is a net-new entry with
-    // a different DV and legitimately carries no back reference.
-    val supersededPaths = committedRemoves.filter(_.backReference.isDefined).map(_.path).toSet
-    val committedFiles: Seq[(String, Option[BackReference])] =
-      committedRemoves.map(r => r.path -> r.backReference) ++
-        committedAdds
-          .filterNot(a => a.backReference.isEmpty && supersededPaths.contains(a.path))
-          .map(a => a.path -> a.backReference)
+    // Keys an intermediate commit (after this AMT) already re-committed. The first superseding
+    // add/remove must carry a back reference; a 2nd superseding one of the same key need not.
+    val intermediateCommittedKeys =
+      deltaLog.getChanges(checkpointVersion + 1).flatMap(_._2).collect {
+        case a: AddFile => (a.path, a.getDeletionVectorUniqueId)
+        case r: RemoveFile => (r.path, r.getDeletionVectorUniqueId)
+      }.toSet
 
-    committedFiles.foreach { case (path, actual) =>
-      expectedPathToBackreferenceMap.get(path) match {
-        case Some(expected) if actual != expected =>
+    committedFiles.foreach { case (key, actual) =>
+      expectedKeyToBackreferenceMap.get(key) match {
+        case Some(expected)
+            if actual != expected && !(intermediateCommittedKeys.contains(key) && actual.isEmpty) =>
           throw new IllegalStateException(
-            s"AMT back reference for file '$path' does not match the AMT. " +
+            s"AMT back reference for file '${key._1}' does not match the AMT. " +
             s"Expected $expected but the committed action carried $actual.")
         case None if actual.isDefined =>
           throw new IllegalStateException(
-            s"File '$path' carries a back reference $actual but is not present in the AMT " +
+            s"File '${key._1}' carries a back reference $actual but is not present in the AMT " +
             "tree, so it must not carry one.")
-        case _ => // Present and matching, or absent and empty: as expected.
+        case _ => // Matching, omitted after a window supersession, or absent+empty: as expected.
       }
     }
   }
@@ -278,7 +298,7 @@ object AMTCheckpointProvider {
 
   /** Tracking Status representing the live [[DataEntry]] in an AMT. */
   private[amt] val liveDataEntryStatuses: Set[Int] =
-    Set(Tracking.Status.Existing, Tracking.Status.Added)
+    Set(Tracking.Status.Existing, Tracking.Status.Added, Tracking.Status.Modified)
 
   /** All Tracking Status for leafs which may have any live files. */
   private[amt] val liveDataManifestEntryStatuses: Set[Int] =

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriteHelper.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriteHelper.scala
@@ -214,7 +214,7 @@ object AMTWriteHelper extends DeltaLogging {
 
     // Capture values so the closures do not reach back into the object / non-serializable Path.
     // The rewritten files already exist in the table, so their leaf entries are EXISTING.
-    val tracking = trackingWithStatus(Tracking.Status.Existing)
+    val tracking = existingTrackingForDataEntry()
     val tableRootSparkPath = SparkPath.fromPath(tableRoot)
     val metadataDirSparkPath = SparkPath.fromPath(metadataDir)
 
@@ -260,7 +260,11 @@ object AMTWriteHelper extends DeltaLogging {
           // The root pointer to this leaf is newly ADDED, even though the leaf's own DATA
           // entries are EXISTING (the referenced data files already lived in the table).
           val (tracking, manifestInfo) =
-            addedTrackingForLeaf(existingFilesCount = entryCount.toInt)
+            addedTrackingForLeaf(
+              addedFilesCount = 0,
+              existingFilesCount = entryCount.toInt,
+              deletedFilesCount = 0,
+              replacedFilesCount = 0)
           Iterator.single(DataManifestEntry(
             location = AMTUtils.relativizeManifestPathToTableRoot(
               leafFs, tableRootSparkPath.toPath, leafFile),
@@ -274,8 +278,8 @@ object AMTWriteHelper extends DeltaLogging {
     }
   }
 
-  // Tracking envelope for a freshly written entry with the given status.
-  private def trackingWithStatus(status: Int): Tracking = Tracking(
+  // Initializes a tracking envelope for a freshly written entry with the given status.
+  private def initializeTracking(status: Int): Tracking = Tracking(
     status = status,
     snapshot_id = None,
     dv_snapshot_id = None,
@@ -285,24 +289,51 @@ object AMTWriteHelper extends DeltaLogging {
     deleted_positions = None,
     replaced_positions = None)
 
-  // Tracking envelope for a freshly written entry: ADDED.
-  private[amt] def addedTracking: Tracking = trackingWithStatus(Tracking.Status.Added)
+  /** Tracking helpers for [[DataEntry]] */
+  private[amt] def addedTrackingForDataEntry() = initializeTracking(Tracking.Status.Added)
+  private[amt] def existingTrackingForDataEntry() = initializeTracking(Tracking.Status.Existing)
+  private[amt] def modifiedTrackingForDataEntry() = initializeTracking(Tracking.Status.Modified)
+  private[amt] def removedTrackingForDataEntry() = initializeTracking(Tracking.Status.Deleted)
+  private[amt] def replacedTrackingForDataEntry() = initializeTracking(Tracking.Status.Replaced)
 
-  // Tracking envelope for a root-resident tombstone: REMOVED.
-  // `deletedPositions`, when present, is the within-file bitmap of rows this commit deleted
-  // (carried for CDF); it is left None for a whole-file removal.
-  private[amt] def removedTracking(deletedPositions: Option[Array[Byte]] = None): Tracking =
-    trackingWithStatus(Tracking.Status.Deleted).copy(deleted_positions = deletedPositions)
+  /** Tracking + ManifestInfo for a newly written leaf derived from its entries. */
+  private[amt] def addedTrackingForLeaf(entryStatuses: Seq[Int]): (Tracking, ManifestInfo) = {
+    val frequencies = entryStatuses.groupBy(identity).map { case (status, s) => status -> s.length }
+    def count(status: Int): Int = frequencies.getOrElse(status, 0)
+    addedTrackingForLeaf(
+      addedFilesCount = count(Tracking.Status.Added) + count(Tracking.Status.Modified),
+      existingFilesCount = count(Tracking.Status.Existing),
+      deletedFilesCount = count(Tracking.Status.Deleted),
+      replacedFilesCount = count(Tracking.Status.Replaced))
+  }
 
-  /** Tracking + ManifestInfo for a newly written leaf file: the root pointer to it is ADDED. */
+  /** Tracking + ManifestInfo for a newly written leaf from its file counts. */
   private[amt] def addedTrackingForLeaf(
-      addedFilesCount: Int = 0,
-      existingFilesCount: Int = 0): (Tracking, ManifestInfo) = {
-    val tracking = trackingWithStatus(Tracking.Status.Added)
+      addedFilesCount: Int,
+      existingFilesCount: Int,
+      deletedFilesCount: Int,
+      replacedFilesCount: Int): (Tracking, ManifestInfo) = {
+    val tracking = initializeTracking(Tracking.Status.Added)
     val manifestInfo = emptyManifestInfo.copy(
       added_files_count = addedFilesCount,
-      existing_files_count = existingFilesCount)
+      existing_files_count = existingFilesCount,
+      deleted_files_count = deletedFilesCount,
+      replaced_files_count = replacedFilesCount)
     (tracking, manifestInfo)
+  }
+
+  /**
+   * Tracking + ManifestInfo for a carried leaf that holds no live file (its live entries are all
+   * MDV-masked, or it only ever held tombstones): it decays to DELETED with its manifest_info kept
+   * and per-commit CDF positions cleared, so the next AMT drops it.
+   */
+  private[amt] def deletedTrackingForCarriedLeaf(
+      oldEntry: DataManifestEntry): (Tracking, ManifestInfo) = {
+    val newTracking = oldEntry.tracking.copy(
+      status = Tracking.Status.Deleted,
+      deleted_positions = None,
+      replaced_positions = None)
+    (newTracking, oldEntry.manifest_info)
   }
 
   /**
@@ -322,32 +353,39 @@ object AMTWriteHelper extends DeltaLogging {
 
   /**
    * Tracking + ManifestInfo for a carried leaf whose MDV grew this commit: MODIFIED, with
-   * `mdvPositions` accumulated into the cumulative MDV and `cdfPositions` recorded for CDF.
-   * If all the MDV bits are set, change the Tracking.Status from MODIFIED to DELETED.
+   * `mdvPositions` accumulated into the cumulative MDV, and this commit's `deletedPositions` /
+   * `replacedPositions` recorded for CDF. If all the MDV bits are set, the leaf decays to DELETED.
    */
   private[amt] def modifiedOrDeletedTrackingForLeaf(
       oldEntry: DataManifestEntry,
       mdvPositions: Seq[Long],
-      cdfPositions: Seq[Long]): (Tracking, ManifestInfo) = {
+      deletedPositions: Seq[Long],
+      replacedPositions: Seq[Long]): (Tracking, ManifestInfo) = {
     val cumulativeMdv = oldEntry.manifest_info.dv
       .map(AMTUtils.deserializeMdv).getOrElse(new RoaringBitmapArray)
     mdvPositions.foreach(cumulativeMdv.add)
-    val deletedPositions =
-      if (cdfPositions.isEmpty) None
-      else Some(AMTUtils.serializeMdv(RoaringBitmapArray(cdfPositions: _*)))
-    // A leaf's MDV masks positions within that leaf, so its cardinality can never exceed the
+    def bitmapOf(positions: Seq[Long]): Option[Array[Byte]] = {
+      if (positions.isEmpty) None
+      else Some(AMTUtils.serializeMdv(RoaringBitmapArray(positions: _*)))
+    }
+    // Every masked / CDF position indexes an entry within this leaf, so no count can exceed the
     // leaf's entry count; a larger value signals a corrupt bitmap or a double-counted position.
-    assert(cumulativeMdv.cardinality <= oldEntry.record_count,
-      s"leaf ${oldEntry.location}: MDV cardinality ${cumulativeMdv.cardinality} exceeds " +
-        s"record_count ${oldEntry.record_count}.")
-    // A leaf whose every entry is masked by the cumulative MDV holds no live file, so it decays to
-    // DELETED rather than MODIFIED.
-    val allEntriesMasked = cumulativeMdv.cardinality == oldEntry.record_count
-    val status = if (allEntriesMasked) Tracking.Status.Deleted else Tracking.Status.Modified
+    def assertWithinLeaf(count: Long, label: String): Unit =
+      assert(count <= oldEntry.record_count,
+        s"leaf ${oldEntry.location}: $label $count exceeds record_count ${oldEntry.record_count}.")
+    assertWithinLeaf(cumulativeMdv.cardinality, "MDV cardinality")
+    assertWithinLeaf(deletedPositions.size.toLong, "deleted_positions")
+    assertWithinLeaf(replacedPositions.size.toLong, "replaced_positions")
+    // A leaf whose every live entry is masked by the cumulative MDV holds no live file, so it
+    // decays to DELETED rather than MODIFIED.
+    val liveFileCount =
+      oldEntry.manifest_info.added_files_count + oldEntry.manifest_info.existing_files_count
+    val noActiveFiles = liveFileCount.toLong - cumulativeMdv.cardinality <= 0
+    val status = if (noActiveFiles) Tracking.Status.Deleted else Tracking.Status.Modified
     val newTracking = oldEntry.tracking.copy(
       status = status,
-      deleted_positions = deletedPositions,
-      replaced_positions = None)
+      deleted_positions = bitmapOf(deletedPositions),
+      replaced_positions = bitmapOf(replacedPositions))
     // manifest_info file/row counts are immutable; only the MDV (dv/dv_cardinality) grows to mask
     // the newly superseded positions. Live count is record_count - dv_cardinality, and this
     // commit's CDF positions live on the tracking, not in the counts.
@@ -366,24 +404,21 @@ object AMTWriteHelper extends DeltaLogging {
       tableRoot: Path,
       metadataDir: Path,
       metadata: Metadata,
-      batch: Seq[AddFile]): DataManifestEntry = {
+      entries: Seq[DataEntry]): DataManifestEntry = {
     val leafFile = FileNames.newAMTLeafManifestFile(metadataDir)
-    val rows: Seq[AMTSingleAction] =
-      batch.map(add =>
-        DataEntry
-          .fromAddFile(add, trackingWithStatus(Tracking.Status.Added), tableRoot)
-          .wrap
-      )
-    writeAMTParquet(spark, hadoopConf, leafFile, metadata, rows)
-    val status = fs.getFileStatus(leafFile)
-    val (tracking, manifestInfo) = addedTrackingForLeaf(addedFilesCount = rows.size)
+    writeAMTParquet(spark, hadoopConf, leafFile, metadata, entries.map(_.wrap))
+    val fileStatus = fs.getFileStatus(leafFile)
+    // A freshly written leaf is always ADDED -- even one holding only tombstones, whose
+    // manifest_info still counts the DELETED / REPLACED entries.
+    val statuses = entries.map(_.tracking.status)
+    val (tracking, manifestInfo) = addedTrackingForLeaf(statuses)
     DataManifestEntry(
       location = AMTUtils.relativizeManifestPathToTableRoot(fs, tableRoot, leafFile),
       file_format = AMTSingleAction.FileFormatParquet,
       tracking = tracking,
       // Number of content entries the referenced leaf manifest holds.
-      record_count = manifestInfo.added_files_count.toLong,
-      file_size_in_bytes = status.getLen,
+      record_count = entries.size.toLong,
+      file_size_in_bytes = fileStatus.getLen,
       manifest_info = manifestInfo)
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriterManager.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriterManager.scala
@@ -70,9 +70,15 @@ case class IncrementalAMTWriteMetrics(
     numOldLeavesUpdated: Int,
     numOldLeavesUntouched: Int,
     numNewLeaves: Int,
-    numRootLiveAdds: Int,
-    numRootTombstones: Int,
+    // Per-status breakdown over root-resident DATA entries (see [[Tracking.Status]]).
+    numRootEntriesAddedStatus: Int,
+    numRootEntriesExistingStatus: Int,
+    numRootEntriesModifiedStatus: Int,
+    numRootEntriesReplacedStatus: Int,
+    numRootEntriesDeletedStatus: Int,
     numLeafMdvBitsAdded: Int,
+    numLeafDeleteCDFBitsAdded: Int = 0,
+    numLeafReplaceCDFBitsAdded: Int = 0,
     // Per-status breakdown over all leaf pointers in the new tree (see [[Tracking.Status]]), plus
     // the stale DELETED tombstones from the previous tree that this rewrite dropped.
     numLeavesAddedStatus: Int = 0,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/IncrementalAMTWriter.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/IncrementalAMTWriter.scala
@@ -21,8 +21,8 @@ import java.util.concurrent.TimeUnit.NANOSECONDS
 import scala.collection.mutable.ArrayBuffer
 
 import org.apache.spark.sql.delta.{DeltaFileProviderUtils, DeltaLog, SingleCommit}
-import org.apache.spark.sql.delta.actions.{Action, AddFile, Checkpoint, ContentRoot, InMemoryLogReplay, Metadata, RemoveFile}
-import org.apache.spark.sql.delta.actions.InMemoryLogReplay.UniqueFileActionTuple
+import org.apache.spark.sql.delta.actions.{Action, AddFile, BackReference, Checkpoint, ContentRoot, DomainMetadata, FileAction, InMemoryLogReplay, Metadata, Protocol, RemoveFile, SetTransaction}
+import org.apache.spark.sql.delta.actions.InMemoryLogReplay.{UniqueAddFileTuple, UniqueFileActionTuple, UniqueRemoveFileTuple}
 import org.apache.spark.sql.delta.deletionvectors.RoaringBitmapArray
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.FileNames
@@ -43,25 +43,32 @@ import org.apache.spark.sql.SparkSession
  *   (part-2) + commitActions that we want to commit (part-3) -- the logReplay of above becomes
  *   [[DataEntry]]s for the new AMT root.
  * - The previous tree's leaves ([[DataManifestEntry]]s) are carried forward by pointer.
- * - The [[RemoveFile]] actions from part-2 / part-3 that have backreferences contribute towards
- *   MDVs for existing leafs.
+ * - The [[AddFile]] / [[RemoveFile]] actions from part-2 / part-3 that have backreferences
+ *   contribute towards MDVs for existing leafs.
  * - Tombstones:
  *   - The RemoveFile from the current proposed commit (part-3) contributes for CDF.
- *   - The one with backreferences contributes to deleted_positions on the [[DataManifestEntry]]
- *     corresponding to existing leafs.
- *   - The one without backreferences contributes to a tombstone [[DataEntry]] in the new root.
- * - If the root crosses the maxEntriesPerLeaf threshold, live [[DataEntry]]s are spilled to a new
- *   leaf.
+ *   - The one with backreferences contributes to deleted_positions / replaced_positions on the
+ *     [[DataManifestEntry]] corresponding to existing leafs.
+ *   - The one without backreferences contributes to a tombstone [[DataEntry]] in the new root /
+ *     spilled leaves.
+ * - If the root crosses the maxEntriesPerLeaf threshold, live [[DataEntry]]s / tombstone
+ *   [[DataEntry]]s are spilled to a new leaf.
+ *
+ * [[DataEntry]] tracking.status is set to reflect THIS commit's CDF: only this commit's own actions
+ * contribute ADDED (inserts), DELETED (deletes), and REPLACED + MODIFIED (updates -- the prior and
+ * new copies of a re-added file). A file carried forward untouched is EXISTING and contributes no
+ * CDF. Window (intermediate) commits already emitted their CDF, so their files carry forward as
+ * EXISTING, not re-attributed to this commit.
  *
  * [[DataManifestEntry]] tracking.status state transitions (re-derived on every carry-forward to a
  * new AMT, from the masking the leaf gains that commit -- prior live status does not matter):
- * - A new leaf is born ADDED (from spilled live [[DataEntry]]s) or DELETED (from spilled
- *   tombstones).
+ * - A new leaf is always born ADDED, whether it holds spilled live [[DataEntry]]s or only spilled
+ *   tombstones (a tombstone-only leaf holds no live file, but is still born ADDED).
  * - ADDED ->
- *   - EXISTING -- the next AMT masks nothing new in the leaf (its MDV is unchanged).
- *   - MODIFIED -- the next AMT masks some, but not all, of its entries.
- *   - DELETED  -- the next AMT masks its last live entry (cumulative MDV cardinality reaches
- *     record_count); the pointer becomes a tombstone.
+ *   - EXISTING -- the leaf still holds a live file and gains no new masking this commit.
+ *   - MODIFIED -- this commit masks some, but not all, of its live entries.
+ *   - DELETED  -- the leaf holds no live file: this commit masks its last live entry, or it only
+ *     ever held tombstones; the pointer becomes a tombstone.
  * - EXISTING ->
  *   - EXISTING / MODIFIED / DELETED -- same rule as ADDED, from this commit's masking.
  * - MODIFIED ->
@@ -107,14 +114,14 @@ class IncrementalAMTWriter(spark: SparkSession, deltaLog: DeltaLog) {
     // [oldAMTVersion + 1, attemptVersion) with no holes.
     assertWindowCoversRange(intermediateLogCommits, oldAMTVersion, attemptVersion)
 
-    // ---- Step 1: gather the actions of all three parts. ----
+    // ---- Step 1: gather the actions of all three parts and process them. ----
     // 1.a: old AMT root -- its live root-resident files, plus its inline non-content state
     // (protocol, metadata, setTxns, domainMetadata). Leaf-resident files are NOT read here.
     val fileActionsFromOldRoot = AMTCheckpointProvider.readLiveRootDataEntries(
       deltaLog, oldCheckpoint)
-    val nonContentFromOldRoot: Iterator[Action] =
-      Iterator(oldCheckpoint.protocol, oldCheckpoint.metaData) ++
-        oldCheckpoint.txns.iterator ++ oldCheckpoint.domainMetadata.iterator
+    val nonContentFromOldCheckpoint: Seq[Action] =
+      Seq[Action](oldCheckpoint.protocol, oldCheckpoint.metaData) ++
+        oldCheckpoint.txns ++ oldCheckpoint.domainMetadata
     // 1.b: the log commits / minor compactions committed after the old AMT, read in parallel (the
     // MinorCompactionHook primitive). Each segment delta file becomes a SingleCommit keyed by its
     // version (a compacted delta's version is its endVersion, via getFileVersion).
@@ -123,78 +130,67 @@ class IncrementalAMTWriter(spark: SparkSession, deltaLog: DeltaLog) {
     val actionsFromDeltas =
       DeltaFileProviderUtils.parallelReadAndParseDeltaFilesAsSeq(spark, windowCommits)
     // 1.c: this commit attempt's own actions (actionsToCommit).
+    val processedActions = new ProcessedActions(
+      oldAMTVersion = oldAMTVersion,
+      oldRootAdds = fileActionsFromOldRoot,
+      nonContentFromOldCheckpoint = nonContentFromOldCheckpoint,
+      windowCommits = windowCommits,
+      windowCommitActions = actionsFromDeltas,
+      attemptVersion = attemptVersion,
+      actionsToCommit = actionsToCommit)
 
-    // ---- Step 2: log-replay all three parts, keyed by their real commit versions. ----
-    // The version handed to `append` feeds InMemoryLogReplay's monotonic-progress assert: the old
-    // AMT root describes oldAMTVersion, each window delta carries its own commit version
-    // (FileNames.getFileVersion; for a minor compaction that is a good proxy), and this commit
-    // lands at attemptVersion. Because 1.a seeds the old inline non-content state and 1.b/1.c
-    // override it (last-writer-wins), the replay's protocol/metadata/setTxns/domainMetadata equal
-    // the post-commit values.
-    val replay = new InMemoryLogReplay(
-      minFileRetentionTimestamp = None, minSetTransactionRetentionTimestamp = None)
-    replay.append(
-      oldAMTVersion,
-      fileActionsFromOldRoot.iterator ++ nonContentFromOldRoot)
-    windowCommits.zip(actionsFromDeltas).foreach { case (commit, actions) =>
-      replay.append(commit.version, actions.iterator)
+    // ---- Step 2: carry the old leaf pointers forward, patching MDV + CDF positions. ----
+    val (carriedLeafPointers, leafPositions) =
+      carryForwardLeaves(
+        oldAMTCheckpointProvider,
+        processedActions.mdvSupersededBackrefs,
+        processedActions.cdfDeletedBackrefs,
+        processedActions.cdfReplacedBackrefs)
+
+    // ---- Step 3: build the root DATA entries (with per-file status). ----
+    // 3.a: live files -- classify each by whether THIS commit changed it:
+    // - ADDED if inserted by this commit (not live before it).
+    // - MODIFIED if replaced (re-added under a new DV) this commit.
+    // - else EXISTING -- carried from the old root, or a window (intermediate) commit, whose own
+    //   CDF already fired, so this commit proposes no change to it.
+    val liveAddFiles = processedActions.liveAddFiles
+    // A re-add of a file already live before this commit (carries a leaf back reference, or its key
+    // is in the pre-commit live set; not a replace) is a metadata-only refresh: it stays EXISTING
+    // and its old leaf slot is MDV-masked (ProcessedActions asserts the re-add invariants).
+    def trackingForLiveAdd(add: AddFile): Tracking = {
+      if (processedActions.replacedPaths.contains(add.path)) {
+        AMTWriteHelper.modifiedTrackingForDataEntry()
+      } else if (add.backReference.isDefined ||
+          processedActions.preCommitLiveKeys.contains(add.toUniqueFileActionTuple)) {
+        AMTWriteHelper.existingTrackingForDataEntry()
+      } else {
+        AMTWriteHelper.addedTrackingForDataEntry()
+      }
     }
-    replay.append(attemptVersion, actionsToCommit.iterator)
+    val liveEntries =
+      liveAddFiles.map(add => DataEntry.fromAddFile(add, trackingForLiveAdd(add), tableRoot))
+    // 3.b: root remove entries (for CDF) -- this commit's net-removed no-backref files, built from
+    // the matching AddFile (old root + window) so CDF gets full stats.
+    val removeEntries = buildRootRemoveEntries(
+      processedActions.cdfNoBackrefRemoves, liveAddFiles, processedActions.rootAndWindowAdds,
+      processedActions.commitAddedPaths)
 
-    // ---- Step 3: gather the removes that drive MDV masking and CDF, from different scopes. ----
-    val windowActions = actionsFromDeltas.flatten
-    // 3.a: MDV masking -- ALL leaf-resident removes since the old AMT (window + commit). The MDV
-    // must hide every entry deleted since the last full tree, so it accumulates the window's
-    // removes too, regardless of which commit deleted them.
-    // NOTE: this can NOT come from `replay.getActiveRemoveFiles`. Leaf files are not seeded into
-    // the replay, and a leaf file removed then re-added within the window (e.g. RESTORE) has its
-    // remove cancelled by the re-add there, so getActiveRemoveFiles would omit it -- yet its old
-    // leaf entry still needs masking (the re-added copy lives in the root). We must mask by every
-    // backref position deleted since the old AMT, which is exactly this scan.
-    val mdvBackrefRemoves = (windowActions ++ actionsToCommit)
-      .collect { case r: RemoveFile if r.backReference.isDefined => r }
-    // 3.b: CDF -- ONLY this commit's removes. A window remove already emitted its CDF (deleted DV /
-    // root tombstone) in its own commit; re-emitting here would double-count. So this commit's
-    // with-backref removes drive tracking.deleted_positions on the touched leaf pointers, and its
-    // without-backref removes drive the root tombstones.
-    val commitRemoves = actionsToCommit.collect { case r: RemoveFile => r }
-    val (cdfBackrefRemoves, cdfNoBackrefRemoves) =
-      commitRemoves.partition(_.backReference.isDefined)
+    // ---- Step 4: spill entries into new leaves if the root would exceed the per-leaf cap. ----
+    val fixedRootCount = carriedLeafPointers.size
+    val (rootLiveEntries, rootRemoveEntries, spilledLeafPointers) =
+      spillIfNeeded(liveEntries, removeEntries, fixedRootCount, processedActions.postCommitMetadata)
+    val allLeafPointers = carriedLeafPointers ++ spilledLeafPointers
 
-    // ---- Step 4: carry the old leaf pointers forward, patching MDV + deleted_positions. ----
-    // Also returns the MDV positions this write added per leaf (keyed by relative location), reused
-    // for the shape metrics below rather than recomputed.
-    val (carriedLeafPointers, mdvPositionsByLeaf) =
-      carryForwardLeaves(oldAMTCheckpointProvider, mdvBackrefRemoves, cdfBackrefRemoves)
-
-    // ---- Step 5: build the root DATA entries. ----
-    // 5.a: live files (added/existing) -- the net-new files, held directly in the root.
-    val liveAdds = replay.allFiles
-    // 5.b: removed tombstones (for CDF) -- net-removed no-backref files removed by THIS commit,
-    // built from the matching AddFile (root + window) so CDF gets full stats, never from the sparse
-    // RemoveFile.
-    val rootAndWindowAdds = fileActionsFromOldRoot ++ windowActions.collect { case a: AddFile => a }
-    val tombstoneEntries = buildTombstones(cdfNoBackrefRemoves, liveAdds, rootAndWindowAdds)
-
-    // ---- Step 6: spill live adds into new leaves if the root would exceed the per-leaf cap. ----
-    // The post-commit metadata shapes the persisted manifest schema (the Iceberg partition struct),
-    // so every manifest written below needs it, as does the Checkpoint action in step 8.
-    val postCommitMetadata = replay.getMetadata.getOrElse(
-      throw new IllegalStateException("Replay produced no metadata for the incremental AMT."))
-    val fixedRootCount = carriedLeafPointers.size + tombstoneEntries.size
-    val (rootAdds, spilledLeafPointers) =
-      spillIfNeeded(liveAdds, fixedRootCount, postCommitMetadata)
-
-    // ---- Step 7: write the new root. ----
-    val addedTracking = AMTWriteHelper.addedTracking
+    // ---- Step 5: write the new root. The post-commit metadata shapes the persisted manifest
+    // schema (the Iceberg partition struct), so every manifest write needs it.
     val rootRows =
-      (carriedLeafPointers ++ spilledLeafPointers).map(_.wrap) ++
-        rootAdds.map(add => DataEntry.fromAddFile(add, addedTracking, tableRoot).wrap) ++
-        tombstoneEntries.map(_.wrap)
+      allLeafPointers.map(_.wrap) ++
+        rootLiveEntries.map(_.wrap) ++
+        rootRemoveEntries.map(_.wrap)
     val contentRootBase = AMTWriteHelper.writeRoot(
-      spark, fs, hadoopConf, tableRoot, metadataDir, postCommitMetadata, rootRows)
+      spark, fs, hadoopConf, tableRoot, metadataDir, processedActions.postCommitMetadata, rootRows)
 
-    // ---- Step 8: generate the Checkpoint action. ----
+    // ---- Step 6: generate the Checkpoint action. ----
     // The version the tree describes: an inline commit describes itself; a deferred OPTIMIZE
     // CHECKPOINT (no user actions) describes the last committed version (attemptVersion - 1).
     val contentStateVersion =
@@ -202,22 +198,19 @@ class IncrementalAMTWriter(spark: SparkSession, deltaLog: DeltaLog) {
     // An incremental rewrite carries forward the previous tree's last-full-rewrite marker.
     val lastFullRewriteVersion = oldCheckpoint.contentRoot
       .lastManifestCommitWithFullRewrite.getOrElse(contentStateVersion)
-    val allLeafPointers = carriedLeafPointers ++ spilledLeafPointers
     val contentRoot = ContentRoot(
       path = contentRootBase.path,
       sizeInBytes = contentRootBase.sizeInBytes,
       isIncremental = true,
       lastManifestCommitWithFullRewrite = lastFullRewriteVersion,
       numLeaves = allLeafPointers.size.toLong)
-    val postCommitProtocol = replay.getProtocol.getOrElse(
-      throw new IllegalStateException("Replay produced no protocol for the incremental AMT."))
     val checkpoint = Checkpoint(
       version = contentStateVersion,
       contentRoot = contentRoot,
-      protocol = postCommitProtocol,
-      metaData = postCommitMetadata,
-      domainMetadata = replay.getDomainMetadatas.toSeq,
-      txns = replay.getTransactions.toSeq,
+      protocol = processedActions.postCommitProtocol,
+      metaData = processedActions.postCommitMetadata,
+      domainMetadata = processedActions.domainMetadatas,
+      txns = processedActions.transactions,
       sidecars = Seq.empty)
     val result = AMTWriteResult(
       contentRootVersion = contentStateVersion,
@@ -225,21 +218,30 @@ class IncrementalAMTWriter(spark: SparkSession, deltaLog: DeltaLog) {
       leaves = allLeafPointers,
       includeActionsInCommitJson = true)
     val numOldLeavesUpdated = carriedLeafPointers.count(p =>
-      mdvPositionsByLeaf.getOrElse(p.location, Set.empty[Long]).nonEmpty)
+      leafPositions.newMDVPositionsByLeaf.getOrElse(p.location, Set.empty[Long]).nonEmpty)
     // Per-status breakdown over every leaf pointer in the new tree (carried + newly spilled).
     val leavesByStatus = allLeafPointers.groupBy(_.tracking.status).map {
       case (status, ps) => status -> ps.size
     }
     val numStaleDeletedLeavesDropped =
       oldAMTCheckpointProvider.leaves.count(_.tracking.status == Tracking.Status.Deleted)
+    def positionCount(byLeaf: Map[String, Set[Long]]): Int = byLeaf.valuesIterator.map(_.size).sum
+    // Per-status breakdown over the new tree's root-resident DATA entries (live + remove entries).
+    val rootEntriesByStatus = (rootLiveEntries ++ rootRemoveEntries)
+      .groupBy(_.tracking.status).map { case (status, es) => status -> es.size }
     val incrementalWriteMetrics = IncrementalAMTWriteMetrics(
       numIntermediateCommits = intermediateLogCommits.size,
       numOldLeavesUpdated = numOldLeavesUpdated,
       numOldLeavesUntouched = carriedLeafPointers.size - numOldLeavesUpdated,
       numNewLeaves = spilledLeafPointers.size,
-      numRootLiveAdds = rootAdds.size,
-      numRootTombstones = tombstoneEntries.size,
-      numLeafMdvBitsAdded = mdvPositionsByLeaf.valuesIterator.map(_.size).sum,
+      numRootEntriesAddedStatus = rootEntriesByStatus.getOrElse(Tracking.Status.Added, 0),
+      numRootEntriesExistingStatus = rootEntriesByStatus.getOrElse(Tracking.Status.Existing, 0),
+      numRootEntriesModifiedStatus = rootEntriesByStatus.getOrElse(Tracking.Status.Modified, 0),
+      numRootEntriesReplacedStatus = rootEntriesByStatus.getOrElse(Tracking.Status.Replaced, 0),
+      numRootEntriesDeletedStatus = rootEntriesByStatus.getOrElse(Tracking.Status.Deleted, 0),
+      numLeafMdvBitsAdded = positionCount(leafPositions.newMDVPositionsByLeaf),
+      numLeafDeleteCDFBitsAdded = positionCount(leafPositions.deleteCDFPositionByLeaf),
+      numLeafReplaceCDFBitsAdded = positionCount(leafPositions.replaceCDFPositionByLeaf),
       numLeavesAddedStatus = leavesByStatus.getOrElse(Tracking.Status.Added, 0),
       numLeavesExistingStatus = leavesByStatus.getOrElse(Tracking.Status.Existing, 0),
       numLeavesModifiedStatus = leavesByStatus.getOrElse(Tracking.Status.Modified, 0),
@@ -262,102 +264,165 @@ class IncrementalAMTWriter(spark: SparkSession, deltaLog: DeltaLog) {
    *   - `manifest_info.dv` (MDV, masking) accumulates ALL leaf positions removed since the old AMT
    *     (`mdvRemoves` = window + commit), so the reader hides every entry deleted since the last
    *     full tree; and
-   *   - `tracking.deleted_positions` (CDF) is RESET to just THIS commit's removed positions
-   *     (`cdfRemoves`) -- a window remove already emitted its CDF in its own commit, and the old
-   *     pointer's stale positions must not carry forward, so this is cleared on every pointer and
-   *     re-set only for leaves this commit touched.
+   *   - `tracking.{deleted_positions / replaced_positions}` (CDF) is RESET to just THIS commit's
+   *     removed positions -- a window remove already emitted its CDF in its own commit, and the
+   *     old pointer's stale positions must not carry forward, so this is cleared on every pointer
+   *     and re-set only for leaves this commit touched.
    * Leaf parquet files are never re-read or rewritten.
    *
-   * Returns the carried-forward pointers and the MDV positions this write added per leaf (keyed by
-   * relative location), so the caller can derive the shape metrics without recomputing it.
+   * Returns the carried-forward pointers and an [[MDVAndCDFPositions]] that has been set per-leaf.
    */
   private def carryForwardLeaves(
       provider: AMTCheckpointProvider,
-      mdvRemoves: Seq[RemoveFile],
-      cdfRemoves: Seq[RemoveFile]): (Seq[DataManifestEntry], Map[String, Set[Long]]) = {
-    // A position is a SET member: the MDV and deleted_positions are both bitmaps, so removing
-    // the same (leaf, position) twice -- e.g. a leaf file removed, re-added and removed again --
-    // masks it once. Deduplicating here keeps numLeafMdvBitsAdded equal to the bits the MDV
-    // actually gained.
-    def positionsByLeaf(removes: Seq[RemoveFile]): Map[String, Set[Long]] =
-      removes.flatMap(r => r.backReference.map(br => br.manifest -> br.pos))
+      mdvSupersededBackrefs: Seq[BackReference],
+      cdfDeletedBackrefs: Seq[BackReference],
+      cdfReplacedBackrefs: Seq[BackReference])
+      : (Seq[DataManifestEntry], MDVAndCDFPositions) = {
+    // A (leaf, position) can be superseded multiple times, e.g. a leaf file removed, re-added and
+    // removed again. We use a Set to dedupe the positions so the count matches the number of bits
+    // gained by the MDV or CDF bitmap.
+    def positionsByLeaf(backrefs: Seq[BackReference]): Map[String, Set[Long]] =
+      backrefs.map(br => br.manifest -> br.pos)
         .groupBy(_._1).map { case (leaf, pairs) => leaf -> pairs.map(_._2).toSet }
-    val mdvPositionsByLeaf = positionsByLeaf(mdvRemoves)
-    val cdfPositionsByLeaf = positionsByLeaf(cdfRemoves)
+    val newMDVPositionsByLeaf = positionsByLeaf(mdvSupersededBackrefs)
+    val deletedPositionsByLeaf = positionsByLeaf(cdfDeletedBackrefs)
+    val replacedPositionsByLeaf = positionsByLeaf(cdfReplacedBackrefs)
     val pointers = provider.leaves.flatMap { pointer =>
       if (pointer.tracking.status == Tracking.Status.Deleted) None
       else {
-        val newMdvPositions = mdvPositionsByLeaf.getOrElse(pointer.location, Set.empty[Long]).toSeq
-        val cdfPositions = cdfPositionsByLeaf.getOrElse(pointer.location, Set.empty[Long]).toSeq
-        Some(carryForwardOneLeaf(pointer, newMdvPositions, cdfPositions))
+        val newMdvPositions =
+          newMDVPositionsByLeaf.getOrElse(pointer.location, Set.empty[Long]).toSeq
+        val deletedPositions =
+          deletedPositionsByLeaf.getOrElse(pointer.location, Set.empty[Long]).toSeq
+        val replacedPositions =
+          replacedPositionsByLeaf.getOrElse(pointer.location, Set.empty[Long]).toSeq
+        Some(carryForwardOneLeaf(pointer, newMdvPositions, deletedPositions, replacedPositions))
       }
     }
-    (pointers, mdvPositionsByLeaf)
+    (pointers,
+      MDVAndCDFPositions(newMDVPositionsByLeaf, deletedPositionsByLeaf, replacedPositionsByLeaf))
   }
 
   private def carryForwardOneLeaf(
       pointer: DataManifestEntry,
       newMdvPositions: Seq[Long],
-      cdfPositions: Seq[Long]): DataManifestEntry = {
+      deletedPositions: Seq[Long],
+      replacedPositions: Seq[Long]): DataManifestEntry = {
+    val liveFileCount =
+      pointer.manifest_info.added_files_count + pointer.manifest_info.existing_files_count
+    val tombstoneFileCount =
+      pointer.manifest_info.deleted_files_count + pointer.manifest_info.replaced_files_count
+    if (liveFileCount > 0 && tombstoneFileCount > 0) {
+      throw new IllegalStateException(
+        "Leaves having mix of live files and tombstones are not supported yet")
+    }
+    if (newMdvPositions.nonEmpty && liveFileCount == 0) {
+      throw new IllegalStateException(
+        s"Leaf ${pointer.location} holds no live file but gained new MDV positions.")
+    }
     val (tracking, manifestInfo) =
-      if (newMdvPositions.isEmpty) {
-        AMTWriteHelper.existingTrackingForLeaf(pointer)
+      if (tombstoneFileCount > 0) {
+        // A carried leaf with no live file -- a tombstone-only leaf born ADDED last commit --
+        // decays to DELETED so the next AMT drops it.
+        AMTWriteHelper.deletedTrackingForCarriedLeaf(pointer)
       } else {
-        AMTWriteHelper.modifiedOrDeletedTrackingForLeaf(pointer, newMdvPositions, cdfPositions)
+        // this case means tombstoneFileCount = 0 and liveFileCount >= 0
+        // In this scenario, mark the leaf as DELETED if any of below is true:
+        // a) all live files are marked for deletion in this commit (with newMdvPositions) OR
+        // b) all the live files were already striked off in previous commit itself but the
+        //    leaf was not marked as DELETED then (this is not done by our implementation but
+        //    could be done by external engine).
+        if (newMdvPositions.nonEmpty) {
+          // The MDV grew this commit: MODIFIED, or DELETED once every live entry is masked.
+          AMTWriteHelper.modifiedOrDeletedTrackingForLeaf(
+            pointer, newMdvPositions, deletedPositions, replacedPositions)
+        } else if (pointer.manifest_info.dv_cardinality.getOrElse(0L) == pointer.record_count) {
+          AMTWriteHelper.deletedTrackingForCarriedLeaf(pointer)
+        } else {
+          // Untouched leaf (no new MDVs) that still holds live files: carry it forward EXISTING.
+          AMTWriteHelper.existingTrackingForLeaf(pointer)
+        }
       }
     pointer.copy(manifest_info = manifestInfo, tracking = tracking)
   }
 
   /**
-   * Builds root-resident `tracking=removed` tombstones for THIS commit's net-removed no-backref
-   * files, so Change Data Feed can recover them. (Window removes already emitted their CDF in their
-   * own commits, so they are not passed here.) Each tombstone is built from the removed file's
-   * `AddFile` (found among root + window adds, matched by the `(path, dvId)` key) -- NOT from
-   * the sparse `RemoveFile` -- so it carries full stats/DV. A remove is a tombstone only when its
-   * file is net-removed (not present in the replay's live set) and its `AddFile` is found.
+   * Builds root-resident entries for THIS commit's net-removed no-backref files, so Change Data
+   * Feed can recover them. (Window actions already emitted their CDF in their own commits, so they
+   * are not passed here.)
+   *   - Each entry is built from the removed file's `AddFile` (found among root + window adds) --
+   *     NOT from the sparse `RemoveFile` -- so it carries full stats / DV.
+   *   - A `RemoveFile` for a file ALSO re-added this commit under a new DV yields a REPLACED
+   *     `DataEntry` (its prior state).
+   *   - A `RemoveFile` with no matching re-add for the same path (no DV change -- the full
+   *     `(path, dv)` pair is removed) yields a DELETED `DataEntry`.
    */
-  private def buildTombstones(
+  private def buildRootRemoveEntries(
       withoutBackrefRemoves: Seq[RemoveFile],
       liveAdds: Seq[AddFile],
-      rootAndWindowAdds: Seq[AddFile]): Seq[DataEntry] = {
+      rootAndWindowAdds: Seq[AddFile],
+      commitAddedPaths: Set[String]): Seq[DataEntry] = {
     if (withoutBackrefRemoves.isEmpty) return Seq.empty
-    // Implicit `toUniqueFileActionTuple` on AddFile / RemoveFile.
-    import InMemoryLogReplay.{UniqueAddFileTuple, UniqueRemoveFileTuple}
     val liveKeys: Set[UniqueFileActionTuple] =
       liveAdds.iterator.map(_.toUniqueFileActionTuple).toSet
-    // AddFile lookup from root + window (NOT this commit -- Delta disallows add+remove in one
-    // commit, so a removed file's add always predates the commit).
+    // AddFile lookup from root + window: the removed file's add predates this commit (a replace
+    // re-adds the same path under a new DV -- a distinct key -- so this still finds the prior add).
     val addByKey: Map[UniqueFileActionTuple, AddFile] =
       rootAndWindowAdds.map(a => a.toUniqueFileActionTuple -> a).toMap
-    withoutBackrefRemoves.flatMap { r =>
+    withoutBackrefRemoves.map { r =>
       val removeKey = r.toUniqueFileActionTuple
-      // Only tombstone a genuinely removed file whose originating add we can find.
-      if (liveKeys.contains(removeKey)) None
-      else addByKey.get(removeKey).map(add =>
-        DataEntry.fromAddFile(add, AMTWriteHelper.removedTracking(), tableRoot))
+      // Two invariants a no-backref remove must satisfy (it targets a root-resident or
+      // window-added file, never a leaf); violating either means a corrupt tree:
+      //   - it is net-removed, so its (path, dv) is absent from the live set (a still-live key
+      //     means a malformed add + remove of the same key in one commit); and
+      //   - its originating add is present among root + window adds.
+      if (liveKeys.contains(removeKey)) {
+        throw new IllegalStateException(
+          s"Net-removed no-backref file ${r.path} (key $removeKey) is still in the live set; " +
+            "a file cannot be both removed and live in the same commit.")
+      }
+      val priorAddFile = addByKey.get(removeKey).getOrElse {
+        throw new IllegalStateException(
+          s"No originating AddFile for net-removed no-backref file ${r.path} (key " +
+            s"$removeKey); cannot build its CDF root entry.")
+      }
+      val tracking =
+        if (commitAddedPaths.contains(r.path)) AMTWriteHelper.replacedTrackingForDataEntry()
+        else AMTWriteHelper.removedTrackingForDataEntry()
+      DataEntry.fromAddFile(priorAddFile, tracking, tableRoot)
     }
   }
 
   /**
-   * If the root would exceed `entriesPerLeaf` (carried pointers + tombstones + live adds), moves
-   * whole `entriesPerLeaf`-sized batches of live adds into new leaves until the root's row count
-   * fits. Returns the live adds that remain root-resident and the pointers for any new leaves.
+   * If the root would exceed `entriesPerLeaf` (carried pointers + live entries + remove entries),
+   * moves whole `entriesPerLeaf`-sized batches into new leaves until the root's row count fits --
+   * live entries first, then remove (DELETED / REPLACED) entries. Each spill adds one leaf pointer
+   * to the fixed root count. Returns the live entries and remove entries that remain root-resident,
+   * plus the pointers for any new leaves.
    */
   private def spillIfNeeded(
-      liveAdds: Seq[AddFile],
+      liveEntries: Seq[DataEntry],
+      removeEntries: Seq[DataEntry],
       fixedRootCount: Int,
-      metadata: Metadata): (Seq[AddFile], Seq[DataManifestEntry]) = {
-    var remaining = liveAdds
+      metadata: Metadata): (Seq[DataEntry], Seq[DataEntry], Seq[DataManifestEntry]) = {
     val spilled = ArrayBuffer.empty[DataManifestEntry]
-    // Each spill adds one leaf pointer to the fixed root count; keep spilling while the root would
-    // still overflow.
-    while (fixedRootCount + spilled.size + remaining.size > entriesPerLeaf && remaining.nonEmpty) {
-      val (batch, rest) = remaining.splitAt(entriesPerLeaf)
+    var remainingLive = liveEntries
+    var remainingRemoves = removeEntries
+    def rootRowCount: Int =
+      fixedRootCount + spilled.size + remainingLive.size + remainingRemoves.size
+    while (rootRowCount > entriesPerLeaf && remainingLive.nonEmpty) {
+      val (batch, rest) = remainingLive.splitAt(entriesPerLeaf)
       spilled += AMTWriteHelper.writeLeaf(
         spark, fs, hadoopConf, tableRoot, metadataDir, metadata, batch)
-      remaining = rest
+      remainingLive = rest
     }
-    (remaining, spilled.toSeq)
+    while (rootRowCount > entriesPerLeaf && remainingRemoves.nonEmpty) {
+      val (batch, rest) = remainingRemoves.splitAt(entriesPerLeaf)
+      spilled += AMTWriteHelper.writeLeaf(
+        spark, fs, hadoopConf, tableRoot, metadataDir, metadata, batch)
+      remainingRemoves = rest
+    }
+    (remainingLive, remainingRemoves, spilled.toSeq)
   }
 
   // Asserts the intermediate commit files cover EXACTLY [oldAMTVersion+1, attemptVersion) -- no
@@ -380,3 +445,140 @@ class IncrementalAMTWriter(spark: SparkSession, deltaLog: DeltaLog) {
         s"unexpected ${(covered -- expected).toList.sorted}.")
   }
 }
+
+private class ProcessedActions(
+    oldAMTVersion: Long,
+    oldRootAdds: Seq[AddFile],
+    nonContentFromOldCheckpoint: Seq[Action],
+    windowCommits: Seq[SingleCommit],
+    windowCommitActions: Seq[Seq[Action]],
+    attemptVersion: Long,
+    actionsToCommit: Seq[Action]) {
+
+  private val replay = new InMemoryLogReplay(
+    minFileRetentionTimestamp = None, minSetTransactionRetentionTimestamp = None)
+  private val rootAndWindowAddsBuf = ArrayBuffer.empty[AddFile]
+  private val mdvSupersededBuf = ArrayBuffer.empty[BackReference]
+  // This commit's own file actions, split out for CDF and re-add classification.
+  private val commitAddsBuf = ArrayBuffer.empty[AddFile]
+  private val commitRemovesBuf = ArrayBuffer.empty[RemoveFile]
+
+  // Log replay of part-1/2/3.
+  replay.append(oldAMTVersion, oldRootAdds.iterator ++ nonContentFromOldCheckpoint.iterator)
+  windowCommits.zip(windowCommitActions).foreach { case (commit, actions) =>
+    replay.append(commit.version, actions.iterator)
+  }
+  // Keys of files live in the {old root + window}'s replay BEFORE this commit's actions; a
+  // live add already here (or carrying a leaf back reference) is EXISTING, not ADDED.
+  val preCommitLiveKeys: Set[UniqueFileActionTuple] =
+    replay.allFiles.iterator.map(_.toUniqueFileActionTuple).toSet
+  replay.append(attemptVersion, actionsToCommit.iterator)
+
+  // One more pass over part-1/2/3 to initialize the auxiliary buffers above.
+  rootAndWindowAddsBuf ++= oldRootAdds
+  windowCommits.zip(windowCommitActions).foreach { case (commit, actions) =>
+    actions.foreach {
+      case a: AddFile =>
+        rootAndWindowAddsBuf += a
+        a.backReference.foreach(mdvSupersededBuf += _)
+      case r: RemoveFile => r.backReference.foreach(mdvSupersededBuf += _)
+      case _ =>
+    }
+  }
+  actionsToCommit.foreach {
+    case a: AddFile =>
+      commitAddsBuf += a
+      a.backReference.foreach(mdvSupersededBuf += _)
+    case r: RemoveFile =>
+      commitRemovesBuf += r
+      r.backReference.foreach(mdvSupersededBuf += _)
+    case _ =>
+  }
+
+  /** The net-live files held directly in the new root. */
+  val liveAddFiles: Seq[AddFile] = replay.allFiles
+  /** Post-commit non-content metadata. */
+  val postCommitProtocol: Protocol = replay.getProtocol.getOrElse(
+    throw new IllegalStateException("Replay produced no protocol for the incremental AMT."))
+  val postCommitMetadata: Metadata = replay.getMetadata.getOrElse(
+    throw new IllegalStateException("Replay produced no metadata for the incremental AMT."))
+  val domainMetadatas: Seq[DomainMetadata] = replay.getDomainMetadatas.toSeq
+  val transactions: Seq[SetTransaction] = replay.getTransactions.toSeq
+
+  /**
+   * AddFiles resident in the old root + window: used to generate the tombstone DataEntries for the
+   * RemoveFile actions in actionsToCommit (Part-3). The prior AddFile entries carry richer
+   * information than the RemoveFile, so use them to construct the tombstone.
+   */
+  val rootAndWindowAdds: Seq[AddFile] = rootAndWindowAddsBuf.toSeq
+
+  /**
+   * Leaf positions superseded since the old AMT (window + commit), by a RemoveFile (deleted) or a
+   * back-referenced AddFile (re-added -- the fresh copy lands in the root, so its original leaf
+   * slot is stale). Masking both keeps a stale slot from surfacing.
+   */
+  val mdvSupersededBackrefs: Seq[BackReference] = mdvSupersededBuf.toSeq
+
+  /** Paths this commit adds; a removed path also present here is a same-commit replace. */
+  val commitAddedPaths: Set[String] = commitAddsBuf.iterator.map(_.path).toSet
+  val replacedPaths: Set[String] =
+    commitRemovesBuf.iterator.map(_.path).toSet.intersect(commitAddedPaths)
+
+  /**
+   * The commit's dataChange flag: the first FileAction's (Delta enforces one value per commit),
+   * defaulting to true when the commit carries no file actions.
+   */
+  val dataChange: Boolean =
+    actionsToCommit.collectFirst { case f: FileAction => f.dataChange }.getOrElse(true)
+
+  // CDF is driven ONLY by this commit's removes; a backref remove is REPLACED when its path is
+  // re-added here (under a new DV), else DELETED; a no-backref remove drives a root entry likewise.
+  private def reAddedHere(r: RemoveFile): Boolean = commitAddedPaths.contains(r.path)
+  val cdfReplacedBackrefs: Seq[BackReference] =
+    commitRemovesBuf.iterator.filter(r => r.backReference.isDefined && reAddedHere(r))
+      .map(_.backReference.get).toSeq
+  val cdfDeletedBackrefs: Seq[BackReference] =
+    commitRemovesBuf.iterator.filter(r => r.backReference.isDefined && !reAddedHere(r))
+      .map(_.backReference.get).toSeq
+  val cdfNoBackrefRemoves: Seq[RemoveFile] =
+    commitRemovesBuf.iterator.filter(_.backReference.isEmpty).toSeq
+
+  // ---- Commit-shape invariants, checked once at construction. ----
+  // True if `add` re-commits a file already live before this commit (its key is in the pre-commit
+  // live set, or it carries a back reference to an existing leaf slot) and is not a replace (a
+  // replace changes the DV, a distinct key). Such a re-add is a metadata-only refresh.
+  private def isReCommittedLiveAdd(add: AddFile): Boolean =
+    !replacedPaths.contains(add.path) &&
+      (add.backReference.isDefined || preCommitLiveKeys.contains(add.toUniqueFileActionTuple))
+  val reCommittedLiveAdd: Option[AddFile] = commitAddsBuf.find(isReCommittedLiveAdd)
+  if (dataChange) {
+    // (1) A data-changing commit must not re-add a file already live before it: a same-key re-add
+    // is a metadata-only refresh, so it must carry dataChange=false.
+    reCommittedLiveAdd.foreach { add =>
+      throw new IllegalStateException(
+        s"Re-adding already-live file ${add.path} with dataChange=true is not allowed; a " +
+          "same-key re-add must be a metadata-only change (dataChange=false).")
+    }
+  } else if (commitRemovesBuf.nonEmpty) {
+    // (2) A metadata-only commit that also removes files is a compaction (OPTIMIZE/REORG): its adds
+    // are freshly written files, so none may re-add a file already live before it.
+    reCommittedLiveAdd.foreach { add =>
+      throw new IllegalStateException(
+        s"A metadata-only commit that removes files must not re-add an already-live file, but " +
+          s"${add.path} is re-added.")
+    }
+  } else {
+    // (3) A metadata-only commit with no removes is a metadata refresh (e.g. stats/tags update):
+    // every add must re-commit a file already live before it, under the same (path, dv) key.
+    commitAddsBuf.find(a => !isReCommittedLiveAdd(a)).foreach { add =>
+      throw new IllegalStateException(
+        s"A metadata-only commit with no removes must re-add only already-live files, but " +
+          s"${add.path} is a new file.")
+    }
+  }
+}
+
+private case class MDVAndCDFPositions(
+    newMDVPositionsByLeaf: Map[String, Set[Long]],
+    deleteCDFPositionByLeaf: Map[String, Set[Long]],
+    replaceCDFPositionByLeaf: Map[String, Set[Long]])

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointTestBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointTestBase.scala
@@ -499,17 +499,20 @@ trait AMTCheckpointTestBase
           s"reconstructed=${reconstructed.toSet}")
   }
 
+  /** Forces every write to inline its AMT incrementally (a low action-count threshold). */
+  protected def withInline[T](body: => T): T =
+    withSQLConf(
+      DeltaSQLConf.AMT_LARGE_COMMIT_ACTIONS_COUNT_THRESHOLD_FOR_INLINE_MANIFEST_COMMIT.key -> "1") {
+      body
+    }
+
   /**
    * Runs the test with inline writes forced (a low action-count threshold).
    * AMT checkpoints will be emitted in every commit after the first full OPTIMIZE CHECKPOINT.
    */
   protected def testInline(testName: String)(body: => Unit): Unit = {
     test(s"$testName (inline)") {
-      withSQLConf(
-        DeltaSQLConf.AMT_LARGE_COMMIT_ACTIONS_COUNT_THRESHOLD_FOR_INLINE_MANIFEST_COMMIT.key
-          -> "1") {
-        body
-      }
+      withInline { body }
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointWriteSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointWriteSuite.scala
@@ -36,31 +36,47 @@ class AMTCheckpointWriteSuite extends AMTCheckpointTestBase {
 
   import testImplicits._
 
-  testAcrossAMTCheckpointScenarios(
-      "checkpoint emission writes a manifest tree and carries the user action once",
-      "amt_emit",
-      sqlConfs = leafPackingConfs)(
-      setup = name => appendRowsAsSeparateFiles(name, numRows = leafPackedFiles),
-      inlineCheckpointTriggerActionsOrSQL = Some(_ => Left((
-        Seq(AddFile("missing-file.parquet", Map.empty, 0L, 0L, dataChange = true)
-          .removeWithTimestamp(1L)),
-        DeltaOperations.ManualUpdate)))) { context =>
-    val actionsFromCheckpointedCommit =
-      actionsAt(context.postCheckpointSnapshot.deltaLog, context.checkpoint.version)
-    assert(actionsFromCheckpointedCommit.exists {
-      case _: AddFile | _: RemoveFile => true
-      case _ => false
-    }, "The described business commit must carry the user file action.")
+  test("interval boundary emits a follow-up OPTIMIZE CHECKPOINT commit carrying the Checkpoint") {
+    withTable("amt_inline_emit") {
+      val name = "amt_inline_emit"
+      createAMTTable(name, checkpointInterval = 2)
+      sql(s"INSERT INTO $name VALUES (1)") // v1: not an interval boundary.
+      sql(s"INSERT INTO $name VALUES (2)") // v2: interval boundary -> schedule maintenance.
 
-    val path = tablePath(context.tableName)
-    val rootName = new File(context.checkpoint.contentRoot.path).getName
-    assert(isRootFileName(rootName),
-      s"a written tree's root must carry a root manifest name; got $rootName")
-    assert(rootFiles(path).exists(_.getName == rootName))
-    assertLeafCount(context.provider.leaves)
+      val deltaLog = deltaLogForName(name)
+      val path = tablePath(name)
+      val snapshot = deltaLog.update()
+      // The AMT is written by a follow-up OPTIMIZE CHECKPOINT commit at v3, not inline at v2.
+      assert(snapshot.version == 3, "A follow-up OPTIMIZE CHECKPOINT commit lands at v3.")
 
-    // The emitted tree must reconstruct exactly the table's live files.
-    assertReconstructsLiveFileSet(context)
+      // Note the leaf may be promoted to root -- in that case no file with root naming pattern
+      // will exist.
+      assert(rootFiles(path).size + leafFiles(path).size > 0,
+        "At least one root/leaf should be written")
+
+      // The v2 commit carries only the user AddFile, no Checkpoint.
+      val v2Actions = actionsAt(deltaLog, 2)
+      assert(v2Actions.exists(_.isInstanceOf[AddFile]), "v2 carries the user AddFile.")
+      assert(v2Actions.collect { case c: Checkpoint => c }.isEmpty,
+        s"v2 must not carry a Checkpoint action; got: $v2Actions")
+
+      // The v3 follow-up commit carries a single Checkpoint action and no user AddFile.
+      val v3Actions = actionsAt(deltaLog, 3)
+      val checkpoints = v3Actions.collect { case c: Checkpoint => c }
+      assert(checkpoints.size == 1, s"Expected one Checkpoint action at v3, got: $v3Actions")
+      assert(!v3Actions.exists(_.isInstanceOf[AddFile]), "v3 carries no user AddFile.")
+      // The Checkpoint describes state as of v2 (the version whose maintenance it fulfills).
+      assert(checkpoints.head.version == 2,
+        s"Checkpoint must describe state as of v2; got ${checkpoints.head.version}")
+
+      // The Checkpoint's contentRoot points at an on-disk manifest file. A single promoted leaf
+      // keeps its leaf-* name, so accept either a root or leaf manifest.
+      val rootName = new File(checkpoints.head.contentRoot.path).getName
+      assert(isRootFileName(rootName) || isLeafFileName(rootName),
+        "contentRoot must follow the given naming pattern")
+      assert((rootFiles(path) ++ leafFiles(path)).exists(_.getName == rootName),
+        s"contentRoot must reference an on-disk manifest; got $rootName")
+    }
   }
 
   testAcrossAMTCheckpointScenarios(

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTIncrementalWriteSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTIncrementalWriteSuite.scala
@@ -24,13 +24,14 @@ import org.apache.spark.sql.delta.actions.{Action, AddFile, DeletionVectorDescri
 import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils._
 import org.apache.spark.sql.delta.deletionvectors.RoaringBitmapArray
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.test.shims.GridTestShim
 import org.apache.spark.sql.delta.util.FileNames
 
 import org.apache.spark.sql.SaveMode
 import org.apache.spark.sql.functions.col
 
 /** Tests for AMT incremental write path */
-class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
+class AMTIncrementalWriteSuite extends AMTCheckpointTestBase with GridTestShim {
 
   import testImplicits._
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTIncrementalWriteSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTIncrementalWriteSuite.scala
@@ -20,7 +20,7 @@ import java.util.UUID
 
 // scalastyle:off import.ordering.noEmptyLine
 import org.apache.spark.sql.delta.{DeltaLog, DeltaOperations, Snapshot}
-import org.apache.spark.sql.delta.actions.{Action, AddFile, RemoveFile}
+import org.apache.spark.sql.delta.actions.{Action, AddFile, DeletionVectorDescriptor, Metadata, Protocol, RemoveFile}
 import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils._
 import org.apache.spark.sql.delta.deletionvectors.RoaringBitmapArray
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
@@ -41,13 +41,15 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
   /////////////////////////////////////////////////////////////
 
   /** A deterministic fake data file. Paths are unique per id so live sets are easy to reason on. */
-  private def fakeAdd(fileID: Int): AddFile =
+  private def fakeAdd(fileID: Int): AddFile = fakeAdd(fileID, dataChange = true)
+
+  private def fakeAdd(fileID: Int, dataChange: Boolean): AddFile =
     AddFile(
       path = f"part-$fileID%05d.parquet",
       partitionValues = Map.empty,
       size = 100L + fileID,
       modificationTime = 1000L + fileID,
-      dataChange = true,
+      dataChange = dataChange,
       stats = s"""{"numRecords":1}""")
 
   /** Creates the non-AMT never-checkpointed baseline table and the AMT-backed subject table. */
@@ -73,14 +75,17 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
 
   /** Commits the identical `actions` as a "WRITE" commit to both tables. */
   private def commitBoth(
-      baselineDeltaLog: DeltaLog, amtDeltaLog: DeltaLog, actions: Seq[Action]): Unit = {
+      baselineDeltaLog: DeltaLog,
+      amtDeltaLog: DeltaLog,
+      actions: Seq[Action],
+      operation: DeltaOperations.Operation = writeOperation): Unit = {
     val baselineActions = actions.map {
       case a: AddFile => a.copy(backReference = None)
       case r: RemoveFile => r.copy(backReference = None)
       case other => other
     }
-    baselineDeltaLog.startTransaction().commit(baselineActions, writeOperation)
-    amtDeltaLog.startTransaction().commit(actions, writeOperation)
+    baselineDeltaLog.startTransaction().commit(baselineActions, operation)
+    amtDeltaLog.startTransaction().commit(actions, operation)
   }
 
   /** The live-file path set of a table via its normal snapshot (log replay for the baseline). */
@@ -99,9 +104,6 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
       .where("add is not null").select("add.path").as[String].collect().toSet
   }
 
-  /** DATA-entry tracking statuses that reconstruct as live files (added/existing). */
-  private val liveDataEntryStatuses = Set(Tracking.Status.Existing, Tracking.Status.Added)
-
   /** DATA-entry tracking statuses that mark a root-resident entry as a CDF tombstone. */
   private val tombstoneTrackingStatuses = Set(Tracking.Status.Deleted, Tracking.Status.Replaced)
 
@@ -115,6 +117,33 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
         .groupBy(col("tracking.status").as("status")).count()
         .as[(Int, Long)].collect().toMap
     }
+
+  /**
+   * DATA-entry `location`s (each `add.path`, a file's unique id) in a manifest parquet, keyed by
+   * `tracking.status`. Lets a test assert *which* file carries each status, not just the counts.
+   */
+  private def trackingStatusToLocationsMap(absManifestPath: String): Map[Int, Set[String]] =
+    allowReadWithinDeltaLog {
+      spark.read.parquet(absManifestPath)
+        .where(col("content_type") === AMTSingleAction.ContentType.Type.Data)
+        .select(col("tracking.status").as("status"), col("location"))
+        .as[(Int, String)].collect()
+        .groupBy(_._1).map { case (status, rows) => status -> rows.map(_._2).toSet }
+    }
+
+  /** Root-resident DATA-entry counts keyed by tracking.status (DATA_MANIFEST pointers excluded). */
+  private def rootDataEntryStatusToCount(amtDeltaLog: DeltaLog): Map[Int, Long] = {
+    val provider = amtProvider(amtDeltaLog.update()).getOrElse(fail("expected AMT"))
+    trackingStatusToAddFileCountMap(
+      provider.checkpointAction.contentRoot.getAbsolutePath(provider.tableRoot).toString)
+  }
+
+  /** Root-resident DATA-entry `location`s keyed by tracking.status (pointers excluded). */
+  private def rootDataEntryStatusToLocations(amtDeltaLog: DeltaLog): Map[Int, Set[String]] = {
+    val provider = amtProvider(amtDeltaLog.update()).getOrElse(fail("expected AMT"))
+    trackingStatusToLocationsMap(
+      provider.checkpointAction.contentRoot.getAbsolutePath(provider.tableRoot).toString)
+  }
 
   /** The live AddFiles of a table's latest snapshot, for building real removes. */
   private def liveAddFilesInLatestSnapshot(deltaLog: DeltaLog): Seq[AddFile] =
@@ -147,6 +176,44 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
     add.remove
   }
 
+  /**
+   * A descriptor-only synthetic deletion vector named `name` (a 'p'-type path descriptor pointing
+   * at no real bytes).
+   */
+  private def syntheticDv(name: String): DeletionVectorDescriptor =
+    DeletionVectorDescriptor.onDiskWithAbsolutePath(
+      // A `p` DV path must parse as an absolute URI (scheme required); the file is never read.
+      path = s"file:/$name", sizeInBytes = 5, cardinality = 5L, offset = Some(1))
+
+  /**
+   * Generates a Remove of the current file path (with whatever DV it has) plus an Add of the same
+   * file under a given DV. E.g. if the table holds file f1 with DV dv4, this returns a remove of
+   * (f1, dv4) and an add of (f1, given_dv).
+   */
+  private def removeAndReAddWithDV(
+      amtDeltaLog: DeltaLog, fileIdOrAddFile: Either[Int, AddFile], dvID: Int = 1): Seq[Action] = {
+    val liveAddFile = fileIdOrAddFile match {
+      case Left(fileID) =>
+        val path = fakeAdd(fileID).path
+        liveAddFilesInLatestSnapshot(amtDeltaLog).find(_.path == path)
+          .getOrElse(fail(s"fileID=$fileID ($path) is not live in the AMT table."))
+      case Right(add) => add
+    }
+    val newDv = syntheticDv(s"${liveAddFile.path}_dv_${dvID}")
+    assert(newDv != liveAddFile.deletionVector,
+      "new DV must differ from the file's current DV to change its (path, dv) key.")
+    // The re-add drops the back reference -- the Remove already carries it (masking the old leaf
+    // slot), and the re-added copy is a fresh (path, dv) key, not an existing leaf entry. It
+    // reports non-tight stats bounds (required for a DV-bearing file).
+    Seq(
+      liveAddFile.remove,
+      liveAddFile.copy(
+        deletionVector = newDv,
+        backReference = None,
+        stats = s"""{"numRecords":1,"tightBounds":false}""",
+        dataChange = true))
+  }
+
   /** The current tree's leaf pointers keyed by relative `location`, with their MDV cardinality. */
   private def leafToLeafMDVCardinalityMap(amtDeltaLog: DeltaLog): Map[String, Long] = {
     val provider = amtProvider(amtDeltaLog.update())
@@ -162,10 +229,21 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
       trackingStatusToAddFileCountMap(
         provider.checkpointAction.contentRoot.getAbsolutePath(provider.tableRoot).toString)
     val liveAdds =
-      byStatus.filter { case (status, _) => liveDataEntryStatuses.contains(status) }.values.sum
+      byStatus.filter { case (status, _) =>
+        AMTCheckpointProvider.liveDataEntryStatuses.contains(status) }.values.sum
     val tombstones = tombstoneTrackingStatuses.toSeq.map(byStatus.getOrElse(_, 0L)).sum
     (liveAdds, tombstones)
   }
+
+  /** The per-commit CDF `tracking.deleted_positions` off a leaf pointer (empty if unset). */
+  private def leafDeletedPositions(leaf: DataManifestEntry): Set[Long] =
+    leaf.tracking.deleted_positions
+      .map(RoaringBitmapArray.readFrom(_).toArray.toSet).getOrElse(Set.empty)
+
+  /** The per-commit CDF `tracking.replaced_positions` off a leaf pointer (empty if unset). */
+  private def leafReplacedPositions(leaf: DataManifestEntry): Set[Long] =
+    leaf.tracking.replaced_positions
+      .map(RoaringBitmapArray.readFrom(_).toArray.toSet).getOrElse(Set.empty)
 
   /** The current snapshot's leaf pointers, keyed by relative location. */
   private def leafPointers(snapshot: Snapshot): Map[String, DataManifestEntry] = {
@@ -178,18 +256,26 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
     leaf.manifest_info.dv_cardinality.getOrElse(0L)
 
   /**
-   * Emits a deferred incremental checkpoint and cross-checks its metrics three ways: the
-   * hand-specified `expectedAMTWriteMetrics` (author intent), the metrics the writer actually
-   * reported, and a structural derivation from the old tree vs. the new tree read straight off
-   * disk.
+   * Emits one incremental AMT and cross-checks its metrics three ways: the hand-specified
+   * `expectedAMTWriteMetrics` (author intent), the metrics the writer actually reported, and a
+   * structural derivation from the old tree vs. the new tree read straight off disk. Also compares
+   * the live files on baselineDeltaLog and amtDeltaLog.
    *
-   * Also compares the live files on baselineDeltaLog and amtDeltaLog.
+   * The emission route depends on `inlineAMTCommitActions`:
+   *   - `None` (deferred): a follow-up OPTIMIZE CHECKPOINT folds the already-committed intermediate
+   *     commits in with an empty actionsToCommit.
+   *   - `Some(actions)` (inline): the actions ride the same commit that emits the tree
+   *     ([[withInline]] sets the inline threshold to 1), so the metrics come off that commit and
+   *     the checkpoint describes its OWN version -- unlike a deferred write (E1), which describes
+   *     attemptVersion - 1.
    */
   private def createIncrementalAMTAndValidate(
       baselineDeltaLog: DeltaLog,
       amtDeltaLog: DeltaLog,
       expectedAMTWriteMetrics: IncrementalAMTWriteMetrics,
-      expectedNumIntermediateCommits: Option[Int] = None): Unit = {
+      expectedNumIntermediateCommits: Option[Int] = None,
+      inlineAMTCommitActions: Option[Seq[Action]] = None,
+      inlineOperation: DeltaOperations.Operation = writeOperation): Unit = {
     // Snapshot the OLD tree's leaf pointers before the write: their MDV cardinality (for the shape
     // derivation), the full pointers (to assert manifest_info counts stay immutable), and the count
     // of DELETED tombstone pointers this rewrite is expected to drop.
@@ -199,8 +285,20 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
       .getOrElse(fail("AMT table must be checkpoint-provider-backed."))
       .leaves.count(_.tracking.status == Tracking.Status.Deleted)
 
-    val actualIncrementalAMTWriteMetrics = commitCheckpoint(amtDeltaLog, incremental = true)
-      .getOrElse(fail("An incremental checkpoint must log IncrementalAMTWriteMetrics."))
+    val actualIncrementalAMTWriteMetrics = inlineAMTCommitActions match {
+      case Some(actions) =>
+        val attemptVersion = amtDeltaLog.update().version + 1
+        val metrics = withInline {
+          trackIncrementalAMTWriteMetrics(attemptVersion) {
+            commitBoth(baselineDeltaLog, amtDeltaLog, actions, inlineOperation)
+          }
+        }.getOrElse(fail("An inline incremental write must log IncrementalAMTWriteMetrics."))
+        assertCheckpointDescribesVersion(amtDeltaLog, attemptVersion)
+        metrics
+      case None =>
+        commitCheckpoint(amtDeltaLog, incremental = true)
+          .getOrElse(fail("An incremental checkpoint must log IncrementalAMTWriteMetrics."))
+    }
 
     // 1) Reported metrics match the author's hand-specified expectation.
     assertIncrementalAMTWriteMetrics(actualIncrementalAMTWriteMetrics, expectedAMTWriteMetrics)
@@ -281,7 +379,7 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
     val untouched = perLeafBitsAdded.count(_ == 0L)
     val newLeaves = newAMTLeafToMDV.keys.count(loc => !oldAMTLeafToMDV.contains(loc))
     val mdvBitsAdded = perLeafBitsAdded.sum
-    val (rootLiveAdds, rootTombstones) = liveAddsAndTombstonesCountInRoot(amtDeltaLog)
+    val rootDataEntryStatusToCountMap = rootDataEntryStatusToCount(amtDeltaLog)
 
     // Per-status breakdown over every leaf pointer in the new tree, derived independently of the
     // writer's self-report; numStaleDeletedLeavesDropped is the old tree's DELETED tombstone count.
@@ -289,14 +387,26 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
       .getOrElse(fail("AMT table must be checkpoint-provider-backed.")).leaves
     val statusToLeafCountMapping =
       newLeafPointers.groupBy(_.tracking.status).map { case (s, ps) => s -> ps.size }
+    val deleteCDFBitsAdded = newLeafPointers.map(p => leafDeletedPositions(p).size).sum
+    val replaceCDFBitsAdded = newLeafPointers.map(p => leafReplacedPositions(p).size).sum
 
     val derived = metrics.copy(
       numOldLeavesUpdated = updated,
       numOldLeavesUntouched = untouched,
       numNewLeaves = newLeaves,
-      numRootLiveAdds = rootLiveAdds.toInt,
-      numRootTombstones = rootTombstones.toInt,
+      numRootEntriesAddedStatus =
+        rootDataEntryStatusToCountMap.getOrElse(Tracking.Status.Added, 0L).toInt,
+      numRootEntriesExistingStatus =
+        rootDataEntryStatusToCountMap.getOrElse(Tracking.Status.Existing, 0L).toInt,
+      numRootEntriesModifiedStatus =
+        rootDataEntryStatusToCountMap.getOrElse(Tracking.Status.Modified, 0L).toInt,
+      numRootEntriesReplacedStatus =
+        rootDataEntryStatusToCountMap.getOrElse(Tracking.Status.Replaced, 0L).toInt,
+      numRootEntriesDeletedStatus =
+        rootDataEntryStatusToCountMap.getOrElse(Tracking.Status.Deleted, 0L).toInt,
       numLeafMdvBitsAdded = mdvBitsAdded.toInt,
+      numLeafDeleteCDFBitsAdded = deleteCDFBitsAdded.toInt,
+      numLeafReplaceCDFBitsAdded = replaceCDFBitsAdded.toInt,
       numLeavesAddedStatus = statusToLeafCountMapping.getOrElse(Tracking.Status.Added, 0),
       numLeavesExistingStatus = statusToLeafCountMapping.getOrElse(Tracking.Status.Existing, 0),
       numLeavesModifiedStatus = statusToLeafCountMapping.getOrElse(Tracking.Status.Modified, 0),
@@ -340,30 +450,38 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
     val statusToCountMap = trackingStatusToAddFileCountMap(rootPath)
     val rootLiveAdds =
       statusToCountMap
-        .filter { case (status, _) => liveDataEntryStatuses.contains(status) }.values.sum
+        .filter { case (status, _) =>
+          AMTCheckpointProvider.liveDataEntryStatuses.contains(status) }.values.sum
 
-    // Leaves: each pointer's MDV must be internally consistent, and the unmasked entries are the
-    // leaf's live contribution to the reconstruction.
-    val leafLiveContribution = provider.leaves.map { leaf =>
-      val leafPath = leaf.getAbsolutePath(tableRoot).toString
-      val statusToCountMapForLeaf = trackingStatusToAddFileCountMap(leafPath)
-      val physicalEntries = statusToCountMapForLeaf.values.sum
-      val mdvDeclaredCardinality = leaf.manifest_info.dv_cardinality.getOrElse(0L)
-      val decoded =
-        leaf.manifest_info.dv.map(RoaringBitmapArray.readFrom).getOrElse(new RoaringBitmapArray)
-      assert(decoded.cardinality == mdvDeclaredCardinality,
-        s"Leaf ${leaf.location}: dv_cardinality=$mdvDeclaredCardinality but the decoded MDV has " +
-          s"${decoded.cardinality} bits.")
-      assert(mdvDeclaredCardinality <= physicalEntries,
-        s"Leaf ${leaf.location}: MDV cardinality ($mdvDeclaredCardinality) exceeds physical " +
-          s"entries " +
-          s"($physicalEntries).")
-      decoded.toArray.foreach { pos =>
-        assert(pos >= 0 && pos < physicalEntries,
-          s"Leaf ${leaf.location}: MDV position $pos is out of range [0, $physicalEntries).")
-      }
-      physicalEntries - mdvDeclaredCardinality
-    }.sum
+    // Leaves: each pointer's MDV must be internally consistent, and the unmasked LIVE entries are
+    // the leaf's live contribution. A tombstone-only leaf (born ADDED but holding no live entry)
+    // and a DELETED leaf both contribute nothing live, matching the reader.
+    val leafLiveContribution = provider.leaves
+      .filter(_.tracking.status != Tracking.Status.Deleted)
+      .map { leaf =>
+        val leafPath = leaf.getAbsolutePath(tableRoot).toString
+        val statusToCountMapForLeaf = trackingStatusToAddFileCountMap(leafPath)
+        val physicalEntries = statusToCountMapForLeaf.values.sum
+        val livePhysicalEntries = statusToCountMapForLeaf
+          .filter { case (status, _) =>
+            AMTCheckpointProvider.liveDataEntryStatuses.contains(status) }
+          .values.sum
+        val mdvDeclaredCardinality = leaf.manifest_info.dv_cardinality.getOrElse(0L)
+        val decoded =
+          leaf.manifest_info.dv.map(RoaringBitmapArray.readFrom).getOrElse(new RoaringBitmapArray)
+        assert(decoded.cardinality == mdvDeclaredCardinality,
+          s"Leaf ${leaf.location}: dv_cardinality=$mdvDeclaredCardinality but the decoded MDV " +
+            s"has ${decoded.cardinality} bits.")
+        assert(mdvDeclaredCardinality <= physicalEntries,
+          s"Leaf ${leaf.location}: MDV cardinality ($mdvDeclaredCardinality) exceeds physical " +
+            s"entries " +
+            s"($physicalEntries).")
+        decoded.toArray.foreach { pos =>
+          assert(pos >= 0 && pos < physicalEntries,
+            s"Leaf ${leaf.location}: MDV position $pos is out of range [0, $physicalEntries).")
+        }
+        livePhysicalEntries - mdvDeclaredCardinality
+      }.sum
 
     val reconstructed = provider.loadActionsForStateReconstruction(spark, amtDeltaLog)
       .getOrElse(fail("AMT provider must contribute leaf-derived file actions."))
@@ -403,9 +521,14 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
       numOldLeavesUpdated: Int = 0,
       numOldLeavesUntouched: Int = 0,
       numNewLeaves: Int = 0,
-      numRootLiveAdds: Int = 0,
-      numRootTombstones: Int = 0,
+      numRootEntriesAddedStatus: Int = 0,
+      numRootEntriesExistingStatus: Int = 0,
+      numRootEntriesModifiedStatus: Int = 0,
+      numRootEntriesReplacedStatus: Int = 0,
+      numRootEntriesDeletedStatus: Int = 0,
       numLeafMdvBitsAdded: Int = 0,
+      numLeafDeleteCDFBitsAdded: Int = 0,
+      numLeafReplaceCDFBitsAdded: Int = 0,
       numLeavesAddedStatus: Int = 0,
       numLeavesExistingStatus: Int = 0,
       numLeavesModifiedStatus: Int = 0,
@@ -416,15 +539,53 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
       numOldLeavesUpdated = numOldLeavesUpdated,
       numOldLeavesUntouched = numOldLeavesUntouched,
       numNewLeaves = numNewLeaves,
-      numRootLiveAdds = numRootLiveAdds,
-      numRootTombstones = numRootTombstones,
+      numRootEntriesAddedStatus = numRootEntriesAddedStatus,
+      numRootEntriesExistingStatus = numRootEntriesExistingStatus,
+      numRootEntriesModifiedStatus = numRootEntriesModifiedStatus,
+      numRootEntriesReplacedStatus = numRootEntriesReplacedStatus,
+      numRootEntriesDeletedStatus = numRootEntriesDeletedStatus,
       numLeafMdvBitsAdded = numLeafMdvBitsAdded,
+      numLeafDeleteCDFBitsAdded = numLeafDeleteCDFBitsAdded,
+      numLeafReplaceCDFBitsAdded = numLeafReplaceCDFBitsAdded,
       numLeavesAddedStatus = numLeavesAddedStatus,
       numLeavesExistingStatus = numLeavesExistingStatus,
       numLeavesModifiedStatus = numLeavesModifiedStatus,
       numLeavesDeletedStatus = numLeavesDeletedStatus,
       numStaleDeletedLeavesDropped = numStaleDeletedLeavesDropped)
   // scalastyle:on argcount
+
+  /**
+   * Bootstraps a tree: the `initialIdRangeInLeaf` files packed into whole leaves via a full
+   * checkpoint, then (when `initialIdRangeInRoot` is non-empty) that id range appended
+   * root-resident via an incremental checkpoint. The caller must have set AMT_ENTRIES_PER_LEAF to
+   * `entriesPerLeaf`. Returns the leaf pointers of the bootstrapped tree.
+   */
+  private def setup(
+      baselineDeltaLog: DeltaLog,
+      amtDeltaLog: DeltaLog,
+      entriesPerLeaf: Int,
+      initialIdRangeInLeaf: Range,
+      initialIdRangeInRoot: Range = Range(0, 0)): Seq[DataManifestEntry] = {
+    require(initialIdRangeInLeaf.size > entriesPerLeaf,
+      s"initialIdRangeInLeaf (${initialIdRangeInLeaf.size}) must exceed entriesPerLeaf " +
+        s"($entriesPerLeaf).")
+    val numLeaves = math.ceil(initialIdRangeInLeaf.size.toDouble / entriesPerLeaf).toInt
+    require(initialIdRangeInRoot.size <= entriesPerLeaf - numLeaves,
+      s"initialIdRangeInRoot (${initialIdRangeInRoot.size}) must be <= " +
+        s"${entriesPerLeaf - numLeaves} (entriesPerLeaf minus $numLeaves leaf pointers) so the " +
+        "root-resident adds do not spill.")
+    commitBoth(baselineDeltaLog, amtDeltaLog, initialIdRangeInLeaf.map(fakeAdd))
+    commitCheckpoint(amtDeltaLog, incremental = false)
+    assert(leafPointers(amtDeltaLog.update()).size == numLeaves,
+      s"the full checkpoint must pack $numLeaves leaves.")
+    if (initialIdRangeInRoot.nonEmpty) {
+      commitBoth(baselineDeltaLog, amtDeltaLog, initialIdRangeInRoot.map(fakeAdd))
+      commitCheckpoint(amtDeltaLog, incremental = true)
+      assert(leafPointers(amtDeltaLog.update()).size == numLeaves,
+        "the root-resident adds must not spill any leaf.")
+    }
+    leafPointers(amtDeltaLog.update()).values.toSeq
+  }
 
   /////////////////////////////////////////////////////////////
   // Section-A:                                              //
@@ -445,9 +606,12 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
         // which is under the cap of 8, so spillIfNeeded does not spill.
         commitBoth(baselineDeltaLog, amtDeltaLog, Seq(fakeAdd(25)))
         createIncrementalAMTAndValidate(
-          baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-          numOldLeavesUntouched = 3, numRootLiveAdds = 1,
-          numLeavesExistingStatus = 3))
+          baselineDeltaLog,
+          amtDeltaLog,
+          createIncrementalAMTWriteMetrics(
+            numOldLeavesUntouched = 3,
+            numRootEntriesExistingStatus = 1,
+            numLeavesExistingStatus = 3))
       }
     }
   }
@@ -465,9 +629,12 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
         // loops while the total is `> cap`, so filling it exactly must not spill.
         commitBoth(baselineDeltaLog, amtDeltaLog, (25 to 29).map(fakeAdd))
         createIncrementalAMTAndValidate(
-          baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-          numOldLeavesUntouched = 3, numRootLiveAdds = 5,
-          numLeavesExistingStatus = 3))
+          baselineDeltaLog,
+          amtDeltaLog,
+          createIncrementalAMTWriteMetrics(
+            numOldLeavesUntouched = 3,
+            numRootEntriesExistingStatus = 5,
+            numLeavesExistingStatus = 3))
       }
     }
   }
@@ -487,12 +654,14 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
         // => 1 new leaf, and the 4 leftover adds stay root-resident.
         commitBoth(baselineDeltaLog, amtDeltaLog, (25 to 36).map(fakeAdd))
         createIncrementalAMTAndValidate(
-          baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-          numOldLeavesUntouched = 3,
-          numNewLeaves = 1,
-          numRootLiveAdds = 4,
-          numLeavesExistingStatus = 3,
-          numLeavesAddedStatus = 1))
+          baselineDeltaLog,
+          amtDeltaLog,
+          createIncrementalAMTWriteMetrics(
+            numOldLeavesUntouched = 3,
+            numNewLeaves = 1,
+            numRootEntriesExistingStatus = 4,
+            numLeavesExistingStatus = 3,
+            numLeavesAddedStatus = 1))
       }
     }
   }
@@ -512,9 +681,14 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
         // At a cap of one, each of the 3 adds spills into its own leaf and none stays in the root.
         commitBoth(baselineDeltaLog, amtDeltaLog, Seq(fakeAdd(25), fakeAdd(26), fakeAdd(27)))
         createIncrementalAMTAndValidate(
-          baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-          numOldLeavesUntouched = 3, numNewLeaves = 3, numRootLiveAdds = 0,
-          numLeavesExistingStatus = 3, numLeavesAddedStatus = 3))
+          baselineDeltaLog,
+          amtDeltaLog,
+          createIncrementalAMTWriteMetrics(
+            numOldLeavesUntouched = 3,
+            numNewLeaves = 3,
+            numRootEntriesAddedStatus = 0,
+            numLeavesExistingStatus = 3,
+            numLeavesAddedStatus = 3))
       }
     }
   }
@@ -538,12 +712,14 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
         // => 4 new leaves, 0 root-resident adds.
         commitBoth(baselineDeltaLog, amtDeltaLog, (25 to 54).map(fakeAdd))
         createIncrementalAMTAndValidate(
-          baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-          numOldLeavesUntouched = 3,
-          numNewLeaves = 4,
-          numRootLiveAdds = 0,
-          numLeavesExistingStatus = 3,
-          numLeavesAddedStatus = 4))
+          baselineDeltaLog,
+          amtDeltaLog,
+          createIncrementalAMTWriteMetrics(
+            numOldLeavesUntouched = 3,
+            numNewLeaves = 4,
+            numRootEntriesAddedStatus = 0,
+            numLeavesExistingStatus = 3,
+            numLeavesAddedStatus = 4))
         // Every leaf this write SPILLED holds at most `cap` physical DATA entries, because
         // spillIfNeeded moves whole cap-sized batches. The bootstrap's own leaves are excluded: a
         // clustered full rewrite derives a leaf count from the cap but does not bound each leaf, so
@@ -576,21 +752,27 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
           amtProvider(amtDeltaLog.update()).getOrElse(fail("expected AMT")).leaves.size
         assert(numLeafCountBefore >= 2,
           s"Need >= 2 carried leaves to exercise fixedRootCount; got $numLeafCountBefore.")
-        // Append one file. All carried pointers stay untouched; whether the new file lands in the
-        // root or a spilled leaf depends only on the carried count vs the cap. The cross-check
-        // derives the exact split from the on-disk old->new tree, so pin only what we control.
+        // Append one file. All carried pointers stay untouched. The carried leaf pointers already
+        // fill the root to the cap (fixedRootCount counts them, and numLeafCountBefore >= cap = 2),
+        // so the appended file has no root capacity and must spill into exactly one new leaf --
+        // which is the accounting this test guards.
         val oldAMTLeafToMDV = leafToLeafMDVCardinalityMap(amtDeltaLog)
         commitBoth(baselineDeltaLog, amtDeltaLog, Seq(fakeAdd(7)))
-        val actual = commitCheckpoint(amtDeltaLog, incremental = true)
+        val actualIncrementalMetrics = commitCheckpoint(amtDeltaLog, incremental = true)
           .getOrElse(fail("An incremental checkpoint must log metrics."))
-        assert(actual.numOldLeavesUntouched == numLeafCountBefore,
+        assert(actualIncrementalMetrics.numOldLeavesUntouched == numLeafCountBefore,
           s"All $numLeafCountBefore carried leaves must be untouched by an append; got " +
-            s"${actual.numOldLeavesUntouched}.")
-        assert(actual.numRootLiveAdds + actual.numNewLeaves == 1,
-          "The one appended file must land in exactly one place (root or a spilled leaf).")
+            s"${actualIncrementalMetrics.numOldLeavesUntouched}.")
+        assert(actualIncrementalMetrics.numNewLeaves == 1,
+          s"The appended file must spill into one new leaf; got " +
+            s"${actualIncrementalMetrics.numNewLeaves}.")
+        assert(actualIncrementalMetrics.numRootEntriesAddedStatus == 0 &&
+          actualIncrementalMetrics.numRootEntriesExistingStatus == 0 &&
+          actualIncrementalMetrics.numRootEntriesModifiedStatus == 0,
+          "The appended file must not land in the root (the carried pointers fill it).")
         // The old tree is a fresh full rewrite, so it carries no DELETED tombstones to drop.
         assertMetricsMatchTreeDelta(amtDeltaLog, oldAMTLeafToMDV, oldDeletedLeafCount = 0,
-          metrics = actual)
+          metrics = actualIncrementalMetrics)
         assertLiveAddFilesEquals(baselineDeltaLog, amtDeltaLog)
       }
     }
@@ -613,9 +795,12 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
         commitBoth(baselineDeltaLog, amtDeltaLog, Seq(fakeAdd(27)))
         commitBoth(baselineDeltaLog, amtDeltaLog, Seq(fakeAdd(28)))
         createIncrementalAMTAndValidate(
-          baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-          numOldLeavesUntouched = 3, numRootLiveAdds = 4,
-          numLeavesExistingStatus = 3),
+          baselineDeltaLog,
+          amtDeltaLog,
+          createIncrementalAMTWriteMetrics(
+            numOldLeavesUntouched = 3,
+            numRootEntriesExistingStatus = 4,
+            numLeavesExistingStatus = 3),
           expectedNumIntermediateCommits = Some(5))
       }
     }
@@ -649,8 +834,10 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
         // well under the cap of 8: nothing spills and every live add stays root-resident.
         commitBoth(baselineDeltaLog, amtDeltaLog, (2 to 4).map(fakeAdd))
         createIncrementalAMTAndValidate(
-          baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-          numRootLiveAdds = 4))
+          baselineDeltaLog,
+          amtDeltaLog,
+          createIncrementalAMTWriteMetrics(
+            numRootEntriesExistingStatus = 4))
       }
     }
   }
@@ -664,8 +851,10 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
         // while the total is `> cap`, so an exactly-full root must not spill.
         commitBoth(baselineDeltaLog, amtDeltaLog, (2 to 8).map(fakeAdd))
         createIncrementalAMTAndValidate(
-          baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-          numRootLiveAdds = 8))
+          baselineDeltaLog,
+          amtDeltaLog,
+          createIncrementalAMTWriteMetrics(
+            numRootEntriesExistingStatus = 8))
       }
     }
   }
@@ -680,9 +869,12 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
         // => 1 new leaf, 1 root-resident add.
         commitBoth(baselineDeltaLog, amtDeltaLog, (2 to 9).map(fakeAdd))
         createIncrementalAMTAndValidate(
-          baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-          numNewLeaves = 1, numRootLiveAdds = 1,
-          numLeavesAddedStatus = 1))
+          baselineDeltaLog,
+          amtDeltaLog,
+          createIncrementalAMTWriteMetrics(
+            numNewLeaves = 1,
+            numRootEntriesExistingStatus = 1,
+            numLeavesAddedStatus = 1))
       }
     }
   }
@@ -698,9 +890,12 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
         // => 3 new leaves, 0 root-resident adds.
         commitBoth(baselineDeltaLog, amtDeltaLog, (2 to 24).map(fakeAdd))
         createIncrementalAMTAndValidate(
-          baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-          numNewLeaves = 3, numRootLiveAdds = 0,
-          numLeavesAddedStatus = 3))
+          baselineDeltaLog,
+          amtDeltaLog,
+          createIncrementalAMTWriteMetrics(
+            numNewLeaves = 3,
+            numRootEntriesAddedStatus = 0,
+            numLeavesAddedStatus = 3))
       }
     }
   }
@@ -718,8 +913,10 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
         // deferred D1): no leaf is touched and, deferred, no root tombstone is written.
         commitBoth(baselineDeltaLog, amtDeltaLog, Seq(removeOf(amtDeltaLog, 2)))
         createIncrementalAMTAndValidate(
-          baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-          numRootLiveAdds = 2))
+          baselineDeltaLog,
+          amtDeltaLog,
+          createIncrementalAMTWriteMetrics(
+            numRootEntriesExistingStatus = 2))
         val (rootLiveAdds, tombstones) = liveAddsAndTombstonesCountInRoot(amtDeltaLog)
         assert(rootLiveAdds == 2, s"Two files must remain live in the root; got $rootLiveAdds.")
         assert(tombstones == 0,
@@ -741,7 +938,9 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
           baselineDeltaLog, amtDeltaLog, Seq(removeOf(amtDeltaLog, 1), removeOf(amtDeltaLog, 2)))
         commitBoth(baselineDeltaLog, amtDeltaLog, Seq(removeOf(amtDeltaLog, 3)))
         createIncrementalAMTAndValidate(
-          baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics())
+          baselineDeltaLog,
+          amtDeltaLog,
+          createIncrementalAMTWriteMetrics())
         assert(leafPointers(amtDeltaLog.update()).isEmpty,
           "The tree must remain leafless.")
         assert(livePathsInLatestAMTCheckpoint(amtDeltaLog).isEmpty,
@@ -769,12 +968,14 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
         val victim = leafToAddFileMap(amtDeltaLog).toSeq.sortBy(_._1).head._2.head
         commitBoth(baselineDeltaLog, amtDeltaLog, Seq(victim.remove))
         createIncrementalAMTAndValidate(
-          baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-          numOldLeavesUpdated = 1,
-          numOldLeavesUntouched = leafCount - 1,
-          numLeafMdvBitsAdded = 1,
-          numLeavesModifiedStatus = 1,
-          numLeavesExistingStatus = leafCount - 1))
+          baselineDeltaLog,
+          amtDeltaLog,
+          createIncrementalAMTWriteMetrics(
+            numOldLeavesUpdated = 1,
+            numOldLeavesUntouched = leafCount - 1,
+            numLeafMdvBitsAdded = 1,
+            numLeavesModifiedStatus = 1,
+            numLeavesExistingStatus = leafCount - 1))
       }
     }
   }
@@ -785,20 +986,23 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
         // 15 files at cap 5 -> ceil(15/5)=3 leaves, all non-empty (the full-rewrite fills them).
         commitBoth(baselineDeltaLog, amtDeltaLog, (1 to 15).map(fakeAdd))
         commitCheckpoint(amtDeltaLog, incremental = false)
-        val byLeaf = leafToAddFileMap(amtDeltaLog)
-        assert(byLeaf.size >= 2, s"Need >= 2 leaves; got ${byLeaf.size}.")
+        val leafToAddFileMapping = leafToAddFileMap(amtDeltaLog)
+        assert(leafToAddFileMapping.size >= 2,
+          s"Need >= 2 leaves; got ${leafToAddFileMapping.size}.")
         // Pick one file from each of two distinct leaves, so exactly two leaves are updated.
-        val twoLeaves = byLeaf.toSeq.sortBy(_._1).take(2)
+        val twoLeaves = leafToAddFileMapping.toSeq.sortBy(_._1).take(2)
         val victims = twoLeaves.map { case (_, files) => files.head }
-        val untouchedLeaves = byLeaf.size - 2
+        val untouchedLeaves = leafToAddFileMapping.size - 2
         commitBoth(baselineDeltaLog, amtDeltaLog, victims.map(_.remove))
         createIncrementalAMTAndValidate(
-          baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-          numOldLeavesUpdated = 2,
-          numOldLeavesUntouched = untouchedLeaves,
-          numLeafMdvBitsAdded = 2,
-          numLeavesModifiedStatus = 2,
-          numLeavesExistingStatus = untouchedLeaves))
+          baselineDeltaLog,
+          amtDeltaLog,
+          createIncrementalAMTWriteMetrics(
+            numOldLeavesUpdated = 2,
+            numOldLeavesUntouched = untouchedLeaves,
+            numLeafMdvBitsAdded = 2,
+            numLeavesModifiedStatus = 2,
+            numLeavesExistingStatus = untouchedLeaves))
       }
     }
   }
@@ -808,19 +1012,21 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
       withTables() { (baselineDeltaLog, amtDeltaLog) =>
         commitBoth(baselineDeltaLog, amtDeltaLog, (1 to 15).map(fakeAdd))
         commitCheckpoint(amtDeltaLog, incremental = false)
-        val byLeaf = leafToAddFileMap(amtDeltaLog)
+        val leafToAddFileMapping = leafToAddFileMap(amtDeltaLog)
         // A leaf holding >= 2 files; delete two of them -> one leaf updated, two bits.
-        val (_, files) = byLeaf.toSeq.sortBy(_._1).find(_._2.size >= 2)
+        val (_, files) = leafToAddFileMapping.toSeq.sortBy(_._1).find(_._2.size >= 2)
           .getOrElse(fail("Expected some leaf to hold >= 2 files at cap 5 with 15 files."))
-        val untouchedLeaves = byLeaf.size - 1
+        val untouchedLeaves = leafToAddFileMapping.size - 1
         commitBoth(baselineDeltaLog, amtDeltaLog, files.take(2).map(_.remove))
         createIncrementalAMTAndValidate(
-          baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-          numOldLeavesUpdated = 1,
-          numOldLeavesUntouched = untouchedLeaves,
-          numLeafMdvBitsAdded = 2,
-          numLeavesModifiedStatus = 1,
-          numLeavesExistingStatus = untouchedLeaves))
+          baselineDeltaLog,
+          amtDeltaLog,
+          createIncrementalAMTWriteMetrics(
+            numOldLeavesUpdated = 1,
+            numOldLeavesUntouched = untouchedLeaves,
+            numLeafMdvBitsAdded = 2,
+            numLeavesModifiedStatus = 1,
+            numLeavesExistingStatus = untouchedLeaves))
       }
     }
   }
@@ -831,11 +1037,12 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
         // 15 files at cap 5 clusters into several leaves rather than one promoted root manifest.
         commitBoth(baselineDeltaLog, amtDeltaLog, (1 to 15).map(fakeAdd))
         commitCheckpoint(amtDeltaLog, incremental = false)
-        val byLeaf = leafToAddFileMap(amtDeltaLog)
-        assert(byLeaf.size >= 2, s"Need a tree-shaped bootstrap; got ${byLeaf.size} leaves.")
+        val leafToAddFileMapping = leafToAddFileMap(amtDeltaLog)
+        assert(leafToAddFileMapping.size >= 2,
+          s"Need a tree-shaped bootstrap; got ${leafToAddFileMapping.size} leaves.")
         // One victim from each of two distinct leaves, so the two intermediate commits land their
         // bits on different carried pointers.
-        val twoLeaves = byLeaf.toSeq.sortBy(_._1).take(2)
+        val twoLeaves = leafToAddFileMapping.toSeq.sortBy(_._1).take(2)
         val victimFromLeaf1 = twoLeaves.head._2.head
         val victimFromLeaf2 = twoLeaves(1)._2.head
         // Two separate intermediate commits each remove one leaf file; the deferred incremental
@@ -843,12 +1050,14 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
         commitBoth(baselineDeltaLog, amtDeltaLog, Seq(victimFromLeaf1.remove))
         commitBoth(baselineDeltaLog, amtDeltaLog, Seq(victimFromLeaf2.remove))
         createIncrementalAMTAndValidate(
-          baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-          numOldLeavesUpdated = 2,
-          numOldLeavesUntouched = byLeaf.size - 2,
-          numLeafMdvBitsAdded = 2,
-          numLeavesModifiedStatus = 2,
-          numLeavesExistingStatus = byLeaf.size - 2))
+          baselineDeltaLog,
+          amtDeltaLog,
+          createIncrementalAMTWriteMetrics(
+            numOldLeavesUpdated = 2,
+            numOldLeavesUntouched = leafToAddFileMapping.size - 2,
+            numLeafMdvBitsAdded = 2,
+            numLeavesModifiedStatus = 2,
+            numLeavesExistingStatus = leafToAddFileMapping.size - 2))
       }
     }
   }
@@ -859,30 +1068,35 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
         // 15 files at cap 5 clusters into several leaves rather than one promoted root manifest.
         commitBoth(baselineDeltaLog, amtDeltaLog, (1 to 15).map(fakeAdd))
         commitCheckpoint(amtDeltaLog, incremental = false)
-        val byLeaf = leafToAddFileMap(amtDeltaLog)
-        assert(byLeaf.size >= 2, s"Need a tree-shaped bootstrap; got ${byLeaf.size} leaves.")
+        val leafToAddFileMapping = leafToAddFileMap(amtDeltaLog)
+        assert(leafToAddFileMapping.size >= 2,
+          s"Need a tree-shaped bootstrap; got ${leafToAddFileMapping.size} leaves.")
         // Both victims share one leaf, so each write updates that same carried pointer.
-        val victims = byLeaf.toSeq.sortBy(_._1).find(_._2.size >= 2)
+        val victims = leafToAddFileMapping.toSeq.sortBy(_._1).find(_._2.size >= 2)
           .getOrElse(fail("Expected some leaf to hold >= 2 files."))._2.take(2)
-        val untouched = byLeaf.size - 1
+        val untouched = leafToAddFileMapping.size - 1
         commitBoth(baselineDeltaLog, amtDeltaLog, Seq(victims.head.remove))
         createIncrementalAMTAndValidate(
-          baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-          numOldLeavesUpdated = 1,
-          numOldLeavesUntouched = untouched,
-          numLeafMdvBitsAdded = 1,
-          numLeavesModifiedStatus = 1,
-          numLeavesExistingStatus = untouched))
+          baselineDeltaLog,
+          amtDeltaLog,
+          createIncrementalAMTWriteMetrics(
+            numOldLeavesUpdated = 1,
+            numOldLeavesUntouched = untouched,
+            numLeafMdvBitsAdded = 1,
+            numLeavesModifiedStatus = 1,
+            numLeavesExistingStatus = untouched))
         // The second write adds only its own bit; the leaf's cumulative MDV covers both, checked
         // by the live-set baselineDeltaLog.
         commitBoth(baselineDeltaLog, amtDeltaLog, Seq(victims(1).remove))
         createIncrementalAMTAndValidate(
-          baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-          numOldLeavesUpdated = 1,
-          numOldLeavesUntouched = untouched,
-          numLeafMdvBitsAdded = 1,
-          numLeavesModifiedStatus = 1,
-          numLeavesExistingStatus = untouched))
+          baselineDeltaLog,
+          amtDeltaLog,
+          createIncrementalAMTWriteMetrics(
+            numOldLeavesUpdated = 1,
+            numOldLeavesUntouched = untouched,
+            numLeafMdvBitsAdded = 1,
+            numLeavesModifiedStatus = 1,
+            numLeavesExistingStatus = untouched))
       }
     }
   }
@@ -901,23 +1115,26 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
           // 15 files at cap 5 clusters into several leaves rather than one promoted root manifest.
           commitBoth(baselineDeltaLog, amtDeltaLog, (1 to 15).map(fakeAdd))
           commitCheckpoint(amtDeltaLog, incremental = false)
-          val byLeaf = leafToAddFileMap(amtDeltaLog)
-          assert(byLeaf.size >= 2, s"Need a tree-shaped bootstrap; got ${byLeaf.size} leaves.")
+          val leafToAddFileMapping = leafToAddFileMap(amtDeltaLog)
+          assert(leafToAddFileMapping.size >= 2,
+          s"Need a tree-shaped bootstrap; got ${leafToAddFileMapping.size} leaves.")
           // Every leaf key must be table-root-relative, never the absolute path that would make the
           // string match below succeed only by coincidence.
-          byLeaf.keys.foreach { leaf =>
+          leafToAddFileMapping.keys.foreach { leaf =>
             assert(leaf.startsWith("metadata/") && !leaf.contains(baseDir.toString),
               s"Leaf key must be table-root-relative; got $leaf.")
           }
-          val victim = byLeaf.toSeq.sortBy(_._1).head._2.head
+          val victim = leafToAddFileMapping.toSeq.sortBy(_._1).head._2.head
           commitBoth(baselineDeltaLog, amtDeltaLog, Seq(victim.remove))
           createIncrementalAMTAndValidate(
-            baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-            numOldLeavesUpdated = 1,
-            numOldLeavesUntouched = byLeaf.size - 1,
-            numLeafMdvBitsAdded = 1,
-            numLeavesModifiedStatus = 1,
-            numLeavesExistingStatus = byLeaf.size - 1))
+            baselineDeltaLog,
+            amtDeltaLog,
+            createIncrementalAMTWriteMetrics(
+              numOldLeavesUpdated = 1,
+              numOldLeavesUntouched = leafToAddFileMapping.size - 1,
+              numLeafMdvBitsAdded = 1,
+              numLeavesModifiedStatus = 1,
+              numLeavesExistingStatus = leafToAddFileMapping.size - 1))
         }
       }
     }
@@ -942,16 +1159,18 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
           }.toSet
         val before = leafFingerprints(provider)
         // A delete of a leaf-resident file: the pointer's MDV changes, but the leaf FILE must not.
-        val byLeaf = leafToAddFileMap(amtDeltaLog)
-        val victim = byLeaf.toSeq.sortBy(_._1).head._2.head
+        val leafToAddFileMapping = leafToAddFileMap(amtDeltaLog)
+        val victim = leafToAddFileMapping.toSeq.sortBy(_._1).head._2.head
         commitBoth(baselineDeltaLog, amtDeltaLog, Seq(victim.remove))
         createIncrementalAMTAndValidate(
-          baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-          numOldLeavesUpdated = 1,
-          numOldLeavesUntouched = byLeaf.size - 1,
-          numLeafMdvBitsAdded = 1,
-          numLeavesModifiedStatus = 1,
-          numLeavesExistingStatus = byLeaf.size - 1))
+          baselineDeltaLog,
+          amtDeltaLog,
+          createIncrementalAMTWriteMetrics(
+            numOldLeavesUpdated = 1,
+            numOldLeavesUntouched = leafToAddFileMapping.size - 1,
+            numLeafMdvBitsAdded = 1,
+            numLeavesModifiedStatus = 1,
+            numLeavesExistingStatus = leafToAddFileMapping.size - 1))
         val after =
           leafFingerprints(amtProvider(amtDeltaLog.update()).getOrElse(fail("expected AMT")))
         assert(after == before,
@@ -965,18 +1184,21 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
       withTables() { (baselineDeltaLog, amtDeltaLog) =>
         commitBoth(baselineDeltaLog, amtDeltaLog, (1 to 15).map(fakeAdd)) // 3 leaves at cap 5.
         commitCheckpoint(amtDeltaLog, incremental = false)
-        val byLeaf = leafToAddFileMap(amtDeltaLog)
-        assert(byLeaf.size >= 2, s"Need >= 2 leaves; got ${byLeaf.size}.")
+        val leafToAddFileMapping = leafToAddFileMap(amtDeltaLog)
+        assert(leafToAddFileMapping.size >= 2,
+          s"Need >= 2 leaves; got ${leafToAddFileMapping.size}.")
         // Delete one file from exactly one leaf; the other leaves must keep an empty MDV.
-        val (victimLeaf, victimFiles) = byLeaf.toSeq.minBy(_._1)
+        val (victimLeaf, victimFiles) = leafToAddFileMapping.toSeq.minBy(_._1)
         commitBoth(baselineDeltaLog, amtDeltaLog, Seq(victimFiles.head.remove))
         createIncrementalAMTAndValidate(
-          baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-          numOldLeavesUpdated = 1,
-          numOldLeavesUntouched = byLeaf.size - 1,
-          numLeafMdvBitsAdded = 1,
-          numLeavesModifiedStatus = 1,
-          numLeavesExistingStatus = byLeaf.size - 1))
+          baselineDeltaLog,
+          amtDeltaLog,
+          createIncrementalAMTWriteMetrics(
+            numOldLeavesUpdated = 1,
+            numOldLeavesUntouched = leafToAddFileMapping.size - 1,
+            numLeafMdvBitsAdded = 1,
+            numLeavesModifiedStatus = 1,
+            numLeavesExistingStatus = leafToAddFileMapping.size - 1))
         val provider = amtProvider(amtDeltaLog.update()).getOrElse(fail("expected AMT"))
         provider.leaves.foreach { leaf =>
           val card = leaf.manifest_info.dv_cardinality.getOrElse(0L)
@@ -1029,19 +1251,23 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
         // reconstructs an empty live set.
         commitBoth(baselineDeltaLog, amtDeltaLog, (1 to leafPackedFiles).map(fakeAdd))
         commitCheckpoint(amtDeltaLog, incremental = false)
-        val byLeaf = leafToAddFileMap(amtDeltaLog)
-        assert(byLeaf.size >= 2, s"Need a tree-shaped bootstrap; got ${byLeaf.size} leaves.")
-        val allLeafFiles = byLeaf.values.flatten.toSeq
+        val leafToAddFileMapping = leafToAddFileMap(amtDeltaLog)
+        assert(leafToAddFileMapping.size >= 2,
+          s"Need a tree-shaped bootstrap; got ${leafToAddFileMapping.size} leaves.")
+        val allLeafFiles = leafToAddFileMapping.values.flatten.toSeq
         commitBoth(baselineDeltaLog, amtDeltaLog, allLeafFiles.map(_.remove))
         createIncrementalAMTAndValidate(
-          baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-          numOldLeavesUpdated = byLeaf.size,
-          numLeafMdvBitsAdded = allLeafFiles.size,
-          numLeavesDeletedStatus = byLeaf.size))
+          baselineDeltaLog,
+          amtDeltaLog,
+          createIncrementalAMTWriteMetrics(
+            numOldLeavesUpdated = leafToAddFileMapping.size,
+            numLeafMdvBitsAdded = allLeafFiles.size,
+            numLeavesDeletedStatus = leafToAddFileMapping.size))
         // Every carried leaf pointer is now a DELETED tombstone.
         val statuses = amtProvider(amtDeltaLog.update()).getOrElse(fail("expected AMT"))
           .leaves.map(_.tracking.status)
-        assert(statuses.forall(_ == Tracking.Status.Deleted) && statuses.size == byLeaf.size,
+        assert(statuses.forall(_ == Tracking.Status.Deleted) &&
+          statuses.size == leafToAddFileMapping.size,
           s"Every fully-masked leaf must be DELETED; got $statuses.")
         assert(livePathsInLatestSnapshot(baselineDeltaLog).isEmpty,
           "The baseline table must have no live files.")
@@ -1083,15 +1309,21 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
         // Append id=31 -> becomes root-resident (no leaf, no backref).
         commitBoth(baselineDeltaLog, amtDeltaLog, Seq(fakeAdd(leafPackedFiles + 1)))
         createIncrementalAMTAndValidate(
-          baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-          numOldLeavesUntouched = numLeafCountBefore, numRootLiveAdds = 1,
-          numLeavesExistingStatus = numLeafCountBefore))
+          baselineDeltaLog,
+          amtDeltaLog,
+          createIncrementalAMTWriteMetrics(
+            numOldLeavesUntouched = numLeafCountBefore,
+            numRootEntriesExistingStatus = 1,
+            numLeavesExistingStatus = numLeafCountBefore))
         // Delete id=31 (root-resident): remove has NO backref -> dropped by replay, no MDV bit.
         commitBoth(baselineDeltaLog, amtDeltaLog, Seq(removeOf(amtDeltaLog, leafPackedFiles + 1)))
         createIncrementalAMTAndValidate(
-          baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-          numOldLeavesUntouched = numLeafCountBefore, numLeafMdvBitsAdded = 0,
-          numLeavesExistingStatus = numLeafCountBefore))
+          baselineDeltaLog,
+          amtDeltaLog,
+          createIncrementalAMTWriteMetrics(
+            numOldLeavesUntouched = numLeafCountBefore,
+            numLeafMdvBitsAdded = 0,
+            numLeavesExistingStatus = numLeafCountBefore))
       }
     }
   }
@@ -1110,9 +1342,12 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
         commitBoth(baselineDeltaLog, amtDeltaLog, Seq(fakeAdd(leafPackedFiles + 1)))
         commitBoth(baselineDeltaLog, amtDeltaLog, Seq(removeOf(amtDeltaLog, leafPackedFiles + 1)))
         createIncrementalAMTAndValidate(
-          baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-          numOldLeavesUntouched = numLeafCountBefore, numLeafMdvBitsAdded = 0,
-          numLeavesExistingStatus = numLeafCountBefore))
+          baselineDeltaLog,
+          amtDeltaLog,
+          createIncrementalAMTWriteMetrics(
+            numOldLeavesUntouched = numLeafCountBefore,
+            numLeafMdvBitsAdded = 0,
+            numLeavesExistingStatus = numLeafCountBefore))
       }
     }
   }
@@ -1122,24 +1357,27 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
       withTables() { (baselineDeltaLog, amtDeltaLog) =>
         commitBoth(baselineDeltaLog, amtDeltaLog, (1 to leafPackedFiles).map(fakeAdd))
         commitCheckpoint(amtDeltaLog, incremental = false)
-        val byLeaf = leafToAddFileMap(amtDeltaLog)
-        assert(byLeaf.size >= 2, s"Need a tree-shaped bootstrap; got ${byLeaf.size} leaves.")
+        val leafToAddFileMapping = leafToAddFileMap(amtDeltaLog)
+        assert(leafToAddFileMapping.size >= 2,
+          s"Need a tree-shaped bootstrap; got ${leafToAddFileMapping.size} leaves.")
         // Window: remove a leaf-resident file (it carries a backref) then re-add the SAME path. The
-        // old leaf entry is MDV-masked and the re-added copy is root-resident; reconstructed once.
-        // The re-add keeps the back reference the file was stamped with: its path is still the one
-        // the leaf holds, and a commit reusing a leaf-resident path must carry that leaf's
-        // reference.
-        val victim = byLeaf.toSeq.sortBy(_._1).head._2.head
+        // old leaf entry is MDV-masked and the re-added copy becomes a root-resident EXISTING entry
+        // (a re-commit of an already-live key, not a new add); reconstructed once. The re-add keeps
+        // the back reference the file was stamped with: its path is still the one the leaf holds,
+        // and a commit reusing a leaf-resident path must carry that leaf's reference.
+        val victim = leafToAddFileMapping.toSeq.sortBy(_._1).head._2.head
         commitBoth(baselineDeltaLog, amtDeltaLog, Seq(victim.remove))
         commitBoth(baselineDeltaLog, amtDeltaLog, Seq(victim))
         createIncrementalAMTAndValidate(
-          baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-          numOldLeavesUpdated = 1,
-          numOldLeavesUntouched = byLeaf.size - 1,
-          numRootLiveAdds = 1,
-          numLeafMdvBitsAdded = 1,
-          numLeavesModifiedStatus = 1,
-          numLeavesExistingStatus = byLeaf.size - 1))
+          baselineDeltaLog,
+          amtDeltaLog,
+          createIncrementalAMTWriteMetrics(
+            numOldLeavesUpdated = 1,
+            numOldLeavesUntouched = leafToAddFileMapping.size - 1,
+            numRootEntriesExistingStatus = 1,
+            numLeafMdvBitsAdded = 1,
+            numLeavesModifiedStatus = 1,
+            numLeavesExistingStatus = leafToAddFileMapping.size - 1))
       }
     }
   }
@@ -1149,14 +1387,15 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
       withTables() { (baselineDeltaLog, amtDeltaLog) =>
         commitBoth(baselineDeltaLog, amtDeltaLog, (1 to leafPackedFiles).map(fakeAdd))
         commitCheckpoint(amtDeltaLog, incremental = false)
-        val byLeaf = leafToAddFileMap(amtDeltaLog)
-        assert(byLeaf.size >= 2, s"Need a tree-shaped bootstrap; got ${byLeaf.size} leaves.")
+        val leafToAddFileMapping = leafToAddFileMap(amtDeltaLog)
+        assert(leafToAddFileMapping.size >= 2,
+          s"Need a tree-shaped bootstrap; got ${leafToAddFileMapping.size} leaves.")
         // Remove a leaf-resident file, re-add the same path, then remove it again. Both removes
         // carry the same back reference, so both target the same (leaf, position). Note the re-add
         // can only follow a remove: re-adding a path that is still live would be an in-place file
         // metadata update, which a WRITE is not allowed to perform.
-        val victim = byLeaf.toSeq.sortBy(_._1).head._2.head
-        val victimLeaf = byLeaf.toSeq.sortBy(_._1).head._1
+        val victim = leafToAddFileMapping.toSeq.sortBy(_._1).head._2.head
+        val victimLeaf = leafToAddFileMapping.toSeq.sortBy(_._1).head._1
         commitBoth(baselineDeltaLog, amtDeltaLog, Seq(victim.remove))
         commitBoth(baselineDeltaLog, amtDeltaLog, Seq(victim))
         commitBoth(baselineDeltaLog, amtDeltaLog, Seq(victim.remove))
@@ -1165,12 +1404,14 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
         // agreement is what lets this go through the shared validator, whose second check
         // derives the bits from the on-disk dv_cardinality delta.
         createIncrementalAMTAndValidate(
-          baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-          numOldLeavesUpdated = 1,
-          numOldLeavesUntouched = byLeaf.size - 1,
-          numLeafMdvBitsAdded = 1,
-          numLeavesModifiedStatus = 1,
-          numLeavesExistingStatus = byLeaf.size - 1))
+          baselineDeltaLog,
+          amtDeltaLog,
+          createIncrementalAMTWriteMetrics(
+            numOldLeavesUpdated = 1,
+            numOldLeavesUntouched = leafToAddFileMapping.size - 1,
+            numLeafMdvBitsAdded = 1,
+            numLeavesModifiedStatus = 1,
+            numLeavesExistingStatus = leafToAddFileMapping.size - 1))
         val maskedLeaf = leafPointers(amtDeltaLog.update()).getOrElse(victimLeaf,
           fail(s"Leaf $victimLeaf must still be carried forward."))
         assert(mdvCardinality(maskedLeaf) == 1L,
@@ -1185,21 +1426,24 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
       withTables() { (baselineDeltaLog, amtDeltaLog) =>
         commitBoth(baselineDeltaLog, amtDeltaLog, (1 to leafPackedFiles).map(fakeAdd))
         commitCheckpoint(amtDeltaLog, incremental = false)
-        val byLeaf = leafToAddFileMap(amtDeltaLog)
-        assert(byLeaf.size >= 2, s"Need a tree-shaped bootstrap; got ${byLeaf.size} leaves.")
+        val leafToAddFileMapping = leafToAddFileMap(amtDeltaLog)
+        assert(leafToAddFileMapping.size >= 2,
+          s"Need a tree-shaped bootstrap; got ${leafToAddFileMapping.size} leaves.")
         // Delete a leaf-resident file, then add a NEW file at a different path. The leaf gets one
         // MDV bit, the new file is a root-resident live add; both reconstruct exactly once.
-        val victim = byLeaf.toSeq.sortBy(_._1).head._2.head
+        val victim = leafToAddFileMapping.toSeq.sortBy(_._1).head._2.head
         commitBoth(baselineDeltaLog, amtDeltaLog, Seq(victim.remove))
         commitBoth(baselineDeltaLog, amtDeltaLog, Seq(fakeAdd(leafPackedFiles + 1)))
         createIncrementalAMTAndValidate(
-          baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-          numOldLeavesUpdated = 1,
-          numOldLeavesUntouched = byLeaf.size - 1,
-          numRootLiveAdds = 1,
-          numLeafMdvBitsAdded = 1,
-          numLeavesModifiedStatus = 1,
-          numLeavesExistingStatus = byLeaf.size - 1))
+          baselineDeltaLog,
+          amtDeltaLog,
+          createIncrementalAMTWriteMetrics(
+            numOldLeavesUpdated = 1,
+            numOldLeavesUntouched = leafToAddFileMapping.size - 1,
+            numRootEntriesExistingStatus = 1,
+            numLeafMdvBitsAdded = 1,
+            numLeavesModifiedStatus = 1,
+            numLeavesExistingStatus = leafToAddFileMapping.size - 1))
       }
     }
   }
@@ -1246,69 +1490,48 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
           amtDeltaLog,
           createIncrementalAMTWriteMetrics(
             numOldLeavesUntouched = numLeafCountBefore,
-            numRootLiveAdds = businessCommits,
+            numRootEntriesExistingStatus = businessCommits,
             numLeavesExistingStatus = numLeafCountBefore),
           expectedNumIntermediateCommits = Some(businessCommits + 1))
       }
     }
   }
 
-
-  test("D8: writeIncremental rejects intermediate commits with a hole up to attemptVersion") {
-    withSQLConf(leafPackingConfs: _*) {
-      withTables() { (baselineDeltaLog, amtDeltaLog) =>
-        commitBoth(baselineDeltaLog, amtDeltaLog, Seq(fakeAdd(1), fakeAdd(2)))
-        // A base AMT to build intermediate commits on.
-        commitCheckpoint(amtDeltaLog, incremental = false)
-        val snapshot = amtDeltaLog.update()
-        val provider = amtProvider(snapshot).getOrElse(fail("expected AMTCheckpointProvider"))
-        val oldAMTVersion = provider.checkpointAction.version
-        val intermediateLogCommits = snapshot.logSegment.deltas
-          .filter(f => FileNames.getFileVersion(f) > oldAMTVersion)
-        // They only reach snapshot.version, so [oldAMTVersion+1, snapshot.version+5) has a
-        // hole -> the Step-0 coverage assert must fire.
-        intercept[AssertionError] {
-          new IncrementalAMTWriter(spark, amtDeltaLog).writeIncremental(
-            oldAMTVersion = oldAMTVersion,
-            oldAMTCheckpointProvider = provider,
-            intermediateLogCommits = intermediateLogCommits,
-            attemptVersion = snapshot.version + 5,
-            actionsToCommit = Seq.empty,
-            trigger = AMTTriggerMode.CheckpointIntervalIncremental.name)
-        }
-      }
-    }
-  }
-
-  test("D10: replay re-derives the root across a chain of incremental AMTs") {
+  test("D9: replay re-derives the root across a chain of incremental AMTs") {
     withSQLConf(leafPackingConfs: _*) {
       withTables() { (baselineDeltaLog, amtDeltaLog) =>
         commitBoth(baselineDeltaLog, amtDeltaLog, (1 to leafPackedFiles).map(fakeAdd))
         commitCheckpoint(amtDeltaLog, incremental = false)
-        val byLeaf = leafToAddFileMap(amtDeltaLog)
-        assert(byLeaf.size >= 2, s"Need a tree-shaped bootstrap; got ${byLeaf.size} leaves.")
-        val numLeafCountBefore = byLeaf.size
+        val leafToAddFileMapping = leafToAddFileMap(amtDeltaLog)
+        assert(leafToAddFileMapping.size >= 2,
+          s"Need a tree-shaped bootstrap; got ${leafToAddFileMapping.size} leaves.")
+        val numLeafCountBefore = leafToAddFileMapping.size
 
         // incr 1: append one file, which stays root-resident (carried pointers + 1 add <= cap).
         commitBoth(baselineDeltaLog, amtDeltaLog, Seq(fakeAdd(leafPackedFiles + 1)))
         createIncrementalAMTAndValidate(
-          baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-          numOldLeavesUntouched = numLeafCountBefore, numRootLiveAdds = 1,
-          numLeavesExistingStatus = numLeafCountBefore))
+          baselineDeltaLog,
+          amtDeltaLog,
+          createIncrementalAMTWriteMetrics(
+            numOldLeavesUntouched = numLeafCountBefore,
+            numRootEntriesExistingStatus = 1,
+            numLeavesExistingStatus = numLeafCountBefore))
 
-        // incr 2: delete a leaf-resident file -> its leaf gets one MDV bit. numRootLiveAdds is
-        // still 1: the file appended by incr 1 must survive as a root-resident live add, which is
-        // replay re-deriving the root's live set from the PREVIOUS incremental's root (part 1a).
-        val victim = byLeaf.toSeq.sortBy(_._1).head._2.head
+        // incr 2: delete a leaf-resident file -> its leaf gets one MDV bit. The file appended by
+        // incr 1 must survive as a root-resident EXISTING entry, which is replay re-deriving the
+        // root's live set from the PREVIOUS incremental's root (part 1a).
+        val victim = leafToAddFileMapping.toSeq.sortBy(_._1).head._2.head
         commitBoth(baselineDeltaLog, amtDeltaLog, Seq(victim.remove))
         createIncrementalAMTAndValidate(
-          baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-          numOldLeavesUpdated = 1,
-          numOldLeavesUntouched = numLeafCountBefore - 1,
-          numRootLiveAdds = 1,
-          numLeafMdvBitsAdded = 1,
-          numLeavesModifiedStatus = 1,
-          numLeavesExistingStatus = numLeafCountBefore - 1))
+          baselineDeltaLog,
+          amtDeltaLog,
+          createIncrementalAMTWriteMetrics(
+            numOldLeavesUpdated = 1,
+            numOldLeavesUntouched = numLeafCountBefore - 1,
+            numRootEntriesExistingStatus = 1,
+            numLeafMdvBitsAdded = 1,
+            numLeavesModifiedStatus = 1,
+            numLeavesExistingStatus = numLeafCountBefore - 1))
 
         // incr 3: append enough files to push the root past the cap, forcing a spill.
         commitBoth(
@@ -1321,18 +1544,19 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
     }
   }
 
-  test("D11: a long mixed chain of writes folds into ONE incremental AMT") {
+  test("D10: a long mixed chain of writes folds into ONE incremental AMT") {
     withSQLConf(leafPackingConfs: _*) {
       withTables() { (baselineDeltaLog, amtDeltaLog) =>
         commitBoth(baselineDeltaLog, amtDeltaLog, (1 to leafPackedFiles).map(fakeAdd))
         commitCheckpoint(amtDeltaLog, incremental = false)
-        val byLeaf = leafToAddFileMap(amtDeltaLog)
-        assert(byLeaf.size >= 2, s"Need a tree-shaped bootstrap; got ${byLeaf.size} leaves.")
+        val leafToAddFileMapping = leafToAddFileMap(amtDeltaLog)
+        assert(leafToAddFileMapping.size >= 2,
+          s"Need a tree-shaped bootstrap; got ${leafToAddFileMapping.size} leaves.")
 
-        // The opposite packing of D10: NOTHING is checkpointed until the very end, so instead of
+        // The opposite packing of D9: NOTHING is checkpointed until the very end, so instead of
         // one write per incremental, all these interleaved appends and deletes land in a single
         // incremental's intermediate commits, to be folded in at once.
-        val leafVictims = byLeaf.toSeq.sortBy(_._1).flatMap(_._2.take(1))
+        val leafVictims = leafToAddFileMapping.toSeq.sortBy(_._1).flatMap(_._2.take(1))
         commitBoth(baselineDeltaLog, amtDeltaLog, Seq(fakeAdd(leafPackedFiles + 1)))
         commitBoth(baselineDeltaLog, amtDeltaLog, Seq(leafVictims.head.remove))
         commitBoth(
@@ -1353,12 +1577,52 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
           amtDeltaLog,
           createIncrementalAMTWriteMetrics(
             numOldLeavesUpdated = 2,
-            numOldLeavesUntouched = byLeaf.size - 2,
-            numRootLiveAdds = 4,
+            numOldLeavesUntouched = leafToAddFileMapping.size - 2,
+            numRootEntriesExistingStatus = 4,
             numLeafMdvBitsAdded = 2,
             numLeavesModifiedStatus = 2,
-            numLeavesExistingStatus = byLeaf.size - 2),
+            numLeavesExistingStatus = leafToAddFileMapping.size - 2),
           expectedNumIntermediateCommits = Some(8))
+      }
+    }
+  }
+
+  test("D11: re-adding an already-live file leaves it live exactly once, no double-count") {
+    withSQLConf(leafPackingConfs: _*) {
+      withTables() { (baselineDeltaLog, amtDeltaLog) =>
+        commitBoth(baselineDeltaLog, amtDeltaLog, (1 to leafPackedFiles).map(fakeAdd))
+        commitCheckpoint(amtDeltaLog, incremental = false)
+        val leafToAddFileMapping = leafToAddFileMap(amtDeltaLog)
+        assert(leafToAddFileMapping.size >= 2,
+          s"Need a tree-shaped bootstrap; got ${leafToAddFileMapping.size} leaves.")
+        val livePathsBefore = livePathsInLatestAMTCheckpoint(amtDeltaLog)
+
+        // Re-commit a currently-live leaf file's AddFile with NO remove.
+        // The re-added AddFile carries the leaf back reference it was reconstructed with.
+        val liveLeafFile = leafToAddFileMapping.toSeq.sortBy(_._1).head._2.head
+        assert(liveLeafFile.backReference.isDefined, "The re-added file must be leaf-resident.")
+        commitBoth(
+          baselineDeltaLog, amtDeltaLog, Seq(liveLeafFile),
+          operation = DeltaOperations.ComputeStats(predicate = Nil))
+        // The re-added AddFile carries the leaf back reference it was reconstructed with, so the
+        // writer recognizes it as a re-commit of an already-live file and keeps it EXISTING in the
+        // root (numRootEntriesExistingStatus = 1), not ADDED. The back reference marks the original
+        // leaf slot as superseded, so that leaf's MDV masks it (numOldLeavesUpdated = 1,
+        // numLeafMdvBitsAdded = 1). The root EXISTING copy and the masked leaf slot net to no
+        // change in the live set, and -- crucially -- the file is surfaced exactly once rather
+        // than once from the leaf and once from the root.
+        createIncrementalAMTAndValidate(
+          baselineDeltaLog,
+          amtDeltaLog,
+          createIncrementalAMTWriteMetrics(
+            numOldLeavesUpdated = 1,
+            numOldLeavesUntouched = leafToAddFileMapping.size - 1,
+            numRootEntriesExistingStatus = 1,
+            numLeafMdvBitsAdded = 1,
+            numLeavesModifiedStatus = 1,
+            numLeavesExistingStatus = leafToAddFileMapping.size - 1))
+        assert(livePathsInLatestAMTCheckpoint(amtDeltaLog) == livePathsBefore,
+          "Re-adding an already-live file must not change the reconstructed live set.")
       }
     }
   }
@@ -1380,9 +1644,12 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
         commitBoth(baselineDeltaLog, amtDeltaLog, Seq(fakeAdd(leafPackedFiles + 1)))
         val lastCommitted = amtDeltaLog.update().version
         createIncrementalAMTAndValidate(
-          baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-          numOldLeavesUntouched = numLeafCountBefore, numRootLiveAdds = 1,
-          numLeavesExistingStatus = numLeafCountBefore))
+          baselineDeltaLog,
+          amtDeltaLog,
+          createIncrementalAMTWriteMetrics(
+            numOldLeavesUntouched = numLeafCountBefore,
+            numRootEntriesExistingStatus = 1,
+            numLeavesExistingStatus = numLeafCountBefore))
         val provider = amtProvider(amtDeltaLog.update()).getOrElse(fail("expected AMT"))
         // A deferred OPTIMIZE CHECKPOINT (no user actions) describes the last committed version,
         // i.e. attemptVersion - 1.
@@ -1415,15 +1682,21 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
         // checkpoint at v4 describes v3, then v5 / v6 describes v5.
         commitBoth(baselineDeltaLog, amtDeltaLog, Seq(fakeAdd(leafPackedFiles + 1)))
         createIncrementalAMTAndValidate(
-          baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-          numOldLeavesUntouched = numLeafCountBefore, numRootLiveAdds = 1,
-          numLeavesExistingStatus = numLeafCountBefore))
+          baselineDeltaLog,
+          amtDeltaLog,
+          createIncrementalAMTWriteMetrics(
+            numOldLeavesUntouched = numLeafCountBefore,
+            numRootEntriesExistingStatus = 1,
+            numLeavesExistingStatus = numLeafCountBefore))
         assertCheckpointDescribesVersion(amtDeltaLog, expectedVersion = 3L)
         commitBoth(baselineDeltaLog, amtDeltaLog, Seq(fakeAdd(leafPackedFiles + 2)))
         createIncrementalAMTAndValidate(
-          baselineDeltaLog, amtDeltaLog, createIncrementalAMTWriteMetrics(
-          numOldLeavesUntouched = numLeafCountBefore, numRootLiveAdds = 2,
-          numLeavesExistingStatus = numLeafCountBefore))
+          baselineDeltaLog,
+          amtDeltaLog,
+          createIncrementalAMTWriteMetrics(
+            numOldLeavesUntouched = numLeafCountBefore,
+            numRootEntriesExistingStatus = 2,
+            numLeavesExistingStatus = numLeafCountBefore))
         assertCheckpointDescribesVersion(amtDeltaLog, expectedVersion = 5L)
         val marker = amtProvider(amtDeltaLog.update()).getOrElse(fail("expected AMT"))
           .checkpointAction.contentRoot.lastManifestCommitWithFullRewrite
@@ -1477,9 +1750,11 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
   private def bootstrapTargetLeaf(baselineDeltaLog: DeltaLog, amtDeltaLog: DeltaLog): String = {
     commitBoth(baselineDeltaLog, amtDeltaLog, (1 to leafPackedFiles).map(fakeAdd))
     commitCheckpoint(amtDeltaLog, incremental = false)
-    val byLeaf = leafToAddFileMap(amtDeltaLog)
-    assert(byLeaf.size >= 2, s"Need a tree-shaped bootstrap; got ${byLeaf.size} leaves.")
-    val target = byLeaf.toSeq.sortBy { case (loc, files) => (-files.size, loc) }.head._1
+    val leafToAddFileMapping = leafToAddFileMap(amtDeltaLog)
+    assert(leafToAddFileMapping.size >= 2,
+      s"Need a tree-shaped bootstrap; got ${leafToAddFileMapping.size} leaves.")
+    val target =
+      leafToAddFileMapping.toSeq.sortBy { case (loc, files) => (-files.size, loc) }.head._1
     assertLeafStatus(amtDeltaLog, target, Tracking.Status.Added, "bootstrap")
     target
   }
@@ -1613,4 +1888,1001 @@ class AMTIncrementalWriteSuite extends AMTCheckpointTestBase {
       }
     }
   }
+
+  /////////////////////////////////////////////////////////////
+  // Section-G:                                              //
+  //     The inline emission path: statuses, tombstones,     //
+  //      and DELETE vs REPLACE                              //
+  /////////////////////////////////////////////////////////////
+
+  test("G1: an inline write emits an incremental AMT that describes its own commit version") {
+    withSQLConf(DeltaSQLConf.AMT_ENTRIES_PER_LEAF.key -> "10") {
+      withTables() { (baselineDeltaLog, amtDeltaLog) =>
+        val leavesBefore = setup(baselineDeltaLog, amtDeltaLog, entriesPerLeaf = 10,
+          initialIdRangeInLeaf = 1 to 30).map(_.location).toSet
+        assert(leavesBefore.size >= 2,
+          s"Need a tree-shaped bootstrap; got ${leavesBefore.size} leaves.")
+
+        // Inline-append one net-new file. It stays root-resident (carried pointers + 1 add is under
+        // the cap), so no leaf is added or rewritten.
+        createIncrementalAMTAndValidate(
+          baselineDeltaLog, amtDeltaLog,
+          createIncrementalAMTWriteMetrics(
+            numOldLeavesUntouched = leavesBefore.size,
+            numRootEntriesAddedStatus = 1,
+            numLeavesExistingStatus = leavesBefore.size),
+          inlineAMTCommitActions = Some(Seq(fakeAdd(31))))
+        assert(leafPointers(amtDeltaLog.update()).keySet == leavesBefore,
+          "An append below the spill threshold must add no leaf and rewrite none.")
+      }
+    }
+  }
+
+  test("G2: an inline-appended file is ADDED, then EXISTING once carried by the next commit") {
+    withSQLConf(DeltaSQLConf.AMT_ENTRIES_PER_LEAF.key -> "10") {
+      withTables() { (baselineDeltaLog, amtDeltaLog) =>
+        setup(baselineDeltaLog, amtDeltaLog, entriesPerLeaf = 10, initialIdRangeInLeaf = 1 to 30)
+        // A full-rewrite root holds only leaf pointers, so it has no root-resident DATA entries.
+        val bootstrapCounts = rootDataEntryStatusToCount(amtDeltaLog)
+        assert(bootstrapCounts.isEmpty,
+          s"A full-rewrite root must hold no DATA entries; got $bootstrapCounts.")
+        // Append one net-new file INLINE: this commit inserts it, so it is ADDED. (A deferred fold
+        // would carry it forward as EXISTING, since that insert belongs to its own commit's CDF.)
+        withInline { commitBoth(baselineDeltaLog, amtDeltaLog, Seq(fakeAdd(31))) }
+        val afterFirst = rootDataEntryStatusToLocations(amtDeltaLog)
+        assert(afterFirst == Map(Tracking.Status.Added -> Set(fakeAdd(31).path)),
+          s"the freshly appended file 31 must be ADDED; got $afterFirst.")
+        assertLiveAddFilesEquals(baselineDeltaLog, amtDeltaLog)
+        // Append a second file INLINE: this commit inserts the second (32) as ADDED and carries the
+        // first (31), which decays to EXISTING.
+        withInline { commitBoth(baselineDeltaLog, amtDeltaLog, Seq(fakeAdd(32))) }
+        val afterSecond = rootDataEntryStatusToLocations(amtDeltaLog)
+        assert(afterSecond == Map(
+          Tracking.Status.Added -> Set(fakeAdd(32).path),
+          Tracking.Status.Existing -> Set(fakeAdd(31).path)),
+          s"file 32 must be ADDED and file 31 EXISTING; got $afterSecond.")
+        assertLiveAddFilesEquals(baselineDeltaLog, amtDeltaLog)
+      }
+    }
+  }
+
+  test("G3: an inline delete of a leaf-resident file masks it via a cumulative MDV") {
+    withSQLConf(DeltaSQLConf.AMT_ENTRIES_PER_LEAF.key -> "10") {
+      withTables() { (baselineDeltaLog, amtDeltaLog) =>
+        val leavesBefore = setup(baselineDeltaLog, amtDeltaLog, entriesPerLeaf = 10,
+          initialIdRangeInLeaf = 1 to 30).map(_.location).toSet
+        assert(leavesBefore.size >= 2,
+          s"Need a tree-shaped bootstrap; got ${leavesBefore.size} leaves.")
+        val physicalEntriesBefore = currentLeafDataEntries(amtDeltaLog.update())
+        assert(physicalEntriesBefore == 30,
+          "Every bootstrap file is spread across the AMT's leaves.")
+
+        // Inline delete of a leaf-resident file: the owning leaf is carried forward by pointer and
+        // masked with one cumulative MDV bit; the leaf parquet keeps every physical entry.
+        createIncrementalAMTAndValidate(
+          baselineDeltaLog, amtDeltaLog,
+          createIncrementalAMTWriteMetrics(
+            numOldLeavesUpdated = 1,
+            numOldLeavesUntouched = leavesBefore.size - 1,
+            numLeafMdvBitsAdded = 1,
+            numLeafDeleteCDFBitsAdded = 1,
+            numLeavesExistingStatus = leavesBefore.size - 1,
+            numLeavesModifiedStatus = 1),
+          inlineAMTCommitActions = Some(Seq(removeOf(amtDeltaLog, 1))))
+        assert(leafPointers(amtDeltaLog.update()).keySet == leavesBefore,
+          "The delete must carry every leaf forward, not rewrite or drop one.")
+        assert(currentLeafDataEntries(amtDeltaLog.update()) == physicalEntriesBefore,
+          "The carried leaf keeps every physical entry; a delete only sets the MDV.")
+      }
+    }
+  }
+
+  test("G4: an inline delete of a root-resident file writes a root tombstone for CDF") {
+    withSQLConf(DeltaSQLConf.AMT_ENTRIES_PER_LEAF.key -> "10") {
+      withTables() { (baselineDeltaLog, amtDeltaLog) =>
+        val leavesBefore = setup(baselineDeltaLog, amtDeltaLog, entriesPerLeaf = 10,
+          initialIdRangeInLeaf = 1 to 30).map(_.location).toSet
+        assert(leavesBefore.size >= 2,
+          s"Need a tree-shaped bootstrap; got ${leavesBefore.size} leaves.")
+
+        // Inline-append one net-new file; it stays root-resident (under the spill threshold), so
+        // its later remove carries no back reference.
+        val rootId = 31
+        withInline {
+          commitBoth(baselineDeltaLog, amtDeltaLog, Seq(fakeAdd(rootId)))
+        }
+        val (rootLiveAddsBefore, tombstonesBefore) = liveAddsAndTombstonesCountInRoot(amtDeltaLog)
+        assert(rootLiveAddsBefore == 1L,
+          s"The appended file must be the one root-resident live add; got $rootLiveAddsBefore.")
+        assert(tombstonesBefore == 0L, "An append must not write a tombstone.")
+
+        // Inline delete of the root-resident file. Deferred D1 drops such a file through replay
+        // with NO tombstone; inline instead has the remove in actionsToCommit, so it becomes a
+        // tracking=removed root entry for CDF.
+        createIncrementalAMTAndValidate(
+          baselineDeltaLog, amtDeltaLog,
+          createIncrementalAMTWriteMetrics(
+            numOldLeavesUntouched = leavesBefore.size,
+            numRootEntriesDeletedStatus = 1,
+            numLeavesExistingStatus = leavesBefore.size),
+          inlineAMTCommitActions = Some(Seq(removeOf(amtDeltaLog, rootId))))
+        val (rootLiveAdds, tombstones) = liveAddsAndTombstonesCountInRoot(amtDeltaLog)
+        assert(tombstones == 1L,
+          s"Removing a root-resident file inline must leave one root tombstone; got $tombstones.")
+        assert(rootLiveAdds == 0L,
+          s"The removed file must no longer be a live root add; got $rootLiveAdds.")
+        // A no-backref remove is replay-resolved; it must not touch any leaf's MDV.
+        leafPointers(amtDeltaLog.update()).foreach { case (location, leaf) =>
+          assert(mdvCardinality(leaf) == 0L,
+            s"Removing a root-resident file must not touch leaf $location's MDV.")
+        }
+      }
+    }
+  }
+
+  test("G5: an inline leaf delete stamps deleted_positions, and resets it on the next commit") {
+    withSQLConf(DeltaSQLConf.AMT_ENTRIES_PER_LEAF.key -> "10") {
+      withTables() { (baselineDeltaLog, amtDeltaLog) =>
+        val leavesBefore = setup(baselineDeltaLog, amtDeltaLog, entriesPerLeaf = 10,
+          initialIdRangeInLeaf = 1 to 30).map(_.location).toSet
+        assert(leavesBefore.size >= 2,
+          s"Need a tree-shaped bootstrap; got ${leavesBefore.size} leaves.")
+
+        // Inline delete of a leaf-resident file stamps this commit's deleted position on the owning
+        // leaf. deleted_positions is sourced from this commit's with-backref removes, so only the
+        // inline path populates it.
+        createIncrementalAMTAndValidate(
+          baselineDeltaLog, amtDeltaLog,
+          createIncrementalAMTWriteMetrics(
+            numOldLeavesUpdated = 1,
+            numOldLeavesUntouched = leavesBefore.size - 1,
+            numLeafMdvBitsAdded = 1,
+            numLeafDeleteCDFBitsAdded = 1,
+            numLeavesExistingStatus = leavesBefore.size - 1,
+            numLeavesModifiedStatus = 1),
+          inlineAMTCommitActions = Some(Seq(removeOf(amtDeltaLog, 1))))
+        val stamped =
+          leafPointers(amtDeltaLog.update()).values.filter(leafDeletedPositions(_).nonEmpty).toSeq
+        assert(stamped.size == 1,
+          s"Exactly one leaf must carry this commit's deleted_positions; got ${stamped.size}.")
+        assert(leafDeletedPositions(stamped.head).size == 1,
+          s"deleted_positions must hold this commit's single deletion; " +
+            s"got ${leafDeletedPositions(stamped.head)}.")
+        assert(mdvCardinality(stamped.head) == 1L,
+          "The same leaf's cumulative MDV must also carry that one bit.")
+
+        // A following inline commit that deletes from no leaf must RESET deleted_positions (it is
+        // per-commit, never the stale prior value); the cumulative MDV persists.
+        createIncrementalAMTAndValidate(
+          baselineDeltaLog, amtDeltaLog,
+          createIncrementalAMTWriteMetrics(
+            numOldLeavesUntouched = leavesBefore.size,
+            numRootEntriesAddedStatus = 1,
+            numLeavesExistingStatus = leavesBefore.size),
+          inlineAMTCommitActions = Some(Seq(fakeAdd(31))))
+        val afterAppend = amtDeltaLog.update()
+        leafPointers(afterAppend).foreach { case (location, leaf) =>
+          assert(leafDeletedPositions(leaf).isEmpty,
+            s"deleted_positions must reset on leaf $location when this commit deletes nothing " +
+              s"from it; got ${leafDeletedPositions(leaf)}.")
+        }
+        assert(leafPointers(afterAppend).values.map(mdvCardinality).sum == 1L,
+          "The cumulative MDV bit from the earlier delete must survive the append.")
+      }
+    }
+  }
+
+
+  test("G6: an inline leaf-resident REPLACE stamps replaced_positions and re-adds MODIFIED") {
+    withSQLConf(DeltaSQLConf.AMT_ENTRIES_PER_LEAF.key -> "10") {
+      withTables() { (baselineDeltaLog, amtDeltaLog) =>
+        val leavesBefore = setup(baselineDeltaLog, amtDeltaLog, entriesPerLeaf = 10,
+          initialIdRangeInLeaf = 1 to 30).map(_.location).toSet
+        assert(leavesBefore.size >= 2, s"Need a tree-shaped bootstrap; got ${leavesBefore.size}.")
+
+        // Inline REPLACE of a leaf file: remove f, re-add it under a new DV, in one commit.
+        // The owning leaf is carried forward with the position masked in its cumulative MDV and
+        // recorded as this commit's replaced_positions (not deleted_positions). The re-added
+        // copy is a live MODIFIED root DATA entry.
+        createIncrementalAMTAndValidate(
+          baselineDeltaLog, amtDeltaLog,
+          createIncrementalAMTWriteMetrics(
+            numOldLeavesUpdated = 1,
+            numOldLeavesUntouched = leavesBefore.size - 1,
+            numRootEntriesModifiedStatus = 1,
+            numLeafMdvBitsAdded = 1,
+            numLeafReplaceCDFBitsAdded = 1,
+            numLeavesExistingStatus = leavesBefore.size - 1,
+            numLeavesModifiedStatus = 1),
+          inlineAMTCommitActions = Some(removeAndReAddWithDV(amtDeltaLog, Left(1))))
+        val replaced = leafPointers(amtDeltaLog.update()).values
+          .filter(leafReplacedPositions(_).nonEmpty).toSeq
+        assert(replaced.size == 1,
+          s"Exactly one leaf must carry this commit's replaced_positions; got ${replaced.size}.")
+        assert(leafReplacedPositions(replaced.head).size == 1 &&
+          leafDeletedPositions(replaced.head).isEmpty,
+          s"REPLACE sets replaced_positions, not deleted; got ${replaced.head.tracking}.")
+        assert(
+          rootDataEntryStatusToCount(amtDeltaLog).getOrElse(Tracking.Status.Modified, 0L) == 1L,
+          "The re-added copy must be a MODIFIED root DATA entry.")
+        assertLiveAddFilesEquals(baselineDeltaLog, amtDeltaLog)
+      }
+    }
+  }
+
+  test("G7: an inline root-resident REPLACE writes a REPLACED root entry, not DELETED") {
+    withSQLConf(DeltaSQLConf.AMT_ENTRIES_PER_LEAF.key -> "10") {
+      withTables() { (baselineDeltaLog, amtDeltaLog) =>
+        val leavesBefore = setup(baselineDeltaLog, amtDeltaLog, entriesPerLeaf = 10,
+          initialIdRangeInLeaf = 1 to 30).map(_.location).toSet
+        assert(leavesBefore.size >= 2, s"Need a tree-shaped bootstrap; got ${leavesBefore.size}.")
+        // Append a net-new file; being root-resident, its later remove carries no back reference.
+        val rootId = 31
+        withInline { commitBoth(baselineDeltaLog, amtDeltaLog, Seq(fakeAdd(rootId))) }
+
+        // Inline REPLACE of the root-resident file: a no-backref remove whose path is re-added this
+        // commit becomes a REPLACED root DataEntry (buildRootRemoveEntries), and the re-added copy
+        // is MODIFIED -- unlike G4, where a pure root delete leaves a DELETED tombstone.
+        createIncrementalAMTAndValidate(
+          baselineDeltaLog, amtDeltaLog,
+          createIncrementalAMTWriteMetrics(
+            numOldLeavesUntouched = leavesBefore.size,
+            numRootEntriesModifiedStatus = 1,
+            numRootEntriesReplacedStatus = 1,
+            numLeavesExistingStatus = leavesBefore.size),
+          inlineAMTCommitActions = Some(removeAndReAddWithDV(amtDeltaLog, Left(rootId))))
+        val rootCounts = rootDataEntryStatusToCount(amtDeltaLog)
+        assert(rootCounts.getOrElse(Tracking.Status.Replaced, 0L) == 1L,
+          s"A re-added root file must leave one REPLACED root entry; got $rootCounts.")
+        assert(rootCounts.getOrElse(Tracking.Status.Modified, 0L) == 1L,
+          s"The re-added copy must be MODIFIED; got $rootCounts.")
+        assertLiveAddFilesEquals(baselineDeltaLog, amtDeltaLog)
+      }
+    }
+  }
+
+  test("G8: a root DATA entry goes ADDED -> EXISTING -> MODIFIED across incremental writes") {
+    withSQLConf(DeltaSQLConf.AMT_ENTRIES_PER_LEAF.key -> "10") {
+      withTables() { (baselineDeltaLog, amtDeltaLog) =>
+        val leavesBefore = setup(baselineDeltaLog, amtDeltaLog, entriesPerLeaf = 10,
+          initialIdRangeInLeaf = 1 to 30).map(_.location).toSet
+        val rootId = 31
+
+        // Append rootId inline: it is an ADDED root DATA entry.
+        withInline { commitBoth(baselineDeltaLog, amtDeltaLog, Seq(fakeAdd(rootId))) }
+        assert(rootDataEntryStatusToCount(amtDeltaLog) == Map(Tracking.Status.Added -> 1L),
+          s"the appended root file must start ADDED; got " +
+            s"${rootDataEntryStatusToCount(amtDeltaLog)}.")
+
+        // Carry rootId forward under an unrelated inline append: rootId decays ADDED -> EXISTING
+        // while the filler is the new ADDED entry.
+        val fillerId = 32
+        createIncrementalAMTAndValidate(
+          baselineDeltaLog, amtDeltaLog,
+          createIncrementalAMTWriteMetrics(
+            numOldLeavesUntouched = leavesBefore.size,
+            numRootEntriesAddedStatus = 1,
+            numRootEntriesExistingStatus = 1,
+            numLeavesExistingStatus = leavesBefore.size),
+          inlineAMTCommitActions = Some(Seq(fakeAdd(fillerId))))
+        assert(rootDataEntryStatusToCount(amtDeltaLog) ==
+          Map(Tracking.Status.Added -> 1L, Tracking.Status.Existing -> 1L),
+          s"rootId must decay to EXISTING while the filler is ADDED; " +
+            s"got ${rootDataEntryStatusToCount(amtDeltaLog)}.")
+
+        // Re-add rootId with a new DV: its EXISTING copy becomes a REPLACED root entry and the
+        // re-added copy is MODIFIED.
+        createIncrementalAMTAndValidate(
+          baselineDeltaLog, amtDeltaLog,
+          createIncrementalAMTWriteMetrics(
+            numOldLeavesUntouched = leavesBefore.size,
+            numRootEntriesExistingStatus = 1,
+            numRootEntriesModifiedStatus = 1,
+            numRootEntriesReplacedStatus = 1,
+            numLeavesExistingStatus = leavesBefore.size),
+          inlineAMTCommitActions = Some(removeAndReAddWithDV(amtDeltaLog, Left(rootId))))
+        val finalCounts = rootDataEntryStatusToCount(amtDeltaLog)
+        assert(finalCounts.getOrElse(Tracking.Status.Modified, 0L) == 1L &&
+          finalCounts.getOrElse(Tracking.Status.Replaced, 0L) == 1L,
+          s"the re-added rootId must be MODIFIED with a REPLACED prior entry; got $finalCounts.")
+      }
+    }
+  }
+
+  test("G9: a freshly spilled leaf can have ADDED/MODIFIED/EXISTING and its manifest_info " +
+    "counts partition its entries") {
+    // A cap of 10 entries per leaf: 20 files pack into 2 whole leaves, and the 8 live entries this
+    // commit produces spill whole into one new leaf.
+    withSQLConf(DeltaSQLConf.AMT_ENTRIES_PER_LEAF.key -> "10") {
+      withTables() { (baselineDeltaLog, amtDeltaLog) =>
+        // Old tree: 5 root-resident DATA entries over 2 leaves (files 1..20 packed into 2 whole
+        // leaves, then files 21..25 appended root-resident under the cap of 10).
+        val oldLeafLocations = setup(baselineDeltaLog, amtDeltaLog, entriesPerLeaf = 10,
+          initialIdRangeInLeaf = 1 to 20, initialIdRangeInRoot = 21 to 25).map(_.location).toSet
+        assert(rootDataEntryStatusToCount(amtDeltaLog).values.sum == 5,
+          "the old root must hold exactly the 5 root-resident DATA entries.")
+
+        // A deferred (window) log commit appends files 26..28; not checkpointed, so they enter the
+        // next incremental write as intermediate window commits.
+        val windowIds = 26 to 28
+        commitBoth(baselineDeltaLog, amtDeltaLog, windowIds.map(fakeAdd))
+
+        // One inline commit exercising every live-status class:
+        //   - REPLACE 3 root files (remove + re-add under a new DV): 3 REPLACED + 3 MODIFIED.
+        //   - DELETE 1 root file (remove, no re-add): 1 DELETED.
+        //   - REPLACE 2 window files: 2 REPLACED + 2 MODIFIED.
+        //   - REPLACE 1 leaf-resident file: masks its old slot in that leaf (which becomes
+        //     MODIFIED) and re-adds it live as 1 MODIFIED.
+        //   - 1 net-new insert: 1 ADDED.
+        // The untouched 5th root file and 3rd window file stay EXISTING. The 9 live entries
+        // (1 ADDED + 6 MODIFIED + 2 EXISTING) overflow the cap of 10 and spill whole into one new
+        // leaf; the 6 root tombstones (5 REPLACED + 1 DELETED) stay root-resident, while the
+        // replaced leaf slot is masked in its now-MODIFIED leaf.
+        val replaceRoots =
+          Seq(21, 22, 23).flatMap(id => removeAndReAddWithDV(amtDeltaLog, Left(id)))
+        val deleteRoot = Seq(removeOf(amtDeltaLog, 24))
+        val replaceWindows =
+          Seq(26, 27).flatMap(id => removeAndReAddWithDV(amtDeltaLog, Left(id)))
+        // File 1 is leaf-resident (one of the 20 files packed into the 2 full-rewrite leaves).
+        val replaceLeaf = removeAndReAddWithDV(amtDeltaLog, Left(1))
+        val netNewAdd = Seq(fakeAdd(29))
+        val inlineActions =
+          replaceRoots ++ deleteRoot ++ replaceWindows ++ replaceLeaf ++ netNewAdd
+
+        createIncrementalAMTAndValidate(
+          baselineDeltaLog,
+          amtDeltaLog,
+          createIncrementalAMTWriteMetrics(
+            numOldLeavesUpdated = 1,
+            numOldLeavesUntouched = 1,
+            numNewLeaves = 1,
+            numRootEntriesReplacedStatus = 5,
+            numRootEntriesDeletedStatus = 1,
+            numLeafMdvBitsAdded = 1,
+            numLeafReplaceCDFBitsAdded = 1,
+            numLeavesAddedStatus = 1,
+            numLeavesModifiedStatus = 1,
+            numLeavesExistingStatus = 1),
+          expectedNumIntermediateCommits = Some(2),
+          inlineAMTCommitActions = Some(inlineActions))
+
+        // Exactly one freshly spilled leaf, pointer ADDED, holding all 8 live entries.
+        val newLeaves = leafPointers(amtDeltaLog.update())
+        val spilled = (newLeaves.keySet -- oldLeafLocations).toSeq
+        assert(spilled.size == 1, s"exactly one new leaf must spill; got $spilled.")
+        val spilledLeaf = newLeaves(spilled.head)
+        assert(spilledLeaf.tracking.status == Tracking.Status.Added,
+          s"a freshly spilled leaf pointer must be ADDED; got ${spilledLeaf.tracking.status}.")
+        assert(spilledLeaf.record_count == 9,
+          s"the spilled leaf must hold 9 entries; got ${spilledLeaf.record_count}.")
+
+        // The leaf parquet's raw per-entry statuses: ADDED, MODIFIED, and EXISTING all present.
+        val provider = amtProvider(amtDeltaLog.update()).getOrElse(fail("expected AMT"))
+        val leafStatusToCount = trackingStatusToAddFileCountMap(
+          spilledLeaf.getAbsolutePath(provider.tableRoot).toString)
+        assert(leafStatusToCount == Map(
+          Tracking.Status.Added -> 1L,
+          Tracking.Status.Modified -> 6L,
+          Tracking.Status.Existing -> 2L),
+          s"leaf entries must be 1 ADDED + 6 MODIFIED + 2 EXISTING; got $leafStatusToCount.")
+
+        // manifest_info collapses ADDED + MODIFIED into added_files_count; EXISTING stands alone,
+        // and a live spilled leaf carries no tombstone counts.
+        val mi = spilledLeaf.manifest_info
+        assert(mi.added_files_count == 7 && mi.existing_files_count == 2 &&
+          mi.deleted_files_count == 0 && mi.replaced_files_count == 0,
+          s"leaf manifest_info must be added=7 (1 ADDED + 6 MODIFIED), existing=2, no " +
+            s"tombstones; got $mi.")
+        assert(mi.added_files_count + mi.existing_files_count == spilledLeaf.record_count.toInt,
+          s"added + existing must partition the leaf's ${spilledLeaf.record_count} entries.")
+      }
+    }
+  }
+
+  test("G10: an inline commit deleting one leaf file and replacing another on the same leaf") {
+    withSQLConf(DeltaSQLConf.AMT_ENTRIES_PER_LEAF.key -> "10") {
+      withTables() { (baselineDeltaLog, amtDeltaLog) =>
+        setup(baselineDeltaLog, amtDeltaLog, entriesPerLeaf = 10, initialIdRangeInLeaf = 1 to 30)
+        val leafToAddFileMapping = leafToAddFileMap(amtDeltaLog)
+        val (targetLeaf, files) = leafToAddFileMapping.toSeq.sortBy(_._1).find(_._2.size >= 2)
+          .getOrElse(fail("need a leaf holding at least two files."))
+        val leavesBefore = leafToAddFileMapping.keySet
+        val fileToDelete = files.head
+        val fileToReplace = files(1)
+
+        // One inline commit: DELETE fileToDelete (no re-add) and REPLACE fileToReplace (remove +
+        // re-add with a new DV). Both land on the same leaf, so its pointer carries this commit's
+        // deleted_positions AND replaced_positions (MODIFIED), with two masked MDV bits.
+        val replaceActions = removeAndReAddWithDV(amtDeltaLog, Right(fileToReplace))
+        createIncrementalAMTAndValidate(
+          baselineDeltaLog, amtDeltaLog,
+          createIncrementalAMTWriteMetrics(
+            numOldLeavesUpdated = 1,
+            numOldLeavesUntouched = leavesBefore.size - 1,
+            numRootEntriesModifiedStatus = 1,
+            numLeafMdvBitsAdded = 2,
+            numLeafDeleteCDFBitsAdded = 1,
+            numLeafReplaceCDFBitsAdded = 1,
+            numLeavesModifiedStatus = 1,
+            numLeavesExistingStatus = leavesBefore.size - 1),
+          inlineAMTCommitActions = Some(fileToDelete.remove +: replaceActions))
+        val touched = leafPointers(amtDeltaLog.update()).values
+          .filter(l => leafDeletedPositions(l).nonEmpty || leafReplacedPositions(l).nonEmpty).toSeq
+        assert(touched.size == 1, s"exactly one leaf must be touched; got ${touched.size}.")
+        assert(leafDeletedPositions(touched.head).size == 1 &&
+          leafReplacedPositions(touched.head).size == 1,
+          s"leaf must carry a deleted AND replaced position; got ${touched.head.tracking}.")
+        assertLiveAddFilesEquals(baselineDeltaLog, amtDeltaLog)
+      }
+    }
+  }
+
+  test("G11: an overflowing tombstone leaf is born ADDED, decays to DELETED, then is dropped") {
+    withSQLConf(DeltaSQLConf.AMT_ENTRIES_PER_LEAF.key -> "10") {
+      withTables() { (baselineDeltaLog, amtDeltaLog) =>
+        setup(baselineDeltaLog, amtDeltaLog, entriesPerLeaf = 10,
+          initialIdRangeInLeaf = 1 to 30, initialIdRangeInRoot = 31 to 37)
+        // Inline: delete every root-resident file (no-backref -> DELETED tombstones) and append
+        // enough net-new files that the live adds spill into new leaves; the extra pointers push
+        // the tombstones past the cap, so they spill into their own leaf.
+        val actions =
+          (31 to 37).map(id => removeOf(amtDeltaLog, id)) ++ (130 to 150).map(fakeAdd)
+        withInline { commitBoth(baselineDeltaLog, amtDeltaLog, actions) }
+
+        // The freshly spilled tombstone leaf (7 DELETED entries, no live file) is born ADDED, not
+        // DELETED, and no leaf is DELETED on the commit that writes it.
+        val bornLeaves = leafPointers(amtDeltaLog.update())
+        val tombstoneLeaves =
+          bornLeaves.values.filter(_.manifest_info.deleted_files_count > 0).toSeq
+        assert(tombstoneLeaves.size == 1,
+          s"exactly one spilled tombstone leaf; got ${tombstoneLeaves.size}.")
+        val tombstoneLeaf = tombstoneLeaves.head
+        assert(tombstoneLeaf.tracking.status == Tracking.Status.Added,
+          s"a freshly spilled tombstone leaf is born ADDED; got ${tombstoneLeaf.tracking.status}.")
+        assert(tombstoneLeaf.manifest_info.added_files_count == 0 &&
+          tombstoneLeaf.manifest_info.existing_files_count == 0,
+          s"the tombstone leaf holds no live entries; got ${tombstoneLeaf.manifest_info}.")
+        assert(!bornLeaves.values.exists(_.tracking.status == Tracking.Status.Deleted),
+          "no leaf is DELETED on the commit that spills the tombstone leaf.")
+        assertLiveAddFilesEquals(baselineDeltaLog, amtDeltaLog)
+
+        // Next AMT: the carried tombstone leaf holds no live file, so it decays to DELETED.
+        val tombstoneLoc = tombstoneLeaf.location
+        commitCheckpoint(amtDeltaLog, incremental = true)
+        assert(leafPointers(amtDeltaLog.update())(tombstoneLoc).tracking.status ==
+          Tracking.Status.Deleted,
+          "a carried leaf with no live file must decay to DELETED.")
+
+        // Next AMT: the DELETED leaf is dropped.
+        commitCheckpoint(amtDeltaLog, incremental = true)
+        assert(!leafPointers(amtDeltaLog.update()).contains(tombstoneLoc),
+          "a DELETED leaf must be dropped by the next AMT.")
+      }
+    }
+  }
+
+  test("G12: a spilled tombstone leaf counts a REPLACED + DELETED mix") {
+    withSQLConf(DeltaSQLConf.AMT_ENTRIES_PER_LEAF.key -> "10") {
+      withTables() { (baselineDeltaLog, amtDeltaLog) =>
+        setup(baselineDeltaLog, amtDeltaLog, entriesPerLeaf = 10,
+          initialIdRangeInLeaf = 1 to 30, initialIdRangeInRoot = 31 to 37)
+        // Inline: DELETE 3 root-resident files (31..33) and REPLACE the other 4 (34..37, remove +
+        // re-add with a new DV), plus append net-new files so the tombstones overflow into a
+        // spilled leaf.
+        val actions =
+          Seq(31, 32, 33).map(id => removeOf(amtDeltaLog, id)) ++
+            Seq(34, 35, 36, 37).flatMap(id => removeAndReAddWithDV(amtDeltaLog, Left(id))) ++
+            (130 to 150).map(fakeAdd)
+        withInline { commitBoth(baselineDeltaLog, amtDeltaLog, actions) }
+        // The 7 tombstones spill into exactly one leaf, born ADDED (not DELETED) with no live
+        // entry; its manifest_info counts the 3 DELETED + 4 REPLACED mix.
+        val tombstoneLeaves = leafPointers(amtDeltaLog.update()).values.filter(l =>
+          l.manifest_info.deleted_files_count + l.manifest_info.replaced_files_count > 0).toSeq
+        assert(tombstoneLeaves.size == 1,
+          s"the 7 tombstones must spill into exactly one leaf; got ${tombstoneLeaves.size}.")
+        val mi = tombstoneLeaves.head.manifest_info
+        assert(tombstoneLeaves.head.tracking.status == Tracking.Status.Added,
+          s"a freshly spilled tombstone leaf is born ADDED; got ${tombstoneLeaves.head.tracking}.")
+        assert(mi.deleted_files_count == 3 && mi.replaced_files_count == 4,
+          s"the tombstone leaf must count 3 DELETED + 4 REPLACED entries; got $mi.")
+        assert(mi.added_files_count == 0 && mi.existing_files_count == 0,
+          s"the tombstone leaf holds no live entries; got $mi.")
+        assertLiveAddFilesEquals(baselineDeltaLog, amtDeltaLog)
+      }
+    }
+  }
+
+  test("G13: one inline write spills live leaves and a tombstone leaf, all born ADDED") {
+    withSQLConf(DeltaSQLConf.AMT_ENTRIES_PER_LEAF.key -> "10") {
+      withTables() { (baselineDeltaLog, amtDeltaLog) =>
+        setup(baselineDeltaLog, amtDeltaLog, entriesPerLeaf = 10,
+          initialIdRangeInLeaf = 1 to 30, initialIdRangeInRoot = 31 to 37)
+        val actions =
+          (31 to 37).map(id => removeOf(amtDeltaLog, id)) ++ (130 to 150).map(fakeAdd)
+        withInline { commitBoth(baselineDeltaLog, amtDeltaLog, actions) }
+        // The single write spills freshly ADDED live leaves (from the net-new adds) and an ADDED
+        // tombstone leaf (from the overflowing DELETED tombstones); every newly written leaf is
+        // born ADDED, distinguished only by its manifest_info counts, and none is born DELETED.
+        val newLeaves = leafPointers(amtDeltaLog.update()).values
+          .filter(_.tracking.status == Tracking.Status.Added).toSeq
+        assert(newLeaves.exists(_.manifest_info.added_files_count > 0),
+          s"the net-new adds must spill into ADDED live leaves; got $newLeaves.")
+        assert(newLeaves.count(_.manifest_info.deleted_files_count > 0) == 1,
+          s"the overflowing tombstones must spill into one ADDED tombstone leaf; got $newLeaves.")
+        assert(!leafPointers(amtDeltaLog.update()).values.exists(
+          _.tracking.status == Tracking.Status.Deleted),
+          "no leaf is born DELETED.")
+        assertLiveAddFilesEquals(baselineDeltaLog, amtDeltaLog)
+      }
+    }
+  }
+
+  test("G14: an inline same-key re-add of an already-live file with dataChange=false is allowed") {
+    withSQLConf(DeltaSQLConf.AMT_ENTRIES_PER_LEAF.key -> "10") {
+      withTables() { (baselineDeltaLog, amtDeltaLog) =>
+        setup(baselineDeltaLog, amtDeltaLog, entriesPerLeaf = 10, initialIdRangeInLeaf = 1 to 30)
+        val leafToAddFileMapping = leafToAddFileMap(amtDeltaLog)
+        assert(leafToAddFileMapping.size >= 2,
+          s"Need a tree-shaped bootstrap; got ${leafToAddFileMapping.size} leaves.")
+        val livePathsBefore = livePathsInLatestAMTCheckpoint(amtDeltaLog)
+        // The allowed counterpart to H4 and the happy path of invariant (3): ComputeStats
+        // re-commits a currently-live leaf file with recomputed stats and dataChange=false. It
+        // stays EXISTING and the file is surfaced exactly once -- one EXISTING root entry, its old
+        // leaf slot MDV-masked.
+        val liveLeafFile = leafToAddFileMapping.toSeq.sortBy(_._1).head._2.head
+        assert(liveLeafFile.backReference.isDefined, "The re-added file must be leaf-resident.")
+        withInline {
+          amtDeltaLog.startTransaction().commit(
+            Seq(liveLeafFile.copy(dataChange = false)),
+            DeltaOperations.ComputeStats(predicate = Nil))
+        }
+        assert(livePathsInLatestAMTCheckpoint(amtDeltaLog) == livePathsBefore,
+          "Re-adding an already-live file must not change the reconstructed live set.")
+        assert(rootDataEntryStatusToCount(amtDeltaLog) == Map(Tracking.Status.Existing -> 1L),
+          s"The re-added file must be a single EXISTING root entry; got " +
+            s"${rootDataEntryStatusToCount(amtDeltaLog)}.")
+      }
+    }
+  }
+
+  /**
+   * A leaf-resident file F (back reference -> its leaf slot) AND a root-resident file R (no back
+   * reference) are each re-committed under their SAME (path, dv) key with dataChange=false in TWO
+   * commits -- first a deferred window commit, then an inline commit (metadata-only refreshes, e.g.
+   * ComputeStats). Both must stay live EXACTLY once as EXISTING root entries (F's old leaf slot
+   * MDV-masked), no matter what the inline re-add carries.
+   *
+   * `dropInlineBackReference` toggles how F's inline re-add is recognized as an already-live key:
+   *   - false: it carries F's leaf back reference (recognized via the back reference);
+   *   - true:  it carries NO back reference (recognized via the pre-commit live set, since the
+   *            window commit already put F's key there -- the branch that would silently regress if
+   *            preCommitLiveKeys were dropped).
+   * R is root-resident (no leaf slot), so it is always recognized via the pre-commit live set --
+   * every variant exercises that path for the root file.
+   */
+  private def assertWindowThenInlineSameKeyReAddStaysExisting(
+      dropInlineBackReference: Boolean): Unit = {
+    withSQLConf(DeltaSQLConf.AMT_ENTRIES_PER_LEAF.key -> "10") {
+      withTables() { (baselineDeltaLog, amtDeltaLog) =>
+        setup(baselineDeltaLog, amtDeltaLog, entriesPerLeaf = 10, initialIdRangeInLeaf = 1 to 30)
+        // Append one net-new file that stays root-resident (no leaf slot -> no back reference).
+        val rootId = 31
+        withInline { commitBoth(baselineDeltaLog, amtDeltaLog, Seq(fakeAdd(rootId))) }
+
+        val leafToAddFileMapping = leafToAddFileMap(amtDeltaLog)
+        assert(leafToAddFileMapping.size >= 2,
+          s"Need a tree-shaped bootstrap; got ${leafToAddFileMapping.size} leaves.")
+        val leafFile = leafToAddFileMapping.toSeq.sortBy(_._1).head._2.head
+        assert(leafFile.backReference.isDefined, "F must be leaf-resident (has a back reference).")
+        val rootPath = fakeAdd(rootId).path
+        val rootFile = liveAddFilesInLatestSnapshot(amtDeltaLog).find(_.path == rootPath)
+          .getOrElse(fail(s"root file $rootId is not live."))
+        assert(rootFile.backReference.isEmpty, "R must be root-resident (no back reference).")
+        val livePathsBefore = livePathsInLatestAMTCheckpoint(amtDeltaLog)
+
+        // Deferred window commit: re-add both F and R (same key, dataChange=false). F carries its
+        // leaf back reference; R carries none.
+        commitBoth(
+          baselineDeltaLog, amtDeltaLog,
+          Seq(leafFile.copy(dataChange = false), rootFile.copy(dataChange = false)),
+          operation = DeltaOperations.ComputeStats(predicate = Nil))
+
+        // Inline commit: re-add both again. The variant decides whether F's inline action carries
+        // its back reference; R never has one. F becomes a root EXISTING entry with its old leaf
+        // slot masked; R stays a root EXISTING entry -- two EXISTING root entries, one masked bit.
+        val inlineLeafReAdd = leafFile.copy(
+          dataChange = false,
+          backReference = if (dropInlineBackReference) None else leafFile.backReference)
+        createIncrementalAMTAndValidate(
+          baselineDeltaLog, amtDeltaLog,
+          createIncrementalAMTWriteMetrics(
+            numOldLeavesUpdated = 1,
+            numOldLeavesUntouched = leafToAddFileMapping.size - 1,
+            numRootEntriesExistingStatus = 2,
+            numLeafMdvBitsAdded = 1,
+            numLeavesModifiedStatus = 1,
+            numLeavesExistingStatus = leafToAddFileMapping.size - 1),
+          inlineAMTCommitActions =
+            Some(Seq(inlineLeafReAdd, rootFile.copy(dataChange = false))),
+          inlineOperation = DeltaOperations.ComputeStats(predicate = Nil))
+        assert(livePathsInLatestAMTCheckpoint(amtDeltaLog) == livePathsBefore,
+          "Re-adding already-live files across a window + inline commit must not change the " +
+            "reconstructed live set.")
+        assert(rootDataEntryStatusToCount(amtDeltaLog) == Map(Tracking.Status.Existing -> 2L),
+          s"F and R must be two EXISTING root entries; got " +
+            s"${rootDataEntryStatusToCount(amtDeltaLog)}.")
+      }
+    }
+  }
+
+  test("G15: a window then inline same-key re-add (dataChange=false) of a leaf and a root file, " +
+      "the inline actions carrying back references, keeps both EXISTING") {
+    assertWindowThenInlineSameKeyReAddStaysExisting(dropInlineBackReference = false)
+  }
+
+  test("G16: a window then inline same-key re-add (dataChange=false) where the inline leaf " +
+      "action carries no back reference still keeps both EXISTING (recognized via the live set)") {
+    assertWindowThenInlineSameKeyReAddStaysExisting(dropInlineBackReference = true)
+  }
+
+  test("G17: a restore round-trip re-adds removed leaf and root files and drops the interim " +
+      "add, returning the reconstructed live set to the prior committed state") {
+    withSQLConf(DeltaSQLConf.AMT_ENTRIES_PER_LEAF.key -> "10") {
+      withTables() { (baselineDeltaLog, amtDeltaLog) =>
+        // Commit-A / tree: the bootstrap adds files into a mixed committed state A that holds both
+        // leaf-resident files and root-resident files (it fills the root exactly, so adding more
+        // would spill those root entries into leaves -- keep it as the state we restore back to).
+        val rootIds = 31 to 37
+        setup(baselineDeltaLog, amtDeltaLog, entriesPerLeaf = 10,
+          initialIdRangeInLeaf = 1 to 30, initialIdRangeInRoot = rootIds)
+        assert(rootIds.nonEmpty, "need at least one root-resident file.")
+        val stateA = livePathsInLatestAMTCheckpoint(amtDeltaLog)
+
+        // Pick a leaf-resident (back-referenced) and a root-resident (no back reference) victim.
+        val leafVictim = leafToAddFileMap(amtDeltaLog).toSeq.sortBy(_._1).head._2.head
+        assert(leafVictim.backReference.isDefined, "leaf victim must be leaf-resident.")
+        val rootPaths = rootIds.map(id => fakeAdd(id).path).toSet
+        val rootVictim = liveAddFilesInLatestSnapshot(amtDeltaLog)
+          .find(a => a.backReference.isEmpty && rootPaths.contains(a.path))
+          .getOrElse(fail("need a live root-resident file to remove."))
+        val newId = 330
+
+        // Commit: remove both victims from the tree and add a new file; checkpoint -> state B, so
+        // the victims are gone (leaf slot masked, root tombstoned) and the new file is live.
+        commitBoth(baselineDeltaLog, amtDeltaLog,
+          Seq(leafVictim.remove, rootVictim.remove, fakeAdd(newId)))
+        commitCheckpoint(amtDeltaLog, incremental = true)
+        val stateB = livePathsInLatestAMTCheckpoint(amtDeltaLog)
+        assert(!stateB.contains(leafVictim.path) && !stateB.contains(rootVictim.path),
+          "both victims must be gone in state B.")
+        assert(stateB.contains(fakeAdd(newId).path), "the new file must be live in state B.")
+
+        // Commit_Inline (restore): re-add both victims as fresh adds -- their tree slots are gone,
+        // so they carry no back reference and land as new root entries -- and remove the interim
+        // new file, restoring the reconstructed live set to state A.
+        withInline {
+          commitBoth(baselineDeltaLog, amtDeltaLog, Seq(
+            leafVictim.copy(backReference = None, dataChange = true),
+            rootVictim.copy(backReference = None, dataChange = true),
+            removeOf(amtDeltaLog, newId)))
+        }
+        assert(livePathsInLatestAMTCheckpoint(amtDeltaLog) == stateA,
+          s"the restore must return the reconstructed live set to state A; " +
+            s"got ${livePathsInLatestAMTCheckpoint(amtDeltaLog).diff(stateA)} extra / " +
+            s"${stateA.diff(livePathsInLatestAMTCheckpoint(amtDeltaLog))} missing.")
+        assertLiveAddFilesEquals(baselineDeltaLog, amtDeltaLog)
+      }
+    }
+  }
+
+  /**
+   * A mixed old root deleted across every file-residence at once, folded into one incremental AMT
+   * on both the deferred and the inline route (the gridTest parameter). Steps:
+   *   - Full-rewrite a tree of 2 leaves holding 20 [[DataEntry]]s; the root holds no DataEntry.
+   *   - Add 8 more files and take a deferred manifest commit: they stay root-resident, so the root
+   *     is now MIXED -- 8 live root DataEntries alongside the 2 leaf pointers.
+   *   - IC-1: add 10 files.
+   *   - IC-2: remove one IC-1 file -- cancels against its own add in replay.
+   *   - IC-3: remove across three sources -- an old-root, two leaf and two IC-1 files.
+   *   - IC-4: the same three-source remove, plus 10 new adds in the one commit.
+   *   - IC-5: add 4 files and remove two more old-root files.
+   *   - Final write: remove one file from each source (IC-4, IC-1, old-root, a leaf) plus 4 new
+   *     adds, folded either as a deferred manifest commit (empty actionsToCommit) or inline (the
+   *     final commit carries the actions -- the only route that writes tombstones).
+   *   - Assert the folded tree reconstructs the expected live set and the per-route metrics.
+   *
+   * Residence decides how a remove resolves: a leaf-resident file is masked by an MDV bit on its
+   * carried pointer (no leaf rewrite); a root-resident file is dropped by replay (and only inline
+   * leaves a tracking=removed tombstone); an intermediate add's remove cancels against its own add.
+   */
+  gridTest("G18: a mixed old root plus multi-source deletes across intermediate commits" +
+    " folds into one incremental AMT")(Seq(false, true)) { inlineFinalWrite =>
+    withSQLConf(DeltaSQLConf.AMT_ENTRIES_PER_LEAF.key -> "10") {
+      withTables() { (baselineDeltaLog, amtDeltaLog) =>
+        // ---- Old root: 20 files packed into leaves, then 8 more added root-resident. ----
+        // The full rewrite puts all 20 in leaves; the incremental that follows keeps its 8 net-new
+        // adds in the root (2 carried pointers + 8 adds == the cap of 10, so nothing spills). That
+        // leaves the old root genuinely mixed, which a full checkpoint alone can never produce.
+        setup(baselineDeltaLog, amtDeltaLog, entriesPerLeaf = 10, initialIdRangeInLeaf = 1 to 20)
+        val oldLeaves = leafToAddFileMap(amtDeltaLog)
+
+        val rootIds = 101 to 108
+        commitBoth(baselineDeltaLog, amtDeltaLog, rootIds.map(fakeAdd))
+        createIncrementalAMTAndValidate(
+          baselineDeltaLog,
+          amtDeltaLog,
+          createIncrementalAMTWriteMetrics(
+            numOldLeavesUntouched = oldLeaves.size,
+            numRootEntriesExistingStatus = rootIds.size,
+            numLeavesExistingStatus = oldLeaves.size))
+        val (rootLiveAddsBefore, _) = liveAddsAndTombstonesCountInRoot(amtDeltaLog)
+        assert(rootLiveAddsBefore == rootIds.size,
+          s"The old root must hold ${rootIds.size} live adds of its own; got $rootLiveAddsBefore.")
+
+        // Leaf victims are picked against the ACTUAL hash-based assignment rather than assumed, so
+        // the removes carry the back references the writer really stamped. IC-3 and IC-4 take two
+        // each and the final write takes one more, so five are needed; taking three per leaf keeps
+        // that satisfied without depending on how the rewrite distributed the files.
+        val leafVictims = oldLeaves.toSeq.sortBy(_._1).flatMap(_._2.take(3))
+        assert(leafVictims.size >= 5, s"Need >= 5 leaf victims; got ${leafVictims.size}.")
+
+        // ---- IC-1: add 10 files. Root-resident (they do not spill until the fold). ----
+        val ic1Ids = 201 to 210
+        commitBoth(baselineDeltaLog, amtDeltaLog, ic1Ids.map(fakeAdd))
+
+        // ---- IC-2: delete one of IC-1's files -> cancels against its own add in replay. ----
+        commitBoth(baselineDeltaLog, amtDeltaLog, Seq(removeOf(amtDeltaLog, ic1Ids.head)))
+
+        // ---- IC-3: delete from THREE sources at once: old root, leaves, IC-1. ----
+        commitBoth(
+          baselineDeltaLog, amtDeltaLog,
+          Seq(removeOf(amtDeltaLog, rootIds.head)) ++
+            leafVictims.take(2).map(_.remove) ++
+            ic1Ids.slice(1, 3).map(removeOf(amtDeltaLog, _)))
+
+        // ---- IC-4: the same three-source delete, plus 10 more adds in the same commit. ----
+        val ic4Ids = 301 to 310
+        commitBoth(
+          baselineDeltaLog, amtDeltaLog,
+          Seq(removeOf(amtDeltaLog, rootIds(1))) ++
+            leafVictims.slice(2, 4).map(_.remove) ++
+            ic1Ids.slice(3, 5).map(removeOf(amtDeltaLog, _)) ++
+            ic4Ids.map(fakeAdd))
+
+        // ---- IC-5: add 4, and delete 2 more of the old root's files. ----
+        val ic5Ids = 401 to 404
+        commitBoth(
+          baselineDeltaLog, amtDeltaLog,
+          ic5Ids.map(fakeAdd) ++ rootIds.slice(2, 4).map(removeOf(amtDeltaLog, _)))
+
+        // ---- The final write: one file from each source removed, plus 4 new adds. ----
+        val finalIds = 501 to 504
+        val finalActions =
+          Seq(
+            removeOf(amtDeltaLog, ic4Ids.head),
+            removeOf(amtDeltaLog, ic1Ids(5)),
+            removeOf(amtDeltaLog, rootIds(4))) ++
+            Seq(leafVictims(4).remove) ++
+            finalIds.map(fakeAdd)
+
+        // Live net-new adds surviving into the new root, by origin:
+        //   old root  8 - 1 (IC-3) - 1 (IC-4) - 2 (IC-5) - 1 (final) = 3
+        //   IC-1     10 - 1 (IC-2) - 2 (IC-3) - 2 (IC-4) - 1 (final) = 4
+        //   IC-4     10 - 1 (final)                                  = 9
+        //   IC-5      4                                              = 4
+        //   final     4                                              = 4
+        val expectedLiveAdds = 3 + 4 + 9 + 4 + 4
+        // Five leaf-resident removes across IC-3, IC-4 and the final write, each contributing one
+        // MDV bit. Which leaves those five land on follows the rewrite's hash placement, so derive
+        // the updated/untouched split from the victims actually chosen rather than assuming every
+        // leaf is hit.
+        val expectedMdvBits = 5
+        val victimLeaves = leafVictims.take(expectedMdvBits)
+          .flatMap(_.backReference.map(_.manifest)).toSet
+        val leavesUpdated = victimLeaves.size
+        val leavesUntouched = oldLeaves.size - leavesUpdated
+        // Only the inline route sources CDF from actionsToCommit, so only it writes tombstones --
+        // one per no-backref remove in the final commit (the IC-4, IC-1 and old-root files; the
+        // leaf one is masked instead).
+        val expectedTombstones = if (inlineFinalWrite) 3 else 0
+        // spillIfNeeded moves whole cap-sized batches of live adds out until the root fits:
+        //   while (fixedRootCount + spilled + remaining > cap && remaining.nonEmpty)
+        // with fixedRootCount = carried pointers + tombstones.
+        val fixedRootCount = oldLeaves.size + expectedTombstones
+        var spilled = 0
+        var remaining = expectedLiveAdds
+        while (fixedRootCount + spilled + remaining > 10 && remaining > 0) {
+          remaining = math.max(0, remaining - 10)
+          spilled += 1
+        }
+        // Under this branch's enriched metrics the writer also reports the new tree's leaf-pointer
+        // status mix (untouched -> EXISTING, MDV-grown -> MODIFIED, freshly spilled -> ADDED) and,
+        // on the inline route only, the per-commit deleted CDF bit for the one leaf-resident remove
+        // in the final commit (leafVictims(4)); the deferred route sources no CDF from its fold.
+        val expectedLeafDeleteCDFBits = if (inlineFinalWrite) 1 else 0
+        // Of the live adds that remain in the root after spilling, the deferred fold proposes no
+        // insert (empty actionsToCommit), so every remaining root live add is EXISTING; the inline
+        // route spills them all (remaining == 0).
+        val rootExistingLiveAdds = if (inlineFinalWrite) 0 else remaining
+        val expectedMetrics = createIncrementalAMTWriteMetrics(
+          numOldLeavesUpdated = leavesUpdated,
+          numOldLeavesUntouched = leavesUntouched,
+          numNewLeaves = spilled,
+          numRootEntriesAddedStatus = remaining - rootExistingLiveAdds,
+          numRootEntriesExistingStatus = rootExistingLiveAdds,
+          numRootEntriesDeletedStatus = expectedTombstones,
+          numLeafMdvBitsAdded = expectedMdvBits,
+          numLeafDeleteCDFBitsAdded = expectedLeafDeleteCDFBits,
+          numLeavesAddedStatus = spilled,
+          numLeavesExistingStatus = leavesUntouched,
+          numLeavesModifiedStatus = leavesUpdated)
+
+        if (inlineFinalWrite) {
+          // The inline route commits the actions and the tree in ONE commit, so the metrics come
+          // off that commit rather than a follow-up OPTIMIZE CHECKPOINT.
+          createIncrementalAMTAndValidate(
+            baselineDeltaLog, amtDeltaLog, expectedMetrics,
+            inlineAMTCommitActions = Some(finalActions))
+        } else {
+          // The deferred route commits the actions as one more intermediate commit, then folds
+          // everything in with an empty actionsToCommit.
+          commitBoth(baselineDeltaLog, amtDeltaLog, finalActions)
+          createIncrementalAMTAndValidate(
+            baselineDeltaLog, amtDeltaLog, expectedMetrics,
+            // IC-1..IC-5, the final write, and the bootstrap incremental's own commit.
+            expectedNumIntermediateCommits = Some(7))
+        }
+
+        // The differential oracle above already pins the live set; state the total explicitly too,
+        // since the whole point of the scenario is that 39 files survive this churn.
+        val expectedLiveTotal = expectedLiveAdds + (20 - expectedMdvBits)
+        assert(livePathsInLatestAMTCheckpoint(amtDeltaLog).size == expectedLiveTotal,
+          s"The tree must reconstruct exactly $expectedLiveTotal live files; got " +
+            s"${livePathsInLatestAMTCheckpoint(amtDeltaLog).size}.")
+      }
+    }
+  }
+
+  /////////////////////////////////////////////////////////////
+  // Section-H:                                              //
+  //     Invariant enforcement: rejecting commits that       //
+  //      break a write- or commit-shape invariant           //
+  /////////////////////////////////////////////////////////////
+
+  private def processedActions(
+      oldRootAdds: Seq[AddFile],
+      actionsToCommit: Seq[Action]): ProcessedActions =
+    new ProcessedActions(
+      oldAMTVersion = 0L,
+      oldRootAdds = oldRootAdds,
+      nonContentFromOldCheckpoint = Seq[Action](Protocol(), Metadata()),
+      windowCommits = Nil,
+      windowCommitActions = Nil,
+      attemptVersion = 1L,
+      actionsToCommit = actionsToCommit)
+
+  test("H1: writeIncremental rejects intermediate commits with a hole up to attemptVersion") {
+    withSQLConf(leafPackingConfs: _*) {
+      withTables() { (baselineDeltaLog, amtDeltaLog) =>
+        commitBoth(baselineDeltaLog, amtDeltaLog, Seq(fakeAdd(1), fakeAdd(2)))
+        // A base AMT to build intermediate commits on.
+        commitCheckpoint(amtDeltaLog, incremental = false)
+        val snapshot = amtDeltaLog.update()
+        val provider = amtProvider(snapshot).getOrElse(fail("expected AMTCheckpointProvider"))
+        val oldAMTVersion = provider.checkpointAction.version
+        val intermediateLogCommits = snapshot.logSegment.deltas
+          .filter(f => FileNames.getFileVersion(f) > oldAMTVersion)
+        // They only reach snapshot.version, so [oldAMTVersion+1, snapshot.version+5) has a
+        // hole -> the Step-0 coverage assert must fire.
+        intercept[AssertionError] {
+          new IncrementalAMTWriter(spark, amtDeltaLog).writeIncremental(
+            oldAMTVersion = oldAMTVersion,
+            oldAMTCheckpointProvider = provider,
+            intermediateLogCommits = intermediateLogCommits,
+            attemptVersion = snapshot.version + 5,
+            actionsToCommit = Seq.empty,
+            trigger = AMTTriggerMode.CheckpointIntervalIncremental.name)
+        }
+      }
+    }
+  }
+
+  test("H2: an inline no-backref remove with no originating AddFile is rejected") {
+    withSQLConf(leafPackingConfs: _*) {
+      withTables() { (baselineDeltaLog, amtDeltaLog) =>
+        commitBoth(baselineDeltaLog, amtDeltaLog, (1 to leafPackedFiles).map(fakeAdd))
+        commitCheckpoint(amtDeltaLog, incremental = false)
+        // A no-backref remove for a path that was never added has no originating AddFile in
+        // root + window, so buildRootRemoveEntries cannot build a CDF entry, and rejects it.
+        val ex = intercept[IllegalStateException] {
+          withInline {
+            amtDeltaLog.startTransaction().commit(Seq(fakeAdd(999999).remove), writeOperation)
+          }
+        }
+        assert(ex.getMessage.contains("No originating AddFile"),
+          s"expected the missing-origin invariant; got: ${ex.getMessage}")
+      }
+    }
+  }
+
+  test("H3: an inline same-key re-add of an already-live file with dataChange=true is rejected") {
+    withSQLConf(leafPackingConfs: _*) {
+      withTables() { (baselineDeltaLog, amtDeltaLog) =>
+        commitBoth(baselineDeltaLog, amtDeltaLog, (1 to leafPackedFiles).map(fakeAdd))
+        commitCheckpoint(amtDeltaLog, incremental = false)
+        val leafToAddFileMapping = leafToAddFileMap(amtDeltaLog)
+        assert(leafToAddFileMapping.size >= 2,
+          s"Need a tree-shaped bootstrap; got ${leafToAddFileMapping.size} leaves.")
+        // Re-commit a currently-live leaf file under its SAME (path, dv) key -- carrying the leaf
+        // back reference it was reconstructed with -- in one inline commit with dataChange = true.
+        // A same-key re-add of an already-live file is a metadata-only refresh (dataChange = false,
+        // as in D11); a data-changing re-add is rejected by the incremental writer.
+        val liveLeafFile = leafToAddFileMapping.toSeq.sortBy(_._1).head._2.head
+        assert(liveLeafFile.backReference.isDefined, "The re-added file must be leaf-resident.")
+        val ex = intercept[IllegalStateException] {
+          withInline {
+            amtDeltaLog.startTransaction().commit(
+              Seq(liveLeafFile.copy(dataChange = true)),
+              DeltaOperations.ComputeStats(predicate = Nil))
+          }
+        }
+        assert(ex.getMessage.contains("dataChange=true is not allowed"),
+          s"expected the data-changing re-add rejection; got: ${ex.getMessage}")
+      }
+    }
+  }
+
+  test("H4: (1) a dataChange=true commit rejects a same-key re-add of an already-live file") {
+    val ex = intercept[IllegalStateException] {
+      processedActions(
+        oldRootAdds = Seq(fakeAdd(1)),
+        actionsToCommit = Seq(fakeAdd(1, dataChange = true)))
+    }
+    assert(ex.getMessage.contains("dataChange=true is not allowed"),
+      s"expected invariant (1); got: ${ex.getMessage}")
+  }
+
+  test("H5: (2) a dataChange=false commit with removes rejects a re-add of an already-live file") {
+    val ex = intercept[IllegalStateException] {
+      processedActions(
+        oldRootAdds = Seq(fakeAdd(1), fakeAdd(2)),
+        actionsToCommit = Seq(
+          fakeAdd(1).remove.copy(dataChange = false),
+          fakeAdd(2, dataChange = false)))
+    }
+    assert(ex.getMessage.contains("must not re-add an already-live file"),
+      s"expected invariant (2); got: ${ex.getMessage}")
+  }
+
+  test("H6: (3) a dataChange=false commit with no removes rejects a new (non-re-add) file") {
+    val ex = intercept[IllegalStateException] {
+      processedActions(
+        oldRootAdds = Seq(fakeAdd(1)),
+        actionsToCommit = Seq(fakeAdd(99, dataChange = false)))
+    }
+    assert(ex.getMessage.contains("must re-add only already-live files"),
+      s"expected invariant (3); got: ${ex.getMessage}")
+  }
+
+  test("H7: the three legal commit shapes construct and classify their adds correctly") {
+    // (1)-legal: a data-changing append of a genuinely new file -> not a re-add.
+    val append = processedActions(
+      oldRootAdds = Seq(fakeAdd(1)),
+      actionsToCommit = Seq(fakeAdd(2, dataChange = true)))
+    assert(append.reCommittedLiveAdd.isEmpty)
+    // (2)-legal: a metadata-only compaction removing a live file and adding a fresh one -> not a
+    // re-add of an already-live file.
+    val compaction = processedActions(
+      oldRootAdds = Seq(fakeAdd(1)),
+      actionsToCommit = Seq(
+        fakeAdd(1).remove.copy(dataChange = false),
+        fakeAdd(2, dataChange = false)))
+    assert(compaction.reCommittedLiveAdd.isEmpty)
+    // (3)-legal: a metadata-only stats refresh re-adding an already-live file under the same key.
+    val refresh = processedActions(
+      oldRootAdds = Seq(fakeAdd(1)),
+      actionsToCommit = Seq(fakeAdd(1, dataChange = false)))
+    assert(refresh.reCommittedLiveAdd.isDefined)
+  }
+
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This fixes the per-entry `tracking.status` of `DATA` entries and the leaf `ManifestInfo`
file counts on the incremental AMT (Adaptive Metadata Tree) write path, and records the
Change Data Feed (CDF) information the incremental writer did not previously populate.

- A live root-resident `DataEntry` is now classified per file: `ADDED` when this commit
  inserted it, `MODIFIED` when this commit re-added it under a new deletion vector (an
  update / replace), and `EXISTING` when it is carried forward unchanged.
- A spilled leaf's `ManifestInfo` counts its entries by status
  (added / existing / deleted / replaced) instead of counting every entry as added.
- DELETE vs REPLACE is recorded structurally: a removed file with no re-add becomes a
  `DELETED` tombstone; a removed file re-added under a new deletion vector becomes a
  `REPLACED` entry paired with a `MODIFIED` live copy, with `deleted_positions` /
  `replaced_positions` stamped on the affected leaf pointer and the superseded leaf slot
  masked in that leaf's manifest deletion vector.
- Leaf-pointer lifecycle: a freshly written leaf (including a tombstone-only leaf) is born
  `ADDED`; on a later commit it decays to `DELETED` once it holds no live file, and the
  tombstone pointer is dropped by the commit after that.
- Net-removed files that overflow the per-leaf cap spill into their own leaf.

The full-rewrite path is unchanged.

## How was this patch tested?

Extended `AMTIncrementalWriteSuite` with end-to-end coverage of per-entry status
classification, leaf `ManifestInfo` counts, the DELETE-vs-REPLACE distinction,
deletion-vector masking of superseded slots, tombstone spilling, and the
born-`ADDED` -> `DELETED` -> dropped leaf-pointer lifecycle; `AMTCheckpointWriteSuite`
continues to pass.

## Does this PR introduce _any_ user-facing change?

No.
