### PR TITLE
[Spark] Preserve AddFile tags in Kernel-backed snapshots

### DIFF
--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/v2/interop/KernelSnapshotUtilsSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/v2/interop/KernelSnapshotUtilsSuite.scala
@@ -16,6 +16,10 @@
 
 package org.apache.spark.sql.delta.v2.interop
 
+import java.io.File
+import java.nio.charset.StandardCharsets.UTF_8
+import java.nio.file.Files
+
 import org.apache.spark.sql.delta.{DeltaConfigs, DeltaLog}
 import org.apache.spark.sql.delta.actions.AddFile
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
@@ -34,6 +38,20 @@ class KernelSnapshotUtilsSuite extends DeltaSQLCommandTest {
 
   private def kernelSnapshotFor(path: String, engine: Engine): SnapshotImpl =
     TableManager.loadSnapshot(path).build(engine).asInstanceOf[SnapshotImpl]
+
+  private def appendTaggedAddFile(path: File, tags: Map[String, String]): String = {
+    val dataPath = "tagged.parquet"
+    val taggedAddFile = AddFile(
+      path = dataPath,
+      partitionValues = Map.empty,
+      size = 1L,
+      modificationTime = 2L,
+      dataChange = true,
+      tags = tags)
+    val commitFile = new File(path, "_delta_log/00000000000000000001.json")
+    Files.writeString(commitFile.toPath, taggedAddFile.json, UTF_8)
+    dataPath
+  }
 
   private def allFilesFor(path: String): (Array[AddFile], Array[AddFile]) = {
     val kernelEngine = engine
@@ -63,6 +81,7 @@ class KernelSnapshotUtilsSuite extends DeltaSQLCommandTest {
         assert(kernelFile.modificationTime === v1File.modificationTime)
         assert(kernelFile.dataChange === v1File.dataChange)
         assert(kernelFile.stats === v1File.stats)
+        assert(kernelFile.tags === v1File.tags)
         assert(kernelFile.deletionVector === v1File.deletionVector)
         assert(kernelFile.baseRowId === v1File.baseRowId)
         assert(kernelFile.defaultRowCommitVersion === v1File.defaultRowCommitVersion)
@@ -136,6 +155,25 @@ class KernelSnapshotUtilsSuite extends DeltaSQLCommandTest {
         assert(v1Files.exists(_.defaultRowCommitVersion.nonEmpty))
         assertSameAddFilesAsV1(kernelFiles, v1Files)
       }
+    }
+  }
+
+  test("buildAllFiles and filesForScan preserve AddFile tags from commit JSON") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      spark.range(1).coalesce(1).write.format("delta").save(path)
+      val expectedTags = Map(AddFile.Tags.ZCUBE_ID.name -> "cube-id")
+      val taggedPath = appendTaggedAddFile(dir, expectedTags)
+
+      val kernelEngine = engine
+      val kernelSnapshot = kernelSnapshotFor(path, kernelEngine)
+      val kernelFiles =
+        KernelSnapshotUtils.buildAllFiles(kernelSnapshot, spark, kernelEngine).collect()
+      assert(kernelFiles.find(_.path == taggedPath).map(_.tags).contains(expectedTags))
+
+      val snapshot = new DeltaV2Snapshot(kernelSnapshot, spark)
+      val selectedFiles = snapshot.filesForScan(Nil).files
+      assert(selectedFiles.find(_.path == taggedPath).map(_.tags).contains(expectedTags))
     }
   }
 }

--- a/spark/v2/src/main/scala/org/apache/spark/sql/delta/v2/interop/KernelSnapshotUtils.scala
+++ b/spark/v2/src/main/scala/org/apache/spark/sql/delta/v2/interop/KernelSnapshotUtils.scala
@@ -87,8 +87,8 @@ private[delta] object KernelSnapshotUtils {
    * Builds one V1 [[AddFile]] from one Kernel AddFile.
    *
    * The returned AddFile keeps the path, partition values, size, modification time, stats,
-   * deletion vector, and row tracking fields from Kernel. The row tracking fields are baseRowId
-   * and defaultRowCommitVersion.
+   * tags, deletion vector, and row tracking fields from Kernel. The row tracking fields are
+   * baseRowId and defaultRowCommitVersion.
    */
   private def toV1AddFile(kernelAddFile: KernelAddFile): AddFile = {
     AddFile(
@@ -99,6 +99,7 @@ private[delta] object KernelSnapshotUtils {
       // V1 Snapshot.allFiles normalizes active files to dataChange = false.
       dataChange = false,
       stats = kernelAddFile.getStatsJson.toScala.orNull,
+      tags = toV1Tags(kernelAddFile),
       deletionVector = toV1DeletionVectorDescriptor(kernelAddFile),
       baseRowId = kernelAddFile.getBaseRowId.toScala.map(_.longValue()),
       defaultRowCommitVersion =
@@ -147,5 +148,24 @@ private[delta] object KernelSnapshotUtils {
     } else {
       Map.empty
     }
+  }
+
+  /**
+   * Returns the tags for one AddFile as a Scala map.
+   *
+   * Kernel stores tags as an optional string-to-string map, the same shape as partition values.
+   * A missing Kernel tags map stays null, matching V1 AddFile.tags.
+   */
+  private def toV1Tags(kernelAddFile: KernelAddFile): Map[String, String] = {
+    kernelAddFile.getTags.toScala
+      .map { tags =>
+        val keys = tags.getKeys
+        val values = tags.getValues
+        (0 until tags.getSize).map { index =>
+          val value = if (values.isNullAt(index)) null else values.getString(index)
+          keys.getString(index) -> value
+        }.toMap
+      }
+      .orNull
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Copy nullable tag maps when adapting Kernel files to AddFile actions so snapshot metadata remains complete. Add coverage for tagged commit actions through file selection.

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Added new tests and CI 

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
