### PR TITLE
Record CommitInfo.dataChange on the commitLarge path

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -2081,7 +2081,8 @@ trait OptimisticTransactionImpl extends TransactionHelper
       newProtocolOpt: Option[Protocol],
       op: DeltaOperations.Operation,
       context: Map[String, String],
-      metrics: Map[String, String]
+      metrics: Map[String, String],
+      dataChange: Option[Boolean]
   ): (Long, Snapshot) = recordDeltaOperation(deltaLog, "delta.commit.large") {
     assert(committed.isEmpty, "Transaction already committed.")
     commitStartNano = System.nanoTime()
@@ -2126,7 +2127,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
         readVersion = Some(readVersion),
         isolationLevel = Some(Serializable.toString),
         isBlindAppend = Some(false),
-        dataChange = None,
+        dataChange = dataChange,
         operationMetrics = Some(metrics),
         userMetadata = getUserMetadata(op),
         tags = if (tags.nonEmpty) Some(tags) else None,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/PreDowngradeTableFeatureCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/PreDowngradeTableFeatureCommand.scala
@@ -271,7 +271,11 @@ case class DeletionVectorsPreDowngradeCommand(table: DeltaTableV2)
         op = DeltaOperations.AddDeletionVectorsTombstones,
         newProtocolOpt = None,
         context = Map.empty,
-        metrics = Map("dvTombstonesWithinRetentionPeriod" -> tombstonesToAddCount.toString))
+        metrics = Map("dvTombstonesWithinRetentionPeriod" -> tombstonesToAddCount.toString),
+        // The commit is only DV tombstones: RemoveFiles whose path is a deletion vector file
+        // rather than a data file, written so that VACUUM can delete those DVs. They drop no
+        // rows so dataChange is false.
+        dataChange = Some(false))
     } else {
       table.startTransaction(Some(snapshotToUse))
         .commit(actionsToCommit.toList, DeltaOperations.AddDeletionVectorsTombstones)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableBase.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableBase.scala
@@ -260,6 +260,11 @@ abstract class CloneTableBase(
         }
       }
 
+      // Every file action above is stamped with `dataChangeInFileAction`, so the commit changes
+      // data exactly when that is true and there is at least one file action.
+      val fileActionCount = addedFileCount
+      val commitDataChange = dataChangeInFileAction && fileActionCount > 0
+
       recordDeltaOperation(
         destinationTable, s"delta.${deltaOperation.name.toLowerCase()}.commit") {
         txn.commitLarge(
@@ -268,7 +273,8 @@ abstract class CloneTableBase(
           Some(newProtocol),
           deltaOperation,
           context,
-          commitOpMetrics.mapValues(_.toString()).toMap)
+          commitOpMetrics.mapValues(_.toString()).toMap,
+          dataChange = Some(commitDataChange))
       }
 
       val cloneLogData = getOperationMetricsForEventRecord(opMetrics) ++ Map(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/ConvertToDeltaCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/ConvertToDeltaCommand.scala
@@ -399,19 +399,24 @@ abstract class ConvertToDeltaCommandBase(
       checkConversionIsAllowed(txn, targetTable)
 
       val numFiles = targetTable.numFiles
-      val addFilesIter = createDeltaActions(spark, manifest, partitionFields, txn, fs)
+      val addFilesIter = createDeltaActions(spark, manifest, partitionFields, txn, fs).buffered
       val transactionMetrics = Map[String, String](
         "numConvertedFiles" -> numFiles.toString
       )
       metrics("numConvertedFiles") += numFiles
       sendDriverMetrics(spark, metrics)
+      val convertsAnyFile = addFilesIter.hasNext
+      if (convertsAnyFile) {
+        assert(addFilesIter.head.dataChange, "CONVERT must emit AddFiles with dataChange = true")
+      }
       txn.commitLarge(
         spark,
         addFilesIter,
         Some(txn.protocol),
         getOperation(numFiles, convertProperties, targetTable.format),
         getContext,
-        transactionMetrics)
+        transactionMetrics,
+        dataChange = Some(convertsAnyFile))
     } finally {
       manifest.close()
     }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/RestoreTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/RestoreTableCommand.scala
@@ -222,13 +222,17 @@ case class RestoreTableCommand(sourceTable: DeltaTableV2)
         val actions = addActions ++ removeActions ++
           DomainMetadataUtils.handleDomainMetadataForRestoreTable(snapshotToRestore, latestSnapshot)
 
