### PR TITLE
[Cherry-pick][Kernel] Fix last checkpoint search issue (#6048)

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checkpoints/Checkpointer.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checkpoints/Checkpointer.java
@@ -196,8 +196,11 @@ public class Checkpointer {
           } else if (FileNames.isCheckpointFile(fileName)) {
             currentFileVersion = FileNames.checkpointVersion(fileName);
           } else {
-            // allow all other types of files.
-            currentFileVersion = currentVersion;
+            // Skip unrecognized file types (e.g. .crc files). If we assigned
+            // them a version, they could prematurely trigger the break condition
+            // below and cause us to miss recent checkpoints.
+            numberOfFilesSearched++;
+            continue;
           }
 
           boolean shouldContinue =


### PR DESCRIPTION
Cherry-pick https://github.com/delta-io/delta/commit/42a44c25a115b7a71c29c95c86b8fd8db22e8a9b

#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

- findLastCompleteCheckpointBefore searches backwards through the delta log in 1000-version windows. It uses a shouldContinue check to stop when a file's version exceeds
   the current window.
- Unrecognized files (e.g. .crc checksum files) don't have a version. The old code assigned them currentFileVersion = currentVersion, which equals version on the first
window. This made the shouldContinue check (currentFileVersion < version) evaluate to false, immediately breaking the loop.
- The first search window was always abandoned after hitting its first .crc file, causing the search to fall back to an older window and miss nearby checkpoints.
- The fix skips unrecognized files entirely so they don't trigger the window boundary check.

## How was this patch tested?

- Test added


```
Without fix: finds the wrong checkpoint (not the last)
[info] CheckpointerSuite:
[info] - findLastCompleteCheckpointBefore - checksum files don't break first search iteration *** FAILED ***
[info]   1000 did not equal 2000 Incorrect checkpoint version before version=2100 (CheckpointerSuite.scala:240)
[info]   org.scalatest.exceptions.TestFailedException:

With fix:
passes
```

## Does this PR introduce _any_ user-facing changes?

No