### PR TITLE
[Spark] Support Kernel-backed size in bytes, file-size histogram, and domain metadata in DeltaV2Snapshot

### DIFF
--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/v2/interop/DeltaV2SnapshotSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/v2/interop/DeltaV2SnapshotSuite.scala
@@ -16,7 +16,10 @@
 
 package org.apache.spark.sql.delta.v2.interop
 
-import org.apache.spark.sql.delta.{DeltaLog, Snapshot}
+import org.apache.spark.sql.delta.{DeltaLog, DeltaOperations, NoMapping, Snapshot}
+import org.apache.spark.sql.delta.actions.DomainMetadata
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.stats.FileSizeHistogramUtils
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.hadoop.fs.Path
 import io.delta.kernel.TableManager
@@ -91,6 +94,10 @@ class DeltaV2SnapshotSuite extends DeltaSQLCommandTest {
     def fileKeys(s: Snapshot) =
       s.allFiles.collect().map(f => (f.path, f.size, f.partitionValues)).toSet
     assert(fileKeys(v2) === fileKeys(v1))
+
+    // Both bin the same file sizes with the same default bins, so the histograms agree.
+    assert(v2.sizeInBytes === v1.sizeInBytes)
+    assert(v2.fileSizeHistogram === v1.fileSizeHistogram)
   }
 
   /**
@@ -159,6 +166,118 @@ class DeltaV2SnapshotSuite extends DeltaSQLCommandTest {
       intercept[UnsupportedOperationException](snapshot.stateDS)
       intercept[UnsupportedOperationException](snapshot.tombstones)
       intercept[UnsupportedOperationException](snapshot.computeChecksum)
+      intercept[UnsupportedOperationException](snapshot.deltaFileIndexOpt)
+      intercept[UnsupportedOperationException](snapshot.checkpointProvider)
+
+      assert(snapshot.deltaFileSizeInBytes() === -1L)
+      assert(snapshot.checkpointSizeInBytes() === -1L)
+    }
+  }
+
+  test("domainMetadata is served correctly") {
+    withTempDir { dir =>
+      val path = dir.getCanonicalPath
+      spark.sql(
+        s"CREATE TABLE delta.`$path` (id LONG) USING delta " +
+          "TBLPROPERTIES ('delta.feature.domainMetadata' = 'supported')")
+
+      // Use DeltaLog to create a domain metadata easier for DeltaV2Snapshot read testing.
+      DeltaLog.forTable(spark, path).startTransaction().commit(
+        DomainMetadata("test.userDomain", """{"key":"value"}""", removed = false) :: Nil,
+        DeltaOperations.ManualUpdate)
+
+      val snapshot = new DeltaV2Snapshot(loadKernelSnapshot(path), spark)
+
+      val userDomain = snapshot.domainMetadata.find(_.domain == "test.userDomain")
+        .getOrElse(fail("expected the test.userDomain domain"))
+      assert(!userDomain.removed)
+      assert(userDomain.configuration === """{"key":"value"}""")
+      // Inherited from SnapshotStateManager (not overridden here): Kernel serves domain metadata
+      // without V1 state reconstruction, so it is always "known".
+      assert(snapshot.domainMetadatasIfKnown.contains(snapshot.domainMetadata))
+    }
+  }
+
+  test("fileSizeHistogram is served from the checksum when one exists") {
+    withTempDir { dir =>
+      val path = dir.getCanonicalPath
+      spark.range(0, 1000).write.format("delta").save(path)
+      spark.range(0, 5).write.format("delta").mode("append").save(path)
+      val kernelSnapshot = loadKernelSnapshot(path)
+      assert(kernelSnapshot.getCurrentCrcInfo.get().getFileSizeHistogram.isPresent)
+      val snapshot = new DeltaV2Snapshot(kernelSnapshot, spark)
+
+      assert(snapshot.fileSizeHistogram.nonEmpty)
+      assert(
+        snapshot.fileSizeHistogram.get.sortedBinBoundaries ===
+        FileSizeHistogramUtils.DEFAULT_BINS)
+      assert(
+        snapshot.fileSizeHistogram.get.fileCounts.sum === snapshot.numOfFiles
+      )
+      assert(
+        snapshot.fileSizeHistogram.get.totalBytes.sum === snapshot.sizeInBytes
+      )
+    }
+  }
+
+  test("fileSizeHistogram is None when the checksum has none") {
+    withTempDir { dir =>
+      val path = dir.getCanonicalPath
+      withSQLConf(DeltaSQLConf.DELTA_WRITE_CHECKSUM_ENABLED.key -> "false") {
+        spark.range(0, 1000).write.format("delta").save(path)
+      }
+      val snapshot = new DeltaV2Snapshot(loadKernelSnapshot(path), spark)
+      assert(snapshot.fileSizeHistogram.isEmpty)
+    }
+  }
+
+  test("sizeInBytes is served from the checksum when one exists") {
+    withTempDir { dir =>
+      val path = dir.getCanonicalPath
+      spark.range(0, 1000).write.format("delta").save(path)
+
+      val kernelSnapshot = loadKernelSnapshot(path)
+      assert(kernelSnapshot.getCurrentCrcInfo.isPresent)
+
+      val snapshot = new DeltaV2Snapshot(kernelSnapshot, spark)
+      assert(snapshot.sizeInBytesIfKnown.nonEmpty)
+      assert(
+        snapshot.sizeInBytes === snapshot.allFiles.collect().map(_.size).sum
+      )
+    }
+  }
+
+  test("sizeInBytes is -1 when the checksum has none") {
+    withTempDir { dir =>
+      val path = dir.getCanonicalPath
+      withSQLConf(DeltaSQLConf.DELTA_WRITE_CHECKSUM_ENABLED.key -> "false") {
+        spark.range(0, 1000).write.format("delta").save(path)
+      }
+
+      val snapshot = new DeltaV2Snapshot(loadKernelSnapshot(path), spark)
+      assert(snapshot.sizeInBytesIfKnown.isEmpty)
+      assert(snapshot.sizeInBytes === -1L)
+    }
+  }
+
+  test("fileSizeHistogram is None when the histogram config is disabled") {
+    withTempDir { dir =>
+      val path = dir.getCanonicalPath
+      spark.range(5).write.format("delta").save(path)
+
+      withSQLConf(DeltaSQLConf.DELTA_FILE_SIZE_HISTOGRAM_ENABLED.key -> "false") {
+        assert(new DeltaV2Snapshot(loadKernelSnapshot(path), spark).fileSizeHistogram.isEmpty)
+      }
+    }
+  }
+
+  test("domainMetadata is empty for a table with no domains") {
+    withTempDir { dir =>
+      val path = dir.getCanonicalPath
+      spark.range(1).write.format("delta").save(path)
+
+      val snapshot = new DeltaV2Snapshot(loadKernelSnapshot(path), spark)
+      assert(snapshot.domainMetadata.isEmpty)
     }
   }
 

--- a/spark/v2/src/main/scala/org/apache/spark/sql/delta/v2/interop/DeltaV2Snapshot.scala
+++ b/spark/v2/src/main/scala/org/apache/spark/sql/delta/v2/interop/DeltaV2Snapshot.scala
@@ -16,14 +16,17 @@
 
 package org.apache.spark.sql.delta.v2.interop
 
+import scala.collection.JavaConverters._
+import scala.jdk.OptionConverters._
+
 import io.delta.kernel.engine.Engine
 import io.delta.kernel.internal.{SnapshotImpl => KernelSnapshot}
 import io.delta.spark.internal.v2.kernel.KernelEngineFactory
 
 import org.apache.spark.sql.delta.{CheckpointProvider, DeltaColumnMappingMode, DeltaLogFileIndex, Snapshot, VersionChecksum}
-import org.apache.spark.sql.delta.actions.{AddFile, Metadata, Protocol, RemoveFile, SingleAction}
+import org.apache.spark.sql.delta.actions.{AddFile, DomainMetadata, Metadata, Protocol, RemoveFile, SingleAction}
 import org.apache.spark.sql.delta.coordinatedcommits.TableCommitCoordinatorClient
-import org.apache.spark.sql.delta.stats.{DeltaStatsColumnSpec, StatisticsCollection}
+import org.apache.spark.sql.delta.stats.{DeltaStatsColumnSpec, FileSizeHistogram, StatisticsCollection}
 
 import com.databricks.spark.util.TagDefinition
 import org.apache.hadoop.fs.Path
@@ -139,15 +142,24 @@ class DeltaV2Snapshot(
     None
   }
 
-  // Kernel does not surface a cheap total table size, so report None; the data-skipping path
-  // derives the scanned size from per-file sizes instead.
-  override protected[delta] def sizeInBytesIfKnown: Option[Long] = None
+  /**
+   * Table size in bytes from CRC when present; None otherwise.
+   */
+  override protected[delta] def sizeInBytesIfKnown: Option[Long] =
+    kernelSnapshot.getCurrentCrcInfo.toScala.map(_.getTableSizeBytes)
 
   // No V1 commit-file index; not used by the Kernel scan path.
   override protected[delta] lazy val deltaFileIndexOpt: Option[DeltaLogFileIndex] = unimplemented
 
   // No V1 checkpoint provider; not used by the Kernel scan path.
   override lazy val checkpointProvider: CheckpointProvider = unimplemented
