### PR TITLE
[Spark] Fix flaky identity column streaming test

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/IdentityColumnAdmissionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/IdentityColumnAdmissionSuite.scala
@@ -272,6 +272,9 @@ trait IdentityColumnAdmissionSuiteBase
       withTempDir { checkpointDir =>
         val ex = intercept[StreamingQueryException] {
           val stream = MemoryStream[Int]
+          // AvailableNow snapshots the source data when the query starts, so enqueue data first.
+          // Otherwise, the query can finish before exercising the identity column write.
+          stream.addData(1 to 10)
           val q = stream
             .toDF
             .map(_ => Tuple2(1L, 1))
@@ -282,7 +285,6 @@ trait IdentityColumnAdmissionSuiteBase
             .option("checkpointLocation", checkpointDir.getCanonicalPath)
             .trigger(Trigger.AvailableNow)
             .start(path)
-          stream.addData(1 to 10)
           q.processAllAvailable()
           q.stop()
         }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Fixes the flaky `IdentityColumnAdmissionScalaSuite / streaming` failure observed in [Spark 4.0 shard 2 on #7487](https://github.com/delta-io/delta/actions/runs/32213242068/job/95950048600).

`Trigger.AvailableNow` snapshots the source offsets when the query starts. The test started the query before adding data to its `MemoryStream`, so the query could capture an empty input snapshot and terminate normally before exercising the invalid explicit identity-column write. The surrounding `intercept[StreamingQueryException]` would then fail because no exception was thrown.

Enqueue the input before starting the query. This guarantees that the available-now batch includes the data and that the test reaches the expected identity-column validation.

This is an active, separate flake from #7487's AMT issue. The same signature appeared in 10 of 61 master Spark 4.0 shard-2 jobs from August 1-19, 2026; the vulnerable test sequence dates to 2024, but the failures are current.

## How was this patch tested?

- `IdentityColumnAdmissionScalaSuite` on Spark 4.0: 13/13 passed.
- Delta OSS flake-finder stress run of `streaming`, CPU-pinned to two cores: 20/20 fresh-process runs passed.
- Spark test Scalastyle: 0 errors and 0 warnings.
- `git diff --check` passed.

## Does this PR introduce _any_ user-facing changes?

No. This only makes an existing streaming test deterministic.
