### PR TITLE
[Spark] Fix flaky AMT partition values test

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTPartitionValuesSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTPartitionValuesSuite.scala
@@ -131,13 +131,14 @@ class AMTPartitionValuesSuite extends AMTCheckpointTestBase {
   }
 
   /**
-   * The physical-name partition-value maps `forRead` reconstructs from `leaves`' DATA entries.
+   * The physical-name partition-value maps `forRead` reconstructs from the manifest tree's DATA
+   * entries.
    */
   private def reconstructPartitionValues(
-      leaves: Seq[String],
+      manifests: Seq[String],
       partitionSchema: StructType): Set[Map[String, String]] =
     allowReadWithinDeltaLog {
-      val entries = spark.read.parquet(leaves: _*)
+      val entries = spark.read.parquet(manifests: _*)
         .where(col("content_type") === AMTSingleAction.ContentType.Type.Data)
       AMTPartitionValues.forRead(entries, partitionSchema)
         .select(col("partition"))
@@ -154,8 +155,11 @@ class AMTPartitionValuesSuite extends AMTCheckpointTestBase {
       val snapshot = deltaLog.update()
       val provider = amtProvider(snapshot).getOrElse(fail("expected AMTCheckpointProvider"))
       val partitionSchema = snapshot.metadata.partitionSchema
-      val leaves = provider.liveLeafManifestAbsolutePaths.map(_.toString)
-      assert(leaves.nonEmpty, "Expected at least one leaf manifest.")
+      // A full rewrite can hash every file into one Spark partition. In that valid representation,
+      // the sole leaf is promoted to the root and there are no leaf pointers to read.
+      val manifests = provider.topLevelFiles.map(_.getPath.toString) ++
+        provider.liveLeafManifestAbsolutePaths.map(_.toString)
+      assert(manifests.nonEmpty, "Expected at least a root manifest.")
 
       // Read the commit json directly rather than going through the snapshot: an AMT snapshot
       // reconstructs its AddFiles through `forRead`, so comparing against it would compare
@@ -172,7 +176,7 @@ class AMTPartitionValuesSuite extends AMTCheckpointTestBase {
         .toSet
       assert(logged.size == numFiles, s"Expected one logged add per file, got ${logged.size}.")
 
-      val reconstructed = reconstructPartitionValues(leaves, partitionSchema)
+      val reconstructed = reconstructPartitionValues(manifests, partitionSchema)
       assert(reconstructed == logged,
         s"forRead did not reproduce the logged partition values.\n" +
           s"  logged=$logged\n  reconstructed=$reconstructed")


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Fixes a flaky `AMTPartitionValuesSuite` failure observed in [Spark 4.2 shard 5](https://github.com/delta-io/delta/actions/runs/32203468585/job/95922073677?pr=7483).

The end-to-end partition-values test assumed that every full AMT rewrite produces at least one leaf manifest. Its four random data-file paths are hashed across two writer partitions, however, so all four land in one partition about one run in eight. In that valid topology the writer promotes the sole manifest to the root and emits no leaf pointers; the test then failed at `Expected at least one leaf manifest.` even though the checkpoint was valid.

Read DATA entries from the complete active manifest tree instead: the root manifest plus all live leaf manifests. Filtering by DATA content still excludes pointer rows, and the test retains its exact comparison against partition values read directly from the Delta JSON log. This also matches the root-plus-leaves pattern already used in `AMTCheckpointWriteSuite`.

## How was this patch tested?

- `AMTPartitionValuesSuite` on Spark 4.2: 3/3 passed.
- `AMTPartitionValuesSuite` on Spark 4.1: 3/3 passed.
- `AMTPartitionValuesSuite` on Spark 4.0: 3/3 passed.
- Delta OSS flake-finder stress run on the failing configuration: 20/20 fresh-process runs passed.
- Spark test Scalastyle: 0 errors.

## Does this PR introduce _any_ user-facing changes?

No. This only corrects a test's assumption about valid AMT manifest topology.
