### PR TITLE
[Spark] Write AMT content stats as typed Iceberg V4 values

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTCheckpointProvider.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTCheckpointProvider.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.delta.amt
 
 import org.apache.spark.sql.delta.{CheckpointPolicy, CheckpointProvider, DeltaLog, DeltaLogFileIndex, Snapshot}
 import org.apache.spark.sql.delta.DeltaLogFileIndex.COMMIT_VERSION_COLUMN
-import org.apache.spark.sql.delta.actions.{Action, AddFile, BackReference, Checkpoint, ContentRoot, Metadata, RemoveFile, SingleAction}
+import org.apache.spark.sql.delta.actions.{Action, AddFile, BackReference, Checkpoint, ContentRoot, Metadata, Protocol, RemoveFile, SingleAction}
 import org.apache.spark.sql.delta.deletionvectors.RoaringBitmapArray
 import org.apache.spark.sql.delta.util.DeltaEncoder
 import org.apache.hadoop.fs.{FileStatus, Path}
@@ -163,7 +163,7 @@ final class AMTCheckpointProvider(
     }.toMap
     val mdvBroadcast = spark.sparkContext.broadcast(mdvByLeaf)
     val dataEntries = AMTCheckpointProvider.loadEntriesWithLocation(
-      deltaLog, index, checkpointAction.metaData)
+      deltaLog, index, checkpointAction.metaData, checkpointAction.protocol)
       .where(col("entry.content_type") === lit(AMTSingleAction.ContentType.Type.Data))
       .where(col("entry.tracking.status").isin(
         AMTCheckpointProvider.liveDataEntryStatuses.toSeq: _*))
