### PR TITLE
[Spark] Make Row Tracking backfill errors actionable

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/backfill/RowTrackingBackfillBatch.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/backfill/RowTrackingBackfillBatch.scala
@@ -16,7 +16,7 @@
 
 package org.apache.spark.sql.delta.commands.backfill
 
-import org.apache.spark.sql.delta.{DeltaConfigs, DeltaOperations, OptimisticTransaction, RowTrackingFeature}
+import org.apache.spark.sql.delta.{DeltaConfigs, DeltaErrors, DeltaOperations, OptimisticTransaction, RowTrackingFeature}
 import org.apache.spark.sql.delta.actions.AddFile
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.{Utils => DeltaUtils}
@@ -39,11 +39,11 @@ case class RowTrackingBackfillBatch(filesInBatch: Seq[AddFile]) extends Backfill
     val ignoreSuspension = DeltaUtils.isTesting && spark.conf.get(ignoreProperty).toBoolean
     val suspendRowTracking =
       DeltaConfigs.ROW_TRACKING_SUSPENDED.fromMetaData(metadata) && !ignoreSuspension
-    if (!isRowTrackingSupported || suspendRowTracking) {
-      throw new IllegalStateException(
-        """
-          |Cannot run backfill command if row tracking is not supported or
-          |row ID generation is suspended.""".stripMargin)
+    if (!isRowTrackingSupported) {
+      throw DeltaErrors.protocolChangedException(None)
+    }
+    if (suspendRowTracking) {
+      throw DeltaErrors.rowTrackingIllegalPropertyCombination()
     }
 
     val filesToCommit = filesInBatch.map(_.copy(dataChange = false))

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowTrackingRemovalConcurrencySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowTrackingRemovalConcurrencySuite.scala
@@ -502,10 +502,16 @@ class RowTrackingRemovalConcurrencySuite
               }
               assert(e.getErrorClass === "DELTA_ROW_TRACKING_ILLEGAL_PROPERTY_COMBINATION")
             } else {
-              // Backfill fails if run together backfill.
-              assertThrows[IllegalStateException] {
+              // Backfill fails while the table is suspended during unbackfill.
+              val e = intercept[DeltaIllegalStateException] {
                 backfillTransaction(deltaLog)
               }
+              checkError(
+                e,
+                "DELTA_ROW_TRACKING_ILLEGAL_PROPERTY_COMBINATION",
+                parameters = Map(
+                  "property1" -> DeltaConfigs.ROW_TRACKING_ENABLED.key,
+                  "property2" -> DeltaConfigs.ROW_TRACKING_SUSPENDED.key))
             }
 
             // Commit batch 2.

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowTrackingRemovalSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowTrackingRemovalSuite.scala
@@ -255,13 +255,19 @@ class RowTrackingRemovalSuite extends RowTrackingRemovalSuiteBase {
            |${DeltaConfigs.ROW_TRACKING_ENABLED.key} = 'true'
            |)""".stripMargin)
 
-      assertThrows[IllegalStateException] {
+      val suspensionError = intercept[DeltaIllegalStateException] {
         sql(
           s"""ALTER TABLE delta.`${dir.getAbsolutePath}`
              |SET TBLPROPERTIES(
              |${DeltaConfigs.ROW_TRACKING_SUSPENDED.key} = 'true'
              |)""".stripMargin)
       }
+      checkError(
+        suspensionError,
+        "DELTA_ROW_TRACKING_ILLEGAL_PROPERTY_COMBINATION",
+        parameters = Map(
+          "property1" -> DeltaConfigs.ROW_TRACKING_ENABLED.key,
+          "property2" -> DeltaConfigs.ROW_TRACKING_SUSPENDED.key))
 
       sql(
         s"""ALTER TABLE delta.`${dir.getAbsolutePath}`
@@ -271,13 +277,19 @@ class RowTrackingRemovalSuite extends RowTrackingRemovalSuiteBase {
            |)""".stripMargin)
 
 
-      assertThrows[IllegalStateException] {
+      val reenableError = intercept[DeltaIllegalStateException] {
         sql(
           s"""ALTER TABLE delta.`${dir.getAbsolutePath}`
              |SET TBLPROPERTIES(
              |${DeltaConfigs.ROW_TRACKING_ENABLED.key} = 'true'
              |)""".stripMargin)
       }
+      checkError(
+        reenableError,
+        "DELTA_ROW_TRACKING_ILLEGAL_PROPERTY_COMBINATION",
+        parameters = Map(
+          "property1" -> DeltaConfigs.ROW_TRACKING_ENABLED.key,
+          "property2" -> DeltaConfigs.ROW_TRACKING_SUSPENDED.key))
     }
   }
 


### PR DESCRIPTION
## Description

Improve the error messages raised during Row Tracking backfill by replacing
generic `IllegalStateException`s with structured Delta errors:

- When Row Tracking is not supported by the table protocol, backfill now raises
  `DELTA_PROTOCOL_CHANGED`.
- When Row Tracking is suspended, backfill now raises
  `DELTA_ROW_TRACKING_ILLEGAL_PROPERTY_COMBINATION`.

This makes the failures actionable by pointing at the specific protocol/property
combination that caused them instead of a generic, hard-to-diagnose message.

## How was this patch tested?

Updated existing tests in `RowTrackingRemovalSuite` and
`RowTrackingRemovalConcurrencySuite` to assert the specific error classes and their
parameters (`property1`/`property2`) via `checkError`.

## Does this PR introduce _any_ user-facing changes?

No functional change. The affected operations already failed in these situations;
the errors surfaced are now structured, actionable Delta errors instead of generic
`IllegalStateException`s.
