### PR TITLE
[Spark] Add scoped profiling for Delta V2 planning

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/metering/DeltaLogging.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/metering/DeltaLogging.scala
@@ -16,6 +16,8 @@
 
 package org.apache.spark.sql.delta.metering
 
+import java.util.function.Supplier
+
 import scala.concurrent.duration._
 import scala.util.Try
 import scala.util.control.NonFatal
@@ -173,6 +175,23 @@ trait DeltaLogging
   protected def recordFrameProfile[T](group: String, name: String)(thunk: => T): T = {
     // future work to capture runtime information ...
     thunk
+  }
+
+
+  /** Java adapter for a value-returning frame with fixed system-code group and name literals. */
+  protected def recordFrameProfileValue[T](
+      group: String,
+      name: String,
+      body: Supplier[T]): T = {
+    recordFrameProfile(group, name)(body.get())
+  }
+
+  /** Java adapter for a void frame with fixed system-code group and name literals. */
+  protected def recordFrameProfileAction(
+      group: String,
+      name: String,
+      body: Runnable): Unit = {
+    recordFrameProfile(group, name)(body.run())
   }
 
   private def withDmqTag[T](thunk: => T): T = {

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
@@ -90,7 +90,7 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 import scala.jdk.javaapi.CollectionConverters;
 
 /** DataSource V2 Table implementation for Delta Lake using the Delta Kernel API. */
-public class DeltaV2Table extends DeltaV2TableShims
+public class DeltaV2Table extends DeltaV2TableLogging
     implements Table,
         SupportsRead,
         SupportsWrite,
@@ -255,10 +255,14 @@ public class DeltaV2Table extends DeltaV2TableShims
     this.kernelEngine = KernelEngineFactory.createDefaultEngine(this.hadoopConf);
     this.snapshotManager = SnapshotManagerFactory.create(tablePath, kernelEngine, catalogTable);
     try {
-      this.initialSnapshot =
-          timeTravelVersion.isPresent()
-              ? loadSnapshotAtCheckedVersion(snapshotManager, timeTravelVersion.getAsLong())
-              : snapshotManager.loadLatestSnapshot();
+      if (timeTravelVersion.isPresent()) {
+        this.initialSnapshot =
+            loadSnapshotAtCheckedVersion(snapshotManager, timeTravelVersion.getAsLong());
+      } else {
+        this.initialSnapshot =
+            recordFrameProfileValue(
+                "Delta", "DeltaV2.snapshot.loadLatest", snapshotManager::loadLatestSnapshot);
+      }
     } catch (io.delta.kernel.exceptions.TableNotFoundException e) {
       // Rethrow as the Delta-module wrapper so catalog/interop layer never names a Kernel type.
       throw new TableNotFoundException(tablePath);
@@ -562,11 +566,11 @@ public class DeltaV2Table extends DeltaV2TableShims
   /**
    * Validates that {@code version} exists in the Delta log, then loads the snapshot pinned to it.
    */
-  private static Snapshot loadSnapshotAtCheckedVersion(
-      DeltaV2SnapshotManager manager, long version) {
+  private Snapshot loadSnapshotAtCheckedVersion(DeltaV2SnapshotManager manager, long version) {
     manager.checkVersionExists(
         version, /* mustBeRecreatable = */ true, /* allowOutOfRange = */ false);
-    return manager.loadSnapshotAt(version);
+    return recordFrameProfileValue(
+        "Delta", "DeltaV2.snapshot.loadAtVersion", () -> manager.loadSnapshotAt(version));
   }
 
   @Override

--- a/spark/v2/src/main/scala/io/delta/spark/internal/v2/catalog/DeltaV2TableLogging.scala
+++ b/spark/v2/src/main/scala/io/delta/spark/internal/v2/catalog/DeltaV2TableLogging.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.catalog
+
+import org.apache.spark.sql.delta.metering.DeltaLogging
+
+/**
+ * Scala inheritance bridge for the Java [[DeltaV2Table]]. This lets the table use the scoped
+ * profiling helpers on [[DeltaLogging]] without duplicating them in a companion object.
+ */
+private[catalog] abstract class DeltaV2TableLogging
+  extends DeltaV2TableShims
+  with DeltaLogging

--- a/spark/v2/src/main/scala/io/delta/spark/internal/v2/read/DeltaV2ScanBuilder.scala
+++ b/spark/v2/src/main/scala/io/delta/spark/internal/v2/read/DeltaV2ScanBuilder.scala
@@ -24,6 +24,7 @@ import io.delta.kernel.engine.Engine
 import io.delta.kernel.internal.SnapshotImpl
 import io.delta.spark.internal.v2.read.cdc.CDCSchemaContext
 
+import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.stats.DeltaScan
 import org.apache.spark.sql.delta.v2.interop.DeltaV2Snapshot
 import org.apache.spark.sql.delta.v2.interop.DeltaV2SnapshotManager
@@ -75,7 +76,8 @@ private[read] class DeltaV2ScanBuilder(
     extends ScanBuilder
     with SupportsPushDownRequiredColumns
     with SupportsPushDownCatalystFilters
-    with SupportsPushDownLimit {
+    with SupportsPushDownLimit
+    with DeltaLogging {
 
   // Use Objects.requireNonNull (throws NullPointerException) rather than Scala's require (throws
   // IllegalArgumentException) to preserve the exact null-check behavior of the original Java class.
@@ -103,30 +105,32 @@ private[read] class DeltaV2ScanBuilder(
   private var hasPostScanResidualFilters: Boolean = false
   private var pushedLimit: OptionalInt = OptionalInt.empty()
 
-  override def pushFilters(filters: Seq[Expression]): Seq[Expression] = {
-    val (partitionFilters, dataFilters) =
-      DataSourceUtils.getPartitionFiltersAndDataFilters(partitionSchema, filters)
-    partitionCatalystFilters = partitionFilters.toArray
-    dataCatalystFilters = dataFilters.toArray
-    // Data filters need post-scan evaluation (min/max skipping is not row-exact); partition
-    // filters are exact and need no re-evaluation. ScanBuilder mutations can be cumulative, so a
-    // later pushFilters call must not make an earlier residual safe to ignore.
-    hasPostScanResidualFilters |= dataFilters.nonEmpty
-    dataFilters
-  }
+  override def pushFilters(filters: Seq[Expression]): Seq[Expression] =
+    recordFrameProfile("Delta", "DeltaV2.scanBuilder.pushFilters") {
+      val (partitionFilters, dataFilters) =
+        DataSourceUtils.getPartitionFiltersAndDataFilters(partitionSchema, filters)
+      partitionCatalystFilters = partitionFilters.toArray
+      dataCatalystFilters = dataFilters.toArray
+      // Data filters need post-scan evaluation (min/max skipping is not row-exact); partition
+      // filters are exact and need no re-evaluation. ScanBuilder mutations can be cumulative, so a
+      // later pushFilters call must not make an earlier residual safe to ignore.
+      hasPostScanResidualFilters |= dataFilters.nonEmpty
+      dataFilters
+    }
 
   // Filters are kept as Catalyst expressions and are not translated to data source predicates.
   override def pushedFilters: Array[Predicate] = Array.empty
 
-  override def pruneColumns(requiredSchema: StructType): Unit = {
-    Objects.requireNonNull(requiredSchema, "requiredSchema is null")
-    // CDC columns are injected later by CDCReadFunction, so strip them here.
-    requiredDataSchema = new StructType(
-      requiredSchema.fields.filter { f =>
-        val name = f.name.toLowerCase(Locale.ROOT)
-        !partitionColumnSet.contains(name) && !CDCSchemaContext.isCDCColumn(name)
-      })
-  }
+  override def pruneColumns(requiredSchema: StructType): Unit =
+    recordFrameProfile("Delta", "DeltaV2.scanBuilder.pruneColumns") {
+      Objects.requireNonNull(requiredSchema, "requiredSchema is null")
+      // CDC columns are injected later by CDCReadFunction, so strip them here.
+      requiredDataSchema = new StructType(
+        requiredSchema.fields.filter { f =>
+          val name = f.name.toLowerCase(Locale.ROOT)
+          !partitionColumnSet.contains(name) && !CDCSchemaContext.isCDCColumn(name)
+        })
+    }
 
   /**
    * Accepts a LIMIT hint from Spark's optimizer.
@@ -151,7 +155,8 @@ private[read] class DeltaV2ScanBuilder(
   // isPartiallyPushed() intentionally uses the interface default (true). Because pruning happens at
   // file granularity, the scan may produce more rows than requested, so Spark must reapply LIMIT.
 
-  override def build(): Scan = {
+  override def build(): Scan =
+    recordFrameProfile("Delta", "DeltaV2.scanBuilder.build") {
     // Capture the planning inputs here, but defer constructing the Kernel-backed V1 snapshot and
     // running filesForScan until DeltaV2Scan actually plans a batch. A MicroBatchStream performs
     // its own snapshot and commit-range reads and never consumes batch-selected files.


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other

## Description

Delta V2 planning spans Java and Scala call sites. The existing scoped `DeltaLogging` helper is a Scala by-name API, which Java cannot call directly. This change adds protected `Supplier` and `Runnable` adapters and a package-private Scala inheritance bridge so `DeltaV2Table` can use the same scoped logging contract without duplicating profiling logic.

It records fixed system-code frames around latest and versioned snapshot loading and the scan-builder `pushFilters`, `pruneColumns`, and `build` callbacks. The adapters delegate to the existing `recordFrameProfile` behavior, so return values, exceptions, and planning behavior are unchanged.

## How was this patch tested?

- `build/sbt "sparkV2 / Compile / compile" "sparkV2 / Test / compile"`
- `build/sbt "sparkV2 / Test / testOnly io.delta.spark.internal.v2.catalog.DeltaV2TableTest" "sparkV2 / Test / testOnly io.delta.spark.internal.v2.read.DeltaV2ScanBuilderTest"` (71 tests passed: 36 + 35)

## Does this PR introduce _any_ user-facing changes?

No.