### PR TITLE
[Spark] Validate against only existing commit config in UniForm enforcement on v1 saveAsTable overwrite

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
@@ -362,14 +362,14 @@ case class CreateDeltaTableCommand(
     // A V1 saveAsTable overwrite only overwrites data: it skips replaceMetadataIfNecessary, so
     // table properties are left untouched, the committed config stays the snapshot's, and
     // deltaWriter.configuration (writer/catalog options only) never persists. We pass
-    // snapshot ++ writer to the enforcement check below only so it sees that committed (snapshot)
+    // the snapshot config to the enforcement check below only so it sees that committed (snapshot)
     // config -- which includes properties kept solely in the Delta log (e.g.
     // delta.enableIcebergCompatV3 set via ALTER TABLE). Without it the check reads
     // deltaWriter.configuration alone, misses the snapshot's flag, and wrongly fails the write with
     // "IcebergCompat cannot be disabled". (V2 createOrReplace / SQL REPLACE do redefine properties,
     // via replaceMetadataIfNecessary.)
     val writerConfiguration = if (isV1WriterSaveAsTableOverwrite) {
-      txn.snapshot.metadata.configuration ++ deltaWriter.configuration
+      txn.snapshot.metadata.configuration
     } else deltaWriter.configuration
     val updatedConfiguration = UniversalFormat.enforceDependenciesInConfiguration(
       sparkSession,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/UniversalFormatSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/UniversalFormatSuiteBase.scala
@@ -541,6 +541,29 @@ trait UniversalFormatMiscSuiteBase extends IcebergCompatUtilsBase with Universal
     }
   }
 
+  test("V1 saveAsTable overwrite keeps deletion vectors disabled on a UniForm table") {
+    withTempTableAndDir { case (id, _) =>
+      // Create with DVs on so the deletionVectors feature stays in the protocol, then disable DVs
+      // and enable UniForm. The feature remains supported while the property is false.
+      executeSql(s"""CREATE TABLE $id (id INT, name STRING) USING DELTA CLUSTER BY (id)
+        TBLPROPERTIES (
+          'delta.columnMapping.mode' = 'name', 'delta.enableDeletionVectors' = 'true')""")
+      executeSql(s"INSERT INTO $id VALUES (1, 'a')")
+      executeSql(s"ALTER TABLE $id SET TBLPROPERTIES ('delta.enableDeletionVectors' = 'false')")
+      executeSql(s"""ALTER TABLE $id SET TBLPROPERTIES (
+        'delta.enableIcebergCompatV2' = 'true',
+        'delta.universalFormat.enabledFormats' = 'iceberg')""")
+
+      // With DVs enabled by default at the session level, the overwrite must keep the table's
+      // disabled setting rather than adopt the default.
+      withSQLConf("spark.databricks.delta.properties.defaults.enableDeletionVectors" -> "true") {
+        spark.sql("SELECT 2 AS id, 'b' AS name").write
+          .format("delta").mode("overwrite").clusterBy("id").saveAsTable(id)
+      }
+      assert(getProperties(id).get("delta.enableDeletionVectors") === Some("false"))
+    }
+  }
+
   test("UniForm config validation") {
     Seq("ICEBERG", "iceberg,iceberg", "iceber", "paimon").foreach { invalidConf =>
       withTempTableAndDir { case (id, loc) =>


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

A v1 `saveAsTable` overwrite on a UniForm (IcebergCompat) table can fail with
`DELETION_VECTORS_SHOULD_BE_DISABLED` even when deletion vectors are already disabled on the table.

The UniForm dependency check in `CreateDeltaTableCommand` validates `deltaWriter.configuration`.
Currently, we validate against `snapshot.metadata.configuration ++ deltaWriter.configuration` after https://github.com/delta-io/delta/pull/7187 but this was to remain compatible with the previous check which just did deltaWriter.configuration. Including deltaWRiter.configuration in any case is incorrect though.

For a v1 `saveAsTable`
overwrite that is the wrong config to check. This overwrite is data only: it skips
`replaceMetadataIfNecessary`, does not change table properties, and commits the snapshot's config.
`deltaWriter.configuration` never persists here, and it can carry session default properties the
write never set, for example `spark.databricks.delta.properties.defaults.enableDeletionVectors=true`.
When the table still has the `deletionVectors` feature in its protocol (the state after you disable
DVs and enable UniForm), the check reads deletion vectors as enabled and fails the write, even though
that value is never committed.

The fix validates the snapshot config, which is what the overwrite commits. The snapshot config
already includes Delta-log-only properties like `delta.enableIcebergCompatV3`, so the check still
sees the full committed config.

## How was this patch tested?

New unit test in `UniversalFormatMiscSuiteBase`. It creates a UniForm table that still supports the
`deletionVectors` feature with deletion vectors disabled, sets `enableDeletionVectors=true` as a
session default, and runs a v1 `saveAsTable` overwrite. The write succeeds and leaves deletion
vectors disabled. Without the change the same test fails with `DELETION_VECTORS_SHOULD_BE_DISABLED`.

## Does this PR introduce _any_ user-facing changes?

No