### PR TITLE
[Spark] Tag the V2 connector's UC user-agent with the Spark streaming workload

### DIFF
--- a/spark-unified/src/main/scala/io/delta/internal/ApplyV2ReadOptions.scala
+++ b/spark-unified/src/main/scala/io/delta/internal/ApplyV2ReadOptions.scala
@@ -19,6 +19,7 @@ package io.delta.internal
 import io.delta.spark.internal.v2.catalog.DeltaV2Table
 import io.delta.spark.internal.v2.read.MetadataEvolutionHandler
 import io.delta.spark.internal.v2.read.cdc.CDCSchemaContext
+import io.delta.spark.internal.v2.snapshot.WorkloadType
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
 
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
@@ -42,8 +43,12 @@ class ApplyV2ReadOptions extends Rule[LogicalPlan] {
       val merged = new java.util.HashMap[String, String]()
       merged.putAll(table.getOptions)
       merged.putAll(extraOptions.asCaseSensitiveMap())
+      // This rule only rewrites streaming relations, so the rebuilt table serves a streaming read.
+      // Tag the UC client accordingly on the catalog path; path-based tables issue no catalog
+      // requests, so there is no User-Agent to tag.
       val rebuilt = if (table.getCatalogTable.isPresent) {
-        new DeltaV2Table(table.getIdentifier, table.getCatalogTable.get, merged)
+        new DeltaV2Table(
+          table.getIdentifier, table.getCatalogTable.get, merged, WorkloadType.STREAMING)
       } else {
         new DeltaV2Table(table.getIdentifier, table.getTablePath.toString, merged)
       }

--- a/spark-unified/src/main/scala/io/delta/internal/ApplyV2Streaming.scala
+++ b/spark-unified/src/main/scala/io/delta/internal/ApplyV2Streaming.scala
@@ -20,6 +20,7 @@ import scala.jdk.CollectionConverters._
 import scala.jdk.OptionConverters._
 
 import io.delta.spark.internal.v2.catalog.DeltaV2Table
+import io.delta.spark.internal.v2.snapshot.WorkloadType
 import io.delta.spark.internal.v2.utils.ScalaUtils
 import org.apache.spark.sql.delta.DeltaV2Mode
 import org.apache.spark.sql.delta.sources.DeltaSourceUtils
@@ -84,7 +85,9 @@ class ApplyV2Streaming(
           catalogTable,
           // Use user-specified streaming options to override catalog storage properties.
           // DeltaV2Table handles merging catalogTable storage props internally.
-          ScalaUtils.toJavaMap(s.dataSource.options))
+          ScalaUtils.toJavaMap(s.dataSource.options),
+          // Tag the UC client's User-Agent so the catalog can tell this is a streaming read.
+          WorkloadType.STREAMING)
       val catalog = catalogTable.identifier.catalog.map(
         session.sessionState.catalogManager.catalog)
 

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
@@ -36,6 +36,7 @@ import io.delta.spark.internal.v2.read.MetadataEvolutionHandler;
 import io.delta.spark.internal.v2.read.cdc.CDCSchemaContext;
 import io.delta.spark.internal.v2.shims.CatalogV2UtilShims;
 import io.delta.spark.internal.v2.snapshot.SnapshotManagerFactory;
+import io.delta.spark.internal.v2.snapshot.WorkloadType;
 import io.delta.spark.internal.v2.utils.SchemaUtils;
 import io.delta.spark.internal.v2.write.DeltaRowLevelOperationBuilder;
 import io.delta.spark.internal.v2.write.DeltaV2WriteBuilder;
