### PR TITLE
[Spark] Preserve root columns during V2 nested pruning

### DIFF
--- a/spark/v2/src/main/scala/io/delta/spark/internal/v2/read/DeltaV2ScanBuilder.scala
+++ b/spark/v2/src/main/scala/io/delta/spark/internal/v2/read/DeltaV2ScanBuilder.scala
@@ -121,11 +121,16 @@ private[read] class DeltaV2ScanBuilder(
   override def pruneColumns(requiredSchema: StructType): Unit = {
     Objects.requireNonNull(requiredSchema, "requiredSchema is null")
     // CDC columns are injected later by CDCReadFunction, so strip them here.
-    requiredDataSchema = new StructType(
+    val requestedDataSchema = new StructType(
       requiredSchema.fields.filter { f =>
         val name = f.name.toLowerCase(Locale.ROOT)
         !partitionColumnSet.contains(name) && !CDCSchemaContext.isCDCColumn(name)
       })
+
+    // Match the V1 LogicalRelation behavior: retain every root-level data column while applying
+    // Spark's pruning inside requested roots.
+    requiredDataSchema = DeltaV2SchemaPruningUtils.retainRootColumns(
+      dataSchema, requestedDataSchema, SQLConf.get.resolver)
   }
 
   /**
@@ -266,8 +271,8 @@ private[read] object DeltaV2ScanBuilder {
    * Rather than duplicate the DeltaScan-production logic (which must construct the `private[v2]`
    * [[DeltaV2Snapshot]] and run the V1 data-skipping path), this reuses the normal build path with
    * no pushed filters: an empty filter set makes `filesForScan` take its no-filter fast path and
-   * return a full-table [[DeltaScan]]. Column pruning is applied so the returned scan reads only
-   * `requiredSchema`.
+   * return a full-table [[DeltaScan]]. Column pruning narrows requested nested fields while
+   * retaining every logical root.
    *
    * @param tableName the table name (used only for identification)
    * @param snapshot the Kernel snapshot to read

--- a/spark/v2/src/main/scala/io/delta/spark/internal/v2/read/DeltaV2SchemaPruningUtils.scala
+++ b/spark/v2/src/main/scala/io/delta/spark/internal/v2/read/DeltaV2SchemaPruningUtils.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.read
+
+import org.apache.spark.sql.catalyst.analysis.Resolver
+import org.apache.spark.sql.types.StructType
+
+private[v2] object DeltaV2SchemaPruningUtils {
+
+  /**
+   * Applies Spark's nested pruning inside requested roots while retaining every table root.
+   * Required non-table fields, such as metadata columns, are appended to the result.
+   */
+  def retainRootColumns(
+      tableSchema: StructType,
+      requiredSchema: StructType,
+      resolver: Resolver): StructType = {
+    val tableFields = tableSchema.fields.map { tableField =>
+      requiredSchema.fields.find(requiredField => resolver(tableField.name, requiredField.name))
+        .getOrElse(tableField)
+    }
+    val nonTableFields = requiredSchema.fields.filterNot { requiredField =>
+      tableSchema.fields.exists(tableField => resolver(tableField.name, requiredField.name))
+    }
+    StructType(tableFields ++ nonTableFields)
+  }
+
+}

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2ScanBuilderTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2ScanBuilderTest.java
@@ -84,18 +84,84 @@ public class DeltaV2ScanBuilderTest extends DeltaV2TestBase {
     DeltaV2ScanBuilder builder =
         newScanBuilder(tableName, path, dataSchema, partitionSchema, tableSchema);
 
-    StructType expectedSparkSchema =
+    StructType requiredSparkSchema =
         DataTypes.createStructType(
             new StructField[] {
               DataTypes.createStructField("id", DataTypes.IntegerType, true /*nullable*/),
               DataTypes.createStructField("dep_id", DataTypes.IntegerType, true)
             });
+    StructType expectedScanSchema = tableSchema;
 
-    builder.pruneColumns(expectedSparkSchema);
+    builder.pruneColumns(new StructType());
+    assertEquals(expectedScanSchema, builder.build().readSchema());
+
+    builder.pruneColumns(tableSchema);
+    assertEquals(expectedScanSchema, builder.build().readSchema());
+
+    builder.pruneColumns(requiredSparkSchema);
     Scan scan = builder.build();
 
     assertTrue(scan instanceof DeltaV2Scan);
-    assertEquals(expectedSparkSchema, scan.readSchema());
+    assertEquals(expectedScanSchema, scan.readSchema());
+  }
+
+  @Test
+  public void testPruneColumns_prunesNestedFieldsAndRetainsRootColumns(@TempDir File tempDir) {
+    String path = tempDir.getAbsolutePath();
+    String tableName = "scan_builder_nested_pruning_test";
+    spark.sql(
+        String.format(
+            "CREATE TABLE %s (id INT, payload STRUCT<a: INT, b: STRING>, unused STRING, p INT) "
+                + "USING delta PARTITIONED BY (p) LOCATION '%s'",
+            tableName, path));
+
+    StructType fullPayload =
+        DataTypes.createStructType(
+            new StructField[] {
+              DataTypes.createStructField("a", DataTypes.IntegerType, true),
+              DataTypes.createStructField("b", DataTypes.StringType, true)
+            });
+    StructType prunedPayload =
+        DataTypes.createStructType(
+            new StructField[] {DataTypes.createStructField("b", DataTypes.StringType, true)});
+    StructType dataSchema =
+        DataTypes.createStructType(
+            new StructField[] {
+              DataTypes.createStructField("id", DataTypes.IntegerType, true),
+              DataTypes.createStructField("payload", fullPayload, true),
+              DataTypes.createStructField("unused", DataTypes.StringType, true)
+            });
+    StructType partitionSchema =
+        DataTypes.createStructType(
+            new StructField[] {DataTypes.createStructField("p", DataTypes.IntegerType, true)});
+    StructType tableSchema =
+        DataTypes.createStructType(
+            new StructField[] {
+              DataTypes.createStructField("id", DataTypes.IntegerType, true),
+              DataTypes.createStructField("payload", fullPayload, true),
+              DataTypes.createStructField("unused", DataTypes.StringType, true),
+              DataTypes.createStructField("p", DataTypes.IntegerType, true)
+            });
+    StructType requiredSchema =
+        DataTypes.createStructType(
+            new StructField[] {
+              DataTypes.createStructField("payload", prunedPayload, true),
+              DataTypes.createStructField("p", DataTypes.IntegerType, true)
+            });
+    StructType expectedScanSchema =
+        DataTypes.createStructType(
+            new StructField[] {
+              DataTypes.createStructField("id", DataTypes.IntegerType, true),
+              DataTypes.createStructField("payload", prunedPayload, true),
+              DataTypes.createStructField("unused", DataTypes.StringType, true),
+              DataTypes.createStructField("p", DataTypes.IntegerType, true)
+            });
+
+    DeltaV2ScanBuilder builder =
+        newScanBuilder(tableName, path, dataSchema, partitionSchema, tableSchema);
+    builder.pruneColumns(requiredSchema);
+
+    assertEquals(expectedScanSchema, builder.build().readSchema());
   }
 
   @Test
@@ -248,15 +314,15 @@ public class DeltaV2ScanBuilderTest extends DeltaV2TestBase {
   }
 
   @Test
-  public void testPruneColumnsRetainsFullyPushedFilterColumn(@TempDir File tempDir)
-      throws Exception {
+  public void testPruneColumnsRetainsAllRootColumns(@TempDir File tempDir) throws Exception {
     DeltaV2ScanBuilder builder = newFilterScanBuilder(tempDir);
     pushFilters(builder, new EqualTo("dep_id", 1));
     builder.pruneColumns(new StructType().add("id", DataTypes.IntegerType, true /* nullable */));
 
     Scan scan = builder.build();
     assertEquals(
-        Arrays.asList("id", "dep_id", "dep_name"), Arrays.asList(scan.readSchema().fieldNames()));
+        Arrays.asList("id", "name", "dep_id", "dep_name"),
+        Arrays.asList(scan.readSchema().fieldNames()));
   }
 
   @Test

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2ScanTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2ScanTest.java
@@ -343,7 +343,7 @@ public class DeltaV2ScanTest extends DeltaV2TestBase {
   }
 
   @Test
-  public void testGetReadDataSchemaWithColumnPruning() {
+  public void testGetReadDataSchemaRetainsRootColumns() {
     DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) table.newScanBuilder(options);
 
     StructType prunedSchema =
@@ -361,10 +361,7 @@ public class DeltaV2ScanTest extends DeltaV2TestBase {
 
     assertEquals(2, dataSchema.fields().length, "dataSchema should still have 2 fields");
     assertEquals(
-        1,
-        readDataSchema.fields().length,
-        "readDataSchema should have 1 field (name) after pruning cnt");
-    assertEquals("name", readDataSchema.fields()[0].name());
+        dataSchema, readDataSchema, "logical readDataSchema should retain all root data columns");
   }
 
   @Test
@@ -797,8 +794,8 @@ public class DeltaV2ScanTest extends DeltaV2TestBase {
   public void testPruneColumns_cdcRead_filtersCDCColumns() {
     // pruneColumns should filter out partition and CDC columns from the data schema, since
     // partition columns are read separately and CDC columns are injected by CDCReadFunction.
-    // The remaining data columns are honored - pruning a data column ("cnt") shrinks the
-    // underlying parquet read.
+    // Root data columns are retained to match V1 logical pruning. Partition and CDC fields are
+    // still handled separately.
     Map<String, String> cdcOptions = new HashMap<>();
     cdcOptions.put("readChangeFeed", "true");
     CaseInsensitiveStringMap cdcOptionsMap = new CaseInsensitiveStringMap(cdcOptions);
@@ -815,10 +812,11 @@ public class DeltaV2ScanTest extends DeltaV2TestBase {
 
     DeltaV2Scan scan = (DeltaV2Scan) builder.build();
 
-    // readDataSchema reflects pruning: only "name" remains (cnt dropped, partition + CDC filtered)
+    // readDataSchema retains both root data columns; partition + CDC fields are filtered here.
     StructType readDataSchema = scan.getReadDataSchema();
-    assertEquals(1, readDataSchema.fields().length);
+    assertEquals(2, readDataSchema.fields().length);
     assertEquals("name", readDataSchema.fields()[0].name());
+    assertEquals("cnt", readDataSchema.fields()[1].name());
 
     // readSchema = readDataSchema + partition + CDC
     StructType readSchema = scan.readSchema();
@@ -827,8 +825,7 @@ public class DeltaV2ScanTest extends DeltaV2TestBase {
     assertTrue(readSchema.fieldIndex("_change_type") >= 0);
     assertTrue(readSchema.fieldIndex("_commit_version") >= 0);
     assertTrue(readSchema.fieldIndex("_commit_timestamp") >= 0);
-    // Pruned column "cnt" should not appear.
-    assertThrows(IllegalArgumentException.class, () -> readSchema.fieldIndex("cnt"));
+    assertTrue(readSchema.fieldIndex("cnt") >= 0);
   }
 
   @Test


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

The Delta V1 `LogicalRelation` schema-pruning rule retains every root-level data column and only narrows fields inside requested nested columns. The Delta V2 scan builder instead removed complete root columns in `pruneColumns`, so its logical scan schema diverged from V1.

This change gives the Delta V2 scan builder the same logical behavior as V1: retain all table roots, apply nested pruning within the requested roots, and preserve required non-table fields such as metadata columns. A new `DeltaV2SchemaPruningUtils.retainRootColumns` helper implements this by matching each table root against the requested schema (using the SQL analyzer resolver), keeping the pruned form where present and the full root otherwise, then appending any required non-table fields.

## How was this patch tested?

Added and updated unit tests in `DeltaV2ScanBuilderTest` and `DeltaV2ScanTest`:
- New coverage that nested fields are pruned within a requested struct while every root column is retained.
- Updated expectations so pruning an unrequested root column keeps the root in the logical read schema.
- CDC read coverage confirming root data columns are retained while partition and CDC columns are still handled separately.

## Does this PR introduce _any_ user-facing changes?

No.
