### PR TITLE
[Spark] Keep row-tracking domain metadata in sync after row ID reassignment

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
@@ -1358,10 +1358,19 @@ private[delta] class ConflictChecker(
       case d: DomainMetadata if RowTrackingMetadataDomain.isSameDomain(d) => None
       case a => Some(a)
     }
+    val rowTrackingDomainMetadata = RowTrackingMetadataDomain(highWaterMark).toDomainMetadata
+    // The reassigned row IDs advance the high water mark, so the row-tracking [[DomainMetadata]]
+    // must reflect the new value. Besides updating the action list, we also refresh the
+    // separately tracked `domainMetadata`: some commit paths surface `domainMetadata` to the
+    // commit coordinator independently of the action list, and a stale copy would advertise the
+    // pre-reassignment high water mark while the committed AddFiles already use the reassigned,
+    // higher one, causing the commit to be rejected.
+    val updatedDomainMetadata = rowTrackingDomainMetadata +:
+      currentTransactionInfo.domainMetadata.filterNot(RowTrackingMetadataDomain.isSameDomain)
     currentTransactionInfo = currentTransactionInfo.copy(
       // Add row ID high water mark at the front for faster retrieval.
-      actions = RowTrackingMetadataDomain(highWaterMark).toDomainMetadata +:
-        actionsWithReassignedRowIds,
+      actions = rowTrackingDomainMetadata +: actionsWithReassignedRowIds,
+      domainMetadata = updatedDomainMetadata,
       readRowIdHighWatermark = winningHighWaterMark)
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowtracking/RowTrackingConflictResolutionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowtracking/RowTrackingConflictResolutionSuite.scala
@@ -18,13 +18,15 @@ package org.apache.spark.sql.delta.rowtracking
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.DeltaOperations.{ManualUpdate, Truncate}
+import org.apache.spark.sql.delta.RowId.RowTrackingMetadataDomain
 import org.apache.spark.sql.delta.actions.{Action, AddFile}
-import org.apache.spark.sql.delta.actions.{Metadata, Protocol, RemoveFile}
+import org.apache.spark.sql.delta.actions.{DomainMetadata, Metadata, Protocol, RemoveFile}
 import org.apache.spark.sql.delta.commands.backfill.{BackfillCommandStats, RowTrackingBackfillExecutor}
 import org.apache.spark.sql.delta.deletionvectors.RoaringBitmapArray
 import org.apache.spark.sql.delta.rowid.RowIdTestUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
+import org.apache.spark.sql.delta.util.FileNames
 import io.delta.exceptions.MetadataChangedException
 
 import org.apache.spark.SparkConf
@@ -167,6 +169,90 @@ class RowTrackingConflictResolutionSuite extends QueryTest
       txn.commit(Seq(addFile(filePath)), DeltaOperations.ManualUpdate)
 
       assertRowIdsAreValid(deltaLog)