@@ -139,7 +140,13 @@ public class DeltaV2Table extends DeltaV2TableShims
    * @throws NullPointerException if identifier or tablePath is null
    */
   public DeltaV2Table(Identifier identifier, String tablePath) {
-    this(identifier, tablePath, Collections.emptyMap(), Optional.empty(), OptionalLong.empty());
+    this(
+        identifier,
+        tablePath,
+        Collections.emptyMap(),
+        Optional.empty(),
+        OptionalLong.empty(),
+        WorkloadType.BATCH);
   }
 
   /**
@@ -151,7 +158,8 @@ public class DeltaV2Table extends DeltaV2TableShims
    * @throws NullPointerException if identifier or tablePath is null
    */
   public DeltaV2Table(Identifier identifier, String tablePath, Map<String, String> options) {
-    this(identifier, tablePath, options, Optional.empty(), OptionalLong.empty());
+    this(
+        identifier, tablePath, options, Optional.empty(), OptionalLong.empty(), WorkloadType.BATCH);
   }
 
   /**
@@ -167,7 +175,7 @@ public class DeltaV2Table extends DeltaV2TableShims
       String tablePath,
       Map<String, String> options,
       OptionalLong timeTravelVersion) {
-    this(identifier, tablePath, options, Optional.empty(), timeTravelVersion);
+    this(identifier, tablePath, options, Optional.empty(), timeTravelVersion, WorkloadType.BATCH);
   }
 
   /**
@@ -202,7 +210,32 @@ public class DeltaV2Table extends DeltaV2TableShims
         getDecodedPath(requireNonNull(catalogTable, "catalogTable is null").location()),
         options,
         Optional.of(catalogTable),
-        timeTravelVersion);
+        timeTravelVersion,
+        WorkloadType.BATCH);
+  }
+
+  /**
+   * Catalog-table constructor that records the {@link WorkloadType} the table serves. Used by the
+   * streaming analyzer rules so the UC client built for a Structured Streaming read advertises the
+   * streaming workload in its User-Agent.
+   *
+   * @param identifier logical table identifier used by Spark's catalog
+   * @param catalogTable the Spark CatalogTable containing table metadata including location
+   * @param options user-provided options to override catalog properties
+   * @param workloadType the workload this table serves
+   */
+  public DeltaV2Table(
+      Identifier identifier,
+      CatalogTable catalogTable,
+      Map<String, String> options,
+      WorkloadType workloadType) {
+    this(
+        identifier,
+        getDecodedPath(requireNonNull(catalogTable, "catalogTable is null").location()),
+        options,
+        Optional.of(catalogTable),
+        OptionalLong.empty(),
+        workloadType);
   }
 
   /**
@@ -222,7 +255,8 @@ public class DeltaV2Table extends DeltaV2TableShims
       String tablePath,
       Map<String, String> userOptions,
       Optional<CatalogTable> catalogTable,
-      OptionalLong timeTravelVersion) {
+      OptionalLong timeTravelVersion,
+      WorkloadType workloadType) {
     this.identifier = requireNonNull(identifier, "identifier is null");
     this.tablePath = requireNonNull(tablePath, "tablePath is null");
     this.catalogTable = catalogTable;
@@ -247,7 +281,8 @@ public class DeltaV2Table extends DeltaV2TableShims
     this.hadoopConf =
         SparkSession.active().sessionState().newHadoopConfWithOptions(toScalaMap(options));
     this.kernelEngine = KernelEngineFactory.createDefaultEngine(this.hadoopConf);
-    this.snapshotManager = SnapshotManagerFactory.create(tablePath, kernelEngine, catalogTable);
+    this.snapshotManager =
+        SnapshotManagerFactory.create(tablePath, kernelEngine, catalogTable, workloadType);
     try {
       this.initialSnapshot =
           timeTravelVersion.isPresent()
@@ -553,12 +588,19 @@ public class DeltaV2Table extends DeltaV2TableShims
   @Override
   public WriteBuilder newWriteBuilder(LogicalWriteInfo info) {
     requireNonNull(info, "write info is null");
+    // The write path's snapshot manager is consumed only by the streaming write (which reloads the
+    // latest snapshot and commits through it per epoch); the batch write commits off
+    // initialSnapshot and never touches it. Tag it STREAMING so the streaming write's catalog
+    // requests are attributed to a streaming workload via the client User-Agent.
+    DeltaV2SnapshotManager streamingSnapshotManager =
+        SnapshotManagerFactory.create(
+            tablePath, kernelEngine, catalogTable, WorkloadType.STREAMING);
     return new DeltaV2WriteBuilder(
         kernelEngine,
         tablePath,
         hadoopConf,
         initialSnapshot,
-        snapshotManager,
+        streamingSnapshotManager,
         schemaProvider.getDataSchema(),
         schemaProvider.getPartitionSchema(),
         info);

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/snapshot/SnapshotManagerFactory.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/snapshot/SnapshotManagerFactory.java
@@ -48,7 +48,7 @@ public final class SnapshotManagerFactory {
   private SnapshotManagerFactory() {}
 
   /**
-   * Creates a snapshot manager for the given table.
+   * Creates a batch snapshot manager for the given table.
    *
    * @param tablePath the filesystem path to the Delta table
    * @param kernelEngine the pre-configured Kernel {@link Engine} to use for table operations
@@ -57,27 +57,61 @@ public final class SnapshotManagerFactory {
    */
   public static DeltaV2SnapshotManager create(
       String tablePath, Engine kernelEngine, Optional<CatalogTable> catalogTable) {
+    return create(tablePath, kernelEngine, catalogTable, WorkloadType.BATCH);
+  }
+
+  /**
+   * Creates a snapshot manager for the given table and workload.
+   *
+   * @param tablePath the filesystem path to the Delta table
+   * @param kernelEngine the pre-configured Kernel {@link Engine} to use for table operations
+   * @param catalogTable optional Spark catalog table metadata
+   * @param workloadType the workload the manager serves; for a UC-managed table it is advertised in
+   *     the catalog client's User-Agent (see {@link #connectorAppVersions})
+   * @return a {@link DeltaV2SnapshotManager} appropriate for the table type
+   */
+  public static DeltaV2SnapshotManager create(
+      String tablePath,
+      Engine kernelEngine,
+      Optional<CatalogTable> catalogTable,
+      WorkloadType workloadType) {
 
     if (catalogTable.isPresent()) {
       Optional<UCTableInfo> ucTableInfo =
           UCUtils.extractTableInfo(catalogTable.get(), SparkSession.active());
       if (ucTableInfo.isPresent()) {
-        return createUCManagedSnapshotManager(ucTableInfo.get(), kernelEngine);
+        return createUCManagedSnapshotManager(ucTableInfo.get(), kernelEngine, workloadType);
       }
       // Catalog table without UC metadata falls back to path-based handling.
     }
 
-    // Default: path-based snapshot manager for non-UC tables
+    // Default: path-based snapshot manager for non-UC tables. Path-based tables issue no catalog
+    // requests, so there is no User-Agent to tag and the workload type is not threaded here.
     return new PathBasedSnapshotManager(tablePath, kernelEngine);
   }
 
   private static UCManagedTableSnapshotManager createUCManagedSnapshotManager(
-      UCTableInfo tableInfo, Engine kernelEngine) {
+      UCTableInfo tableInfo, Engine kernelEngine, WorkloadType workloadType) {
     Map<String, String> ucConfig = new HashMap<>(tableInfo.toUcConfig());
-    ucConfig.put("appVersions.Kernel", Meta.KERNEL_VERSION);
-    ucConfig.put("appVersions.Delta V2 connector", "true");
+    ucConfig.putAll(connectorAppVersions(workloadType));
     UCClient ucClient = UCTokenBasedRestClientFactory$.MODULE$.createUCClient(ucConfig);
     UCCatalogManagedClient ucCatalogClient = new UCCatalogManagedClient(ucClient);
     return new UCManagedTableSnapshotManager(ucCatalogClient, tableInfo, kernelEngine);
+  }
+
+  /**
+   * The {@code appVersions.*} entries the V2 connector contributes to the UC client's User-Agent.
+   * Always advertises the Kernel version and the V2 connector marker; for a streaming workload it
+   * also adds a {@code Streaming} marker so the catalog can tell a Structured Streaming read/write
+   * apart from a batch one. Package-private for testing.
+   */
+  static Map<String, String> connectorAppVersions(WorkloadType workloadType) {
+    Map<String, String> appVersions = new HashMap<>();
+    appVersions.put("appVersions.Kernel", Meta.KERNEL_VERSION);
+    appVersions.put("appVersions.Delta V2 connector", "true");
+    if (workloadType == WorkloadType.STREAMING) {
+      appVersions.put("appVersions.Streaming", "true");
+    }
+    return appVersions;
   }
 }

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/snapshot/WorkloadType.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/snapshot/WorkloadType.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.snapshot;
+
+/**
+ * The kind of Spark workload a snapshot manager (and, for catalog-managed tables, the Unity Catalog
+ * client it builds) serves. It is threaded into {@link SnapshotManagerFactory} so the catalog
+ * client can advertise the workload in its User-Agent, letting the catalog distinguish a Structured
+ * Streaming read/write from a batch one.
+ */
+public enum WorkloadType {
+  /** A batch read or write. */
+  BATCH,
+  /** A Structured Streaming micro-batch read or write. */
+  STREAMING
+}

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/snapshot/SnapshotManagerFactoryTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/snapshot/SnapshotManagerFactoryTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.snapshot;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import io.delta.kernel.Meta;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link SnapshotManagerFactory}. */
+public class SnapshotManagerFactoryTest {
+
+  @Test
+  public void connectorAppVersions_batch_advertisesKernelAndConnectorOnly() {
+    Map<String, String> appVersions =
+        SnapshotManagerFactory.connectorAppVersions(WorkloadType.BATCH);
+
+    assertEquals(Meta.KERNEL_VERSION, appVersions.get("appVersions.Kernel"));
+    assertEquals("true", appVersions.get("appVersions.Delta V2 connector"));
+    // A batch workload carries no streaming marker.
+    assertFalse(appVersions.containsKey("appVersions.Streaming"));
+  }
+
+  @Test
+  public void connectorAppVersions_streaming_addsStreamingMarker() {
+    Map<String, String> appVersions =
+        SnapshotManagerFactory.connectorAppVersions(WorkloadType.STREAMING);
+
+    assertEquals(Meta.KERNEL_VERSION, appVersions.get("appVersions.Kernel"));
+    assertEquals("true", appVersions.get("appVersions.Delta V2 connector"));
+    assertEquals("true", appVersions.get("appVersions.Streaming"));
+  }
+}

