### PR TITLE
[4.4][Flink] Publish versioned artifacts for Flink 2.0 through 2.3

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,12 +39,12 @@ jobs:
           key: delta-sbt-cache-cross-spark-${{ hashFiles('project/scripts/setup_unitycatalog_main.sh') }}
 
       # publishM2 compiles every aggregated project, including storage, which has
-      # unitycatalog-client as a compile-scope dependency. test_cross_spark_publish.py also
+      # unitycatalog-client as a compile-scope dependency. test_published_artifacts.py also
       # iterates over released Spark versions (sbt -DsparkVersion=<X.Y>), so we need UC's
       # spark connector published for each variant Delta will resolve. Discover the version list
       # at runtime from project/spark-versions.json (same source the matrix workflows use) and
       # invoke the setup script per variant; cache hits (the steady state) make the script a
-      # no-op. Snapshot versions are skipped by the cross-Spark test, so only released ones are
+      # no-op. Snapshot versions are skipped by the published-artifact test, so only released ones are
       # published here.
       - name: Set up pinned Unity Catalog for each released Spark version
         run: |
@@ -54,8 +54,8 @@ jobs:
             echo "::endgroup::"
           done
 
-      - name: Run cross-Spark build test
-        run: python project/tests/test_cross_spark_publish.py
+      - name: Test published artifacts
+        run: python project/tests/test_published_artifacts.py
 
       - name: Save SBT cache
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'

--- a/.github/workflows/flink_test.yaml
+++ b/.github/workflows/flink_test.yaml
@@ -6,6 +6,9 @@ on:
     paths:
       - 'flink/**'
       - 'kernel/**'
+      - 'build.sbt'
+      - 'project/CrossFlinkVersions.scala'
+      - '.github/workflows/flink_test.yaml'
       - '!**/*.md'
       - '!**/*.txt'
   pull_request:
@@ -13,6 +16,9 @@ on:
     paths:
       - 'flink/**'
       - 'kernel/**'
+      - 'build.sbt'
+      - 'project/CrossFlinkVersions.scala'
+      - '.github/workflows/flink_test.yaml'
       - '!**/*.md'
       - '!**/*.txt'
 
@@ -26,9 +32,34 @@ env:
   SBT_OPTS: "-Dsbt.coursier.home-dir=/home/runner/.cache/coursier -Dsbt.ivy.home=/home/runner/.ivy2"
 
 jobs:
-  test:
-    name: "DF"
+  generate-matrix:
+    name: "Generate Flink versions matrix"
     runs-on: ubuntu-24.04
