### PR TITLE
[Build] Allow local overwrites during release publishing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1859,6 +1859,13 @@ lazy val releaseSettings = Seq(
   releasePublishArtifactsAction := PgpKeys.publishSigned.value,
   releaseCrossBuild := true,
   pgpPassphrase := sys.env.get("PGP_PASSPHRASE").map(_.toArray),
+  // Allow local Maven overwrites for release versions. The cross-Spark publish workflow
+  // publishes modules like delta-contribs (no Spark suffix) in both the backward-compat
+  // step and the per-version steps, producing identical artifacts. SBT 1.9+ blocks
+  // overwriting release artifacts by default; this restores the prior behavior for local
+  // publishing only (remote publish via publishSigned is unaffected).
+  publishLocalConfiguration := publishLocalConfiguration.value.withOverwrite(true),
+  publishM2Configuration := publishM2Configuration.value.withOverwrite(true),
 
   // TODO: This isn't working yet ...
   sonatypeProfileName := "io.delta", // sonatype account domain name prefix / group ID


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (build and release)

## Description

The cross-Spark release workflow can publish the same local Maven artifact more than once. For example, `delta-contribs` has no Spark-version suffix, so the backward-compatibility step and a per-version step produce the same release artifact. SBT 1.9 rejects the second write because release artifacts cannot be overwritten by default.

This change enables overwrites for local Ivy and Maven publishing in the shared release settings. Remote signed publishing is unchanged.

## How was this patch tested?

- `git diff --check`
- `./build/sbt "show storage/publishLocalConfiguration" "show storage/publishM2Configuration"`
- Ran the local release publishing workflow with the default Spark version, backward-compatible Spark version, and Spark 4.0, 4.1, and 4.2. The repeated artifacts published successfully.

## Does this PR introduce _any_ user-facing changes?

No.