### PR TITLE
[Spark][Storage] Honor Spark's declared write intent when requesting UC storage credentials

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalog.scala
@@ -56,7 +56,7 @@ import org.apache.spark.sql.catalyst.analysis.{NoSuchDatabaseException, NoSuchNa
 import org.apache.spark.sql.catalyst.catalog.{BucketSpec, CatalogTable, CatalogTableType, CatalogUtils, SessionCatalog}
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, QualifiedColType, QualifiedColTypeShims, SyncIdentity}
 import org.apache.spark.sql.catalyst.util.{GeneratedColumn => SparkGeneratedColumn, IdentityColumn => SparkIdentityColumn}
-import org.apache.spark.sql.connector.catalog.{CatalogV2Util, Column, DelegatingCatalogExtension, Identifier, StagedTable, StagingTableCatalog, SupportsWrite, Table, TableCapability, TableCatalog, TableCatalogCapability, TableChange, V1Table}
+import org.apache.spark.sql.connector.catalog.{CatalogV2Util, Column, DelegatingCatalogExtension, Identifier, StagedTable, StagingTableCatalog, SupportsWrite, Table, TableCapability, TableCatalog, TableCatalogCapability, TableChange, TableWritePrivilege, V1Table}
 import org.apache.spark.sql.connector.catalog.TableCapability._
 import org.apache.spark.sql.connector.catalog.TableChange._
 import org.apache.spark.sql.connector.expressions.{FieldReference, IdentityTransform, Literal, NamedReference, Transform}
@@ -411,13 +411,28 @@ class AbstractDeltaCatalog extends DelegatingCatalogExtension
     loadTable(ident)
   }
 
