### PR TITLE
Add required version field to ContentRoot

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
@@ -528,7 +528,10 @@ trait Checkpoints extends DeltaLogging {
     } finally {
       actions.close()
     }
+    // It reads an inline (non-standalone) Checkpoint from a manifest commit,
+    // so both Checkpoint.version and ContentRoot.version must match the CRC pointer.
     assert(checkpoint.version == contentRootVersion)
+    assert(checkpoint.contentRoot.version == contentRootVersion)
     checkpoint
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -1696,11 +1696,16 @@ sealed trait CheckpointOnlyAction extends Action
  *
  * @param path        root manifest path, relative to the table root.
  * @param sizeInBytes size of the root manifest file in bytes.
+ * @param version     table version this root reflects. Must be `<=` the enclosing
+ *                    [[Checkpoint.version]]; equal in a manifest commit, and less
+ *                    or equal in a standalone checkpoint (the gap is covered by
+ *                    inline file actions).
  * @param tags        additional metadata about the AMT. See [[ContentRoot.Tags]] for known keys.
  */
 case class ContentRoot(
     path: String,
     sizeInBytes: Long,
+    version: Long,
     tags: Map[String, String] = null) {
 
   private def tag(key: ContentRoot.Tags.KeyType): Option[String] =
@@ -1740,12 +1745,14 @@ object ContentRoot {
   def apply(
       path: String,
       sizeInBytes: Long,
+      version: Long,
       isIncremental: Boolean,
       lastManifestCommitWithFullRewrite: Long,
       numLeaves: Long): ContentRoot = {
     ContentRoot(
       path = path,
       sizeInBytes = sizeInBytes,
+      version = version,
       tags = Map(
         Tags.IS_INCREMENTAL.name -> isIncremental.toString,
         Tags.LAST_MANIFEST_COMMIT_WITH_FULL_REWRITE.name ->
@@ -1806,7 +1813,8 @@ object SidecarType {
  *
  * @param version        version at which this checkpoint is valid. May belong to a previous
  *                       commit (the checkpoint can lag the enclosing commit).
- * @param contentRoot    pointer to the Iceberg v4 root manifest.
+ * @param contentRoot    pointer to the Iceberg v4 root manifest. `contentRoot.version` is
+ *                       the table version the tree reflects.
  * @param protocol       protocol snapshot at `version`. Must be non null.
  * @param metaData       metadata snapshot at `version`. Must be non null.
  * @param domainMetadata all [[DomainMetadata]] entries carried inline. An empty list means
@@ -1831,6 +1839,9 @@ case class Checkpoint(
   // AMT checkpoint sidecars must always declare their type.
   require(sidecars.forall(_.sidecarType.isDefined),
     "All sidecars in a Checkpoint must have a sidecarType.")
+  require(
+    contentRoot.version <= version,
+    s"contentRoot.version (${contentRoot.version}) must be <= checkpoint version ($version).")
 
   override def wrap: SingleAction = SingleAction(checkpoint = this)
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTUtils.scala
@@ -144,7 +144,7 @@ object AMTUtils {
         commitInfo = currentTransactionInfo.commitInfo.map(_.copy(
           lastManifestCommit = Some(LastManifestCommit(
             version = winningCommitSummary.commitVersion,
-            contentRootVersion = winningAMTCheckpoint.version))))
+            contentRootVersion = winningAMTCheckpoint.contentRoot.version))))
       )
     }.getOrElse(currentTransactionInfo)
     // Clear `currentCommitAttemptAMTCheckpointOpt` because it is stale once we rebase.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriteHelper.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriteHelper.scala
@@ -59,16 +59,17 @@ object AMTWriteHelper extends DeltaLogging {
     val hadoopConf = deltaLog.newDeltaHadoopConf()
     val entriesPerLeaf = spark.sessionState.conf.getConf(DeltaSQLConf.AMT_ENTRIES_PER_LEAF)
 
+    // A full rewrite of the read snapshot's live files; it carries no commit actions, so the tree
+    // describes the read snapshot's version.
+    val contentStateVersion = readSnapshot.version
     val (contentRootBase, leaves) = writeClusteredManifestTree(
       spark = spark,
       deltaLog = deltaLog,
       readSnapshot = readSnapshot,
       hadoopConf = hadoopConf,
       metadata = readSnapshot.metadata,
-      entriesPerLeaf = entriesPerLeaf)
-    // A full rewrite of the read snapshot's live files; it carries no commit actions, so the tree
-    // describes the read snapshot's version.
-    val contentStateVersion = readSnapshot.version
+      entriesPerLeaf = entriesPerLeaf,
+      contentStateVersion = contentStateVersion)
     val contentRoot = policyTaggedContentRoot(
       readSnapshot, contentRootBase, incremental = false, contentStateVersion,
       numLeaves = leaves.size.toLong)
@@ -105,6 +106,7 @@ object AMTWriteHelper extends DeltaLogging {
     ContentRoot(
       path = contentRootBase.path,
       sizeInBytes = contentRootBase.sizeInBytes,
+      version = contentStateVersion,
       isIncremental = incremental,
       lastManifestCommitWithFullRewrite = lastFullRewriteVersion,
       numLeaves = numLeaves)
@@ -167,7 +169,8 @@ object AMTWriteHelper extends DeltaLogging {
       readSnapshot: Snapshot,
       hadoopConf: Configuration,
       metadata: Metadata,
-      entriesPerLeaf: Int): (ContentRoot, Seq[DataManifestEntry]) = {
+      entriesPerLeaf: Int,
+      contentStateVersion: Long): (ContentRoot, Seq[DataManifestEntry]) = {
     require(entriesPerLeaf > 0, "entriesPerLeaf must be positive.")
     val tableRoot = deltaLog.dataPath
     val fs = tableRoot.getFileSystem(hadoopConf)
@@ -191,11 +194,15 @@ object AMTWriteHelper extends DeltaLogging {
       case Seq(onlyLeaf) =>
         // If there is only one leaf, promote it to the root.
         val contentRoot =
-          ContentRoot(path = onlyLeaf.location, sizeInBytes = onlyLeaf.file_size_in_bytes)
+          ContentRoot(
+            path = onlyLeaf.location,
+            sizeInBytes = onlyLeaf.file_size_in_bytes,
+            version = contentStateVersion)
         (contentRoot, Seq.empty)
       case _ =>
         val contentRoot = writeRoot(
-          spark, fs, hadoopConf, tableRoot, metadataDir, metadata, leafEntries.map(_.wrap))
+          spark, fs, hadoopConf, tableRoot, metadataDir, metadata, leafEntries.map(_.wrap),
+          version = contentStateVersion)
         (contentRoot, leafEntries)
     }
   }
@@ -471,8 +478,10 @@ object AMTWriteHelper extends DeltaLogging {
   }
 
   /**
-   * Writes the root parquet file from a pre-built row set and returns the ContentRoot. The rows may
-   * be `DATA_MANIFEST` leaf pointers, root-resident `DATA` entries, or both.
+   * Writes the root parquet file from a pre-built row set and returns a [[ContentRoot]]
+   * carrying its path, size, and version. The rows may be `DATA_MANIFEST` leaf pointers,
+   * root-resident `DATA` entries, or both. Callers still attach tags before embedding it in a
+   * [[Checkpoint]].
    */
   private[amt] def writeRoot(
       spark: SparkSession,
@@ -481,13 +490,15 @@ object AMTWriteHelper extends DeltaLogging {
       tableRoot: Path,
       metadataDir: Path,
       metadata: Metadata,
-      rows: Seq[AMTSingleAction]): ContentRoot = {
+      rows: Seq[AMTSingleAction],
+      version: Long): ContentRoot = {
     val rootFile = FileNames.newAMTRootManifestFile(metadataDir)
     writeAMTParquet(spark, hadoopConf, rootFile, metadata, rows)
     val status = fs.getFileStatus(rootFile)
     ContentRoot(
       path = AMTUtils.relativizeManifestPathToTableRoot(fs, tableRoot, rootFile),
-      sizeInBytes = status.getLen)
+      sizeInBytes = status.getLen,
+      version = version)
   }
 
   // Returns a copy of a carried-forward leaf's ManifestInfo with `mdv` recorded as its Manifest

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriterManager.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriterManager.scala
@@ -182,7 +182,7 @@ class AMTWriterManager(
     }
     val (result, singleMetric) =
       if (incremental && amtProviderOpt.isDefined) {
-        val oldAMTVersion = amtProviderOpt.get.checkpointAction.version
+        val oldAMTVersion = amtProviderOpt.get.checkpointAction.contentRoot.version
         // The commits written after the old AMT, up to the last committed version.
         val intermediateLogCommits = preCommitLogSegment.deltas
           .filter(f => FileNames.getFileVersion(f) > oldAMTVersion)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/IncrementalAMTWriter.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/IncrementalAMTWriter.scala
@@ -192,20 +192,22 @@ class IncrementalAMTWriter(spark: SparkSession, deltaLog: DeltaLog) {
       allLeafPointers.map(_.wrap) ++
         rootLiveEntries.map(_.wrap) ++
         rootRemoveEntries.map(_.wrap)
-    val contentRootBase = AMTWriteHelper.writeRoot(
-      spark, fs, hadoopConf, tableRoot, metadataDir, processedActions.postCommitMetadata, rootRows)
-
-    // ---- Step 6: generate the Checkpoint action. ----
     // The version the tree describes: an inline commit describes itself; a deferred OPTIMIZE
     // CHECKPOINT (no user actions) describes the last committed version (attemptVersion - 1).
     val contentStateVersion =
       if (actionsToCommit.isEmpty) attemptVersion - 1 else attemptVersion
+    val contentRootBase = AMTWriteHelper.writeRoot(
+      spark, fs, hadoopConf, tableRoot, metadataDir, processedActions.postCommitMetadata, rootRows,
+      version = contentStateVersion)
+
+    // ---- Step 6: generate the Checkpoint action. ----
     // An incremental rewrite carries forward the previous tree's last-full-rewrite marker.
     val lastFullRewriteVersion = oldCheckpoint.contentRoot
       .lastManifestCommitWithFullRewrite.getOrElse(contentStateVersion)
     val contentRoot = ContentRoot(
       path = contentRootBase.path,
       sizeInBytes = contentRootBase.sizeInBytes,
+      version = contentStateVersion,
       isIncremental = true,
       lastManifestCommitWithFullRewrite = lastFullRewriteVersion,
       numLeaves = allLeafPointers.size.toLong)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/LastCheckpointInfoSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/LastCheckpointInfoSuite.scala
@@ -242,7 +242,7 @@ class LastCheckpointInfoSuite extends SharedSparkSession
       rootPath: String = "metadata/root-abc.parquet",
       rootSizeInBytes: Long = 4096L): Checkpoint = Checkpoint(
     version = version,
-    contentRoot = ContentRoot(path = rootPath, sizeInBytes = rootSizeInBytes),
+    contentRoot = ContentRoot(path = rootPath, sizeInBytes = rootSizeInBytes, version = version),
     protocol = Protocol(minReaderVersion = 3, minWriterVersion = 7),
     metaData = Metadata(id = "metadata-id", name = "t"),
     domainMetadata = Nil,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointTestBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointTestBase.scala
@@ -461,6 +461,9 @@ trait AMTCheckpointTestBase
     assert(checkpoint.contentRoot.lastManifestCommitWithFullRewrite.contains(expectedLastFull),
       s"${scenario.name}: wrong last-full marker " +
         checkpoint.contentRoot.lastManifestCommitWithFullRewrite)
+    assert(checkpoint.contentRoot.version == checkpoint.version,
+      s"${scenario.name}: contentRoot.version ${checkpoint.contentRoot.version} must equal " +
+        s"checkpoint.version ${checkpoint.version}")
     assert(context.provider.checkpointVersion == checkpoint.version)
     assert(context.provider.checkpointAction == checkpoint)
     assert(context.postCheckpointSnapshot.version == context.manifestCommitVersion)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointWriteSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointWriteSuite.scala
@@ -68,6 +68,8 @@ class AMTCheckpointWriteSuite extends AMTCheckpointTestBase {
       // The Checkpoint describes state as of v2 (the version whose maintenance it fulfills).
       assert(checkpoints.head.version == 2,
         s"Checkpoint must describe state as of v2; got ${checkpoints.head.version}")
+      assert(checkpoints.head.contentRoot.version == 2,
+        s"contentRoot.version must be v2; got ${checkpoints.head.contentRoot.version}")
 
       // The Checkpoint's contentRoot points at an on-disk manifest file. A single promoted leaf
       // keeps its leaf-* name, so accept either a root or leaf manifest.
@@ -320,7 +322,8 @@ class AMTCheckpointWriteSuite extends AMTCheckpointTestBase {
         file_size_in_bytes = leafSize,
         manifest_info = emptyManifestInfo.copy(added_files_count = 1))
       val (rootLoc, rootSize) = writeManifest("root with space.parquet", Seq(leafPointer.wrap))
-      val checkpoint = base.copy(contentRoot = ContentRoot(path = rootLoc, sizeInBytes = rootSize))
+      val checkpoint = base.copy(
+        contentRoot = ContentRoot(path = rootLoc, sizeInBytes = rootSize, version = base.version))
 
       // The synthesized pointers really do carry spaces and are not URL-encoded.
       assert(rootLoc.contains("root with space.parquet") && !rootLoc.contains("%20"))
@@ -497,8 +500,8 @@ class AMTCheckpointWriteSuite extends AMTCheckpointTestBase {
     }
 
     // `version` names the tree's content-root version, and `parts` the leaf count.
-    assert(info.version == context.checkpoint.version,
-      s"Expected content root v${context.checkpoint.version}, got v${info.version}.")
+    assert(info.version == context.checkpoint.contentRoot.version,
+      s"Expected content root v${context.checkpoint.contentRoot.version}, got v${info.version}.")
     assert(info.parts.contains(context.provider.leaves.size),
       s"Expected ${context.provider.leaves.size} leaves, got ${info.parts}.")
     assert(info.sizeInBytes.exists(_ > 0L), "The AMT size in bytes must be recorded.")

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTIncrementalWriteInvariantSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTIncrementalWriteInvariantSuite.scala
@@ -45,7 +45,7 @@ class AMTIncrementalWriteInvariantSuite extends AMTIncrementalWriteTestBase {
         commitCheckpoint(amtDeltaLog, incremental = false)
         val snapshot = amtDeltaLog.update()
         val provider = amtProvider(snapshot).getOrElse(fail("expected AMTCheckpointProvider"))
-        val oldAMTVersion = provider.checkpointAction.version
+        val oldAMTVersion = provider.checkpointAction.contentRoot.version
         val intermediateLogCommits = snapshot.logSegment.deltas
           .filter(f => FileNames.getFileVersion(f) > oldAMTVersion)
         // They only reach snapshot.version, so [oldAMTVersion+1, snapshot.version+5) has a

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotSuite.scala
@@ -1310,6 +1310,7 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
       outputSchema = Some(AMTSingleAction.persistedSchema(metadata.partitionSchema)),
       useDeltaParquetWriteSupport = true)
     val size = rootFile.getFileSystem(hadoopConf).getFileStatus(rootFile).getLen
-    base.copy(contentRoot = ContentRoot(path = rootFile.toString, sizeInBytes = size))
+    base.copy(contentRoot = ContentRoot(
+      path = rootFile.toString, sizeInBytes = size, version = base.version))
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AdaptiveMetadataActionsSerializerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AdaptiveMetadataActionsSerializerSuite.scala
@@ -31,7 +31,8 @@ class AdaptiveMetadataActionsSerializerSuite extends SparkFunSuite {
 
   private val sampleRoot = ContentRoot(
     path = "metadata/root-abc.parquet",
-    sizeInBytes = 4096L)
+    sizeInBytes = 4096L,
+    version = 1L)
 
   private val sampleProtocol = Protocol(minReaderVersion = 3, minWriterVersion = 7)
   private val sampleMetadata = Metadata(id = "metadata-id", name = "t")
@@ -57,15 +58,17 @@ class AdaptiveMetadataActionsSerializerSuite extends SparkFunSuite {
   test("ContentRoot: ser-de") {
     val root = ContentRoot(
       path = "metadata/root-abc.parquet",
-      sizeInBytes = 4096L)
+      sizeInBytes = 4096L,
+      version = 1L)
     val json = JsonUtils.toJson(root)
     assert(json ===
-      """{"path":"metadata/root-abc.parquet","sizeInBytes":4096}""")
+      """{"path":"metadata/root-abc.parquet","sizeInBytes":4096,"version":1}""")
     val pretty = JsonUtils.toPrettyJson(root)
     assert(pretty ===
       """{
         |  "path" : "metadata/root-abc.parquet",
-        |  "sizeInBytes" : 4096
+        |  "sizeInBytes" : 4096,
+        |  "version" : 1
         |}""".stripMargin)
     assert(JsonUtils.fromJson[ContentRoot](json) === root)
     assert(JsonUtils.fromJson[ContentRoot](pretty) === root)
@@ -74,7 +77,8 @@ class AdaptiveMetadataActionsSerializerSuite extends SparkFunSuite {
   test("ContentRoot: serde handles Long.MaxValue size") {
     val root = ContentRoot(
       path = "metadata/root-big.parquet",
-      sizeInBytes = Long.MaxValue)
+      sizeInBytes = Long.MaxValue,
+      version = Long.MaxValue)
     val json = JsonUtils.toJson(root)
     val roundTripped = JsonUtils.fromJson[ContentRoot](json)
     assert(roundTripped === root)
@@ -84,14 +88,17 @@ class AdaptiveMetadataActionsSerializerSuite extends SparkFunSuite {
     val root = ContentRoot(
       path = "metadata/root-abc.parquet",
       sizeInBytes = 4096L,
+      version = 7L,
       isIncremental = true,
       lastManifestCommitWithFullRewrite = 7L,
       numLeaves = 3L)
+    assert(root.version === 7L)
     assert(root.isIncremental === Some(true))
     assert(root.lastManifestCommitWithFullRewrite === Some(7L))
     assert(root.numLeaves === Some(3L))
     val roundTripped = JsonUtils.fromJson[ContentRoot](JsonUtils.toJson(root))
     assert(roundTripped === root)
+    assert(roundTripped.version === 7L)
     assert(roundTripped.isIncremental === Some(true))
     assert(roundTripped.lastManifestCommitWithFullRewrite === Some(7L))
     assert(roundTripped.numLeaves === Some(3L))
@@ -210,7 +217,8 @@ class AdaptiveMetadataActionsSerializerSuite extends SparkFunSuite {
         |    "version" : 1,
         |    "contentRoot" : {
         |      "path" : "metadata/root-abc.parquet",
-        |      "sizeInBytes" : 4096
+        |      "sizeInBytes" : 4096,
+        |      "version" : 1
         |    },
         |    "protocol" : {
         |      "minReaderVersion" : 3,
@@ -267,7 +275,7 @@ class AdaptiveMetadataActionsSerializerSuite extends SparkFunSuite {
       SetTransaction(appId = "app-2", version = 8L, lastUpdated = None))
     val cp = Checkpoint(
       version = 41L,
-      contentRoot = sampleRoot,
+      contentRoot = sampleRoot.copy(version = 41L),
       protocol = protocol,
       metaData = sampleMetadata,
       domainMetadata = dm,
@@ -279,7 +287,8 @@ class AdaptiveMetadataActionsSerializerSuite extends SparkFunSuite {
         |    "version" : 41,
         |    "contentRoot" : {
         |      "path" : "metadata/root-abc.parquet",
-        |      "sizeInBytes" : 4096
+        |      "sizeInBytes" : 4096,
+        |      "version" : 41
         |    },
         |    "protocol" : {
         |      "minReaderVersion" : 3,
@@ -336,7 +345,8 @@ class AdaptiveMetadataActionsSerializerSuite extends SparkFunSuite {
         |    "version" : 1,
         |    "contentRoot" : {
         |      "path" : "metadata/root-abc.parquet",
-        |      "sizeInBytes" : 4096
+        |      "sizeInBytes" : 4096,
+        |      "version" : 1
         |    },
         |    "protocol" : {
         |      "minReaderVersion" : 3,
@@ -419,5 +429,33 @@ class AdaptiveMetadataActionsSerializerSuite extends SparkFunSuite {
     assert(parsed === cp)
     assert(parsed.sidecars.length === 2)
     assert(parsed.sidecars.forall(_.sidecarType.contains(SidecarType.Type.DomainMetadata)))
+  }
+
+  test("Checkpoint: contentRoot.version may lag checkpoint.version") {
+    val cp = Checkpoint(
+      version = 10L,
+      contentRoot = sampleRoot.copy(version = 5L),
+      protocol = sampleProtocol,
+      metaData = sampleMetadata,
+      domainMetadata = Seq.empty,
+      txns = Seq.empty,
+      sidecars = Seq.empty)
+    val parsed = Action.fromJson(cp.json).asInstanceOf[Checkpoint]
+    assert(parsed.contentRoot.version === 5L)
+    assert(parsed.version === 10L)
+  }
+
+  test("Checkpoint: rejects contentRoot.version ahead of checkpoint.version") {
+    val ex = intercept[IllegalArgumentException] {
+      Checkpoint(
+        version = 1L,
+        contentRoot = sampleRoot.copy(version = 2L),
+        protocol = sampleProtocol,
+        metaData = sampleMetadata,
+        domainMetadata = Seq.empty,
+        txns = Seq.empty,
+        sidecars = Seq.empty)
+    }
+    assert(ex.getMessage.contains("contentRoot.version"))
   }
 }


### PR DESCRIPTION
## Description

`ContentRoot` (the pointer to the root manifest embedded in a `Checkpoint`) records the
manifest's path and size but not the table version the manifest tree reflects. Callers
inferred that version from the enclosing `Checkpoint.version`, which is only correct when
the two coincide. They do not always coincide: a checkpoint may lag the enclosing commit,
and a standalone checkpoint covers the gap with inline file actions, so the tree can
describe an older version than the checkpoint.

This change adds a required `version: Long` field to `ContentRoot` and threads it through
the writers:

- `AMTWriteHelper` computes the content-state version from the read snapshot and passes it
  into `writeClusteredManifestTree` / `writeRoot`, stamping every constructed `ContentRoot`.
- `IncrementalAMTWriter` stamps the version the tree describes (an inline commit describes
  itself; a deferred checkpoint with no user actions describes the last committed version).
- Read paths (`AMTUtils`, `AMTWriterManager`) now read `contentRoot.version` instead of
  reusing `checkpoint.version`.

An invariant is enforced on construction: `contentRoot.version <= checkpoint.version`
(equal in a manifest commit, less in a standalone checkpoint). `Checkpoints` additionally
asserts equality when reading an inline checkpoint from a manifest commit.

The field is serialized in the `ContentRoot` JSON. Serializer tests cover round-tripping,
the lagging-version case, and rejection of a content-root version ahead of the checkpoint.

## How was this patch tested?

Unit tests (`AdaptiveMetadataActionsSerializerSuite`, AMT checkpoint/write suites).

## Does this PR introduce _any_ user-facing changes?

No.