+    outputs:
+      flink-versions: ${{ steps.versions.outputs.flink-versions }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - name: Install Java
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
+        with:
+          distribution: "zulu"
+          java-version: "17"
+      - name: Generate matrix
+        id: versions
+        run: |
+          build/sbt exportFlinkVersionsJson
+          versions="$(jq -c '[.[].fullVersion]' target/flink-versions.json)"
+          echo "flink-versions=$versions" >> "$GITHUB_OUTPUT"
+
+  test:
+    name: "DF: Flink ${{ matrix.flink }}"
+    needs: generate-matrix
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        flink: ${{ fromJson(needs.generate-matrix.outputs.flink-versions) }}
     steps:
       - name: Show runner specs
         run: |
@@ -56,7 +87,7 @@ jobs:
             ~/.sbt
             ~/.ivy2
             ~/.cache/coursier
-          key: sbt-flink
+          key: sbt-flink-${{ matrix.flink }}
       - name: Check cache status
         run: |
           if [ "${{ steps.cache-sbt.outputs.cache-hit }}" == "true" ]; then
@@ -70,7 +101,7 @@ jobs:
         uses: ./.github/actions/setup-unitycatalog
       - name: Run unit tests
         run: |
-          build/sbt flinkGroup/test
+          build/sbt -DflinkVersion=${{ matrix.flink }} flinkGroup/test
       - name: Save SBT cache
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
@@ -79,4 +110,4 @@ jobs:
             ~/.sbt
             ~/.ivy2
             ~/.cache/coursier
-          key: sbt-flink
+          key: sbt-flink-${{ matrix.flink }}

--- a/build.sbt
+++ b/build.sbt
@@ -64,7 +64,7 @@ val scalaTestVersionForConnectors = "3.0.8"
 val parquet4sVersion = "1.9.4"
 val protoVersion = "3.25.1"
 val grpcVersion = "1.62.2"
-val flinkVersion = "2.0.1"
+val flinkVersion = CrossFlinkVersions.getFlinkArtifactVersion()
 val gcsConnectorVersion = "4.0.4"
 
 // Optional kernel version override. See `project/KernelVersion.scala` for the
@@ -1636,9 +1636,14 @@ lazy val flink = (project in file("flink"))
   .dependsOn(kernelUnityCatalog)
   .settings(
     name := "delta-flink",
+    // Publish one artifact per compatible Flink minor line, for example delta-flink_2.0.
+    moduleName := s"delta-flink_${CrossFlinkVersions.getFlinkVersionSpec().shortVersion}",
     commonSettings,
     releaseSettings,
     javafmtCheckSettings(),
+    // The base release publishes non-Flink modules. Flink versions are published separately by
+    // CrossFlinkVersions.crossFlinkReleaseSteps.
+    publish / skip := sys.props.getOrElse("skipFlinkPublish", "false").toBoolean,
     publishArtifact := scalaBinaryVersion.value == "2.13", // only publish once
     autoScalaLibrary := false, // exclude scala-library from dependencies
     assembly / assemblyJarName := s"delta-flink-$flinkVersion-${version.value}.jar",
@@ -1946,7 +1951,8 @@ releaseProcess := Seq[ReleaseStep](
   setReleaseVersion,
   commitReleaseVersion,
   tagRelease
-) ++ CrossSparkVersions.crossSparkReleaseSteps("publishSigned") ++ Seq[ReleaseStep](
+) ++ CrossSparkVersions.crossSparkReleaseSteps("publishSigned") ++
+  CrossFlinkVersions.crossFlinkReleaseSteps("publishSigned") ++ Seq[ReleaseStep](
 
   // Do NOT use `sonatypeBundleRelease` - it will actually release to Maven! We want to do that
   // manually.

--- a/flink/README.md
+++ b/flink/README.md
@@ -8,7 +8,24 @@ Note: this is a private build right now. Suggestions and feedbacks are welcome.
 ```
 
 ### Supported Flink Versions
-- **Flink v2.0**
+
+Delta tests the latest patch release from each supported Flink minor line:
+
+| Flink line | Tested version |
+|------------|----------------|
+| 2.0        | 2.0.2          |
+| 2.1        | 2.1.3          |
+| 2.2        | 2.2.1          |
+| 2.3        | 2.3.0          |
+
+The default build uses Flink 2.3.0. To select a supported Flink version during development, set
+`flinkVersion` on the command line:
+
+```bash
+build/sbt -DflinkVersion=2.1 flink/test
+```
+
+The full tested version, such as `2.1.3`, is also accepted.
 
 ### Connector Overview
 - Built on **Flink Connector V2 API**

--- a/project/CrossFlinkVersions.scala
+++ b/project/CrossFlinkVersions.scala
@@ -1,0 +1,127 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.io.{File, PrintWriter}
+
+import sbt._
+import sbt.Keys._
+import sbtrelease.ReleasePlugin.autoImport.ReleaseStep
+
+case class FlinkVersionSpec(fullVersion: String) {
+
+  /** Returns the Flink compatibility version used in the Maven artifact name. */
+  def shortVersion: String = {
+    val (major, minor, _) = Mima.getMajorMinorPatch(fullVersion)
+    s"$major.$minor"
+  }
+}
+
+object FlinkVersionSpec {
+  private val defaultVersion = "2.3.0"
+
+  val DEFAULT = FlinkVersionSpec(defaultVersion)
+
+  val ALL_SPECS =
+    Seq("2.0.2", "2.1.3", "2.2.1", "2.3.0", defaultVersion)
+      .distinct
+      .map(FlinkVersionSpec.apply)
+
+  require(
+    ALL_SPECS.map(_.shortVersion).distinct.size == ALL_SPECS.size,
+    "Only one patch release can be published for each Flink compatibility line")
+}
+
+object CrossFlinkVersions extends AutoPlugin {
+
+  /** Returns the selected Flink version specification. */
+  def getFlinkVersionSpec(): FlinkVersionSpec = {
+    val input = sys.props.getOrElse("flinkVersion", FlinkVersionSpec.DEFAULT.fullVersion)
+    FlinkVersionSpec.ALL_SPECS.find { spec =>
+      spec.fullVersion == input || spec.shortVersion == input
+    }.getOrElse {
+      val validInputs = FlinkVersionSpec.ALL_SPECS.flatMap { spec =>
+        Seq(spec.fullVersion, spec.shortVersion)
+      }
+      throw new IllegalArgumentException(
+        s"Invalid flinkVersion: $input. Valid values: ${validInputs.mkString(", ")}")
+    }
+  }
+
+  /** Returns the Maven artifact version used for Apache Flink dependencies. */
+  def getFlinkArtifactVersion(): String = getFlinkVersionSpec().fullVersion
+
+  override def trigger = allRequirements
+
+  /** Adds one release step for every supported Flink version. */
+  def crossFlinkReleaseSteps(task: String): Seq[ReleaseStep] = {
+    FlinkVersionSpec.ALL_SPECS.map { spec =>
+      { (state: State) =>
+        val extracted = Project.extract(state)
+        val baseDir = extracted.get(ThisBuild / Keys.baseDirectory)
+        val command = Seq(
+          s"${baseDir.getAbsolutePath}/build/sbt",
+          s"-DflinkVersion=${spec.fullVersion}",
+          s"flink/$task")
+
+        println(s"[info] Publishing Flink module for Flink ${spec.fullVersion}")
+        val exitCode = scala.sys.process.Process(command, baseDir).!
+        if (exitCode != 0) {
+          sys.error(
+            s"Publishing Flink module for Flink ${spec.fullVersion} failed with exit code $exitCode")
+        }
+        state
+      }: ReleaseStep
+    }
+  }
+
+  override lazy val projectSettings = Seq(
+    // Runs the same Flink publication steps used by releaseProcess. This command lets CI exercise
+    // the real release path with a non-releasing task such as publishM2.
+    commands += Command.args("publishFlinkVersions", "<task>") { (state, args) =>
+      if (args.isEmpty) {
+        sys.error(
+          "Usage: publishFlinkVersions <task>\n" +
+            "Example: build/sbt \"publishFlinkVersions publishM2\"")
+      }
+      crossFlinkReleaseSteps(args.mkString(" ")).foldLeft(state) { (currentState, step) =>
+        step(currentState)
+      }
+    },
+    // Exports the supported Flink versions so CI can build its test matrix from the SBT source of
+    // truth instead of maintaining a separate version list in the workflow.
+    commands += Command.command("exportFlinkVersionsJson") { state =>
+      val outputFile = new File("target/flink-versions.json")
+      outputFile.getParentFile.mkdirs()
+
+      val writer = new PrintWriter(outputFile)
+      try {
+        writer.println("[")
+        FlinkVersionSpec.ALL_SPECS.zipWithIndex.foreach { case (spec, index) =>
+          val comma = if (index < FlinkVersionSpec.ALL_SPECS.size - 1) "," else ""
+          writer.println("  {")
+          writer.println(s"""    "fullVersion": "${spec.fullVersion}",""")
+          writer.println(s"""    "compatibilityVersion": "${spec.shortVersion}"""")
+          writer.println(s"  }$comma")
+        }
+        writer.println("]")
+      } finally {
+        writer.close()
+      }
+
+      println(s"[info] Flink version information exported to: ${outputFile.getAbsolutePath}")
+      state
+    })
+}

--- a/project/CrossSparkVersions.scala
+++ b/project/CrossSparkVersions.scala
@@ -518,7 +518,7 @@ object CrossSparkVersions extends AutoPlugin {
    * Generates release steps for cross-Spark publishing.
    *
    * Returns a sequence of release steps that:
-   * 1. Publishes all modules WITHOUT Spark suffix (backward compatibility)
+   * 1. Publishes non-Flink modules WITHOUT Spark suffix (backward compatibility)
    * 2. Publishes Spark-dependent modules WITH Spark suffix for each non-master version
    *
    * For example, with Spark versions 4.0, 4.1, and 4.2 (default):
@@ -560,13 +560,13 @@ object CrossSparkVersions extends AutoPlugin {
       state
     }
 
-    // Step 1: Publish ALL modules WITHOUT Spark suffix (backward compatibility)
-    // Uses skipSparkSuffix=true to get artifact names like delta-spark_2.13
+    // Step 1: Publish non-Flink modules WITHOUT Spark suffix (backward compatibility).
+    // Flink is published separately for every supported version.
     val backwardCompatStep: ReleaseStep = { (state: State) =>
       runSbtSubprocess(
         state,
-        Seq("-DskipSparkSuffix=true", task),
-        "Publishing all modules without Spark suffix (backward compat)"
+        Seq("-DskipSparkSuffix=true", "-DskipFlinkPublish=true", task),
+        "Publishing non-Flink modules without Spark suffix (backward compat)"
       )
     }
 

--- a/project/tests/test_published_artifacts.py
+++ b/project/tests/test_published_artifacts.py
@@ -1,19 +1,19 @@
 #!/usr/bin/env python3
 """
-Cross-Spark Version Build Testing
+Published Artifact Build Testing
 
-Tests the Delta Lake build system by validating JAR file names for:
+Tests the Delta Lake build system by validating published JAR file names for:
 1. Default publish (publishM2) - publishes ALL modules WITH Spark suffix
 2. Backward-compat publish (skipSparkSuffix=true) - publishes WITHOUT suffix
-3. Full cross-version workflow publishes both with and without suffix
+3. Full release workflow publishes every Spark and Flink artifact
 
 Usage:
-    python project/tests/test_cross_spark_publish.py
+    python project/tests/test_published_artifacts.py
 
 The script will:
 1. Test default publishM2 command publishes all modules WITH Spark suffix
 2. Test skipSparkSuffix=true publishes WITHOUT suffix (backward compatibility)
-3. Test full cross-version build workflow (both with and without suffix)
+3. Test the full Spark and Flink release workflow
 4. Exit with status 0 on success, 1 on failure
 """
 
@@ -61,7 +61,6 @@ NON_SPARK_RELATED_JAR_TEMPLATES = [
     "delta-kernel-defaults-{version}.jar",
     "delta-storage-s3-dynamodb-{version}.jar",
     "delta-kernel-unitycatalog-{version}.jar",
-    "delta-flink-{version}.jar",
     "delta-contribs_2.13-{version}.jar",
 ]
 
@@ -105,6 +104,12 @@ class SparkVersionSpec:
         return self.spark_related_jars + self.non_spark_related_jars + self.iceberg_jars + self.hudi_jars
 
 
+@dataclass
+class FlinkVersionSpec:
+    """Expected artifact for a supported Flink version."""
+    jar_template: str
+
+
 # Spark versions to test (key = full version string, value = spec with suffix)
 # By default, ALL versions get a Spark suffix (e.g., delta-spark_4.0_2.13)
 # skipSparkSuffix=true removes the suffix (used during release for backward compat)
@@ -115,9 +120,20 @@ SPARK_VERSIONS: Dict[str, SparkVersionSpec] = {
     "4.2.0": SparkVersionSpec(suffix="_4.2", support_iceberg=False, support_hudi=False)
 }
 
+# Keep this map independent from CrossFlinkVersions so this test detects missing artifacts.
+FLINK_VERSIONS: Dict[str, FlinkVersionSpec] = {
+    "2.0.2": FlinkVersionSpec(jar_template="delta-flink_2.0-{version}.jar"),
+    "2.1.3": FlinkVersionSpec(jar_template="delta-flink_2.1-{version}.jar"),
+    "2.2.1": FlinkVersionSpec(jar_template="delta-flink_2.2-{version}.jar"),
+    "2.3.0": FlinkVersionSpec(jar_template="delta-flink_2.3-{version}.jar"),
+}
+
 # The default Spark version
 # This is intentionally hardcoded here to explicitly test the default version.
 DEFAULT_SPARK = "4.2.0"
+
+# The default Flink version. This is intentionally hardcoded to test the default version.
+DEFAULT_FLINK = "2.3.0"
 
 
 def substitute_xversion(jar_templates: List[str], delta_version: str) -> Set[str]:
@@ -127,8 +143,8 @@ def substitute_xversion(jar_templates: List[str], delta_version: str) -> Set[str
     return {jar.format(version=delta_version) for jar in jar_templates}
 
 
-class CrossSparkPublishTest:
-    """Tests cross-Spark version builds."""
+class PublishedArtifactsTest:
+    """Tests the artifacts produced by default and cross-version builds."""
 
     def __init__(self, delta_root: Path):
         self.delta_root = delta_root
@@ -183,6 +199,35 @@ class CrossSparkPublishTest:
             print(f"  ✗ Command failed: {' '.join(command)}")
             return False
 
+    def test_flink_version_selection(self) -> bool:
+        """Flink selection accepts a compatibility version and rejects unknown versions."""
+        result = subprocess.run(
+            ["build/sbt", "-no-colors", "-DflinkVersion=2.1", "show flink/moduleName", "show flink/assembly/assemblyJarName"],
+            cwd=self.delta_root,
+            capture_output=True,
+            text=True,
+        )
+        output = result.stdout + result.stderr
+        if (result.returncode != 0 or "[info] delta-flink_2.1" not in output or
+                "[info] delta-flink-2.1.3-" not in output):
+            print("  ✗ Flink 2.1 did not select artifact version 2.1.3")
+            return False
+
+        result = subprocess.run(
+            ["build/sbt", "-no-colors", "-DflinkVersion=9.9.9", "show flink/name"],
+            cwd=self.delta_root,
+            capture_output=True,
+            text=True,
+        )
+        output = result.stdout + result.stderr
+        expected_error = "Invalid flinkVersion: 9.9.9."
+        if result.returncode == 0 or expected_error not in output:
+            print("  ✗ Unsupported Flink version was not rejected as expected")
+            return False
+
+        print("  ✓ Flink compatibility-version selection is valid")
+        return True
+
     def validate_jars(self, expected: Set[str], test_name: str) -> bool:
         """Validates that found JARs match expected JARs exactly."""
         found = self.find_all_jars()
@@ -233,6 +278,7 @@ class CrossSparkPublishTest:
 
         # Default behavior: all Spark-dependent modules have suffix (e.g., delta-spark_4.0_2.13)
         expected = substitute_xversion(spark_spec.all_jars, self.delta_version)
+        expected.add(FLINK_VERSIONS[DEFAULT_FLINK].jar_template.format(version=self.delta_version))
         return self.validate_jars(expected, "Default publishM2 (with suffix)")
 
     def test_backward_compat_publish(self) -> bool:
@@ -256,21 +302,26 @@ class CrossSparkPublishTest:
 
         # Expect artifacts WITHOUT suffix (e.g., delta-spark_2.13 instead of delta-spark_4.0_2.13)
         expected = substitute_xversion(spark_spec_no_suffix.all_jars, self.delta_version)
+        expected.add(FLINK_VERSIONS[DEFAULT_FLINK].jar_template.format(version=self.delta_version))
         return self.validate_jars(expected, "skipSparkSuffix=true (backward compat)")
 
-    def test_cross_spark_workflow(self) -> bool:
-        """Full cross-Spark workflow: backward-compat (no suffix) + all versions (with suffix)."""
+    def test_publish_workflow(self) -> bool:
+        """Full publish workflow: backward compatibility plus Spark and Flink cross-builds."""
         print("\n" + "="*70)
-        print("TEST: Cross-Spark Workflow (backward-compat + all non-master with suffix)")
+        print("TEST: Published Artifact Workflow")
         print("="*70)
 
         self.clean_maven_cache()
 
-        # Step 1: Publish all modules WITHOUT suffix (backward compatibility)
+        # Step 1: Publish non-Flink modules WITHOUT a Spark suffix.
         if not self.run_sbt_command(
-            "Step 1: build/sbt -DskipSparkSuffix=true publishM2 (backward compat, no suffix)",
-            ["build/sbt", "-DskipSparkSuffix=true", "publishM2"]
+            "Step 1: Publish base modules",
+            ["build/sbt", "-DskipSparkSuffix=true", "-DskipFlinkPublish=true", "publishM2"]
         ):
+            return False
+
+        if any(jar.startswith("delta-flink_") for jar in self.find_all_jars()):
+            print("  ✗ Base release unexpectedly published a Flink artifact")
             return False
 
         # Step 2: Publish Spark-dependent modules WITH suffix for each non-master version
@@ -285,10 +336,18 @@ class CrossSparkPublishTest:
             ):
                 return False
 
+        # Step 3: Publish every supported Flink version through the release implementation.
+        if not self.run_sbt_command(
+            "Step 3: build/sbt \"publishFlinkVersions publishM2\"",
+            ["build/sbt", "publishFlinkVersions publishM2"]
+        ):
+            return False
+
         # Build expected JARs:
-        # 1. All modules WITHOUT suffix (from Step 1 - backward compat)
+        # 1. Non-Flink modules WITHOUT a Spark suffix (from Step 1)
         # 2. Spark-dependent modules WITH suffix for each non-master version (from Step 2)
         # 3. Iceberg/Hudi JARs for supported versions (no Spark suffix)
+        # 4. Flink JARs for every supported compatibility version (from Step 3)
         expected = set()
 
         # Step 1: All modules without suffix (uses default Spark version's iceberg support)
@@ -305,7 +364,9 @@ class CrossSparkPublishTest:
             expected.update(substitute_xversion(spark_spec.iceberg_jars, self.delta_version))
             expected.update(substitute_xversion(spark_spec.hudi_jars, self.delta_version))
 
-        return self.validate_jars(expected, "Cross-Spark Workflow")
+        expected.update(substitute_xversion([spec.jar_template for spec in FLINK_VERSIONS.values()], self.delta_version))
+
+        return self.validate_jars(expected, "Published Artifact Workflow")
 
     def validate_spark_versions(self) -> None:
         """
@@ -850,7 +911,7 @@ def main():
             sys.exit(1)
 
         print("="*70)
-        print("Cross-Spark Build Test Suite")
+        print("Published Artifact Build Test Suite")
         print("="*70)
         print()
 
@@ -869,17 +930,18 @@ def main():
         script_test6c_passed = script_test.test_source_build_artifact_version_format()
         script_test7_passed = script_test.test_get_field()
 
-        # Test cross-Spark build workflow
+        # Test published artifact workflows
         print("\n" + "="*70)
-        print("PART 2: Cross-Spark Build Tests")
+        print("PART 2: Published Artifact Tests")
         print("="*70)
-        build_test = CrossSparkPublishTest(delta_root)
+        build_test = PublishedArtifactsTest(delta_root)
         build_test.validate_spark_versions()
 
         # Run all build tests
+        build_test0_passed = build_test.test_flink_version_selection()
         build_test1_passed = build_test.test_default_publish()
         build_test2_passed = build_test.test_backward_compat_publish()
-        build_test3_passed = build_test.test_cross_spark_workflow()
+        build_test3_passed = build_test.test_publish_workflow()
 
         # Summary
         print("\n" + "="*70)
@@ -895,17 +957,18 @@ def main():
         print(f"  Source-Build Cache Key (non-block):   {'✓ PASSED' if script_test6b_passed else '✗ FAILED'}")
         print(f"  Source-Build Artifact Version:          {'✓ PASSED' if script_test6c_passed else '✗ FAILED'}")
         print(f"  Get Field Functionality:                {'✓ PASSED' if script_test7_passed else '✗ FAILED'}")
-        print("\nPart 2: Cross-Spark Build Tests")
+        print("\nPart 2: Published Artifact Tests")
+        print(f"  Flink version selection:                {'✓ PASSED' if build_test0_passed else '✗ FAILED'}")
         print(f"  Default publishM2 (with suffix):        {'✓ PASSED' if build_test1_passed else '✗ FAILED'}")
         print(f"  skipSparkSuffix (backward compat):      {'✓ PASSED' if build_test2_passed else '✗ FAILED'}")
-        print(f"  Cross-Spark Workflow (both):            {'✓ PASSED' if build_test3_passed else '✗ FAILED'}")
+        print(f"  Full publish workflow:                  {'✓ PASSED' if build_test3_passed else '✗ FAILED'}")
         print("="*70)
 
         all_tests_passed = (
             script_test1_passed and script_test2_passed and script_test3_passed and script_test4_passed and
             script_test5_passed and script_test6_passed and script_test6b_passed and
             script_test6c_passed and script_test7_passed and
-            build_test1_passed and build_test2_passed and build_test3_passed
+            build_test0_passed and build_test1_passed and build_test2_passed and build_test3_passed
         )
 
         if all_tests_passed:


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [x] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This backports #7421 to `branch-4.4`.

The published Flink artifact does not say which Flink version line it supports. For example, an artifact named `delta-flink-4.4.0.jar` could target Flink 2.0 or Flink 2.3, and both builds would use the same Maven coordinate.

This change publishes `delta-flink_2.0`, `delta-flink_2.1`, `delta-flink_2.2`, and `delta-flink_2.3`. The release process publishes each supported Flink version, and CI reads the same version list to create its test matrix.

## How was this patch tested?

- Verified that `-DflinkVersion=2.1` selects the `delta-flink_2.1` module and the full Flink 2.1.3 dependency version.
- Verified that an unsupported Flink version is rejected.
- Ran `build/sbt -DflinkVersion=2.3 flink/test`: 259 tests, 0 failures, 4 skipped.
- Ran `python3.9 -m py_compile project/tests/test_published_artifacts.py`.
- Ran `git diff --check`.

## Does this PR introduce _any_ user-facing changes?

Yes. Flink artifacts now include the compatible Flink line in the Maven artifact name. For example, users of Flink 2.3 use `delta-flink_2.3` instead of `delta-flink`.