-  override def loadTable(ident: Identifier): Table = recordFrameProfile(
+  override def loadTable(ident: Identifier): Table =
+    loadTableWithWriteIntent(ident, writeIntent = false, () => super.loadTable(ident))
+
+  // Spark resolves the target of INSERT / UPDATE / DELETE / MERGE through this overload; pass
+  // the declared intent on so the catalog client can request matching storage credentials. The
+  // delegate fallback drops the privileges: `DelegatingCatalogExtension` has no privileged
+  // forward, so the delegate would receive them stripped by the default method anyway.
+  override def loadTable(
+      ident: Identifier,
+      writePrivileges: util.Set[TableWritePrivilege]): Table =
+    loadTableWithWriteIntent(ident, writeIntent = true, () => super.loadTable(ident))
+
+  private def loadTableWithWriteIntent(
+      ident: Identifier,
+      writeIntent: Boolean,
+      loadFromDelegate: () => Table): Table = recordFrameProfile(
       "DeltaCatalog", "loadTable") {
     setVariantBlockingConfigIfUC()
     try {
       val table = deltaCatalogClient
-        .map(_.loadTable(ident))
-        .getOrElse(super.loadTable(ident))
+        .map(_.loadTable(ident, writeIntent))
+        .getOrElse(loadFromDelegate())
 
       table match {
         case v1: V1Table if DeltaTableUtils.isDeltaTable(v1.catalogTable) =>

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClient.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClient.scala
@@ -60,6 +60,13 @@ private[delta] trait AbstractDeltaCatalogClient {
   def loadTable(ident: Identifier): Table
 
   /**
+   * Same as [[loadTable(ident:*]], additionally declaring whether Spark resolved the table as
+   * the target of a write (`TableCatalog.loadTable(ident, writePrivileges)`). The default
+   * ignores the intent.
+   */
+  def loadTable(ident: Identifier, writeIntent: Boolean): Table = loadTable(ident)
+
+  /**
    * Reserves a fresh staging entry with the catalog for a new Delta table and returns
    * `properties` augmented with the catalog-supplied LOCATION, the catalog-assigned table
    * id, and the storage credentials Delta needs to write the initial commit.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImpl.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImpl.scala
@@ -104,7 +104,9 @@ private[catalog] class UCDeltaCatalogClientImpl(
             log"UCDeltaClient; falling back to the legacy catalog path. Cause: " +
             log"${MDC(DeltaLogKeys.EXCEPTION, e.getMessage)}")
           return fallbackLoadTableFunc(ident)
-        case e: CredentialFetchFailedException if serverSidePlanningEnabled =>
+        // Server-side planning is read-only; a declared write must surface the denial rather
+        // than be handed a read-only SSP table that fails later with "does not support writes".
+        case e: CredentialFetchFailedException if serverSidePlanningEnabled && !writeIntent =>
           logWarning(log"Credential fetch failed for " +
             log"${MDC(DeltaLogKeys.TABLE_NAME, fullQualifiedTableName(ident))}; enabling " +
             log"server-side planning fallback. Cause: " +

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImpl.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/UCDeltaCatalogClientImpl.scala
@@ -90,11 +90,13 @@ private[catalog] class UCDeltaCatalogClientImpl(
   // DeltaCatalogClient: loadTable
   // -------------------------------------------------------------------------
 
-  override def loadTable(ident: Identifier): Table = {
+  override def loadTable(ident: Identifier): Table = loadTable(ident, writeIntent = false)
+
+  override def loadTable(ident: Identifier, writeIntent: Boolean): Table = {
     UCDeltaCatalogClientImpl.loadTableInvocationsCounter.incrementAndGet()
     val tid = toStorageTableIdent(ident)
     val info =
-      try ucClient.loadTable(tid)
+      try ucClient.loadTable(tid, writeIntent)
       catch {
         case _: StorageNoSuchTableException => throw new NoSuchTableException(ident)
         case e: UnsupportedTableFormatException =>

--- a/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
@@ -203,6 +203,26 @@ class AbstractDeltaCatalogClientRoutingSuite extends QueryTest with DeltaSQLComm
     assert(recordedIntents.toList === List(false, true))
   }
 
+  test("the server-side-planning fallback never serves a declared write") {
+    val info = existingDeltaTableInfo()
+    val stub = new ThrowingUCDeltaClient {
+      override def loadTable(
+          tableIdentifier: StorageTableIdentifier, writeIntent: Boolean): TableInfo =
+        throw new CredentialFetchFailedException("denied", null, info)
+    }
+    val client = new UCDeltaCatalogClientImpl(
+      catalogName = "main", ucClient = stub, serverSidePlanningEnabled = true)
+    val ident = Identifier.of(Array("sch"), "tbl")
+
+    // SSP tables are read-only, so a declared write must surface the credential denial instead
+    // of being handed a table that fails later with "does not support writes".
+    intercept[CredentialFetchFailedException] {
+      client.loadTable(ident, writeIntent = true)
+    }
+    // The intent-less load keeps the SSP fallback.
+    assert(client.loadTable(ident) != null)
+  }
+
   test("createStagingTable: managed Delta create on the new path stages + augments props") {
     val (client, stub) = newRecordingClient()
     val ident = Identifier.of(Array("sch"), "tbl")

--- a/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/catalog/AbstractDeltaCatalogClientRoutingSuite.scala
@@ -182,6 +182,27 @@ class AbstractDeltaCatalogClientRoutingSuite extends QueryTest with DeltaSQLComm
     m
   }
 
+  test("loadTable passes the declared write intent to the UC client") {
+    val recordedIntents = scala.collection.mutable.ArrayBuffer.empty[Boolean]
+    val stub = new ThrowingUCDeltaClient {
+      override def loadTable(
+          tableIdentifier: StorageTableIdentifier, writeIntent: Boolean): TableInfo = {
+        recordedIntents += writeIntent
+        throw new StorageNoSuchTableException("sentinel: metadata fetch not under test")
+      }
+    }
+    val client = new UCDeltaCatalogClientImpl(catalogName = "main", ucClient = stub)
+    val ident = Identifier.of(Array("sch"), "tbl")
+
+    intercept[org.apache.spark.sql.catalyst.analysis.NoSuchTableException] {
+      client.loadTable(ident)
+    }
+    intercept[org.apache.spark.sql.catalyst.analysis.NoSuchTableException] {
+      client.loadTable(ident, writeIntent = true)
+    }
+    assert(recordedIntents.toList === List(false, true))
+  }
+
   test("createStagingTable: managed Delta create on the new path stages + augments props") {
     val (client, stub) = newRecordingClient()
     val ident = Identifier.of(Array("sch"), "tbl")

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaClient.java
@@ -46,6 +46,17 @@ public interface UCDeltaClient extends UCClient {
   TableInfo loadTable(TableIdentifier tableIdentifier) throws IOException;
 
   /**
+   * Same as {@link #loadTable(TableIdentifier)}, additionally declaring whether the caller
+   * resolved the table as the target of a write (Spark's
+   * {@code loadTable(ident, writePrivileges)}). Implementations may use the intent to request
+   * matching storage credentials; the default ignores it.
+   */
+  default TableInfo loadTable(TableIdentifier tableIdentifier, boolean writeIntent)
+      throws IOException {
+    return loadTable(tableIdentifier);
+  }
+
+  /**
    * Reserves a staging slot for a new Delta table. The returned response contains the table ID,
    * storage location, and protocol/property requirements that the caller must honor when
    * finalizing the table with {@link #createTable}.

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
@@ -86,7 +86,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
 import org.apache.hadoop.conf.Configuration;
@@ -184,13 +186,36 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
     return colon > 0 ? location.substring(0, colon) : "";
   }
 
+  // Full names of tables whose READ_WRITE credential request was denied, so intent-less loads
+  // (SELECT resolution) skip the doomed round-trip on every query. An entry is cleared when a
+  // declared write for the table succeeds.
+  private final Set<String> writeDeniedTables = ConcurrentHashMap.newKeySet();
+
   private Map<String, String> fetchTableCredentials(
-      String catalog, String schema, String table, String location) throws ApiException {
+      String catalog, String schema, String table, String location, boolean writeIntent)
+      throws ApiException {
     UCCredentialHadoopConfs.Builder b = newCredBuilder(schemeOf(location));
+    String fullName = catalog + "." + schema + "." + table;
     try {
-      return b.buildForTable(catalog, schema, table, TableOperation.READ_WRITE, location);
-    } catch (ApiException rw) {
-      return b.buildForTable(catalog, schema, table, TableOperation.READ, location);
+      if (writeIntent) {
+        // Declared write: READ credentials would only defer the same denial to the storage
+        // layer mid-job, so let it surface now.
+        Map<String, String> props =
+            b.buildForTable(catalog, schema, table, TableOperation.READ_WRITE, location);
+        writeDeniedTables.remove(fullName);
+        return props;
+      }
+      if (writeDeniedTables.contains(fullName)) {
+        return b.buildForTable(catalog, schema, table, TableOperation.READ, location);
+      }
+      // Intent-less loads still try READ_WRITE first: some write paths (e.g. OPTIMIZE) resolve
+      // through the intent-less overload.
+      try {
+        return b.buildForTable(catalog, schema, table, TableOperation.READ_WRITE, location);
+      } catch (ApiException rw) {
+        writeDeniedTables.add(fullName);
+        return b.buildForTable(catalog, schema, table, TableOperation.READ, location);
+      }
     } catch (IllegalArgumentException malformed) {
       // UC Hadoop's response validator (DeltaStorageCredentialUtil.requireSingleCloudConfig)
       // throws when the scheme has no cloud cred (e.g. file://). Treat as no creds.
@@ -445,13 +470,19 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
 
   @Override
   public TableInfo loadTable(TableIdentifier tableIdentifier) throws IOException {
+    return loadTable(tableIdentifier, false);
+  }
+
+  @Override
+  public TableInfo loadTable(TableIdentifier tableIdentifier, boolean writeIntent)
+      throws IOException {
     ensureOpen();
     ResolvedTableName name = requireThreePartName(tableIdentifier);
 
     try {
       return toTableInfo(
           deltaTablesApi.loadTable(name.catalog, name.schema, name.table),
-          name.catalog, name.schema, name.table);
+          name.catalog, name.schema, name.table, writeIntent);
     } catch (ApiException e) {
       if (e.getCode() == HTTP_NOT_FOUND) {
         throw new NoSuchTableException(
@@ -540,7 +571,8 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
           deltaTablesApi.createTable(name.catalog, name.schema, sdkRequest),
           name.catalog,
           name.schema,
-          name.table);
+          name.table,
+          /* writeIntent= */ true);
     } catch (ApiException e) {
       throw new IOException(
           String.format("Failed to create table %s (HTTP %s): %s",
@@ -598,7 +630,8 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
   // ===========================
 
   private TableInfo toTableInfo(
-      DeltaLoadTableResponse response, String catalog, String schema, String name)
+      DeltaLoadTableResponse response, String catalog, String schema, String name,
+      boolean writeIntent)
       throws IOException {
     DeltaTableMetadata m = response.getMetadata();
     String location = m.getLocation();
@@ -623,7 +656,7 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
     }
     Map<String, String> storageProps;
     try {
-      storageProps = fetchTableCredentials(catalog, schema, name, location);
+      storageProps = fetchTableCredentials(catalog, schema, name, location, writeIntent);
     } catch (ApiException e) {
       // Surface as a typed failure so callers with a fallback (e.g. server-side planning) can
       // recover. The exception carries the catalog-side TableInfo (with empty storageProperties)

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
@@ -86,9 +86,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 import org.apache.hadoop.conf.Configuration;
@@ -186,39 +186,73 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
     return colon > 0 ? location.substring(0, colon) : "";
   }
 
-  // Full names of tables whose READ_WRITE credential request was denied, so intent-less loads
-  // (SELECT resolution) skip the doomed round-trip on every query. An entry is cleared when a
-  // declared write for the table succeeds.
-  private final Set<String> writeDeniedTables = ConcurrentHashMap.newKeySet();
+  private static final int HTTP_FORBIDDEN = 403;
+
+  // How long an intent-less load trusts a remembered READ_WRITE denial before probing again.
+  // Bounds the staleness window for a grant added after a denial (e.g. before an OPTIMIZE).
+  private static final long WRITE_DENIAL_TTL_MILLIS = TimeUnit.MINUTES.toMillis(5);
+
+  // Full names of tables whose READ_WRITE credential request was 403-denied, mapped to the
+  // deadline until which intent-less loads skip the doomed round-trip. Entries expire, and a
+  // successful declared write clears them early. Package-visible for tests.
+  final Map<String, Long> writeDeniedTables = new ConcurrentHashMap<>();
+
+  private void markWriteDenied(String fullName) {
+    writeDeniedTables.put(fullName, System.currentTimeMillis() + WRITE_DENIAL_TTL_MILLIS);
+  }
+
+  private boolean isWriteDenied(String fullName) {
+    Long deadline = writeDeniedTables.get(fullName);
+    if (deadline == null) {
+      return false;
+    }
+    if (System.currentTimeMillis() >= deadline) {
+      writeDeniedTables.remove(fullName, deadline);
+      return false;
+    }
+    return true;
+  }
 
   private Map<String, String> fetchTableCredentials(
       String catalog, String schema, String table, String location, boolean writeIntent)
       throws ApiException {
     UCCredentialHadoopConfs.Builder b = newCredBuilder(schemeOf(location));
     String fullName = catalog + "." + schema + "." + table;
-    try {
-      if (writeIntent) {
-        // Declared write: READ credentials would only defer the same denial to the storage
-        // layer mid-job, so let it surface now.
-        Map<String, String> props =
-            b.buildForTable(catalog, schema, table, TableOperation.READ_WRITE, location);
-        writeDeniedTables.remove(fullName);
-        return props;
-      }
-      if (writeDeniedTables.contains(fullName)) {
-        return b.buildForTable(catalog, schema, table, TableOperation.READ, location);
-      }
-      // Intent-less loads still try READ_WRITE first: some write paths (e.g. OPTIMIZE) resolve
-      // through the intent-less overload.
+    if (writeIntent) {
+      Map<String, String> props;
       try {
-        return b.buildForTable(catalog, schema, table, TableOperation.READ_WRITE, location);
+        props = b.buildForTable(catalog, schema, table, TableOperation.READ_WRITE, location);
       } catch (ApiException rw) {
-        writeDeniedTables.add(fullName);
-        return b.buildForTable(catalog, schema, table, TableOperation.READ, location);
+        // Declared write: READ credentials would only defer the same denial to the storage
+        // layer mid-job, so let it surface now. A 403 also proves the denial for later reads.
+        if (rw.getCode() == HTTP_FORBIDDEN) {
+          markWriteDenied(fullName);
+        }
+        throw rw;
+      } catch (IllegalArgumentException malformed) {
+        // UC Hadoop's response validator (DeltaStorageCredentialUtil.requireSingleCloudConfig)
+        // throws when the scheme has no cloud cred (e.g. file://). Treat as no creds.
+        return Collections.emptyMap();
       }
+      writeDeniedTables.remove(fullName);
+      return props;
+    }
+    if (isWriteDenied(fullName)) {
+      return b.buildForTable(catalog, schema, table, TableOperation.READ, location);
+    }
+    // Intent-less loads still try READ_WRITE first: some write paths (e.g. OPTIMIZE) resolve
+    // through the intent-less overload.
+    try {
+      return b.buildForTable(catalog, schema, table, TableOperation.READ_WRITE, location);
+    } catch (ApiException rw) {
+      // Only a permission denial is worth remembering; a transient failure must keep the
+      // READ_WRITE-first retry on the next load.
+      if (rw.getCode() == HTTP_FORBIDDEN) {
+        markWriteDenied(fullName);
+      }
+      return b.buildForTable(catalog, schema, table, TableOperation.READ, location);
     } catch (IllegalArgumentException malformed) {
-      // UC Hadoop's response validator (DeltaStorageCredentialUtil.requireSingleCloudConfig)
-      // throws when the scheme has no cloud cred (e.g. file://). Treat as no creds.
+      // See above: scheme with no cloud cred (e.g. file://).
       return Collections.emptyMap();
     }
   }

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
@@ -87,8 +87,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 import org.apache.hadoop.conf.Configuration;
@@ -186,73 +184,23 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
     return colon > 0 ? location.substring(0, colon) : "";
   }
 
-  private static final int HTTP_FORBIDDEN = 403;
-
-  // How long an intent-less load trusts a remembered READ_WRITE denial before probing again.
-  // Bounds the staleness window for a grant added after a denial (e.g. before an OPTIMIZE).
-  private static final long WRITE_DENIAL_TTL_MILLIS = TimeUnit.MINUTES.toMillis(5);
-
-  // Full names of tables whose READ_WRITE credential request was 403-denied, mapped to the
-  // deadline until which intent-less loads skip the doomed round-trip. Entries expire, and a
-  // successful declared write clears them early. Package-visible for tests.
-  final Map<String, Long> writeDeniedTables = new ConcurrentHashMap<>();
-
-  private void markWriteDenied(String fullName) {
-    writeDeniedTables.put(fullName, System.currentTimeMillis() + WRITE_DENIAL_TTL_MILLIS);
-  }
-
-  private boolean isWriteDenied(String fullName) {
-    Long deadline = writeDeniedTables.get(fullName);
-    if (deadline == null) {
-      return false;
-    }
-    if (System.currentTimeMillis() >= deadline) {
-      writeDeniedTables.remove(fullName, deadline);
-      return false;
-    }
-    return true;
-  }
-
   private Map<String, String> fetchTableCredentials(
       String catalog, String schema, String table, String location, boolean writeIntent)
       throws ApiException {
     UCCredentialHadoopConfs.Builder b = newCredBuilder(schemeOf(location));
-    String fullName = catalog + "." + schema + "." + table;
-    if (writeIntent) {
-      Map<String, String> props;
-      try {
-        props = b.buildForTable(catalog, schema, table, TableOperation.READ_WRITE, location);
-      } catch (ApiException rw) {
-        // Declared write: READ credentials would only defer the same denial to the storage
-        // layer mid-job, so let it surface now. A 403 also proves the denial for later reads.
-        if (rw.getCode() == HTTP_FORBIDDEN) {
-          markWriteDenied(fullName);
-        }
-        throw rw;
-      } catch (IllegalArgumentException malformed) {
-        // UC Hadoop's response validator (DeltaStorageCredentialUtil.requireSingleCloudConfig)
-        // throws when the scheme has no cloud cred (e.g. file://). Treat as no creds.
-        return Collections.emptyMap();
-      }
-      writeDeniedTables.remove(fullName);
-      return props;
-    }
-    if (isWriteDenied(fullName)) {
-      return b.buildForTable(catalog, schema, table, TableOperation.READ, location);
-    }
-    // Intent-less loads still try READ_WRITE first: some write paths (e.g. OPTIMIZE) resolve
-    // through the intent-less overload.
+    // Intent-less loads still request READ_WRITE first: write paths such as OPTIMIZE resolve
+    // their target through the intent-less overload.
     try {
       return b.buildForTable(catalog, schema, table, TableOperation.READ_WRITE, location);
     } catch (ApiException rw) {
-      // Only a permission denial is worth remembering; a transient failure must keep the
-      // READ_WRITE-first retry on the next load.
-      if (rw.getCode() == HTTP_FORBIDDEN) {
-        markWriteDenied(fullName);
+      if (writeIntent) {
+        // Fail fast: READ credentials would only defer the denial to the storage layer mid-job.
+        throw rw;
       }
       return b.buildForTable(catalog, schema, table, TableOperation.READ, location);
     } catch (IllegalArgumentException malformed) {
-      // See above: scheme with no cloud cred (e.g. file://).
+      // UC Hadoop's response validator (DeltaStorageCredentialUtil.requireSingleCloudConfig)
+      // throws when the scheme has no cloud cred (e.g. file://). Treat as no creds.
       return Collections.emptyMap();
     }
   }

--- a/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClientSuite.scala
+++ b/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClientSuite.scala
@@ -75,7 +75,12 @@ class UCDeltaTokenBasedRestClientSuite
   }
 
   override def afterAll(): Unit = if (server != null) server.stop(0)
-  override def beforeEach(): Unit = { deltaHandler = null }
+  override def beforeEach(): Unit = {
+    deltaHandler = null
+    // The UC hadoop credential cache is JVM-global; clear it so no test inherits (or leaves
+    // behind) cached credentials for `testIdentifier`.
+    clearUcCredentialCache()
+  }
 
   // --------------- helpers ---------------
 
@@ -291,18 +296,22 @@ class UCDeltaTokenBasedRestClientSuite
       .clear()
   }
 
-  /** Routes credential requests through `recordedOps`, denying READ_WRITE while `denyRw` is on. */
+  /**
+   * Routes credential requests through `recordedOps`; a non-zero status from `denyRwStatus`
+   * fails READ_WRITE requests with that HTTP status.
+   */
   private def credentialOpHandler(
       recordedOps: java.util.List[String],
-      denyRw: () => Boolean): (HttpExchange, String) => Unit = (exchange, _) => {
+      denyRwStatus: () => Int): (HttpExchange, String) => Unit = (exchange, _) => {
     val path = exchange.getRequestURI.getPath
     if (path.endsWith("/credentials")) {
       val query = Option(exchange.getRequestURI.getQuery).getOrElse("")
       val op = if (query.contains("READ_WRITE")) "READ_WRITE" else "READ"
       recordedOps.add(op)
-      if (op == "READ_WRITE" && denyRw()) {
-        sendJson(exchange, HttpStatus.SC_FORBIDDEN,
-          """{"error":{"message":"PERMISSION_DENIED","type":"PermissionDenied","code":403}}""")
+      val status = if (op == "READ_WRITE") denyRwStatus() else 0
+      if (status != 0) {
+        sendJson(exchange, status,
+          s"""{"error":{"message":"DENIED","type":"Denied","code":$status}}""")
       } else {
         sendJson(
           exchange,
@@ -316,10 +325,43 @@ class UCDeltaTokenBasedRestClientSuite
     }
   }
 
+  test("a transient READ_WRITE failure does not poison the denial memory") {
+    val ops = java.util.Collections.synchronizedList(new java.util.ArrayList[String]())
+    // 503 until the "outage" ends. The client retries 503s internally, so exact READ_WRITE
+    // counts vary; assert on the fallback, the memory, and the post-outage probe instead.
+    @volatile var outage = true
+    deltaHandler = credentialOpHandler(
+      ops, () => if (outage) HttpStatus.SC_SERVICE_UNAVAILABLE else 0)
+    withClient { c =>
+      // Retries exhaust, the load falls back to READ, and no denial is remembered.
+      assert(!c.loadTable(testIdentifier).getStorageProperties.isEmpty)
+      assert(ops.asScala.count(_ == "READ") === 1)
+      assert(c.writeDeniedTables.isEmpty)
+      // Once the outage ends, the next load probes READ_WRITE again and succeeds with it.
+      outage = false
+      clearUcCredentialCache()
+      c.loadTable(testIdentifier)
+      assert(ops.asScala.last === "READ_WRITE")
+    }
+  }
+
+  test("an expired denial entry restores READ_WRITE-first probing") {
+    val ops = java.util.Collections.synchronizedList(new java.util.ArrayList[String]())
+    deltaHandler = credentialOpHandler(ops, () => HttpStatus.SC_FORBIDDEN)
+    withClient { c =>
+      c.loadTable(testIdentifier)
+      assert(ops.asScala.toList === List("READ_WRITE", "READ"))
+      // Simulate the TTL elapsing (e.g. a grant added later): the next load probes again.
+      c.writeDeniedTables.put(s"$testCatalog.$testSchema.$testTable", 0L)
+      clearUcCredentialCache()
+      c.loadTable(testIdentifier)
+      assert(ops.asScala.toList === List("READ_WRITE", "READ", "READ_WRITE", "READ"))
+    }
+  }
+
   test("intent-less load remembers a READ_WRITE denial and skips the retry") {
     val ops = java.util.Collections.synchronizedList(new java.util.ArrayList[String]())
-    deltaHandler = credentialOpHandler(ops, () => true)
-    clearUcCredentialCache()
+    deltaHandler = credentialOpHandler(ops, () => HttpStatus.SC_FORBIDDEN)
     withClient { c =>
       // First load: READ_WRITE denied once, READ succeeds.
       assert(!c.loadTable(testIdentifier).getStorageProperties.isEmpty)
@@ -334,8 +376,7 @@ class UCDeltaTokenBasedRestClientSuite
 
   test("declared write requests READ_WRITE and surfaces a denial without READ fallback") {
     val ops = java.util.Collections.synchronizedList(new java.util.ArrayList[String]())
-    deltaHandler = credentialOpHandler(ops, () => true)
-    clearUcCredentialCache()
+    deltaHandler = credentialOpHandler(ops, () => HttpStatus.SC_FORBIDDEN)
     withClient { c =>
       intercept[CredentialFetchFailedException] {
         c.loadTable(testIdentifier, true)
@@ -347,8 +388,7 @@ class UCDeltaTokenBasedRestClientSuite
   test("successful declared write clears the denial memory") {
     val ops = java.util.Collections.synchronizedList(new java.util.ArrayList[String]())
     @volatile var deny = true
-    deltaHandler = credentialOpHandler(ops, () => deny)
-    clearUcCredentialCache()
+    deltaHandler = credentialOpHandler(ops, () => if (deny) HttpStatus.SC_FORBIDDEN else 0)
     withClient { c =>
       // Prime the denial memory through an intent-less load.
       c.loadTable(testIdentifier)

--- a/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClientSuite.scala
+++ b/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClientSuite.scala
@@ -27,7 +27,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.sun.net.httpserver.{HttpExchange, HttpServer}
 import io.delta.storage.commit.{Commit, CommitFailedException, TableIdentifier}
 import io.delta.storage.commit.actions.{AbstractDomainMetadata, AbstractMetadata, AbstractProtocol}
-import io.delta.storage.commit.uccommitcoordinator.exceptions.NoSuchTableException
+import io.delta.storage.commit.uccommitcoordinator.exceptions.{CredentialFetchFailedException, NoSuchTableException}
 import io.delta.storage.commit.uniform.{IcebergMetadata, UniformMetadata}
 
 import org.apache.hadoop.fs.{FileStatus, Path}
@@ -273,6 +273,96 @@ class UCDeltaTokenBasedRestClientSuite
       assert(!c.createStagingTable(testIdentifier).getStorageProperties.isEmpty)
     }
     assert(credentialRequests.get() === 2)
+  }
+
+  // --------------- write-intent credential selection ---------------
+
+  /**
+   * The UC hadoop package keeps a JVM-global credential cache keyed by (context, table,
+   * operation); earlier tests in this suite populate it for `testIdentifier`. Clear it so every
+   * fetch in these tests reaches the stub server.
+   */
+  private def clearUcCredentialCache(): Unit = {
+    val field = classOf[io.unitycatalog.hadoop.internal.CredPropsUtil]
+      .getDeclaredField("initialCredCache")
+    field.setAccessible(true)
+    field.get(null)
+      .asInstanceOf[io.unitycatalog.hadoop.internal.auth.CredentialCache]
+      .clear()
+  }
+
+  /** Routes credential requests through `recordedOps`, denying READ_WRITE while `denyRw` is on. */
+  private def credentialOpHandler(
+      recordedOps: java.util.List[String],
+      denyRw: () => Boolean): (HttpExchange, String) => Unit = (exchange, _) => {
+    val path = exchange.getRequestURI.getPath
+    if (path.endsWith("/credentials")) {
+      val query = Option(exchange.getRequestURI.getQuery).getOrElse("")
+      val op = if (query.contains("READ_WRITE")) "READ_WRITE" else "READ"
+      recordedOps.add(op)
+      if (op == "READ_WRITE" && denyRw()) {
+        sendJson(exchange, HttpStatus.SC_FORBIDDEN,
+          """{"error":{"message":"PERMISSION_DENIED","type":"PermissionDenied","code":403}}""")
+      } else {
+        sendJson(
+          exchange,
+          HttpStatus.SC_OK,
+          s"""{"storage-credentials":[{"prefix":"s3://bucket/table","operation":"$op",""" +
+            """"expiration-time-ms":4102444800000,"config":{"s3.access-key-id":"ak",""" +
+            """"s3.secret-access-key":"sk","s3.session-token":"st"}}]}""")
+      }
+    } else {
+      sendJson(exchange, HttpStatus.SC_OK, loadTableJson())
+    }
+  }
+
+  test("intent-less load remembers a READ_WRITE denial and skips the retry") {
+    val ops = java.util.Collections.synchronizedList(new java.util.ArrayList[String]())
+    deltaHandler = credentialOpHandler(ops, () => true)
+    clearUcCredentialCache()
+    withClient { c =>
+      // First load: READ_WRITE denied once, READ succeeds.
+      assert(!c.loadTable(testIdentifier).getStorageProperties.isEmpty)
+      assert(ops.asScala.toList === List("READ_WRITE", "READ"))
+      // Force a re-fetch (drop the cached READ credential): the load must go straight to READ
+      // without retrying the denied READ_WRITE.
+      clearUcCredentialCache()
+      assert(!c.loadTable(testIdentifier).getStorageProperties.isEmpty)
+      assert(ops.asScala.toList === List("READ_WRITE", "READ", "READ"))
+    }
+  }
+
+  test("declared write requests READ_WRITE and surfaces a denial without READ fallback") {
+    val ops = java.util.Collections.synchronizedList(new java.util.ArrayList[String]())
+    deltaHandler = credentialOpHandler(ops, () => true)
+    clearUcCredentialCache()
+    withClient { c =>
+      intercept[CredentialFetchFailedException] {
+        c.loadTable(testIdentifier, true)
+      }
+      assert(ops.asScala.toList === List("READ_WRITE"))
+    }
+  }
+
+  test("successful declared write clears the denial memory") {
+    val ops = java.util.Collections.synchronizedList(new java.util.ArrayList[String]())
+    @volatile var deny = true
+    deltaHandler = credentialOpHandler(ops, () => deny)
+    clearUcCredentialCache()
+    withClient { c =>
+      // Prime the denial memory through an intent-less load.
+      c.loadTable(testIdentifier)
+      assert(ops.asScala.toList === List("READ_WRITE", "READ"))
+      // Write access granted: a declared write requests READ_WRITE (never gated by the memory)
+      // and clears it.
+      deny = false
+      c.loadTable(testIdentifier, true)
+      assert(ops.asScala.toList === List("READ_WRITE", "READ", "READ_WRITE"))
+      // Intent-less loads are back on the READ_WRITE-first path.
+      clearUcCredentialCache()
+      c.loadTable(testIdentifier)
+      assert(ops.asScala.toList === List("READ_WRITE", "READ", "READ_WRITE", "READ_WRITE"))
+    }
   }
 
   test("loadTable schema emits Delta camelCase wire format for array and map") {

--- a/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClientSuite.scala
+++ b/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClientSuite.scala
@@ -296,22 +296,18 @@ class UCDeltaTokenBasedRestClientSuite
       .clear()
   }
 
-  /**
-   * Routes credential requests through `recordedOps`; a non-zero status from `denyRwStatus`
-   * fails READ_WRITE requests with that HTTP status.
-   */
+  /** Routes credential requests through `recordedOps`, denying READ_WRITE with a 403 on demand. */
   private def credentialOpHandler(
       recordedOps: java.util.List[String],
-      denyRwStatus: () => Int): (HttpExchange, String) => Unit = (exchange, _) => {
+      denyReadWrite: () => Boolean): (HttpExchange, String) => Unit = (exchange, _) => {
     val path = exchange.getRequestURI.getPath
     if (path.endsWith("/credentials")) {
       val query = Option(exchange.getRequestURI.getQuery).getOrElse("")
       val op = if (query.contains("READ_WRITE")) "READ_WRITE" else "READ"
       recordedOps.add(op)
-      val status = if (op == "READ_WRITE") denyRwStatus() else 0
-      if (status != 0) {
-        sendJson(exchange, status,
-          s"""{"error":{"message":"DENIED","type":"Denied","code":$status}}""")
+      if (op == "READ_WRITE" && denyReadWrite()) {
+        sendJson(exchange, HttpStatus.SC_FORBIDDEN,
+          """{"error":{"message":"DENIED","type":"Denied","code":403}}""")
       } else {
         sendJson(
           exchange,
@@ -325,58 +321,18 @@ class UCDeltaTokenBasedRestClientSuite
     }
   }
 
-  test("a transient READ_WRITE failure does not poison the denial memory") {
+  test("intent-less load falls back to READ when READ_WRITE is denied") {
     val ops = java.util.Collections.synchronizedList(new java.util.ArrayList[String]())
-    // 503 until the "outage" ends. The client retries 503s internally, so exact READ_WRITE
-    // counts vary; assert on the fallback, the memory, and the post-outage probe instead.
-    @volatile var outage = true
-    deltaHandler = credentialOpHandler(
-      ops, () => if (outage) HttpStatus.SC_SERVICE_UNAVAILABLE else 0)
+    deltaHandler = credentialOpHandler(ops, () => true)
     withClient { c =>
-      // Retries exhaust, the load falls back to READ, and no denial is remembered.
-      assert(!c.loadTable(testIdentifier).getStorageProperties.isEmpty)
-      assert(ops.asScala.count(_ == "READ") === 1)
-      assert(c.writeDeniedTables.isEmpty)
-      // Once the outage ends, the next load probes READ_WRITE again and succeeds with it.
-      outage = false
-      clearUcCredentialCache()
-      c.loadTable(testIdentifier)
-      assert(ops.asScala.last === "READ_WRITE")
-    }
-  }
-
-  test("an expired denial entry restores READ_WRITE-first probing") {
-    val ops = java.util.Collections.synchronizedList(new java.util.ArrayList[String]())
-    deltaHandler = credentialOpHandler(ops, () => HttpStatus.SC_FORBIDDEN)
-    withClient { c =>
-      c.loadTable(testIdentifier)
-      assert(ops.asScala.toList === List("READ_WRITE", "READ"))
-      // Simulate the TTL elapsing (e.g. a grant added later): the next load probes again.
-      c.writeDeniedTables.put(s"$testCatalog.$testSchema.$testTable", 0L)
-      clearUcCredentialCache()
-      c.loadTable(testIdentifier)
-      assert(ops.asScala.toList === List("READ_WRITE", "READ", "READ_WRITE", "READ"))
-    }
-  }
-
-  test("intent-less load remembers a READ_WRITE denial and skips the retry") {
-    val ops = java.util.Collections.synchronizedList(new java.util.ArrayList[String]())
-    deltaHandler = credentialOpHandler(ops, () => HttpStatus.SC_FORBIDDEN)
-    withClient { c =>
-      // First load: READ_WRITE denied once, READ succeeds.
       assert(!c.loadTable(testIdentifier).getStorageProperties.isEmpty)
       assert(ops.asScala.toList === List("READ_WRITE", "READ"))
-      // Force a re-fetch (drop the cached READ credential): the load must go straight to READ
-      // without retrying the denied READ_WRITE.
-      clearUcCredentialCache()
-      assert(!c.loadTable(testIdentifier).getStorageProperties.isEmpty)
-      assert(ops.asScala.toList === List("READ_WRITE", "READ", "READ"))
     }
   }
 
   test("declared write requests READ_WRITE and surfaces a denial without READ fallback") {
     val ops = java.util.Collections.synchronizedList(new java.util.ArrayList[String]())
-    deltaHandler = credentialOpHandler(ops, () => HttpStatus.SC_FORBIDDEN)
+    deltaHandler = credentialOpHandler(ops, () => true)
     withClient { c =>
       intercept[CredentialFetchFailedException] {
         c.loadTable(testIdentifier, true)
@@ -385,23 +341,12 @@ class UCDeltaTokenBasedRestClientSuite
     }
   }
 
-  test("successful declared write clears the denial memory") {
+  test("granted declared write requests READ_WRITE only") {
     val ops = java.util.Collections.synchronizedList(new java.util.ArrayList[String]())
-    @volatile var deny = true
-    deltaHandler = credentialOpHandler(ops, () => if (deny) HttpStatus.SC_FORBIDDEN else 0)
+    deltaHandler = credentialOpHandler(ops, () => false)
     withClient { c =>
-      // Prime the denial memory through an intent-less load.
-      c.loadTable(testIdentifier)
-      assert(ops.asScala.toList === List("READ_WRITE", "READ"))
-      // Write access granted: a declared write requests READ_WRITE (never gated by the memory)
-      // and clears it.
-      deny = false
-      c.loadTable(testIdentifier, true)
-      assert(ops.asScala.toList === List("READ_WRITE", "READ", "READ_WRITE"))
-      // Intent-less loads are back on the READ_WRITE-first path.
-      clearUcCredentialCache()
-      c.loadTable(testIdentifier)
-      assert(ops.asScala.toList === List("READ_WRITE", "READ", "READ_WRITE", "READ_WRITE"))
+      assert(!c.loadTable(testIdentifier, true).getStorageProperties.isEmpty)
+      assert(ops.asScala.toList === List("READ_WRITE"))
     }
   }
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [x] Other (Storage — `uccommitcoordinator` UC Delta REST client)

## Description

Partially addresses #7517 (does not close it — see "What remains" below).

`UCDeltaTokenBasedRestClient.fetchTableCredentials` requests `READ_WRITE` storage credentials for every table load, falling back to `READ` on `ApiException`, regardless of what the statement is about to do. Unity Catalog vends `READ_WRITE` only to `OWNER` or `SELECT`+`MODIFY` principals. For a declared write by a principal without that grant, the old fallback vended `READ` credentials and let the job fail later at the storage layer.

Spark has been declaring the intent all along: the analyzer resolves INSERT / UPDATE / DELETE / MERGE targets through `TableCatalog.loadTable(ident, writePrivileges)`. `DeltaCatalog` never overrode that overload, so the default implementation dropped the privileges before the credential layer could see them. This PR threads the intent through:

- `AbstractDeltaCatalog` overrides `loadTable(ident, writePrivileges)`; both overloads share one implementation carrying a `writeIntent` flag. (The delegate fallback keeps calling the intent-less `super.loadTable(ident)`: `DelegatingCatalogExtension` has no privileged forward, so the delegate received stripped privileges before this change too.)
- `AbstractDeltaCatalogClient` and `UCDeltaClient` gain intent-carrying `loadTable` overloads whose defaults preserve existing behavior for other implementations.
- `UCDeltaTokenBasedRestClient`:
  - **declared write** → request `READ_WRITE`; a denial surfaces immediately instead of vending `READ` credentials to a write that will fail at the storage layer mid-job;
  - **no declared intent** → unchanged: request `READ_WRITE` first, fall back to `READ`. Intent-less loads cannot be assumed to be reads: `OPTIMIZE`/`VACUUM`, every `ALTER TABLE` variant, and `writeStream.toTable()` resolve their target through the intent-less overload, so defaulting them to `READ` would break writers who hold the grant;
  - `createTable`'s credential fetch is a write by definition and now requests with intent;
  - the server-side-planning fallback in `UCDeltaCatalogClientImpl` no longer serves **declared writes** — SSP tables are read-only, so handing one to a write only deferred the failure into a confusing "table does not support writes"; the credential denial now surfaces at analysis time;
  - the `IllegalArgumentException` scope of the old code is preserved: a credential-less response (e.g. `file://`) is treated as "no creds".

## What remains of #7517

#7517 is about the redundant denied `READ_WRITE` round-trip that a SELECT-only principal pays on every query. This PR does **not** remove it: SELECT resolves through the intent-less overload, which keeps the `READ_WRITE`-first probe for the reasons above. An earlier revision remembered denials per table to skip the probe; it was dropped to match the review outcome on the connector-side counterpart (unitycatalog/unitycatalog#1803), where the maintainers rejected a negative cache as prone to staleness (a grant added after a denial does not reach intent-less paths like `OPTIMIZE` until the entry expires) and unbounded growth.

The Unity Catalog Spark connector's legacy (non Delta REST API) credential path received the equivalent fix in unitycatalog/unitycatalog#1803.

## Blast radius

For most deployments this change is a wire-level no-op: with authorization disabled, or for any principal holding write access, the request pattern is byte-identical to before (READ_WRITE first, granted, done). Every behavioral difference is confined to declared writes whose READ_WRITE request fails — and for them the underlying operation was already going to fail; what changes is when and how cleanly.

One scenario deserves explicit mention: if a server variant vends credentials that are not actually operation-scoped (the same storage credential for READ and READ_WRITE), the old fallback allowed a catalog-denied write to silently succeed at the storage layer. This change enforces the catalog's denial at analysis time. That is intentional: the catalog's authorization decision, not an accident of credential scoping, should decide whether a write proceeds.

## How was this patch tested?

New tests in `UCDeltaTokenBasedRestClientSuite` (stub HTTP server records the `operation` of every credentials request and can deny `READ_WRITE`):

- intent-less load: denied `READ_WRITE` then `READ`, storage properties returned;
- declared write: `READ_WRITE` only, denial propagates as `CredentialFetchFailedException`, no `READ` fallback;
- granted declared write: `READ_WRITE` only.

New tests in `AbstractDeltaCatalogClientRoutingSuite`: `UCDeltaCatalogClientImpl` passes `writeIntent=false` / `true` through to the `UCDeltaClient` for the plain and privileged overloads respectively, and the SSP fallback rethrows for declared writes while still serving intent-less loads.

```
build/sbt "storage/testOnly io.delta.storage.commit.uccommitcoordinator.UCDeltaTokenBasedRestClientSuite"
build/sbt "spark/testOnly org.apache.spark.sql.delta.catalog.AbstractDeltaCatalogClientRoutingSuite"
```

## Does this PR introduce _any_ user-facing changes?

No API changes (new overloads have defaults). One behavior change on authorization-enabled UC: a write by a principal without write access now fails at analysis time with the catalog's permission error, instead of failing later at the storage layer with read-only credentials.
