### PR TITLE
[Spark] Reconcile deletion vectors by object identity in log replay

### DIFF
--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConverter.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConverter.scala
@@ -992,7 +992,12 @@ class DummySnapshotWithAllFilesSupport(
   override def allFiles: Dataset[AddFile] = {
     SparkSession.getActiveSession.map { spark =>
       import org.apache.spark.sql.delta.implicits._
-      val replay = new InMemoryLogReplay(None, None)
+      val replay = new InMemoryLogReplay(
+        minFileRetentionTimestamp = None,
+        minSetTransactionRetentionTimestamp = None,
+        tableRoot = deltaLog.dataPath,
+        useDeletionVectorObjectIdentity = FileAction.useDeletionVectorObjectIdentity(
+          protocol, spark))
       val baseVersion = version - 1
       if (baseVersion < 0) { // No prior commit exists
         replay.append(0, txnInfo.finalActionsToCommit.iterator)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/Checksum.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Checksum.scala
@@ -604,7 +604,11 @@ trait RecordChecksum extends DeltaLogging {
     // We can also ignore file retention because that only affects [[RemoveFile]] actions.
     val logReplay = new InMemoryLogReplay(
       minFileRetentionTimestamp = None,
-      minSetTransactionRetentionTimestamp = None)
+      minSetTransactionRetentionTimestamp = None,
+      tableRoot = deltaLog.dataPath,
+      // Using object identity or not doesn't matter here for computing SetTransactions.
+      useDeletionVectorObjectIdentity = spark.sessionState.conf.getConf(
+        DeltaSQLConf.DELETION_VECTORS_USE_OBJECT_IDENTITY_FOR_INCREMENTAL_CRC))
 
     logReplay.append(attemptVersion - 1, oldSetTransactions.toIterator)
     logReplay.append(attemptVersion, setTransactionsToCommit.toIterator)
@@ -633,7 +637,11 @@ trait RecordChecksum extends DeltaLogging {
     // We only work with DomainMetadata, so RemoveFile and SetTransaction retention don't matter.
     val logReplay = new InMemoryLogReplay(
       minFileRetentionTimestamp = None,
-      minSetTransactionRetentionTimestamp = None)
+      minSetTransactionRetentionTimestamp = None,
+      tableRoot = deltaLog.dataPath,
+      // Using object identity or not doesn't matter here for computing DomainMetadata.
+      useDeletionVectorObjectIdentity = spark.sessionState.conf.getConf(
+        DeltaSQLConf.DELETION_VECTORS_USE_OBJECT_IDENTITY_FOR_INCREMENTAL_CRC))
 
     val threshold = spark.sessionState.conf.getConf(DeltaSQLConf.DELTA_MAX_DOMAIN_METADATAS_IN_CRC)
 
@@ -701,7 +709,10 @@ trait RecordChecksum extends DeltaLogging {
     // We only work with AddFile, so RemoveFile and SetTransaction retention don't matter.
     val logReplay = new InMemoryLogReplay(
       minFileRetentionTimestamp = None,
-      minSetTransactionRetentionTimestamp = None)
+      minSetTransactionRetentionTimestamp = None,
+      tableRoot = deltaLog.dataPath,
+      useDeletionVectorObjectIdentity = spark.sessionState.conf.getConf(
+        DeltaSQLConf.DELETION_VECTORS_USE_OBJECT_IDENTITY_FOR_INCREMENTAL_CRC))
 
     logReplay.append(attemptVersion - 1, oldAllFiles.map(normalizePath).toIterator)
     logReplay.append(attemptVersion, actionsToCommit.map(normalizePath).toIterator)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
@@ -600,6 +600,9 @@ class Snapshot(
       // for serializability
       val localMinFileRetentionTimestamp = minFileRetentionTimestamp
       val localMinSetTransactionRetentionTimestamp = minSetTransactionRetentionTimestamp
+      val localTableRoot = deltaLog.dataPath.toString
+      val localUseDeletionVectorObjectIdentity =
+        FileAction.useDeletionVectorObjectIdentity(protocol, spark)
 
       val canonicalPath = deltaLog.getCanonicalPathUdf()
 
@@ -646,7 +649,9 @@ class Snapshot(
           val state: LogReplay =
             new InMemoryLogReplay(
               Some(localMinFileRetentionTimestamp),
-              localMinSetTransactionRetentionTimestamp)
+              localMinSetTransactionRetentionTimestamp,
+              tableRoot = new Path(localTableRoot),
+              useDeletionVectorObjectIdentity = localUseDeletionVectorObjectIdentity)
           state.append(0, iter.map(_.unwrap))
           state.checkpoint.map(_.wrap)
         }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/InMemoryLogReplay.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/InMemoryLogReplay.scala
@@ -16,7 +16,8 @@
 
 package org.apache.spark.sql.delta.actions
 
-import java.net.URI
+import org.apache.spark.sql.delta.actions.FileAction.UniqueFileActionTuple
+import org.apache.hadoop.fs.Path
 
 
 /**
@@ -27,7 +28,7 @@ import java.net.URI
  *    tombstone until `minFileRetentionTimestamp` has passed. If `minFileRetentionTimestamp` is
  *    None, all [[RemoveFile]] actions are retained.
  *    A [[RemoveFile]] "corresponds" to the [[AddFile]] that matches both the parquet file URI
- *    *and* the deletion vector's URI (if any).
+ *    *and* the deletion vector id (if any).
  *  - The most recent version for any `appId` in a [[SetTransaction]] wins.
  *  - The most recent [[Metadata]] wins.
  *  - The most recent [[Protocol]] version wins.
@@ -38,9 +39,9 @@ import java.net.URI
  */
 class InMemoryLogReplay(
     minFileRetentionTimestamp: Option[Long],
-    minSetTransactionRetentionTimestamp: Option[Long]) extends LogReplay {
-
-  import InMemoryLogReplay._
+    minSetTransactionRetentionTimestamp: Option[Long],
+    tableRoot: Path,
+    useDeletionVectorObjectIdentity: Boolean) extends LogReplay {
 
   private var currentProtocolVersion: Protocol = null
   private var currentVersion: Long = -1
@@ -72,7 +73,7 @@ class InMemoryLogReplay(
       case a: Protocol =>
         currentProtocolVersion = a
       case add: AddFile =>
-        val uniquePath = UniqueFileActionTuple(add.pathAsUri, add.getLegacyDeletionVectorUniqueId)
+        val uniquePath = add.toUniqueFileActionTuple(tableRoot, useDeletionVectorObjectIdentity)
         activeFiles(uniquePath) = add.copy(dataChange = false)
         // Remove the tombstone to make sure we only output one `FileAction`.
         cancelledRemoveFiles.remove(uniquePath)
@@ -80,7 +81,7 @@ class InMemoryLogReplay(
         activeRemoveFiles.remove(uniquePath)
       case remove: RemoveFile =>
         val uniquePath =
-          UniqueFileActionTuple(remove.pathAsUri, remove.getLegacyDeletionVectorUniqueId)
+          remove.toUniqueFileActionTuple(tableRoot, useDeletionVectorObjectIdentity)
         activeFiles.remove(uniquePath) match {
           case Some(_) => cancelledRemoveFiles(uniquePath) = remove
           case None => activeRemoveFiles(uniquePath) = remove
@@ -135,19 +136,4 @@ class InMemoryLogReplay(
 
   /** Returns all [[AddFile]] actions after the Log Replay */
   private[delta] def allFiles: Seq[AddFile] = activeFiles.values.toSeq
-}
-
-object InMemoryLogReplay{
-  /** The unit of path uniqueness in delta log actions is the tuple `(parquet file, dv)`. */
-  final case class UniqueFileActionTuple(fileURI: URI, deletionVectorURI: Option[String])
-
-  implicit class UniqueAddFileTuple(a: AddFile) {
-    def toUniqueFileActionTuple: UniqueFileActionTuple =
-      UniqueFileActionTuple(a.pathAsUri, a.getLegacyDeletionVectorUniqueId)
-  }
-
-  implicit class UniqueRemoveFileTuple(r: RemoveFile) {
-    def toUniqueFileActionTuple: UniqueFileActionTuple =
-      UniqueFileActionTuple(r.pathAsUri, r.getLegacyDeletionVectorUniqueId)
-  }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -825,6 +825,37 @@ sealed trait FileAction extends Action {
   }
 }
 
+object FileAction {
+  /** The path unique tuple in delta log actions: (parquet file, deletion vector id). */
+  final case class UniqueFileActionTuple private (fileURI: URI, deletionVectorId: Option[String])
+
+  /**
+   * Whether deletion vectors should be reconciled by their normalized object identity for the
+   * given table (see [[DeletionVectorDescriptor.uniqueId]]).
+   *
+   * @param protocol the table protocol.
+   */
+  def useDeletionVectorObjectIdentity(
+      protocol: Protocol,
+      spark: SparkSession): Boolean =
+    protocol.isFeatureSupported(AdaptiveMetadataTableFeature) ||
+      spark.conf.get(DeltaSQLConf.DELETION_VECTORS_USE_OBJECT_IDENTITY_FOR_NON_AMT)
+
+  /**
+   * The unique tuple `(parquet file, deletion vector id)` of a file action, as a method on
+   * [[AddFile]] / [[RemoveFile]]. See [[DeletionVectorDescriptor.uniqueId]] for the
+   * `useObjectIdentity` semantics.
+   */
+  implicit class FileActionUniqueTupleOps(val action: FileAction) {
+    def toUniqueFileActionTuple(
+        tableRoot: Path,
+        useObjectIdentity: Boolean): UniqueFileActionTuple =
+      UniqueFileActionTuple(
+        action.pathAsUri,
+        Option(action.deletionVector).map(_.uniqueId(tableRoot, useObjectIdentity)))
+  }
+}
+
 case class ParsedStatsFields(
   numLogicalRecords: Option[Long],
   tightBounds: Option[Boolean])

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/IncrementalAMTWriter.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/IncrementalAMTWriter.scala
@@ -22,11 +22,11 @@ import scala.collection.mutable.ArrayBuffer
 
 import org.apache.spark.sql.delta.{DeltaFileProviderUtils, DeltaLog, SingleCommit}
 import org.apache.spark.sql.delta.actions.{Action, AddFile, BackReference, Checkpoint, ContentRoot, DomainMetadata, FileAction, InMemoryLogReplay, Metadata, Protocol, RemoveFile, SetTransaction}
-import org.apache.spark.sql.delta.actions.InMemoryLogReplay.{UniqueAddFileTuple, UniqueFileActionTuple, UniqueRemoveFileTuple}
+import org.apache.spark.sql.delta.actions.FileAction.UniqueFileActionTuple
 import org.apache.spark.sql.delta.deletionvectors.RoaringBitmapArray
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.FileNames
-import org.apache.hadoop.fs.FileStatus
+import org.apache.hadoop.fs.{FileStatus, Path}
 
 import org.apache.spark.sql.SparkSession
 
@@ -82,6 +82,8 @@ class IncrementalAMTWriter(spark: SparkSession, deltaLog: DeltaLog) {
 
   private val hadoopConf = deltaLog.newDeltaHadoopConf()
   private val tableRoot = deltaLog.dataPath
+  // Always use object identity for AMT tables here.
+  private val useDeletionVectorObjectIdentity = true
   private val fs = tableRoot.getFileSystem(hadoopConf)
   private val metadataDir = FileNames.amtMetadataDirPath(tableRoot)
 
@@ -137,7 +139,9 @@ class IncrementalAMTWriter(spark: SparkSession, deltaLog: DeltaLog) {
       windowCommits = windowCommits,
       windowCommitActions = actionsFromDeltas,
       attemptVersion = attemptVersion,
-      actionsToCommit = actionsToCommit)
+      actionsToCommit = actionsToCommit,
+      tableRoot = tableRoot,
+      useDeletionVectorObjectIdentity = useDeletionVectorObjectIdentity)
 
     // ---- Step 2: carry the old leaf pointers forward, patching MDV + CDF positions. ----
     val (carriedLeafPointers, leafPositions) =
@@ -161,7 +165,8 @@ class IncrementalAMTWriter(spark: SparkSession, deltaLog: DeltaLog) {
       if (processedActions.replacedPaths.contains(add.path)) {
         AMTWriteHelper.modifiedTrackingForDataEntry()
       } else if (add.backReference.isDefined ||
-          processedActions.preCommitLiveKeys.contains(add.toUniqueFileActionTuple)) {
+          processedActions.preCommitLiveKeys.contains(
+            add.toUniqueFileActionTuple(tableRoot, useDeletionVectorObjectIdentity))) {
         AMTWriteHelper.existingTrackingForDataEntry()
       } else {
         AMTWriteHelper.addedTrackingForDataEntry()
@@ -363,13 +368,17 @@ class IncrementalAMTWriter(spark: SparkSession, deltaLog: DeltaLog) {
       commitAddedPaths: Set[String]): Seq[DataEntry] = {
     if (withoutBackrefRemoves.isEmpty) return Seq.empty
     val liveKeys: Set[UniqueFileActionTuple] =
-      liveAdds.iterator.map(_.toUniqueFileActionTuple).toSet
+      liveAdds.iterator
+        .map(_.toUniqueFileActionTuple(tableRoot, useDeletionVectorObjectIdentity))
+        .toSet
     // AddFile lookup from root + window: the removed file's add predates this commit (a replace
     // re-adds the same path under a new DV -- a distinct key -- so this still finds the prior add).
     val addByKey: Map[UniqueFileActionTuple, AddFile] =
-      rootAndWindowAdds.map(a => a.toUniqueFileActionTuple -> a).toMap
+      rootAndWindowAdds
+        .map(a => a.toUniqueFileActionTuple(tableRoot, useDeletionVectorObjectIdentity) -> a)
+        .toMap
     withoutBackrefRemoves.map { r =>
-      val removeKey = r.toUniqueFileActionTuple
+      val removeKey = r.toUniqueFileActionTuple(tableRoot, useDeletionVectorObjectIdentity)
       // Two invariants a no-backref remove must satisfy (it targets a root-resident or
       // window-added file, never a leaf); violating either means a corrupt tree:
       //   - it is net-removed, so its (path, dv) is absent from the live set (a still-live key
@@ -452,10 +461,14 @@ private class ProcessedActions(
     windowCommits: Seq[SingleCommit],
     windowCommitActions: Seq[Seq[Action]],
     attemptVersion: Long,
-    actionsToCommit: Seq[Action]) {
-
+    actionsToCommit: Seq[Action],
+    tableRoot: Path,
+    useDeletionVectorObjectIdentity: Boolean) {
   private val replay = new InMemoryLogReplay(
-    minFileRetentionTimestamp = None, minSetTransactionRetentionTimestamp = None)
+    minFileRetentionTimestamp = None,
+    minSetTransactionRetentionTimestamp = None,
+    tableRoot = tableRoot,
+    useDeletionVectorObjectIdentity = useDeletionVectorObjectIdentity)
   private val rootAndWindowAddsBuf = ArrayBuffer.empty[AddFile]
   private val mdvSupersededBuf = ArrayBuffer.empty[BackReference]
   // This commit's own file actions, split out for CDF and re-add classification.
@@ -470,7 +483,9 @@ private class ProcessedActions(
   // Keys of files live in the {old root + window}'s replay BEFORE this commit's actions; a
   // live add already here (or carrying a leaf back reference) is EXISTING, not ADDED.
   val preCommitLiveKeys: Set[UniqueFileActionTuple] =
-    replay.allFiles.iterator.map(_.toUniqueFileActionTuple).toSet
+    replay.allFiles.iterator
+      .map(_.toUniqueFileActionTuple(tableRoot, useDeletionVectorObjectIdentity))
+      .toSet
   replay.append(attemptVersion, actionsToCommit.iterator)
 
   // One more pass over part-1/2/3 to initialize the auxiliary buffers above.
@@ -546,9 +561,12 @@ private class ProcessedActions(
   // True if `add` re-commits a file already live before this commit (its key is in the pre-commit
   // live set, or it carries a back reference to an existing leaf slot) and is not a replace (a
   // replace changes the DV, a distinct key). Such a re-add is a metadata-only refresh.
-  private def isReCommittedLiveAdd(add: AddFile): Boolean =
+  private def isReCommittedLiveAdd(add: AddFile): Boolean = {
+    val preCommitLiveKeysContainAddFile = preCommitLiveKeys.contains(
+      add.toUniqueFileActionTuple(tableRoot, useDeletionVectorObjectIdentity))
     !replacedPaths.contains(add.path) &&
-      (add.backReference.isDefined || preCommitLiveKeys.contains(add.toUniqueFileActionTuple))
+      (add.backReference.isDefined || preCommitLiveKeysContainAddFile)
+  }
   val reCommittedLiveAdd: Option[AddFile] = commitAddsBuf.find(isReCommittedLiveAdd)
   if (dataChange) {
     // (1) A data-changing commit must not re-add a file already live before it: a same-key re-add

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/actions.scala
@@ -705,7 +705,6 @@ case class DeletionVector(
     cardinality: Long)        // ID: 156, required.
 
 object DeletionVector {
-
   /** Maps a Delta on-disk [[DeletionVectorDescriptor]] onto the AMT sub-struct; rejects inline. */
   def fromDescriptor(dv: DeletionVectorDescriptor, tableRoot: Path): DeletionVector = {
     require(dv.isOnDisk,
@@ -729,11 +728,20 @@ object DeletionVector {
     // AMT stored paths are unencoded.
     val absolutePath = DeletionVectorStore.unescapedStringToPath(dv.location)
     require(absolutePath.isAbsolute)
-    DeletionVectorDescriptor.onDiskWithAbsolutePath(
-      path = DeletionVectorStore.pathToEscapedString(absolutePath),
-      sizeInBytes = rawSize,
-      cardinality = dv.cardinality,
-      offset = Some(dv.offset.toInt))
+    val relativePath = AMTUtils.relativizeLocation(tableRoot.toString, absolutePath.toString)
+    if (AMTUtils.isAbsoluteLocation(relativePath)) {
+      DeletionVectorDescriptor.onDiskWithAbsolutePath(
+        path = DeletionVectorStore.pathToEscapedString(absolutePath),
+        sizeInBytes = rawSize,
+        cardinality = dv.cardinality,
+        offset = Some(dv.offset.toInt))
+    } else {
+      DeletionVectorDescriptor.createRelativePathDVDescriptor(
+        relativePath = relativePath,
+        sizeInBytes = rawSize,
+        cardinality = dv.cardinality,
+        offset = Some(dv.offset.toInt))
+    }
   }
 }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
@@ -46,7 +46,6 @@ import org.apache.spark.sql.execution.metric.SQLMetrics.createMetric
 import org.apache.spark.sql.types._
 import org.apache.spark.util.{SystemClock, ThreadUtils}
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
-import org.apache.spark.sql.delta.actions.InMemoryLogReplay.UniqueFileActionTuple
 
 /** Base class defining abstract optimize command */
 abstract class OptimizeTableCommandBase extends RunnableCommand with DeltaCommand {
@@ -475,15 +474,21 @@ class OptimizeExecutor(
         val newPartitionSchema = newTxn.metadata.partitionSchema
         // Note: When checking if the candidate set is the same, we need to consider (Path, DV)
         //       as the key.
-        val candidateSetOld = filesToProcess.
-          map(f => UniqueFileActionTuple(f.pathAsUri, f.getLegacyDeletionVectorUniqueId)).toSet
+        val useObjectIdentity =
+          FileAction.useDeletionVectorObjectIdentity(snapshot.protocol, sparkSession)
+        val candidateSetOld = filesToProcess
+          .map(f =>
+            f.toUniqueFileActionTuple(snapshot.dataPath, useObjectIdentity))
+          .toSet
 
         // We specifically don't list the files through the transaction since we are potentially
         // only processing a subset of them below. If the transaction is still valid, we will
         // register the files and predicate below
         val candidateSetNew =
           newTxn.snapshot.filesForScan(partitionPredicate).files
-            .map(f => UniqueFileActionTuple(f.pathAsUri, f.getLegacyDeletionVectorUniqueId)).toSet
+            .map(f =>
+              f.toUniqueFileActionTuple(newTxn.snapshot.dataPath, useObjectIdentity))
+            .toSet
 
         // As long as all of the files that we compacted are still part of the table,
         // and the partitioning has not changed it is valid to continue to try

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -2983,6 +2983,17 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .booleanConf
       .createWithDefault(false)
 
+  val DELETION_VECTORS_USE_OBJECT_IDENTITY_FOR_INCREMENTAL_CRC =
+    buildConf("deletionVectors.useObjectIdentityForIncrementalCRCComputation")
+      .internal()
+      .doc(
+        """Kill-switch for reconciling deletion vectors by their normalized object identity when
+          |incrementally computing the checksum (CRC). When false, deletion vectors fall back to
+          |their legacy descriptor identity.
+          |""".stripMargin)
+      .booleanConf
+      .createWithDefault(true)
+
   val DELETION_VECTOR_PACKING_TARGET_SIZE =
     buildConf("deletionVectors.packing.targetSize")
       .internal()

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogMinorCompactionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogMinorCompactionSuite.scala
@@ -46,7 +46,10 @@ class DeltaLogMinorCompactionSuite extends QueryTest
     val deltaLog = DeltaLog.forTable(spark, tablePath)
     val logReplay = new InMemoryLogReplay(
       minFileRetentionTimestamp = None,
-      minSetTransactionRetentionTimestamp = None)
+      minSetTransactionRetentionTimestamp = None,
+      tableRoot = deltaLog.dataPath,
+      useDeletionVectorObjectIdentity = FileAction.useDeletionVectorObjectIdentity(
+        deltaLog.update().protocol, spark))
     val hadoopConf = deltaLog.newDeltaHadoopConf()
 
     (startVersion to endVersion).foreach { versionToRead =>

--- a/spark/src/test/scala/org/apache/spark/sql/delta/actions/DeletionVectorDescriptorSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/actions/DeletionVectorDescriptorSuite.scala
@@ -323,6 +323,54 @@ class DeletionVectorDescriptorSuite extends SparkFunSuite {
       base.copy(offset = Some(9)).uniqueId(testTablePath, useObjectIdentity = true))
   }
 
+  test("log replay keeps descriptor identity when object identity is disabled") {
+    val uuid = UUID.randomUUID()
+    val uDv = onDiskWithUuidRelativePath(
+      uuid, randomPrefix = "prefix", sizeInBytes = 15, cardinality = 25)
+    val rDv = rFormOf(uuid, "prefix", offset = None)
+    val replay = new InMemoryLogReplay(
+      minFileRetentionTimestamp = None,
+      minSetTransactionRetentionTimestamp = None,
+      tableRoot = testTablePath,
+      useDeletionVectorObjectIdentity = false)
+
+    replay.append(0, Iterator(addFileWithDv(uDv)))
+    replay.append(1, Iterator(removeFileWithDv(rDv)))
+
+    assert(replay.allFiles.map(_.deletionVector) === Seq(uDv))
+  }
+
+  test("log replay uses object identity when enabled") {
+    val uuid = UUID.randomUUID()
+    val uDv = onDiskWithUuidRelativePath(
+      uuid, randomPrefix = "prefix", sizeInBytes = 15, cardinality = 25)
+    val rDv = rFormOf(uuid, "prefix", offset = None)
+    val replay = new InMemoryLogReplay(
+      minFileRetentionTimestamp = None,
+      minSetTransactionRetentionTimestamp = None,
+      tableRoot = testTablePath,
+      useDeletionVectorObjectIdentity = true)
+
+    replay.append(0, Iterator(addFileWithDv(uDv)))
+    replay.append(1, Iterator(removeFileWithDv(rDv)))
+
+    assert(replay.allFiles.isEmpty)
+  }
+
+  private def addFileWithDv(dv: DeletionVectorDescriptor): AddFile = {
+    AddFile(
+      path = "part-000.parquet",
+      partitionValues = Map.empty,
+      size = 1,
+      modificationTime = 1,
+      dataChange = true,
+      deletionVector = dv)
+  }
+
+  private def removeFileWithDv(dv: DeletionVectorDescriptor): RemoveFile = {
+    addFileWithDv(dv).removeWithTimestamp(timestamp = 2L)
+  }
+
   private def assertCardinality(dv: DeletionVectorDescriptor, expSize: Int): Unit = {
     if (expSize == 0) {
       assert(dv.isEmpty, s"Expected DV to be empty: $dv")

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTIncrementalWriteInvariantSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTIncrementalWriteInvariantSuite.scala
@@ -33,7 +33,9 @@ class AMTIncrementalWriteInvariantSuite extends AMTIncrementalWriteTestBase {
       windowCommits = Nil,
       windowCommitActions = Nil,
       attemptVersion = 1L,
-      actionsToCommit = actionsToCommit)
+      actionsToCommit = actionsToCommit,
+      tableRoot = new org.apache.hadoop.fs.Path("s3://bucket/prefix/amt_test_table"),
+      useDeletionVectorObjectIdentity = true)
 
   test("writeIncremental rejects intermediate commits with a hole up to attemptVersion") {
     withSQLConf(leafPackingConfs: _*) {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSingleActionSerializerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSingleActionSerializerSuite.scala
@@ -308,7 +308,7 @@ class AMTSingleActionSerializerSuite extends QueryTest with SharedSparkSession {
   // Framing bytes that DeletionVectorStore adds around the raw bitmap on disk (length + checksum).
   private val dvFraming = DeletionVectorStore.getTotalSizeOfDVFieldsInFile(0)
 
-  test("DeletionVector.fromDescriptor maps a UUID-relative DV to an unencoded absolute location") {
+  test("u DV round trip") {
     val id = UUID.randomUUID()
     val dv = DeletionVectorDescriptor.onDiskWithUuidRelativePath(
       id = id,
@@ -325,9 +325,8 @@ class AMTSingleActionSerializerSuite extends QueryTest with SharedSparkSession {
     assert(amtDv.size_in_bytes == 20L + dvFraming)
 
     val roundTripped = DeletionVector.toDescriptor(amtDv, tableRoot)
-    assert(roundTripped.storageType == DeletionVectorDescriptor.PATH_DV_MARKER)
-    assert(roundTripped.pathOrInlineDv == dv.urlEncodedPath(tableRoot))
-    assert(roundTripped.pathOrInlineDv.contains("test%25dv%25prefix-"))
+    assert(roundTripped.storageType == DeletionVectorDescriptor.RELATIVE_DV_MARKER)
+    assert(roundTripped.pathOrInlineDv.contains("test%dv%prefix-"))
     assert(roundTripped.absolutePath(tableRoot) == dv.absolutePath(tableRoot))
   }
 
@@ -419,7 +418,10 @@ class AMTSingleActionSerializerSuite extends QueryTest with SharedSparkSession {
     // Below simulates the real write path in [[writeIncrementalMaterialization]]
     assert(add.copy(dataChange = false).amtPassthrough == passthrough)
     val replay = new InMemoryLogReplay(
-      minFileRetentionTimestamp = None, minSetTransactionRetentionTimestamp = None)
+      minFileRetentionTimestamp = None,
+      minSetTransactionRetentionTimestamp = None,
+      tableRoot = tableRoot,
+      useDeletionVectorObjectIdentity = true)
     replay.append(0, Iterator(add))
     val reconstructed = replay.allFiles
     assert(reconstructed.length == 1)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotSuite.scala
@@ -370,6 +370,313 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
     path.map(p => live.filter(_.path == p)).getOrElse(live)
   }
 
+  /**
+   * Returns the latest snapshot after the caller adds trailing LOG commits.
+   * This asserts that the tail does not emit a new AMT.
+   */
+  private def latestSnapshotAfterLogTail(context: AMTCheckpointScenarioContext): Snapshot = {
+    val log = context.postCheckpointSnapshot.deltaLog
+    val snapshot = log.update()
+    assert(snapshot.version > context.postCheckpointSnapshot.version)
+    assert(checkpointAt(log, snapshot.version).isEmpty)
+    val provider = amtProvider(snapshot).getOrElse(
+      fail("The latest snapshot must still use the AMT checkpoint provider."))
+    assert(provider.checkpointAction == context.provider.checkpointAction)
+    snapshot
+  }
+
+  testAcrossAMTCheckpointScenarios(
+      "snapshot replays trailing append after an AMT checkpoint",
+      "amt_tail_append")(
+      setup = name => sql(s"INSERT INTO $name VALUES (1)"),
+      inlineCheckpointTriggerActionsOrSQL = Some(name => Right(
+        s"INSERT INTO $name VALUES (2)"))) { context =>
+    val addFilesAtCheckpointVersion = context.postCheckpointSnapshot.allFiles.collect()
+    val addFilePathsAtCheckpointVersion = addFilesAtCheckpointVersion.map(_.path).toSet
+    assert(addFilePathsAtCheckpointVersion.size == 2)
+
+    sql(s"INSERT INTO ${context.tableName} VALUES (3)")
+    val finalSnapshot = latestSnapshotAfterLogTail(context)
+
+    assert(amtFilesInTree(finalSnapshot).map(_.path).toSet == addFilePathsAtCheckpointVersion)
+    assert(finalSnapshot.allFiles.count() == addFilesAtCheckpointVersion.length + 1)
+    checkAnswer(spark.read.table(context.tableName), Seq(Row(1), Row(2), Row(3)))
+  }
+
+  testAcrossAMTCheckpointScenarios(
+      "snapshot replays trailing remove after an AMT checkpoint",
+      "amt_tail_remove")(
+      setup = name => sql(s"INSERT INTO $name VALUES (1)"),
+      inlineCheckpointTriggerActionsOrSQL = Some(name => Right(
+        s"INSERT INTO $name VALUES (2)"))) { context =>
+    val log = context.postCheckpointSnapshot.deltaLog
+    val addFilesAtCheckpointVersion = context.postCheckpointSnapshot.allFiles.collect()
+    assert(addFilesAtCheckpointVersion.length == 2)
+    val setupFile = addFilesAtCheckpointVersion.head
+
+    log.startTransaction().commit(
+      Seq(setupFile.removeWithTimestamp()),
+      DeltaOperations.ManualUpdate)
+    val finalSnapshot = latestSnapshotAfterLogTail(context)
+
+    assert(
+      amtFilesInTree(finalSnapshot).map(_.path).toSet == addFilesAtCheckpointVersion
+        .map(_.path)
+        .toSet
+    )
+    val livePaths = finalSnapshot.allFiles.collect().map(_.path).toSet
+    assert(!livePaths.contains(setupFile.path))
+    assert(livePaths.size == 1)
+    checkAnswer(
+      spark.read.table(context.tableName).groupBy().count(),
+      Seq(Row(1L)))
+  }
+
+  testAcrossAMTCheckpointScenarios(
+      "snapshot replays trailing overwrite after an AMT checkpoint",
+      "amt_tail_overwrite")(
+      setup = name => sql(s"INSERT INTO $name VALUES (1)"),
+      inlineCheckpointTriggerActionsOrSQL = Some(name => Right(
+        s"INSERT INTO $name VALUES (2)"))) { context =>
+    val addFilePathsAtCheckpointVersion =
+      context.postCheckpointSnapshot.allFiles.collect().map(_.path).toSet
+    assert(addFilePathsAtCheckpointVersion.size == 2)
+
+    sql(s"INSERT OVERWRITE ${context.tableName} VALUES (10), (20)")
+    val finalSnapshot = latestSnapshotAfterLogTail(context)
+
+    val livePaths = finalSnapshot.allFiles.collect().map(_.path).toSet
+    assert(livePaths.nonEmpty)
+    assert((livePaths & addFilePathsAtCheckpointVersion).isEmpty)
+    checkAnswer(spark.read.table(context.tableName), Seq(Row(10), Row(20)))
+  }
+
+  testAcrossAMTCheckpointScenarios(
+      "snapshot replays trailing DV update after an AMT checkpoint",
+      "amt_tail_dv",
+      sqlConfs = Seq(DeltaSQLConf.DELTA_HISTORY_METRICS_ENABLED.key -> "false"))(
+      setup = name => {
+        Seq(10, 20, 30, 40, 50).toDF("id").coalesce(1)
+          .write.mode("append").insertInto(name)
+      },
+      inlineCheckpointTriggerActionsOrSQL = Some(name => Right(
+        s"INSERT INTO $name VALUES (60)"))) { context =>
+    val log = context.postCheckpointSnapshot.deltaLog
+    val addFilesAtCheckpointVersion =
+      context.postCheckpointSnapshot.allFiles.collect()
+    val addFilesAtSetupVersion =
+      context.preCheckpointSnapshot.allFiles.collect()
+    assert(addFilesAtSetupVersion.length == 1, "The five setup rows must land in a single file.")
+    val setupFileAtSetupVersion = addFilesAtSetupVersion.head
+
+    // Write a DV to the setup file.
+    val dvActions = writeFileWithDVOnDisk(
+      log,
+      setupFileAtSetupVersion,
+      RoaringBitmapArray(0L, 2L, 4L)
+    )
+    log.startTransaction().commit(dvActions, DeltaOperations.Delete(predicate = Seq.empty))
+    val finalSnapshot = latestSnapshotAfterLogTail(context)
+
+    // Tree correctness test
+    val addFilesInAmt = amtFilesInTree(finalSnapshot, Some(setupFileAtSetupVersion.path))
+    assert(addFilesInAmt.length == 1)
+    assert(
+      addFilesInAmt.head.deletionVector == null,
+      "The AMT provider should still expose the pre-DV checkpointed file.")
+    checkAnswer(spark.read.table(context.tableName), Seq(Row(20), Row(40), Row(60)))
+
+    // The setup file now has a DV associated with 3 rows deleted.
+    val addFilesInFinalVersion = finalSnapshot.allFiles.collect()
+    assert(addFilesInFinalVersion.length == addFilesAtCheckpointVersion.length)
+    val setupFileAtFinalVersion = addFilesInFinalVersion
+      .find(_.path == setupFileAtSetupVersion.path)
+      .getOrElse(
+        fail(
+          s"The DV-updated file ${setupFileAtSetupVersion.path} must stay live."
+        )
+      )
+    assert(setupFileAtFinalVersion.deletionVector != null)
+    assert(setupFileAtFinalVersion.numPhysicalRecords.contains(5L))
+    assert(setupFileAtFinalVersion.numLogicalRecords.contains(2L))
+  }
+
+  testAcrossAMTCheckpointScenarios(
+      "snapshot replays trailing DV that fully deletes a file after an AMT checkpoint",
+      "amt_tail_dv_full_delete",
+      sqlConfs = Seq(DeltaSQLConf.DELTA_HISTORY_METRICS_ENABLED.key -> "false"))(
+      setup = name => {
+        Seq(1, 2).toDF("id").coalesce(1).write.mode("append").insertInto(name)
+      },
+      inlineCheckpointTriggerActionsOrSQL = Some(name => Right(
+        s"INSERT INTO $name VALUES (3)"))) { context =>
+    val log = context.postCheckpointSnapshot.deltaLog
+    val addFilesAtCheckpointVersion = context.postCheckpointSnapshot.allFiles.collect()
+    val addFilesAtSetupVersion = context.preCheckpointSnapshot.allFiles.collect()
+    assert(addFilesAtSetupVersion.length == 1, "The two setup rows must land in a single file.")
+    val setupFileAtSetupVersion = addFilesAtSetupVersion.head
+
+    // Fully delete the setup file.
+    val dvActions = writeFileWithDVOnDisk(log, setupFileAtSetupVersion, RoaringBitmapArray(0L, 1L))
+    log.startTransaction().commit(dvActions, DeltaOperations.Delete(predicate = Seq.empty))
+    val finalSnapshot = latestSnapshotAfterLogTail(context)
+
+    checkAnswer(spark.read.table(context.tableName), Seq(Row(3)))
+
+    // The setup file now has a DV associated with all rows deleted.
+    val addFilesInFinalVersion = finalSnapshot.allFiles.collect()
+    assert(addFilesInFinalVersion.length == addFilesAtCheckpointVersion.length)
+    val setupFileAtFinalVersion = addFilesInFinalVersion
+      .find(_.path == setupFileAtSetupVersion.path)
+      .getOrElse(fail(s"The fully-deleted file ${setupFileAtSetupVersion.path} must stay live."))
+    assert(setupFileAtFinalVersion.deletionVector != null)
+    assert(setupFileAtFinalVersion.numPhysicalRecords.contains(2L))
+    assert(setupFileAtFinalVersion.numLogicalRecords.contains(0L))
+  }
+
+  testAcrossAMTCheckpointScenarios(
+      "snapshot replays trailing shared-DV update after an AMT checkpoint",
+      "amt_tail_dv_shared_blob",
+      sqlConfs = Seq(DeltaSQLConf.DELTA_HISTORY_METRICS_ENABLED.key -> "false"))(
+      setup = name => {
+        Seq(1, 2).toDF("id").coalesce(1).write.mode("append").insertInto(name)
+        Seq(3, 4).toDF("id").coalesce(1).write.mode("append").insertInto(name)
+      },
+      inlineCheckpointTriggerActionsOrSQL = Some(name => Right(
+        s"INSERT INTO $name VALUES (5)"))) { context =>
+    val log = context.postCheckpointSnapshot.deltaLog
+    val addFilesAtSetupVersion = context.preCheckpointSnapshot.allFiles.collect()
+    assert(addFilesAtSetupVersion.length == 2)
+
+    // Attach DVs to both setup files.
+    val dvActions = writeFilesWithDVsOnDisk(log, Seq(
+      addFilesAtSetupVersion(0) -> RoaringBitmapArray(0L),
+      addFilesAtSetupVersion(1) -> RoaringBitmapArray(0L)))
+    log.startTransaction().commit(dvActions, DeltaOperations.Delete(predicate = Seq.empty))
+    val finalSnapshot = latestSnapshotAfterLogTail(context)
+
+    checkAnswer(spark.read.table(context.tableName), Seq(Row(2), Row(4), Row(5)))
+    val addFilesInFinalVersion = finalSnapshot.allFiles.collect()
+    assert(addFilesInFinalVersion.length == 3,
+      "Both DV'd files and the trigger file must remain live.")
+    val filesWithDvs = addFilesInFinalVersion.filter(_.deletionVector != null)
+    assert(filesWithDvs.length == 2)
+    assert(filesWithDvs.forall(_.numLogicalRecords.contains(1L)))
+    val blobPaths = filesWithDvs.map(_.deletionVector.absolutePath(log.dataPath)).toSet
+    assert(blobPaths.size == 1)
+  }
+
+  testAcrossAMTCheckpointScenarios(
+      "snapshot replays trailing remove of a file with DV in an AMT",
+      "amt_tail_remove_dv_in_amt",
+      sqlConfs = Seq(DeltaSQLConf.DELTA_HISTORY_METRICS_ENABLED.key -> "false"))(
+      setup = name => {
+        Seq(10, 20, 30, 40, 50).toDF("id").coalesce(1)
+          .write.mode("append").insertInto(name)
+        // Attach a DV and checkpoint with AMT.
+        val log = deltaLogForName(name)
+        val fileToDv = log.update().allFiles.collect()
+        assert(fileToDv.length == 1, "The five setup rows must land in a single file.")
+        val dvActions = writeFileWithDVOnDisk(log, fileToDv.head, RoaringBitmapArray(0L, 2L, 4L))
+        log.startTransaction().commit(dvActions, DeltaOperations.Delete(predicate = Seq.empty))
+      },
+      inlineCheckpointTriggerActionsOrSQL = Some(name => Right(
+        s"INSERT INTO $name VALUES (60)"))) { context =>
+    val log = context.postCheckpointSnapshot.deltaLog
+    val addFilesAtCheckpointVersion = context.postCheckpointSnapshot.allFiles.collect()
+    assert(addFilesAtCheckpointVersion.length == 2)
+
+    // AMT converts the DV type from u to r when reading it back.
+    val addFilesAtSetupVersion = context.preCheckpointSnapshot.allFiles.collect()
+    assert(addFilesAtSetupVersion.length == 1)
+    val setupFileAtSetupVersion = addFilesAtSetupVersion.head
+    assert(setupFileAtSetupVersion.deletionVector.storageType ==
+      DeletionVectorDescriptor.UUID_DV_MARKER)
+    val addFilesInAmt =
+      amtFilesInTree(context.postCheckpointSnapshot, Some(setupFileAtSetupVersion.path))
+    assert(addFilesInAmt.head.deletionVector.storageType ==
+      DeletionVectorDescriptor.RELATIVE_DV_MARKER)
+
+    // Delete the setup file
+    log.startTransaction().commit(
+      Seq(setupFileAtSetupVersion.removeWithTimestamp()),
+      DeltaOperations.ManualUpdate)
+    val finalSnapshot = latestSnapshotAfterLogTail(context)
+
+    assert(
+      amtFilesInTree(finalSnapshot).map(_.path).toSet ==
+        addFilesAtCheckpointVersion.map(_.path).toSet)
+    val livePaths = finalSnapshot.allFiles.collect().map(_.path).toSet
+    assert(!livePaths.contains(setupFileAtSetupVersion.path))
+    assert(livePaths.size == 1)
+    checkAnswer(spark.read.table(context.tableName), Seq(Row(60)))
+  }
+
+  testAcrossAMTCheckpointScenarios(
+      "snapshot replays trailing DV update of a file with DV in an AMT",
+      "amt_tail_update_dv_in_amt",
+      sqlConfs = Seq(DeltaSQLConf.DELTA_HISTORY_METRICS_ENABLED.key -> "false"))(
+      setup = name => {
+        Seq(10, 20, 30, 40, 50).toDF("id").coalesce(1)
+          .write.mode("append").insertInto(name)
+        // Attach a DV and checkpoint with AMT.
+        val log = deltaLogForName(name)
+        val fileToDv = log.update().allFiles.collect()
+        assert(fileToDv.length == 1, "The five setup rows must land in a single file.")
+        val dvActions = writeFileWithDVOnDisk(log, fileToDv.head, RoaringBitmapArray(0L, 2L, 4L))
+        log.startTransaction().commit(dvActions, DeltaOperations.Delete(predicate = Seq.empty))
+      },
+      inlineCheckpointTriggerActionsOrSQL = Some(name => Right(
+        s"INSERT INTO $name VALUES (60)"))) { context =>
+    val log = context.postCheckpointSnapshot.deltaLog
+    val addFilesAtCheckpointVersion = context.postCheckpointSnapshot.allFiles.collect()
+    assert(addFilesAtCheckpointVersion.length == 2)
+
+    // The checkpointed file's DV is committed in u form but stored in the leaf in r form.
+    val addFilesAtSetupVersion = context.preCheckpointSnapshot.allFiles.collect()
+    assert(addFilesAtSetupVersion.length == 1)
+    val setupFileAtSetupVersion = addFilesAtSetupVersion.head
+    assert(setupFileAtSetupVersion.deletionVector.storageType ==
+      DeletionVectorDescriptor.UUID_DV_MARKER)
+
+    // Supersede the checkpointed DV with a wider one
+    val dvActions =
+      writeFileWithDVOnDisk(log, setupFileAtSetupVersion, RoaringBitmapArray(0L, 1L, 2L, 4L))
+    log.startTransaction().commit(dvActions, DeltaOperations.Delete(predicate = Seq.empty))
+    val finalSnapshot = latestSnapshotAfterLogTail(context)
+
+    checkAnswer(spark.read.table(context.tableName), Seq(Row(40), Row(60)))
+    val addFilesInFinalVersion = finalSnapshot.allFiles.collect()
+    assert(addFilesInFinalVersion.length == addFilesAtCheckpointVersion.length)
+    val setupFileAtFinalVersion = addFilesInFinalVersion
+      .find(_.path == setupFileAtSetupVersion.path)
+      .getOrElse(fail(s"The DV-updated file ${setupFileAtSetupVersion.path} must stay live."))
+    assert(setupFileAtFinalVersion.deletionVector != null)
+    assert(setupFileAtFinalVersion.deletionVector.cardinality == 4L)
+    assert(setupFileAtFinalVersion.numPhysicalRecords.contains(5L))
+    assert(setupFileAtFinalVersion.numLogicalRecords.contains(1L))
+  }
+
+  testAcrossAMTCheckpointScenarios(
+      "snapshot exposes trailing AMTPassthrough add after an AMT checkpoint",
+      "amt_tail_passthrough")(
+      setup = name => sql(s"INSERT INTO $name VALUES (1)"),
+      inlineCheckpointTriggerActionsOrSQL = Some(name => Right(
+        s"INSERT INTO $name VALUES (2)"))) { context =>
+    val log = context.postCheckpointSnapshot.deltaLog
+    val path = "trailing-passthrough-file"
+    val add = createTestAddFile(encodedPath = path)
+      .copy(amtPassthrough = Some(fullPassthrough), stats = """{"numRecords":1}""")
+
+    log.startTransaction().commit(Seq(add), DeltaOperations.ManualUpdate)
+    val finalSnapshot = latestSnapshotAfterLogTail(context)
+
+    assert(amtFilesInTree(finalSnapshot, Some(path)).isEmpty)
+    val live = finalSnapshot.allFiles.collect().filter(_.path == path)
+    assert(live.length == 1)
+    assert(live.head.amtPassthrough.contains(fullPassthrough))
+  }
+
   testAcrossAMTCheckpointScenarios(
       "filtered scan is correct after emission (trimmed deltas + leaves)",
       "amt_filtered_scan")(
@@ -389,7 +696,7 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
   }
 
   testAcrossAMTCheckpointScenarios(
-      "deletion vector round-trips through the leaves as an absolute-path DV",
+      "deletion vector round-trips through the leaves as a relative-path DV",
       "amt_dv",
       sqlConfs = Seq(DeltaSQLConf.DELTA_HISTORY_METRICS_ENABLED.key -> "false"))(
       setup = name => {
@@ -431,7 +738,7 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
       sizeInBytes = committedDv.sizeInBytes,
       cardinality = committedDv.cardinality)
     val tableRoot = snapshot.deltaLog.dataPath
-    // Not comparing the uniqueId here as it will soon not be the identity of the DV.
+    assert(reconstructedDv.storageType == DeletionVectorDescriptor.RELATIVE_DV_MARKER)
     assert(reconstructedDv.absolutePath(tableRoot) == committedDv.absolutePath(tableRoot))
     assert(reconstructedDv.offset == committedDv.offset)
 
@@ -519,6 +826,60 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
     // Offsets are still different.
     val offsets = dvs.map(_.offset).toSet
     assert(offsets.size == 2)
+  }
+
+  testAcrossAMTCheckpointScenarios(
+      "snapshot replays trailing remove of a shared checkpointed DV file",
+      "amt_tail_remove_checkpointed_dv",
+      sqlConfs = Seq(
+        DeltaSQLConf.DELTA_HISTORY_METRICS_ENABLED.key -> "false"
+      ))(
+      setup = name => {
+        Seq(1, 2).toDF("id").coalesce(1).write.mode("append").insertInto(name)
+        Seq(3, 4).toDF("id").coalesce(1).write.mode("append").insertInto(name)
+        val log = deltaLogForName(name)
+        val files = log.unsafeVolatileSnapshot.allFiles.collect()
+        assert(files.length == 2)
+
+        val dvActions = writeFilesWithDVsOnDisk(log, Seq(
+          files(0) -> RoaringBitmapArray(0L),
+          files(1) -> RoaringBitmapArray(0L)))
+        log.startTransaction().commit(dvActions, DeltaOperations.Delete(predicate = Seq.empty))
+      },
+      inlineCheckpointTriggerActionsOrSQL = Some(name => Right(
+        s"INSERT INTO $name VALUES (5)"))) { context =>
+    val log = context.postCheckpointSnapshot.deltaLog
+    val addFilesAtSetupVersion = context.preCheckpointSnapshot.allFiles.collect()
+      .filter(_.deletionVector != null)
+    assert(addFilesAtSetupVersion.length == 2)
+    val addFilesAtCheckpointVersion = context.postCheckpointSnapshot.allFiles.collect()
+    assert(addFilesAtCheckpointVersion.count(_.deletionVector != null) == 2)
+    assert(addFilesAtCheckpointVersion.filter(_.deletionVector != null).forall(
+      _.deletionVector.storageType == DeletionVectorDescriptor.RELATIVE_DV_MARKER))
+    val checkpointRowCount = spark.read.table(context.tableName).count()
+
+    val firstFile = addFilesAtSetupVersion.head
+    log.startTransaction().commit(
+      Seq(firstFile.removeWithTimestamp()),
+      DeltaOperations.ManualUpdate)
+    val finalSnapshot = latestSnapshotAfterLogTail(context)
+
+    val addFilesInAmt = amtFilesInTree(finalSnapshot)
+    assert(addFilesInAmt.length == addFilesAtCheckpointVersion.length,
+      "The AMT provider should still expose every checkpointed file.")
+    val addFilesInFinalVersion = finalSnapshot.allFiles.collect()
+    assert(addFilesInFinalVersion.length == addFilesAtCheckpointVersion.length - 1,
+      "Only one file left after the last remove.")
+    val liveFiles = addFilesInFinalVersion.filter(_.deletionVector != null)
+    assert(liveFiles.length == 1)
+    assert(
+      liveFiles.head.deletionVector.absolutePath(log.dataPath) ==
+        firstFile.deletionVector.absolutePath(log.dataPath),
+      "The surviving file should share the same DV path as the removed file.")
+    assert(liveFiles.head.deletionVector.offset != firstFile.deletionVector.offset)
+    checkAnswer(
+      spark.read.table(context.tableName).groupBy().count(),
+      Seq(Row(checkpointRowCount - 1)))
   }
 
   testAcrossAMTCheckpointScenarios(

--- a/spark/src/test/scala/org/apache/spark/sql/delta/storage/dv/DeletionVectorFileSizeSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/storage/dv/DeletionVectorFileSizeSuite.scala
@@ -26,14 +26,15 @@ import org.apache.spark.sql.delta.test.{DeltaSQLCommandTest, DeltaSQLTestUtils}
 import org.apache.commons.io.FileUtils
 import org.apache.hadoop.fs.Path
 
+import org.apache.spark.SparkConf
 import org.apache.spark.sql.QueryTest
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 
 class DeletionVectorFileSizeSuite extends QueryTest
     with SharedSparkSession
     with DeltaSQLTestUtils
     with DeltaSQLCommandTest {
+
   private def getAddAndRemoveFilesFromCommitVersion(
       deltaLog: DeltaLog,
       commitVersion: Long): (Seq[AddFile], Seq[RemoveFile]) = {


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

`InMemoryLogReplay` reconciles `AddFile`/`RemoveFile` actions by a
`(file path, deletion vector id)` key. Until now that key used the deletion
vector's *serialized descriptor* identity, so the same physical DV object
referenced through different descriptor forms -- `u` (UUID-relative), `r`
(relative-path), or in-root `p` (absolute path) -- was treated as three
different DVs. This matters for adaptive metadata tree (AMT) tables: the
checkpoint stores DVs in `r` form, while a trailing log commit may reference the
same DV in `u` or `p` form, so a `RemoveFile` in the tail would fail to cancel
the matching `AddFile` reconstructed from the checkpoint.

This PR keys log replay on the DV's normalized *object identity* (see
`DeletionVectorDescriptor.uniqueId(tableRoot, useObjectIdentity)`), so
equivalent `u` / `r` / in-root `p` descriptors compare equal:

- `InMemoryLogReplay` now takes `tableRoot` and `useDeletionVectorObjectIdentity`
  and reconciles Add/Remove by the object-identity key. The old
  `InMemoryLogReplay.UniqueFileActionTuple` and its implicit tuple helpers move
  to a new `FileAction` companion object as
  `toUniqueFileActionTuple(tableRoot, useObjectIdentity)`.
- `FileAction.useDeletionVectorObjectIdentity(protocol, spark)` centralizes the
  choice: object identity is always used for AMT tables, and is gated behind
  `deletionVectors.useObjectIdentityForNonAMTTables` otherwise.
- Callers are updated: `Snapshot` state reconstruction, incremental checksum
  (CRC) computation (behind a new kill-switch conf
  `deletionVectors.useObjectIdentityForIncrementalCRCComputation`, default on),
  `OptimizeExecutor` candidate-set comparison, and the incremental AMT writer.
- When rebuilding a `DeletionVectorDescriptor` from an AMT sub-struct,
  `DeletionVector.fromDescriptor` now emits a relative-path (`r`) descriptor when
  the blob resolves under the table root, and an absolute-path (`p`) descriptor
  otherwise.

## How was this patch tested?

- `DeletionVectorDescriptorSuite`: log replay keeps descriptor identity when
  object identity is disabled, and collapses an equivalent `u` add / `r` remove
  pair when enabled.
- `AMTSnapshotSuite`: trailing append / remove / overwrite / DV-update /
  full-delete / shared-blob / passthrough log commits after an AMT checkpoint;
  remove and DV-update of a file whose DV is already in the checkpoint; remove of
  a shared checkpointed DV file; and `r`-form round-trip through the leaves.
- `AMTSingleActionSerializerSuite`, `AMTIncrementalWriteInvariantSuite`,
  `DeltaLogMinorCompactionSuite`, `DeletionVectorFileSizeSuite`: updated for the
  new `InMemoryLogReplay` signature and `r`-form conversion.

## Does this PR introduce _any_ user-facing changes?

No.
