### PR TITLE
Give metadata-domain conflicts their own error class

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -801,6 +801,12 @@
     ],
     "sqlState" : "56038"
   },
+  "DELTA_CONFLICTING_METADATA_DOMAIN" : {
+    "message" : [
+      "A concurrent transaction added a conflicting metadata domain <domain>."
+    ],
+    "sqlState" : "2D521"
+  },
   "DELTA_CONFLICT_SET_COLUMN" : {
     "message" : [
       "There is a conflict from these SET columns: <columnList>."

--- a/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
@@ -1264,9 +1264,8 @@ private[delta] class ConflictChecker(
         case (domain, _) if RowTrackingMetadataDomain.isSameDomain(domain) => domain
         case (_, Some(_)) =>
           // Any conflict not specifically handled by a previous case must fail the transaction.
-          throw new io.delta.exceptions.ConcurrentTransactionException(
-            s"A conflicting metadata domain ${domainMetadataFromCurrentTransaction.domain} is " +
-              "added.")
+          throw DeltaErrors.conflictingMetadataDomainException(
+            domainMetadataFromCurrentTransaction.domain)
       }
 
     val mergedDomainMetadata = mutable.Buffer.empty[DomainMetadata]

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -2977,6 +2977,11 @@ trait DeltaErrorsBase
     )
   }
 
+  def conflictingMetadataDomainException(
+      domain: String): ConflictingMetadataDomainException = {
+    new ConflictingMetadataDomainException(Array(domain))
+  }
+
   def restoreMissedDataFilesError(missedFiles: Array[String], version: Long): Throwable =
     new IllegalArgumentException(
       s"""Not all files from version $version are available in file system.
@@ -4392,6 +4397,22 @@ class ConcurrentTransactionException(message: String)
         "into this table. Did you run multiple instances of the same streaming query" +
         " at the same time?",
       conflictingCommit))
+}
+
+/**
+ * Thrown when the current transaction adds a metadata domain that conflicts with a metadata domain
+ * added by a concurrent transaction. Subclasses
+ * [[io.delta.exceptions.ConcurrentTransactionException]] for backward compatibility, but reports
+ * its own error class.
+ */
+class ConflictingMetadataDomainException(messageParameters: Array[String] = Array.empty)
+  extends io.delta.exceptions.ConcurrentTransactionException(
+    DeltaThrowableHelper.getMessage("DELTA_CONFLICTING_METADATA_DOMAIN", messageParameters))
+    with DeltaThrowable {
+  override def getErrorClass: String = "DELTA_CONFLICTING_METADATA_DOMAIN"
+  override def getMessageParameters: java.util.Map[String, String] =
+    DeltaThrowableHelper.getMessageParameters(
+      "DELTA_CONFLICTING_METADATA_DOMAIN", errorSubClass = null, messageParameters)
 }
 
 /** A helper class in building a helpful error message in case of metadata mismatches. */

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -2902,6 +2902,14 @@ trait DeltaErrorsSuiteBase
         "same streaming query at the same time?"))
     }
     {
+      val e = intercept[ConflictingMetadataDomainException] {
+        throw org.apache.spark.sql.delta.DeltaErrors
+          .conflictingMetadataDomainException("delta.liquid")
+      }
+      checkError(e, "DELTA_CONFLICTING_METADATA_DOMAIN", "2D521",
+        Map("domain" -> "delta.liquid"))
+    }
+    {
       val e = intercept[io.delta.exceptions.ConcurrentWriteException] {
         throw org.apache.spark.sql.delta.DeltaErrors.concurrentWriteException(None)
       }


### PR DESCRIPTION
## Description

A conflict between a metadata domain added by the current transaction and one added by a
concurrent transaction was previously surfaced by throwing `ConcurrentTransactionException` with a
hardcoded message that did not correspond to any defined error class.

This change introduces a dedicated `DELTA_CONFLICTING_METADATA_DOMAIN` error class
(SQLSTATE `2D521`) and a `ConflictingMetadataDomainException`. The new exception subclasses
`ConcurrentTransactionException` for backward compatibility while reporting its own error class and
message parameters. `ConflictChecker` now throws it instead of constructing a raw exception with an
ad-hoc message.

## How was this patch tested?

Added a unit test in `DeltaErrorsSuite` that asserts the error class, SQLSTATE, and message
parameter via `checkError`.

## Does this PR introduce _any_ user-facing changes?

No.