--- a/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCConfigUtilsSuite.scala
+++ b/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCConfigUtilsSuite.scala
@@ -73,8 +73,10 @@ class UCConfigUtilsSuite extends AnyFunSuite {
     val versions = UCConfigUtils.extractAppVersions(config(
       "uri" -> "https://uc.example.com",
       "appVersions.Kernel" -> "0.7.0",
-      "appVersions.Delta V2 connector" -> "true"))
-    assert(versions.asScala === Map("Kernel" -> "0.7.0", "Delta V2 connector" -> "true"))
+      "appVersions.Delta V2 connector" -> "true",
+      "appVersions.Streaming" -> "true"))
+    assert(versions.asScala === Map(
+      "Kernel" -> "0.7.0", "Delta V2 connector" -> "true", "Streaming" -> "true"))
   }
 
   test("isDeltaRestApiEnabled defaults to true and honors explicit values") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Here are some tips for you:
 1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
 2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
 3. Be sure to keep the PR description updated to reflect all changes.
 4. Please write your PR title to summarize what this PR proposes.
 5. If possible, provide a concise example to reproduce the issue for a faster review.
 6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

The Kernel-based Delta V2 connector talks to Unity Catalog (UC) through a REST client whose `User-Agent` already advertises a `Delta V2 connector/true` token (assembled in `SnapshotManagerFactory` and rendered by the UC Java client). Today there is no signal in that request to tell whether an external read/write originated from a Structured Streaming workload or a batch one, so streaming usage cannot be attributed from the catalog side.

