### PR TITLE
[Spark] Add sort_order_id, key_metadata, split_offsets to AMTPassthrough

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/actions.scala
@@ -25,6 +25,8 @@ import org.apache.spark.sql.delta.actions.{Action, AddFile, DeletionVectorDescri
 import org.apache.spark.sql.delta.stats.DeltaStatistics
 import org.apache.spark.sql.delta.storage.dv.DeletionVectorStore
 import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.{DeserializationContext, JsonDeserializer}
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import org.apache.hadoop.fs.{FileStatus, Path}
 
@@ -486,8 +488,19 @@ object DataEntry {
       deletion_vector =
         Option(add.deletionVector).map(DeletionVector.fromDescriptor(_, tableRoot)),
       spec_id = passthrough.flatMap(_.spec_id),
+      sort_order_id = passthrough.flatMap(_.sort_order_id),
+      key_metadata = passthrough.flatMap(_.key_metadata),
+      split_offsets = passthrough.flatMap(_.split_offsets),
       content_stats = None)
   }
+}
+
+/**
+ * Deserializes split_offsets from commit-log JSON as a Seq[Long].
+ */
+private[amt] class AMTSplitOffsetsDeserializer extends JsonDeserializer[Seq[Long]] {
+  override def deserialize(p: JsonParser, ctxt: DeserializationContext): Seq[Long] =
+    p.readValueAs(classOf[Array[Long]]).toSeq
 }
 
 /**
@@ -495,7 +508,32 @@ object DataEntry {
  */
 case class AMTPassthrough(
     @JsonDeserialize(contentAs = classOf[java.lang.Integer])
-    spec_id: Option[Int] = None)
+    spec_id: Option[Int] = None,
+    @JsonDeserialize(contentAs = classOf[java.lang.Integer])
+    sort_order_id: Option[Int] = None,
+    key_metadata: Option[Array[Byte]] = None,
+    @JsonDeserialize(contentUsing = classOf[AMTSplitOffsetsDeserializer])
+    split_offsets: Option[Seq[Long]] = None) {
+
+  // override equals and hashCode to compare by content for some fields.
+  override def equals(obj: Any): Boolean = obj match {
+    case that: AMTPassthrough =>
+      spec_id == that.spec_id &&
+        sort_order_id == that.sort_order_id &&
+        split_offsets == that.split_offsets &&
+        ((key_metadata, that.key_metadata) match {
+          case (Some(a), Some(b)) => java.util.Arrays.equals(a, b)
+          case (None, None) => true
+          case _ => false
+        })
+    case _ => false
+  }
+
+  override def hashCode(): Int = {
+    val keyMetadataHash = key_metadata.map(b => java.util.Arrays.hashCode(b)).getOrElse(0)
+    (spec_id, sort_order_id, keyMetadataHash, split_offsets).hashCode()
+  }
+}
 
 object AMTPassthrough {
   /** Name of the `amtPassthrough` field on the AddFile schema. */
@@ -508,7 +546,13 @@ object AMTPassthrough {
   /**
    * Positions of the `amtPassthrough` struct within an [[InternalRow]].
    */
-  case class RowIndices(structIndex: Int, numFields: Int, specId: Int)
+  case class RowIndices(
+      structIndex: Int,
+      numFields: Int,
+      specId: Int,
+      sortOrderId: Int,
+      keyMetadata: Int,
+      splitOffsets: Int)
 
   object RowIndices {
     /**
@@ -521,7 +565,10 @@ object AMTPassthrough {
         RowIndices(
           structIndex = structIndex,
           numFields = passthroughSchema.fields.length,
-          specId = passthroughSchema.fieldIndex("spec_id"))
+          specId = passthroughSchema.fieldIndex("spec_id"),
+          sortOrderId = passthroughSchema.fieldIndex("sort_order_id"),
+          keyMetadata = passthroughSchema.fieldIndex("key_metadata"),
+          splitOffsets = passthroughSchema.fieldIndex("split_offsets"))
       }
   }
 
@@ -536,7 +583,16 @@ object AMTPassthrough {
       val struct = row.getStruct(indices.structIndex, indices.numFields)
       Some(AMTPassthrough(
         spec_id =
-          if (struct.isNullAt(indices.specId)) None else Some(struct.getInt(indices.specId))))
+          if (struct.isNullAt(indices.specId)) None else Some(struct.getInt(indices.specId)),
+        sort_order_id =
+          if (struct.isNullAt(indices.sortOrderId)) None
+          else Some(struct.getInt(indices.sortOrderId)),
+        key_metadata =
+          if (struct.isNullAt(indices.keyMetadata)) None
+          else Some(struct.getBinary(indices.keyMetadata)),
+        split_offsets =
+          if (struct.isNullAt(indices.splitOffsets)) None
+          else Some(struct.getArray(indices.splitOffsets).toLongArray().toSeq)))
     }
   }
 
@@ -550,7 +606,11 @@ object AMTPassthrough {
         entry.format_version == AMTSingleAction.FormatVersionV4,
       s"amtPassthrough only supports parquet/v4. got " +
         s"${entry.file_format}/${entry.format_version}.")
-    val passthrough = AMTPassthrough(spec_id = entry.spec_id)
+    val passthrough = AMTPassthrough(
+      spec_id = entry.spec_id,
+      sort_order_id = entry.sort_order_id,
+      key_metadata = entry.key_metadata,
+      split_offsets = entry.split_offsets)
     if (passthrough == AMTPassthrough()) None else Some(passthrough)
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSingleActionSerializerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSingleActionSerializerSuite.scala
@@ -24,6 +24,7 @@ import org.apache.hadoop.fs.Path
 
 import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
+import org.apache.spark.sql.catalyst.util.GenericArrayData
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{StringType, StructField, StructType}
 
@@ -357,14 +358,17 @@ class AMTSingleActionSerializerSuite extends QueryTest with SharedSparkSession {
     assert(ex.getMessage.contains("missing an offset"))
   }
 
-  /** A DATA entry carrying the AMT-native `spec_id` that has no Delta equivalent. */
+  /** A DATA entry carrying the AMT-native fields that have no Delta equivalent. */
   private def entryWithPassthrough: DataEntry = DataEntry(
     location = "f.parquet",
     file_format = AMTSingleAction.FileFormatParquet,
     tracking = addedTracking,
     record_count = 10L,
     file_size_in_bytes = 100L,
-    spec_id = Some(7))
+    spec_id = Some(7),
+    sort_order_id = Some(3),
+    key_metadata = Some(Array[Byte](4, 5, 6)),
+    split_offsets = Some(Seq(0L, 64L, 128L)))
 
   test("toAddFile carries no passthrough for the default parquet/v4 entry") {
     val add = DataEntry(
@@ -378,6 +382,9 @@ class AMTSingleActionSerializerSuite extends QueryTest with SharedSparkSession {
     assert(add.amtPassthrough.isDefined, "a genuine passthrough must be carried")
     val restored = DataEntry.fromAddFile(add, addedTracking, tableRoot)
     assert(restored.spec_id.contains(7))
+    assert(restored.sort_order_id.contains(3))
+    assert(restored.key_metadata.exists(_.sameElements(Array[Byte](4, 5, 6))))
+    assert(restored.split_offsets.contains(Seq(0L, 64L, 128L)))
     // file_format / format_version are not carried; they are reconstructed at the M1 defaults.
     assert(restored.file_format == AMTSingleAction.FileFormatParquet)
     assert(restored.format_version == AMTSingleAction.FormatVersionV4)
@@ -395,14 +402,20 @@ class AMTSingleActionSerializerSuite extends QueryTest with SharedSparkSession {
     assert(add.amtPassthrough.isDefined)
     val json = add.json
     assert(json.contains("amtPassthrough"), s"amtPassthrough must be serialized; got $json")
-    assert(json.contains("spec_id"), s"spec_id must be serialized; got $json")
+    Seq("spec_id", "sort_order_id", "key_metadata", "split_offsets").foreach { f =>
+      assert(json.contains(f), s"$f must be serialized; got $json")
+    }
 
     val roundTripped = Action.fromJson(json) match {
       case a: AddFile => a
       case other => fail(s"expected an AddFile, got $other")
     }
     assert(roundTripped.amtPassthrough == add.amtPassthrough)
-    assert(roundTripped.amtPassthrough.flatMap(_.spec_id).contains(7))
+    val passthrough = roundTripped.amtPassthrough.getOrElse(fail("passthrough must round-trip"))
+    assert(passthrough.spec_id.contains(7))
+    assert(passthrough.sort_order_id.contains(3))
+    assert(passthrough.key_metadata.exists(_.sameElements(Array[Byte](4, 5, 6))))
+    assert(passthrough.split_offsets.contains(Seq(0L, 64L, 128L)))
   }
 
   test("an AddFile with no amtPassthrough keeps it out of the commit JSON") {
@@ -427,17 +440,31 @@ class AMTSingleActionSerializerSuite extends QueryTest with SharedSparkSession {
     assert(reconstructed.length == 1)
     // The passthrough survives replay and is still usable end-to-end.
     assert(reconstructed.head.amtPassthrough == passthrough)
-    assert(DataEntry.fromAddFile(reconstructed.head, addedTracking, tableRoot).spec_id.contains(7))
+    val restored = DataEntry.fromAddFile(reconstructed.head, addedTracking, tableRoot)
+    assert(restored.spec_id.contains(7))
+    assert(restored.sort_order_id.contains(3))
+    assert(restored.key_metadata.exists(_.sameElements(Array[Byte](4, 5, 6))))
+    assert(restored.split_offsets.contains(Seq(0L, 64L, 128L)))
   }
 
   test("amtPassthrough participates in AddFile equality") {
     val base = sampleAddFile
-    val withA = base.copy(amtPassthrough = Some(AMTPassthrough(spec_id = Some(7))))
-    val withB = base.copy(amtPassthrough = Some(AMTPassthrough(spec_id = Some(7))))
+    // Distinct `key_metadata` array instances with identical content.
+    def createAddFile(specId: Int, keyMetadata: Array[Byte]): AddFile = base.copy(
+      amtPassthrough =
+        Some(AMTPassthrough(spec_id = Some(specId), key_metadata = Some(keyMetadata))))
+    val withA = createAddFile(7, Array[Byte](1, 2, 3))
+    val withB = createAddFile(7, Array[Byte](1, 2, 3))
     assert(withA == withB && withA.hashCode == withB.hashCode,
       "equal-content passthrough must compare equal")
-    val withC = base.copy(amtPassthrough = Some(AMTPassthrough(spec_id = Some(9))))
-    assert(withA != withC, "different passthrough content must compare unequal")
+    assert(
+      withA != createAddFile(9, Array[Byte](1, 2, 3)),
+      "different spec_id must compare unequal"
+    )
+    assert(
+      withA != createAddFile(7, Array[Byte](1, 2, 4)),
+      "different key_metadata must compare unequal"
+    )
     // Present vs absent -> unequal.
     assert(withA != base && base != withA)
   }
@@ -454,18 +481,41 @@ class AMTSingleActionSerializerSuite extends QueryTest with SharedSparkSession {
     assert(addSchema.fieldNames(indices.structIndex) == AMTPassthrough.FIELD_NAME)
     assert(indices.numFields == AMTPassthrough.STRUCT_TYPE.fields.length)
 
-    // A row carrying spec_id -> read back; a row with a null struct -> None.
-    val withPassthrough = new GenericInternalRow(addSchema.fields.length)
-    withPassthrough.update(indices.structIndex, new GenericInternalRow(Array[Any](7)))
-    assert(AMTPassthrough.fromRow(withPassthrough, indices)
-      .contains(AMTPassthrough(spec_id = Some(7))))
+    def structRow(
+        specId: Any = null,
+        sortOrderId: Any = null,
+        keyMetadata: Any = null,
+        splitOffsets: Any = null): GenericInternalRow = {
+      val fields = new Array[Any](indices.numFields)
+      fields(indices.specId) = specId
+      fields(indices.sortOrderId) = sortOrderId
+      fields(indices.keyMetadata) = keyMetadata
+      fields(indices.splitOffsets) = splitOffsets
+      new GenericInternalRow(fields)
+    }
+    def rowWith(struct: GenericInternalRow): GenericInternalRow = {
+      val row = new GenericInternalRow(addSchema.fields.length)
+      row.update(indices.structIndex, struct)
+      row
+    }
 
+    // A row carrying every field -> read back structurally.
+    val full = rowWith(structRow(
+      specId = 7,
+      sortOrderId = 3,
+      keyMetadata = Array[Byte](4, 5, 6),
+      splitOffsets = new GenericArrayData(Array[Long](0L, 64L, 128L))))
+    assert(AMTPassthrough.fromRow(full, indices).contains(AMTPassthrough(
+      spec_id = Some(7),
+      sort_order_id = Some(3),
+      key_metadata = Some(Array[Byte](4, 5, 6)),
+      split_offsets = Some(Seq(0L, 64L, 128L)))))
+
+    // A null struct -> None.
     val withoutPassthrough = new GenericInternalRow(addSchema.fields.length)
     assert(AMTPassthrough.fromRow(withoutPassthrough, indices).isEmpty)
 
-    // A present struct whose own field is null -> present, but with no spec_id.
-    val nullSpecId = new GenericInternalRow(addSchema.fields.length)
-    nullSpecId.update(indices.structIndex, new GenericInternalRow(Array[Any](null)))
-    assert(AMTPassthrough.fromRow(nullSpecId, indices).contains(AMTPassthrough(spec_id = None)))
+    // A present struct whose fields are all null -> present but empty.
+    assert(AMTPassthrough.fromRow(rowWith(structRow()), indices).contains(AMTPassthrough()))
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotSuite.scala
@@ -353,7 +353,11 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
   /**
    * A passthrough with every [[AMTPassthrough]] field set, so tests use the whole carrier.
    */
-  private def fullPassthrough: AMTPassthrough = AMTPassthrough(spec_id = Some(42))
+  private def fullPassthrough: AMTPassthrough = AMTPassthrough(
+    spec_id = Some(42),
+    sort_order_id = Some(7),
+    key_metadata = Some(Array[Byte](1, 2, 3)),
+    split_offsets = Some(Seq(0L, 128L, 256L)))
 
   /**
    * The AMT-derived live [[AddFile]]s in the snapshot's current tree, optionally restricted to


### PR DESCRIPTION
## Description

This PR extends `AMTPassthrough` -- the carrier for AMT-native fields on `AddFile`
that have no Delta equivalent -- with three additional fields:

- `sort_order_id: Option[Int]`
- `key_metadata: Option[Array[Byte]]`
- `split_offsets: Option[Seq[Long]]`

These fields are threaded through the full round-trip: `DataEntry` <-> `AMTPassthrough`
conversion, commit-log JSON serialization/deserialization (including a small custom
deserializer for `split_offsets`), and `InternalRow` read-back via `RowIndices`.
`equals`/`hashCode` are overridden so that `key_metadata` (a byte array) is compared by
content.

## How was this patch tested?

Updated unit tests in `AMTSingleActionSerializerSuite` and `AMTSnapshotSuite` to cover
the new fields across JSON round-trip, `AddFile` equality, and `InternalRow` read-back.

## Does this PR introduce _any_ user-facing changes?

No.
