### PR TITLE
[Spark] Extract DeltaFileSystemOptions from DeltaLog

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -1060,9 +1060,7 @@ object DeltaLog extends DeltaLogging {
       spark: SparkSession,
       options: Map[String, String],
       rootPath: Path): Path = {
-    val fileSystemOptions =
-      DeltaFileSystemOptions.fileSystemOptionsFromDataFrameOptions(
-        spark, options)
+    val fileSystemOptions = DeltaFileSystemOptions.buildFsOptions(spark, options)
     // scalastyle:off deltahadoopconfiguration
     val hadoopConf = spark.sessionState.newHadoopConfWithOptions(fileSystemOptions)
     // scalastyle:on deltahadoopconfiguration
@@ -1095,8 +1093,7 @@ object DeltaLog extends DeltaLogging {
       clock: Clock
   ): DeltaLog = {
     val fileSystemOptions =
-      DeltaFileSystemOptions.fileSystemOptionsFromDataFrameOptions(
-        spark, options, initialCatalogTable)
+      DeltaFileSystemOptions.buildFsOptions(spark, options, initialCatalogTable)
 
     // scalastyle:off deltahadoopconfiguration
     val hadoopConf = spark.sessionState.newHadoopConfWithOptions(fileSystemOptions)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -41,7 +41,7 @@ import org.apache.spark.sql.delta.redirect.RedirectFeature
 import org.apache.spark.sql.delta.schema.{SchemaMergingUtils, SchemaUtils}
 import org.apache.spark.sql.delta.sources._
 import org.apache.spark.sql.delta.storage.LogStoreProvider
-import org.apache.spark.sql.delta.util.{FileNames, PathWithFileSystem, Utils => DeltaUtils}
+import org.apache.spark.sql.delta.util.{DeltaFileSystemOptions, FileNames, PathWithFileSystem, Utils => DeltaUtils}
 import com.google.common.cache.{Cache, CacheBuilder, RemovalNotification}
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, FileSystem, Path}
@@ -1060,15 +1060,9 @@ object DeltaLog extends DeltaLogging {
       spark: SparkSession,
       options: Map[String, String],
       rootPath: Path): Path = {
-    val fileSystemOptions: Map[String, String] =
-      if (spark.sessionState.conf.getConf(
-        DeltaSQLConf.LOAD_FILE_SYSTEM_CONFIGS_FROM_DATAFRAME_OPTIONS)) {
-        options.filterKeys { k =>
-          DeltaTableUtils.validDeltaTableHadoopPrefixes.exists(k.startsWith)
-        }.toMap
-      } else {
-        Map.empty
-      }
+    val fileSystemOptions =
+      DeltaFileSystemOptions.fileSystemOptionsFromDataFrameOptions(
+        spark, options)
     // scalastyle:off deltahadoopconfiguration
     val hadoopConf = spark.sessionState.newHadoopConfWithOptions(fileSystemOptions)
     // scalastyle:on deltahadoopconfiguration
@@ -1100,25 +1094,9 @@ object DeltaLog extends DeltaLogging {
       initialCatalogTable: Option[CatalogTable],
       clock: Clock
   ): DeltaLog = {
-    // Construct the filesystem options based on the DataFrameReader/Writer options, and if it's
-    // a catalog based table, we need combine both options and catalog-based table storage
-    // properties since all cloud credential information are stored in storage properties.
-    val catalogTableStorageProps = initialCatalogTable
-      .map(t => t.storage.properties.filter { case (k, _) =>
-          DeltaTableUtils.validDeltaTableHadoopPrefixes.exists(k.startsWith)
-        })
-      .getOrElse(Map.empty)
-    val fileSystemOptions: Map[String, String] =
-      if (spark.sessionState.conf.getConf(
-          DeltaSQLConf.LOAD_FILE_SYSTEM_CONFIGS_FROM_DATAFRAME_OPTIONS)) {
-        // We pick up only file system options so that we don't pass any parquet or json options to
-        // the code that reads Delta transaction logs.
-        catalogTableStorageProps ++ options.filterKeys { k =>
-          DeltaTableUtils.validDeltaTableHadoopPrefixes.exists(k.startsWith)
-        }.toMap
-      } else {
-        catalogTableStorageProps
-      }
+    val fileSystemOptions =
+      DeltaFileSystemOptions.fileSystemOptionsFromDataFrameOptions(
+        spark, options, initialCatalogTable)
 
     // scalastyle:off deltahadoopconfiguration
     val hadoopConf = spark.sessionState.newHadoopConfWithOptions(fileSystemOptions)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/DeltaFileSystemOptions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/DeltaFileSystemOptions.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.delta.util
+
+import org.apache.spark.sql.delta.DeltaTableUtils
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
+
+/**
+ * Shared helpers for deriving Hadoop filesystem
+ * options from DataFrame options and catalog table
+ * storage properties.
+ */
+private[delta] object DeltaFileSystemOptions {
+
+  /**
+   * Extracts file-system-relevant storage properties
+   * from a catalog table, filtering to keys that match
+   * [[DeltaTableUtils.validDeltaTableHadoopPrefixes]].
+   */
+  def extractCatalogTableFsOptions(
+      catalogTableOpt: Option[CatalogTable])
+      : Map[String, String] = {
+    catalogTableOpt
+      .map(_.storage.properties.filter {
+        case (k, _) =>
+          DeltaTableUtils
+            .validDeltaTableHadoopPrefixes
+            .exists(k.startsWith)
+      })
+      .getOrElse(Map.empty)
+  }
+
+  /**
+   * Constructs filesystem options by combining catalog
+   * table storage properties with DataFrame reader/writer
+   * options. Only keys matching valid Hadoop prefixes are
+   * picked up so that parquet or json options are not
+   * passed to the code that reads Delta transaction logs.
+   *
+   * Gated by
+   * [[DeltaSQLConf.LOAD_FILE_SYSTEM_CONFIGS_FROM_DATAFRAME_OPTIONS]].
+   */
+  def fileSystemOptionsFromDataFrameOptions(
+      spark: SparkSession,
+      options: Map[String, String],
+      catalogTableOpt: Option[CatalogTable] = None)
+      : Map[String, String] = {
+    val catalogStorageProps =
+      extractCatalogTableFsOptions(catalogTableOpt)
+    if (spark.sessionState.conf.getConf(
+        DeltaSQLConf
+          .LOAD_FILE_SYSTEM_CONFIGS_FROM_DATAFRAME_OPTIONS)) {
+      catalogStorageProps ++ options.filterKeys {
+        key =>
+          DeltaTableUtils
+            .validDeltaTableHadoopPrefixes
+            .exists(key.startsWith)
+      }.toMap
+    } else {
+      catalogStorageProps
+    }
+  }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/DeltaFileSystemOptions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/DeltaFileSystemOptions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (2026) The Delta Lake Project Authors.
+ * Copyright (2021) The Delta Lake Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,55 +22,40 @@ import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
 
 /**
- * Shared helpers for deriving Hadoop filesystem
- * options from DataFrame options and catalog table
+ * Shared helpers for deriving Hadoop filesystem options from DataFrame options and catalog table
  * storage properties.
  */
 private[delta] object DeltaFileSystemOptions {
 
   /**
-   * Extracts file-system-relevant storage properties
-   * from a catalog table, filtering to keys that match
-   * [[DeltaTableUtils.validDeltaTableHadoopPrefixes]].
+   * Extracts file-system-relevant storage properties from a catalog table, filtering to keys
+   * that match [[DeltaTableUtils.validDeltaTableHadoopPrefixes]].
    */
-  def extractCatalogTableFsOptions(
-      catalogTableOpt: Option[CatalogTable])
-      : Map[String, String] = {
+  private def extractCatalogTableFsOptions(
+      catalogTableOpt: Option[CatalogTable]): Map[String, String] = {
     catalogTableOpt
-      .map(_.storage.properties.filter {
-        case (k, _) =>
-          DeltaTableUtils
-            .validDeltaTableHadoopPrefixes
-            .exists(k.startsWith)
+      .map(_.storage.properties.filter { case (k, _) =>
+        DeltaTableUtils.validDeltaTableHadoopPrefixes.exists(k.startsWith)
       })
       .getOrElse(Map.empty)
   }
 
   /**
-   * Constructs filesystem options by combining catalog
-   * table storage properties with DataFrame reader/writer
-   * options. Only keys matching valid Hadoop prefixes are
-   * picked up so that parquet or json options are not
-   * passed to the code that reads Delta transaction logs.
+   * Constructs filesystem options by combining catalog table storage properties with DataFrame
+   * reader/writer options. Only keys matching valid Hadoop prefixes are picked up so that parquet
+   * or json options are not passed to the code that reads Delta transaction logs.
    *
-   * Gated by
-   * [[DeltaSQLConf.LOAD_FILE_SYSTEM_CONFIGS_FROM_DATAFRAME_OPTIONS]].
+   * Gated by [[DeltaSQLConf.LOAD_FILE_SYSTEM_CONFIGS_FROM_DATAFRAME_OPTIONS]].
    */
-  def fileSystemOptionsFromDataFrameOptions(
+  def buildFsOptions(
       spark: SparkSession,
       options: Map[String, String],
-      catalogTableOpt: Option[CatalogTable] = None)
-      : Map[String, String] = {
-    val catalogStorageProps =
-      extractCatalogTableFsOptions(catalogTableOpt)
+      catalogTableOpt: Option[CatalogTable] = None): Map[String, String] = {
+    val catalogStorageProps = extractCatalogTableFsOptions(catalogTableOpt)
     if (spark.sessionState.conf.getConf(
-        DeltaSQLConf
-          .LOAD_FILE_SYSTEM_CONFIGS_FROM_DATAFRAME_OPTIONS)) {
-      catalogStorageProps ++ options.filterKeys {
-        key =>
-          DeltaTableUtils
-            .validDeltaTableHadoopPrefixes
-            .exists(key.startsWith)
+        DeltaSQLConf.LOAD_FILE_SYSTEM_CONFIGS_FROM_DATAFRAME_OPTIONS)) {
+      catalogStorageProps ++ options.filterKeys { key =>
+        DeltaTableUtils.validDeltaTableHadoopPrefixes.exists(key.startsWith)
       }.toMap
     } else {
       catalogStorageProps

--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/DeltaFileSystemOptions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/DeltaFileSystemOptions.scala
@@ -41,7 +41,7 @@ private[delta] object DeltaFileSystemOptions {
   /**
    * Extracts file-system-relevant storage properties from a catalog table.
    */
-  private[delta] def extractCatalogTableFsOptions(
+  def extractCatalogTableFsOptions(
       catalogTableOpt: Option[CatalogTable]): Map[String, String] = {
     catalogTableOpt
       .map(ct => filterHadoopOptions(ct.storage.properties))

--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/DeltaFileSystemOptions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/DeltaFileSystemOptions.scala
@@ -28,15 +28,23 @@ import org.apache.spark.sql.catalyst.catalog.CatalogTable
 private[delta] object DeltaFileSystemOptions {
 
   /**
-   * Extracts file-system-relevant storage properties from a catalog table, filtering to keys
-   * that match [[DeltaTableUtils.validDeltaTableHadoopPrefixes]].
+   * Retains only entries whose key starts with a recognised Hadoop filesystem
+   * prefix ([[DeltaTableUtils.validDeltaTableHadoopPrefixes]]).
+   */
+  private[delta] def filterHadoopOptions(
+      options: Map[String, String]): Map[String, String] = {
+    options.filter { case (k, _) =>
+      DeltaTableUtils.validDeltaTableHadoopPrefixes.exists(k.startsWith)
+    }
+  }
+
+  /**
+   * Extracts file-system-relevant storage properties from a catalog table.
    */
   private def extractCatalogTableFsOptions(
       catalogTableOpt: Option[CatalogTable]): Map[String, String] = {
     catalogTableOpt
-      .map(_.storage.properties.filter { case (k, _) =>
-        DeltaTableUtils.validDeltaTableHadoopPrefixes.exists(k.startsWith)
-      })
+      .map(ct => filterHadoopOptions(ct.storage.properties))
       .getOrElse(Map.empty)
   }
 
@@ -54,9 +62,7 @@ private[delta] object DeltaFileSystemOptions {
     val catalogStorageProps = extractCatalogTableFsOptions(catalogTableOpt)
     if (spark.sessionState.conf.getConf(
         DeltaSQLConf.LOAD_FILE_SYSTEM_CONFIGS_FROM_DATAFRAME_OPTIONS)) {
-      catalogStorageProps ++ options.filterKeys { key =>
-        DeltaTableUtils.validDeltaTableHadoopPrefixes.exists(key.startsWith)
-      }.toMap
+      catalogStorageProps ++ filterHadoopOptions(options)
     } else {
       catalogStorageProps
     }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/DeltaFileSystemOptions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/DeltaFileSystemOptions.scala
@@ -41,7 +41,7 @@ private[delta] object DeltaFileSystemOptions {
   /**
    * Extracts file-system-relevant storage properties from a catalog table.
    */
-  private def extractCatalogTableFsOptions(
+  private[delta] def extractCatalogTableFsOptions(
       catalogTableOpt: Option[CatalogTable]): Map[String, String] = {
     catalogTableOpt
       .map(ct => filterHadoopOptions(ct.storage.properties))

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
@@ -69,7 +69,6 @@ import org.apache.spark.sql.connector.write.RowLevelOperationBuilder;
 import org.apache.spark.sql.connector.write.RowLevelOperationInfo;
 import org.apache.spark.sql.connector.write.WriteBuilder;
 import org.apache.spark.sql.delta.DeltaTableUtils;
-import org.apache.spark.sql.delta.util.DeltaFileSystemOptions;
 import org.apache.spark.sql.delta.RowCommitVersion$;
 import org.apache.spark.sql.delta.RowId$;
 import org.apache.spark.sql.delta.RowTracking$;
@@ -77,6 +76,7 @@ import org.apache.spark.sql.delta.Snapshot;
 import org.apache.spark.sql.delta.catalog.DeltaV2TableMarker;
 import org.apache.spark.sql.delta.commands.cdc.CDCReader;
 import org.apache.spark.sql.delta.sources.PersistedMetadata;
+import org.apache.spark.sql.delta.util.DeltaFileSystemOptions;
 import org.apache.spark.sql.delta.v2.interop.AbstractMetadata;
 import org.apache.spark.sql.delta.v2.interop.AbstractProtocol;
 import org.apache.spark.sql.delta.v2.interop.DeltaV2Snapshot$;
@@ -234,10 +234,10 @@ public class DeltaV2Table extends DeltaV2TableLogging
     this.catalogTable = catalogTable;
     // Merge options: file system options from catalog + user options (user takes precedence)
     // This follows the same pattern as DeltaTableV2 in delta-spark
-    Map<String, String> merged = new HashMap<>(
-        scala.collection.JavaConverters.mapAsJavaMap(
-            DeltaFileSystemOptions.extractCatalogTableFsOptions(
-                toScalaOption(catalogTable))));
+    Map<String, String> merged =
+        new HashMap<>(
+            scala.collection.JavaConverters.mapAsJavaMap(
+                DeltaFileSystemOptions.extractCatalogTableFsOptions(toScalaOption(catalogTable))));
     // User options override catalog properties
     merged.putAll(userOptions);
     this.options = Collections.unmodifiableMap(merged);

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
@@ -17,6 +17,7 @@ package io.delta.spark.internal.v2.catalog;
 
 import static io.delta.spark.internal.v2.utils.ScalaUtils.toJavaOptional;
 import static io.delta.spark.internal.v2.utils.ScalaUtils.toScalaMap;
+import static io.delta.spark.internal.v2.utils.ScalaUtils.toScalaOption;
 import static io.delta.spark.internal.v2.utils.StatsUtils.toV2Statistics;
 import static java.util.Objects.requireNonNull;
 
@@ -68,6 +69,7 @@ import org.apache.spark.sql.connector.write.RowLevelOperationBuilder;
 import org.apache.spark.sql.connector.write.RowLevelOperationInfo;
 import org.apache.spark.sql.connector.write.WriteBuilder;
 import org.apache.spark.sql.delta.DeltaTableUtils;
+import org.apache.spark.sql.delta.util.DeltaFileSystemOptions;
 import org.apache.spark.sql.delta.RowCommitVersion$;
 import org.apache.spark.sql.delta.RowId$;
 import org.apache.spark.sql.delta.RowTracking$;
@@ -232,18 +234,10 @@ public class DeltaV2Table extends DeltaV2TableLogging
     this.catalogTable = catalogTable;
     // Merge options: file system options from catalog + user options (user takes precedence)
     // This follows the same pattern as DeltaTableV2 in delta-spark
-    Map<String, String> merged = new HashMap<>();
-    // Only extract file system options from table storage properties
-    catalogTable.ifPresent(
-        table ->
-            scala.collection.JavaConverters.mapAsJavaMap(table.storage().properties())
-                .forEach(
-                    (key, value) -> {
-                      if (DeltaTableUtils.validDeltaTableHadoopPrefixes()
-                          .exists(prefix -> key.startsWith(prefix))) {
-                        merged.put(key, value);
-                      }
-                    }));
+    Map<String, String> merged = new HashMap<>(
+        scala.collection.JavaConverters.mapAsJavaMap(
+            DeltaFileSystemOptions.extractCatalogTableFsOptions(
+                toScalaOption(catalogTable))));
     // User options override catalog properties
     merged.putAll(userOptions);
     this.options = Collections.unmodifiableMap(merged);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Move the inline filesystem-options derivation logic from `DeltaLog.forTable` into a new `DeltaFileSystemOptions` utility object in the `delta.util` package:

- `fileSystemOptionsFromDataFrameOptions` combines catalog table storage properties with DataFrame reader/writer options, filtering to keys that match valid Hadoop prefixes.
- `extractCatalogTableFsOptions` extracts catalog table storage properties.

This is a pure refactor with no behavioral change — the two `forTable` overloads now delegate to the utility instead of inlining the logic.

## How was this patch tested?

Existing DeltaLog tests cover the affected code paths. No new tests needed for a mechanical extraction.