### PR TITLE
Split DELTA_REPLACE_WHERE_MISMATCH into subclasses to stop embedding message text

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -2651,9 +2651,21 @@
   },
   "DELTA_REPLACE_WHERE_MISMATCH" : {
     "message" : [
-      "Written data does not conform to partial table overwrite condition or constraint '<replaceWhere>'.",
-      "<message>"
+      "Written data does not conform to partial table overwrite condition or constraint '<replaceWhere>'."
     ],
+    "subClass" : {
+      "INVALID_PARTITIONS" : {
+        "message" : [
+          "Invalid data would be written to partitions <badPartitions>."
+        ]
+      },
+      "INVARIANT_VIOLATION" : {
+        "message" : [
+          "<invariantViolationMessage>",
+          ""
+        ]
+      }
+    },
     "sqlState" : "44000"
   },
   "DELTA_REPLACE_WHERE_WITH_DYNAMIC_PARTITION_OVERWRITE" : {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -1286,16 +1286,15 @@ trait DeltaErrorsBase
       replaceWhere: String,
       invariantViolation: InvariantViolationException): Throwable = {
     new DeltaAnalysisException(
-      errorClass = "DELTA_REPLACE_WHERE_MISMATCH",
+      errorClass = "DELTA_REPLACE_WHERE_MISMATCH.INVARIANT_VIOLATION",
       messageParameters = Array(replaceWhere, invariantViolation.getMessage),
       cause = Some(invariantViolation))
   }
 
   def replaceWhereMismatchException(replaceWhere: String, badPartitions: String): Throwable = {
     new DeltaAnalysisException(
-      errorClass = "DELTA_REPLACE_WHERE_MISMATCH",
-      messageParameters = Array(replaceWhere,
-        s"Invalid data would be written to partitions $badPartitions."))
+      errorClass = "DELTA_REPLACE_WHERE_MISMATCH.INVALID_PARTITIONS",
+      messageParameters = Array(replaceWhere, badPartitions))
   }
 
   def illegalFilesFound(file: String): Throwable = {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaDataFrameWriterV2Suite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaDataFrameWriterV2Suite.scala
@@ -150,10 +150,14 @@ trait OpenSourceDataFrameWriterV2Tests
     val e = intercept[AnalysisException] {
       spark.table("source2").writeTo("table_name").overwrite($"id" === 3)
     }
-    assert(e.getErrorClass == "DELTA_REPLACE_WHERE_MISMATCH")
-    assert(e.getMessage.startsWith(
-      "[DELTA_REPLACE_WHERE_MISMATCH] Written data does not conform to partial table overwrite " +
-        "condition or constraint"))
+    checkError(
+      exception = e,
+      condition = "DELTA_REPLACE_WHERE_MISMATCH.INVARIANT_VIOLATION",
+      sqlState = Some("44000"),
+      parameters = Map(
+        "replaceWhere" -> "\\(id = 3L\\)",
+        "invariantViolationMessage" -> "(?s).*"),
+      matchPVals = true)
 
     checkAnswer(
       spark.table("table_name"),

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -580,16 +580,16 @@ trait DeltaErrorsSuiteBase
         throw DeltaErrors.replaceWhereMismatchException("replaceWhereArgValue",
           new InvariantViolationException("Invariant violated."))
       }
-      checkError(e, "DELTA_REPLACE_WHERE_MISMATCH", "44000",
-        Map("replaceWhere" -> "replaceWhereArgValue", "message" -> "Invariant violated."))
+      checkError(e, "DELTA_REPLACE_WHERE_MISMATCH.INVARIANT_VIOLATION", "44000",
+        Map("replaceWhere" -> "replaceWhereArgValue",
+          "invariantViolationMessage" -> "Invariant violated."))
     }
     {
       val e = intercept[DeltaAnalysisException] {
         throw DeltaErrors.replaceWhereMismatchException("replaceWhere", "badPartitions")
       }
-      checkError(e, "DELTA_REPLACE_WHERE_MISMATCH", "44000",
-        Map("replaceWhere" -> "replaceWhere",
-          "message" -> "Invalid data would be written to partitions badPartitions."))
+      checkError(e, "DELTA_REPLACE_WHERE_MISMATCH.INVALID_PARTITIONS", "44000",
+        Map("replaceWhere" -> "replaceWhere", "badPartitions" -> "badPartitions"))
     }
     {
       val e = intercept[DeltaIllegalStateException] {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceWhereTargetAliasSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceWhereTargetAliasSuite.scala
@@ -526,10 +526,10 @@ class DeltaInsertReplaceWhereTargetAliasSuite
               .option("replaceWhere", "t.id = 1")
               .saveAsTable(testTableName)
           },
-          condition = "DELTA_REPLACE_WHERE_MISMATCH",
+          condition = "DELTA_REPLACE_WHERE_MISMATCH.INVARIANT_VIOLATION",
           parameters = Map(
             "replaceWhere" -> "t.id = 1",
-            "message" -> "(?s).*id : 99.*"),
+            "invariantViolationMessage" -> "(?s).*id : 99.*"),
           matchPVals = true)
       }
     }
