### PR TITLE
Use DeltaTableProvider indirection for format literals in DeltaInsertIntoTest

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoTest.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoTest.scala
@@ -42,7 +42,8 @@ import org.apache.spark.sql.types.StructType
 trait DeltaInsertIntoTest
   extends QueryTest
   with DeltaDMLTestUtilsPathBased
-  with DeltaSQLCommandTest {
+  with DeltaSQLCommandTest
+  with DeltaTableProvider {
 
   val catalogName = "spark_catalog"
 
@@ -227,7 +228,7 @@ trait DeltaInsertIntoTest
         withSchemaEvolution: Boolean): Unit =
       spark.read.table("source").write.mode(mode)
         .option("mergeSchema", withSchemaEvolution.toString)
-        .format("delta")
+        .format(writeFormat)
         .insertInto("target")
   }
 
@@ -243,7 +244,7 @@ trait DeltaInsertIntoTest
         withSchemaEvolution: Boolean): Unit = {
       spark.read.table("source").write.mode(mode)
         .option("mergeSchema", withSchemaEvolution.toString)
-        .format("delta")
+        .format(writeFormat)
         .saveAsTable("target")
     }
   }
@@ -261,7 +262,7 @@ trait DeltaInsertIntoTest
       val deltaLog = DeltaLog.forTable(spark, TableIdentifier("target"))
       spark.read.table("source").write.mode(mode)
         .option("mergeSchema", withSchemaEvolution.toString)
-        .format("delta")
+        .format(writeFormat)
         .save(deltaLog.dataPath.toString)
     }
   }
@@ -283,7 +284,7 @@ trait DeltaInsertIntoTest
           .option("replaceOn", s"t.$whereCol = $whereValue")
           .option("targetAlias", "t")
           .option("mergeSchema", withSchemaEvolution.toString)
-          .format("delta")
+          .format(writeFormat)
           .insertInto("target")
       }
     }
@@ -307,7 +308,7 @@ trait DeltaInsertIntoTest
           .option("replaceOn", s"t.$whereCol = $whereValue")
           .option("targetAlias", "t")
           .option("mergeSchema", withSchemaEvolution.toString)
-          .format("delta")
+          .format(writeFormat)
           .save(deltaLog.dataPath.toString)
       }
     }
@@ -328,7 +329,7 @@ trait DeltaInsertIntoTest
         .mode(mode)
         .option("partitionOverwriteMode", "dynamic")
         .option("mergeSchema", withSchemaEvolution.toString)
-        .format("delta")
+        .format(writeFormat)
         .insertInto("target")
   }
 
@@ -404,7 +405,7 @@ trait DeltaInsertIntoTest
         .writeStream
         .option("checkpointLocation", checkpointLocation.toString)
         .option("mergeSchema", withSchemaEvolution.toString)
-        .format("delta")
+        .format(writeFormat)
         .trigger(Trigger.AvailableNow())
         .toTable("target")
       try {
@@ -529,14 +530,14 @@ trait DeltaInsertIntoTest
     for (insert <- inserts) {
       test(s"${insert.name} - $name") {
         withTable("source", "target") {
-          val writer = initialData.toDF.write.format("delta")
+          val writer = initialData.toDF.write.format(writeFormat)
           if (partitionBy.nonEmpty) {
             writer.partitionBy(partitionBy: _*)
           }
           writer.saveAsTable("target")
           // Write the data to insert to a table so that we can use it in both SQL and dataframe
           // writer inserts.
-          insertData.toDF.write.format("delta").saveAsTable("source")
+          insertData.toDF.write.format(writeFormat).saveAsTable("source")
 
           def runInsert(): Unit =
             insert.runInsert(


### PR DESCRIPTION
`DeltaInsertIntoTest` hard-coded the table format as `.format("delta")` in several places. This change mixes the existing `DeltaTableProvider` trait into the suite and replaces those literals with `.format(writeFormat)`, which defaults to `"delta"`. It is behavior-preserving for the current tests and lets the suite be reused with other table-format providers without editing the test bodies, following the pattern already used by other Delta test suites.