### PR TITLE
Move `DELTA_PROTOCOL_CHANGED` additional info into error subclasses

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -2581,8 +2581,20 @@
   },
   "DELTA_PROTOCOL_CHANGED" : {
     "message" : [
-      "ProtocolChangedException: The protocol version of the Delta table has been changed by a concurrent update. <additionalInfo><conflictingCommit>\nRefer to <docLink> for more details."
+      "ProtocolChangedException: The protocol version of the Delta table has been changed by a concurrent update."
     ],
+    "subClass" : {
+      "GENERIC" : {
+        "message" : [
+          "<conflictingCommit>\nRefer to <docLink> for more details."
+        ]
+      },
+      "WRITE_TO_EMPTY_DIRECTORY" : {
+        "message" : [
+          "This happens when multiple writers are writing to an empty directory. Creating the table ahead of time will avoid this conflict. <conflictingCommit>\nRefer to <docLink> for more details."
+        ]
+      }
+    },
     "sqlState" : "2D521"
   },
   "DELTA_PROTOCOL_PROPERTY_NOT_INT" : {

--- a/spark/src/main/scala/io/delta/exceptions/DeltaConcurrentExceptions.scala
+++ b/spark/src/main/scala/io/delta/exceptions/DeltaConcurrentExceptions.scala
@@ -88,14 +88,29 @@ class MetadataChangedException private (
  * @since 1.0.0
  */
 @Evolving
-class ProtocolChangedException(message: String)
+class ProtocolChangedException private (
+    errorClass: String,
+    message: String,
+    messageParameters: Array[String] = Array.empty)
   extends org.apache.spark.sql.delta.ProtocolChangedException(message)
     with DeltaThrowable {
+  def this(message: String) = this("DELTA_PROTOCOL_CHANGED.GENERIC", message, Array.empty)
   def this(messageParameters: Array[String]) = {
-    this(DeltaThrowableHelper.getMessage("DELTA_PROTOCOL_CHANGED", messageParameters))
+    this(
+      "DELTA_PROTOCOL_CHANGED.GENERIC",
+      DeltaThrowableHelper.getMessage("DELTA_PROTOCOL_CHANGED.GENERIC", messageParameters),
+      messageParameters)
   }
-  override def getErrorClass: String = "DELTA_PROTOCOL_CHANGED"
+  override def getErrorClass: String = errorClass
   override def getMessage: String = message
+}
+
+object ProtocolChangedException {
+  def apply(subClass: String, messageParameters: Array[String]): ProtocolChangedException = {
+    val errorClass = s"DELTA_PROTOCOL_CHANGED.$subClass"
+    val message = DeltaThrowableHelper.getMessage(errorClass, messageParameters)
+    new ProtocolChangedException(errorClass, message, messageParameters)
+  }
 }
 
 /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -2697,17 +2697,17 @@ trait DeltaErrorsBase
 
   def protocolChangedException(
       conflictingCommit: Option[CommitInfo]): io.delta.exceptions.ProtocolChangedException = {
-    val additionalInfo = conflictingCommit.map { v =>
-      if (v.version.getOrElse(-1) == 0) {
-        "This happens when multiple writers are writing to an empty directory. " +
-          "Creating the table ahead of time will avoid this conflict. "
-      } else {
-        ""
-      }
-    }.getOrElse("")
-    new io.delta.exceptions.ProtocolChangedException(
+    // A conflicting commit at version 0 means the table was created by a concurrent writer while
+    // this transaction was writing to an empty directory. That case gets a dedicated subclass with
+    // a more specific hint; everything else uses the generic subclass.
+    val subClass = if (conflictingCommit.exists(_.version.getOrElse(-1L) == 0)) {
+      "WRITE_TO_EMPTY_DIRECTORY"
+    } else {
+      "GENERIC"
+    }
+    io.delta.exceptions.ProtocolChangedException(
+      subClass,
       Array(
-        additionalInfo,
         conflictingCommit.map(ci => s"\nConflicting commit: ${JsonUtils.toJson(ci)}").getOrElse(""),
         DeltaErrors.generateDocsLink(SparkEnv.get.conf, "/concurrency-control.html")
       )

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -27,7 +27,7 @@ import scala.sys.process.Process
 // scalastyle:off import.ordering.noEmptyLine
 // scalastyle:off line.size.limit
 import org.apache.spark.sql.delta.DeltaErrors.generateDocsLink
-import org.apache.spark.sql.delta.actions.{Action, Metadata, Protocol}
+import org.apache.spark.sql.delta.actions.{Action, CommitInfo, Metadata, Protocol}
 import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils.{TABLE_FEATURES_MIN_READER_VERSION, TABLE_FEATURES_MIN_WRITER_VERSION}
 import org.apache.spark.sql.delta.catalog.DeltaCatalog
 import org.apache.spark.sql.delta.constraints.CharVarcharConstraint
@@ -2913,9 +2913,23 @@ trait DeltaErrorsSuiteBase
       val e = intercept[io.delta.exceptions.ProtocolChangedException] {
         throw org.apache.spark.sql.delta.DeltaErrors.protocolChangedException(None)
       }
-      checkError(e, "DELTA_PROTOCOL_CHANGED", "2D521", Map.empty[String, String])
+      checkError(e, "DELTA_PROTOCOL_CHANGED.GENERIC", "2D521", Map.empty[String, String])
       assert(e.getMessage.contains("The protocol version of the Delta table has been changed " +
         "by a concurrent update."))
+    }
+    {
+      // A conflicting commit at version 0 selects the WRITE_TO_EMPTY_DIRECTORY subclass. The
+      // commit is serialized into the message, so it needs a non-null timestamp and parameters.
+      val conflictingCommit = CommitInfo.empty(version = Some(0))
+        .copy(timestamp = new Timestamp(0), operationParameters = Map.empty)
+      val e = intercept[io.delta.exceptions.ProtocolChangedException] {
+        throw org.apache.spark.sql.delta.DeltaErrors
+          .protocolChangedException(Some(conflictingCommit))
+      }
+      checkError(e, "DELTA_PROTOCOL_CHANGED.WRITE_TO_EMPTY_DIRECTORY", "2D521",
+        Map.empty[String, String])
+      assert(e.getMessage.contains(
+        "This happens when multiple writers are writing to an empty directory."))
     }
     {
       val e = intercept[io.delta.exceptions.MetadataChangedException] {


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other

## Description

`DELTA_PROTOCOL_CHANGED` previously built the "writing to an empty directory" hint
as an English string in Scala and passed it through the `<additionalInfo>` message
parameter. This moves that text into two error subclasses so the message text lives
entirely in the error class definitions:

- `WRITE_TO_EMPTY_DIRECTORY` — a conflicting commit at version 0 (the table was
  created by a concurrent writer while this transaction was writing to an empty
  directory).
- `GENERIC` — every other case (the former empty-`additionalInfo` path).

`protocolChangedException` now selects the subclass from the conflicting commit's
version, and `io.delta.exceptions.ProtocolChangedException` gains a subclass-aware
companion `apply` mirroring `ConcurrentAppendException`, keeping its public
constructors. The rendered message text and SQLSTATE (`2D521`) are unchanged.

## How was this patch tested?

Updated `DeltaErrorsSuite` to assert the subclass via `checkError`:
`DELTA_PROTOCOL_CHANGED.GENERIC` when there is no conflicting commit, and a new case
for `DELTA_PROTOCOL_CHANGED.WRITE_TO_EMPTY_DIRECTORY` with a version-0 conflicting
commit.

## Does this PR introduce _any_ user-facing changes?

Yes. The error condition now carries a subclass
(`DELTA_PROTOCOL_CHANGED.GENERIC` / `DELTA_PROTOCOL_CHANGED.WRITE_TO_EMPTY_DIRECTORY`).
SQLSTATE and the rendered message text are unchanged.