+    }
+  }
+
+  /** Extract the row-tracking high water mark carried by a set of domain metadata actions. */
+  private def rowTrackingHighWaterMark(actions: Seq[Action]): Long =
+    actions.collectFirst {
+      case RowTrackingMetadataDomain(domain) => domain.rowIdHighWaterMark
+    }.getOrElse(fail("Expected exactly one row-tracking domain metadata action, found none."))
+
+  test("Conflict resolution keeps the tracked domain metadata in sync with reassigned row IDs") {
+    withTestTable {
+      val filePath = "file_path"
+      activateRowTracking()
+
+      // Establish a baseline high water mark that the current transaction reads.
+      commitRecords(numRecords = 5)
+      val readSnapshot = latestSnapshot
+      val readHighWaterMark = RowId.extractHighWatermark(readSnapshot)
+        .getOrElse(fail("Expected the read snapshot to have a row-tracking high water mark."))
+
+      // Build the transaction as it looks right before conflict resolution: a new AddFile whose
+      // row IDs were assigned from the read high water mark, plus the matching row-tracking domain
+      // metadata. The domain metadata is tracked both inside the action list and in the dedicated
+      // `domainMetadata` field, exactly as OptimisticTransaction populates it before committing.
+      val stagedHighWaterMark = readHighWaterMark + 1
+      val stagedRowTrackingDomain = RowTrackingMetadataDomain(stagedHighWaterMark).toDomainMetadata
+      val stagedAddFile = addFile(filePath).copy(baseRowId = Some(stagedHighWaterMark))
+      val currentTransactionInfo = CurrentTransactionInfo(
+        txnId = "current-txn",
+        readPredicates = Vector.empty,
+        readFiles = Set.empty,
+        readWholeTable = false,
+        readAppIds = Set.empty,
+        metadata = readSnapshot.metadata,
+        protocol = readSnapshot.protocol,
+        actions = Seq(stagedRowTrackingDomain, stagedAddFile),
+        readSnapshot = readSnapshot,
+        commitInfo = None,
+        readRowIdHighWatermark = readHighWaterMark,
+        catalogTable = None,
+        domainMetadata = Seq(stagedRowTrackingDomain),
+        op = DeltaOperations.ManualUpdate)
+
+      // A concurrent transaction wins and bumps the high water mark beyond the staged value, so
+      // the current transaction has to reassign its row IDs during conflict resolution.
+      commitRecords(numRecords = 10)
+      val winningSnapshot = latestSnapshot
+      val winningHighWaterMark = RowId.extractHighWatermark(winningSnapshot)
+        .getOrElse(fail("Expected the winning snapshot to have a row-tracking high water mark."))
+      assert(winningHighWaterMark > stagedHighWaterMark,
+        "The winning commit must advance the high water mark to trigger row ID reassignment.")
+
+      val hadoopConf = deltaLog.newDeltaHadoopConf()
+      val winningCommitPath = FileNames.unsafeDeltaFile(deltaLog.logPath, winningSnapshot.version)
+      val winningCommitFileStatus =
+        deltaLog.logPath.getFileSystem(hadoopConf).getFileStatus(winningCommitPath)
+      val winningCommitSummary =
+        WinningCommitSummary.createFromFileStatus(deltaLog, winningCommitFileStatus)
+
+      val resolvedInfo = new ConflictChecker(
+        spark,
+        initialCurrentTransactionInfo = currentTransactionInfo,
+        winningCommitSummary = winningCommitSummary,
+        isolationLevel = WriteSerializable).checkConflictsAndValidateActions()
+
+      // The AddFile's base row ID is reassigned right after the winning high water mark, and the
+      // action list advertises the corresponding, advanced high water mark.
+      val reassignedFile = resolvedInfo.actions.collectFirst {
+        case a: AddFile if a.path == filePath => a
+      }.getOrElse(fail("Expected the reassigned AddFile in the resolved actions."))
+      val expectedHighWaterMark = winningHighWaterMark + 1
+      assert(reassignedFile.baseRowId === Some(winningHighWaterMark + 1))
+      assert(rowTrackingHighWaterMark(resolvedInfo.actions) === expectedHighWaterMark)
+
+      // Regression check for the stale-watermark bug: the dedicated `domainMetadata` field is what
+      // some commit paths (e.g. a commit coordinator) surface independently of the action list, so
+      // it must advertise the same reassigned high water mark. Before the fix it retained the
+      // pre-reassignment value, which caused those commits to be rejected.
+      assert(resolvedInfo.domainMetadata.count(RowTrackingMetadataDomain.isSameDomain) === 1,
+        "Exactly one row-tracking domain metadata must be tracked after reassignment.")
+      assert(rowTrackingHighWaterMark(resolvedInfo.domainMetadata) === expectedHighWaterMark)
+      assert(rowTrackingHighWaterMark(resolvedInfo.domainMetadata) ===
+        rowTrackingHighWaterMark(resolvedInfo.actions),
+        "The tracked domain metadata must stay in sync with the committed action list.")
     }
   }
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

