### PR TITLE
[Spark] Add scoped profiling frames to Delta V2 scan planning

### DIFF
--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
@@ -90,7 +90,7 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 import scala.jdk.javaapi.CollectionConverters;
 
 /** DataSource V2 Table implementation for Delta Lake using the Delta Kernel API. */
-public class DeltaV2Table extends DeltaV2TableLogging
+public class DeltaV2Table extends DeltaV2TableShimsWithLogging
     implements Table,
         SupportsRead,
         SupportsWrite,
@@ -247,10 +247,13 @@ public class DeltaV2Table extends DeltaV2TableLogging
     this.kernelEngine = KernelEngineFactory.createDefaultEngine(this.hadoopConf);
     this.snapshotManager = SnapshotManagerFactory.create(tablePath, kernelEngine, catalogTable);
     try {
-      this.initialSnapshot =
-          timeTravelVersion.isPresent()
-              ? loadSnapshotAtCheckedVersion(snapshotManager, timeTravelVersion.getAsLong())
-              : snapshotManager.loadLatestSnapshot();
+      if (timeTravelVersion.isPresent()) {
+        this.initialSnapshot =
+            loadSnapshotAtCheckedVersion(snapshotManager, timeTravelVersion.getAsLong());
+      } else {
+        this.initialSnapshot =
+            recordFrameProfileValue("snapshot.loadLatest", snapshotManager::loadLatestSnapshot);
+      }
     } catch (io.delta.kernel.exceptions.TableNotFoundException e) {
       // Rethrow as the Delta-module wrapper so catalog/interop layer never names a Kernel type.
       throw new TableNotFoundException(tablePath);
@@ -552,8 +555,8 @@ public class DeltaV2Table extends DeltaV2TableLogging
   private Snapshot loadSnapshotAtCheckedVersion(DeltaV2SnapshotManager manager, long version) {
     manager.checkVersionExists(
         version, /* mustBeRecreatable = */ true, /* allowOutOfRange = */ false);
-    return recordFrameProfileValue(
-        "Delta", "DeltaV2.snapshot.loadAtVersion", () -> manager.loadSnapshotAt(version));
+    final Supplier<Snapshot> loadSnapshot = () -> manager.loadSnapshotAt(version);
+    return recordFrameProfileValue("snapshot.loadAtVersion", loadSnapshot);
   }
 
   @Override

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2Batch.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2Batch.java
@@ -17,6 +17,7 @@ package io.delta.spark.internal.v2.read;
 
 import io.delta.kernel.Snapshot;
 import io.delta.kernel.expressions.Predicate;
+import io.delta.spark.internal.v2.DeltaV2JavaLogging;
 import io.delta.spark.internal.v2.utils.PartitionUtils;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -39,7 +40,7 @@ import org.apache.spark.sql.types.StructType;
  * <p>This class must remain package-private so callers outside {@code v2.read} depend only on
  * Spark's public connector interfaces instead of coupling to Delta's internal V2 implementation.
  */
-class DeltaV2Batch implements Batch {
+class DeltaV2Batch extends DeltaV2JavaLogging implements Batch {
   private final Snapshot snapshot;
   private final StructType readDataSchema;
   private final StructType dataSchema;
@@ -97,24 +98,30 @@ class DeltaV2Batch implements Batch {
 
   @Override
   public InputPartition[] planInputPartitions() {
-    return PartitionUtils.planInputPartitions(
-        SparkSession.active(), partitionedFiles, totalBytes, hadoopConf, sqlConf);
+    return recordFrameProfileValue(
+        "batchScan.planInputPartitions",
+        () ->
+            PartitionUtils.planInputPartitions(
+                SparkSession.active(), partitionedFiles, totalBytes, hadoopConf, sqlConf));
   }
 
   @Override
   public PartitionReaderFactory createReaderFactory() {
     // Non-CDC plain table scan. Write-time CDF streaming reads route through
     // DeltaV2MicroBatchStream; read-time CDF batch reads use a dedicated batch implementation.
-    return PartitionUtils.createDeltaParquetReaderFactory(
-        snapshot,
-        dataSchema,
-        partitionSchema,
-        readDataSchema,
-        ddlOrderedReadOutputSchema,
-        dataFilters,
-        scalaOptions,
-        hadoopConf,
-        sqlConf);
+    return recordFrameProfileValue(
+        "batchScan.createReaderFactory",
+        () ->
+            PartitionUtils.createDeltaParquetReaderFactory(
+                snapshot,
+                dataSchema,
+                partitionSchema,
+                readDataSchema,
+                ddlOrderedReadOutputSchema,
+                dataFilters,
+                scalaOptions,
+                hadoopConf,
+                sqlConf));
   }
 
   @Override

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2Scan.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2Scan.java
@@ -19,6 +19,7 @@ import static io.delta.spark.internal.v2.utils.ExpressionUtils.dsv2PredicateToCa
 
 import io.delta.kernel.expressions.Predicate;
 import io.delta.kernel.internal.SnapshotImpl;
+import io.delta.spark.internal.v2.DeltaV2JavaLogging;
 import io.delta.spark.internal.v2.kernel.KernelEngineFactory;
 import io.delta.spark.internal.v2.read.cdc.CDCSchemaContext;
 import io.delta.spark.internal.v2.read.deletionvector.DeletionVectorSchemaContext;
@@ -60,7 +61,8 @@ import scala.Option;
  * <p>This class must remain package-private so callers outside {@code v2.read} depend only on
  * Spark's public connector interfaces instead of coupling to Delta's internal V2 implementation.
  */
-class DeltaV2Scan implements Scan, SupportsReportStatistics, SupportsRuntimeV2Filtering {
+class DeltaV2Scan extends DeltaV2JavaLogging
+    implements Scan, SupportsReportStatistics, SupportsRuntimeV2Filtering {
 
   private final DeltaV2SnapshotManager snapshotManager;
   private final io.delta.kernel.Snapshot initialSnapshot;
@@ -207,6 +209,11 @@ class DeltaV2Scan implements Scan, SupportsReportStatistics, SupportsRuntimeV2Fi
   // point and the Batch-only bookkeeping below goes away with it.
   @Override
   public Batch toBatch() {
+    return recordFrameProfileValue("batchScan.toBatch", this::createBatch);
+  }
+
+  /** Constructs the fallback batch without putting its multi-step body inside a Java lambda. */
+  private Batch createBatch() {
     if (isCDCRead) {
       throw new UnsupportedOperationException(
           "Batch reads with CDC (readChangeFeed / readChangeData) are not supported in the V2 "
@@ -422,8 +429,18 @@ class DeltaV2Scan implements Scan, SupportsReportStatistics, SupportsRuntimeV2Fi
     //     out AddFile.stats (DataSkippingReader.getFilesAndNumRecords defaults keepStats=false),
     //     but it does report the aggregate in DeltaScan.scanned.rows -- the very field V1's
     //     PreparedDeltaFileIndex.getNumOfRows reads. The aggregate fallback below picks it up.
-    final DeltaScan deltaScan =
-        Objects.requireNonNull(deltaScanSupplier.get(), "deltaScanSupplier returned null");
+    final Supplier<DeltaScan> selectFiles =
+        () -> Objects.requireNonNull(deltaScanSupplier.get(), "deltaScanSupplier returned null");
+    final DeltaScan deltaScan = recordFrameProfileValue("scan.awaitFileSelection", selectFiles);
+    final Runnable materializeFiles = () -> materializeSelectedFiles(deltaScan, tablePath);
+    recordFrameProfileAction("scan.materializeSelectedFiles", materializeFiles);
+  }
+
+  /**
+   * Converts the files selected by {@code deltaScan} to connector scan objects and aggregates scan
+   * size statistics.
+   */
+  private void materializeSelectedFiles(DeltaScan deltaScan, String tablePath) {
     rowCountKnown = arePlanStatsEnabled();
     final List<org.apache.spark.sql.delta.actions.AddFile> scanFiles =
         scala.jdk.javaapi.CollectionConverters.asJava(deltaScan.files());
@@ -473,7 +490,7 @@ class DeltaV2Scan implements Scan, SupportsReportStatistics, SupportsRuntimeV2Fi
   private synchronized void ensurePlanned(List<RuntimePredicate> runtimePredicates) {
     // First, ensure planning is done
     if (!planned) {
-      planScanFiles();
+      recordFrameProfileAction("scan.planFiles", this::planScanFiles);
       planned = true;
     }
 

--- a/spark/v2/src/main/scala/io/delta/spark/internal/v2/DeltaV2Logging.scala
+++ b/spark/v2/src/main/scala/io/delta/spark/internal/v2/DeltaV2Logging.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2
+
+import java.util.function.Supplier
+
+import org.apache.spark.sql.delta.metering.DeltaLogging
+
+/**
+ * Delta V2 specialization of [[DeltaLogging]]. Frame-name suffixes passed here must be fixed
+ * system-code literals; this trait supplies the shared `Delta` group and `v2.` prefix.
+ */
+private[v2] trait DeltaV2Logging extends DeltaLogging {
+  private def deltaV2FrameName(nameSuffix: String): String = "v2." + nameSuffix
+
+  protected final def recordFrameProfile[T](
+      nameSuffix: String)(thunk: => T): T = {
+    super.recordFrameProfile("Delta", deltaV2FrameName(nameSuffix))(thunk)
+  }
+
+  protected final def recordFrameProfileValue[T](
+      nameSuffix: String,
+      body: Supplier[T]): T =
+    super.recordFrameProfileValue("Delta", deltaV2FrameName(nameSuffix), body)
+
+  protected final def recordFrameProfileAction(
+      nameSuffix: String,
+      body: Runnable): Unit =
+    super.recordFrameProfileAction("Delta", deltaV2FrameName(nameSuffix), body)
+}
+
+/** Java inheritance bridge for Delta V2 classes that do not already have a superclass. */
+private[v2] abstract class DeltaV2JavaLogging extends DeltaV2Logging

--- a/spark/v2/src/main/scala/io/delta/spark/internal/v2/catalog/DeltaV2TableShimsWithLogging.scala
+++ b/spark/v2/src/main/scala/io/delta/spark/internal/v2/catalog/DeltaV2TableShimsWithLogging.scala
@@ -15,12 +15,12 @@
  */
 package io.delta.spark.internal.v2.catalog
 
-import org.apache.spark.sql.delta.metering.DeltaLogging
+import io.delta.spark.internal.v2.DeltaV2Logging
 
 /**
- * Scala inheritance bridge for the Java [[DeltaV2Table]]. This lets the table use the scoped
- * profiling helpers on [[DeltaLogging]] without duplicating them in a companion object.
+ * Scala inheritance bridge that combines the Java table's Spark-version shims with scoped Delta
+ * V2 logging.
  */
-private[catalog] abstract class DeltaV2TableLogging
+private[catalog] abstract class DeltaV2TableShimsWithLogging
   extends DeltaV2TableShims
-  with DeltaLogging
+  with DeltaV2Logging

--- a/spark/v2/src/main/scala/io/delta/spark/internal/v2/read/DeltaV2ScanBuilder.scala
+++ b/spark/v2/src/main/scala/io/delta/spark/internal/v2/read/DeltaV2ScanBuilder.scala
@@ -23,8 +23,8 @@ import io.delta.kernel.engine.Engine
 import io.delta.spark.internal.v2.read.cdc.CDCSchemaContext
 
 import org.apache.spark.sql.delta.Snapshot
-import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.stats.DeltaScan
+import io.delta.spark.internal.v2.DeltaV2Logging
 import org.apache.spark.sql.delta.v2.interop.DeltaV2Snapshot
 import org.apache.spark.sql.delta.v2.interop.DeltaV2SnapshotManager
 
@@ -75,7 +75,7 @@ private[read] class DeltaV2ScanBuilder(
     with SupportsPushDownRequiredColumns
     with SupportsPushDownCatalystFilters
     with SupportsPushDownLimit
-    with DeltaLogging {
+    with DeltaV2Logging {
 
   // Use Objects.requireNonNull (throws NullPointerException) rather than Scala's require (throws
   // IllegalArgumentException) to preserve the exact null-check behavior of the original Java class.
@@ -104,7 +104,7 @@ private[read] class DeltaV2ScanBuilder(
   private var pushedLimit: OptionalInt = OptionalInt.empty()
 
   override def pushFilters(filters: Seq[Expression]): Seq[Expression] =
-    recordFrameProfile("Delta", "DeltaV2.scanBuilder.pushFilters") {
+    recordFrameProfile("scanBuilder.pushFilters") {
       val (partitionFilters, dataFilters) =
         DataSourceUtils.getPartitionFiltersAndDataFilters(partitionSchema, filters)
       partitionCatalystFilters = partitionFilters.toArray
@@ -120,7 +120,7 @@ private[read] class DeltaV2ScanBuilder(
   override def pushedFilters: Array[Predicate] = Array.empty
 
   override def pruneColumns(requiredSchema: StructType): Unit =
-    recordFrameProfile("Delta", "DeltaV2.scanBuilder.pruneColumns") {
+    recordFrameProfile("scanBuilder.pruneColumns") {
       Objects.requireNonNull(requiredSchema, "requiredSchema is null")
       // CDC columns are injected later by CDCReadFunction, so strip them here.
       requiredDataSchema = new StructType(
@@ -154,7 +154,7 @@ private[read] class DeltaV2ScanBuilder(
   // file granularity, the scan may produce more rows than requested, so Spark must reapply LIMIT.
 
   override def build(): Scan =
-    recordFrameProfile("Delta", "DeltaV2.scanBuilder.build") {
+    recordFrameProfile("scanBuilder.build") {
       // Capture the planning inputs here, but defer constructing the Kernel-backed V1 snapshot and
       // running filesForScan until DeltaV2Scan actually plans a batch. A MicroBatchStream performs
       // its own snapshot and commit-range reads and never consumes batch-selected files.
@@ -185,13 +185,13 @@ private[read] class DeltaV2ScanBuilder(
           // record counts until the limit is satisfied.
           def selectFiles(): DeltaScan =
             if (effectiveLimit.isPresent) {
-              recordFrameProfile("Delta", "DeltaV2.filesForScan.limitAndFilters") {
+              recordFrameProfile("filesForScan.limitAndFilters") {
                 snapshot.filesForScan(
                   effectiveLimit.getAsInt.toLong,
                   partitionFiltersForScan)
               }
             } else {
-              recordFrameProfile("Delta", "DeltaV2.filesForScan.filters") {
+              recordFrameProfile("filesForScan.filters") {
                 snapshot.filesForScan(catalystFilters, keepNumRecords)
               }
             }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

DataSource V2 scan planning spans both Scala and Java classes, but the only existing bridge to `DeltaLogging` was specific to `DeltaV2Table`. Repeating that bridge along with its fixed profiling group and frame-name prefix in every class would make further instrumentation inconsistent.

This PR adds a package-scoped `DeltaV2Logging` trait that specializes the existing `DeltaLogging` trait. It owns the fixed `Delta` profiling group and the concise `v2.` frame-name prefix in one place, lets Scala classes mix it in directly, and supplies a small `DeltaV2JavaLogging` inheritance bridge for Java classes that have no other superclass. `DeltaV2Table` keeps its Spark-version shim superclass through the renamed `DeltaV2TableShimsWithLogging`.

The facade is then used to record scan-planning frames across the V2 read path:

- `DeltaV2ScanBuilder`: `scanBuilder.pushFilters`, `scanBuilder.pruneColumns`, `scanBuilder.build`, `filesForScan.limitAndFilters`, `filesForScan.filters`
- `DeltaV2Scan`: `scan.planFiles`, `scan.awaitFileSelection`, `scan.materializeSelectedFiles`, `batchScan.toBatch`
- `DeltaV2Batch`: `batchScan.planInputPartitions`, `batchScan.createReaderFactory`
- `DeltaV2Table`: `snapshot.loadLatest`, `snapshot.loadAtVersion`

`DeltaV2Scan.toBatch` and the file selection/materialization step are refactored into small private methods so their multi-step bodies are not embedded in Java lambdas. This is instrumentation only — planning results, public connector APIs, and on-disk behavior are unchanged.

## How was this patch tested?

This is a pure instrumentation change: it wraps existing scan-planning call sites in profiling frames and consolidates their frame naming, without altering planning output or query results. The affected read paths are covered by the existing DataSource V2 scan and read suites (e.g. `DeltaV2ScanTest`).

## Does this PR introduce _any_ user-facing changes?

No.
