### PR TITLE
Install the correct AMT checkpoint provider upon warm snapshot update

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
@@ -123,7 +123,8 @@ case class CheckpointInstance(
           // large, we need a fallback mechanism. For now, we expect it to be always present.
           throw new IllegalStateException("AMT checkpoint action is expected to be always present.")
         }
-        AMTCheckpointProvider.fromCheckpoint(deltaLog, checkpointAction)
+        AMTCheckpointProvider.fromCheckpoint(
+          deltaLog, checkpointAction, lastAMTCheckpointInfo.manifestCommitVersion)
       // Treat single file checkpoints also as V2 Checkpoints because we don't know if it is
       // actually a V2 checkpoint until we read it.
       case CheckpointInstance.Format.V2 | CheckpointInstance.Format.SINGLE =>
@@ -274,6 +275,15 @@ object CheckpointInstance {
       manifestCommitVersion = metadata.amtCheckpoint.map(_.manifestCommitVersion))
   }
 
+  def apply(amtCheckpointProvider: AMTCheckpointProvider): CheckpointInstance = {
+    CheckpointInstance(
+      version = amtCheckpointProvider.version,
+      format = Format.AMT,
+      fileName = None,
+      numParts = Some(amtCheckpointProvider.leaves.size),
+      manifestCommitVersion = Some(amtCheckpointProvider.manifestCommitVersion))
+  }
+
   val MaxValue: CheckpointInstance = sentinelValue(versionOpt = None)
 
   def sentinelValue(versionOpt: Option[Long]): CheckpointInstance = {
@@ -384,12 +394,27 @@ trait Checkpoints extends DeltaLogging {
     writeLastCheckpointFile(this, lastCheckpointInfo, LastCheckpointInfo.checksumEnabled(spark))
   }
 
-  /** Resolves the AMT checkpoint instance from the last checkpoint hint. */
-  protected def resolveAMTCheckpointInstance(
-      lastCheckpointInfo: Option[LastCheckpointInfo]): Option[CheckpointInstance] = {
-    lastCheckpointInfo
+  /**
+   * Resolves the AMT checkpoint instances from the last checkpoint info and old checkpoint
+   * provider.
+   */
+  protected def resolveAMTCheckpointInstances(
+      lastCheckpointInfo: Option[LastCheckpointInfo],
+      oldCheckpointProviderOpt: Option[UninitializedCheckpointProvider])
+    : Seq[CheckpointInstance] = {
+    val instanceFromLastCheckpointInfo = lastCheckpointInfo
       .filter(_.amtCheckpoint.isDefined)
       .map(CheckpointInstance.apply)
+    val instanceFromOldCheckpointProvider = oldCheckpointProviderOpt.collect {
+      case amt: AMTCheckpointProvider => CheckpointInstance.apply(amt)
+    }
+    // If the hint and the old provider describe the same AMT checkpoint, they'll both be discarded
+    // in `getLatestCompleteCheckpointFromList`. Dedup so a single instance survives. Prioritize the
+    // old checkpoint provider instance for better semantics, as we will reuse the old checkpoint
+    // provider in `getLogSegmentForVersion` if the version matches.
+    instanceFromLastCheckpointInfo
+      .filterNot(info => instanceFromOldCheckpointProvider.exists(_.version == info.version))
+      .toSeq ++ instanceFromOldCheckpointProvider
   }
 
   /**
@@ -471,10 +496,12 @@ trait Checkpoints extends DeltaLogging {
       logSegment: LogSegment,
       lastManifestCommit: LastManifestCommit): LogSegment = {
     recordDeltaOperation(this, "delta.v4amt.readManifestCommitAndUpdateAMTCheckpointProvider") {
+      val LastManifestCommit(manifestCommitVersion, contentRootVersion) = lastManifestCommit
       // The initial log segment must have all the deltas after the content root version.
-      require(logSegment.checkpointProvider.version <= lastManifestCommit.contentRootVersion)
+      require(logSegment.checkpointProvider.version <= contentRootVersion)
       val checkpoint = readCheckpointActionFromCommit(logSegment, lastManifestCommit)
-      val newCheckpointProvider = AMTCheckpointProvider.fromCheckpoint(this, checkpoint)
+      val newCheckpointProvider = AMTCheckpointProvider.fromCheckpoint(
+        this, checkpoint, manifestCommitVersion)
       logSegment.copy(
         checkpointProvider = newCheckpointProvider,
         deltas = logSegment.deltas.filter(f => deltaVersion(f) > newCheckpointProvider.version))

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -3012,7 +3012,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
       newChecksumOpt,
       preCommitLogSegment,
       catalogTableForPostCommitSnapshot,
-      amtCheckpointOpt = amtWriteResultOpt.map(_.checkpoint),
+      amtCheckpointWrittenInCommitOpt = amtWriteResultOpt.map(_.checkpoint),
       isIdempotentRetry = isIdempotentRetry)
     val postCommitReconstructionTime = System.nanoTime()
     maintenanceOperation = if (

--- a/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
@@ -518,8 +518,9 @@ trait SnapshotManagement { self: DeltaLog =>
       // Find the latest checkpoint in the listing that is not older than the versionToLoad
       val fileBasedCheckpointInstances = checkpoints.map(f => CheckpointInstance(f.getPath))
       // An AMT checkpoint has no dedicated file in the listing; it is resolved from hint instead.
-      val amtCheckpointInstanceOpt = resolveAMTCheckpointInstance(lastCheckpointInfo)
-      val checkpointInstances = fileBasedCheckpointInstances ++ amtCheckpointInstanceOpt
+      val amtCheckpointInstances = resolveAMTCheckpointInstances(
+        lastCheckpointInfo, oldCheckpointProviderOpt)
+      val checkpointInstances = fileBasedCheckpointInstances ++ amtCheckpointInstances
       val newCheckpoint = getLatestCompleteCheckpointFromList(checkpointInstances, versionToLoad)
       val newCheckpointVersion = newCheckpoint.map(_.version).getOrElse {
         // If we do not have any checkpoint, pass new checkpoint version as -1 so that first
@@ -1092,10 +1093,6 @@ trait SnapshotManagement { self: DeltaLog =>
     // that there's no chance of a race condition changing the snapshot partway through the update.
     val capturedSnapshot = currentSnapshot
     val oldVersion = capturedSnapshot.snapshot.version
-    // TODO: implement deltaLog.update() rediscovery for AMT tables.
-    if (capturedSnapshot.snapshot.protocol.isFeatureSupported(AdaptiveMetadataTableFeature)) {
-      return capturedSnapshot.snapshot
-    }
     def sendEvent(
       newSnapshot: Snapshot,
       snapshotAlreadyUpdatedAfterRequiredTimestamp: Boolean = false
@@ -1488,7 +1485,7 @@ trait SnapshotManagement { self: DeltaLog =>
       newChecksumOpt: Option[VersionChecksum],
       preCommitLogSegment: LogSegment,
       catalogTableOpt: Option[CatalogTable],
-      amtCheckpointOpt: Option[Checkpoint] = None,
+      amtCheckpointWrittenInCommitOpt: Option[Checkpoint] = None,
       isIdempotentRetry: Boolean = false): Snapshot = {
     var previousSnapshot: Snapshot = null
     recordDeltaOperation(this, "delta.log.updateAfterCommit") {
@@ -1500,8 +1497,8 @@ trait SnapshotManagement { self: DeltaLog =>
         val commitCoordinatorOpt = populateCommitCoordinator(
           spark, catalogTableOpt, previousSnapshot
         )
-        val amtCheckpointProviderOpt =
-          amtCheckpointOpt.map(cp => AMTCheckpointProvider.fromCheckpoint(this, cp))
+        val amtCheckpointProviderOpt = amtCheckpointWrittenInCommitOpt.map(
+          AMTCheckpointProvider.fromCheckpoint(this, _, committedVersion))
         val segment = if (isIdempotentRetry) {
           // The commit already landed and the preCommitLogSegment has been advanced to a
           // segment at  >= committedVersion by conflict checking, so it is already the

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTCheckpointProvider.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTCheckpointProvider.scala
@@ -37,6 +37,7 @@ import org.apache.spark.util.SerializableConfiguration
  * This provider is only for inline manifest-commit checkpoints, and this is not intended for
  * standalone checkpoint which also refers to an AMT.
  *
+ * @param manifestCommitVersion The version of the manifest commit that wrote this checkpoint.
  * @param checkpointAction The inline-emitted Checkpoint action this tree was committed with;
  *                         carries the version, contentRoot, and inline non-file state.
  * @param leaves           The root's `DATA_MANIFEST` pointer entries, one per leaf reachable from
@@ -45,6 +46,7 @@ import org.apache.spark.util.SerializableConfiguration
  * @param tableRoot        The table's data path.
  */
 final class AMTCheckpointProvider(
+    val manifestCommitVersion: Long,
     val checkpointAction: Checkpoint,
     val leaves: Seq[DataManifestEntry],
     val tableRoot: Path)
@@ -283,7 +285,8 @@ object AMTCheckpointProvider {
    */
   def fromCheckpoint(
       deltaLog: DeltaLog,
-      checkpoint: Checkpoint): AMTCheckpointProvider = {
+      checkpoint: Checkpoint,
+      manifestCommitVersion: Long): AMTCheckpointProvider = {
     val tableRoot = deltaLog.dataPath
     val rootFile = checkpoint.contentRoot.toFileStatus(tableRoot)
     val index =
@@ -293,7 +296,11 @@ object AMTCheckpointProvider {
     val leaves = loadEntries(deltaLog, index, checkpoint.metaData).collect().toSeq
       .filter(_.content_type == AMTSingleAction.ContentType.Type.DataManifest)
       .map(_.unwrap.asInstanceOf[DataManifestEntry])
-    new AMTCheckpointProvider(checkpointAction = checkpoint, leaves = leaves, tableRoot = tableRoot)
+    new AMTCheckpointProvider(
+      manifestCommitVersion = manifestCommitVersion,
+      checkpointAction = checkpoint,
+      leaves = leaves,
+      tableRoot = tableRoot)
   }
 
   /** Tracking Status representing the live [[DataEntry]] in an AMT. */

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointWriteSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointWriteSuite.scala
@@ -326,7 +326,8 @@ class AMTCheckpointWriteSuite extends AMTCheckpointTestBase {
       assert(rootLoc.contains("root with space.parquet") && !rootLoc.contains("%20"))
       assert(leafLoc.contains("leaf with space.parquet") && !leafLoc.contains("%20"))
 
-      val provider = AMTCheckpointProvider.fromCheckpoint(deltaLog, checkpoint)
+      val provider = AMTCheckpointProvider.fromCheckpoint(
+        deltaLog, checkpoint, manifestCommitVersion = checkpoint.version)
       // The provider resolves the spaced pointers to absolute, raw paths under the table root.
       assert(provider.liveLeafManifestAbsolutePaths.forall(p =>
         p.isAbsolute && p.toString.contains("leaf with space.parquet") &&

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotDiscoverySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotDiscoverySuite.scala
@@ -24,6 +24,7 @@ import org.apache.commons.io.IOUtils
 import org.apache.hadoop.fs.{FileSystem, Path}
 
 import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
 
 class AMTSnapshotDiscoverySuite extends AMTCheckpointTestBase {
 
@@ -303,6 +304,325 @@ class AMTSnapshotDiscoverySuite extends AMTCheckpointTestBase {
   ///////////////////////////
   // deltaLog.update()
   ///////////////////////////
+
+  /** The catalog table for a catalog-managed AMT table accessed by name. */
+  private def catalogTableFor(tableName: String): CatalogTable =
+    spark.sessionState.catalog.getTableMetadata(new TableIdentifier(tableName))
+
+  /** The delta versions of the deltas kept in the snapshot's log segment. */
+  private def segmentDeltaVersions(snapshot: Snapshot): Seq[Long] =
+    snapshot.logSegment.deltas.map(FileNames.deltaVersion)
+
+  /**
+   * The master equivalence oracle for the warm-update path. It checks two independent things:
+   *
+   *  1. Absolute expectations on the warm snapshot (version, AMT provider checkpoint version,
+   *     trailing delta versions). These do NOT use cold as the oracle, so a discovery bug that
+   *     corrupts BOTH the warm and the cold path identically is still caught here.
+   *  2. That the warm snapshot is otherwise indistinguishable from a fresh cold load: structural
+   *     fields, the manifest-commit reference, the installed CRC's file count, protocol/metadata,
+   *     and -- the strongest check -- that state reconstructed from each yields identical contents.
+   */
+  private def assertWarmMatchesCold(
+      warmSnapshot: Snapshot,
+      tableName: String,
+      expectedVersion: Int,
+      expectedProviderVersion: Option[Int],
+      expectedTrailingDeltas: Seq[Int]): Unit = {
+    // (1) Absolute expectations -- pinned literals, independent of the cold path.
+    assert(warmSnapshot.version == expectedVersion,
+      s"warm v${warmSnapshot.version} != expected v$expectedVersion.")
+    assert(amtProvider(warmSnapshot).map(_.checkpointVersion) == expectedProviderVersion,
+      s"warm provider ${amtProvider(warmSnapshot).map(_.checkpointVersion)} != " +
+        s"expected $expectedProviderVersion.")
+    assert(segmentDeltaVersions(warmSnapshot) == expectedTrailingDeltas,
+      s"warm deltas ${segmentDeltaVersions(warmSnapshot)} != expected $expectedTrailingDeltas.")
+
+    // (2) Warm must additionally match a fresh cold load in every observable field.
+    val (coldDeltaLog, coldSnapshot) = coldLoad(tableName)
+    assert(warmSnapshot.version == coldSnapshot.version,
+      s"warm v${warmSnapshot.version} != cold v${coldSnapshot.version}.")
+    assert(warmSnapshot.logSegment.equals(coldSnapshot.logSegment),
+      "log segment must be equal between warm and cold.")
+    assert(warmSnapshot.lastManifestCommitOpt == coldSnapshot.lastManifestCommitOpt,
+      s"warm ${warmSnapshot.lastManifestCommitOpt} != cold ${coldSnapshot.lastManifestCommitOpt}.")
+    assert(warmSnapshot.checksumOpt == coldSnapshot.checksumOpt,
+      "checksum must be equal between warm and cold.")
+    assert(warmSnapshot.protocol == coldSnapshot.protocol,
+      "protocol must be equal between warm and cold.")
+    assert(warmSnapshot.metadata == coldSnapshot.metadata,
+      "metadata must be equal between warm and cold.")
+    // Data-level: reconstructed contents must match, which catches a wrong log segment even when
+    // the scalar fields above happen to agree.
+    checkAnswer(
+      warmSnapshot.deltaLog.createDataFrame(
+        warmSnapshot, warmSnapshot.allFilesViaStateReconstruction.collect().toSeq),
+      coldDeltaLog.createDataFrame(
+        coldSnapshot, coldSnapshot.allFilesViaStateReconstruction.collect().toSeq).collect().toSeq)
+  }
+
+  /**
+   * Context for the warm update test harness.
+   *
+   * @param label The test name.
+   * @param staleVersion The version of the stale DeltaLog handle.
+   * @param cpProviderVersions The versions of all the checkpoint providers in the table.
+   * @param expectedVersion The expected snapshot version after update().
+   * @param expectedCpVersion The expected checkpoint provider version installed by update().
+   * @param expectedTrailingDeltas The expected trailing deltas installed by update().
+   */
+  private case class WarmUpdateContext(
+      label: String,
+      staleVersion: Int,
+      cpProviderVersions: Seq[Int],
+      latestCommitVersion: Int,
+      expectedCpVersion: Option[Int],
+      expectedTrailingDeltas: Seq[Int]) {
+    // For simplicity in versioning, the test harness always uses inline manifest commits. But since
+    // the first checkpoint cannot be inline, we trigger a full checkpoint at v1, defer its emission
+    // to v2, and bump up the checkpoint interval to avoid emitting more deferred checkpoints in v3.
+    // The test harness then starts from v3.
+    require(staleVersion >= 3)
+    require(cpProviderVersions.head == 1)
+    require(staleVersion <= latestCommitVersion)
+    require(cpProviderVersions.forall(_ <= latestCommitVersion))
+    require(expectedCpVersion.forall(_ <= latestCommitVersion))
+    require(expectedTrailingDeltas.forall(_ <= latestCommitVersion))
+  }
+
+  private def runWarmUpdateContext(ctx: WarmUpdateContext): Unit = {
+    val name = s"amt_warm_matrix"
+    withTable(name) {
+      createAMTTable(name, checkpointInterval = 1)
+      sql(s"INSERT INTO $name VALUES (1)")  // v1: triggers a deferred checkpoint
+                                            // v2: OPTIMIZE CHECKPOINT (state@v1)
+      sql(s"ALTER TABLE $name SET TBLPROPERTIES ('delta.checkpointInterval' = '1000')")
+                                            // v3: bump up the interval for maneuverability
+      assert(deltaLogForName(name).unsafeVolatileSnapshot.version == 3)
+
+      (4 to ctx.staleVersion).foreach { i =>
+        if (ctx.cpProviderVersions.contains(i)) {
+          withInline {
+            sql(s"INSERT INTO $name VALUES ($i)")
+          }
+        } else {
+          sql(s"INSERT INTO $name VALUES ($i)")
+        }
+      }
+
+      val staleLog = deltaLogForName(name)
+      assert(staleLog.unsafeVolatileSnapshot.version == ctx.staleVersion,
+        s"expected stale v${ctx.staleVersion}, got v${staleLog.unsafeVolatileSnapshot.version}.")
+      DeltaLog.clearCache()
+
+      // Advance the true table past the pin through fresh instances (cache cleared above).
+      ((ctx.staleVersion + 1) to ctx.latestCommitVersion).foreach { i =>
+        if (ctx.cpProviderVersions.contains(i)) {
+          withInline {
+            sql(s"INSERT INTO $name VALUES ($i)")
+          }
+        } else {
+          sql(s"INSERT INTO $name VALUES ($i)")
+        }
+      }
+
+      // The handle must still be stale at the pin before update().
+      assert(staleLog.unsafeVolatileSnapshot.version == ctx.staleVersion,
+        s"handle must remain stale at v${ctx.staleVersion} before update(), but was at " +
+          s"v${staleLog.unsafeVolatileSnapshot.version}.")
+
+      val snapshotAfterUpdate = staleLog.update(catalogTableOpt = Some(catalogTableFor(name)))
+      assertWarmMatchesCold(
+        snapshotAfterUpdate,
+        name,
+        ctx.latestCommitVersion,
+        ctx.expectedCpVersion,
+        ctx.expectedTrailingDeltas)
+    }
+  }
+
+  Seq(
+    WarmUpdateContext(
+      label = "after a checkpoint",
+      staleVersion = 3,
+      cpProviderVersions = Seq(1),
+      latestCommitVersion = 3,
+      expectedCpVersion = Some(1),
+      expectedTrailingDeltas = Seq(2, 3)
+    ),
+    WarmUpdateContext(
+      label = "on a checkpoint",
+      staleVersion = 4,
+      cpProviderVersions = Seq(1, 4),
+      latestCommitVersion = 4,
+      expectedCpVersion = Some(4),
+      expectedTrailingDeltas = Seq.empty
+    ),
+    WarmUpdateContext(
+      label = "long trailing deltas",
+      staleVersion = 10,
+      cpProviderVersions = Seq(1, 4),
+      latestCommitVersion = 10,
+      expectedCpVersion = Some(4),
+      expectedTrailingDeltas = Seq(5, 6, 7, 8, 9, 10)
+    )
+  ).foreach { ctx =>
+    test(s"[warm update] no-op on the same version: ${ctx.label}") {
+      runWarmUpdateContext(ctx)
+    }
+  }
+
+  Seq(
+    WarmUpdateContext(
+      label = "no new checkpoints",
+      staleVersion = 3,
+      cpProviderVersions = Seq(1),
+      latestCommitVersion = 4,
+      expectedCpVersion = Some(1),
+      expectedTrailingDeltas = Seq(2, 3, 4)
+    ),
+    WarmUpdateContext(
+      label = "one new checkpoint",
+      staleVersion = 3,
+      cpProviderVersions = Seq(1, 4),
+      latestCommitVersion = 5,
+      expectedCpVersion = Some(4),
+      expectedTrailingDeltas = Seq(5)
+    ),
+    WarmUpdateContext(
+      label = "multiple new checkpoints",
+      staleVersion = 3,
+      cpProviderVersions = Seq(1, 4, 7, 10),
+      latestCommitVersion = 12,
+      expectedCpVersion = Some(10),
+      expectedTrailingDeltas = Seq(11, 12)
+    )
+  ).foreach { ctx =>
+    test(
+      s"[warm update] builds the correct latest snapshot: some=>some trailing deltas,${ctx.label}"
+    ) {
+      runWarmUpdateContext(ctx)
+    }
+  }
+
+  Seq(
+    WarmUpdateContext(
+      label = "one new checkpoint",
+      staleVersion = 3,
+      cpProviderVersions = Seq(1, 4),
+      latestCommitVersion = 4,
+      expectedCpVersion = Some(4),
+      expectedTrailingDeltas = Seq.empty
+    ),
+    WarmUpdateContext(
+      label = "multiple new checkpoints",
+      staleVersion = 3,
+      cpProviderVersions = Seq(1, 4, 7, 10),
+      latestCommitVersion = 10,
+      expectedCpVersion = Some(10),
+      expectedTrailingDeltas = Seq.empty
+    )
+  ).foreach { ctx =>
+    test(
+      s"[warm update] builds the correct latest snapshot: some=>none trailing deltas, ${ctx.label}"
+    ) {
+      runWarmUpdateContext(ctx)
+    }
+  }
+
+  Seq(
+    WarmUpdateContext(
+      label = "no new checkpoints",
+      staleVersion = 4,
+      cpProviderVersions = Seq(1, 4),
+      latestCommitVersion = 5,
+      expectedCpVersion = Some(4),
+      expectedTrailingDeltas = Seq(5)
+    ),
+    WarmUpdateContext(
+      label = "one new checkpoint",
+      staleVersion = 4,
+      cpProviderVersions = Seq(1, 4, 7),
+      latestCommitVersion = 8,
+      expectedCpVersion = Some(7),
+      expectedTrailingDeltas = Seq(8)
+    ),
+    WarmUpdateContext(
+      label = "multiple new checkpoints",
+      staleVersion = 4,
+      cpProviderVersions = Seq(1, 4, 7, 10),
+      latestCommitVersion = 12,
+      expectedCpVersion = Some(10),
+      expectedTrailingDeltas = Seq(11, 12)
+    )
+  ).foreach { ctx =>
+    test(
+      s"[warm update] builds the correct latest snapshot: none=>some trailing deltas, ${ctx.label}"
+    ) {
+      runWarmUpdateContext(ctx)
+    }
+  }
+
+  Seq(
+    WarmUpdateContext(
+      label = "one new checkpoint",
+      staleVersion = 4,
+      cpProviderVersions = Seq(1, 4, 7),
+      latestCommitVersion = 7,
+      expectedCpVersion = Some(7),
+      expectedTrailingDeltas = Seq.empty
+    ),
+    WarmUpdateContext(
+      label = "multiple new checkpoints",
+      staleVersion = 4,
+      cpProviderVersions = Seq(1, 4, 7, 10),
+      latestCommitVersion = 10,
+      expectedCpVersion = Some(10),
+      expectedTrailingDeltas = Seq.empty
+    )
+  ).foreach { ctx =>
+    test(
+      s"[warm update] builds the correct latest snapshot: none=>none trailing deltas, ${ctx.label}"
+    ) {
+      runWarmUpdateContext(ctx)
+    }
+  }
+
+  // The above test harness doesn't cover the case of a checkpoint-less stale handle acquiring its
+  // first AMT checkpoint through update(), for the sake of versioning simplicity.
+  test("[warm update] a checkpoint-less stale handle acquires its first AMT checkpoint") {
+    val name = "amt_warm_no_cp_to_amt"
+    withTable(name) {
+      createAMTTable(name, checkpointInterval = 3)
+      sql(s"INSERT INTO $name VALUES (1)") // v1: before the first checkpoint -- no provider
+      sql(s"INSERT INTO $name VALUES (2)") // v2: still before the first checkpoint -- no provider
+
+      // Pin a stale handle at v2, which precedes the first checkpoint and has no AMT provider.
+      val staleLog = deltaLogForName(name)
+      assert(staleLog.unsafeVolatileSnapshot.version == 2,
+        s"expected stale v2, got v${staleLog.unsafeVolatileSnapshot.version}.")
+      assert(amtProvider(staleLog.unsafeVolatileSnapshot).isEmpty,
+        "the stale handle must have no AMT checkpoint provider before update().")
+      DeltaLog.clearCache()
+
+      sql(s"INSERT INTO $name VALUES (3)") // v3: reaches the boundary
+                                           // v4: OPTIMIZE CHECKPOINT (state@v3) -- the first AMT
+      assert(deltaLogForName(name).update().version == 4, "the first deferred AMT must land at v4.")
+
+      // The handle must still be stale at v2 before update().
+      assert(staleLog.unsafeVolatileSnapshot.version == 2,
+        s"handle must remain stale at v2 before update(), but was at " +
+          s"v${staleLog.unsafeVolatileSnapshot.version}.")
+
+      val warm = staleLog.update(catalogTableOpt = Some(catalogTableFor(name)))
+      assertWarmMatchesCold(
+        warm,
+        tableName = name,
+        expectedVersion = 4,
+        expectedProviderVersion = Some(3),
+        expectedTrailingDeltas = Seq(4))
+    }
+  }
 
   ///////////////////////////
   // Post commit snapshot

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotSuite.scala
@@ -672,7 +672,8 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
       val checkpoint =
         checkpointWithSyntheticRoot(deltaLog, provider.checkpointAction, rootDataRows)
 
-      val rootProvider = AMTCheckpointProvider.fromCheckpoint(deltaLog, checkpoint)
+      val rootProvider = AMTCheckpointProvider.fromCheckpoint(
+        deltaLog, checkpoint, manifestCommitVersion = provider.manifestCommitVersion)
       assert(rootProvider.leaves.isEmpty, "A DATA-only root must yield no leaf pointers.")
 
       val expected = rootAdds.map(_.path).toSet
@@ -715,8 +716,8 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
       leaf.copy(manifest_info =
         leaf.manifest_info.copy(dv = Some(mdvBytesFor(deletedPos)), dv_cardinality = Some(1L))) +:
         base.leaves.tail
-    val provider =
-      new AMTCheckpointProvider(base.checkpointAction, patchedLeaves, base.tableRoot)
+    val provider = new AMTCheckpointProvider(
+      base.manifestCommitVersion, base.checkpointAction, patchedLeaves, base.tableRoot)
 
     val reconstructed = reconstructedPaths(provider, snapshot.deltaLog)
     assert(reconstructed.size == baseCount - 1,
@@ -778,7 +779,8 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
         case _ => leaf
       }
     }
-    val provider = new AMTCheckpointProvider(base.checkpointAction, patched, base.tableRoot)
+    val provider = new AMTCheckpointProvider(
+      base.manifestCommitVersion, base.checkpointAction, patched, base.tableRoot)
 
     val dropped =
       twoPositions.map(locs(twoLeaf)).toSet ++
@@ -847,7 +849,8 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
           dv = Some(mdvBytesFor(bLeafAndPos._2)), dv_cardinality = Some(1L)))
       } else leaf
     }
-    val provider = new AMTCheckpointProvider(base.checkpointAction, patched, base.tableRoot)
+    val provider = new AMTCheckpointProvider(
+      base.manifestCommitVersion, base.checkpointAction, patched, base.tableRoot)
 
     val survivors = provider.loadActionsForStateReconstruction(spark, snapshot.deltaLog)
       .getOrElse(fail("AMT provider must contribute leaf-derived file actions."))
@@ -882,7 +885,8 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
       base.leaves.head.copy(manifest_info = base.leaves.head.manifest_info.copy(
         dv = Some(mdvBytesFor(0L)), dv_cardinality = None)) +:
         base.leaves.tail
-    val provider = new AMTCheckpointProvider(base.checkpointAction, patched, base.tableRoot)
+    val provider = new AMTCheckpointProvider(
+      base.manifestCommitVersion, base.checkpointAction, patched, base.tableRoot)
 
     val e = intercept[IllegalStateException] {
       provider.loadActionsForStateReconstruction(

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/SnapshotLastManifestCommitSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/SnapshotLastManifestCommitSuite.scala
@@ -407,7 +407,8 @@ class SnapshotLastManifestCommitWithoutCRCSuite extends SnapshotLastManifestComm
       val checkpoint = checkpointAt(deltaLog, 4).getOrElse {
         fail("v4 must emit an inline AMT checkpoint action.")
       }
-      val provider = AMTCheckpointProvider.fromCheckpoint(deltaLog, checkpoint)
+      val provider = AMTCheckpointProvider.fromCheckpoint(
+        deltaLog, checkpoint, manifestCommitVersion = 4L)
       val baseSnapshot = deltaLog.unsafeVolatileSnapshot
       assert(baseSnapshot.version == 4,
         s"Expected volatile snapshot at v4, got ${baseSnapshot.version}.")


### PR DESCRIPTION
## Description

Follow-up to the adaptive metadata tree (AMT) checkpoint discovery work: installs
the correct AMT checkpoint provider during a **warm** snapshot update, mirroring the
handling already in place for cold snapshot initialization.

On a warm update the `_last_checkpoint` hint may be stale or absent, so it cannot be
relied on to carry the latest manifest-commit `checkpoint` action. This change resolves
the correct AMT checkpoint by cross-verifying against the CRC (`VersionChecksum`)'s
recorded manifest-commit reference, installs the matching provider, and trims the log
segment's trailing deltas accordingly. When neither a usable hint nor a corroborating
CRC is available, it falls back to log replay.

Touches `Checkpoints`, `SnapshotManagement`, `OptimisticTransaction`, and
`AMTCheckpointProvider`.

## How was this patch tested?

New and expanded coverage in `AMTSnapshotDiscoverySuite` covering the warm-update stale
and missing `_last_checkpoint` paths and the CRC-based cross-verification, plus updates
to `AMTCheckpointWriteSuite`, `AMTSnapshotSuite`, and `SnapshotLastManifestCommitSuite`.

## Does this PR introduce _any_ user-facing change?

No.
