### PR TITLE
[Release] Prepare version 4.4.0 for release

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1859,6 +1859,13 @@ lazy val releaseSettings = Seq(
   releasePublishArtifactsAction := PgpKeys.publishSigned.value,
   releaseCrossBuild := true,
   pgpPassphrase := sys.env.get("PGP_PASSPHRASE").map(_.toArray),
+  // Allow local Maven overwrites for release versions. The cross-Spark publish workflow
+  // publishes modules like delta-contribs (no Spark suffix) in both the backward-compat
+  // step and the per-version steps, producing identical artifacts. SBT 1.9+ blocks
+  // overwriting release artifacts by default; this restores the prior behavior for local
+  // publishing only (remote publish via publishSigned is unaffected).
+  publishLocalConfiguration := publishLocalConfiguration.value.withOverwrite(true),
+  publishM2Configuration := publishM2Configuration.value.withOverwrite(true),
 
   // TODO: This isn't working yet ...
   sonatypeProfileName := "io.delta", // sonatype account domain name prefix / group ID

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "4.4.0-SNAPSHOT"
+ThisBuild / version := "4.4.0"


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (release)

## Description

The release branch normally uses version 4.4.0-SNAPSHOT. That would give published artifacts a development version instead of the final 4.4.0 version.

This PR changes version.sbt to 4.4.0 for the release. It also allows local Maven overwrites during cross-Spark release publishing. The release workflow publishes unsuffixed modules such as delta-contribs in both the backward-compatible step and the per-Spark-version steps. SBT rejects those identical local writes for a non-snapshot version unless overwrite is enabled. This setting affects local publishLocal and publishM2 operations only; it does not allow overwriting artifacts on Maven Central.

After this PR merges, tag its merge commit as v4.4.0 before merging the snapshot-restoration PR.

## How was this patch tested?

- Ran the published-artifact test with Python 3.9.
- Verified the default and backward-compatible artifact layouts, each with all 12 expected version 4.4.0 JARs.
- Verified the full release workflow completed the Spark 4.0, 4.1, and 4.2 publish stages. The run was stopped during the later Flink stage to push the requested update.
- Ran git diff --check.

## Does this PR introduce _any_ user-facing changes?

No runtime behavior changes. This sets the version and local publishing behavior needed to produce the Delta Lake 4.4.0 release artifacts.