### PR TITLE
[Release] Restore version to 4.4.1-SNAPSHOT

### DIFF
--- a/python/delta/version.py
+++ b/python/delta/version.py
@@ -18,4 +18,4 @@
 # Do not edit manually - edit version.sbt instead and run:
 #   build/sbt sparkV1/generatePythonVersion
 
-__version__ = "4.4.0"
+__version__ = "4.4.1"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "4.4.0"
+ThisBuild / version := "4.4.1-SNAPSHOT"


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (release)

## Description

This PR is stacked on #7493. It returns branch-4.4 to snapshot development mode after the 4.4.0 release by changing version.sbt from 4.4.0 to 4.4.1-SNAPSHOT. It also regenerates the Python version as 4.4.1.

Merge this PR only after #7493 is merged and its merge commit is tagged v4.4.0.

## How was this patch tested?

- Ran build/sbt sparkV1/generatePythonVersion successfully.
- Confirmed the generated Python version is 4.4.1.
- Ran git diff --check.

## Does this PR introduce _any_ user-facing changes?

No runtime behavior changes. This restores the next development snapshot version after the 4.4.0 release.