### PR TITLE
Add string-based path helpers to AMTUtils

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTUtils.scala
@@ -31,6 +31,70 @@ import org.apache.hadoop.fs.{FileSystem, Path}
  * This differs from Delta's `AddFile.path`, which is URL-encoded.
  */
 object AMTUtils {
+  private val PathSeparator = "/"
+
+  /**
+   * Returns true if the location contains a URI scheme, per RFC 3986 section 3.1.
+   * https://datatracker.ietf.org/doc/html/rfc3986#section-3.1
+   */
+  private[amt] def hasScheme(location: String): Boolean = {
+    var i = 0
+    while (i < location.length) {
+      val ch = location.charAt(i)
+      if (ch == ':') {
+        return i > 0
+      }
+      if (!isSchemeChar(ch, i)) {
+        return false
+      }
+      i += 1
+    }
+    false
+  }
+
+  private def isSchemeChar(ch: Char, position: Int): Boolean = {
+    (ch >= 'a' && ch <= 'z') ||
+      (ch >= 'A' && ch <= 'Z') ||
+      (position > 0 && ((ch >= '0' && ch <= '9') || ch == '+' || ch == '-' || ch == '.'))
+  }
+
+  /**
+   * Returns true if a location is absolute.
+   * NOTE: This is not the same implementation as Hadoop [[Path.isAbsolute]].
+   */
+  def isAbsoluteLocation(location: String): Boolean = {
+    hasScheme(location) || location.startsWith(PathSeparator)
+  }
+
+  /**
+   * Relativizes a location against a table location. A trailing slash on `tableLocation` is
+   * ignored. If `location` starts with the normalized table location immediately followed by `/`,
+   * the prefix and separator are removed. Otherwise, `location` is returned as-is.
+   * This is a lightweight string manipulation compared to [[DeltaFileOperations.tryRelativizePath]]
+   * and should be preferred in hot paths.
+   *
+   * Because the relativization is prefix matching based, callers are expected to pass locations in
+   * the same format and encoding. No such checks are performed here.
+   */
+  def relativizeLocation(tableLocation: String, location: String): String = {
+    // Strip trailing slash from tableLocation if present.
+    val normalizedTableLocation =
+      if (tableLocation.length > PathSeparator.length && tableLocation.endsWith(PathSeparator)) {
+        tableLocation.dropRight(PathSeparator.length)
+      } else {
+        tableLocation
+      }
+
+    // Prefix matching based location relativization
+    val prefixLength = normalizedTableLocation.length
+    if (location.length > prefixLength &&
+        location.startsWith(PathSeparator, prefixLength) &&
+        location.startsWith(normalizedTableLocation)) {
+      location.substring(prefixLength + PathSeparator.length)
+    } else {
+      location
+    }
+  }
 
   /**
    * Relativizes an AMT manifest file `path` against `tableRoot`, returning the raw

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTUtilsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTUtilsSuite.scala
@@ -26,6 +26,68 @@ class AMTUtilsSuite extends SparkFunSuite {
   private val tableRoot = new Path("file:/tables/t1")
   private val fs = tableRoot.getFileSystem(new Configuration())
 
+  test("hasScheme: follows URI scheme grammar") {
+    assert(AMTUtils.hasScheme("s3://bucket/path"))
+    assert(AMTUtils.hasScheme("file:/tmp/table"))
+    assert(AMTUtils.hasScheme("git+ssh://host/repo"))
+    assert(AMTUtils.hasScheme("ab.c-1+2://host/repo"))
+
+    assert(!AMTUtils.hasScheme("data/partition=key:value/file.parquet"))
+    assert(!AMTUtils.hasScheme("metadata/snap-123:456.avro"))
+    assert(!AMTUtils.hasScheme("3com://host"))
+    assert(!AMTUtils.hasScheme("+ssh://host"))
+    assert(!AMTUtils.hasScheme(".bar://host"))
+  }
+
+  test("isAbsoluteLocation: detects absolute locations without constructing Path") {
+    assert(AMTUtils.isAbsoluteLocation("s3://bucket/path"))
+    assert(AMTUtils.isAbsoluteLocation("file:/tmp/table"))
+    assert(AMTUtils.isAbsoluteLocation("git+ssh://host/repo"))
+    assert(AMTUtils.isAbsoluteLocation("/tmp/table"))
+
+    assert(!AMTUtils.isAbsoluteLocation("metadata/file.parquet"))
+    assert(!AMTUtils.isAbsoluteLocation("data/partition=key:value/file.parquet"))
+    assert(!AMTUtils.isAbsoluteLocation("metadata/snap-123:456.avro"))
+    assert(!AMTUtils.isAbsoluteLocation("3com://host"))
+  }
+
+  test("relativizeLocation: child locations under the table location become relative") {
+    val root = "s3://bucket/db/table"
+    Seq(
+      "s3://bucket/db/table/metadata/file.parquet" -> "metadata/file.parquet",
+      "s3://bucket/db/table/data/00000-0.parquet" -> "data/00000-0.parquet"
+    ).foreach { case (location, expected) =>
+      assert(AMTUtils.relativizeLocation(root, location) === expected)
+    }
+  }
+
+  test("relativizeLocation: non-child locations stay unchanged") {
+    val root = "s3://bucket/db/table"
+    Seq(
+      "s3://other-bucket/db/table/data/file.parquet",
+      "s3://bucket/db/other-table/data/file.parquet",
+      "s3://bucket/db/table_v2/data/00000-0.parquet",
+      root
+    ).foreach { location =>
+      assert(AMTUtils.relativizeLocation(root, location) === location)
+    }
+  }
+
+  test("relativizeLocation: mismatched file URI forms stay unchanged") {
+    assert(AMTUtils.relativizeLocation(
+      "file:/tmp/table", "file:///tmp/table/metadata/file.parquet") ===
+      "file:///tmp/table/metadata/file.parquet")
+    assert(AMTUtils.relativizeLocation(
+      "file:///tmp/table", "file:/tmp/table/metadata/file.parquet") ===
+      "file:/tmp/table/metadata/file.parquet")
+  }
+
+  test("relativizeLocation: trailing slash table location matches child") {
+    assert(AMTUtils.relativizeLocation(
+      "s3://bucket/db/table/", "s3://bucket/db/table/data/00000-0.parquet") ===
+      "data/00000-0.parquet")
+  }
+
   test("relativizeManifestPathToTableRoot: a file under the table root becomes relative") {
     val leaf = new Path("file:/tables/t1/metadata/leaf-1.parquet")
     assert(AMTUtils.relativizeManifestPathToTableRoot(fs, tableRoot, leaf) ===


### PR DESCRIPTION
## Description

Adds lightweight, string-based location helpers to `AMTUtils`:

- `isAbsoluteLocation(location)`: returns whether a location is absolute (it has a URI
  scheme per [RFC 3986 section 3.1](https://datatracker.ietf.org/doc/html/rfc3986#section-3.1),
  or begins with `/`) without constructing a Hadoop `Path`.
- `relativizeLocation(tableLocation, location)`: prefix-based relativization of a location
  against a table location. A trailing slash on the table location is ignored; when
  `location` sits directly under the normalized table location, the table-location prefix
  and separator are stripped, otherwise `location` is returned unchanged. This is a cheaper
  alternative to `DeltaFileOperations.tryRelativizePath` and is intended for hot paths.
  Because matching is purely prefix based, callers are expected to pass locations in the
  same format and encoding; no such checks are performed.
- `hasScheme(location)` (package-private helper): returns whether a location string begins
  with a valid URI scheme per RFC 3986 section 3.1.

## How was this patch tested?

Added unit tests in `AMTUtilsSuite` covering: URI scheme detection (valid schemes and
strings that only look scheme-like, such as `partition=key:value` path segments), absolute
vs. relative location detection, relativization of child locations under a table location,
non-child locations left unchanged, mismatched `file:` URI forms left unchanged, and a
trailing-slash table location matching a child.

## Does this PR introduce _any_ user-facing change?

No.