+
+  /**
+   * No V1 commit-file index or checkpoint provider, so these V1 commit-file/checkpoint sizes are
+   * not applicable. -1 is the "did not collect this stat" sentinel.
+   */
+  override def deltaFileSizeInBytes(): Long = -1L
+  override def checkpointSizeInBytes(): Long = -1L
 
   // V1 reads these from logSegment; report zero.
   override def numDeltaFiles: Long = 0L
@@ -168,6 +180,37 @@ class DeltaV2Snapshot(
 
   override lazy val statsColumnSpec: DeltaStatsColumnSpec =
     StatisticsCollection.configuredDeltaStatsColumnSpec(metadata)
+
+  /**
+   * Table size in bytes, served from the Kernel CRC when known. Returns the -1 "did not collect
+   * this stat" sentinel.
+   */
+  override lazy val sizeInBytes: Long = sizeInBytesIfKnown.getOrElse(-1L)
+
+  /**
+   * File-size histogram, served from the Kernel CRC when known and gated by
+   * [[fileSizeHistogramEnabled]]. Returns None when the config is disabled or the CRC has no
+   * histogram.
+   */
+  override lazy val fileSizeHistogram: Option[FileSizeHistogram] =
+    if (fileSizeHistogramEnabled) {
+      kernelSnapshot.getCurrentCrcInfo.toScala
+        .flatMap(_.getFileSizeHistogram.toScala)
+        .map { bins =>
+          val result = bins.captureFileSizeHistogramResult()
+          FileSizeHistogram(
+            sortedBinBoundaries = result.getSortedBinBoundaries.toIndexedSeq,
+            fileCounts = result.getFileCounts,
+            totalBytes = result.getTotalBytes)
+        }
+    } else {
+      None
+    }
+
+  override lazy val domainMetadata: Seq[DomainMetadata] =
+    kernelSnapshot.getActiveDomainMetadataMap.asScala.map { case (domain, kernelDomainMetadata) =>
+      DomainMetadata(domain, kernelDomainMetadata.getConfiguration, kernelDomainMetadata.isRemoved)
+    }.toSeq
 
   // --- ValidateChecksum: Kernel has no V1 checksum to validate; no-op ------------------------
   override def validateChecksum(contextInfo: Map[String, String]): Boolean = true


### PR DESCRIPTION
## Description

This change teaches `DeltaV2Snapshot` (the Kernel-backed `Snapshot` implementation) to serve three snapshot-level statistics directly from the Kernel snapshot instead of leaving them unimplemented:

- **`sizeInBytes` / `sizeInBytesIfKnown`**: served from the Kernel CRC (checksum) when present; falls back to the `-1` "did not collect this stat" sentinel (and `None`) otherwise.
- **`fileSizeHistogram`**: served from the Kernel CRC when present, gated by the file-size histogram config; `None` when the config is disabled or the CRC carries no histogram.
- **`domainMetadata`**: served from the Kernel snapshot's active domain-metadata map.

It also implements `deltaFileSizeInBytes()` and `checkpointSizeInBytes()` to return the `-1` sentinel, since the Kernel scan path has no V1 commit-file index or checkpoint provider.

## How was this patch tested?

Added unit tests in `DeltaV2SnapshotSuite` covering:
- `sizeInBytes` and `fileSizeHistogram` served from the checksum, and the `None` / `-1` results when the checksum is absent or the relevant config is disabled;
- `domainMetadata` served for a table with a user domain, and empty for a table with no domains;
- parity of `sizeInBytes` and `fileSizeHistogram` between the Kernel-backed and existing snapshots;
- the accessors with no Kernel scan-path equivalent raising / returning the expected sentinels.

## Does this PR introduce _any_ user-facing change?

No.