@@ -827,10 +827,10 @@ class DeltaInsertReplaceWhereTargetAliasSuite
               .option("replaceWhere", "t.data IS NULL")
               .saveAsTable(testTableName)
           },
-          condition = "DELTA_REPLACE_WHERE_MISMATCH",
+          condition = "DELTA_REPLACE_WHERE_MISMATCH.INVARIANT_VIOLATION",
           parameters = Map(
             "replaceWhere" -> "t.data IS NULL",
-            "message" -> "(?s).*data : non-null.*"),
+            "invariantViolationMessage" -> "(?s).*data : non-null.*"),
           matchPVals = true)
       }
     }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
@@ -265,8 +265,26 @@ class DeltaSuite extends QueryTest
             .mode("overwrite")
             .option(DeltaOptions.REPLACE_WHERE_OPTION, "is_odd = true")
             .save(tempDir.toString)
-        }.getMessage
-        assert(e1.contains("does not conform to partial table overwrite condition or constraint"))
+        }
+        if (enabled) {
+          checkError(
+            exception = e1,
+            condition = "DELTA_REPLACE_WHERE_MISMATCH.INVARIANT_VIOLATION",
+            sqlState = Some("44000"),
+            parameters = Map(
+              "replaceWhere" -> "is_odd = true",
+              "invariantViolationMessage" -> "(?s).*"),
+            matchPVals = true)
+        } else {
+          checkError(
+            exception = e1,
+            condition = "DELTA_REPLACE_WHERE_MISMATCH.INVALID_PARTITIONS",
+            sqlState = Some("44000"),
+            parameters = Map(
+              "replaceWhere" -> "is_odd = true",
+              "badPartitions" -> "(?s).*=false"),
+            matchPVals = true)
+        }
 
         val e2 = intercept[AnalysisException] {
           Seq(true).toDF("is_odd")
@@ -307,14 +325,20 @@ class DeltaSuite extends QueryTest
             .mode("overwrite")
             .option(DeltaOptions.REPLACE_WHERE_OPTION, "value = 1")
             .save(tempDir.toString)
-        }.getMessage
+        }
         if (enabled) {
-          assert(e4.contains(
-            "Written data does not conform to partial table overwrite condition " +
-              "or constraint 'value = 1'"))
+          checkError(
+            exception = e4,
+            condition = "DELTA_REPLACE_WHERE_MISMATCH.INVARIANT_VIOLATION",
+            sqlState = Some("44000"),
+            parameters = Map(
+              "replaceWhere" -> "value = 1",
+              "invariantViolationMessage" -> "(?s).*"),
+            matchPVals = true)
         } else {
-          assert(e4.contains("Predicate references non-partition column 'value'. Only the " +
-            "partition columns may be referenced: [is_odd]"))
+          assert(e4.getMessage.contains(
+            "Predicate references non-partition column 'value'. Only the " +
+              "partition columns may be referenced: [is_odd]"))
         }
 
         val e5 = intercept[AnalysisException] {
@@ -2250,8 +2274,14 @@ class DeltaSuite extends QueryTest
           .mode("overwrite")
           .saveAsTable(table)
       }
-      assert(e.getMessage.startsWith("[DELTA_REPLACE_WHERE_MISMATCH] " +
-        "Written data does not conform to partial table overwrite condition or constraint"))
+      checkError(
+        exception = e,
+        condition = "DELTA_REPLACE_WHERE_MISMATCH.INVARIANT_VIOLATION",
+        sqlState = Some("44000"),
+        parameters = Map(
+          "replaceWhere" -> "a\\.b = 'a' AND `a\\.b` = 'a'",
+          "invariantViolationMessage" -> "(?s).*"),
+        matchPVals = true)
 
       Seq(("a", "b", "c"), ("d", "e", "f"))
         .toDF("a.b", "c.d", "ab")


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

`DELTA_REPLACE_WHERE_MISMATCH` previously used a free-form `<message>` parameter to
carry two distinct failure causes: an invariant violation, and data written to
invalid partitions. Embedding that text as an error parameter made the message
wording part of the error contract and prevented callers from matching reliably
on the specific cause.

This splits `DELTA_REPLACE_WHERE_MISMATCH` into two subclasses:

- `INVARIANT_VIOLATION` — surfaces the invariant violation text via the
  `<invariantViolationMessage>` parameter.
- `INVALID_PARTITIONS` — surfaces the offending partitions via the
  `<badPartitions>` parameter.

The parent condition keeps its leading sentence; the variant-specific detail now
lives in structured subclass parameters instead of an interpolated `<message>`
string.

## How was this patch tested?

Updated `DeltaErrorsSuite`, `DeltaDataFrameWriterV2Suite`,
`DeltaInsertReplaceWhereTargetAliasSuite`, and `DeltaSuite` to assert the new
subclasses and their structured parameters via `checkError`.

## Does this PR introduce _any_ user-facing changes?

Yes. The error condition `DELTA_REPLACE_WHERE_MISMATCH` now has two subclasses
(`INVARIANT_VIOLATION` and `INVALID_PARTITIONS`). The rendered message text is
unchanged, but the structured error condition name is now more specific.
