### PR TITLE
Discover the AMT checkpoint on cold/warm snapshot init via parallel CommitInfo reads

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/CheckpointProvider.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/CheckpointProvider.scala
@@ -23,7 +23,7 @@ import scala.util.control.NonFatal
 import org.apache.spark.sql.delta.ClassicColumnConversions._
 import org.apache.spark.sql.delta.DataFrameUtils
 import org.apache.spark.sql.delta.DeltaLogFileIndex.COMMIT_VERSION_COLUMN
-import org.apache.spark.sql.delta.SnapshotManagement.checkpointV2ThreadPool
+import org.apache.spark.sql.delta.SnapshotManagement.checkpointThreadPool
 import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.expressions.EncodeNestedVariantAsZ85String
 import org.apache.spark.sql.delta.metering.DeltaLogging
@@ -244,7 +244,7 @@ object CheckpointProvider extends DeltaLogging {
       // a lazy checkpoint provider wrapping the future. we won't wait on the future unless/until
       // somebody calls a complete checkpoint provider method.
       val deltaLog = snapshotDescriptor.deltaLog
-      val future = checkpointV2ThreadPool.submitNonFateSharing { spark: SparkSession =>
+      val future = checkpointThreadPool.submitNonFateSharing { spark: SparkSession =>
         provider.readV2Actions(
           spark, deltaLog.store, deltaLog.newDeltaHadoopConf(), deltaLog.options)
       }
@@ -571,7 +571,7 @@ case class UninitializedV2CheckpointProvider(
 
   val nonFateSharingCheckpointReadFuture
       : NonFateSharingFuture[(Option[CheckpointMetadata], Seq[SidecarFile])] = {
-    checkpointV2ThreadPool.submitNonFateSharing { spark: SparkSession =>
+    checkpointThreadPool.submitNonFateSharing { spark: SparkSession =>
       loadV2Actions(spark, logStore, hadoopConf, deltaLogOptions)
     }
   }
@@ -712,7 +712,7 @@ object V2CheckpointProvider {
     def getSidecarSchemaFetcher: () => Option[StructType] = {
       val sidecarSchemaFromMetadata = checkpointMetadata.sidecarFileSchema
       val nonFateSharingSidecarSchemaFuture: NonFateSharingFuture[Option[StructType]] = {
-        checkpointV2ThreadPool.submitNonFateSharing { spark: SparkSession =>
+        checkpointThreadPool.submitNonFateSharing { spark: SparkSession =>
           sidecarFiles.headOption.map { sidecarFile =>
             val sidecarFileStatus =
               sidecarFile.toFileStatus(uninitializedV2LikeCheckpointProvider.logPath)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
@@ -18,15 +18,17 @@ package org.apache.spark.sql.delta
 
 import java.io.FileNotFoundException
 import java.util.UUID
+import java.util.concurrent.Future
 
 import scala.collection.mutable
+import scala.concurrent.duration.Duration
 import scala.math.Ordering.Implicits._
 import scala.util.Try
 import scala.util.control.NonFatal
 
 // scalastyle:off import.ordering.noEmptyLine
 import org.apache.spark.sql.delta.ClassicColumnConversions._
-import org.apache.spark.sql.delta.actions.{Action, Checkpoint, CheckpointMetadata, LastManifestCommit, Metadata, SidecarFile, SingleAction}
+import org.apache.spark.sql.delta.actions.{Action, Checkpoint, CheckpointMetadata, CommitInfo, LastManifestCommit, Metadata, SidecarFile, SingleAction}
 import org.apache.spark.sql.delta.amt.{AMTCheckpointProvider, AMTWriteResult}
 import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.metering.DeltaLogging
@@ -61,7 +63,7 @@ import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
 import org.apache.spark.sql.functions.{coalesce, col, struct, when}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.StructType
-import org.apache.spark.util.{LongAccumulator, SerializableConfiguration, Utils}
+import org.apache.spark.util.{LongAccumulator, SerializableConfiguration, ThreadUtils, Utils}
 
 /**
  * A class to help with comparing checkpoints with each other, where we may have had concurrent
@@ -417,24 +419,64 @@ trait Checkpoints extends DeltaLogging {
       .toSeq ++ instanceFromOldCheckpointProvider
   }
 
+  /** Starts an async read of the last commit's CommitInfo if needed and flag enabled. */
+  protected def maybeReadLastCommitInfoAsync(
+      logSegment: LogSegment,
+      shouldReconcileAMTCheckpointProvider: Boolean): Option[Future[Option[CommitInfo]]] = {
+    val shouldKickOffAsyncCommitInfoRead = shouldReconcileAMTCheckpointProvider &&
+      spark.conf.get(DeltaSQLConf.AMT_SNAPSHOT_DISCOVERY_ASYNC_COMMIT_INFO_READ_ENABLED)
+    Option.when(shouldKickOffAsyncCommitInfoRead) {
+      SnapshotManagement.checkpointThreadPool.submit(spark) { readLastCommitInfo(logSegment) }
+    }
+  }
+
   /**
-   * Verifies the AMT checkpoint provider (if any) of the log segment against LastManifestCommit.
-   * Updates the log segment with the correct AMT if possible; throws otherwise.
+   * Reconciles the AMT checkpoint provider (if any) of the log segment against the last manifest
+   * commit reference, updating/trimming the segment as needed and throwing on inconsistency.
+   *
+   * @param initSegment initial log segment; may contain some initial checkpoint provider.
+   * @param lastChecksumOpt optional checksum at the log segment's version.
+   * @param lastCommitInfoFuture future of the CommitInfo from the last commit in the log segment.
+   *
+   * @return updated log segment with reconciled AMT checkpoint provider and trimmed deltas.
    */
   protected def reconcileAMTCheckpointProvider(
-      logSegment: LogSegment,
-      finalChecksumOpt: Option[VersionChecksum]): LogSegment = {
-    (logSegment.checkpointProvider, finalChecksumOpt) match {
-      case (amtCheckpointProvider: AMTCheckpointProvider, Some(checksum)) =>
-        val lastManifestCommit = checksum.lastManifestCommit.getOrElse {
-          throw new IllegalStateException(
-            s"An AMT checkpoint provider at version ${amtCheckpointProvider.version} was " +
-              s"discovered for table $logPath, but the checksum at version ${logSegment.version} " +
-              s"carries no lastManifestCommit. Refusing to trust the AMT checkpoint.")
+      initSegment: LogSegment,
+      lastChecksumOpt: Option[VersionChecksum],
+      lastCommitInfoFutureOpt: Option[Future[Option[CommitInfo]]]): LogSegment = {
+    val lastManifestCommitOpt = (lastChecksumOpt, lastCommitInfoFutureOpt) match {
+      case (Some(checksum), _) =>
+        lastCommitInfoFutureOpt.foreach { lastCommitInfoFuture =>
+          if (DeltaUtils.isTesting) {
+            // In testing, we always complete the async read to avoid flaky file operation counts.
+            ThreadUtils.awaitResult(lastCommitInfoFuture, Duration.Inf)
+          } else {
+            // In prod, the async CommitInfo read is no longer needed and we can cancel it.
+            // We trust the CRC and the CommitInfo have the same lastManifestCommit.
+            lastCommitInfoFuture.cancel(false)
+          }
         }
+        checksum.lastManifestCommit
+
+      case (None, Some(lastCommitInfoFuture)) =>
+        // No CRC is available, so fall back to the reference from the last commit's CommitInfo.
+        // Block on the read that was started in parallel with the CRC read.
+        ThreadUtils.awaitResult(lastCommitInfoFuture, Duration.Inf).flatMap(_.lastManifestCommit)
+
+      case (None, None) =>
+        // Without either a CRC or a CommitInfo, we cannot differentiate between:
+        //  1. There is no lastManifestCommit at all;
+        //  2. There is a lastManifestCommit, but we chose not to read it (flag disabled).
+        // We return None in both cases, but note that case-2 could lead to an existing AMT
+        // checkpoint provider not discovered, and cause missing file actions.
+        None
+    }
+
+    (initSegment.checkpointProvider, lastManifestCommitOpt) match {
+      case (amtCheckpointProvider: AMTCheckpointProvider, Some(lastManifestCommit)) =>
         if (amtCheckpointProvider.version == lastManifestCommit.contentRootVersion) {
           // Happy-path: the versions match. Safe to use the initial AMT checkpoint provider.
-          return logSegment
+          return initSegment
         } else if (amtCheckpointProvider.version < lastManifestCommit.contentRootVersion) {
           // The initial AMT checkpoint provider is stale, which could happen during:
           //  - `deltaLog.createSnapshotAtInit()` when _last_checkpoint is stale;
@@ -445,7 +487,7 @@ trait Checkpoints extends DeltaLogging {
           //    least one newer manifest commit has landed.
           //  - If that newer manifest commit is an inline one, having it in the trailing deltas
           //    would lead to missing file actions.
-          return readManifestCommitAndUpdateAMTCheckpointProvider(logSegment, lastManifestCommit)
+          return readManifestCommitAndUpdateAMTCheckpointProvider(initSegment, lastManifestCommit)
         } else if (amtCheckpointProvider.version > lastManifestCommit.contentRootVersion) {
           // This should not happen.
           throw new IllegalStateException(
@@ -457,33 +499,39 @@ trait Checkpoints extends DeltaLogging {
       case (amtCheckpointProvider: AMTCheckpointProvider, None) =>
         throw new IllegalStateException(
           s"An AMT checkpoint provider at version ${amtCheckpointProvider.version} was " +
-            s"discovered for table $logPath, but no checksum (CRC) file is available to " +
-            s"corroborate it. Refusing to trust the AMT checkpoint.")
+            s"discovered for table $logPath, but no lastManifestCommit is available from either " +
+            s"the CRC or the latest commit's CommitInfo to corroborate it. Refusing to trust the " +
+            s"AMT checkpoint.")
 
-      case (otherCheckpointProvider, Some(checksum)) if checksum.lastManifestCommit.isDefined =>
-        // Treat the LastManifestCommit as the source of truth for the AMT checkpoint provider,
-        // even the initial log segment has a non-AMT or empty checkpoint provider.
-        checksum.lastManifestCommit.foreach { lastManifestCommit =>
-          if (otherCheckpointProvider.version <= lastManifestCommit.contentRootVersion) {
-            // We have all the deltas needed after the accurate content root version, so we update.
-            return readManifestCommitAndUpdateAMTCheckpointProvider(logSegment, lastManifestCommit)
-          } else {
-            // The initial log segment somehow has a non-AMT provider, while the lastManifestCommit
-            // claims that there is some AMT content root available describing an earlier version.
-            // This might happen across upgrade/downgrade code paths. Throw until we support them.
-            throw new IllegalStateException(
-              s"The LastManifestCommit of version ${logSegment.version} carries a content root " +
-                s"version ${lastManifestCommit.contentRootVersion} that is ahead of the initial " +
-                s"non-AMT checkpoint version ${otherCheckpointProvider.version}. Refusing to " +
-                s"trust the checkpoint.")
-          }
+      case (otherCheckpointProvider, Some(lastManifestCommit)) =>
+        // Treat the lastManifestCommit as the source of truth for the AMT checkpoint provider,
+        // even when the initial log segment has a non-AMT or empty checkpoint provider.
+        if (otherCheckpointProvider.version <= lastManifestCommit.contentRootVersion) {
+          // We have all the deltas needed after the accurate content root version, so we update.
+          return readManifestCommitAndUpdateAMTCheckpointProvider(initSegment, lastManifestCommit)
+        } else {
+          // The initial log segment somehow has a non-AMT provider, while the lastManifestCommit
+          // claims that there is some AMT content root available describing an earlier version.
+          // This might happen across upgrade/downgrade code paths. Throw until we support them.
+          throw new IllegalStateException(
+            s"The LastManifestCommit of version ${initSegment.version} carries a content root " +
+              s"version ${lastManifestCommit.contentRootVersion} that is ahead of the initial " +
+              s"non-AMT checkpoint version ${otherCheckpointProvider.version}. Refusing to " +
+              s"trust the checkpoint.")
         }
 
+      // A non-AMT / empty provider with no lastManifestCommit: nothing to reconcile.
       case _ => ()
     }
 
     // No changes needed.
-    logSegment
+    initSegment
+  }
+
+  /** Reads the [[CommitInfo]] from the last commit file of the given log segment. */
+  protected def readLastCommitInfo(logSegment: LogSegment): Option[CommitInfo] = {
+    val commitFile = DeltaCommitFileProvider(logPath, logSegment).deltaFile(logSegment.version)
+    DeltaHistoryManager.getCommitInfoOpt(store, commitFile, newDeltaHadoopConf())
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
@@ -757,10 +757,14 @@ trait SnapshotManagement { self: DeltaLog =>
       log"Loading version ${MDC(DeltaLogKeys.VERSION, initSegment.version)}" + startingFrom)
     createSnapshotFromGivenOrEquivalentLogSegment(
         initSegment, tableCommitCoordinatorClientOpt, catalogTableOpt) { segment =>
+      // Start reading the latest commit's CommitInfo (the fallback source of the last manifest
+      // commit reference, used when no CRC is available) in parallel with the CRC read below.
+      val lastCommitInfoFutureOpt = maybeReadLastCommitInfoAsync(
+        segment, shouldReconcileAMTCheckpointProvider)
       val checksumOptAfterRead = checksumOpt.orElse(
         readChecksum(segment.version, lastSeenChecksumFileStatusOpt))
       val finalLogSegment = if (shouldReconcileAMTCheckpointProvider) {
-        reconcileAMTCheckpointProvider(segment, checksumOptAfterRead)
+        reconcileAMTCheckpointProvider(segment, checksumOptAfterRead, lastCommitInfoFutureOpt)
       } else {
         segment
       }
@@ -1723,9 +1727,12 @@ trait SnapshotManagement { self: DeltaLog =>
 }
 
 object SnapshotManagement extends DeltaLogging {
-  // A thread pool for reading checkpoint files and collecting checkpoint v2 actions like
+  // A thread pool for checkpoint resolution.
+  // For v2 checkpoints, we use it to read the checkpoint files and collect the v2 actions like
   // checkpointMetadata, sidecarFiles.
-  private[delta] lazy val checkpointV2ThreadPool = {
+  // For AMT checkpoints, we use it to read the latest commit's CommitInfo during snapshot
+  // construction, as a fallback source when CRC is absent.
+  private[delta] lazy val checkpointThreadPool = {
     val numThreads = SparkSession.active.sessionState.conf.getConf(
       DeltaSQLConf.CHECKPOINT_V2_DRIVER_THREADPOOL_PARALLELISM)
     DeltaThreadPool("checkpointV2-threadpool", numThreads)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -612,6 +612,16 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .checkValue(_ > 0, "fullRewriteCheckpointIntervalMultiplier must be positive.")
       .createWithDefault(5)
 
+  val AMT_SNAPSHOT_DISCOVERY_ASYNC_COMMIT_INFO_READ_ENABLED =
+    buildConf("amt.snapshotDiscovery.asyncCommitInfoRead.enabled")
+      .internal()
+      .doc("When enabled, an async CommitInfo read will be kicked off during snapshot creation " +
+        "in parallel with the CRC read. Enabling it could cause slight performance overhead on " +
+        "non-AMT tables when CRC is absent, and extra checkpoint threadpool contention. " +
+        "Disabling it could result in missing file actions in snapshot discovery for AMT tables.")
+      .booleanConf
+      .createWithDefault(DeltaUtils.isTesting)
+
   val UNSUPPORTED_TESTING_FEATURES_ENABLED =
     buildConf("tableFeatures.dev.unsupportedTableFeatures.enabled")
       .internal()

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
@@ -16,7 +16,7 @@
 
 package org.apache.spark.sql.delta
 
-import java.io.{File, FileInputStream, OutputStream, PrintWriter, StringWriter}
+import java.io.{File, FileInputStream, FileNotFoundException, OutputStream, PrintWriter, StringWriter}
 import java.net.URI
 import java.sql.Timestamp
 import java.util.UUID
@@ -40,7 +40,7 @@ import org.apache.commons.lang3.exception.ExceptionUtils
 import org.apache.hadoop.fs.{FileStatus, Path, RawLocalFileSystem}
 import org.scalatest.time.{Seconds, Span}
 
-import org.apache.spark.{SparkConf, SparkThrowable}
+import org.apache.spark.{SparkConf, SparkException, SparkThrowable}
 import org.apache.spark.sql.{AnalysisException, DataFrame, Dataset, Row}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.util.IntervalUtils
@@ -2282,15 +2282,18 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
             assert(e.getMessage.contains(
               "unexpectedly still requires additional file-system listing"))
           } else {
-            // getBatch reads versions 0-1 (version 2 is gone), so maxVersionSeen = 1.
-            // lastExpectedVersion = 2 in both cases:
-            //   mid-version:  endOffset=(v2, index=0) -> lastExpectedVersion = 2
-            //   fully consumed: endOffset=(v3, BASE_INDEX) -> lastExpectedVersion = 3 - 1 = 2
-            val e = intercept[DeltaIllegalStateException] {
+            // With the parallel CommitInfo read, getBatch's `update()` call eagerly reads the last
+            // commit's file during snapshot construction to source the AMT manifest reference.
+            // Because v2's commit file was deleted, that read fails as a SparkException wrapping a
+            // FileNotFoundException before the streaming's DELTA_STREAMING_TRAILING_COMMIT_MISSING
+            // check fires.
+            val e = intercept[SparkException] {
               source.getBatch(startOffsetOption = None, endOffset)
             }
-            checkError(e, "DELTA_STREAMING_TRAILING_COMMIT_MISSING", "42K03",
-              Map("expectedVersion" -> "2", "seenVersion" -> "1"))
+            assert(
+              Iterator.iterate[Throwable](e)(_.getCause).takeWhile(_ != null)
+                .exists(_.isInstanceOf[FileNotFoundException]),
+              s"expected a FileNotFoundException in the cause chain, got: $e")
           }
         }
       }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotDiscoverySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotDiscoverySuite.scala
@@ -17,23 +17,28 @@
 package org.apache.spark.sql.delta.amt
 
 import org.apache.spark.sql.delta.{DeltaLog, Snapshot}
-import org.apache.spark.sql.delta.actions.LastManifestCommit
+import org.apache.spark.sql.delta.actions.{Action, CommitInfo, LastManifestCommit}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
-import org.apache.spark.sql.delta.util.FileNames
+import org.apache.spark.sql.delta.util.{DeltaCommitFileProvider, FileNames}
 import org.apache.commons.io.IOUtils
 import org.apache.hadoop.fs.{FileSystem, Path}
 
+import org.apache.spark.SparkConf
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
 
 class AMTSnapshotDiscoverySuite extends AMTCheckpointTestBase {
+
+  /** Whether this suite runs with `.crc` files enabled, read from the effective conf. */
+  protected def writeChecksumEnabled: Boolean =
+    spark.conf.get(DeltaSQLConf.DELTA_WRITE_CHECKSUM_ENABLED)
 
   ////////////////////////////
   // Cold snapshot discovery
   ////////////////////////////
 
   /** Loads a genuinely cold deltaLog + snapshot (cache cleared) for the given table. */
-  private def coldLoad(tableName: String): (DeltaLog, Snapshot) = {
+  protected def coldLoad(tableName: String): (DeltaLog, Snapshot) = {
     DeltaLog.clearCache()
     DeltaLog.forTableWithSnapshot(spark, new TableIdentifier(tableName))
   }
@@ -51,12 +56,18 @@ class AMTSnapshotDiscoverySuite extends AMTCheckpointTestBase {
     assert(snapshot.logSegment.deltas.map(FileNames.deltaVersion) == trailingDeltas)
     assert(snapshot.lastManifestCommitOpt == lastManifestCommit)
     assert(amtProvider(snapshot).map(_.version) == amtCheckpointVersion)
-    // The AMT checkpoint is only trusted once the CRC corroborates it, so a cold read of an AMT
-    // table always resolves a checksum carrying the same manifest-commit reference.
-    val checksum = snapshot.checksumOpt.getOrElse(
-      fail(s"v$version: a cold AMT read must resolve a checksum (CRC)."))
-    assert(checksum.lastManifestCommit == lastManifestCommit,
-      s"v$version: the CRC's manifest-commit reference must match the snapshot's.")
+    // The AMT checkpoint is trusted once the manifest-commit reference corroborates it. With a CRC
+    // that reference comes from the checksum; without one it is recovered from the latest commit's
+    // CommitInfo, and no checksum is resolved.
+    if (writeChecksumEnabled) {
+      val checksum = snapshot.checksumOpt.getOrElse(
+        fail(s"v$version: a cold AMT read with CRC enabled must resolve a checksum."))
+      assert(checksum.lastManifestCommit == lastManifestCommit,
+        s"v$version: the CRC's manifest-commit reference must match the snapshot's.")
+    } else {
+      assert(snapshot.checksumOpt.isEmpty,
+        s"v$version: no checksum should be resolved when CRC writes are disabled.")
+    }
   }
 
   testInline("[cold init] installs the correct provider from up-to-date _last_checkpoint: inline") {
@@ -228,25 +239,6 @@ class AMTSnapshotDiscoverySuite extends AMTCheckpointTestBase {
     assert(fs.delete(path, false), s"failed to delete $path")
   }
 
-  test("[cold init] refuses any AMT checkpoint provider without a CRC to cross-verify") {
-    withSQLConf(DeltaSQLConf.DELTA_WRITE_CHECKSUM_ENABLED.key -> "false") {
-      val name = "amt_no_crc_refused"
-      withTable(name) {
-        createAMTTable(name, checkpointInterval = 2)
-        // 2 INSERTs land the v2 tree recorded at v3, so the hint references an AMT checkpoint that
-        // a cold read will install as the provider. Commits reuse the in-memory post-commit
-        // snapshot (which does not verify), so they succeed even though no CRC is written.
-        (1 to 2).foreach(i => sql(s"INSERT INTO $name VALUES ($i)"))
-
-        // A cold read installs the AMT provider from the hint, finds no CRC, and refuses it. The
-        // intercept itself proves the provider was installed (otherwise there would be no throw).
-        val e = intercept[IllegalStateException](coldLoad(name))
-        assert(e.getMessage.contains("no checksum (CRC) file is available to corroborate it"),
-          s"expected the no-CRC refusal, got: ${e.getMessage}")
-      }
-    }
-  }
-
   test("[cold init] updates to the correct provider when _last_checkpoint is stale") {
     val name = "amt_stale_last_checkpoint"
     withTable(name) {
@@ -346,8 +338,10 @@ class AMTSnapshotDiscoverySuite extends AMTCheckpointTestBase {
       "log segment must be equal between warm and cold.")
     assert(warmSnapshot.lastManifestCommitOpt == coldSnapshot.lastManifestCommitOpt,
       s"warm ${warmSnapshot.lastManifestCommitOpt} != cold ${coldSnapshot.lastManifestCommitOpt}.")
-    assert(warmSnapshot.checksumOpt == coldSnapshot.checksumOpt,
-      "checksum must be equal between warm and cold.")
+    if (writeChecksumEnabled) {
+      assert(warmSnapshot.checksumOpt == coldSnapshot.checksumOpt,
+        "checksum must be equal between warm and cold.")
+    }
     assert(warmSnapshot.protocol == coldSnapshot.protocol,
       "protocol must be equal between warm and cold.")
     assert(warmSnapshot.metadata == coldSnapshot.metadata,
@@ -660,5 +654,74 @@ class AMTSnapshotDiscoverySuite extends AMTCheckpointTestBase {
       context.postCheckpointSnapshot.logSegment.deltas.map(f => FileNames.deltaVersion(f))
     assert(segmentDeltaVersions.forall(_ > context.checkpoint.version),
       s"Log segment must trim deltas up to the checkpoint version; got $segmentDeltaVersions.")
+  }
+}
+
+/**
+ * AMT snapshot discovery must work identically via the CommitInfo fallback when CRC is missing.
+ */
+class AMTSnapshotDiscoveryWithoutCRCSuite extends AMTSnapshotDiscoverySuite {
+
+  override protected def sparkConf: SparkConf =
+    super.sparkConf.set(DeltaSQLConf.DELTA_WRITE_CHECKSUM_ENABLED.key, "false")
+
+  test("[cold init] refuses an AMT provider when neither CRC nor CommitInfo carries a reference") {
+    val name = "amt_no_reference_refused"
+    withTable(name) {
+      createAMTTable(name, checkpointInterval = 2)
+      // 2 INSERTs land the v2 tree recorded at v3, so the hint references an AMT checkpoint
+      // that a cold read installs as the provider.
+      (1 to 2).foreach(i => sql(s"INSERT INTO $name VALUES ($i)"))
+
+      // Strip the reference from the recording commit's CommitInfo. With no CRC and no CommitInfo
+      // reference, nothing corroborates the installed AMT provider, so the cold read is refused.
+      val deltaLog = deltaLogForName(name)
+      val commitPath = DeltaCommitFileProvider(deltaLog.unsafeVolatileSnapshot).deltaFile(3)
+      val hadoopConf = deltaLog.newDeltaHadoopConf()
+      val stripped = deltaLog.store.readAsIterator(commitPath, hadoopConf).toList
+        .map(Action.fromJson)
+        .map {
+          case ci: CommitInfo => ci.copy(lastManifestCommit = None).json
+          case other => other.json
+        }
+      deltaLog.store.write(commitPath, stripped.toIterator, overwrite = true, hadoopConf)
+
+      val e = intercept[IllegalStateException](coldLoad(name))
+      assert(e.getMessage.contains("no lastManifestCommit is available from either the CRC"),
+        s"expected the no-reference refusal, got: ${e.getMessage}")
+    }
+  }
+
+  test("[cold init] CommitInfo read is not kicked off when config is disabled: AMT table") {
+    withSQLConf(
+        DeltaSQLConf.AMT_SNAPSHOT_DISCOVERY_ASYNC_COMMIT_INFO_READ_ENABLED.key -> "false") {
+      val name = "amt_slow_commit_info_read"
+      withTable(name) {
+        createAMTTable(name, checkpointInterval = 2)
+        // 2 INSERTs land the v2 tree recorded at v3, so the hint references an AMT checkpoint
+        // that a cold read installs as the provider.
+        (1 to 2).foreach(i => sql(s"INSERT INTO $name VALUES ($i)"))
+
+        // With CommitInfo read not kicked off, the installed AMT provider is refused.
+        val e = intercept[IllegalStateException](coldLoad(name))
+        assert(e.getMessage.contains("no lastManifestCommit is available from either the CRC"))
+      }
+    }
+  }
+
+  test("[cold init] CommitInfo read is not kicked off when config is disabled: non-AMT table") {
+    withSQLConf(
+        DeltaSQLConf.AMT_SNAPSHOT_DISCOVERY_ASYNC_COMMIT_INFO_READ_ENABLED.key -> "false") {
+      val name = "non_amt_slow_commit_info_read"
+      withTable(name) {
+        sql(s"CREATE TABLE $name (id INT) USING delta")
+        (1 to 2).foreach(i => sql(s"INSERT INTO $name VALUES ($i)"))
+
+        // With CommitInfo read not kicked off, non-AMT tables can be loaded unaffected.
+        val (_, snapshot) = coldLoad(name)
+        assert(snapshot.version == 2, "the snapshot must be at v2.")
+        assert(amtProvider(snapshot).isEmpty, "the AMT provider must be absent.")
+      }
+    }
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/SnapshotLastManifestCommitSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/SnapshotLastManifestCommitSuite.scala
@@ -210,13 +210,10 @@ trait SnapshotLastManifestCommitSuiteBase extends AMTCheckpointTestBase {
     }
     assert(lastManifestCommitFromCommitInfoAt(deltaLog, version) == expected,
       s"v$version CommitInfo must carry LMC $expected.")
-    // Currently, we are cross-validating the installed checkpoint provider against the CRC, so in
-    // no-CRC mode, exceptions are thrown. We temporarily skip this assertion in no-CRC mode.
-    // TODO: once CommitInfo fallback lands, stop skipping this assertion.
-    if (writeChecksumEnabled) {
-      assert(deltaLog.getSnapshotAt(version).lastManifestCommitOpt == expected,
-        s"v$version snapshot must resolve LMC $expected.")
-    }
+    // The snapshot resolves the reference from the CRC when present, and otherwise from the latest
+    // commit's CommitInfo fallback, so this holds in both CRC and no-CRC modes.
+    assert(deltaLog.getSnapshotAt(version).lastManifestCommitOpt == expected,
+      s"v$version snapshot must resolve LMC $expected.")
   }
 
   test("manifest commits persist lastManifestCommit to the CRC and CommitInfo, " +


### PR DESCRIPTION
## Description

When the `adaptiveMetadata` table feature is enabled, a cold or warm snapshot load must discover the correct AMT checkpoint provider. The `_last_checkpoint` hint is non-authoritative and may be stale or missing, so this change resolves the latest manifest commit from the `lastManifestCommit` field of the most recent commit's `commitInfo` action.

To keep this off the critical path, the `commitInfo` read is issued asynchronously and in parallel with the rest of snapshot construction, then joined when reconciling the checkpoint provider. When no usable reference is available, the reader falls back to log replay.

A new config, `spark.databricks.delta.amt.snapshotDiscovery.asyncCommitInfoRead.enabled`, gates the async read.

## How was this patch tested?

Added cold- and warm-init cases in `AMTSnapshotDiscoverySuite` and `SnapshotLastManifestCommitSuite` covering the parallel CommitInfo read, the config-disabled path, and the fallback when no reference is available.

## Does this PR introduce _any_ user-facing change?

No.
