### PR TITLE
[Spark] Support conflict resolution for AMT log-only commits

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
@@ -1029,8 +1029,13 @@ trait SnapshotManagement { self: DeltaLog =>
       // the Delta log.
       return (oldLogSegment, Nil)
     }
+    // Pass only checkpoint files that follow the deterministic checkpoint file naming pattern to
+    // getLogSegmentForVersion: every file in its `files` argument must be a FileNames
+    // isCheckpointFile / isCompactedDeltaFile / isDeltaFile, otherwise it fails classifying it.
+    val checkpointTopLevelFiles =
+      oldLogSegment.checkpointProvider.topLevelFiles.filter(isCheckpointFile)
     val allFiles = (
-      oldLogSegment.checkpointProvider.topLevelFiles ++
+      checkpointTopLevelFiles ++
         oldLogSegment.deltas ++
         newFiles
       ).toArray

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriterManager.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriterManager.scala
@@ -129,10 +129,22 @@ class AMTWriterManager(
       currentTransactionInfo: CurrentTransactionInfo,
       preCommitLogSegment: LogSegment): Option[AMTWriteResult] = {
     if (!amtEnabled(commitVersion)) return None
-    if (preCommitLogSegment.version > readSnapshot.version) {
-      throw DeltaErrors.concurrentWriteException(conflictingCommit = None)
-    }
     val actionsToCommit = currentTransactionInfo.actions
+    // Whether this attempt would (re)write a manifest tree.
+    val writesTree = initialOperation match {
+      case _: DeltaOperations.OptimizeCheckpoint => true
+      case _ => shouldDoInlineIncrementalCheckpoint(actionsToCommit)
+    }
+
+    if (preCommitLogSegment.version > readSnapshot.version) {
+      // A concurrent commit won our target version and we are rebasing. A commit that writes no
+      // tree, and that lost only to commits that wrote no tree, is safe to rebase as-is; anything
+      // else needs the tree and back-reference rebase that is not implemented yet.
+      if (writesTree || winningCommitInstalledNewAMTTree(currentTransactionInfo)) {
+        throw DeltaErrors.concurrentWriteException(conflictingCommit = None)
+      }
+    }
+
     val resultOpt = initialOperation match {
       case optimize: DeltaOperations.OptimizeCheckpoint =>
         assert(actionsToCommit.isEmpty,
@@ -151,6 +163,9 @@ class AMTWriterManager(
           commitVersion, currentTransactionInfo, preCommitLogSegment,
           incremental = mode.isIncremental, trigger = mode.name))
       case _ =>
+        // A commit that writes no tree emits no AMT.
+        assert(!writesTree,
+          s"writeAMT reached the no-tree branch for a tree-writing commit: $initialOperation.")
         None
     }
     lastAMTWriteResultOpt = resultOpt
@@ -165,6 +180,26 @@ class AMTWriterManager(
   private def shouldDoInlineIncrementalCheckpoint(actionsToCommit: Seq[Action]): Boolean =
     actionsToCommit.size.toLong >= largeCommitActionsCountThresholdForInlineManifestCommit &&
       AMTWriteHelper.previousAMTContentRoot(readSnapshot).isDefined
+
+  /**
+   * True when conflict resolution folded in a winning commit that installed a new AMT tree.
+   */
+  private def winningCommitInstalledNewAMTTree(
+      currentTransactionInfo: CurrentTransactionInfo): Boolean = {
+    val readSnapshotAMTVersion = readSnapshot.lastManifestCommitOpt.map(_.contentRootVersion)
+    val preCommitAMTVersion = currentTransactionInfo.preCommitLatestAMTCheckpointOpt.map(_.version)
+    (readSnapshotAMTVersion, preCommitAMTVersion) match {
+      case (Some(_), None) =>
+        throw new IllegalStateException(
+          "The read snapshot has an AMT but the winning commits has no AMT -- this can happen " +
+            "only during downgrade -- not supported yet")
+      case (Some(readVersion), Some(foldedVersion)) if readVersion > foldedVersion =>
+        throw new IllegalStateException(
+          s"The rebased AMT moved backwards: read-snapshot tree version $readVersion is newer " +
+            s"than the folded tree version $foldedVersion.")
+      case (readOpt, foldedOpt) => readOpt != foldedOpt
+    }
+  }
 
   // Materializes the manifest tree for this commit and records its metrics. An incremental rewrite
   // packs the post-commit live files into leaves in input order on the driver; a full rewrite

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointTestBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointTestBase.scala
@@ -403,25 +403,33 @@ trait AMTCheckpointTestBase
   }
 
   /**
-   * Emits an AMT checkpoint on `deltaLog` via the real commit path and returns the incremental
-   * write's shape metrics, read back out of the logged [[CommitStats]]. `incremental = false`
-   * forces a full rewrite (and returns None, since a full write logs no incremental metrics);
-   * `true` an incremental one.
+   * Emits an AMT checkpoint on `deltaLog` via the real commit path. `incremental = false` forces a
+   * full rewrite; `true` an incremental one.
    */
-  protected def commitCheckpoint(
-      deltaLog: DeltaLog, incremental: Boolean): Option[IncrementalAMTWriteMetrics] = {
+  protected def commitCheckpoint(deltaLog: DeltaLog, incremental: Boolean): Unit = {
     val triggerName = if (incremental) {
       AMTTriggerMode.CheckpointIntervalIncremental.name
     } else {
       AMTTriggerMode.CheckpointIntervalFull.name
     }
+    deltaLog.startTransaction().commit(
+      Seq.empty,
+      DeltaOperations.OptimizeCheckpoint(
+        incremental = incremental,
+        triggerName = triggerName))
+  }
+
+  /**
+   * Emits an incremental AMT checkpoint on `deltaLog` and returns the incremental write's shape
+   * metrics, read back out of the logged [[CommitStats]] (None if no incremental metrics were
+   * logged). Wraps the commit in usage tracking, whose buffer is process-wide, so this must not run
+   * concurrently with another tracked commit.
+   */
+  protected def commitIncrementalCheckpointAndReturnMetrics(
+      deltaLog: DeltaLog): Option[IncrementalAMTWriteMetrics] = {
     val attemptVersion = deltaLog.update().version + 1
     trackIncrementalAMTWriteMetrics(attemptVersion) {
-      deltaLog.startTransaction().commit(
-        Seq.empty,
-        DeltaOperations.OptimizeCheckpoint(
-          incremental = incremental,
-          triggerName = triggerName))
+      commitCheckpoint(deltaLog, incremental = true)
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTConflictResolutionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTConflictResolutionSuite.scala
@@ -1,0 +1,158 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.amt
+
+import scala.concurrent.duration.Duration
+
+import org.apache.spark.sql.delta.{ConcurrentWriteException, DeltaLog}
+import org.apache.spark.sql.delta.concurrency.{PhaseLockingTestMixin, TransactionExecutionTestMixin}
+
+import org.apache.spark.SparkException
+import org.apache.spark.sql.Row
+import org.apache.spark.util.ThreadUtils
+
+/**
+ * Conflict-resolution behavior for AMT-backed tables.
+ */
+class AMTConflictResolutionSuite
+  extends AMTCheckpointTestBase
+  with PhaseLockingTestMixin
+  with TransactionExecutionTestMixin {
+
+  // A large interval keeps the checkpoint-interval maintenance hook from firing its own checkpoint
+  // mid-test; every AMT write here is one the test drives explicitly.
+  private val noAutoCheckpointInterval = 1000
+
+  /** A transaction body that commits an incremental OPTIMIZE CHECKPOINT (writes a new AMT tree). */
+  private def optimizeCheckpointTxn(deltaLog: DeltaLog): () => Array[Row] = () => {
+    commitCheckpoint(deltaLog, incremental = true)
+    Array.empty
+  }
+
+  /** A transaction body that appends `id` as a plain (log-only, no tree) business commit. */
+  private def appendTxn(tableName: String, id: Int): () => Array[Row] = () => {
+    spark.sql(s"INSERT INTO $tableName VALUES ($id)").collect()
+  }
+
+  /**
+   * Creates an AMT table with a full checkpoint base and a few seeded files, then returns its
+   * [[DeltaLog]].
+   */
+  private def setupAMTTable(tableName: String): DeltaLog = {
+    createAMTTable(tableName, checkpointInterval = noAutoCheckpointInterval)
+    val deltaLog = deltaLogForName(tableName)
+    // Do a full checkpoint -- it is to make sure that incremental checkpoints can be done in tests.
+    commitCheckpoint(deltaLog, incremental = false)
+    appendRowsAsSeparateFiles(tableName, numFiles = 3, startId = 1)
+    deltaLog
+  }
+
+  /** Awaits `future`, asserting it fails a rebase with an AMT [[ConcurrentWriteException]]. */
+  private def assertConcurrentWriteFailure(future: scala.concurrent.Future[Array[Row]]): Unit = {
+    val ex = intercept[SparkException] {
+      ThreadUtils.awaitResult(future, Duration.Inf)
+    }
+    // The commit runs on a worker thread and a SQL command re-wraps its failure, so the
+    // ConcurrentWriteException can sit anywhere in the cause chain rather than at `getCause`.
+    val causes = Iterator
+      .iterate[Throwable](ex)(t => if (t.getCause eq t) null else t.getCause)
+      .takeWhile(_ != null)
+      .take(50)
+      .toList
+    assert(causes.exists(_.isInstanceOf[ConcurrentWriteException]),
+      s"expected a ConcurrentWriteException in the cause chain, got " +
+        causes.map(_.getClass.getName).mkString(" -> "))
+  }
+
+  test("Winning Commit [Log Commit] vs Losing commit [Manifest Commit] - FAILS") {
+    withTable("amt_conflict_tree_writer_loses") {
+      val name = "amt_conflict_tree_writer_loses"
+      val deltaLog = setupAMTTable(name)
+
+      // A writes a tree (OPTIMIZE CHECKPOINT); B is a plain append that wins A's target version.
+      val (futureA, futureB) = runTxnsWithOrder__A_Start__B__A_End(
+        optimizeCheckpointTxn(deltaLog),
+        appendTxn(name, id = 100))
+
+      // B commits cleanly; A loses and, because it (re)writes a tree, still hard-fails.
+      ThreadUtils.awaitResult(futureB, Duration.Inf)
+      assertConcurrentWriteFailure(futureA)
+    }
+  }
+
+  test("Winning Commit [log commit] vs Losing commit [log commit] - SUCCESS") {
+    withTable("amt_conflict_log_vs_log") {
+      val name = "amt_conflict_log_vs_log"
+      val deltaLog = setupAMTTable(name)
+      val liveIdsBefore = spark.sql(s"SELECT id FROM $name").collect().map(_.getInt(0)).toSet
+
+      // Both A and B are plain appends of distinct rows: neither writes a tree and blind appends do
+      // not logically conflict, so A must rebase past B and commit.
+      val (futureA, futureB) = runTxnsWithOrder__A_Start__B__A_End(
+        appendTxn(name, id = 100),
+        appendTxn(name, id = 200))
+
+      // Neither future may fail: B wins its version and A rebases onto it.
+      ThreadUtils.awaitResult(futureB, Duration.Inf)
+      ThreadUtils.awaitResult(futureA, Duration.Inf)
+
+      // Neither commit writes a tree, so the base AMT is unchanged. Reading the live set back
+      // still goes through it, and a correct id set proves A rebased its log actions past B.
+      val liveIdsAfter = spark.sql(s"SELECT id FROM $name").collect().map(_.getInt(0)).toSet
+      assert(liveIdsAfter == liveIdsBefore ++ Set(100, 200),
+        s"both appends must survive the rebase; before=$liveIdsBefore after=$liveIdsAfter")
+      assert(amtProvider(deltaLog.update()).isDefined,
+        "the table must remain AMT-backed after the rebase.")
+    }
+  }
+
+  test("Winning Commit [Manifest Commit] vs Losing commit [Log commit] - FAILS") {
+    withTable("amt_conflict_log_vs_tree_winner") {
+      val name = "amt_conflict_log_vs_tree_winner"
+      val deltaLog = setupAMTTable(name)
+
+      // A is a plain (blind) append, so its AddFiles carry no back references. B writes a new
+      // tree (OPTIMIZE CHECKPOINT) and wins A's target version.
+      val (futureA, futureB) = runTxnsWithOrder__A_Start__B__A_End(
+        appendTxn(name, id = 100),
+        optimizeCheckpointTxn(deltaLog))
+
+      // B commits its tree; A loses and hard-fails. Every commit that lost to a tree-installing
+      // winner is blocked for now -- regardless of back references -- because re-seating it onto
+      // the winner's tree is a later milestone.
+      ThreadUtils.awaitResult(futureB, Duration.Inf)
+      assertConcurrentWriteFailure(futureA)
+    }
+  }
+
+  test("Winning Commit [Manifest Commit] vs Losing commit [Manifest Commit] - FAILS") {
+    withTable("amt_conflict_tree_vs_tree") {
+      val name = "amt_conflict_tree_vs_tree"
+      val deltaLog = setupAMTTable(name)
+
+      // Both A and B are OPTIMIZE CHECKPOINTs (tree writers). B wins A's target version; A loses
+      // and, because it (re)writes a tree, still hard-fails -- rebasing a losing tree writer is a
+      // later milestone.
+      val (futureA, futureB) = runTxnsWithOrder__A_Start__B__A_End(
+        optimizeCheckpointTxn(deltaLog),
+        optimizeCheckpointTxn(deltaLog))
+
+      ThreadUtils.awaitResult(futureB, Duration.Inf)
+      assertConcurrentWriteFailure(futureA)
+    }
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTIncrementalWriteSpillSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTIncrementalWriteSpillSuite.scala
@@ -162,7 +162,7 @@ class AMTIncrementalWriteSpillSuite extends AMTIncrementalWriteTestBase {
         // which is the accounting this test guards.
         val oldAMTLeafToMDV = leafToLeafMDVCardinalityMap(amtDeltaLog)
         commitBoth(baselineDeltaLog, amtDeltaLog, Seq(fakeAdd(7)))
-        val actualIncrementalMetrics = commitCheckpoint(amtDeltaLog, incremental = true)
+        val actualIncrementalMetrics = commitIncrementalCheckpointAndReturnMetrics(amtDeltaLog)
           .getOrElse(fail("An incremental checkpoint must log metrics."))
         assert(actualIncrementalMetrics.numOldLeavesUntouched == numLeafCountBefore,
           s"All $numLeafCountBefore carried leaves must be untouched by an append; got " +

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTIncrementalWriteTestBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTIncrementalWriteTestBase.scala
@@ -286,7 +286,7 @@ abstract class AMTIncrementalWriteTestBase extends AMTCheckpointTestBase {
         assertCheckpointDescribesVersion(amtDeltaLog, attemptVersion)
         metrics
       case None =>
-        commitCheckpoint(amtDeltaLog, incremental = true)
+        commitIncrementalCheckpointAndReturnMetrics(amtDeltaLog)
           .getOrElse(fail("An incremental checkpoint must log IncrementalAMTWriteMetrics."))
     }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTIncrementalWriteTrackingMDVSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTIncrementalWriteTrackingMDVSuite.scala
@@ -300,7 +300,7 @@ class AMTIncrementalWriteTrackingMDVSuite extends AMTIncrementalWriteTestBase {
 
         // A second bare incremental rewrite carries nothing new, so it must drop the stale DELETED
         // pointers and report them as numStaleDeletedLeavesDropped, leaving an empty tree.
-        val metrics = commitCheckpoint(amtDeltaLog, incremental = true)
+        val metrics = commitIncrementalCheckpointAndReturnMetrics(amtDeltaLog)
           .getOrElse(fail("An incremental checkpoint must log metrics."))
         assert(metrics.numStaleDeletedLeavesDropped == leafCount,
           s"All $leafCount stale DELETED leaves must be dropped; got " +

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTWriterManagerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTWriterManagerSuite.scala
@@ -17,6 +17,7 @@
 package org.apache.spark.sql.delta.amt
 
 import org.apache.spark.sql.delta.{CurrentTransactionInfo, DeltaOperations, Snapshot}
+import org.apache.spark.sql.delta.actions.{Action, Checkpoint}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import io.delta.exceptions.ConcurrentWriteException
 
@@ -36,8 +37,12 @@ class AMTWriterManagerSuite extends AMTCheckpointTestBase {
   }
 
   // A minimal transaction info over `snapshot` carrying `actions`, for direct writeAMT calls.
+  // `preCommitLatestAMTCheckpointOpt` models the base AMT the attempt would build on: on a rebase
+  // it is the tree the conflict fold advanced to (the winner's, if the winner wrote one).
   private def txnInfoFor(
-      snapshot: Snapshot, actions: Seq[org.apache.spark.sql.delta.actions.Action]) =
+      snapshot: Snapshot,
+      actions: Seq[Action],
+      preCommitLatestAMTCheckpointOpt: Option[Checkpoint] = None) =
     CurrentTransactionInfo(
       txnId = "txn",
       readPredicates = Vector.empty,
@@ -52,7 +57,8 @@ class AMTWriterManagerSuite extends AMTCheckpointTestBase {
       readRowIdHighWatermark = 0L,
       catalogTable = None,
       domainMetadata = Seq.empty,
-      op = DeltaOperations.ManualUpdate)
+      op = DeltaOperations.ManualUpdate,
+      preCommitLatestAMTCheckpointOpt = preCommitLatestAMTCheckpointOpt)
 
   test("writeAMT performs a clustered full rewrite for an OPTIMIZE checkpoint operation") {
     withTable("amt_optimize_ckpt") {
@@ -80,19 +86,67 @@ class AMTWriterManagerSuite extends AMTCheckpointTestBase {
   // End-to-end emission-policy scenarios (interval / full-rewrite cadence / size trigger / minor
   // compaction) live in AMTCheckpointPolicySuite. This suite covers writeAMT's direct behavior.
 
-  test("writeAMT hard-fails an AMT table on a conflict-resolution retry") {
-    withTable("amt_conflict_fail") {
-      val name = "amt_conflict_fail"
+  test("writeAMT hard-fails a tree-writing commit on a conflict-resolution retry") {
+    withTable("amt_conflict_tree_writer") {
+      val name = "amt_conflict_tree_writer"
       createAMTTable(name, checkpointInterval = 2)
       sql(s"INSERT INTO $name VALUES (1)")
 
-      val (manager, snapshot) = managerFor(name)
+      // An OPTIMIZE checkpoint writes a tree, so it still hard-fails on a rebase (the tree-rebuild
+      // rebase is a later milestone).
+      val (manager, snapshot) = managerFor(name, DeltaOperations.OptimizeCheckpoint(
+        incremental = false, triggerName = AMTTriggerMode.CheckpointIntervalFull.name))
       // A retry: conflict resolution advanced the segment past the read snapshot's version.
       val retrySegment = snapshot.logSegment.copy(version = snapshot.version + 1)
       intercept[ConcurrentWriteException] {
         manager.writeAMT(
           commitVersion = snapshot.version + 2,
           currentTransactionInfo = txnInfoFor(snapshot, actions = Seq.empty),
+          preCommitLogSegment = retrySegment)
+      }
+    }
+  }
+
+  test("writeAMT lets a log-only commit rebase past a log-only winner on retry") {
+    withTable("amt_conflict_log_rebase") {
+      val name = "amt_conflict_log_rebase"
+      createAMTTable(name, checkpointInterval = 2)
+      commitCheckpoint(deltaLogForName(name), incremental = false)
+
+      val (manager, snapshot) = managerFor(name)
+      val baseTree = amtProvider(snapshot).map(_.checkpointAction)
+      assert(baseTree.isDefined, "the table must be AMT-backed for this case.")
+      // The winner wrote no tree, so the base AMT is unchanged (the folded pointer still equals the
+      // read snapshot's tree): a log-only commit rebases with no AMT write instead of hard-failing.
+      val retrySegment = snapshot.logSegment.copy(version = snapshot.version + 1)
+      val result = manager.writeAMT(
+        commitVersion = snapshot.version + 2,
+        currentTransactionInfo =
+          txnInfoFor(snapshot, actions = Seq.empty, preCommitLatestAMTCheckpointOpt = baseTree),
+        preCommitLogSegment = retrySegment)
+      assert(result.isEmpty,
+        "a log-only commit that lost to a log-only winner must rebase without an AMT write.")
+    }
+  }
+
+  test("writeAMT hard-fails a log-only commit when the winner installed a new tree") {
+    withTable("amt_conflict_log_vs_tree") {
+      val name = "amt_conflict_log_vs_tree"
+      createAMTTable(name, checkpointInterval = 2)
+      commitCheckpoint(deltaLogForName(name), incremental = false)
+
+      val (manager, snapshot) = managerFor(name)
+      val baseTree = amtProvider(snapshot).map(_.checkpointAction).getOrElse(
+        fail("the table must be AMT-backed for this case."))
+      // A winner installed a newer tree than the read snapshot's, so a log-only commit's back
+      // references are stale and it must hard-fail until they are re-derived (a later milestone).
+      val winnerTree = baseTree.copy(version = baseTree.version + 1)
+      val retrySegment = snapshot.logSegment.copy(version = snapshot.version + 1)
+      intercept[ConcurrentWriteException] {
+        manager.writeAMT(
+          commitVersion = snapshot.version + 2,
+          currentTransactionInfo = txnInfoFor(
+            snapshot, actions = Seq.empty, preCommitLatestAMTCheckpointOpt = Some(winnerTree)),
           preCommitLogSegment = retrySegment)
       }
     }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

When an AMT-backed commit loses its target version to a concurrent commit and has to rebase, `AMTWriterManager.writeAMT` previously raised `ConcurrentWriteException` unconditionally. This PR relaxes that: a commit that writes no manifest tree, and that lost only to commits that also wrote no tree, can now rebase in place without an AMT write (`writeAMT` returns `None`). Commits that (re)write a tree, and log-only commits that lost to a winner which installed a new AMT tree, still hard-fail, because re-deriving their back references against the winner's tree is not yet implemented.

The rebase path now decides up front whether the attempt would write a manifest tree (an `OptimizeCheckpoint`, or a large inline incremental checkpoint) and, on a rebase, compares the pre-commit AMT checkpoint version against the read snapshot's manifest version to detect whether the winning commit installed a new tree.

Separately, `SnapshotManagement` now filters the checkpoint provider's top-level files down to actual checkpoint files before handing them to `getLogSegmentForVersion`, which requires every input file to be classifiable as a checkpoint, compacted-delta, or delta file; an unclassifiable file would otherwise fail there.

## How was this patch tested?

New unit and end-to-end tests:
- `AMTConflictResolutionSuite` drives phase-locked concurrent transactions: a tree-writing commit that loses still hard-fails; two log-only appends where the loser rebases past the winner and both rows survive; and a log-only commit that loses to a tree-installing winner hard-fails.
- `AMTWriterManagerSuite` adds direct `writeAMT` cases covering the log-only rebase (no AMT write), the log-only-vs-tree-winner hard-fail, and the tree-writer hard-fail.

## Does this PR introduce _any_ user-facing changes?

No.
