### PR TITLE
Introduce object-identity unique id for deletion vectors

### DIFF
--- a/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingDataSourceDeltaTestUtils.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingDataSourceDeltaTestUtils.scala
@@ -84,7 +84,9 @@ trait DeltaSharingDataSourceDeltaTestUtils extends SharedSparkSession {
       deletionVector: DeletionVectorDescriptor): (DeletionVectorDescriptor, String) = {
     if (deletionVector != null) {
       if (deletionVector.storageType == DeletionVectorDescriptor.INLINE_DV_MARKER) {
-        (deletionVector, Hashing.sha256().hashString(deletionVector.uniqueId, UTF_8).toString)
+        val responseId =
+          Hashing.sha256().hashString(deletionVector.legacyUniqueId, UTF_8).toString
+        (deletionVector, responseId)
       } else {
         val dvPath = deletionVector.absolutePath(new Path("not-used"))
         (
@@ -93,7 +95,7 @@ trait DeltaSharingDataSourceDeltaTestUtils extends SharedSparkSession {
               SparkPath.fromPathString(dvPath.getName).urlEncoded),
             storageType = DeletionVectorDescriptor.PATH_DV_MARKER
           ),
-          Hashing.sha256().hashString(deletionVector.uniqueId, UTF_8).toString
+          Hashing.sha256().hashString(deletionVector.legacyUniqueId, UTF_8).toString
         )
       }
     } else {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
@@ -1624,7 +1624,7 @@ private[delta] object ConflictChecker extends DeltaLogging {
     actions.map { action =>
       action match {
         case add: AddFile =>
-          val dvId = add.getDeletionVectorUniqueId
+          val dvId = add.getLegacyDeletionVectorUniqueId
           addPaths.put(add.path, dvId).foreach { existingDVId =>
             failDuplicate("add", add.path, dvId, existingDVId)
           }
@@ -1635,7 +1635,7 @@ private[delta] object ConflictChecker extends DeltaLogging {
             }
           }
         case remove: RemoveFile =>
-          val dvId = remove.getDeletionVectorUniqueId
+          val dvId = remove.getLegacyDeletionVectorUniqueId
           removePaths.put(remove.path, dvId).foreach { existingDVId =>
             failDuplicate("remove", remove.path, dvId, existingDVId)
           }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/DeletionVectorDescriptor.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/DeletionVectorDescriptor.scala
@@ -22,8 +22,9 @@ import java.util.{Base64, UUID}
 
 import org.apache.spark.sql.delta.DeltaErrors
 import org.apache.spark.sql.delta.DeltaUDF
+import org.apache.spark.sql.delta.amt.AMTUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
-import org.apache.spark.sql.delta.util.{Codec, DeltaEncoder, JsonUtils}
+import org.apache.spark.sql.delta.util.{Codec, DeltaEncoder}
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import org.apache.hadoop.fs.Path
@@ -87,9 +88,13 @@ case class DeletionVectorDescriptor(
 
   import DeletionVectorDescriptor._
 
+  /**
+   * The legacy unique id of the DV.
+   * Prefer [[uniqueId]] if possible. See more details in the [[uniqueId]] documentation.
+   */
   @JsonIgnore
   @transient
-  lazy val uniqueId: String = {
+  lazy val legacyUniqueId: String = {
     offset match {
       case Some(offset) => s"$uniqueFileId@$offset"
       case None => uniqueFileId
@@ -99,6 +104,21 @@ case class DeletionVectorDescriptor(
   @JsonIgnore
   @transient
   lazy val uniqueFileId: String = s"$storageType$pathOrInlineDv"
+
+  /**
+   * Unique identifier for this DV.
+   *
+   * When `useObjectIdentity` is false, this returns the legacy descriptor identity:
+   * `storageType + pathOrInlineDv + optional offset`. That identity is stable for one serialized
+   * descriptor, but it treats equivalent `u`, `r`, and in-table `p` descriptors as different.
+   *
+   * When `useObjectIdentity` is true, this returns a normalized object identity. That identity
+   * represents the physical DV object relative to the table root when possible, plus the offset, so
+   * equivalent `u`, `r`, and in-table `p` descriptors compare equal.
+   */
+  def uniqueId(tableRoot: Path, useObjectIdentity: Boolean): String = {
+    if (useObjectIdentity) normalizedTableRelativeObjectId(tableRoot) else legacyUniqueId
+  }
 
   @JsonIgnore
   protected[delta] def isOnDisk: Boolean = !isInline
@@ -173,6 +193,36 @@ case class DeletionVectorDescriptor(
     case _ =>
       None
   }
+
+  /**
+   * Computes a normalized object identity for this descriptor. Use this when the caller wants
+   * to identify the underlying DV object rather than this descriptor's storage encoding.
+   */
+  def normalizedTableRelativeObjectId(tableRoot: Path): String = {
+    storageType match {
+      case INLINE_DV_MARKER =>
+        formatIdentity(INLINE_DV_MARKER, pathOrInlineDv, offset)
+      case UUID_DV_MARKER =>
+        val (randomPrefix, uuid) = getRandomPrefixAndUuid.get
+        val fileName = assembleDeletionVectorFileName(uuid)
+        val relativePath = if (randomPrefix.isEmpty) fileName else s"$randomPrefix/$fileName"
+        formatIdentity(RELATIVE_DV_MARKER, relativePath, offset)
+      case RELATIVE_DV_MARKER =>
+        formatIdentity(RELATIVE_DV_MARKER, pathOrInlineDv, offset)
+      case PATH_DV_MARKER =>
+        val path = SparkPath.fromUrlString(pathOrInlineDv).toPath.toString
+        val relativePath = AMTUtils.relativizeLocation(tableRoot.toString, path)
+        if (AMTUtils.isAbsoluteLocation(relativePath)) {
+          formatIdentity(PATH_DV_MARKER, pathOrInlineDv, offset)
+        } else {
+          formatIdentity(RELATIVE_DV_MARKER, relativePath, offset)
+        }
+      case _ =>
+        throw new IllegalArgumentException(
+          s"Unsupported deletion vector storage type: $storageType")
+    }
+  }
+
   /**
    * Produce a copy of this DV, but using an absolute path.
    *
@@ -270,6 +320,16 @@ object DeletionVectorDescriptor {
   final val UUID_DV_MARKER: String = "u"
   final val RELATIVE_DV_MARKER: String = "r"
 
+  private def formatIdentity(
+      storageType: String,
+      pathOrInlineDv: String,
+      offset: Option[Int]): String = {
+    offset match {
+      case Some(offsetValue) => s"$storageType$pathOrInlineDv@$offsetValue"
+      case None => s"$storageType$pathOrInlineDv"
+    }
+  }
+
   private final val deletionVectorFileNameRegex =
     raw"${new Path(DELETION_VECTOR_FILE_NAME_CORE).toUri}_([^.]+)\.bin".r
   private final val deletionVectorFileNamePattern = deletionVectorFileNameRegex.pattern
@@ -322,7 +382,7 @@ object DeletionVectorDescriptor {
       offset: Option[Int] = None,
       maxRowIndex: Option[Long] = None): DeletionVectorDescriptor = {
     if (Utils.isTesting) {
-      require(!new Path(relativePath).isAbsolute,
+      require(!AMTUtils.isAbsoluteLocation(relativePath),
         s"A '$RELATIVE_DV_MARKER' deletion vector must have a relative path, " +
           s"but got: $relativePath")
     }
@@ -385,10 +445,10 @@ object DeletionVectorDescriptor {
       _.urlEncodedRelativePathIfExists(tablePath))(deletionVectorCol)
 
   /**
-   * This produces the same output as [[DeletionVectorDescriptor.uniqueId]] but as a column
-   * expression, so it can be used directly in a Spark query.
+   * This produces the same output as [[DeletionVectorDescriptor.legacyUniqueId]] but as a
+   * column expression, so it can be used directly in a Spark query.
    */
-  def uniqueIdExpression(deletionVectorCol: Column): Column = {
+  def legacyUniqueIdExpression(deletionVectorCol: Column): Column = {
     when(deletionVectorCol("offset").isNotNull,
         concat(
           deletionVectorCol("storageType"),
@@ -398,6 +458,31 @@ object DeletionVectorDescriptor {
       .otherwise(concat(
         deletionVectorCol("storageType"),
         deletionVectorCol("pathOrInlineDv")))
+  }
+
+  /**
+   * Produces the same output as [[DeletionVectorDescriptor.uniqueId]] with object identity, but as
+   * a column expression, so it can be used directly in a Spark query.
+   */
+  def objectUniqueIdExpression(deletionVectorCol: Column, tableRoot: Path): Column = {
+    val objectUniqueId = DeltaUDF.stringFromDeletionVectorDescriptor(
+      _.uniqueId(tableRoot, useObjectIdentity = true))
+    when(deletionVectorCol.isNotNull, objectUniqueId(deletionVectorCol))
+  }
+
+  /**
+   * Produces the same output as [[DeletionVectorDescriptor.uniqueId]] but as a column expression,
+   * so it can be used directly in a Spark query.
+   */
+  def uniqueIdExpression(
+      deletionVectorCol: Column,
+      tableRoot: Path,
+      useObjectIdentity: Boolean): Column = {
+    if (useObjectIdentity) {
+      objectUniqueIdExpression(deletionVectorCol, tableRoot)
+    } else {
+      legacyUniqueIdExpression(deletionVectorCol)
+    }
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/InMemoryLogReplay.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/InMemoryLogReplay.scala
@@ -72,14 +72,15 @@ class InMemoryLogReplay(
       case a: Protocol =>
         currentProtocolVersion = a
       case add: AddFile =>
-        val uniquePath = UniqueFileActionTuple(add.pathAsUri, add.getDeletionVectorUniqueId)
+        val uniquePath = UniqueFileActionTuple(add.pathAsUri, add.getLegacyDeletionVectorUniqueId)
         activeFiles(uniquePath) = add.copy(dataChange = false)
         // Remove the tombstone to make sure we only output one `FileAction`.
         cancelledRemoveFiles.remove(uniquePath)
         // Remove from activeRemoveFiles to handle commits that add a previously-removed file
         activeRemoveFiles.remove(uniquePath)
       case remove: RemoveFile =>
-        val uniquePath = UniqueFileActionTuple(remove.pathAsUri, remove.getDeletionVectorUniqueId)
+        val uniquePath =
+          UniqueFileActionTuple(remove.pathAsUri, remove.getLegacyDeletionVectorUniqueId)
         activeFiles.remove(uniquePath) match {
           case Some(_) => cancelledRemoveFiles(uniquePath) = remove
           case None => activeRemoveFiles(uniquePath) = remove
@@ -142,11 +143,11 @@ object InMemoryLogReplay{
 
   implicit class UniqueAddFileTuple(a: AddFile) {
     def toUniqueFileActionTuple: UniqueFileActionTuple =
-      UniqueFileActionTuple(a.pathAsUri, a.getDeletionVectorUniqueId)
+      UniqueFileActionTuple(a.pathAsUri, a.getLegacyDeletionVectorUniqueId)
   }
 
   implicit class UniqueRemoveFileTuple(r: RemoveFile) {
     def toUniqueFileActionTuple: UniqueFileActionTuple =
-      UniqueFileActionTuple(r.pathAsUri, r.getDeletionVectorUniqueId)
+      UniqueFileActionTuple(r.pathAsUri, r.getLegacyDeletionVectorUniqueId)
   }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -984,13 +984,27 @@ case class AddFile(
   }
 
   /**
-   * Return the unique id of the deletion vector, if present, or `None` if there's no DV.
+   * Return the legacy unique id of the deletion vector, if present, or `None` if there's no DV.
    *
-   * The unique id differentiates DVs, even if there are multiple in the same file
+   * The legacy unique id differentiates DVs, even if there are multiple in the same file
    * or the DV is stored inline.
    */
   @JsonIgnore
-  def getDeletionVectorUniqueId: Option[String] = Option(deletionVector).map(_.uniqueId)
+  def getLegacyDeletionVectorUniqueId: Option[String] =
+    Option(deletionVector).map(_.legacyUniqueId)
+
+  /**
+   * Return the unique id of the deletion vector, if present, or `None` if there's no DV.
+   *
+   * This overload allows callers to use object identity for comparisons. Prefer this
+   * if possible. See document of [[DeletionVectorDescriptor.uniqueId]] for more details.
+   */
+  @JsonIgnore
+  def getDeletionVectorUniqueId(
+      tableRoot: Path,
+      useObjectIdentity: Boolean): Option[String] = {
+    Option(deletionVector).map(_.uniqueId(tableRoot, useObjectIdentity))
+  }
 
   /** Update stats to have tightBounds = false, if file has any stats. */
   def withoutTightBoundStats: AddFile = {
@@ -1194,13 +1208,27 @@ case class RemoveFile(
   val delTimestamp: Long = deletionTimestamp.getOrElse(0L)
 
   /**
-   * Return the unique id of the deletion vector, if present, or `None` if there's no DV.
+   * Return the legacy unique id of the deletion vector, if present, or `None` if there's no DV.
    *
-   * The unique id differentiates DVs, even if there are multiple in the same file
+   * The legacy unique id differentiates DVs, even if there are multiple in the same file
    * or the DV is stored inline.
    */
   @JsonIgnore
-  def getDeletionVectorUniqueId: Option[String] = Option(deletionVector).map(_.uniqueId)
+  def getLegacyDeletionVectorUniqueId: Option[String] =
+    Option(deletionVector).map(_.legacyUniqueId)
+
+  /**
+   * Return the unique id of the deletion vector, if present, or `None` if there's no DV.
+   *
+   * This overload allows callers to use object identity for comparisons. Prefer this
+   * if possible. See document of [[DeletionVectorDescriptor.uniqueId]] for more details.
+   */
+  @JsonIgnore
+  def getDeletionVectorUniqueId(
+      tableRoot: Path,
+      useObjectIdentity: Boolean): Option[String] = {
+    Option(deletionVector).map(_.uniqueId(tableRoot, useObjectIdentity))
+  }
 
   /**
    * Create a copy with the new tag. `extendedFileMetadata` is copied unchanged.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTCheckpointProvider.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTCheckpointProvider.scala
@@ -220,23 +220,23 @@ final class AMTCheckpointProvider(
     // Key by (path, dv) so a same-path replace is handled: the removed (path, oldDv) is checked
     // against the AMT, while the re-added (path, newDv) is a distinct key absent from the tree.
     val committedFiles = committedActions.collect {
-      case a: AddFile => (a.path, a.getDeletionVectorUniqueId) -> a.backReference
-      case r: RemoveFile => (r.path, r.getDeletionVectorUniqueId) -> r.backReference
+      case a: AddFile => (a.path, a.getLegacyDeletionVectorUniqueId) -> a.backReference
+      case r: RemoveFile => (r.path, r.getLegacyDeletionVectorUniqueId) -> r.backReference
     }
     if (committedFiles.isEmpty) return
 
     val expectedKeyToBackreferenceMap =
       liveAddSingleActions(spark, deltaLog)
         .collect()
-        .map(sa => (sa.add.path, sa.add.getDeletionVectorUniqueId) -> sa.add.backReference)
+        .map(sa => (sa.add.path, sa.add.getLegacyDeletionVectorUniqueId) -> sa.add.backReference)
         .toMap
 
     // Keys an intermediate commit (after this AMT) already re-committed. The first superseding
     // add/remove must carry a back reference; a 2nd superseding one of the same key need not.
     val intermediateCommittedKeys =
       deltaLog.getChanges(checkpointVersion + 1).flatMap(_._2).collect {
-        case a: AddFile => (a.path, a.getDeletionVectorUniqueId)
-        case r: RemoveFile => (r.path, r.getDeletionVectorUniqueId)
+        case a: AddFile => (a.path, a.getLegacyDeletionVectorUniqueId)
+        case r: RemoveFile => (r.path, r.getLegacyDeletionVectorUniqueId)
       }.toSet
 
     committedFiles.foreach { case (key, actual) =>

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
@@ -476,14 +476,14 @@ class OptimizeExecutor(
         // Note: When checking if the candidate set is the same, we need to consider (Path, DV)
         //       as the key.
         val candidateSetOld = filesToProcess.
-          map(f => UniqueFileActionTuple(f.pathAsUri, f.getDeletionVectorUniqueId)).toSet
+          map(f => UniqueFileActionTuple(f.pathAsUri, f.getLegacyDeletionVectorUniqueId)).toSet
 
         // We specifically don't list the files through the transaction since we are potentially
         // only processing a subset of them below. If the transaction is still valid, we will
         // register the files and predicate below
         val candidateSetNew =
           newTxn.snapshot.filesForScan(partitionPredicate).files
-            .map(f => UniqueFileActionTuple(f.pathAsUri, f.getDeletionVectorUniqueId)).toSet
+            .map(f => UniqueFileActionTuple(f.pathAsUri, f.getLegacyDeletionVectorUniqueId)).toSet
 
         // As long as all of the files that we compacted are still part of the table,
         // and the partitioning has not changed it is valid to continue to try

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/RestoreTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/RestoreTableCommand.scala
@@ -144,7 +144,7 @@ case class RestoreTableCommand(sourceTable: DeltaTableV2)
           if (mayHaveDVs) {
             normalizedDf.withColumn(
               dvIdColumnName,
-              DeletionVectorDescriptor.uniqueIdExpression(dvAccessColumn))
+              DeletionVectorDescriptor.legacyUniqueIdExpression(dvAccessColumn))
           } else {
             normalizedDf.withColumn(dvIdColumnName, lit(null))
           }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -2969,6 +2969,20 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .booleanConf
       .createWithDefault(true)
 
+  val DELETION_VECTORS_USE_OBJECT_IDENTITY_FOR_NON_AMT =
+    buildConf("deletionVectors.useObjectIdentityForNonAMTTables")
+      .internal()
+      .doc(
+        """When true, Delta compares deletion vectors by their normalized object identity instead
+          |of their legacy descriptor identity for non-AMT tables (AMT tables always use object
+          |identity). The legacy identity is based on the serialized descriptor fields,
+          |so equivalent `u`, `r`, and in-table `p` descriptors compare as different DVs.
+          |The object identity is based on the table-relative DV object location and offset
+          |when possible, so those equivalent descriptors compare as the same DV.
+          |""".stripMargin)
+      .booleanConf
+      .createWithDefault(false)
+
   val DELETION_VECTOR_PACKING_TARGET_SIZE =
     buildConf("deletionVectors.packing.targetSize")
       .internal()

--- a/spark/src/test/scala/org/apache/spark/sql/delta/CloneTableTestMixin.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CloneTableTestMixin.scala
@@ -106,8 +106,9 @@ trait CloneTableTestMixin extends DeltaColumnMappingTestUtils
   protected def uniqueFileActionGroupBy(action: FileAction): String = {
     val filePath = action.pathAsUri.toString
     val dvId = action match {
-      case add: AddFile => Option(add.deletionVector).map(_.uniqueId).getOrElse("")
-      case remove: RemoveFile => Option(remove.deletionVector).map(_.uniqueId).getOrElse("")
+      case add: AddFile => Option(add.deletionVector).map(_.legacyUniqueId).getOrElse("")
+      case remove: RemoveFile =>
+        Option(remove.deletionVector).map(_.legacyUniqueId).getOrElse("")
       case _ => ""
     }
     filePath + dvId

--- a/spark/src/test/scala/org/apache/spark/sql/delta/actions/DeletionVectorDescriptorSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/actions/DeletionVectorDescriptorSuite.scala
@@ -47,7 +47,7 @@ class DeletionVectorDescriptorSuite extends SparkFunSuite {
     assert(dv.offset.isEmpty) // There shouldn't be an offset for inline DV
 
     // Unique id to identify the DV
-    assert(dv.uniqueId === s"i$encodedDVData")
+    assert(dv.legacyUniqueId === s"i$encodedDVData")
     assert(dv.uniqueFileId === s"i$encodedDVData")
 
     // There is no on-disk file name for an inline DV
@@ -76,7 +76,7 @@ class DeletionVectorDescriptorSuite extends SparkFunSuite {
 
       // Unique id to identify the DV
       val offsetSuffix = offset.map(o => s"@$o").getOrElse("")
-      assert(dv.uniqueId === s"p$testDVAbsPath$offsetSuffix")
+      assert(dv.legacyUniqueId === s"p$testDVAbsPath$offsetSuffix")
       assert(dv.uniqueFileId === s"p$testDVAbsPath")
 
       // Given the input already has an absolute path, it should return the path in DV
@@ -113,7 +113,7 @@ class DeletionVectorDescriptorSuite extends SparkFunSuite {
       // Unique id to identify the DV
       val offsetSuffix = offset.map(o => s"@$o").getOrElse("")
       val encodedUUID = encodeUUID(uuid, "prefix")
-      assert(dv.uniqueId === s"u$encodedUUID$offsetSuffix")
+      assert(dv.legacyUniqueId === s"u$encodedUUID$offsetSuffix")
       assert(dv.uniqueFileId === s"u$encodedUUID")
 
       // Expect the DV final path to be under the given table path
@@ -157,7 +157,7 @@ class DeletionVectorDescriptorSuite extends SparkFunSuite {
 
       // Unique id to identify the DV
       val offsetSuffix = offset.map(o => s"@$o").getOrElse("")
-      assert(dv.uniqueId === s"r$testDVRelPath$offsetSuffix")
+      assert(dv.legacyUniqueId === s"r$testDVRelPath$offsetSuffix")
       assert(dv.uniqueFileId === s"r$testDVRelPath")
 
       // Expect the DV path to resolve under the given table path.
@@ -244,6 +244,85 @@ class DeletionVectorDescriptorSuite extends SparkFunSuite {
     }
   }
 
+  /** The `r` form of the `u` DV that `uuid`/`prefix` describe. */
+  private def rFormOf(uuid: UUID, prefix: String, offset: Option[Int]) = {
+    val path = if (prefix.isEmpty) {
+      s"${DELETION_VECTOR_FILE_NAME_CORE}_$uuid.bin"
+    } else {
+      s"$prefix/${DELETION_VECTOR_FILE_NAME_CORE}_$uuid.bin"
+    }
+    createRelativePathDVDescriptor(path, sizeInBytes = 15, cardinality = 25, offset = offset)
+  }
+
+  test("config-aware uniqueId uses descriptor identity when object identity is disabled") {
+    val uuid = UUID.randomUUID()
+    val uDv = onDiskWithUuidRelativePath(
+      uuid, randomPrefix = "prefix", sizeInBytes = 15, cardinality = 25, offset = Some(8))
+    val pDv = uDv.copyWithAbsolutePath(testTablePathWithSpace)
+    val rDv = rFormOf(uuid, "prefix", offset = Some(8))
+
+    assert(pDv.pathOrInlineDv.contains("test%20path"))
+    assert(Set(uDv.legacyUniqueId, pDv.legacyUniqueId, rDv.legacyUniqueId).size === 3)
+    assert(uDv.uniqueId(testTablePathWithSpace, useObjectIdentity = false) === uDv.legacyUniqueId)
+    assert(pDv.uniqueId(testTablePathWithSpace, useObjectIdentity = false) === pDv.legacyUniqueId)
+    assert(rDv.uniqueId(testTablePathWithSpace, useObjectIdentity = false) === rDv.legacyUniqueId)
+  }
+
+  test("config-aware uniqueId collapses u, r, and in-root p with object identity") {
+    val uuid = UUID.randomUUID()
+    val uDv = onDiskWithUuidRelativePath(
+      uuid, randomPrefix = "prefix", sizeInBytes = 15, cardinality = 25, offset = Some(8))
+    val pDv = uDv.copyWithAbsolutePath(testTablePathWithSpace)
+    val rDv = rFormOf(uuid, "prefix", offset = Some(8))
+
+    assert(pDv.pathOrInlineDv.contains("test%20path"))
+    assert(uDv.uniqueId(testTablePathWithSpace, useObjectIdentity = true) ===
+      rDv.uniqueId(testTablePathWithSpace, useObjectIdentity = true))
+    assert(pDv.uniqueId(testTablePathWithSpace, useObjectIdentity = true) ===
+      rDv.uniqueId(testTablePathWithSpace, useObjectIdentity = true))
+  }
+
+  test("object identity keeps out-of-root p distinct") {
+    val uuid = UUID.randomUUID()
+    val uDv = onDiskWithUuidRelativePath(
+      uuid, randomPrefix = "prefix", sizeInBytes = 15, cardinality = 25, offset = Some(8))
+    val pElsewhere = onDiskWithAbsolutePath(
+      SparkPath.fromPath(
+        new Path(s"s3a://other-bucket/tbl/prefix/${DELETION_VECTOR_FILE_NAME_CORE}_$uuid.bin"))
+        .urlEncoded,
+      sizeInBytes = 15,
+      cardinality = 25,
+      offset = Some(8))
+
+    assert(uDv.uniqueId(testTablePath, useObjectIdentity = true) !==
+      pElsewhere.uniqueId(testTablePath, useObjectIdentity = true))
+  }
+
+  test("object identity decodes absolute p path before relativizing") {
+    val pDv = onDiskWithAbsolutePath(
+      "file:///tmp/test%20path/temp_dv.bin", sizeInBytes = 15, cardinality = 25, offset = Some(8))
+
+    assert(pDv.normalizedTableRelativeObjectId(new Path("file:///tmp")) ===
+      // "$storageType$pathOrInlineDv@$offsetValue"
+      "rtest path/temp_dv.bin@8")
+  }
+
+  test("object identity strips table root from decoded absolute p path") {
+    val pDv = onDiskWithAbsolutePath(
+      "file:///tmp/test%20path/temp_dv.bin", sizeInBytes = 15, cardinality = 25, offset = Some(8))
+
+    assert(pDv.normalizedTableRelativeObjectId(new Path("file:///tmp/test path")) ===
+      // "$storageType$pathOrInlineDv@$offsetValue"
+      "rtemp_dv.bin@8")
+  }
+
+  test("object identity includes offset") {
+    val base = createRelativePathDVDescriptor(
+      testDVRelPath, sizeInBytes = 15, cardinality = 25, offset = Some(8))
+    assert(base.uniqueId(testTablePath, useObjectIdentity = true) !==
+      base.copy(offset = Some(9)).uniqueId(testTablePath, useObjectIdentity = true))
+  }
+
   private def assertCardinality(dv: DeletionVectorDescriptor, expSize: Int): Unit = {
     if (expSize == 0) {
       assert(dv.isEmpty, s"Expected DV to be empty: $dv")
@@ -253,6 +332,7 @@ class DeletionVectorDescriptorSuite extends SparkFunSuite {
   }
 
   private val testTablePath = new Path("s3a://table/test")
+  private val testTablePathWithSpace = new Path("s3a://table/test path")
   private val testDVAbsPath = "s3a://table/test/dv1.bin"
   private val testDVRelPath = "data/deletes-abc.puffin"
   private val testDVData: Array[Byte] = Array(1, 2, 3, 4)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSingleActionSerializerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSingleActionSerializerSuite.scala
@@ -337,7 +337,7 @@ class AMTSingleActionSerializerSuite extends QueryTest with SharedSparkSession {
     val roundTripped = DeletionVector.toDescriptor(
       DeletionVector.fromDescriptor(dv, tableRoot), tableRoot)
     assert(roundTripped.storageType == DeletionVectorDescriptor.PATH_DV_MARKER)
-    assert(roundTripped.uniqueId == dv.uniqueId)
+    assert(roundTripped.legacyUniqueId == dv.legacyUniqueId)
     assert(roundTripped.sizeInBytes == dv.sizeInBytes)
     assert(roundTripped.offset == dv.offset)
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/deletionvectors/DeletionVectorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/deletionvectors/DeletionVectorsSuite.scala
@@ -18,11 +18,12 @@ package org.apache.spark.sql.delta.deletionvectors
 
 import java.io.{File, FileNotFoundException}
 import java.net.URISyntaxException
+import java.util.UUID
 
 import org.apache.spark.sql.delta.{DeletionVectorsTableFeature, DeletionVectorsTestUtils, DeltaChecksumException, DeltaConfigs, DeltaLog, DeltaMetricsUtils, DeltaTestUtilsForTempViews}
 import org.apache.spark.sql.delta.DeltaTestUtils.createTestAddFile
 import org.apache.spark.sql.delta.actions.{AddFile, DeletionVectorDescriptor, RemoveFile}
-import org.apache.spark.sql.delta.actions.DeletionVectorDescriptor.EMPTY
+import org.apache.spark.sql.delta.actions.DeletionVectorDescriptor._
 import org.apache.spark.sql.delta.deletionvectors.DeletionVectorsSuite._
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.{DeltaExceptionTestUtils, DeltaSQLCommandTest}
@@ -38,6 +39,7 @@ import org.apache.parquet.hadoop.ParquetFileReader
 
 import org.apache.spark.SparkConf
 import org.apache.spark.SparkException
+import org.apache.spark.paths.SparkPath
 import org.apache.spark.sql.{DataFrame, QueryTest, Row}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.plans.logical.{AppendData, Subquery}
@@ -45,6 +47,7 @@ import org.apache.spark.sql.execution.FileSourceScanLike
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.{StringType, StructField, StructType}
 
 class DeletionVectorsSuite extends QueryTest
   with SharedSparkSession
@@ -734,6 +737,56 @@ class DeletionVectorsSuite extends QueryTest
     }
   }
 
+  test("object uniqueIdExpression matches descriptor uniqueId") {
+    val tableRoot = new Path("s3a://table/test path")
+    val uuid = UUID.randomUUID()
+    val uDv = onDiskWithUuidRelativePath(
+      uuid, randomPrefix = "prefix + %space", sizeInBytes = 15, cardinality = 25, offset = Some(8))
+    val rDv = rFormOf(uuid, "prefix + %space", offset = Some(8))
+    val pDv = onDiskWithAbsolutePath(
+      SparkPath.fromPath(new Path(tableRoot, "data/a space + b.bin")).urlEncoded,
+      sizeInBytes = 15,
+      cardinality = 25,
+      offset = Some(8))
+    val pElsewhere = onDiskWithAbsolutePath(
+      SparkPath.fromPath(
+        new Path(s"s3a://other-bucket/tbl/prefix/${DELETION_VECTOR_FILE_NAME_CORE}_$uuid.bin"))
+        .urlEncoded,
+      sizeInBytes = 15,
+      cardinality = 25,
+      offset = Some(8))
+
+    val testCases = Seq(uDv, rDv, pDv, pElsewhere).map { dv =>
+      (
+        dv,
+        dv.uniqueId(tableRoot, useObjectIdentity = true),
+        dv.uniqueId(tableRoot, useObjectIdentity = false))
+    }
+    val rows = testCases.map { case (dv, expectedObjectId, expectedLegacyId) =>
+      Row(dvStructRow(dv), expectedObjectId, expectedLegacyId)
+    }
+    val input = spark.createDataFrame(
+      spark.sparkContext.parallelize(rows),
+      dvExpressionTestSchema)
+    val actual = input.select(
+      DeletionVectorDescriptor
+        .uniqueIdExpression(col("dv"), tableRoot, useObjectIdentity = true)
+        .as("actualObjectId"),
+      col("expectedObjectId"),
+      DeletionVectorDescriptor
+        .uniqueIdExpression(col("dv"), tableRoot, useObjectIdentity = false)
+        .as("actualLegacyId"),
+      col("expectedLegacyId"))
+
+    checkAnswer(actual, testCases.map { case (_, expectedObjectId, expectedLegacyId) =>
+      Row(
+        expectedObjectId,
+        expectedObjectId,
+        expectedLegacyId,
+        expectedLegacyId)
+    })
+  }
+
   test("Check no resource leak when DV files are missing (table corrupted)") {
     withTempDir { tempDir =>
       val source = new File(table2Path)
@@ -837,6 +890,36 @@ class DeletionVectorsSuite extends QueryTest
     val optimizedPlan = queryDf.queryExecution.analyzed.toString()
     assert(optimizedPlan.contains(expected), s"Plan is missing `$expected`: $optimizedPlan")
   }
+
+  /** The `r` form of the `u` DV that `uuid`/`prefix` describe. */
+  private def rFormOf(
+      uuid: UUID,
+      prefix: String,
+      offset: Option[Int]): DeletionVectorDescriptor = {
+    val path = if (prefix.isEmpty) {
+      s"${DELETION_VECTOR_FILE_NAME_CORE}_$uuid.bin"
+    } else {
+      s"$prefix/${DELETION_VECTOR_FILE_NAME_CORE}_$uuid.bin"
+    }
+    createRelativePathDVDescriptor(path, sizeInBytes = 15, cardinality = 25, offset = offset)
+  }
+
+  private def dvStructRow(dv: DeletionVectorDescriptor): Row = {
+    Row.fromSeq(DeletionVectorDescriptor.STRUCT_TYPE.fieldNames.map {
+      case "storageType" => dv.storageType
+      case "pathOrInlineDv" => dv.pathOrInlineDv
+      case "offset" => dv.offset.map(Int.box).orNull
+      case "sizeInBytes" => Int.box(dv.sizeInBytes)
+      case "cardinality" => Long.box(dv.cardinality)
+      case "maxRowIndex" => dv.maxRowIndex.map(Long.box).orNull
+      case field => fail(s"Unexpected deletion vector field in test schema: $field")
+    })
+  }
+
+  private def dvExpressionTestSchema = StructType(Seq(
+    StructField("dv", DeletionVectorDescriptor.STRUCT_TYPE, nullable = false),
+    StructField("expectedObjectId", StringType, nullable = false),
+    StructField("expectedLegacyId", StringType, nullable = false)))
 }
 
 object DeletionVectorsSuite {


### PR DESCRIPTION
## Description

Deletion vector descriptors currently expose a single `uniqueId` derived from the serialized descriptor fields (`storageType + pathOrInlineDv + optional offset`). That identity is stable for one serialized descriptor, but it treats equivalent `u` (UUID), `r` (relative), and in-table `p` (path) descriptors that point to the same physical DV object as three different DVs.

This PR:
- Renames the existing descriptor-based id to `legacyUniqueId` (adding `legacyUniqueIdExpression` / `getLegacyDeletionVectorUniqueId`), preserving today's behavior for callers that key on the serialized descriptor.
- Introduces `uniqueId(tableRoot, useObjectIdentity)` plus matching `uniqueIdExpression(col, tableRoot, useObjectIdentity)` and `AddFile`/`RemoveFile.getDeletionVectorUniqueId(tableRoot, useObjectIdentity)` overloads. With object identity, a descriptor is normalized to its physical DV object relative to the table root (plus offset) when possible, so equivalent `u`, `r`, and in-root `p` descriptors compare equal while out-of-root `p` descriptors stay distinct.
- Gates the choice for non-AMT tables behind a new internal conf `deletionVectors.useObjectIdentityForNonAMTTables` (default off); AMT tables always use object identity.

Existing call sites that must keep descriptor identity (log replay, conflict detection, OPTIMIZE candidate-set comparison, RESTORE, CLONE grouping) are switched to the explicit `legacy*` helpers, so this change is behavior-preserving on its own.

## How was this patch tested?

Added unit tests:
- `DeletionVectorDescriptorSuite`: legacy vs object identity selection; collapsing equivalent `u`/`r`/in-root `p` under object identity; keeping out-of-root `p` distinct; decoding + relativizing absolute `p` paths; offset inclusion.
- `DeletionVectorsSuite`: `uniqueIdExpression` column expression matches descriptor-level `uniqueId` for both identity modes across `u`/`r`/`p`.
- `AMTSingleActionSerializerSuite`: updated to the renamed `legacyUniqueId`.
