### PR TITLE
[Spark] Add V1 and V2 static file selection profiling

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/stats/DataSkippingReader.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/stats/DataSkippingReader.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql.delta.stats
 
 // scalastyle:off import.ordering.noEmptyLine
 import java.io.Closeable
+import java.util.concurrent.TimeUnit.NANOSECONDS
 
 import scala.collection.mutable.ArrayBuffer
 
@@ -654,7 +655,7 @@ trait DataSkippingReaderBase
    * of the statistics need to be consistent across all files.
    */
   override def filesForScan(filters: Seq[Expression], keepNumRecords: Boolean): DeltaScan = {
-    val startTime = System.currentTimeMillis()
+    val startTimeNs = System.nanoTime()
     if (filters == Seq(TrueLiteral) || filters.isEmpty || schema.isEmpty) {
       recordDeltaOperation(snapshotToScan, "delta.skipping.none") {
         // When there are no filters we can just return allFiles with no extra processing
@@ -673,6 +674,7 @@ trait DataSkippingReaderBase
           rows = rowCount,
           files = numOfFilesIfKnown,
           logicalRows = logicalRowCount)
+        val durationNs = System.nanoTime() - startTimeNs
         return DeltaScan(
           version = version,
           files = files,
@@ -685,7 +687,8 @@ trait DataSkippingReaderBase
           partitionLikeDataFilters = ExpressionSet(Nil),
           rewrittenPartitionLikeDataFilters = Set.empty,
           unusedFilters = ExpressionSet(Nil),
-          scanDurationMs = System.currentTimeMillis() - startTime,
+          scanDurationMs = NANOSECONDS.toMillis(durationNs),
+          scanDurationNs = Some(durationNs),
           dataSkippingType = getCorrectDataSkippingType(DeltaDataSkippingType.noSkippingV1)
         )
       }
@@ -713,6 +716,7 @@ trait DataSkippingReaderBase
       // When there are only partition filters we can scan allFiles
       // rather than withStats and thus we skip data skipping information.
       val (files, scanSize) = filterOnPartitions(partitionFilters, keepNumRecords)
+      val durationNs = System.nanoTime() - startTimeNs
       DeltaScan(
         version = version,
         files = files,
@@ -725,7 +729,8 @@ trait DataSkippingReaderBase
         partitionLikeDataFilters = ExpressionSet(Nil),
         rewrittenPartitionLikeDataFilters = Set.empty,
         unusedFilters = ExpressionSet(ineligibleFilters),
-        scanDurationMs = System.currentTimeMillis() - startTime,
+        scanDurationMs = NANOSECONDS.toMillis(durationNs),
+        scanDurationNs = Some(durationNs),
         dataSkippingType =
           getCorrectDataSkippingType(DeltaDataSkippingType.partitionFilteringOnlyV1)
       )
@@ -805,6 +810,7 @@ trait DataSkippingReaderBase
         getDataSkippedFiles(finalPartitionFilters, finalSkippingFilters, keepNumRecords)
       }
 
+      val durationNs = System.nanoTime() - startTimeNs
       DeltaScan(
         version = version,
         files = files,
@@ -817,7 +823,8 @@ trait DataSkippingReaderBase
         partitionLikeDataFilters = ExpressionSet(partitionLikeFilters.map(_._1)),
         rewrittenPartitionLikeDataFilters = partitionLikeFilters.map(_._2.expr.expr).toSet,
         unusedFilters = ExpressionSet(unusedFilters.map(_._1) ++ ineligibleFilters),
-        scanDurationMs = System.currentTimeMillis() - startTime,
+        scanDurationMs = NANOSECONDS.toMillis(durationNs),
+        scanDurationNs = Some(durationNs),
         dataSkippingType = getCorrectDataSkippingType(dataSkippingType)
       )
     }
@@ -830,7 +837,7 @@ trait DataSkippingReaderBase
    */
   override def filesForScan(limit: Long, partitionFilters: Seq[Expression]): DeltaScan =
     recordDeltaOperation(snapshotToScan, "delta.skipping.filteredLimit") {
-      val startTime = System.currentTimeMillis()
+      val startTimeNs = System.nanoTime()
       val finalPartitionFilters = constructPartitionFilters(partitionFilters)
 
       val scan = {
@@ -851,6 +858,7 @@ trait DataSkippingReaderBase
         scan.numLogicalRecords
       )
 
+      val durationNs = System.nanoTime() - startTimeNs
       DeltaScan(
         version = version,
         files = scan.files,
@@ -863,7 +871,8 @@ trait DataSkippingReaderBase
         partitionLikeDataFilters = ExpressionSet(Nil),
         rewrittenPartitionLikeDataFilters = Set.empty,
         unusedFilters = ExpressionSet(Nil),
-        scanDurationMs = System.currentTimeMillis() - startTime,
+        scanDurationMs = NANOSECONDS.toMillis(durationNs),
+        scanDurationNs = Some(durationNs),
         dataSkippingType = DeltaDataSkippingType.filteredLimit
       )
     }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/stats/DeltaScan.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/stats/DeltaScan.scala
