### PR TITLE
[Storage] Retry UC commit without delta.clustering when the catalog r…

### DIFF
--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
@@ -104,6 +104,18 @@ import org.apache.hadoop.fs.Path;
  */
 public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
 
+  private static final org.slf4j.Logger LOG =
+      org.slf4j.LoggerFactory.getLogger(UCDeltaTokenBasedRestClient.class);
+
+  /**
+   * Table IDs whose catalog has rejected an external {@code delta.clustering} domain-metadata
+   * update (e.g. Databricks Unity Catalog tables with CLUSTER BY AUTO, error 5115). Once a table
+   * lands here, subsequent commits skip the clustering update up front instead of paying a
+   * rejected round-trip each time. Scoped to this client instance (one catalog endpoint).
+   */
+  private final java.util.Set<String> tablesRejectingClusteringUpdates =
+      java.util.concurrent.ConcurrentHashMap.newKeySet();
+
   private static final int HTTP_BAD_REQUEST = 400;
   private static final int HTTP_CONFLICT = 409;
   private static final int HTTP_NOT_FOUND = 404;
@@ -286,13 +298,78 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
           .action("set-protocol")
           .protocol(toSDKDeltaProtocol(newProtocol.get())));
     }
-    addDomainMetadataUpdateActions(request, transactionDomainMetadata);
+    // Catalogs that own table clustering (e.g. Databricks Unity Catalog tables with
+    // CLUSTER BY AUTO) reject delta.clustering domain-metadata updates from external writers
+    // (INVALID_PARAMETER_VALUE, error 5115), which would fail the whole commit. Optimistically
+    // send the full update; if the catalog rejects specifically the clustering domain, retry
+    // once without it and remember the rejection for this table. The clustering domain metadata
+    // is still committed to the Delta log itself, so engine-side clustering is unaffected --
+    // only the catalogs mirrored clustering columns are left to the catalog that owns them.
+    boolean skipClustering = tablesRejectingClusteringUpdates.contains(tableId);
+    List<AbstractDomainMetadata> domainMetadataToSend = skipClustering
+        ? withoutClusteringDomain(transactionDomainMetadata)
+        : transactionDomainMetadata;
+    addDomainMetadataUpdateActions(request, domainMetadataToSend);
 
     try {
       deltaTablesApi.updateTable(name.catalog, name.schema, name.table, request);
     } catch (ApiException e) {
-      handleUpdateTableException(e, name.catalog, name.schema, name.table);
+      List<AbstractDomainMetadata> retryDomainMetadata =
+          withoutClusteringDomain(transactionDomainMetadata);
+      boolean droppedClustering =
+          retryDomainMetadata.size() != transactionDomainMetadata.size();
+      if (!skipClustering && droppedClustering && isClusteringUpdateRejection(e)) {
+        LOG.warn("Catalog rejected external delta.clustering domain-metadata update for table "
+            + "{} ({}.{}.{}); retrying commit without it. Clustering metadata is still "
+            + "recorded in the Delta log.",
+            tableId, name.catalog, name.schema, name.table);
+        tablesRejectingClusteringUpdates.add(tableId);
+        DeltaUpdateTableRequest retryRequest = new DeltaUpdateTableRequest();
+        request.getRequirements().forEach(retryRequest::addRequirementsItem);
+        request.getUpdates().stream()
+            .filter(u -> !(u instanceof DeltaSetDomainMetadataUpdate)
+                && !(u instanceof DeltaRemoveDomainMetadataUpdate))
+            .forEach(retryRequest::addUpdatesItem);
+        addDomainMetadataUpdateActions(retryRequest, retryDomainMetadata);
+        try {
+          deltaTablesApi.updateTable(name.catalog, name.schema, name.table, retryRequest);
+        } catch (ApiException retryException) {
+          handleUpdateTableException(retryException, name.catalog, name.schema, name.table);
+        }
+      } else {
+        handleUpdateTableException(e, name.catalog, name.schema, name.table);
+      }
     }
