### PR TITLE
[Spark] Add streaming partitioned-write tests for column-mapped tables

### DIFF
--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SinkSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SinkSuite.scala
@@ -71,6 +71,7 @@ object DeltaV2SinkSuite {
     // No partition support: the V2 write rejects a partitioned target, surfaced as an async
     // StreamingQueryException, not the outcome these tests expect.
     "partitioned writing and batch reading",
+    "partitioned writing into a column-mapped table",
     "SPARK-21167: encode and decode path correctly",
     "throw exception when users are trying to write in batch with different partitioning",
     // No NullType support, creating a table with void column fails.

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSinkSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSinkSuite.scala
@@ -429,6 +429,80 @@ class DeltaSinkSuite
     }
   }
 
+  /** Asserts each of `partitionValues` is a physical `col-<uuid>=<value>` dir, not logical. */
+  private def assertPhysicalColumnMappedPartitionDirs(
+      tableRoot: File, partitionValues: Seq[String]): Unit = {
+    val dirNames = Option(tableRoot.listFiles()).getOrElse(Array.empty[File])
+      .filter(_.isDirectory).map(_.getName)
+    partitionValues.foreach { value =>
+      assert(
+        dirNames.count(n => n.startsWith("col-") && n.endsWith("=" + value)) == 1,
+        s"expected one physical partition dir col-*=$value under $tableRoot, " +
+          s"got: ${dirNames.mkString(", ")}")
+      assert(
+        !dirNames.exists(n => !n.startsWith("col-") && n.endsWith("=" + value)),
+        s"did not expect a logical partition dir ending in '=$value' under $tableRoot")
+    }
+  }
+
+  test("partitioned writing into a column-mapped table") {
+    // Runs on V1 here and, via DeltaV2SinkSuite's classification, on the V2 Kernel sink.
+    Seq("name", "id").foreach { mode =>
+      withClue(s"columnMappingMode=$mode") {
+        withColumnMappingConf(mode) {
+          withSinkTarget { (target, checkpointDir) =>
+            val inputData = MemoryStream[Int]
+            val ds = inputData.toDS()
+            val query = startStream(
+              ds.map(i => (i, i * 1000))
+                .toDF("id", "value")
+                .writeStream
+                .partitionBy("id")
+                .option("checkpointLocation", checkpointDir.getCanonicalPath)
+                .format("delta"),
+              target)
+            try {
+              inputData.addData(1, 2, 3)
+              failAfter(streamingTimeout) {
+                query.processAllAvailable()
+              }
+
+              // Data round-trips through a batch read.
+              checkDatasetUnorderly(
+                readTarget(target).as[(Int, Int)],
+                (1, 1000), (2, 2000), (3, 3000))
+
+              // Guard that the auto-created table is actually column-mapped.
+              assert(deltaLogForTarget(target).update().metadata.columnMappingMode.name == mode)
+
+              // Partition pruning returns the right rows.
+              checkDatasetUnorderly(
+                readTarget(target).filter("id = 1").as[(Int, Int)], (1, 1000))
+              checkDatasetUnorderly(
+                readTarget(target).filter("id in (1, 2)").as[(Int, Int)], (1, 1000), (2, 2000))
+
+              val tableRoot = new File(deltaLogForTarget(target).dataPath.toUri)
+              // TODO(#7140): Implement randomized file prefixes in the V2 sink and remove
+              // this V1/V2 physical-layout distinction.
+              if (useDsv2) {
+                assertPhysicalColumnMappedPartitionDirs(tableRoot, Seq("1", "2", "3"))
+              } else {
+                val dataDirs = Option(tableRoot.listFiles()).getOrElse(Array.empty[File])
+                  .filter(_.isDirectory).map(_.getName).filterNot(_ == "_delta_log")
+                assert(
+                  dataDirs.nonEmpty && !dataDirs.exists(_.contains("=")),
+                  s"expected V1's random-prefix layout (data dirs, none of the form col=value), " +
+                    s"got: ${dataDirs.mkString(", ")}")
+              }
+            } finally {
+              query.stop()
+            }
+          }
+        }
+      }
+    }
+  }
+
   test("work with aggregation + watermark") {
     withSinkTarget { (target, checkpointDir) =>
       val inputData = MemoryStream[Long]

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/write/DeltaV2StreamingWriteTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/write/DeltaV2StreamingWriteTest.java
@@ -38,6 +38,8 @@ import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Unit tests for {@link DeltaV2StreamingWrite}; the streaming counterpart of DeltaV2BatchWriteTest.
@@ -291,6 +293,76 @@ public class DeltaV2StreamingWriteTest extends DeltaV2TestBase {
   }
 
   /**
+   * Partitioned streaming write to a column-mapped table across two epochs; asserts each partition
+   * lands in a physical {@code col-<uuid>=<value>} directory (not the logical {@code part=<value>}
+   * one). Streaming counterpart of V2WriteTest.writeToPartitionedColumnMappingTable.
+   */
+  @ParameterizedTest(name = "columnMappingMode={0}")
+  @ValueSource(strings = {"name", "id"})
+  public void testCommit_partitionedColumnMapping_appendsAcrossEpochs(
+      String mappingMode, @TempDir File tempDir) throws Exception {
+    // Unique name per mode: the shared session's catalog persists across invocations, so a shared
+    // name would collide on the second run.
+    String path =
+        createPartitionedColumnMappingTable(
+            tempDir, "streaming_partitioned_cm_" + mappingMode, mappingMode);
+    DeltaV2StreamingWrite write = newPartitionedWrite(path);
+
+    // Each epoch spans two partitions (rows pre-sorted by part), exercising file rotation at the
+    // partition boundary.
+    write.commit(
+        0L, new WriterCommitMessage[] {writePartitionedEpoch(write, 0L, 10, "a", 20, "b")});
+    write.commit(
+        1L, new WriterCommitMessage[] {writePartitionedEpoch(write, 1L, 11, "a", 30, "c")});
+
+    List<Row> rows = spark.read().format("delta").load(path).orderBy("value").collectAsList();
+    assertEquals(4, rows.size(), "distinct epochs must accumulate");
+    assertEquals(10, rows.get(0).getInt(rows.get(0).fieldIndex("value")));
+    assertEquals("a", rows.get(0).getString(rows.get(0).fieldIndex("part")));
+
+    // Both epochs' partitions use physical col-<uuid>=<value> dirs, never logical part=<value>.
+    assertPhysicalColumnMappedPartitionDir(path, "a");
+    assertPhysicalColumnMappedPartitionDir(path, "b");
+    assertPhysicalColumnMappedPartitionDir(path, "c");
+
+    // Partition-predicate read returns only that partition across both epochs.
+    List<Row> onlyA =
+        spark
+            .read()
+            .format("delta")
+            .load(path)
+            .filter("part = 'a'")
+            .orderBy("value")
+            .collectAsList();
+    assertEquals(2, onlyA.size());
+    assertEquals(10, onlyA.get(0).getInt(onlyA.get(0).fieldIndex("value")));
+    assertEquals(11, onlyA.get(1).getInt(onlyA.get(1).fieldIndex("value")));
+  }
+
+  /**
+   * A null partition value lands in {@code __HIVE_DEFAULT_PARTITION__} under the physical {@code
+   * col-<uuid>} parent and reads back as null.
+   */
+  @Test
+  public void testCommit_partitionedColumnMapping_nullPartitionValue(@TempDir File tempDir)
+      throws Exception {
+    String path =
+        createPartitionedColumnMappingTable(tempDir, "streaming_partitioned_cm_null", "name");
+    DeltaV2StreamingWrite write = newPartitionedWrite(path);
+
+    write.commit(0L, new WriterCommitMessage[] {writePartitionedEpoch(write, 0L, 10, null)});
+
+    List<Row> rows = spark.read().format("delta").load(path).collectAsList();
+    assertEquals(1, rows.size());
+    assertEquals(10, rows.get(0).getInt(rows.get(0).fieldIndex("value")));
+    assertTrue(
+        rows.get(0).isNullAt(rows.get(0).fieldIndex("part")), "null partition must read back null");
+
+    // The null value is Hive-encoded under the physical col-<uuid> parent, not a logical part=.
+    assertPhysicalColumnMappedPartitionDir(path, "__HIVE_DEFAULT_PARTITION__");
+  }
+
+  /**
    * Runs the executor-side writer for one epoch and returns its commit message. {@code idNamePairs}
    * is a flat list of (int id, String name) values.
    */
@@ -377,5 +449,39 @@ public class DeltaV2StreamingWriteTest extends DeltaV2TestBase {
             PARTITIONED_PART_SCHEMA,
             info);
     return (DeltaV2StreamingWrite) write.toStreaming();
+  }
+
+  /**
+   * Creates a (value INT, part STRING) table partitioned by {@code part} with column mapping in
+   * {@code mappingMode} ({@code name} or {@code id}). The logical schema matches {@link
+   * #PARTITIONED_FULL_SCHEMA}, so {@link #newPartitionedWrite} can drive it.
+   */
+  private String createPartitionedColumnMappingTable(
+      File tempDir, String tableName, String mappingMode) {
+    String path = tempDir.getAbsolutePath();
+    spark.sql(
+        String.format(
+            "CREATE TABLE %s (value INT, part STRING) USING delta PARTITIONED BY (part) "
+                + "LOCATION '%s' TBLPROPERTIES ('delta.columnMapping.mode' = '%s')",
+            tableName, path, mappingMode));
+    return path;
+  }
+
+  /**
+   * Asserts a physical {@code col-<uuid>=<value>} partition directory exists under {@code
+   * tablePath} and that no logical {@code part=<value>} directory was written instead (which would
+   * be a column-mapping regression). Mirrors V2WriteTest.assertPhysicalPartitionDirExists.
+   */
+  private void assertPhysicalColumnMappedPartitionDir(String tablePath, String value) {
+    File[] physical =
+        new File(tablePath).listFiles((d, n) -> n.startsWith("col-") && n.endsWith("=" + value));
+    assertTrue(
+        physical != null && physical.length == 1,
+        "Expected one physical partition directory col-*=" + value);
+    File[] logical =
+        new File(tablePath).listFiles((d, n) -> !n.startsWith("col-") && n.endsWith("=" + value));
+    assertTrue(
+        logical == null || logical.length == 0,
+        "Did not expect a logical partition directory ending in '=" + value + "'");
   }
 }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Adds test coverage for streaming writes that partition into column-mapped Delta tables, covering both the V1 streaming sink and the V2 (Kernel-backed) streaming write path.

- `DeltaSinkSuite`: a new `partitioned writing into a column-mapped table` test runs a partitioned (`partitionBy`) streaming append into an auto-created column-mapped table under both `name` and `id` column-mapping modes. It asserts the data round-trips through a batch read, partition pruning returns the correct rows, and the table is actually column-mapped. It also checks the on-disk partition layout: the V2 (Kernel-backed) sink writes physical `col-<uuid>=<value>` directories, while the V1 sink uses its randomized file-prefix layout (data directories that are not of the form `<column>=<value>`).
- `DeltaV2StreamingWriteTest`: two new tests for the V2 streaming write path — a parameterized test that appends across two epochs into a partitioned column-mapped table (exercising file rotation at the partition boundary) under both mapping modes, and a test that a null partition value is Hive-encoded as `__HIVE_DEFAULT_PARTITION__` under the physical `col-<uuid>` parent and reads back as null.

## How was this patch tested?

This is a test-only change. The added tests exercise the existing streaming write paths and were run as unit tests.

## Does this PR introduce _any_ user-facing changes?

No.