This PR threads a `WorkloadType` (`BATCH`/`STREAMING`) into `SnapshotManagerFactory.create`. For a UC-managed table, a streaming workload contributes an additional `Streaming/true` token to the client `User-Agent`:

- **Reads**: the streaming analyzer rules `ApplyV2Streaming` and `ApplyV2ReadOptions` construct the `DeltaV2Table` with `WorkloadType.STREAMING`, so the table's snapshot manager — the one the micro-batch stream uses for offset/snapshot resolution — is tagged streaming.
- **Writes**: `DeltaV2Table.newWriteBuilder` builds the write path's snapshot manager as `STREAMING`. That manager is consumed **only** by the streaming write (per-epoch snapshot reload + commit); the batch write commits off `initialSnapshot` and never touches it, so batch writes are never mis-tagged.

Batch tables and path-based tables are unchanged. Path-based tables issue no catalog requests, so there is no `User-Agent` to tag, and the workload type is intentionally not threaded on that path.

Example resulting `User-Agent` for a streaming read/write:

```
UnityCatalog-Java-Client/... Java/... Scala/... Delta V2 connector/true Streaming/true Kernel/... Delta/... Spark/...
```

## How was this patch tested?

- New `SnapshotManagerFactoryTest` asserts `connectorAppVersions` advertises the Kernel + connector markers for `BATCH` and additionally emits `Streaming/true` for `STREAMING`.
- Extended `UCConfigUtilsSuite.extractAppVersions` to confirm a `Streaming` app-version entry flows through the config → `appVersions` extraction that feeds the `User-Agent`.
- Existing `ApplyV2StreamingSuite` and `ApplyV2ReadOptionsSuite` (18 tests) pass, covering the streaming read rules that now tag the table.
- `sparkV2` (main + test), `spark` (spark-unified main) and `storage` (test) compile cleanly; `javafmtCheck`, checkstyle and scalastyle pass.

## Does this PR introduce _any_ user-facing changes?

Yes, but only to the outbound `User-Agent` header the V2 connector sends to Unity Catalog: a Structured Streaming read/write now includes an additional `Streaming/true` token. There is no change to APIs, configs, SQL, or on-disk behavior. Batch workloads are unaffected.