+  }
+
+  /** {@code transactionDomainMetadata} minus any {@code delta.clustering} entries. */
+  private static List<AbstractDomainMetadata> withoutClusteringDomain(
+      List<AbstractDomainMetadata> transactionDomainMetadata) {
+    List<AbstractDomainMetadata> filtered = new ArrayList<>(transactionDomainMetadata.size());
+    for (AbstractDomainMetadata dm : transactionDomainMetadata) {
+      if (!DeltaDomainMetadataUpdates.JSON_PROPERTY_DELTA_CLUSTERING.equals(dm.getDomain())) {
+        filtered.add(dm);
+      }
+    }
+    return filtered;
+  }
+
+  /**
+   * Whether this failure is the catalog refusing an external {@code delta.clustering}
+   * domain-metadata update, as opposed to any other invalid request. UC returns no structured
+   * error code for this, so match the shape: HTTP 400 with a body that names the clustering
+   * domain as not allowed/permitted (Databricks emits
+   * "INVALID_PARAMETER_VALUE: Update to Delta domain metadata delta.clustering is not allowed.
+   * (5115)").
+   */
+  private static boolean isClusteringUpdateRejection(ApiException e) {
+    if (e.getCode() != HTTP_BAD_REQUEST) {
+      return false;
+    }
+    String body = e.getResponseBody();
+    return body != null
+        && body.contains(DeltaDomainMetadataUpdates.JSON_PROPERTY_DELTA_CLUSTERING)
+        && (body.contains("not allowed") || body.contains("not permitted"));
   }
 
   @Override


### PR DESCRIPTION
  #### Which Delta project/connector is this regarding?

  - [ ] Spark
  - [ ] Standalone
  - [ ] Flink
  - [ ] Kernel
  - [x] Other (Storage — UC commit coordinator client)

  ## Description

  Fixes a 4.3.0 regression: commits from external engines fail against catalogs that own table clustering (e.g. Databricks Unity Catalog tables with `CLUSTER BY AUTO`).

  Through Delta 4.2.x, the UC commit client (`UCTokenBasedRestClient.commit`) did not send domain metadata to Unity Catalog. Delta 4.3.0 replaced it with `UCDeltaTokenBasedRestClient`, whose `commit()` forwards every domain-metadata action from the transaction to UC's `updateTable` via `addDomainMetadataUpdateActions()` — including `delta.clustering`.

  Catalogs that own table clustering reject that update from an external writer:

  io.delta.storage.commit.CommitFailedException: Invalid updateTable request for <catalog>.<schema>.<table>: {"error":{"message":"... INVALID_PARAMETER_VALUE: Update to Delta domain metadata delta.clustering is not allowed. (5115)","code":400}}

  Because the rejection happens inside `commit()`, the **entire transaction fails**, not just the metadata mirror. Any commit carrying a `delta.clustering` action hits this: `ALTER TABLE ... CLUSTER BY`, the first write that establishes clustering, or clustering changes surfaced through OPTIMIZE. Workloads that worked on Delta ≤ 4.2.x fail after upgrading to 4.3.x.

  **Repro:** on a UC catalog that rejects external clustering updates, create a clustered managed table and change its clustering columns from an external Spark engine:

  ```sql
  CREATE TABLE cat.schema.t (id INT, category STRING) USING delta CLUSTER BY (category);
  ALTER TABLE cat.schema.t CLUSTER BY (id);   -- CommitFailedException (5115)
  ```
  
  **Fix**: commit optimistically with the full update. If the catalog rejects specifically the clustering domain (HTTP 400 whose body names delta.clustering as not allowed), retry the commit once without the clustering action, and remember the rejection per table so subsequent commits skip the failed attempt up front.

  - Clustering domain metadata is still recorded in the Delta log itself, so engine-side clustering behavior is unchanged; only the catalog's mirrored clustering columns are left to the catalog that owns them.
  - Catalogs that accept external clustering updates keep the eager property mirror: no behavior change, no extra round-trip, no configuration.
  - delta.rowTracking and domain-removal actions are unaffected.

  **How was this patch tested?**

  Tested on Spark 4.0.2 with Delta 4.3.1 against both catalog behaviors, using an OSS UC server (one build patched to reject external clustering updates with the 5115 error shape, one stock/permissive):

  1. Rejecting catalog: ALTER TABLE ... CLUSTER BY previously failed with CommitFailedException; with this patch the commit succeeds via the retry (logged at WARN), and the table remains readable and writable.
  2. Permissive catalog: clustering updates flow through on the first attempt (zero retries observed) and the catalog's clusteringColumns property is updated as before.
  3. No regressions: external-table and managed-table create/insert/read/append suites pass identically with and without the patch.

  **Does this PR introduce any user-facing changes?**

  No API changes. Behavior change vs. released 4.3.x: commits that previously failed with CommitFailedException (5115) against clustering-owning catalogs now succeed, with a one-time WARN log per table noting that the clustering domain-metadata update was skipped after catalog rejection.