### PR TITLE
[Spark] Narrow two internal TahoeFileIndex listing helpers to private[delta]

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/files/TahoeFileIndex.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/files/TahoeFileIndex.scala
@@ -90,7 +90,7 @@ abstract class TahoeFileIndex(
    * set by the partition and data filters. Essentially, this is a collection of all the files
    * associated with the identified partitions.
    */
-  def listPartitionsAsAddFiles(
+  private[delta] def listPartitionsAsAddFiles(
       partitionFilters: Seq[Expression],
       dataFilters: Seq[Expression]): (Seq[(InternalRow, Seq[AddFile])], Seq[AddFile]) = {
     val matchedFiles = matchingFiles(partitionFilters, dataFilters)
@@ -142,7 +142,7 @@ abstract class TahoeFileIndex(
     FileStatusWithMetadata(fs, metadata.toMap)
   }
 
-  def makePartitionDirectories(
+  private[delta] def makePartitionDirectories(
       partitionValuesToFiles: Seq[(InternalRow, Seq[AddFile])]): Seq[PartitionDirectory] = {
     val timeZone = spark.sessionState.conf.sessionLocalTimeZone
     partitionValuesToFiles.map {


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Narrows two `TahoeFileIndex` helpers from public to `private[delta]`:

- `listPartitionsAsAddFiles`
- `makePartitionDirectories`

Neither is part of an API anyone outside the `delta` package uses. In this repository
`makePartitionDirectories` has exactly one caller, `listFiles`, in the same class, and
`listPartitionsAsAddFiles` has no callers at all — it is a listing helper that only Delta itself is
meant to reach. Making that explicit keeps `TahoeFileIndex`'s public surface to the `FileIndex`
contract plus the members Delta genuinely shares, and lets the compiler enforce it rather than
relying on review.

`private[delta]` is the established qualifier for this in the repo (221 existing uses across 76
files under `spark/src/main/scala`).

## How was this patch tested?

No behavior change and no new tests: this only reduces the visibility of two methods whose every
call site in this repository is already inside `org.apache.spark.sql.delta`. Existing tests cover the
paths that reach them (`listFiles` on a `TahoeFileIndex`).

## Does this PR introduce _any_ user-facing changes?

No. Both methods are internal listing helpers with no callers outside the `delta` package, so no
supported usage changes.
