### PR TITLE
[4.4][Spark] Block unsupported maintenance on catalog-managed tables

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/MetadataCleanup.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/MetadataCleanup.scala
@@ -66,7 +66,8 @@ trait MetadataCleanup extends DeltaLogging {
   override def doLogCleanup(
       snapshotToCleanup: Snapshot,
       catalogTableOpt: Option[CatalogTable]): Unit = {
-    if (enableExpiredLogCleanup(unsafeVolatileSnapshot.metadata)) {
+    if (enableExpiredLogCleanup(unsafeVolatileSnapshot.metadata) &&
+        !snapshotToCleanup.isCatalogOwned) {
       cleanUpExpiredLogs(snapshotToCleanup, catalogTableOpt)
     }
   }
@@ -77,6 +78,10 @@ trait MetadataCleanup extends DeltaLogging {
       catalogTableOpt: Option[CatalogTable] = None,
       deltaRetentionMillisOpt: Option[Long] = None,
       cutoffTruncationGranularity: TruncationGranularity = DAY): Unit = {
+    if (snapshotToCleanup.isCatalogOwned) {
+      throw DeltaErrors.operationBlockedOnCatalogManagedTable("METADATA_CLEANUP")
+    }
+
     recordDeltaOperation(this, "delta.log.cleanup") {
       val retentionMillis =
         deltaRetentionMillisOpt.getOrElse(deltaRetentionMillis(unsafeVolatileSnapshot.metadata))

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
@@ -158,6 +158,9 @@ case class WriteIntoDelta(
         clusterBySpecOpt
       }
     val rearrangeOnly = options.rearrangeOnly
+    if (rearrangeOnly && txn.snapshot.isCatalogOwned) {
+      throw DeltaErrors.operationBlockedOnCatalogManagedTable("DATA_REORGANIZATION")
+    }
     val charPadding = sparkSession.conf.get(SQLConf.READ_SIDE_CHAR_PADDING)
     val charAsVarchar = sparkSession.conf.get(SQLConf.CHAR_AS_VARCHAR)
     val dataSchema = if (!charAsVarchar && charPadding) {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/columnmapping/RemoveColumnMappingCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/columnmapping/RemoveColumnMappingCommand.scala
@@ -41,6 +41,10 @@ class RemoveColumnMappingCommand(
    */
   def run(spark: SparkSession, removeColumnMappingTableProperty: Boolean): Unit = {
     deltaLog.withNewTransaction(catalogOpt) { txn =>
+      if (txn.snapshot.isCatalogOwned) {
+        throw DeltaErrors.operationBlockedOnCatalogManagedTable("DATA_REORGANIZATION")
+      }
+
       val originalFiles = txn.filterFiles()
       val originalData = buildDataFrame(txn, originalFiles)
       val originalSchema = txn.snapshot.schema

--- a/spark/src/main/scala/org/apache/spark/sql/delta/hooks/AutoCompact.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/hooks/AutoCompact.scala
@@ -98,6 +98,8 @@ trait AutoCompactBase extends PostCommitHook with DeltaLogging {
   }
 
   override def run(spark: SparkSession, txn: CommittedTransaction): Unit = {
+    if (txn.postCommitSnapshot.isCatalogOwned) return
+
     val conf = spark.sessionState.conf
     val autoCompactTypeOpt = getAutoCompactType(conf, txn.postCommitSnapshot.metadata)
     // Skip Auto Compact if current transaction is not qualified or the table is not qualified

--- a/spark/src/test/scala/org/apache/spark/sql/delta/AutoCompactSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/AutoCompactSuite.scala
@@ -239,6 +239,24 @@ class AutoCompactExecutionSuite extends
     checkAutoCompactionWorks(dir, spark.range(10).toDF("id"))
   }
 
+  test("auto compact should not run for a catalog-managed table") {
+    withCatalogManagedTable() { tableName =>
+      val deltaLog = DeltaLog.forTable(spark, TableIdentifier(tableName))
+      val versionBeforeWrite = deltaLog.update().version
+
+      withSQLConf(
+          DeltaSQLConf.DELTA_AUTO_COMPACT_ENABLED.key -> "true",
+          DeltaSQLConf.DELTA_AUTO_COMPACT_MIN_NUM_FILES.key -> "0") {
+        spark.range(10).repartition(2).selectExpr("cast(id as int) AS id")
+          .write.mode("append").insertInto(tableName)
+      }
+
+      val snapshot = deltaLog.update()
+      assert(snapshot.version === versionBeforeWrite + 1)
+      assert(snapshot.numOfFiles === 2)
+    }
+  }
+
   test("variant auto compact kicks in when enabled - table config") {
     withTempDir { dir =>
       withSQLConf(
@@ -386,4 +404,3 @@ class AutoCompactExecutionNameColumnMappingSuite extends AutoCompactExecutionSui
   with DeltaColumnMappingEnableNameMode {
   override def runAllTests: Boolean = true
 }
-

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuite.scala
@@ -33,6 +33,7 @@ import org.apache.hadoop.fs.{FileStatus, FileSystem, Path, RawLocalFileSystem}
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.util.ManualClock
 
 // scalastyle:off: removeFile
@@ -53,6 +54,41 @@ class DeltaRetentionSuite extends QueryTest
       val log = DeltaLog.forTable(spark, new Path(tempDir.getCanonicalPath))
       startTxnWithManualLogCleanup(log).commit(Nil, testOp)
       assert(!log.enableExpiredLogCleanup())
+    }
+  }
+
+  test("metadata cleanup is blocked only for catalog-managed tables") {
+    withTempDir { tempDir =>
+      val log = DeltaLog.forTable(spark, new Path(tempDir.getCanonicalPath))
+      startTxnWithManualLogCleanup(log).commit(Nil, testOp)
+      log.cleanUpExpiredLogs(log.update())
+    }
+
+    withCatalogManagedTable() { tableName =>
+      val log = DeltaLog.forTable(spark, TableIdentifier(tableName))
+      checkError(
+        intercept[DeltaUnsupportedOperationException] {
+          log.cleanUpExpiredLogs(log.update())
+        },
+        "DELTA_UNSUPPORTED_CATALOG_MANAGED_TABLE_OPERATION",
+        parameters = Map("operation" -> "METADATA_CLEANUP")
+      )
+    }
+  }
+
+  test("checkpoint does not clean up catalog-managed table metadata") {
+    withCatalogManagedTable() { tableName =>
+      spark.sql(s"INSERT INTO $tableName VALUES (1)")
+      val log = DeltaLog.forTable(spark, TableIdentifier(tableName))
+      val snapshot = log.update()
+      val firstCommit = FileNames.unsafeDeltaFile(log.logPath, 0)
+      val fs = firstCommit.getFileSystem(log.newDeltaHadoopConf())
+      assert(fs.exists(firstCommit))
+      fs.setTimes(firstCommit, 0L, -1L)
+
+      log.checkpoint(snapshot)
+      assert(log.readLastCheckpointFile().exists(_.version == snapshot.version))
+      assert(fs.exists(firstCommit))
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
@@ -331,6 +331,23 @@ class DeltaSuite extends QueryTest
     }
   }
 
+  test("dataChange false is blocked for a catalog-managed table") {
+    withCatalogManagedTable() { tableName =>
+      checkError(
+        intercept[DeltaUnsupportedOperationException] {
+          spark.table(tableName)
+            .write
+            .format("delta")
+            .mode("overwrite")
+            .option("dataChange", "false")
+            .saveAsTable(tableName)
+        },
+        "DELTA_UNSUPPORTED_CATALOG_MANAGED_TABLE_OPERATION",
+        parameters = Map("operation" -> "DATA_REORGANIZATION")
+      )
+    }
+  }
+
   test("replaceWhere with rearrangeOnly") {
     withTempDir { dir =>
       Seq(1, 2, 3, 4).toDF()

--- a/spark/src/test/scala/org/apache/spark/sql/delta/columnmapping/RemoveColumnMappingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/columnmapping/RemoveColumnMappingSuite.scala
@@ -30,6 +30,27 @@ import org.apache.spark.sql.catalyst.TableIdentifier
  */
 class RemoveColumnMappingSuite extends RemoveColumnMappingSuiteUtils {
 
+  test("column mapping removal is blocked for a catalog-managed table") {
+    withCatalogManagedTable(createTable = false) { tableName =>
+      sql(
+        s"""CREATE TABLE $tableName (id INT)
+           |USING delta
+           |TBLPROPERTIES (
+           |  'delta.feature.catalogManaged' = 'supported',
+           |  '${DeltaConfigs.COLUMN_MAPPING_MODE.key}' = 'name')
+           |""".stripMargin)
+
+      checkError(
+        intercept[DeltaUnsupportedOperationException] {
+          sql(s"ALTER TABLE $tableName SET TBLPROPERTIES " +
+            s"('${DeltaConfigs.COLUMN_MAPPING_MODE.key}' = 'none')")
+        },
+        "DELTA_UNSUPPORTED_CATALOG_MANAGED_TABLE_OPERATION",
+        parameters = Map("operation" -> "DATA_REORGANIZATION")
+      )
+    }
+  }
+
   test("column mapping cannot be removed without the feature flag") {
     withSQLConf(ALLOW_COLUMN_MAPPING_REMOVAL.key -> "false") {
       sql(s"""CREATE TABLE $testTableName


### PR DESCRIPTION
Backport of #7525 to `branch-4.4`.

#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Catalog-managed tables must not run maintenance operations without catalog permission. This patch adds checks at these entry points:

- `MetadataCleanup.doLogCleanup`: Skip automatic expired-log cleanup after a checkpoint.
- `MetadataCleanup.cleanUpExpiredLogs`: Reject a direct metadata-cleanup call.
- `AutoCompact.run`: Skip automatic file compaction after a write.
- `WriteIntoDelta`: Reject rearrange-only writes, which use `dataChange=false`.
- `RemoveColumnMappingCommand.run`: Reject column-mapping removal because it rewrites data files.

Checkpoint creation and normal writes remain enabled. Tables that are not catalog-managed keep their current behavior.

## How was this patch tested?

These focused tests passed:

```text
build/sbt "spark/testOnly org.apache.spark.sql.delta.DeltaRetentionSuite -- -z catalog-managed"
build/sbt "spark/testOnly org.apache.spark.sql.delta.AutoCompactExecutionSuite -- -z catalog-managed"
build/sbt "spark/testOnly org.apache.spark.sql.delta.DeltaSuite org.apache.spark.sql.delta.columnmapping.RemoveColumnMappingSuite -- -z catalog-managed"
```

## Does this PR introduce _any_ user-facing changes?

Yes. Delta Spark no longer runs these unsupported maintenance operations on a catalog-managed table.