### Symptom (user perspective)

On a row-tracking-enabled table that commits through a commit coordinator, two
concurrent appends can make one of them fail on retry with a commit rejection,
even though the conflict is otherwise resolvable and the retry should succeed.
The rejection comes from a row-tracking high water mark check: the commit's data
files require a higher high water mark than the value the commit advertises.

### Concrete example (spark-sql)

Set up a row-tracking table (committed through a commit coordinator):

```sql
CREATE TABLE t (id INT) USING delta
TBLPROPERTIES ('delta.enableRowTracking' = 'true');

-- 6 rows -> row IDs 0..5 -> the table's row ID high water mark is now 5
INSERT INTO t VALUES (1), (2), (3), (4), (5), (6);
```

Now two writers append concurrently. Writer A starts first but is slow to
commit; Writer B commits while A is still in-flight:

```sql
-- Writer A (session 1): starts its transaction while the high water mark is 5,
-- stages one new file with base row ID 6 and a staged high water mark of 6.
INSERT INTO t VALUES (100);
```

```sql
-- Writer B (session 2): commits FIRST, appending 5 rows.
-- row IDs 6..10 -> advances the table's high water mark to 10.
INSERT INTO t VALUES (200), (201), (202), (203), (204);
```

Writer A now conflicts with B and retries. During conflict resolution A reassigns
its file above B's high water mark (base row ID becomes 11, and the high water
mark implied by A's data actions becomes 11). A's staged commit file correctly
carries high water mark 11, but the row-tracking domain metadata A reports to the
commit coordinator still says 6. The coordinator sees data files that require
high water mark >= 11 while the request declares 6, and rejects the commit:
Writer A's ``INSERT INTO t VALUES (100)`` fails.

Note: with the default filesystem-based commit path this mismatch is not
observable (the commit file is the single source of truth). It surfaces only when
a commit coordinator validates the separately-reported row-tracking high water
mark, and only under the A-starts / B-commits-first / A-retries interleaving above.
The added unit test reproduces exactly that interleaving deterministically.

### Root cause

During conflict resolution, `ConflictChecker.reassignOverlappingRowIds` reassigns
base row IDs for the current transaction's new `AddFile`s and advances the
row-tracking high water mark. It rewrote the high water mark carried in
`currentTransactionInfo.actions`, but left the separately tracked
`currentTransactionInfo.domainMetadata` field pointing at the pre-reassignment value.

`CurrentTransactionInfo.domainMetadata` is initialized from the transaction's actions
before conflict resolution and is meant to mirror the `DomainMetadata` actions in the
commit. It is surfaced to the commit coordinator independently of the action list, so
after a conflict retry the two diverged: the staged commit advertised the reassigned
(higher) high water mark while the coordinator payload still carried the stale, lower
one.

### Fix

Update `reassignOverlappingRowIds` to refresh the row-tracking entry in the
`domainMetadata` field together with the action list, so the committed actions and the
tracked domain metadata can no longer diverge on the high water mark.

## How was this patch tested?

Added a regression test in `RowTrackingConflictResolutionSuite` that drives the
`ConflictChecker` through a concurrent commit which advances the high water mark and
forces the current transaction to reassign its row IDs. It asserts that the reassigned
base row ID, the high water mark in the committed action list, and the high water mark
in the tracked `domainMetadata` field all agree. The test fails without the fix (the
`domainMetadata` field keeps the stale watermark) and passes with it. The existing
`RowTrackingConflictResolutionSuite` and `ConflictCheckerRowIdSuite` continue to pass.

## Does this PR introduce _any_ user-facing changes?

No. It fixes an incorrect commit rejection during concurrent writes; there is no API
or behavior change beyond the previously-failing retry now succeeding.