+        val restoreChangesData =
+          metrics.getOrElse(NUM_RESTORED_FILES, 0L) + metrics.getOrElse(NUM_REMOVED_FILES, 0L) > 0
+
         txn.commitLarge(
           spark,
           actions,
           Some(newProtocol),
           DeltaOperations.Restore(version, timestamp),
           Map.empty,
-          metrics.mapValues(_.toString).toMap)
+          metrics.mapValues(_.toString).toMap,
+          dataChange = Some(restoreChangesData))
 
         Seq(Row(
           metrics.get(TABLE_SIZE_AFTER_RESTORE),

--- a/spark/src/test/scala/org/apache/spark/sql/delta/CommitInfoDataChangeSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CommitInfoDataChangeSuite.scala
@@ -1,0 +1,208 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.delta.actions.{Action, AddCDCFile, AddFile, CommitInfo, Metadata, Protocol, SetTransaction}
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.test.SharedSparkSession
+
+/**
+ * Tests that the `dataChange` recorded in a commit's [[CommitInfo]] matches the file actions the
+ * commit actually contains, for the normal transaction path and commitLarge path.
+ */
+class CommitInfoDataChangeSuite
+  extends QueryTest
+  with SharedSparkSession
+  with DeltaSQLCommandTest
+  with DeltaTableProvider {
+
+  private def addFile(path: String, dataChange: Boolean): AddFile =
+    AddFile(path, Map.empty, size = 1L, modificationTime = 1L, dataChange = dataChange)
+
+  /** Reads the `dataChange` recorded in the [[CommitInfo]] of the given commit. */
+  private def commitInfoDataChangeAt(deltaLog: DeltaLog, version: Long): Option[Boolean] =
+    deltaLog
+      .getChanges(version)
+      .collectFirst { case (`version`, actions) => actions }
+      .getOrElse(fail(s"no commit at version $version"))
+      .collectFirst { case ci: CommitInfo => ci }
+      .getOrElse(fail(s"no CommitInfo at version $version"))
+      .dataChange
+
+  private def latestCommitInfoDataChange(path: String): Option[Boolean] = {
+    val deltaLog = DeltaLog.forTable(spark, path)
+    commitInfoDataChangeAt(deltaLog, deltaLog.update().version)
+  }
+
+  test("dataChangeFromActions is false without file actions") {
+    assert(!CommitInfo.dataChangeFromActions(Nil))
+    val nonFileActions: Seq[Action] =
+      Seq(Metadata(), Protocol(1, 2), SetTransaction("app", 1L, None))
+    assert(!CommitInfo.dataChangeFromActions(nonFileActions))
+  }
+
+  test("dataChangeFromActions follows the file actions") {
+    assert(CommitInfo.dataChangeFromActions(Seq(addFile("a", dataChange = true))))
+    assert(!CommitInfo.dataChangeFromActions(Seq(addFile("a", dataChange = false))))
+
+    val rearrange = addFile("a", dataChange = false)
+    val dataChanging = addFile("b", dataChange = true)
+    assert(CommitInfo.dataChangeFromActions(Seq(rearrange, dataChanging)))
+    assert(CommitInfo.dataChangeFromActions(Seq(dataChanging, rearrange)))
+
+    assert(CommitInfo.dataChangeFromActions(Seq(dataChanging.remove)))
+    val rearrangeRemove = rearrange.removeWithTimestamp(dataChange = false)
+    assert(!CommitInfo.dataChangeFromActions(Seq(rearrangeRemove)))
+  }
+
+  test("dataChangeFromActions ignores change data files") {
+    // AddCDCFile always carries dataChange = false, so a commit of only CDC files does not change
+    // the table's data.
+    val cdc = AddCDCFile("cdc", Map.empty, size = 1L)
+    assert(!cdc.dataChange)
+    assert(!CommitInfo.dataChangeFromActions(Seq(cdc)))
+    assert(CommitInfo.dataChangeFromActions(Seq(cdc, addFile("a", dataChange = true))))
+  }
+
+  test("append records dataChange = true") {
+    withTempDir { dir =>
+      val path = dir.getCanonicalPath
+      spark.range(5).write.format(writeFormat).save(path)
+      assert(latestCommitInfoDataChange(path).contains(true))
+
+      spark.range(5, 10).write.format(writeFormat).mode("append").save(path)
+      assert(latestCommitInfoDataChange(path).contains(true))
+    }
+  }
+
+  test("DELETE records dataChange = true") {
+    withTempDir { dir =>
+      val path = dir.getCanonicalPath
+      spark.range(10).write.format(writeFormat).save(path)
+      sql(s"DELETE FROM $tableProvider.`$path` WHERE id < 5")
+      assert(latestCommitInfoDataChange(path).contains(true))
+    }
+  }
+
+  test("metadata-only commit records dataChange = false") {
+    withTempDir { dir =>
+      val path = dir.getCanonicalPath
+      spark.range(5).write.format(writeFormat).save(path)
+      sql(s"ALTER TABLE $tableProvider.`$path` SET TBLPROPERTIES ('someKey' = 'someValue')")
+      assert(latestCommitInfoDataChange(path).contains(false))
+    }
+  }
+
+  test("OPTIMIZE records dataChange = false") {
+    withTempDir { dir =>
+      val path = dir.getCanonicalPath
+      spark.range(5).repartition(1).write.format(writeFormat).save(path)
+      spark.range(5, 10).repartition(1).write.format(writeFormat).mode("append").save(path)
+      val deltaLog = DeltaLog.forTable(spark, path)
+      val versionBeforeOptimize = deltaLog.update().version
+
+      sql(s"OPTIMIZE $tableProvider.`$path`")
+
+      val optimizeVersion = deltaLog.update().version
+      assert(optimizeVersion > versionBeforeOptimize, "OPTIMIZE did not commit")
+      assert(commitInfoDataChangeAt(deltaLog, optimizeVersion).contains(false))
+    }
+  }
+
+  test("a rearrange-only commit records dataChange = false") {
+    withTempDir { dir =>
+      val path = dir.getCanonicalPath
+      spark.range(5).write.format(writeFormat).save(path)
+      val deltaLog = DeltaLog.forTable(spark, path)
+      val file = deltaLog.update().allFiles.head()
+
+      deltaLog.startTransaction().commit(
+        Seq(file.removeWithTimestamp(dataChange = false)),
+        DeltaOperations.ManualUpdate)
+
+      assert(commitInfoDataChangeAt(deltaLog, deltaLog.update().version).contains(false))
+    }
+  }
+
+  test("the dataChange write option records dataChange = false") {
+    withTempDir { dir =>
+      val path = dir.getCanonicalPath
+      spark.range(10).repartition(2).write.format(writeFormat).save(path)
+      val deltaLog = DeltaLog.forTable(spark, path)
+      val versionBeforeCompaction = deltaLog.update().version
+
+      // The option is read as `DeltaOptions.rearrangeOnly`, which makes `WriteIntoDelta` stamp
+      // `dataChange = !rearrangeOnly` on every file action it hands to `txn.commit`. The commit
+      // then derives the CommitInfo summary from those actions.
+      spark.read.format(writeFormat).load(path)
+        .repartition(1)
+        .write.format(writeFormat).mode("overwrite")
+        .option("dataChange", "false")
+        .save(path)
+
+      val compactionVersion = deltaLog.update().version
+      assert(compactionVersion > versionBeforeCompaction, "the compaction did not commit")
+      assert(commitInfoDataChangeAt(deltaLog, compactionVersion).contains(false))
+    }
+  }
+
+  test("an overwrite without the dataChange write option records dataChange = true") {
+    withTempDir { dir =>
+      val path = dir.getCanonicalPath
+      spark.range(10).write.format(writeFormat).save(path)
+      val deltaLog = DeltaLog.forTable(spark, path)
+      val versionBeforeOverwrite = deltaLog.update().version
+
+      spark.range(10, 20).write.format(writeFormat).mode("overwrite").save(path)
+
+      val overwriteVersion = deltaLog.update().version
+      assert(overwriteVersion > versionBeforeOverwrite, "the overwrite did not commit")
+      assert(commitInfoDataChangeAt(deltaLog, overwriteVersion).contains(true))
+    }
+  }
+
+  ///////////////////////////////////////////////////////////////////////////
+  // commitLarge
+  ///////////////////////////////////////////////////////////////////////////
+
+  test("CONVERT TO DELTA records dataChange = true") {
+    withTempPath { dir =>
+      val path = dir.getCanonicalPath
+      spark.range(5).write.format("parquet").save(path)
+      sql(s"CONVERT TO DELTA parquet.`$path`")
+      assert(latestCommitInfoDataChange(path).contains(true))
+    }
+  }
+
+
+  test("SHALLOW CLONE records dataChange = true") {
+    withTempDir { sourceDir =>
+      withTempDir { targetDir =>
+        val sourcePath = sourceDir.getCanonicalPath
+        val targetPath = targetDir.getCanonicalPath
+        spark.range(5).write.format(writeFormat).save(sourcePath)
+
+        sql(s"CREATE OR REPLACE TABLE $tableProvider.`$targetPath` " +
+          s"SHALLOW CLONE $tableProvider.`$sourcePath`")
+
+        assert(latestCommitInfoDataChange(targetPath).contains(true))
+      }
+    }
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/CommitSanityCheckSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CommitSanityCheckSuite.scala
@@ -75,7 +75,8 @@ class CommitSanityCheckSuite extends QueryTest
         newProtocolOpt = None,
         op = DeltaOperations.ManualUpdate,
         context = Map.empty,
-        metrics = Map.empty
+        metrics = Map.empty,
+        dataChange = Some(true)
       )
     } else {
       txn.commit(addFiles, DeltaOperations.ManualUpdate)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/InCommitTimestampSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/InCommitTimestampSuite.scala
@@ -189,7 +189,8 @@ class InCommitTimestampSuite
             newProtocolOpt = None,
             DeltaOperations.ManualUpdate,
             context = Map.empty,
-            metrics = Map.empty)
+            metrics = Map.empty,
+            dataChange = Some(true))
         } else {
           deltaLog.startTransaction().commit(
             Seq(createTestAddFile("1")),

--- a/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
@@ -1195,7 +1195,8 @@ class OptimisticTransactionSuite
               newProtocolOpt = None,
               op = DeltaOperations.Restore(Some(0), None),
               context = Map.empty,
-              metrics = Map.empty)
+              metrics = Map.empty,
+              dataChange = Some(true))
           }
           if (conflict) {
             assert(e.isInstanceOf[ConcurrentWriteException])
@@ -1830,7 +1831,8 @@ class OptimisticTransactionSuite
               newProtocolOpt = None,
               op = DeltaOperations.ManualUpdate,
               context = Map.empty,
-              metrics = Map.empty)
+              metrics = Map.empty,
+              dataChange = Some(true))
           } else {
             log.startTransaction().commit(mixedActions, ManualUpdate)
           }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsSuite.scala