@@ -293,7 +293,8 @@ object AMTCheckpointProvider {
       DeltaLogFileIndex(DeltaLogFileIndex.CHECKPOINT_FILE_FORMAT_PARQUET, Array(rootFile))
     // The root manifest is small (one row per leaf), so collect it to the driver to enumerate the
     // leaf pointers.
-    val leaves = loadEntries(deltaLog, index, checkpoint.metaData).collect().toSeq
+    val leaves = loadEntries(deltaLog, index, checkpoint.metaData, checkpoint.protocol)
+      .collect().toSeq
       .filter(_.content_type == AMTSingleAction.ContentType.Type.DataManifest)
       .map(_.unwrap.asInstanceOf[DataManifestEntry])
     new AMTCheckpointProvider(
@@ -319,7 +320,8 @@ object AMTCheckpointProvider {
     val rootFile = checkpoint.contentRoot.toFileStatus(tableRoot)
     val index =
       DeltaLogFileIndex(DeltaLogFileIndex.CHECKPOINT_FILE_FORMAT_PARQUET, Array(rootFile))
-    loadEntries(deltaLog, index, checkpoint.metaData).collect().toSeq
+    loadEntries(deltaLog, index, checkpoint.metaData, checkpoint.protocol)
+      .collect().toSeq
       .filter(_.content_type == AMTSingleAction.ContentType.Type.Data)
       .map(_.unwrap.asInstanceOf[DataEntry])
       .filter(e => liveDataEntryStatuses.contains(e.tracking.status))
@@ -333,11 +335,14 @@ object AMTCheckpointProvider {
   private def loadEntries(
       deltaLog: DeltaLog,
       index: DeltaLogFileIndex,
-      metadata: Metadata): Dataset[AMTSingleAction] = {
+      metadata: Metadata,
+      protocol: Protocol): Dataset[AMTSingleAction] = {
     import org.apache.spark.sql.delta.implicits._
-    val persistedSchema = AMTSingleAction.persistedSchema(metadata.partitionSchema)
+    val persistedSchema =
+      AMTSingleAction.persistedSchema(metadata, protocol)
     val persisted = deltaLog.loadIndex(index, persistedSchema)
-    AMTPartitionValues.forRead(persisted, metadata.partitionSchema)
+    val withPartition = AMTPartitionValues.forRead(persisted, metadata.partitionSchema)
+    AMTContentStats.forRead(withPartition, metadata, protocol)
       .as[AMTSingleAction]
   }
 
@@ -347,17 +352,20 @@ object AMTCheckpointProvider {
   private def loadEntriesWithLocation(
       deltaLog: DeltaLog,
       index: DeltaLogFileIndex,
-      metadata: Metadata): Dataset[AMTDataEntryWithLocation] = {
+      metadata: Metadata,
+      protocol: Protocol): Dataset[AMTDataEntryWithLocation] = {
     import org.apache.spark.sql.delta.implicits._
     implicit val entryLocEncoder: Encoder[AMTDataEntryWithLocation] =
       amtDataEntryWithLocationEncoder
-    val persistedSchema = AMTSingleAction.persistedSchema(metadata.partitionSchema)
+    val persistedSchema =
+      AMTSingleAction.persistedSchema(metadata, protocol)
     val persisted = deltaLog.loadIndex(index, persistedSchema)
       .select(
         persistedSchema.fieldNames.toIndexedSeq.map(col) :+
           col(s"$METADATA_NAME.$FILE_PATH").as("leafPath") :+
           col(s"$METADATA_NAME.${ParquetFileFormat.ROW_INDEX}").as("pos"): _*)
-    AMTPartitionValues.forRead(persisted, metadata.partitionSchema)
+    val withPartition = AMTPartitionValues.forRead(persisted, metadata.partitionSchema)
+    AMTContentStats.forRead(withPartition, metadata, protocol)
       .select(
         struct(
           amtSingleActionEncoder

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTContentStats.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTContentStats.scala
@@ -1,0 +1,431 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.amt
+
+import org.apache.spark.sql.delta.{DeltaColumnMapping, DeltaColumnMappingMode}
+import org.apache.spark.sql.delta.actions.{Metadata, Protocol}
+import org.apache.spark.sql.delta.stats.{DeltaStatistics, SkippingEligibleDataType, StatisticsCollection, StatsCollectionUtils}
+
+import org.apache.spark.sql.{Column, DataFrame, SparkSession}
+import org.apache.spark.sql.execution.datasources.parquet.ParquetUtils
+import org.apache.spark.sql.functions.{coalesce, col, from_json, lit, struct, to_json, when}
+import org.apache.spark.sql.types.{BooleanType, ByteType, DataType, DateType, DecimalType, DoubleType, FloatType, IntegerType, LongType, MetadataBuilder, ShortType, StringType, StructField, StructType, TimestampNTZType, TimestampType}
+
+/**
+ * Converts between Delta's stats JSON string and Iceberg V4's typed `content_stats` struct
+ * (field 146).
+ *
+ * Iceberg models `content_stats` as a per-table struct-of-structs: one sub-struct per table field,
+ * named by that field's logical name (informational), holding the individual statistics as typed
+ * values. The sub-struct's Parquet field id is derived from the table field id, and each statistic
+ * sits at a fixed offset from it, so a reader resolves stats by id.
+ *
+ * A table column's Delta column-mapping id is its Iceberg field id, so no id translation is needed:
+ * in both `id` and `name` column-mapping mode Delta assigns every column a stable id and stamps it
+ * as the Parquet `field_id`. We use that Iceberg table column field id to compute the stats
+ * sub-struct's field ids.
+ *
+ * Only the statistics Delta actually collects get a slot: `null_value_count`, `lower_bound`,
+ * `upper_bound` and `tight_bounds`. The remaining spec-optional statistics (`value_count`,
+ * `nan_value_count`, `avg_value_size`, `max_value_size`) are omitted.
+ */
+private[amt] object AMTContentStats {
+
+  /** Name of the [[AMTSingleAction]] field this object shapes. */
+  private val CONTENT_STATS_FIELD = "content_stats"
+
+  /**
+   * Start of the Iceberg stats field-id space, and the number of ids reserved per table field.
+   * A table field's stats sub-struct is stamped `STATS_ID_START + STATS_IDS_PER_FIELD * fieldId`,
+   * and each statistic within it sits at a fixed offset from that base. See
+   * https://iceberg.apache.org/spec/#content-stats.
+   */
+  private val STATS_ID_START: Long = 10000L
+  private val STATS_IDS_PER_FIELD: Long = 200L
+
+  /**
+   * Per-statistic offsets from a sub-struct's base id, as defined by the Iceberg V4 spec
+   * (https://iceberg.apache.org/spec/#content-stats).
+   */
+  private val LOWER_BOUND_ID_OFFSET: Long = 1L
+  private val UPPER_BOUND_ID_OFFSET: Long = 2L
+  private val TIGHT_BOUNDS_ID_OFFSET: Long = 3L
+  private val NULL_VALUE_COUNT_ID_OFFSET: Long = 5L
+
+  /** Names of the per-column statistics, as defined by the Iceberg V4 spec. */
+  private val LOWER_BOUND = "lower_bound"
+  private val UPPER_BOUND = "upper_bound"
+  private val TIGHT_BOUNDS = "tight_bounds"
+  private val NULL_VALUE_COUNT = "null_value_count"
+
+  /**
+   * One statistics-collected leaf column:
+   *  - `fieldId`: the id Delta column mapping assigned to the column. Delta stamps it as the
+   *    Parquet `field_id` and Iceberg resolves fields by id, so this one value is both the Delta
+   *    column-mapping id and the column's Iceberg field id.
+   *  - `name`: the logical column name (the underscore-joined path). Informational only, and not
+   *    unique -- a top-level `a_b` and a nested `a`.`b` both flatten to `a_b` -- so it is not used
+   *    to resolve the sub-struct; see `fieldName`.
+   *  - `path`: the physical-name path to the column inside a parsed Delta stats struct (nested).
+   *  - `boundType`: the column's Iceberg bound type, or None.
+   *
+   * `boundType` is None for a column Delta counts nulls for but collects no min/max on (an array
+   * or map, say, or a type with no Iceberg bound representation). Such a leaf still gets a
+   * `null_value_count`; its bound fields are simply omitted.
+   */
+  private case class StatsLeaf(
+      fieldId: Long,
+      name: String,
+      path: Seq[String],
+      boundType: Option[DataType]) {
+    def hasBounds: Boolean = boundType.isDefined
+
+    /**
+     * The sub-struct's field name in the persisted schema: the logical name with the (unique)
+     * field id attached. Iceberg resolves content_stats entries by field id and treats the name as
+     * informational. Attaching the field id -- unique per column -- keeps every sub-struct name
+     * distinct, so name-based resolution stays unambiguous when two logical names collide.
+     */
+    def fieldName: String = s"${name}_$fieldId"
+  }
+
+  /**
+   * A [[StatisticsCollection]] describing the stats this table collects.
+   */
+  private def statisticsCollection(
+      sparkSession: SparkSession,
+      tableMetadata: Metadata,
+      tableProtocol: Protocol): StatisticsCollection = {
+    new StatisticsCollection {
+      override protected def spark: SparkSession = sparkSession
+      // We consume only `statCollectionPhysicalSchema`, which restricts to the configured indexed
+      // columns (statsColumnSpec's numIndexedCols / explicit stats columns) applied to these
+      // schemas. There is no separate stats or attribute projection to reproduce from just
+      // (Metadata, Protocol), so all three are the full data schema; the indexed-column subsetting
+      // still happens inside `getIndexedColumns`.
+      override def tableSchema: StructType = tableMetadata.dataSchema
+      override def outputTableStatsSchema: StructType = tableMetadata.dataSchema
+      override def outputAttributeSchema: StructType = tableMetadata.dataSchema
+      override val statsColumnSpec =
+        StatisticsCollection.configuredDeltaStatsColumnSpec(tableMetadata)
+      override def columnMappingMode: DeltaColumnMappingMode = tableMetadata.columnMappingMode
+      override protected def protocol: Protocol = tableProtocol
+      override protected def getDataSkippingStringPrefixLength: Int =
+        StatsCollectionUtils.getDataSkippingStringPrefixLength(sparkSession, tableMetadata)
+    }
+  }
+
+  /**
+   * The statistics-collected leaf columns that each get a `content_stats` entry, taken from
+   * `statCollectionPhysicalSchema` and ordered by field id so the persisted schema is stable across
+   * writes. That schema is Delta's set of columns it collects per-file statistics for.
+   * This method recurses into structs (a struct column contributes its scalar leaves, not itself)
+   * and sets `boundType` only for types with an Iceberg bound; a boundless leaf (an array, say)
+   * gets a `null_value_count` only.
+   *
+   * Example `statCollectionPhysicalSchema`:
+   *   name     type                          {id, physical name}
+   *   d_long   long                          {1, col-1}
+   *   d_str    string                        {2, col-2}
+   *   d_nested struct<inner: int {4, col-4}> {3, col-3}
+   *   d_arr    array<string>                 {5, col-5}
+   *
+   * The physical names form the path into a parsed Delta stats struct; the logical names name the
+   * sub-structs. This yields (d_nested contributes only its scalar leaf `inner`, not itself):
+   *   StatsLeaf(1, "d_long",         ["col-1"],         Some(LongType))
+   *   StatsLeaf(2, "d_str",          ["col-2"],         Some(StringType))
+   *   StatsLeaf(4, "d_nested_inner", ["col-3","col-4"], Some(IntegerType))  // struct leaf
+   *   StatsLeaf(5, "d_arr",          ["col-5"],         None)               // array: null count
+   *
+   * `name` is the field's full logical name. It names the sub-struct (informational, per the spec)
+   * while the field id is what a reader resolves by; using the full path rather than the bare leaf
+   * name reduces name clashes when two structs share a leaf name.
+   */
+  private def statsLeafColumns(statCollectionPhysicalSchema: StructType): Seq[StatsLeaf] = {
+    def collect(schema: StructType, prefix: Seq[String], names: Seq[String]): Seq[StatsLeaf] =
+      schema.fields.toSeq.flatMap { field =>
+        val path = prefix :+ DeltaColumnMapping.getPhysicalName(field)
+        val namePath = names :+ field.name
+        field.dataType match {
+          case nested: StructType => collect(nested, path, namePath)
+          case dt =>
+            val boundType = if (isBoundTypeSupported(dt)) Some(dt) else None
+            Some(StatsLeaf(
+              fieldId = DeltaColumnMapping.getColumnId(field).toLong,
+              name = namePath.mkString("_"),
+              path = path,
+              boundType = boundType))
+        }
+      }
+    collect(statCollectionPhysicalSchema, Nil, Nil).sortBy(_.fieldId)
+  }
+
+  /**
+   * Whether a min/max bound of this type can be represented as a typed Iceberg value.
+   *
+   * Mirrors `IcebergStatsConverter.isMinMaxStatTypeSupported`, the authority for Delta-to-Iceberg
+   * bound conversion. It is restated rather than called because that object lives in the
+   * `scala-bazel` source tree and pulls in the shaded Iceberg library, neither of which this
+   * package can depend on. Types outside this set are left out of `content_stats`, matching that
+   * converter's behavior of ignoring unsupported stats.
+   */
+  private def isBoundTypeSupported(dataType: DataType): Boolean =
+    SkippingEligibleDataType(dataType) && (dataType match {
+      case _: StringType | _: IntegerType | _: FloatType | _: DoubleType | _: DecimalType |
+          _: BooleanType | _: DateType | _: TimestampType | _: TimestampNTZType | _: LongType |
+          _: ByteType | _: ShortType => true
+      case _ => false
+    })
+
+  /**
+   * Whether the type's stored bound is truncated. Delta prefix-truncates string bounds and rounds
+   * timestamp bounds down to milliseconds, so for those types the stored bound is a valid superset
+   * endpoint but not the exact min/max. Iceberg's `tight_bounds` (bounds equal the min/max) must
+   * therefore be false for them even when Delta's file-level `tightBounds` is true. That flag
+   * describes only the non-truncated columns (everything except String/Timestamp/TimestampNTZ);
+   * the truncated columns are never tight regardless of it.
+   */
+  private def isTruncatedType(dataType: DataType): Boolean = dataType match {
+    case _: StringType | _: TimestampType | _: TimestampNTZType => true
+    case _ => false
+  }
+
+  /**
+   * The persisted `content_stats` struct for a table: one sub-struct per statistics-collected leaf
+   * column, named by that column's logical name. Empty when the table collects no per-column stats,
+   * in which case `AMTSingleAction.persistedSchema` drops the whole `content_stats` field (a struct
+   * with no fields is not Parquet-writable) -- the same way it drops `partition` when the table is
+   * unpartitioned.
+   */
+  def persistedSchema(metadata: Metadata, protocol: Protocol): StructType = {
+    val physicalSchema =
+      statisticsCollection(SparkSession.active, metadata, protocol).statCollectionPhysicalSchema
+    val perColumn = statsLeafColumns(physicalSchema).map { leaf =>
+      val baseId = STATS_ID_START + STATS_IDS_PER_FIELD * leaf.fieldId
+      // A leaf with no bounds gets only its null count; omitting the bound fields keeps them out
+      // of the Parquet schema rather than persisting columns that are always null. Fields are
+      // ordered by ascending id (bounds 1-3, then null count 5).
+      val boundFields = leaf.boundType.toSeq.flatMap { boundType =>
+        Seq(
+          statField(LOWER_BOUND, boundType, baseId + LOWER_BOUND_ID_OFFSET),
+          statField(UPPER_BOUND, boundType, baseId + UPPER_BOUND_ID_OFFSET),
+          statField(TIGHT_BOUNDS, BooleanType, baseId + TIGHT_BOUNDS_ID_OFFSET))
+      }
+      val nullCountField =
+        statField(NULL_VALUE_COUNT, LongType, baseId + NULL_VALUE_COUNT_ID_OFFSET)
+      // The sub-struct is named by the column's logical name with its field id attached (see
+      // StatsLeaf.fieldName) and stamped with the base id. Per the spec, stats are resolved by id;
+      // the name is informational, but the id suffix keeps it unique for Spark's name-based access.
+      statField(leaf.fieldName, StructType(boundFields :+ nullCountField), baseId)
+    }
+    StructType(perColumn)
+  }
+
+  /**
+   * Builds one id-stamped field of a per-column stats sub-struct. Every field is nullable: a
+   * statistic can be absent for a given file (a column with no min/max, or a null bound), and the
+   * Iceberg V4 spec marks these per-column statistics optional.
+   */
+  private def statField(name: String, dataType: DataType, id: Long): StructField =
+    StructField(
+      name,
+      dataType,
+      nullable = true,
+      metadata = new MetadataBuilder().putLong(ParquetUtils.FIELD_ID_METADATA_KEY, id).build())
+
+  /**
+   * Delta's stats JSON string -> the typed `content_stats` struct.
+   *
+   * `df` is a DataFrame of [[AMTSingleAction]] rows whose `content_stats` column still holds the
+   * encoder's shape (the raw Delta stats JSON). An entry with no statistics gets a null struct.
+   */
+  def forWrite(df: DataFrame, metadata: Metadata, protocol: Protocol): DataFrame = {
+    val stats = statisticsCollection(df.sparkSession, metadata, protocol)
+    val statsSchema = stats.statsSchema // Delta's stats_parsed schema
+    val leaves = statsLeafColumns(stats.statCollectionPhysicalSchema)
+    // No per-column stats -> `content_stats` is dropped from the persisted schema (an empty struct
+    // is not Parquet-writable), so drop the column here too. Mirrors `AMTPartitionValues.forWrite`
+    // for an unpartitioned table.
+    if (leaves.isEmpty) return df.drop(CONTENT_STATS_FIELD)
+    // `content_stats` holds the raw Delta stats JSON string (the `Option[String]` encoder shape).
+    val rawJson = col(CONTENT_STATS_FIELD)
+    val statsParsedExpression = from_json(rawJson, statsSchema)
+
+    // Delta's `tightBounds` is a per-file flag; Iceberg's `tight_bounds` is per column and asserts
+    // the bounds equal the min/max. The Delta spec treats an absent `tightBounds` as tight, so
+    // the default is true.
+    val fileTightBounds =
+      coalesce(statsParsedExpression.getField(DeltaStatistics.TIGHT_BOUNDS), lit(true))
+
+    val perColumn = leaves.map { leaf =>
+      // Ordered by ascending id (bounds, then null count) to match the persisted schema.
+      val boundColumns = leaf.boundType.toSeq.flatMap { boundType =>
+        // A column's bounds are exact only when the file is tight AND the type is not truncated, so
+        // a truncated column (string/timestamp) is never `tight_bounds = true`.
+        val columnTightBounds =
+          if (isTruncatedType(boundType)) lit(false) else fileTightBounds
+        Seq(
+          statPath(statsParsedExpression, DeltaStatistics.MIN, leaf.path).as(LOWER_BOUND),
+          statPath(statsParsedExpression, DeltaStatistics.MAX, leaf.path).as(UPPER_BOUND),
+          columnTightBounds.as(TIGHT_BOUNDS))
+      }
+      val nullValueCount = statPath(statsParsedExpression, DeltaStatistics.NULL_COUNT, leaf.path)
+        .cast(LongType).as(NULL_VALUE_COUNT)
+      struct(boundColumns :+ nullValueCount: _*).as(leaf.fieldName)
+    }
+
+    val contentStatsSchema = AMTContentStats.persistedSchema(metadata, protocol)
+    val contentStats = when(rawJson.isNull, lit(null).cast(contentStatsSchema))
+      .otherwise(struct(perColumn: _*))
+    replaceContentStats(df, contentStats)
+  }
+
+  /**
+   * The typed `content_stats` struct -> the raw Delta stats JSON string the `Option[String]` field
+   * holds.
+   *
+   * `numRecords` is not persisted in `content_stats` (the entry carries it as Iceberg field 103
+   * `record_count`); for an entry that has per-column stats it is folded back in here. An entry
+   * with no per-column stats (a table that collects none, a data file written without stats, or
+   * a manifest pointer) reconstructs to `null`; [[toStatsJson]] supplies its record count.
+   */
+  def forRead(df: DataFrame, metadata: Metadata, protocol: Protocol): DataFrame = {
+    val stats = statisticsCollection(df.sparkSession, metadata, protocol)
+    val leaves = statsLeafColumns(stats.statCollectionPhysicalSchema)
+    val numRecords = col("record_count").cast(LongType).as(DeltaStatistics.NUM_RECORDS)
+    val jsonStats = if (leaves.isEmpty) {
+      // No per-column stats were persisted (`content_stats` was dropped from the schema); the
+      // encoder decodes `None` and `toStatsJson` supplies the record count.
+      lit(null).cast(StringType)
+    } else {
+      val typedStats = col(CONTENT_STATS_FIELD)
+
+      // Rebuild the nested minValues/maxValues/nullCount shape from each leaf's recorded path, then
+      // serialize it back to the JSON string Delta expects. minValues/maxValues cover only the
+      // leaves that carry bounds, matching the sub-schemas Delta itself builds.
+      val boundLeaves = leaves.filter(_.hasBounds)
+      // Recover Delta's file-level `tightBounds`. On write each untruncated column carries
+      // `tight_bounds = fileTightBounds`; truncated columns are forced to `false` for Iceberg's
+      // exact-bounds semantics. So AND only the untruncated columns; if a file has none, fall back
+      // to `false` conservatively.
+      val tightBoundLeaves = boundLeaves.filter(_.boundType.exists(bt => !isTruncatedType(bt)))
+      val recoveredTightBounds =
+        if (tightBoundLeaves.nonEmpty) {
+          tightBoundLeaves
+            .map(leaf => coalesce(statOf(typedStats, leaf, TIGHT_BOUNDS), lit(false)))
+            .reduce(_ && _)
+        } else {
+          lit(false)
+        }
+      val statsFields =
+        boundLeaves.headOption.toSeq.flatMap { _ =>
+          Seq(
+            nestByPath(boundLeaves, statOf(typedStats, _, LOWER_BOUND)).as(DeltaStatistics.MIN),
+            nestByPath(boundLeaves, statOf(typedStats, _, UPPER_BOUND)).as(DeltaStatistics.MAX))
+        } ++ leaves.headOption.toSeq.map { _ =>
+          nestByPath(leaves, statOf(typedStats, _, NULL_VALUE_COUNT)).as(DeltaStatistics.NULL_COUNT)
+        } :+ recoveredTightBounds.as(DeltaStatistics.TIGHT_BOUNDS)
+      val statsJson = to_json(struct(numRecords +: statsFields: _*))
+      when(typedStats.isNull, lit(null).cast(StringType)).otherwise(statsJson)
+    }
+    if (df.columns.contains(CONTENT_STATS_FIELD)) {
+      replaceContentStats(df, jsonStats)
+    } else {
+      df.withColumn(CONTENT_STATS_FIELD, jsonStats)
+    }
+  }
+
+  /**
+   * Projects one statistic of one leaf column out of a parsed Delta stats struct (used on write),
+   * following the leaf's nested physical-name path.
+   *
+   * Example: statPath(parsed, "minValues", ["col-3","col-4"]) => parsed.minValues.col-3.col-4.
+   */
+  private def statPath(parsed: Column, statName: String, path: Seq[String]): Column =
+    path.foldLeft(parsed.getField(statName))((column, name) => column.getField(name))
+
+  /**
+   * Reads one statistic out of a leaf's typed, flat `content_stats` sub-struct (used on read) --
+   * the inverse shape of [[statPath]]. The sub-struct is keyed by the leaf's unique `fieldName`.
+   *
+   * Example: statOf(typed, leaf(fieldName="d_nested_inner_4"), "lower_bound") reads the
+   * `lower_bound` of the sub-struct field named "d_nested_inner_4".
+   */
+  private def statOf(typed: Column, leaf: StatsLeaf, statName: String): Column =
+    typed.getField(leaf.fieldName).getField(statName)
+
+  /**
+   * Rebuilds Delta's nested stats shape from the flat leaves, grouping by each leaf's recorded path
+   * so a struct column's per-field statistics land back under that struct.
+   *
+   * Example -- rebuilding `minValues` from the three bound leaves below, where `value` reads
+   * each leaf's `lower_bound` out of the typed `content_stats` sub-struct (e.g. value of leaf id 1
+   * = typed.`1`.lower_bound):
+   *
+   *   StatsLeaf(1, ["col-1"])
+   *   StatsLeaf(2, ["col-2"])
+   *   StatsLeaf(4, ["col-3","col-4"])
+   *
+   * Group by the first path segment -> col-1, col-2, col-3. col-1 and col-2 have a length-1 path so
+   * they take their value directly; col-3 has no length-1 entry, so it recurses on the remaining
+   * path ["col-4"] and builds a sub-struct. The result is:
+   *
+   *   struct(
+   *     "col-1" -> typed.`1`.lower_bound,
+   *     "col-2" -> typed.`2`.lower_bound,
+   *     "col-3" -> struct("col-4" -> typed.`4`.lower_bound))
+   *
+   * which `to_json`s to {"col-1":.., "col-2":.., "col-3":{"col-4":..}} -- the physical-keyed,
+   * nested shape Delta writes minValues/maxValues/nullCount in, with col-4 back under col-3.
+   */
+  private def nestByPath(leaves: Seq[StatsLeaf], value: StatsLeaf => Column): Column = {
+    def build(entries: Seq[(Seq[String], StatsLeaf)]): Column = {
+      val fields = entries
+        .groupBy(_._1.head)
+        .toSeq
+        .sortBy { case (_, group) => group.map(_._2.fieldId).min }
+        .map { case (name, group) =>
+          group.find(_._1.length == 1) match {
+            case Some((_, leaf)) => value(leaf).as(name)
+            case None => build(group.map { case (path, leaf) => (path.tail, leaf) }).as(name)
+          }
+        }
+      struct(fields: _*)
+    }
+    build(leaves.map(leaf => (leaf.path, leaf)))
+  }
+
+  private def replaceContentStats(df: DataFrame, contentStats: Column): DataFrame =
+    df.select(df.columns.map { name =>
+      if (name == CONTENT_STATS_FIELD) contentStats.as(name) else col(name)
+    }.toIndexedSeq: _*)
+
+  /**
+   * The value stored in the `content_stats` field: the `AddFile.stats` JSON string verbatim, or
+   * None when the file has none.
+   */
+  def fromStatsJson(statsJson: String): Option[String] =
+    Option(statsJson).filter(_.nonEmpty)
+
+  /**
+   * The `AddFile.stats` JSON for a data entry. [[forRead]] rebuilds `content_stats` as the complete
+   * stats JSON (including `numRecords`), so it is returned as-is; the fallback covers an entry with
+   * no `content_stats` by emitting the record count alone. The inverse of [[fromStatsJson]].
+   */
+  def toStatsJson(contentStats: Option[String], recordCount: Long): String =
+    contentStats.getOrElse(s"""{"${DeltaStatistics.NUM_RECORDS}":$recordCount}""")
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTPartitionValues.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTPartitionValues.scala
@@ -55,7 +55,6 @@ private[amt] object AMTPartitionValues {
       field.copy(
         nullable = true,
         metadata = new MetadataBuilder()
-          .withMetadata(field.metadata)
           .putLong(ParquetUtils.FIELD_ID_METADATA_KEY, PARTITION_FIELD_ID_START + ordinal)
           .build())
     })
@@ -82,7 +81,8 @@ private[amt] object AMTPartitionValues {
         field.dataType,
         ansiEnabled = true)).as(field.name)
     }
-    val partition = when(raw.isNull, lit(null).cast(persistedSchema(partitionSchema)))
+    val persistedPartitionSchema = AMTPartitionValues.persistedSchema(partitionSchema)
+    val partition = when(raw.isNull, lit(null).cast(persistedPartitionSchema))
       .otherwise(struct(typedFields: _*))
     replacePartition(df, partition)
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriteHelper.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriteHelper.scala
@@ -20,7 +20,7 @@ import java.util.concurrent.TimeUnit.NANOSECONDS
 
 // scalastyle:off import.ordering.noEmptyLine
 import org.apache.spark.sql.delta.{Checkpoints, DeltaLog, DeltaParquetWriteSupport, Snapshot}
-import org.apache.spark.sql.delta.actions.{Action, AddFile, Checkpoint, ContentRoot, DomainMetadata, Metadata, Protocol, SetTransaction}
+import org.apache.spark.sql.delta.actions.{AddFile, Checkpoint, ContentRoot, DomainMetadata, Metadata, Protocol, SetTransaction}
 import org.apache.spark.sql.delta.deletionvectors.RoaringBitmapArray
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
@@ -67,7 +67,8 @@ object AMTWriteHelper extends DeltaLogging {
       deltaLog = deltaLog,
       readSnapshot = readSnapshot,
       hadoopConf = hadoopConf,
-      metadata = readSnapshot.metadata,
+      metadata = postCommitMetadata,
+      protocol = postCommitProtocol,
       entriesPerLeaf = entriesPerLeaf,
       contentStateVersion = contentStateVersion)
     val contentRoot = policyTaggedContentRoot(
@@ -169,6 +170,7 @@ object AMTWriteHelper extends DeltaLogging {
       readSnapshot: Snapshot,
       hadoopConf: Configuration,
       metadata: Metadata,
+      protocol: Protocol,
       entriesPerLeaf: Int,
       contentStateVersion: Long): (ContentRoot, Seq[DataManifestEntry]) = {
     require(entriesPerLeaf > 0, "entriesPerLeaf must be positive.")
@@ -189,6 +191,7 @@ object AMTWriteHelper extends DeltaLogging {
       metadataDir = metadataDir,
       addFilesDf = addFilesDf,
       metadata = metadata,
+      protocol = protocol,
       desiredNumLeaves = desiredNumLeaves)
     leafEntries match {
       case Seq(onlyLeaf) =>
@@ -201,7 +204,14 @@ object AMTWriteHelper extends DeltaLogging {
         (contentRoot, Seq.empty)
       case _ =>
         val contentRoot = writeRoot(
-          spark, fs, hadoopConf, tableRoot, metadataDir, metadata, leafEntries.map(_.wrap),
+          spark = spark,
+          fs = fs,
+          hadoopConf = hadoopConf,
+          tableRoot = tableRoot,
+          metadataDir = metadataDir,
+          metadata = metadata,
+          protocol = protocol,
+          rows = leafEntries.map(_.wrap),
           version = contentStateVersion)
         (contentRoot, leafEntries)
     }
@@ -215,6 +225,7 @@ object AMTWriteHelper extends DeltaLogging {
       metadataDir: Path,
       addFilesDf: DataFrame,
       metadata: Metadata,
+      protocol: Protocol,
       desiredNumLeaves: Int): Seq[DataManifestEntry] = {
     import org.apache.spark.sql.delta.implicits._
     val addFilesDs = addFilesDf.as[AddFile]
@@ -228,8 +239,9 @@ object AMTWriteHelper extends DeltaLogging {
     val amtDs = addFilesDs.map { add =>
       DataEntry.fromAddFile(add, tracking, tableRootSparkPath.toPath).wrap
     }
-    val amtDf = AMTPartitionValues.forWrite(amtDs.toDF(), metadata.partitionSchema)
-    val schema = AMTSingleAction.persistedSchema(metadata.partitionSchema)
+    val amtWithPartition = AMTPartitionValues.forWrite(amtDs.toDF(), metadata.partitionSchema)
+    val amtDf = AMTContentStats.forWrite(amtWithPartition, metadata, protocol)
+    val schema = AMTSingleAction.persistedSchema(metadata, protocol)
     val recordCountIdx = amtDf.schema.fieldIndex("record_count")
     val (factory, serConf) = {
       val format = new ParquetFileFormat()
@@ -460,9 +472,10 @@ object AMTWriteHelper extends DeltaLogging {
       tableRoot: Path,
       metadataDir: Path,
       metadata: Metadata,
+      protocol: Protocol,
       entries: Seq[DataEntry]): DataManifestEntry = {
     val leafFile = FileNames.newAMTLeafManifestFile(metadataDir)
-    writeAMTParquet(spark, hadoopConf, leafFile, metadata, entries.map(_.wrap))
+    writeAMTParquet(spark, hadoopConf, leafFile, metadata, protocol, entries.map(_.wrap))
     val fileStatus = fs.getFileStatus(leafFile)
     // A freshly written leaf is always ADDED -- even one holding only tombstones, whose
     // manifest_info still counts the DELETED / REPLACED entries and their rows.
@@ -490,10 +503,11 @@ object AMTWriteHelper extends DeltaLogging {
       tableRoot: Path,
       metadataDir: Path,
       metadata: Metadata,
+      protocol: Protocol,
       rows: Seq[AMTSingleAction],
       version: Long): ContentRoot = {
     val rootFile = FileNames.newAMTRootManifestFile(metadataDir)
-    writeAMTParquet(spark, hadoopConf, rootFile, metadata, rows)
+    writeAMTParquet(spark, hadoopConf, rootFile, metadata, protocol, rows)
     val status = fs.getFileStatus(rootFile)
     ContentRoot(
       path = AMTUtils.relativizeManifestPathToTableRoot(fs, tableRoot, rootFile),
@@ -538,17 +552,19 @@ object AMTWriteHelper extends DeltaLogging {
       hadoopConf: Configuration,
       finalPath: Path,
       metadata: Metadata,
+      protocol: Protocol,
       rows: Seq[AMTSingleAction]): Unit = {
     import org.apache.spark.sql.delta.implicits._
-    val df = AMTPartitionValues.forWrite(
+    val withPartition = AMTPartitionValues.forWrite(
       spark.createDataset(rows).toDF(), metadata.partitionSchema)
+    val df = AMTContentStats.forWrite(withPartition, metadata, protocol)
     Checkpoints.writeAtomicCheckpointParquetFile(
       spark = spark,
       df = df,
       finalPath = finalPath,
       hadoopConf = hadoopConf,
       useRename = false,
-      outputSchema = Some(AMTSingleAction.persistedSchema(metadata.partitionSchema)),
+      outputSchema = Some(AMTSingleAction.persistedSchema(metadata, protocol)),
       useDeltaParquetWriteSupport = true)
   }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/IncrementalAMTWriter.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/IncrementalAMTWriter.scala
@@ -183,11 +183,13 @@ class IncrementalAMTWriter(spark: SparkSession, deltaLog: DeltaLog) {
     // ---- Step 4: spill entries into new leaves if the root would exceed the per-leaf cap. ----
     val fixedRootCount = carriedLeafPointers.size
     val (rootLiveEntries, rootRemoveEntries, spilledLeafPointers) =
-      spillIfNeeded(liveEntries, removeEntries, fixedRootCount, processedActions.postCommitMetadata)
+      spillIfNeeded(liveEntries, removeEntries, fixedRootCount,
+        processedActions.postCommitMetadata, processedActions.postCommitProtocol)
     val allLeafPointers = carriedLeafPointers ++ spilledLeafPointers
 
-    // ---- Step 5: write the new root. The post-commit metadata shapes the persisted manifest
-    // schema (the Iceberg partition struct), so every manifest write needs it.
+    // ---- Step 5: write the new root. The post-commit metadata and protocol shape the persisted
+    // manifest schema (the Iceberg partition struct and the typed per-column content stats), so
+    // every manifest write needs them.
     val rootRows =
       allLeafPointers.map(_.wrap) ++
         rootLiveEntries.map(_.wrap) ++
@@ -197,7 +199,8 @@ class IncrementalAMTWriter(spark: SparkSession, deltaLog: DeltaLog) {
     val contentStateVersion =
       if (actionsToCommit.isEmpty) attemptVersion - 1 else attemptVersion
     val contentRootBase = AMTWriteHelper.writeRoot(
-      spark, fs, hadoopConf, tableRoot, metadataDir, processedActions.postCommitMetadata, rootRows,
+      spark, fs, hadoopConf, tableRoot, metadataDir, processedActions.postCommitMetadata,
+      processedActions.postCommitProtocol, rootRows,
       version = contentStateVersion)
 
     // ---- Step 6: generate the Checkpoint action. ----
@@ -414,7 +417,8 @@ class IncrementalAMTWriter(spark: SparkSession, deltaLog: DeltaLog) {
       liveEntries: Seq[DataEntry],
       removeEntries: Seq[DataEntry],
       fixedRootCount: Int,
-      metadata: Metadata): (Seq[DataEntry], Seq[DataEntry], Seq[DataManifestEntry]) = {
+      metadata: Metadata,
+      protocol: Protocol): (Seq[DataEntry], Seq[DataEntry], Seq[DataManifestEntry]) = {
     val spilled = ArrayBuffer.empty[DataManifestEntry]
     var remainingLive = liveEntries
     var remainingRemoves = removeEntries
@@ -423,13 +427,13 @@ class IncrementalAMTWriter(spark: SparkSession, deltaLog: DeltaLog) {
     while (rootRowCount > entriesPerLeaf && remainingLive.nonEmpty) {
       val (batch, rest) = remainingLive.splitAt(entriesPerLeaf)
       spilled += AMTWriteHelper.writeLeaf(
-        spark, fs, hadoopConf, tableRoot, metadataDir, metadata, batch)
+        spark, fs, hadoopConf, tableRoot, metadataDir, metadata, protocol, batch)
       remainingLive = rest
     }
     while (rootRowCount > entriesPerLeaf && remainingRemoves.nonEmpty) {
       val (batch, rest) = remainingRemoves.splitAt(entriesPerLeaf)
       spilled += AMTWriteHelper.writeLeaf(
-        spark, fs, hadoopConf, tableRoot, metadataDir, metadata, batch)
+        spark, fs, hadoopConf, tableRoot, metadataDir, metadata, protocol, batch)
       remainingRemoves = rest
     }
     (remainingLive, remainingRemoves, spilled.toSeq)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/actions.scala
@@ -16,13 +16,8 @@
 
 package org.apache.spark.sql.delta.amt
 
-import java.util.UUID
-
-import scala.util.Try
-
 import org.apache.spark.sql.delta.DeltaColumnMapping
-import org.apache.spark.sql.delta.actions.{Action, AddFile, DeletionVectorDescriptor}
-import org.apache.spark.sql.delta.stats.DeltaStatistics
+import org.apache.spark.sql.delta.actions.{Action, AddFile, DeletionVectorDescriptor, Metadata, Protocol}
 import org.apache.spark.sql.delta.storage.dv.DeletionVectorStore
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.core.JsonParser
@@ -69,7 +64,7 @@ case class AMTSingleAction(
     sort_order_id: Option[Int],                 // ID: 140, optional (only when content_type=0).
     record_count: Long,                         // ID: 103, required.
     file_size_in_bytes: Long,                   // ID: 104, required.
-    content_stats: Option[ContentStats],        // ID: 146, optional.
+    content_stats: Option[String],              // ID: 146, optional.
     manifest_info: Option[ManifestInfo],        // ID: 150, required for DATA_MANIFEST.
     key_metadata: Option[Array[Byte]],          // ID: 131, optional.
     split_offsets: Option[Seq[Long]]            // ID: 132, optional.
@@ -364,15 +359,21 @@ object AMTSingleAction {
 
   /**
    * The [[AMTSingleAction]] schema as written to disk, which differs from the encoder's in-memory
-   * schema in four ways: every mapped field carries its Iceberg field id, required/optional is
-   * driven by the field spec rather than the encoder, `partition` holds the table's typed partition
-   * struct instead of a string map, and `partition` is absent entirely for an unpartitioned table.
+   * schema: every mapped field carries its Iceberg field id, required/optional is driven by the
+   * field spec rather than the encoder, and the two per-table fields take their table-dependent
+   * shape -- `partition` holds the typed partition struct (absent entirely for an unpartitioned
+   * table), and `content_stats` holds the typed per-column statistics struct.
    */
-  def persistedSchema(partitionSchema: StructType): StructType =
+  def persistedSchema(metadata: Metadata, protocol: Protocol): StructType =
     StructType(staticStampedSchema.flatMap {
       case field if field.name == "partition" =>
-        if (partitionSchema.isEmpty) None
-        else Some(field.copy(dataType = AMTPartitionValues.persistedSchema(partitionSchema)))
+        if (metadata.partitionSchema.isEmpty) None
+        else Some(field.copy(
+          dataType = AMTPartitionValues.persistedSchema(metadata.partitionSchema)))
+      case field if field.name == "content_stats" =>
+        val contentStatsSchema = AMTContentStats.persistedSchema(metadata, protocol)
+        if (contentStatsSchema.isEmpty) None
+        else Some(field.copy(dataType = contentStatsSchema))
       case field => Some(field)
     })
 }
@@ -422,7 +423,7 @@ case class DataEntry(
     deletion_vector: Option[DeletionVector] = None,
     spec_id: Option[Int] = None,
     sort_order_id: Option[Int] = None,
-    content_stats: Option[ContentStats] = None,
+    content_stats: Option[String] = None,
     key_metadata: Option[Array[Byte]] = None,
     split_offsets: Option[Seq[Long]] = None,
     format_version: Int = AMTSingleAction.FormatVersionV4)
@@ -449,9 +450,7 @@ case class DataEntry(
 
   def toAddFile(tableRoot: Path): AddFile = {
     val dv = deletion_vector.map(DeletionVector.toDescriptor(_, tableRoot)).orNull
-    // `record_count` (Iceberg field 103) and the Delta `numRecords` statistic are both the physical
-    // row count (total records in the file, including DV-deleted rows), so store it directly.
-    val stats = s"""{"${DeltaStatistics.NUM_RECORDS}":$record_count}"""
+    val stats = AMTContentStats.toStatsJson(content_stats, record_count)
     AddFile(
       path = location,
       partitionValues = partition.getOrElse(Map.empty),
@@ -491,7 +490,7 @@ object DataEntry {
       sort_order_id = passthrough.flatMap(_.sort_order_id),
       key_metadata = passthrough.flatMap(_.key_metadata),
       split_offsets = passthrough.flatMap(_.split_offsets),
-      content_stats = None)
+      content_stats = AMTContentStats.fromStatsJson(add.stats))
   }
 }
 
@@ -642,7 +641,7 @@ case class DataManifestEntry(
     manifest_info: ManifestInfo,
     partition: Option[Map[String, String]] = None,
     spec_id: Option[Int] = None,
-    content_stats: Option[ContentStats] = None,
+    content_stats: Option[String] = None,
     key_metadata: Option[Array[Byte]] = None,
     split_offsets: Option[Seq[Long]] = None,
     format_version: Int = AMTSingleAction.FormatVersionV4)
@@ -849,19 +848,3 @@ case class ManifestInfo(
   /** Tombstone file entries: DELETED and REPLACED. */
   def tombstoneFilesCount: Int = deleted_files_count + replaced_files_count
 }
-
-/**
- * Column-level statistics carrier. Iceberg V4 leaves the inner shape
- * up to the caller (it depends on the table schema). A future PR introduces
- * the Delta-stats mapping.
- *
- * The single nullable `raw_stats` field is deliberate: an empty case class encodes to an
- * empty Parquet group, which the Parquet data source rejects
- * (`EMPTY_SCHEMA_NOT_SUPPORTED_FOR_DATASOURCE`). One nullable column keeps
- * `AMTSingleAction` Parquet-writable without committing to the final stats shape; M1
- * writers leave it `None`.
- *
- *
- * @param raw_stats Column-stats payload; M1 writers leave it None.
- */
-case class ContentStats(raw_stats: Option[Array[Byte]] = None)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/LastCheckpointInfoSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/LastCheckpointInfoSuite.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.delta
 
 // scalastyle:off import.ordering.noEmptyLine
 import org.apache.spark.sql.delta.actions.{Checkpoint, ContentRoot, Metadata, Protocol}
-import org.apache.spark.sql.delta.amt.{AMTLeafComparisons, AMTSingleAction, AMTWriteResult, ContentStats, DataManifestEntry, ManifestInfo, Tracking}
+import org.apache.spark.sql.delta.amt.{AMTLeafComparisons, AMTSingleAction, AMTWriteResult, DataManifestEntry, ManifestInfo, Tracking}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
@@ -297,7 +297,7 @@ class LastCheckpointInfoSuite extends SharedSparkSession
       dv_cardinality = Some(5L)),
     partition = Some(Map("part_col" -> "part_val")),
     spec_id = Some(1),
-    content_stats = Some(ContentStats(raw_stats = Some(Array[Byte](42, 43)))),
+    content_stats = Some("""{"minValues":{"col-1":1}}"""),
     key_metadata = Some(Array[Byte](16, 17, 18)),
     split_offsets = Some(Seq(0L, 128L, 256L)))
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointTestBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointTestBase.scala
@@ -18,6 +18,8 @@ package org.apache.spark.sql.delta.amt
 
 import java.io.File
 
+import scala.collection.immutable.ListMap
+
 // scalastyle:off import.ordering.noEmptyLine
 import com.databricks.spark.util.{Log4jUsageLogger, MetricDefinitions}
 import org.apache.spark.sql.delta.{AdaptiveMetadataTableFeature, CommitStats, DeltaLog, DeltaOperations, Snapshot}
@@ -32,7 +34,7 @@ import org.apache.spark.SparkConf
 import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.functions.col
-import org.apache.spark.sql.types.{BinaryType, BooleanType, ByteType, DateType, DecimalType, DoubleType, FloatType, IntegerType, LongType, ShortType, StringType, StructField, StructType, TimestampNTZType, TimestampType}
+import org.apache.spark.sql.types.{ArrayType, BinaryType, BooleanType, ByteType, DataType, DateType, DecimalType, DoubleType, FloatType, IntegerType, LongType, ShortType, StringType, StructField, StructType, TimestampNTZType, TimestampType}
 
 /**
  * Shared fixtures for AMT (`adaptiveMetadata-preview`) test suites: table creation, manifest-tree
@@ -135,70 +137,100 @@ trait AMTCheckpointTestBase
     snapshot.allFiles.collect().toSeq
 
   /**
-   * Partition spec covering one column per partition type Delta supports.
+   * Test column fixture
    */
-  protected val allTypesPartitionSchema: StructType = StructType(Seq(
-    StructField("p_int", IntegerType),
-    StructField("p_long", LongType),
-    StructField("p_short", ShortType),
-    StructField("p_byte", ByteType),
-    StructField("p_str", StringType),
-    StructField("p_date", DateType),
-    StructField("p_ts", TimestampType),
-    StructField("p_ts_ntz", TimestampNTZType),
-    StructField("p_dec", DecimalType(9, 3)),
-    StructField("p_bool", BooleanType),
-    StructField("p_float", FloatType),
-    StructField("p_double", DoubleType),
-    StructField("p_binary", BinaryType)))
+  protected case class TestColumn(
+      name: String,
+      dataType: DataType,
+      valueExpr: String,
+      partitionable: Boolean) {
+    /** This column as a `StructField`, its name prefixed (e.g. `p_`, `c_`, `d_`). */
+    def structField(prefix: String): StructField = StructField(prefix + name, dataType)
 
-  /** `allTypesPartitionSchema` as SQL column definitions, for a `CREATE TABLE` schema. */
-  protected def allTypesPartitionColumns: Seq[String] =
-    allTypesPartitionSchema.map(f => s"${f.name} ${f.dataType.sql}")
-
-  /**
-   * One projection over `range`'s `id` per column of [[allTypesPartitionSchema]], giving each row a
-   * distinct value in every partition column.
-   */
-  protected def allTypesPartitionExprs: Seq[String] = allTypesPartitionSchema.map { field =>
-    field.dataType match {
-      case StringType => "CONCAT('r', CAST(id AS STRING))"
-      case DateType => "DATE '2026-07-25' + CAST(id AS INT)"
-      case TimestampType =>
-        "TIMESTAMP '2026-07-25 01:02:03.456' + MAKE_INTERVAL(0, 0, 0, CAST(id AS INT))"
-      case TimestampNTZType =>
-        "CAST(TIMESTAMP_NTZ '2026-07-25 01:02:03.456' + " +
-          "MAKE_INTERVAL(0, 0, 0, CAST(id AS INT)) AS TIMESTAMP_NTZ)"
-      case BooleanType => "CAST(id % 2 AS BOOLEAN)"
-      case BinaryType => "CAST(CONCAT('b', CAST(id AS STRING)) AS BINARY)"
-      case d: DecimalType => s"CAST(id AS ${d.sql}) / 8"
-      case other => s"CAST(id AS ${other.sql})"
-    }
+    /** This column as a `<name> <type>` SQL column definition, its name prefixed. */
+    def columnDef(prefix: String): String = s"$prefix$name ${dataType.sql}"
   }
 
   /**
-   * Creates an AMT table partitioned by every column of [[allTypesPartitionSchema]] and appends
-   * `numFiles` single-row files, one distinct partition value per row per column, then runs `body`
-   * with the table's [[DeltaLog]]. No checkpoint is committed -- the caller decides which
-   * checkpoint shape it needs.
+   * Every type the AMT fixtures exercise, keyed by column [[TestColumn.name]].
    */
-  protected def withAllPartitionTypesTable(
+  protected val allTypeColumns: ListMap[String, TestColumn] = {
+    val columns = Seq(
+      TestColumn("int", IntegerType, "CAST(id AS INT)", partitionable = true),
+      TestColumn("long", LongType, "CAST(id AS LONG)", partitionable = true),
+      TestColumn("short", ShortType, "CAST(id AS SHORT)", partitionable = true),
+      TestColumn("byte", ByteType, "CAST(id AS BYTE)", partitionable = true),
+      TestColumn("str", StringType, "CONCAT('row', CAST(id AS STRING))", partitionable = true),
+      TestColumn("date", DateType, "DATE '2026-07-25' + CAST(id AS INT)", partitionable = true),
+      TestColumn(
+        "ts",
+        TimestampType,
+        "TIMESTAMP '2026-07-25 01:02:03.456' + MAKE_INTERVAL(0, 0, 0, CAST(id AS INT))",
+        partitionable = true),
+      TestColumn(
+        "ts_ntz",
+        TimestampNTZType,
+        "CAST(TIMESTAMP_NTZ '2026-07-25 01:02:03.456' + " +
+          "MAKE_INTERVAL(0, 0, 0, CAST(id AS INT)) AS TIMESTAMP_NTZ)",
+        partitionable = true),
+      TestColumn("dec", DecimalType(9, 3), "CAST(id AS DECIMAL(9,3)) / 8", partitionable = true),
+      TestColumn("bool", BooleanType, "CAST(id % 2 AS BOOLEAN)", partitionable = true),
+      TestColumn("float", FloatType, "CAST(id AS FLOAT)", partitionable = true),
+      TestColumn("double", DoubleType, "CAST(id AS DOUBLE)", partitionable = true),
+      TestColumn(
+        "binary",
+        BinaryType,
+        "CAST(CONCAT('b', CAST(id AS STRING)) AS BINARY)",
+        partitionable = true),
+      TestColumn(
+        "arr",
+        ArrayType(StringType),
+        "array(CONCAT('a', CAST(id AS STRING)))",
+        partitionable = false),
+      TestColumn(
+        "nested",
+        StructType(Seq(StructField("inner", IntegerType))),
+        "named_struct('inner', CAST(id AS INT))",
+        partitionable = false))
+    ListMap(columns.map(c => c.name -> c): _*)
+  }
+
+  protected def partitionableTestColumns: Seq[TestColumn] =
+    allTypeColumns.values.filter(_.partitionable).toSeq
+
+  protected def allTypeColumnDefinitions: Seq[String] =
+    allTypeColumns.values.map(_.columnDef("c_")).toSeq
+
+  protected def allTypeColumnExprs: Seq[String] =
+    allTypeColumns.values.map(_.valueExpr).toSeq
+
+  /**
+   * Creates an AMT table exercising every partition type (the `p_`-prefixed
+   * [[partitionableTestColumns]]) alongside the `d_`-prefixed data columns that content stats are
+   * collected on. Appends `numFiles` single-row files (one distinct value per row per column), and
+   * runs `body` with the table's [[DeltaLog]].
+   */
+  protected def withAllTypesTable(
       tableName: String,
       numFiles: Int,
-      maxEntriesPerLeaf: Int)(body: DeltaLog => Unit): Unit = {
-    val dataColumns = Seq("d_int INT", "d_str STRING")
+      maxEntriesPerLeaf: Int = entriesPerLeaf)(body: DeltaLog => Unit): Unit = {
+    // Every type, so the content-stats goldens cover the full set of data columns.
+    val dataColumns: Seq[TestColumn] = allTypeColumns.values.toSeq
     withSQLConf(DeltaSQLConf.AMT_ENTRIES_PER_LEAF.key -> maxEntriesPerLeaf.toString) {
       withTable(tableName) {
         createAMTTable(
           tableName,
           checkpointInterval = Int.MaxValue,
-          tableSchema = (dataColumns ++ allTypesPartitionColumns).mkString(", "),
-          partitionColumns = allTypesPartitionSchema.map(_.name))
-        appendRowsAsSeparateFiles(
-          tableName,
-          numFiles = numFiles,
-          columnExprs =
-            Seq("CAST(id AS INT)", "CONCAT('d', CAST(id AS STRING))") ++ allTypesPartitionExprs)
+          tableSchema =
+            (dataColumns.map(_.columnDef("d_")) ++ partitionableTestColumns.map(_.columnDef("p_")))
+              .mkString(", "),
+          partitionColumns = partitionableTestColumns.map("p_" + _.name))
+        if (numFiles > 0) {
+          appendRowsAsSeparateFiles(
+            tableName,
+            numFiles = numFiles,
+            columnExprs = (dataColumns ++ partitionableTestColumns).map(_.valueExpr))
+        }
         body(deltaLogForName(tableName))
       }
     }
@@ -273,7 +305,11 @@ trait AMTCheckpointTestBase
    *
    * @param scenario the placement and materialization strategy used by the test
    * @param tableName the catalog-managed table created by the harness
-   * @param preCheckpointSnapshot the snapshot after `setup` and before the tested checkpoint
+   * @param postSetupSnapshot the snapshot after `setup`
+   * @param preCheckpointSnapshot the snapshot immediately before the checkpoint is constructed: for
+   *                              deferred scenarios, after the trigger's data commit but before the
+   *                              checkpoint commit; for inline scenarios, the same as
+   *                              `postSetupSnapshot`.
    * @param manifestCommitVersion the commit carrying `checkpoint`; this equals
    *                              `checkpoint.version` for inline checkpoints and
    *                              `checkpoint.version + 1` for deferred checkpoints
@@ -284,6 +320,7 @@ trait AMTCheckpointTestBase
   protected case class AMTCheckpointScenarioContext(
       scenario: AMTCheckpointScenario,
       tableName: String,
+      postSetupSnapshot: Snapshot,
       preCheckpointSnapshot: Snapshot,
       manifestCommitVersion: Long,
       checkpoint: Checkpoint,
@@ -361,7 +398,7 @@ trait AMTCheckpointTestBase
     import AMTCheckpointScenario._
 
     val deltaLog = deltaLogForName(tableName)
-    val preCheckpointSnapshot = deltaLog.update()
+    val postSetupSnapshot = deltaLog.update()
 
     def runCheckpointTrigger(): Unit = {
       inlineCheckpointTriggerActionsOrSQL.map(_(tableName)).foreach {
@@ -372,19 +409,27 @@ trait AMTCheckpointTestBase
       }
     }
 
-    scenario match {
+    // The snapshot immediately before the checkpoint is constructed. For deferred scenarios this is
+    // taken after the trigger's data commit but before the checkpoint commit, so it can be compared
+    // against the post-checkpoint snapshot. Inline scenarios write the checkpoint in the same
+    // commit that adds data, so there is no distinct pre-construction state; it stays the
+    // pre-trigger snapshot (and callers skip the before/after comparison for inline).
+    val preCheckpointSnapshot: Snapshot = scenario match {
       case InlineIncremental =>
         withSQLConf(
             DeltaSQLConf.AMT_LARGE_COMMIT_ACTIONS_COUNT_THRESHOLD_FOR_INLINE_MANIFEST_COMMIT.key
               -> "1") {
           runCheckpointTrigger()
         }
+        postSetupSnapshot
       case _ =>
         runCheckpointTrigger()
+        val beforeConstruction = deltaLog.update()
         commitCheckpoint(deltaLog, incremental = scenario.isIncremental)
+        beforeConstruction
     }
 
-    val checkpointedVersion = preCheckpointSnapshot.version +
+    val checkpointedVersion = postSetupSnapshot.version +
       (if (inlineCheckpointTriggerActionsOrSQL.isDefined) 1L else 0L)
     val manifestCommitVersion = checkpointedVersion + (if (scenario.isInline) 0L else 1L)
     val postCheckpointSnapshot = deltaLog.update()
@@ -395,6 +440,7 @@ trait AMTCheckpointTestBase
     AMTCheckpointScenarioContext(
       scenario = scenario,
       tableName = tableName,
+      postSetupSnapshot = postSetupSnapshot,
       preCheckpointSnapshot = preCheckpointSnapshot,
       manifestCommitVersion = manifestCommitVersion,
       checkpoint = checkpoint,
@@ -461,7 +507,7 @@ trait AMTCheckpointTestBase
     val expectedLastFull = scenario match {
       case AMTCheckpointScenario.InlineIncremental |
           AMTCheckpointScenario.DeferredIncremental =>
-        val bootstrap = amtProvider(context.preCheckpointSnapshot).getOrElse(
+        val bootstrap = amtProvider(context.postSetupSnapshot).getOrElse(
           fail("incremental scenario must bootstrap a full checkpoint"))
         bootstrap.checkpointAction.contentRoot.lastManifestCommitWithFullRewrite.get
       case AMTCheckpointScenario.DeferredFull => checkpoint.version
@@ -644,9 +690,7 @@ object AMTLeafComparisons {
       "tracking.replaced_positions differ")
     assert(sameBytes(actual.manifest_info.dv, expected.manifest_info.dv), "manifest_info.dv differ")
     assert(sameBytes(actual.key_metadata, expected.key_metadata), "key_metadata differ")
-    assert(sameBytes(
-        actual.content_stats.flatMap(_.raw_stats), expected.content_stats.flatMap(_.raw_stats)),
-      "content_stats.raw_stats differ")
+    assert(actual.content_stats == expected.content_stats, "content_stats differ")
   }
 
   /** Asserts two leaf sequences are field-by-field equal (see [[assertLeafEquals]]). */

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointWriteSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointWriteSuite.scala
@@ -20,7 +20,7 @@ import java.io.File
 
 // scalastyle:off import.ordering.noEmptyLine
 import com.databricks.spark.util.{Log4jUsageLogger, MetricDefinitions}
-import org.apache.spark.sql.delta.{Checkpoints, CommitStats, CurrentTransactionInfo, DeltaOperations, LastCheckpointInfo, Snapshot}
+import org.apache.spark.sql.delta.{Checkpoints, CommitStats, CurrentTransactionInfo, DeltaOperations, LastCheckpointInfo}
 import org.apache.spark.sql.delta.actions.{AddFile, Checkpoint, ContentRoot, RemoveFile}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.{FileNames, JsonUtils}
@@ -35,6 +35,50 @@ import org.apache.spark.sql.types.StructType
 class AMTCheckpointWriteSuite extends AMTCheckpointTestBase {
 
   import testImplicits._
+
+  /**
+   * The nested `(name, type, field id)` shape of a persisted struct, recursing into sub-structs so
+   * per-field Iceberg ids are covered. Comparing an on-disk struct's shape to the schema
+   * `AMTPartitionValues`/`AMTContentStats` declare verifies the writer stamped exactly the declared
+   * names, types and ids.
+   */
+  private def fieldIdShape(schema: StructType): Seq[(String, String, Long)] =
+    schema.fields.toSeq.flatMap { field =>
+      val id = field.metadata.getLong(ParquetUtils.FIELD_ID_METADATA_KEY)
+      field.dataType match {
+        case nested: StructType => (field.name, "struct", id) +: fieldIdShape(nested)
+        case dataType => Seq((field.name, dataType.sql, id))
+      }
+    }
+
+  /**
+   * Asserts the live AddFiles survive a deferred checkpoint's construction unchanged: the snapshot
+   * captured before the checkpoint is written must match the post-checkpoint snapshot. No-op for
+   * inline scenarios, whose data commit also writes the checkpoint, so `preCheckpointSnapshot` is
+   * still the pre-trigger state and has fewer files than the post-checkpoint snapshot.
+   */
+  private def assertLiveAddFilesRoundTrip(context: AMTCheckpointScenarioContext): Unit = {
+    if (!context.scenario.isInline) {
+      // The AddFiles constructed from pre-checkpoint snapshot might not match exactly the AddFiles
+      // constructed from the post-checkpoint snapshot. This is because the post-checkpoint AddFiles
+      // are reconstructed from the AMT thus going through DataEntry.toAddFile, and fields like
+      // backReference and amtPassthrough are set differently between the pre- and post-checkpoint
+      // AddFiles. Canonicalization is also needed because the stats are JSON strings, so it needs
+      // to be compared as a parsed tree (order-insensitive).
+      def canonical(add: AddFile) =
+        add.copy(
+          modificationTime = 0L,
+          tags = null,
+          stats = null,
+          backReference = None,
+          amtPassthrough = None) -> Option(add.stats).map(JsonUtils.mapper.readTree)
+      val original = context.preCheckpointSnapshot.allFiles.collect().map(canonical).toSet
+      val reconstructed = context.postCheckpointSnapshot.allFiles.collect().map(canonical).toSet
+      assert(reconstructed == original,
+        s"live AddFiles changed across AMT checkpoint construction\n" +
+          s"  before=$original\n  after=$reconstructed")
+    }
+  }
 
   test("interval boundary emits a follow-up OPTIMIZE CHECKPOINT commit carrying the Checkpoint") {
     withTable("amt_inline_emit") {
@@ -108,42 +152,36 @@ class AMTCheckpointWriteSuite extends AMTCheckpointTestBase {
       "partition values use the typed Iceberg struct and round-trip",
       "amt_typed_partition",
       sqlConfs = leafPackingConfs,
-      tableSchema = ("id INT" +: allTypesPartitionColumns).mkString(", "),
-      partitionColumns = allTypesPartitionSchema.map(_.name))(
+      tableSchema =
+        ("id INT" +: partitionableTestColumns.map(_.columnDef("p_"))).mkString(", "),
+      partitionColumns = partitionableTestColumns.map("p_" + _.name))(
       setup = name => appendRowsAsSeparateFiles(
         name,
         numFiles = leafPackedFiles - 1,
-        columnExprs = "CAST(id AS INT)" +: allTypesPartitionExprs),
-      inlineCheckpointTriggerActionsOrSQL = Some(name => Right(
-        s"""INSERT INTO $name
-           |SELECT ${("CAST(id AS INT)" +: allTypesPartitionExprs).mkString(", ")}
-           |FROM range(${leafPackedFiles - 1}, $leafPackedFiles)""".stripMargin))) { context =>
+        columnExprs = "CAST(id AS INT)" +: partitionableTestColumns.map(_.valueExpr)),
+      inlineCheckpointTriggerActionsOrSQL = Some { name =>
+        val cols = ("CAST(id AS INT)" +: partitionableTestColumns.map(_.valueExpr)).mkString(", ")
+        Right(
+          s"""INSERT INTO $name
+             |SELECT $cols
+             |FROM range(${leafPackedFiles - 1}, $leafPackedFiles)""".stripMargin)
+      }) { context =>
     val leafDf = spark.read.parquet(
       context.provider.liveLeafManifestAbsolutePaths.map(_.toString): _*)
     val partitionSchema = context.postCheckpointSnapshot.metadata.partitionSchema
-    // The persisted struct carries the table's partition types under their logical names, with
-    // Iceberg partition-field ids from 1000 in partition-spec order.
     val partition = leafDf.schema("partition")
     assert(partition.nullable)
-    val fields = partition.dataType.asInstanceOf[StructType].fields
-    assert(fields.map(f => f.name -> f.dataType).toSeq ==
-      AMTPartitionValues.persistedSchema(partitionSchema).map(f => f.name -> f.dataType))
-    assert(fields.map(_.metadata.getLong(ParquetUtils.FIELD_ID_METADATA_KEY)).toSeq ==
-      fields.indices.map(1000L + _))
+    val expectedSchema = AMTPartitionValues.persistedSchema(partitionSchema)
+    assert(
+      fieldIdShape(partition.dataType.asInstanceOf[StructType]) == fieldIdShape(expectedSchema),
+      s"persisted partition schema did not match the expected typed shape\n" +
+        s"  actual=${partition.dataType}\n  expected=$expectedSchema")
     assert(leafDf.select("partition.p_int").collect().map(_.getInt(0)).toSet ==
       (0 until leafPackedFiles).toSet)
 
-    // Every physical-name -> string entry must come back exactly as the log recorded it; a cast
-    // that disagrees with Delta's own serialization would corrupt these silently.
-    val restored = context.provider
-      .loadActionsForStateReconstruction(spark, context.postCheckpointSnapshot.deltaLog)
-      .getOrElse(fail("AMT provider must contribute reconstructed actions."))
-      .where(col("add").isNotNull)
-      .select("add.partitionValues")
-      .collect()
-      .map(_.getMap[String, String](0).toMap)
-      .toSet
-    assert(restored == liveAddFiles(context.postCheckpointSnapshot).map(_.partitionValues).toSet)
+    // Every physical-name -> string partition entry must come back exactly as the log recorded it;
+    // a cast that disagrees with Delta's own serialization would corrupt these silently.
+    assertLiveAddFilesRoundTrip(context)
   }
 
   testAcrossAMTCheckpointScenarios(
@@ -168,6 +206,31 @@ class AMTCheckpointWriteSuite extends AMTCheckpointTestBase {
       assert(!columns.contains("partition"),
         s"an unpartitioned manifest must have no `partition` column; $manifest has $columns")
     }
+  }
+
+  testAcrossAMTCheckpointScenarios(
+      "typed content stats round-trip through reconstruction",
+      "amt_typed_content_stats",
+      tableSchema = allTypeColumnDefinitions.mkString(", "))(
+      setup = name =>
+        appendRowsAsSeparateFiles(name, numFiles = 2, columnExprs = allTypeColumnExprs),
+      inlineCheckpointTriggerActionsOrSQL = Some(name => Right(
+        s"INSERT INTO $name SELECT ${allTypeColumnExprs.mkString(", ")} FROM range(2, 3)"))) {
+    context =>
+    val snapshot = context.postCheckpointSnapshot
+
+    val manifest = context.provider.topLevelFiles.map(_.getPath.toString).head
+    val contentStats = spark.read.parquet(manifest).schema("content_stats")
+    assert(contentStats.nullable)
+    val expectedSchema = AMTContentStats.persistedSchema(snapshot.metadata, snapshot.protocol)
+    assert(
+      fieldIdShape(contentStats.dataType.asInstanceOf[StructType]) == fieldIdShape(expectedSchema),
+      s"persisted content_stats schema did not match the expected typed shape\n" +
+        s"  actual=${contentStats.dataType}\n  expected=$expectedSchema")
+
+    // The typed content stats must round-trip: the AddFiles reconstructed from the checkpoint must
+    // carry the same stats Delta originally wrote.
+    assertLiveAddFilesRoundTrip(context)
   }
 
   testAcrossAMTCheckpointScenarios(
@@ -291,15 +354,17 @@ class AMTCheckpointWriteSuite extends AMTCheckpointTestBase {
       def writeManifest(fileName: String, rows: Seq[AMTSingleAction]): (String, Long) = {
         val file = new Path(metadataDir, fileName)
         val metadata = base.metaData
-        val df = AMTPartitionValues.forWrite(
+        val protocol = base.protocol
+        val withPartition = AMTPartitionValues.forWrite(
           spark.createDataset(rows)(enc).toDF(), metadata.partitionSchema)
+        val df = AMTContentStats.forWrite(withPartition, metadata, protocol)
         Checkpoints.writeAtomicCheckpointParquetFile(
           spark,
           df,
           file,
           hadoopConf,
           useRename = false,
-          outputSchema = Some(AMTSingleAction.persistedSchema(metadata.partitionSchema)),
+          outputSchema = Some(AMTSingleAction.persistedSchema(metadata, protocol)),
           useDeltaParquetWriteSupport = true)
         val relative = AMTUtils.relativizeManifestPathToTableRoot(
           file.getFileSystem(hadoopConf), dataPath, file)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTContentStatsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTContentStatsSuite.scala
@@ -1,0 +1,476 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.amt
+
+import org.apache.spark.sql.delta.{CatalogOwnedTableFeature, ColumnMappingTableFeature, DeletionVectorsTableFeature, DeltaColumnMapping, DeltaConfigs, DomainMetadataTableFeature, RowTrackingFeature}
+import org.apache.spark.sql.delta.actions.{AddFile, Metadata, Protocol}
+import org.apache.spark.sql.delta.util.JsonUtils
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.execution.datasources.parquet.ParquetUtils
+import org.apache.spark.sql.functions.{col, lit}
+import org.apache.spark.sql.types.{BooleanType, ByteType, DataType, DateType, DecimalType, DoubleType, FloatType, IntegerType, LongType, ShortType, StringType, StructField, StructType, TimestampNTZType, TimestampType, VariantType}
+
+/**
+ * Tests for [[AMTContentStats]] -- the conversion between Delta's stats JSON string and the typed
+ * Iceberg V4 `content_stats` struct. `forWrite` and `forRead` are exercised end to end against a
+ * real all-types table (see [[withAllTypesTable]]); the edge cases -- unsupported bound types, a
+ * table that collects no statistics, and the `tightBounds` reconstruction -- run on synthesized
+ * `(Metadata, Protocol)` fixtures (see [[metadataWithColumnIds]]).
+ */
+class AMTContentStatsSuite extends AMTCheckpointTestBase {
+
+  import testImplicits._
+
+  /**
+   * The `content_stats` sub-struct field name for logical column `name`. Sub-structs are named by
+   * the logical name with the (unique) field id attached (see `StatsLeaf.fieldName`) -- e.g.
+   * `d_int_1` -- so a test refers to a column by its logical name and this resolves the id suffix.
+   * The logical names used here are unique, so exactly one sub-struct matches.
+   */
+  private def contentStatsField(persisted: DataFrame, name: String): String = {
+    val matches = persisted.schema("content_stats").dataType.asInstanceOf[StructType]
+      .fieldNames.filter(_.matches(java.util.regex.Pattern.quote(name) + "_\\d+"))
+    assert(matches.length == 1,
+      s"expected exactly one content_stats sub-struct for $name, got ${matches.toSeq}")
+    matches.head
+  }
+
+  /** The logical column names of a persisted `content_stats` struct, id suffix stripped. */
+  private def contentStatsLogicalNames(persisted: DataFrame): Seq[String] =
+    persisted.schema("content_stats").dataType.asInstanceOf[StructType]
+      .fieldNames.toSeq.map(_.replaceAll("_\\d+$", ""))
+
+  /**
+   * Asserts the `content_stats` sub-struct `forWrite` produced for column `name` has exactly the
+   * `expected` stat fields: each maps to its Iceberg type and the string form of its value.
+   */
+  private def assertStatFields(
+      persistedDf: DataFrame,
+      columnName: String,
+      expectedSubFieldToValueMapping: Map[String, (DataType, String)]): Unit = {
+    val fieldName = contentStatsField(persistedDf, columnName)
+    val sub = persistedDf.schema("content_stats").dataType.asInstanceOf[StructType](fieldName)
+      .dataType.asInstanceOf[StructType]
+    val row = persistedDf.select(s"content_stats.$fieldName.*").head()
+    val actual = sub.fields.zipWithIndex.map { case (field, i) =>
+      field.name -> (field.dataType, String.valueOf(row.get(i)))
+    }.toMap
+    assert(actual == expectedSubFieldToValueMapping,
+      s"content_stats.$columnName\n  expected=$expectedSubFieldToValueMapping\n  actual=$actual")
+  }
+
+  test("forWrite persists content_stats as the typed struct the delta log's stats fill") {
+    withAllTypesTable("amt_content_stats_write", numFiles = 1) { deltaLog =>
+      val snapshot = deltaLog.update()
+      val metadata = snapshot.metadata
+      val protocol = snapshot.protocol
+      val add = liveAddFiles(snapshot).head
+      val entry = DataEntry.fromAddFile(
+        add, AMTWriteHelper.addedTrackingForDataEntry(), deltaLog.dataPath)
+      val input = Seq(entry.wrap).toDS().toDF()
+      val persisted = AMTContentStats.forWrite(input, metadata, protocol)
+
+      assert(contentStatsLogicalNames(persisted) == Seq(
+        "d_int", "d_long", "d_short", "d_byte", "d_str", "d_date", "d_ts", "d_ts_ntz", "d_dec",
+        "d_bool", "d_float", "d_double", "d_binary", "d_arr", "d_nested_inner"))
+
+      def bounded(name: String, dataType: DataType, value: String, tight: Boolean): Unit =
+        assertStatFields(persisted, name, Map(
+          "lower_bound" -> (dataType, value),
+          "upper_bound" -> (dataType, value),
+          "tight_bounds" -> (BooleanType, tight.toString),
+          "null_value_count" -> (LongType, "0")))
+      def boundless(name: String): Unit =
+        assertStatFields(persisted, name, Map("null_value_count" -> (LongType, "0")))
+
+      bounded("d_int", IntegerType, "0", tight = true)
+      bounded("d_long", LongType, "0", tight = true)
+      bounded("d_short", ShortType, "0", tight = true)
+      bounded("d_byte", ByteType, "0", tight = true)
+      bounded("d_str", StringType, "row0", tight = false)
+      bounded("d_date", DateType, "2026-07-25", tight = true)
+      bounded("d_ts", TimestampType, "2026-07-25 01:02:03.456", tight = false)
+      bounded("d_ts_ntz", TimestampNTZType, "2026-07-25T01:02:03.456", tight = false)
+      bounded("d_dec", DecimalType(9, 3), "0.000", tight = true)
+      bounded("d_float", FloatType, "0.0", tight = true)
+      bounded("d_double", DoubleType, "0.0", tight = true)
+      bounded("d_nested_inner", IntegerType, "0", tight = true)
+      boundless("d_bool")
+      boundless("d_binary")
+      boundless("d_arr")
+    }
+  }
+
+  test("forRead reconstructs the stats JSON the delta log holds, for every type") {
+    withAllTypesTable("amt_content_stats_roundtrip", numFiles = leafPackedFiles) { deltaLog =>
+      commitCheckpoint(deltaLog, incremental = false)
+      val snapshot = deltaLog.update()
+      val provider = amtProvider(snapshot).getOrElse(fail("expected AMTCheckpointProvider"))
+      val metadata = snapshot.metadata
+      val protocol = snapshot.protocol
+      val leaves = provider.liveLeafManifestAbsolutePaths.map(_.toString)
+      assert(leaves.nonEmpty, "Expected at least one leaf manifest.")
+
+      // Read the stats straight from the commit json rather than the snapshot: an AMT snapshot
+      // reconstructs its AddFiles through `forRead`, so comparing against it would compare it with
+      // itself. Compare as parsed JSON trees so field order and formatting do not matter.
+      val loggedSchema = StructType(Seq(StructField("add", StructType(Seq(
+        StructField("stats", StringType))))))
+      val logged = spark.read.schema(loggedSchema)
+        .json(new Path(deltaLog.logPath, "*.json").toString)
+        .where(col("add").isNotNull)
+        .select(col("add.stats"))
+        .as[String].collect()
+        .map(JsonUtils.mapper.readTree).toSet
+      assert(logged.size == leafPackedFiles,
+        s"Expected one logged stats per file, got ${logged.size}.")
+
+      // forRead reconstructs the Delta stats JSON from the leaves' DATA entries; compare as parsed
+      // JSON trees so field order and formatting do not matter.
+      val reconstructed = allowReadWithinDeltaLog {
+        val entries = spark.read.parquet(leaves: _*)
+          .where(col("content_type") === AMTSingleAction.ContentType.Type.Data)
+        AMTContentStats.forRead(entries, metadata, protocol)
+          .select(col("content_stats"))
+          .as[String].collect()
+          .map(JsonUtils.mapper.readTree).toSet
+      }
+      // Precompute the comparison and message: ScalaTest's `assert` macro fails to expand on Scala
+      // 2.12 when its arguments interpolate `Set[JsonNode]` values, so hand it plain Boolean/String
+      // values instead ("macro has not been expanded").
+      val reconstructedMatchesLogged = reconstructed == logged
+      val mismatchClue =
+        s"forRead did not reproduce the logged stats.\n  logged=$logged\n" +
+          s"  reconstructed=$reconstructed"
+      assert(reconstructedMatchesLogged, mismatchClue)
+    }
+  }
+
+  /**
+   * A stand-in table root; synthesized entries carry no DV, so it is only a
+   * path placeholder.
+   */
+  private val tableRoot = new Path("file:/tmp/amt-test-table")
+
+  /**
+   * A [[Protocol]] representative of a real AMT table: it carries every
+   * feature `AdaptiveMetadataTableFeature` requires. In particular it is
+   * DV-capable, so Delta's derived stats schema always carries `tightBounds`.
+   */
+  private def amtProtocol: Protocol =
+    Protocol(3, 7)
+      .withFeature(CatalogOwnedTableFeature)
+      .withFeature(RowTrackingFeature)
+      .withFeature(DomainMetadataTableFeature)
+      .withFeature(DeletionVectorsTableFeature)
+      .withFeature(ColumnMappingTableFeature)
+
+  /** A [[Metadata]] for `schema` in `id` column-mapping mode, with column ids
+   * and physical names assigned the way a real AMT table has them (AMT
+   * requires that mode, and the content-stats field ids are derived from those
+   * column ids). Stats are keyed by whatever physical name Delta assigns, so
+   * it does not matter that the assignment is a fresh UUID per column.
+   */
+  private def metadataWithColumnIds(
+      schema: StructType,
+      partitionColumns: Seq[String] = Seq.empty,
+      configuration: Map[String, String] = Map.empty
+  ): Metadata = {
+    val base = Metadata(
+      id = "amt-content-stats-test",
+      schemaString = schema.json,
+      partitionColumns = partitionColumns,
+      configuration = configuration +
+        (DeltaConfigs.COLUMN_MAPPING_MODE.key -> "id")
+    )
+    DeltaColumnMapping.assignColumnIdAndPhysicalName(
+      newMetadata = base,
+      oldMetadata = Metadata(),
+      isChangingModeOnExistingTable = false,
+      isOverwritingSchema = false
+    )
+  }
+
+  /**
+   * A Delta stats JSON string covering every data column of `metadata` (keyed by physical name, as
+   * Delta writes it): a placeholder min/max, a zero null count, and the given file-level
+   * `tightBounds`. Boundless types (variant, geometry/geography) get a null count but no min/max.
+   */
+  private def getSampleStatsJson(metadata: Metadata, tightBounds: Boolean): String = {
+    def bounds(dataType: DataType): Option[(String, String)] = dataType match {
+      case _: IntegerType | _: LongType => Some(("1", "9"))
+      case _: StringType => Some(("\"apple\"", "\"pear\""))
+      case _: TimestampType =>
+        Some(("\"2020-01-01T00:00:00.000Z\"", "\"2020-12-31T00:00:00.000Z\""))
+      case _: VariantType => None
+      case other => fail(s"getSampleStatsJson has no placeholder for $other")
+    }
+    val columns = metadata.dataSchema
+    def obj(value: StructField => Option[String]): String =
+      columns.flatMap(f =>
+        value(f).map(v => s""""${DeltaColumnMapping.getPhysicalName(f)}":$v""")).mkString(",")
+    s"""{"numRecords":10,
+       |"minValues":{${obj(f => bounds(f.dataType).map(_._1))}},
+       |"maxValues":{${obj(f => bounds(f.dataType).map(_._2))}},
+       |"nullCount":{${obj(_ => Some("0"))}},
+       |"tightBounds":$tightBounds}""".stripMargin
+  }
+
+  /**
+   * Builds the [[AMTSingleAction]] input for one data file carrying `statsJson`, then runs
+   * [[AMTContentStats.forWrite]] to get the persisted, typed `content_stats`.
+   */
+  private def writeStats(statsJson: String, metadata: Metadata, protocol: Protocol): DataFrame = {
+    val addFile = AddFile(
+      path = "part-00000.parquet",
+      partitionValues = Map("p" -> "1"),
+      size = 1024L,
+      modificationTime = 100L,
+      dataChange = true,
+      stats = statsJson)
+    val entry = DataEntry.fromAddFile(
+      addFile, AMTWriteHelper.addedTrackingForDataEntry(), tableRoot)
+    val input = Seq(entry.wrap).toDS().toDF()
+    AMTContentStats.forWrite(input, metadata, protocol)
+  }
+
+  /**
+   * Runs [[AMTContentStats.forRead]] on a persisted DataFrame and returns the single entry's
+   * reconstructed Delta stats JSON.
+   */
+  private def readStats(persisted: DataFrame, metadata: Metadata, protocol: Protocol): String =
+    AMTContentStats.forRead(persisted, metadata, protocol)
+      .as[AMTSingleAction].head()
+      .unwrap.asInstanceOf[DataEntry].toAddFile(tableRoot).stats
+
+  test("variant columns persist a null count but no bounds") {
+    // Delta collects min/max for VARIANT, but AMTContentStats has no Iceberg V4 bound
+    // representation for it yet, so `isBoundTypeSupported` rejects it. It is still counted for
+    // nulls, so it surfaces with a `null_value_count` only -- like a plain array column.
+    val metadata = metadataWithColumnIds(
+      new StructType()
+        .add("id", LongType)    // supported bound type: full typed bounds
+        .add("v", VariantType)) // unsupported bound type
+    val protocol = amtProtocol
+    val persisted =
+      writeStats(getSampleStatsJson(metadata, tightBounds = true), metadata, protocol)
+    assertStatFields(persisted, "id", Map(
+      "lower_bound" -> (LongType, "1"),
+      "upper_bound" -> (LongType, "9"),
+      "tight_bounds" -> (BooleanType, "true"),
+      "null_value_count" -> (LongType, "0")))
+    assertStatFields(persisted, "v", Map("null_value_count" -> (LongType, "0")))
+  }
+
+  test("content stats adapter round-trips a table that collects no statistics") {
+    // numIndexedCols = 0 means Delta collects only numRecords, so there are no per-column stats and
+    // `content_stats` is dropped from the schema (an empty struct is not Parquet-writable).
+    val metadata = metadataWithColumnIds(
+      schema = new StructType().add("id", LongType),
+      configuration = Map(DeltaConfigs.DATA_SKIPPING_NUM_INDEXED_COLS.key -> "0"))
+    val protocol = amtProtocol
+
+    assert(
+      !AMTSingleAction.persistedSchema(metadata, protocol).fieldNames.contains(
+        "content_stats"),
+      "a table with no per-column statistics omits content_stats from the persisted schema")
+
+    val persisted = writeStats("""{"numRecords":7}""", metadata, protocol)
+    // record_count alone reconstructs the stats Delta had.
+    val restoredJson = readStats(persisted, metadata, protocol)
+    assert(JsonUtils.mapper.readTree(restoredJson) ==
+      JsonUtils.mapper.readTree("""{"numRecords":7}"""))
+  }
+
+  test("content stats cover only the indexed columns, not every column") {
+    // Delta collects stats only for the first `dataSkippingNumIndexedCols` columns, so
+    // `statCollectionPhysicalSchema` -- and therefore `content_stats` -- covers only that prefix.
+    // Three columns with a limit of 2: only `a` and `b` get a sub-struct; `c` is left out.
+    val metadata = metadataWithColumnIds(
+      schema = new StructType().add("a", LongType).add("b", LongType).add("c", LongType),
+      configuration = Map(DeltaConfigs.DATA_SKIPPING_NUM_INDEXED_COLS.key -> "2"))
+    val protocol = amtProtocol
+    val persisted =
+      writeStats(getSampleStatsJson(metadata, tightBounds = true), metadata, protocol)
+
+    assert(contentStatsLogicalNames(persisted) == Seq("a", "b"),
+      s"only the first 2 indexed columns get content_stats; got " +
+        s"${contentStatsLogicalNames(persisted)}")
+    assertStatFields(persisted, "a", Map(
+      "lower_bound" -> (LongType, "1"),
+      "upper_bound" -> (LongType, "9"),
+      "tight_bounds" -> (BooleanType, "true"),
+      "null_value_count" -> (LongType, "0")))
+  }
+
+  test("reading back with fewer indexed columns than were written keeps only the read subset") {
+    // Written with 3 indexed columns, then read back after the stats-columns config was lowered to
+    // 2 (same table, physical names/ids unchanged). `forRead` derives its leaves from the read
+    // metadata, so it projects only a and b; c's typed sub-struct is still on disk but drops out of
+    // the reconstructed Delta stats. A superset of persisted stats is never an error, just unused.
+    val schema = new StructType().add("a", LongType).add("b", LongType).add("c", LongType)
+    val writeMetadata = metadataWithColumnIds(
+      schema, configuration = Map(DeltaConfigs.DATA_SKIPPING_NUM_INDEXED_COLS.key -> "3"))
+    val readMetadata = writeMetadata.copy(
+      configuration = writeMetadata.configuration +
+        (DeltaConfigs.DATA_SKIPPING_NUM_INDEXED_COLS.key -> "2"))
+    val protocol = amtProtocol
+
+    val persisted =
+      writeStats(getSampleStatsJson(writeMetadata, tightBounds = true), writeMetadata, protocol)
+    assert(contentStatsLogicalNames(persisted) == Seq("a", "b", "c"),
+      s"written with 3 indexed columns, content_stats should carry a, b, c; got " +
+        s"${contentStatsLogicalNames(persisted)}")
+
+    val physical = readMetadata.dataSchema
+      .map(f => f.name -> DeltaColumnMapping.getPhysicalName(f)).toMap
+    val minValues = JsonUtils.mapper.readTree(readStats(persisted, readMetadata, protocol))
+      .get("minValues")
+    assert(
+      minValues.has(physical("a")) && minValues.has(physical("b")) && !minValues.has(physical("c")),
+      s"reading back with 2 indexed columns keeps only a and b, dropping c; got $minValues")
+  }
+
+  test("content stats round-trip a schema whose flattened leaf names collide") {
+    // A top-level column `a_b` and a nested leaf `a`.`b` both flatten to the logical name "a_b".
+    // Naming each content_stats sub-struct by that flattened name makes the two collide: the
+    // persisted struct gets two "a_b" fields and `forRead`'s by-name lookup is ambiguous. Keying
+    // the sub-structs by the (unique) column id keeps them distinct. This asserts each column's
+    // stats reconstruct into its own physical-name slot -- it fails while the sub-structs are named
+    // by the flattened logical name and passes once they are keyed by column id.
+    val schema = new StructType()
+      .add("a_b", LongType)
+      .add("a", new StructType().add("b", LongType))
+    val metadata = metadataWithColumnIds(schema)
+    val protocol = amtProtocol
+
+    val physTop = DeltaColumnMapping.getPhysicalName(metadata.dataSchema("a_b"))
+    val structA = metadata.dataSchema("a")
+    val physA = DeltaColumnMapping.getPhysicalName(structA)
+    val physB = DeltaColumnMapping.getPhysicalName(structA.dataType.asInstanceOf[StructType]("b"))
+
+    // Distinct bounds per column so a mixed-up mapping is detectable: a_b -> [1,9], a.b -> [2,8].
+    val statsJson =
+      s"""{"numRecords":10,
+         |"minValues":{"$physTop":1,"$physA":{"$physB":2}},
+         |"maxValues":{"$physTop":9,"$physA":{"$physB":8}},
+         |"nullCount":{"$physTop":0,"$physA":{"$physB":0}},
+         |"tightBounds":true}""".stripMargin
+
+    val persisted = writeStats(statsJson, metadata, protocol)
+    val reconstructed = JsonUtils.mapper.readTree(readStats(persisted, metadata, protocol))
+    val minValues = reconstructed.get("minValues")
+    val maxValues = reconstructed.get("maxValues")
+
+    assert(minValues.get(physTop).asLong == 1 && maxValues.get(physTop).asLong == 9,
+      s"top-level a_b stats must reconstruct into its own slot; got $reconstructed")
+    assert(minValues.get(physA).get(physB).asLong == 2 &&
+      maxValues.get(physA).get(physB).asLong == 8,
+      s"nested a.b stats must reconstruct into its own slot; got $reconstructed")
+  }
+
+  /** The persisted Iceberg `tight_bounds` of the sub-struct for logical column `column`. */
+  private def persistedTightBounds(persisted: DataFrame, column: String): Boolean = {
+    val sub = col("content_stats").getField(contentStatsField(persisted, column))
+    persisted.select(sub.getField("tight_bounds")).as[Boolean].head()
+  }
+
+  /** The file-level `tightBounds` recorded in a Delta stats JSON, or None if absent. */
+  private def tightBoundsOf(statsJson: String): Option[Boolean] =
+    Option(JsonUtils.mapper.readTree(statsJson).get("tightBounds")).map(_.asBoolean)
+
+  test("all columns have truncated type: Delta tightBounds is reconstructed conservatively false") {
+    // The only bounded columns are string/timestamp. Each is forced to tight_bounds=false on write,
+    // and on read there is no untruncated column to recover the file flag from, so it falls back
+    // to false -- a safe precision loss even though the source file was tight.
+    val metadata = metadataWithColumnIds(
+      new StructType().add("s", StringType).add("ts", TimestampType))
+    Seq(true, false).foreach { tight =>
+      val persisted =
+        writeStats(getSampleStatsJson(metadata, tightBounds = tight), metadata, amtProtocol)
+      assert(!persistedTightBounds(persisted, "s"), "a string column is never tight")
+      assert(!persistedTightBounds(persisted, "ts"), "a timestamp column is never tight")
+      assert(tightBoundsOf(readStats(persisted, metadata, amtProtocol)).contains(false),
+        "with no untruncated column to vouch for it, the file flag reconstructs to false")
+    }
+  }
+
+  test("no truncated column types: the Delta tightBounds round-trips exactly") {
+    // Every column is untruncated, so each carries the file flag verbatim and the
+    // reconstructed flag matches -- tight and wide both round-trip unchanged.
+    val metadata = metadataWithColumnIds(
+      new StructType().add("id", LongType).add("n", IntegerType))
+    Seq(true, false).foreach { tight =>
+      val persisted =
+        writeStats(getSampleStatsJson(metadata, tightBounds = tight), metadata, amtProtocol)
+      assert(persistedTightBounds(persisted, "id") == tight)
+      assert(persistedTightBounds(persisted, "n") == tight)
+      assert(tightBoundsOf(readStats(persisted, metadata, amtProtocol)).contains(tight),
+        s"an all-untruncated table must round-trip tightBounds=$tight unchanged")
+    }
+  }
+
+  test("mixed column types: the Delta tightBounds round-trips via the untruncated column") {
+    // A mix of an untruncated (long) and a truncated (string) column. The untruncated column
+    // carries the file flag, the string is never tight, and the reconstructed flag comes back from
+    // the untruncated column -- so both tight and wide round-trip unchanged.
+    val metadata = metadataWithColumnIds(
+      new StructType().add("id", LongType).add("name", StringType))
+    Seq(true, false).foreach { tight =>
+      val persisted =
+        writeStats(getSampleStatsJson(metadata, tightBounds = tight), metadata, amtProtocol)
+      assert(persistedTightBounds(persisted, "id") == tight,
+        "the untruncated column carries the file flag")
+      assert(!persistedTightBounds(persisted, "name"), "a string column is never tight")
+      assert(tightBoundsOf(readStats(persisted, metadata, amtProtocol)).contains(tight),
+        s"a mixed table must round-trip tightBounds=$tight via the untruncated column")
+    }
+  }
+
+  test("reading back to Delta ignores a string column's Iceberg tight_bounds") {
+    val metadata = metadataWithColumnIds(new StructType().add("name", StringType))
+    // `forWrite` never marks a string tight, so this happens only when an external writer sets a
+    // string column with tight_bounds=true.
+    val persisted =
+      writeStats(getSampleStatsJson(metadata, tightBounds = true), metadata, amtProtocol)
+    val tampered = persisted.withColumn("content_stats",
+      col("content_stats").withField(s"${contentStatsField(persisted, "name")}.tight_bounds",
+        lit(true)))
+    assert(persistedTightBounds(tampered, "name"), "the tampered Iceberg flag reads back as true")
+    assert(tightBoundsOf(readStats(tampered, metadata, amtProtocol)).contains(false),
+      "Delta ignores a truncated column's tightness, so the reconstructed flag stays false")
+  }
+
+  test("reading back to Delta ANDs untruncated columns, so a mix reconstructs tightBounds false") {
+    // Two untruncated columns. A tight file makes both tight_bounds=true, but if a manifest carries
+    // a mix (one column not tight), `forRead` ANDs the untruncated columns, so the reconstructed
+    // Delta tightBounds is false even though the other column is still tight.
+    val metadata = metadataWithColumnIds(
+      new StructType().add("id", LongType).add("id2", LongType))
+    val persisted =
+      writeStats(getSampleStatsJson(metadata, tightBounds = true), metadata, amtProtocol)
+    val tampered = persisted.withColumn("content_stats",
+      col("content_stats").withField(s"${contentStatsField(persisted, "id2")}.tight_bounds",
+        lit(false)))
+    assert(persistedTightBounds(tampered, "id"), "the untouched column stays tight")
+    assert(!persistedTightBounds(tampered, "id2"), "the tampered column is not tight")
+    assert(tightBoundsOf(readStats(tampered, metadata, amtProtocol)).contains(false),
+      "a mix of tight and non-tight untruncated columns reconstructs to false")
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTFieldSpecSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTFieldSpecSuite.scala
@@ -60,7 +60,11 @@ class AMTFieldSpecSuite extends AMTCheckpointTestBase {
     collect(group, Seq.empty)
   }
 
-  private def assertFieldIds(hadoopConf: Configuration, file: File, label: String): Unit = {
+  private def assertFieldIds(
+      hadoopConf: Configuration,
+      file: File,
+      label: String,
+      expected: Map[String, Int]): Unit = {
     val schema = ParquetFileReader.readFooter(
       hadoopConf, new Path(file.getAbsolutePath), ParquetMetadataConverter.NO_FILTER)
       .getFileMetaData.getSchema
@@ -69,10 +73,10 @@ class AMTFieldSpecSuite extends AMTCheckpointTestBase {
       actual.values.toSet.size == actual.size,
       s"$label contains duplicate field ids: $actual")
     assert(
-      actual == AMTSingleAction.allFieldIdByName,
-      s"$label field ids did not match AMTSingleAction.allFieldIdByName\n" +
-        s"  missing=${AMTSingleAction.allFieldIdByName.toSet.diff(actual.toSet)}\n" +
-        s"  unexpected=${actual.toSet.diff(AMTSingleAction.allFieldIdByName.toSet)}")
+      actual == expected,
+      s"$label field ids did not match the schema the writer derived\n" +
+        s"  missing=${expected.toSet.diff(actual.toSet)}\n" +
+        s"  unexpected=${actual.toSet.diff(expected.toSet)}")
   }
 
   /**
@@ -116,27 +120,60 @@ class AMTFieldSpecSuite extends AMTCheckpointTestBase {
   }
 
   test("persistedSchema stamps an id on every mapped field of AMTSingleAction") {
-    val stamped = stampedFieldIdByName(
-      AMTSingleAction.persistedSchema(allTypesPartitionSchema))
-    // Partition fields take Iceberg ids from 1000 in partition-spec order, whatever their type.
-    val expected = AMTSingleAction.allFieldIdByName ++ Map("partition" -> 102) ++
-      allTypesPartitionSchema.fields.zipWithIndex.map { case (field, ordinal) =>
-        s"partition.${field.name}" -> (1000 + ordinal)
-      }
-    assert(
-      stamped == expected,
-      "persistedSchema field ids did not match AMTSingleAction.allFieldIdByName\n" +
-        s"  missing=${expected.toSet.diff(stamped.toSet)}\n" +
-        s"  unexpected=${stamped.toSet.diff(expected.toSet)}")
+    withAllTypesTable("amt_fieldid_schema", numFiles = 0) { deltaLog =>
+      val snapshot = deltaLog.update()
+      val metadata = snapshot.metadata
+      val protocol = snapshot.protocol
+      val stamped = stampedFieldIdByName(AMTSingleAction.persistedSchema(metadata, protocol))
 
-    // Guard against a field added to a nested id-bearing struct (tracking / deletion_vector /
-    // manifest_info) without a corresponding id: every scalar of those structs must be stamped.
-    val schema = AMTSingleAction.persistedSchema(allTypesPartitionSchema)
-    Seq("tracking", "deletion_vector", "manifest_info").foreach { parent =>
-      val struct = schema(parent).dataType.asInstanceOf[StructType]
-      struct.fields.foreach { f =>
-        assert(f.metadata.contains(ParquetUtils.FIELD_ID_METADATA_KEY),
-          s"nested field '$parent.${f.name}' has no stamped Iceberg field id.")
+      // Content-stats sub-structs are based at 10_000 + 200 * columnId, with the per-statistic
+      // offsets from the Iceberg V4 column-stats proposal. The sub-struct carries the base id
+      // (stats are resolved by id) and is named by the column's logical name with its field id
+      // attached (see StatsLeaf.fieldName), so the name stays unique. An array is not
+      // skipping-eligible, so it gets a null count and no bounds; a struct contributes its leaf.
+      def statsIds(columnId: Int, name: String, withBounds: Boolean): Seq[(String, Int)] = {
+        val base = 10000 + 200 * columnId
+        val field = s"${name}_$columnId" // sub-struct field name: logical name + field id
+        // Iceberg V4 offsets: lower_bound=1, upper_bound=2, tight_bounds=3, null_value_count=5.
+        Seq(
+          s"content_stats.$field" -> base,
+          s"content_stats.$field.null_value_count" -> (base + 5)) ++
+          (if (!withBounds) Nil
+           else Seq(
+             s"content_stats.$field.lower_bound" -> (base + 1),
+             s"content_stats.$field.upper_bound" -> (base + 2),
+             s"content_stats.$field.tight_bounds" -> (base + 3)))
+      }
+      // Partition fields take Iceberg ids from 1000 in partition-spec order, whatever their type.
+      val expected = AMTSingleAction.allFieldIdByName ++ Map("partition" -> 102) ++
+        partitionableTestColumns.map(_.structField("p_")).zipWithIndex.map {
+          case (field, ordinal) => s"partition.${field.name}" -> (1000 + ordinal)
+        } ++
+        // Data columns are one per type in `allTypeColumns` order, so column ids run d_int=1 ..
+        // d_double=12, d_binary=13, d_arr=14, d_nested=15 (inner=16).
+        Seq(
+          (1, "d_int"), (2, "d_long"), (3, "d_short"), (4, "d_byte"), (5, "d_str"),
+          (6, "d_date"), (7, "d_ts"), (8, "d_ts_ntz"), (9, "d_dec"),
+          (11, "d_float"), (12, "d_double"), (16, "d_nested_inner"))
+          .flatMap { case (id, name) => statsIds(id, name, withBounds = true) } ++
+        // Boolean, array, and binary are not skipping-eligible (no min/max): null count only.
+        Seq((10, "d_bool"), (13, "d_binary"), (14, "d_arr"))
+          .flatMap { case (id, name) => statsIds(id, name, withBounds = false) }
+      assert(
+        stamped == expected,
+        "persistedSchema field ids did not match the expected map\n" +
+          s"  missing=${expected.toSet.diff(stamped.toSet)}\n" +
+          s"  unexpected=${stamped.toSet.diff(expected.toSet)}")
+
+      // Guard against a field added to a nested id-bearing struct (tracking / deletion_vector /
+      // manifest_info) without a corresponding id: every scalar of those structs must be stamped.
+      val schema = AMTSingleAction.persistedSchema(metadata, protocol)
+      Seq("tracking", "deletion_vector", "manifest_info").foreach { parent =>
+        val struct = schema(parent).dataType.asInstanceOf[StructType]
+        struct.fields.foreach { f =>
+          assert(f.metadata.contains(ParquetUtils.FIELD_ID_METADATA_KEY),
+            s"nested field '$parent.${f.name}' has no stamped Iceberg field id.")
+        }
       }
     }
   }
@@ -149,12 +186,61 @@ class AMTFieldSpecSuite extends AMTCheckpointTestBase {
       inlineCheckpointTriggerActionsOrSQL = Some(name => Right(
         s"INSERT INTO $name VALUES (${leafPackedFiles - 1})"))) { context =>
     val hadoopConf = context.postCheckpointSnapshot.deltaLog.newDeltaHadoopConf()
+    // `content_stats` is shaped per table, so the footer's ids can't match a static map. Compare
+    // against the schema the writer actually derived from the metadata/protocol the checkpoint
+    // recorded -- which is exactly what a reader projects with.
+    val checkpointAction = context.provider.checkpointAction
+    val expected = stampedFieldIdByName(AMTSingleAction.persistedSchema(
+      checkpointAction.metaData, checkpointAction.protocol))
     // `leaf.location` and `contentRoot.path` are stored table-root-relative, so go through the
     // provider, which resolves them against the table root.
     val leaves = context.provider.liveLeafManifestAbsolutePaths.map(path => new File(path.toUri))
     val root = new File(context.provider.topLevelFiles.head.getPath.toUri)
     assert(leaves.nonEmpty, "Expected at least one leaf manifest.")
-    leaves.foreach(f => assertFieldIds(hadoopConf, f, s"leaf ${f.getName}"))
-    assertFieldIds(hadoopConf, root, s"root ${root.getName}")
+    leaves.foreach(f => assertFieldIds(hadoopConf, f, s"leaf ${f.getName}", expected))
+    assertFieldIds(hadoopConf, root, s"root ${root.getName}", expected)
+  }
+
+  test("a full checkpoint rewrite refreshes content_stats names after a column rename") {
+    withTable("amt_rename_rewrite") {
+      // A huge checkpoint interval keeps the rename commit from auto-checkpointing, so the only
+      // rewrites are the two explicit ones below.
+      createAMTTable(
+        "amt_rename_rewrite", tableSchema = "c LONG", checkpointInterval = Int.MaxValue)
+      appendRowsAsSeparateFiles(
+        "amt_rename_rewrite", numFiles = 2, columnExprs = Seq("CAST(id AS LONG)"))
+      val deltaLog = deltaLogForName("amt_rename_rewrite")
+
+      // The logical name of the single `content_stats` sub-struct on the latest checkpoint's
+      // manifests. Sub-structs are named `<logical name>_<field id>` (the id keeps the name unique;
+      // see StatsLeaf.fieldName), so strip the id suffix to compare the logical part that a rename
+      // refreshes.
+      def contentStatsNames(): Seq[String] = {
+        val snapshot = deltaLog.update()
+        val provider = amtProvider(snapshot).getOrElse(fail("expected AMTCheckpointProvider"))
+        val manifestPaths =
+          (provider.topLevelFiles.map(_.getPath.toString) ++
+            provider.liveLeafManifestAbsolutePaths.map(_.toString)).distinct
+        allowReadWithinDeltaLog {
+          val manifestDf = spark.read.parquet(manifestPaths: _*)
+          manifestDf.schema("content_stats").dataType.asInstanceOf[StructType]
+            .fieldNames.toSeq.map(_.replaceAll("_\\d+$", ""))
+        }
+      }
+
+      // The pre-rename checkpoint names the sub-struct by the original logical name.
+      commitCheckpoint(deltaLog, incremental = false)
+      assert(contentStatsNames() == Seq("c"))
+
+      // A metadata-only rename does not rewrite the existing manifests, so the checkpoint on disk
+      // still names the sub-struct by the old logical name until it is rewritten.
+      sql("ALTER TABLE amt_rename_rewrite RENAME COLUMN c TO c_renamed")
+      assert(contentStatsNames() == Seq("c"))
+
+      // Forcing a full rewrite re-derives content_stats from the current metadata, so the
+      // sub-struct picks up the new logical name (same field id).
+      commitCheckpoint(deltaLog, incremental = false)
+      assert(contentStatsNames() == Seq("c_renamed"))
+    }
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTPartitionValuesSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTPartitionValuesSuite.scala
@@ -148,9 +148,7 @@ class AMTPartitionValuesSuite extends AMTCheckpointTestBase {
     }
 
   test("forRead reproduces the partition values the delta log holds, for every type") {
-    val numFiles = 4
-    withAllPartitionTypesTable(
-        "amt_partition_roundtrip", numFiles = numFiles, maxEntriesPerLeaf = 2) { deltaLog =>
+    withAllTypesTable("amt_partition_roundtrip", numFiles = leafPackedFiles) { deltaLog =>
       commitCheckpoint(deltaLog, incremental = false)
       val snapshot = deltaLog.update()
       val provider = amtProvider(snapshot).getOrElse(fail("expected AMTCheckpointProvider"))
@@ -174,7 +172,8 @@ class AMTPartitionValuesSuite extends AMTCheckpointTestBase {
         .collect()
         .map(_.getMap[String, String](0).toMap)
         .toSet
-      assert(logged.size == numFiles, s"Expected one logged add per file, got ${logged.size}.")
+      assert(logged.size == leafPackedFiles,
+        s"Expected one logged add per file, got ${logged.size}.")
 
       val reconstructed = reconstructPartitionValues(manifests, partitionSchema)
       assert(reconstructed == logged,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSingleActionSerializerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSingleActionSerializerSuite.scala
@@ -228,7 +228,7 @@ class AMTSingleActionSerializerSuite extends QueryTest with SharedSparkSession {
 
   test("parquet round-trip preserves every binary field") {
     // Binary columns are `Array[Byte]`, whose case-class `==` is reference equality, so this
-    // asserts the bytes structurally. Populate all five Option[Array[Byte]] fields across the
+    // asserts the bytes structurally. Populate all four Option[Array[Byte]] fields across the
     // row and its sub-structs on a single DATA_MANIFEST entry (the only kind that reaches
     // `manifest_info.dv`) so none is silently dropped by wrap/unwrap or the encoder.
     withTempDir { dir =>
@@ -236,7 +236,6 @@ class AMTSingleActionSerializerSuite extends QueryTest with SharedSparkSession {
       val deletedPos = Array[Byte](5, 6)
       val replacedPos = Array[Byte](7, 8, 9)
       val manifestDv = Array[Byte](10, 11)
-      val rawStats = Array[Byte](12, 13, 14)
       val entry = DataManifestEntry(
         location = "dm.parquet",
         file_format = AMTSingleAction.FileFormatParquet,
@@ -245,7 +244,6 @@ class AMTSingleActionSerializerSuite extends QueryTest with SharedSparkSession {
         record_count = 1L,
         file_size_in_bytes = 1L,
         manifest_info = sampleManifestInfo.copy(dv = Some(manifestDv), dv_cardinality = Some(2L)),
-        content_stats = Some(ContentStats(Some(rawStats))),
         key_metadata = Some(keyMeta)).wrap
       val path = new java.io.File(dir, "binary").getCanonicalPath
       spark.createDataset(Seq(entry)).write.parquet(path)
@@ -259,8 +257,6 @@ class AMTSingleActionSerializerSuite extends QueryTest with SharedSparkSession {
         "tracking.replaced_positions did not round-trip.")
       assert(r.manifest_info.flatMap(_.dv).exists(_.sameElements(manifestDv)),
         "manifest_info.dv did not round-trip.")
-      assert(r.content_stats.flatMap(_.raw_stats).exists(_.sameElements(rawStats)),
-        "content_stats.raw_stats did not round-trip.")
     }
   }
 
@@ -517,5 +513,23 @@ class AMTSingleActionSerializerSuite extends QueryTest with SharedSparkSession {
 
     // A present struct whose fields are all null -> present but empty.
     assert(AMTPassthrough.fromRow(rowWith(structRow()), indices).contains(AMTPassthrough()))
+  }
+
+  test("toAddFile keeps numRecords physical for a file with a deletion vector") {
+    // Iceberg's record_count and Delta's numRecords are both physical counts, so neither
+    // fromAddFile nor toAddFile may adjust for the DV -- AddFile subtracts the cardinality itself
+    // when it derives numLogicalRecords. Adjusting in either place would double-count.
+    // AMT only supports on-disk deletion vectors.
+    val dv = DeletionVectorDescriptor.onDiskWithUuidRelativePath(
+      id = UUID.randomUUID(), sizeInBytes = 20, cardinality = 4L, offset = Some(8))
+    val add = sampleAddFile.copy(stats = """{"numRecords":10}""", deletionVector = dv)
+    assert(add.numPhysicalRecords.contains(10L))
+    assert(add.numLogicalRecords.contains(6L))
+
+    val entry = DataEntry.fromAddFile(add, addedTracking, tableRoot)
+    assert(entry.record_count == 10L, "record_count is the physical count")
+    val roundTripped = entry.toAddFile(tableRoot)
+    assert(roundTripped.numPhysicalRecords.contains(10L))
+    assert(roundTripped.numLogicalRecords.contains(6L))
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSingleCommitSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSingleCommitSuite.scala
@@ -179,7 +179,7 @@ class AMTSingleCommitSuite extends AMTCheckpointTestBase {
     inlineCheckpointTriggerActionsOrSQL = insertThirdRow
   ) { context =>
     val deltaLog = deltaLogForName(context.tableName)
-    val firstLogCommit = context.preCheckpointSnapshot.version
+    val firstLogCommit = context.postSetupSnapshot.version
     assert(checkpointAt(deltaLog, firstLogCommit).isEmpty, s"v$firstLogCommit must be a log commit")
     val commits = DeltaFileProviderUtils.getCommitsInVersionRange(
       spark,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotSuite.scala
@@ -122,7 +122,7 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
     inlineCheckpointTriggerActionsOrSQL =
       Some(name => Right(s"INSERT INTO $name VALUES (100)"))
   ) { context =>
-    val seededVersion = amtProvider(context.preCheckpointSnapshot)
+    val seededVersion = amtProvider(context.postSetupSnapshot)
       .getOrElse(fail("the seed commit must have emitted an AMT"))
       .version
     assert(
@@ -248,7 +248,7 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
       Some(name => Right(s"INSERT INTO $name VALUES (100)"))
   ) { context =>
     // A new AMT re-materialized past the rewrite and still carries the passthrough.
-    val seededVersion = amtProvider(context.preCheckpointSnapshot)
+    val seededVersion = amtProvider(context.postSetupSnapshot)
       .getOrElse(fail("the seed commit must have emitted an AMT"))
       .version
     assert(
@@ -469,7 +469,7 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
     val addFilesAtCheckpointVersion =
       context.postCheckpointSnapshot.allFiles.collect()
     val addFilesAtSetupVersion =
-      context.preCheckpointSnapshot.allFiles.collect()
+      context.postSetupSnapshot.allFiles.collect()
     assert(addFilesAtSetupVersion.length == 1, "The five setup rows must land in a single file.")
     val setupFileAtSetupVersion = addFilesAtSetupVersion.head
 
@@ -516,7 +516,7 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
         s"INSERT INTO $name VALUES (3)"))) { context =>
     val log = context.postCheckpointSnapshot.deltaLog
     val addFilesAtCheckpointVersion = context.postCheckpointSnapshot.allFiles.collect()
-    val addFilesAtSetupVersion = context.preCheckpointSnapshot.allFiles.collect()
+    val addFilesAtSetupVersion = context.postSetupSnapshot.allFiles.collect()
     assert(addFilesAtSetupVersion.length == 1, "The two setup rows must land in a single file.")
     val setupFileAtSetupVersion = addFilesAtSetupVersion.head
 
@@ -549,7 +549,7 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
       inlineCheckpointTriggerActionsOrSQL = Some(name => Right(
         s"INSERT INTO $name VALUES (5)"))) { context =>
     val log = context.postCheckpointSnapshot.deltaLog
-    val addFilesAtSetupVersion = context.preCheckpointSnapshot.allFiles.collect()
+    val addFilesAtSetupVersion = context.postSetupSnapshot.allFiles.collect()
     assert(addFilesAtSetupVersion.length == 2)
 
     // Attach DVs to both setup files.
@@ -591,7 +591,7 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
     assert(addFilesAtCheckpointVersion.length == 2)
 
     // AMT converts the DV type from u to r when reading it back.
-    val addFilesAtSetupVersion = context.preCheckpointSnapshot.allFiles.collect()
+    val addFilesAtSetupVersion = context.postSetupSnapshot.allFiles.collect()
     assert(addFilesAtSetupVersion.length == 1)
     val setupFileAtSetupVersion = addFilesAtSetupVersion.head
     assert(setupFileAtSetupVersion.deletionVector.storageType ==
@@ -637,7 +637,7 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
     assert(addFilesAtCheckpointVersion.length == 2)
 
     // The checkpointed file's DV is committed in u form but stored in the leaf in r form.
-    val addFilesAtSetupVersion = context.preCheckpointSnapshot.allFiles.collect()
+    val addFilesAtSetupVersion = context.postSetupSnapshot.allFiles.collect()
     assert(addFilesAtSetupVersion.length == 1)
     val setupFileAtSetupVersion = addFilesAtSetupVersion.head
     assert(setupFileAtSetupVersion.deletionVector.storageType ==
@@ -853,7 +853,7 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
       inlineCheckpointTriggerActionsOrSQL = Some(name => Right(
         s"INSERT INTO $name VALUES (5)"))) { context =>
     val log = context.postCheckpointSnapshot.deltaLog
-    val addFilesAtSetupVersion = context.preCheckpointSnapshot.allFiles.collect()
+    val addFilesAtSetupVersion = context.postSetupSnapshot.allFiles.collect()
       .filter(_.deletionVector != null)
     assert(addFilesAtSetupVersion.length == 2)
     val addFilesAtCheckpointVersion = context.postCheckpointSnapshot.allFiles.collect()
@@ -1303,15 +1303,17 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
     val useRename = deltaLog.store.isPartialWriteVisible(deltaLog.logPath, hadoopConf)
     val enc = org.apache.spark.sql.delta.implicits.amtSingleActionEncoder
     val metadata = base.metaData
-    val df = AMTPartitionValues.forWrite(
+    val protocol = base.protocol
+    val withPartition = AMTPartitionValues.forWrite(
       spark.createDataset(rows)(enc).toDF(), metadata.partitionSchema)
+    val df = AMTContentStats.forWrite(withPartition, metadata, protocol)
     Checkpoints.writeAtomicCheckpointParquetFile(
       spark,
       df,
       rootFile,
       hadoopConf,
       useRename,
-      outputSchema = Some(AMTSingleAction.persistedSchema(metadata.partitionSchema)),
+      outputSchema = Some(AMTSingleAction.persistedSchema(metadata, protocol)),
       useDeltaParquetWriteSupport = true)
     val size = rootFile.getFileSystem(hadoopConf).getFileStatus(rootFile).getLen
     base.copy(contentRoot = ContentRoot(


### PR DESCRIPTION
### What changes were proposed in this pull request?

AMT (adaptive metadata) checkpoints persist one row per data file, carrying each file's
per-column statistics in the Iceberg V4 `content_stats` field. Until now `content_stats` was a
placeholder, so an AMT checkpoint discarded every min/max/null-count statistic: a reader
rebuilding table state from the checkpoint lost column-level data skipping and fell back to
record-count-only pruning.

This change persists the statistics as typed, per-column Iceberg V4 values. For each
stats-collected leaf column it writes a sub-struct -- named by the column's logical name with its
field id attached, and based at id `10000 + 200 * fieldId` -- carrying `null_value_count`,
`lower_bound`, `upper_bound`, and `tight_bounds`, all resolved by field id per the spec. A small
private residual field carries the remaining stats (e.g. the per-file tight-bounds flag) so the
stats round-trip is lossless. Reconstructing state from an AMT checkpoint now recovers the full
per-column statistics, restoring data skipping.

### How was this patch tested?

Added unit and round-trip tests: field-id pinning on the persisted schema, stats JSON
round-trip (including flattened-name collision cases), and end-to-end checkpoint read/write across
inline and deferred checkpoint scenarios.

### Does this PR introduce _any_ user-facing change?

No.