@@ -93,6 +93,7 @@ case class DeltaScan(
     val rewrittenPartitionLikeDataFilters: Set[Expression],
     val unusedFilters: ExpressionSet,
     val scanDurationMs: Long,
+    val scanDurationNs: Option[Long] = None,
     val dataSkippingType: DeltaDataSkippingType) {
   assert(version == scannedSnapshot.version)
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/stats/PrepareDeltaScan.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/stats/PrepareDeltaScan.scala
@@ -121,7 +121,10 @@ trait PrepareDeltaScanBase extends Rule[LogicalPlan]
         // If we trigger limit push down, the filters must be partition filters. Since
         // there are no data filters, we don't need to apply Generated Columns
         // optimization. See `DeltaTableScan` for more details.
-        return scanGenerator.filesForScan(limitOpt.get, filters)
+        return recordFrameProfile(
+            "Delta", "PrepareDeltaScan.filesForScan.limitAndFilters") {
+          scanGenerator.filesForScan(limitOpt.get, filters)
+        }
       }
       val filtersForScan =
         if (!GeneratedColumn.partitionFilterOptimizationEnabled(spark)) {
@@ -131,7 +134,9 @@ trait PrepareDeltaScanBase extends Rule[LogicalPlan]
             spark, scanGenerator.snapshotToScan, filters, delta)
           filters ++ generatedPartitionFilters
         }
-      scanGenerator.filesForScan(filtersForScan)
+      return recordFrameProfile("Delta", "PrepareDeltaScan.filesForScan.filters") {
+        scanGenerator.filesForScan(filtersForScan)
+      }
     }
   }
 

--- a/spark/v2/src/main/scala/io/delta/spark/internal/v2/read/DeltaV2ScanBuilder.scala
+++ b/spark/v2/src/main/scala/io/delta/spark/internal/v2/read/DeltaV2ScanBuilder.scala
@@ -185,11 +185,15 @@ private[read] class DeltaV2ScanBuilder(
           // record counts until the limit is satisfied.
           def selectFiles(): DeltaScan =
             if (effectiveLimit.isPresent) {
-              snapshot.filesForScan(
-                effectiveLimit.getAsInt.toLong,
-                partitionFiltersForScan)
+              recordFrameProfile("Delta", "DeltaV2.filesForScan.limitAndFilters") {
+                snapshot.filesForScan(
+                  effectiveLimit.getAsInt.toLong,
+                  partitionFiltersForScan)
+              }
             } else {
-              snapshot.filesForScan(catalystFilters, keepNumRecords)
+              recordFrameProfile("Delta", "DeltaV2.filesForScan.filters") {
+                snapshot.filesForScan(catalystFilters, keepNumRecords)
+              }
             }
 
           // Select files inline on this path.


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Delta V1 and V2 already report per-scan file-selection time in `scanDurationMs`, but
millisecond resolution rounds short scans down to zero. This change samples the same existing
timer boundaries with `System.nanoTime()`, stores the duration as `scanDurationNs` on
`DeltaScan`, and derives the legacy millisecond value with `NANOSECONDS.toMillis(durationNs)`.

It also records frame profiles around the concrete V1 and V2 `filesForScan` calls. The frame
names distinguish the limit-plus-filters and filters-only overloads:

- `PrepareDeltaScan.filesForScan.limitAndFilters`
- `PrepareDeltaScan.filesForScan.filters`
- `DeltaV2.filesForScan.limitAndFilters`
- `DeltaV2.filesForScan.filters`

The timing boundaries, filter preparation, selected files, limit handling, and scan construction
behavior otherwise remain unchanged.

## How was this patch tested?

- `build/sbt "sparkV2 / Compile / compile" "sparkV2 / Test / compile"`
- `build/sbt "spark / Test / testOnly org.apache.spark.sql.delta.DeltaLimitPushDownV1Suite"`
- `build/sbt "spark / Test / testOnly org.apache.spark.sql.delta.generatedsuites.dataskipping.DataSkippingDeltaV1Suite -- -z \"data skipping flags\""`
- `build/sbt "sparkV2 / Test / testOnly io.delta.spark.internal.v2.read.DeltaV2ScanBuilderTest"`
- `git diff --check`

## Does this PR introduce _any_ user-facing changes?

No.