@@ -1185,7 +1185,8 @@ abstract class CommitCoordinatorSuiteBase
         Some(newProtocol),
         DeltaOperations.TestOperation("TEST"),
         Map.empty,
-        Map.empty)
+        Map.empty,
+        dataChange = Some(false))
       log = DeltaLog.forTable(spark, tablePath)
       assert(cs.numRegisterTableCalled.get === 1)
       assert(cs.numCommitsCalled.get === 0)


### PR DESCRIPTION
## Description

The `dataChange` flag on `CommitInfo` summarizes whether a commit's file actions
change table data. Commits written through the normal `commit` path already record
it, but commits written through `commitLarge` left it absent.

`commitLarge` cannot derive the value the way the normal path does: its actions are a
single-pass iterator that is deliberately never materialized, and the `CommitInfo` is
serialized as the first action of the commit, before any file action has been seen.
This change adds a `dataChange: Option[Boolean]` parameter to `commitLarge` so callers
declare the value, and threads it through the existing callers:

- **`ConvertToDeltaCommand`** — declares whether the add iterator emits anything.
  `ConvertUtils.createAddFile` hardcodes `dataChange = true`, so the commit changes data
  exactly when it emits an add (not `numFiles`: stats collection can drop empty files, so
  a manifest of only empty files converts to nothing). The iterator is buffered and peeked
  so this forces at most the work the commit is about to do anyway.
- **`DeletionVectorsPreDowngradeCommand`** — `false`; the commit is only DV tombstones,
  built inline as `dataChange = false` removes.
- **`RestoreTableCommand`** — restored + removed file count > 0; every restored add and
  every remove is data-changing, and the metrics already counted them.
- **`CloneTableBase`** — `dataChangeInFileAction && fileActionCount > 0`; every file action
  of the clone is stamped with that one flag.

Callers that cannot tell pass `None`, and readers then fall back to inspecting the file
actions. Because the value is declared rather than derived, `commitLarge` now asserts it
against the file actions under `Utils.isTesting`.

The field remains a summary of the commit's own file actions, so it carries no information
a reader could not already derive by reading them, and it remains optional: readers that do
not know it ignore it, and readers that do must still fall back to the file actions when it
is absent.

## How was this patch tested?

Unit tests.

## Does this PR introduce _any_ user-facing changes?

No.
