### PR TITLE
[Spark] Centralize the AMT-enabled check in AMTUtils.amtEnabled

### DIFF
--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConverter.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConverter.scala
@@ -997,7 +997,7 @@ class DummySnapshotWithAllFilesSupport(
         minSetTransactionRetentionTimestamp = None,
         tableRoot = deltaLog.dataPath,
         useDeletionVectorObjectIdentity = FileAction.useDeletionVectorObjectIdentity(
-          protocol, spark))
+          metadata, protocol, spark))
       val baseVersion = version - 1
       if (baseVersion < 0) { // No prior commit exists
         replay.append(0, txnInfo.finalActionsToCommit.iterator)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/Checksum.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Checksum.scala
@@ -28,6 +28,7 @@ import scala.util.control.NonFatal
 
 import org.apache.spark.sql.delta.Relocated._
 import org.apache.spark.sql.delta.actions._
+import org.apache.spark.sql.delta.amt.AMTUtils
 import org.apache.spark.sql.delta.commands.DeletionVectorUtils
 import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.metering.DeltaLogging
@@ -878,7 +879,7 @@ trait ValidateChecksum extends DeltaLogging { self: Snapshot =>
     // AMT manifest trees do not yet round-trip every AddFile field: `DataEntry.toAddFile` zeroes
     // `modificationTime`, forces `dataChange = false`, drops `tags`, and reduces `stats` to
     // `{"numRecords":n}`. Project both sides through that lossy lens before comparing.
-    if (protocol.isFeatureSupported(AdaptiveMetadataTableFeature)) {
+    if (AMTUtils.amtEnabled(self)) {
       def normalizeForAmtTreeRoundTrip(f: AddFile): AddFile = f.copy(
         modificationTime = 0L,
         dataChange = false,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -1093,7 +1093,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
    */
   private def enableAdaptiveMetadataDependentFeatures(metadata: Metadata): Metadata = {
     val adaptiveMetadataEnabled =
-      protocol.isFeatureSupported(AdaptiveMetadataTableFeature) ||
+      AMTUtils.amtEnabled(metadata, protocol) ||
         TableFeatureProtocolUtils.isFeatureSupportedInTableConfigs(
           metadata.configuration, AdaptiveMetadataTableFeature)
     if (!adaptiveMetadataEnabled) {
@@ -1101,7 +1101,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
     }
 
     val existingTableHasAdaptiveMetadata =
-      snapshot.protocol.isFeatureSupported(AdaptiveMetadataTableFeature)
+      AMTUtils.amtEnabled(snapshot)
     if (!isCreatingNewTable && !existingTableHasAdaptiveMetadata) {
       throw DeltaErrors.adaptiveMetadataUpgradeNotSupported(AdaptiveMetadataTableFeature.name)
     }
@@ -2466,7 +2466,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
       log"${MDC(DeltaLogKeys.NUM_ACTIONS, commitSize.toLong)} actions.")
 
     // If the table has AMT enabled, do not emit a classic checkpoint.
-    if (currentSnapshot.protocol.isFeatureSupported(AdaptiveMetadataTableFeature)) {
+    if (AMTUtils.amtEnabled(currentSnapshot)) {
       return currentSnapshot
     }
 
@@ -3017,7 +3017,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
       isIdempotentRetry = isIdempotentRetry)
     val postCommitReconstructionTime = System.nanoTime()
     maintenanceOperation = if (
-        !postCommitSnapshot.protocol.isFeatureSupported(AdaptiveMetadataTableFeature)) {
+        !AMTUtils.amtEnabled(postCommitSnapshot)) {
       MaintenanceOperation(
         shouldCheckpoint = isCheckpointNeeded(attemptVersion, postCommitSnapshot))
     } else if (amtWriteResultOpt.isEmpty) {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
@@ -26,7 +26,7 @@ import scala.util.Try
 import com.databricks.spark.util.TagDefinition
 import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.actions.Action.logSchema
-import org.apache.spark.sql.delta.amt.{AMTCheckpointProvider, AMTUsageLogs}
+import org.apache.spark.sql.delta.amt.{AMTCheckpointProvider, AMTUsageLogs, AMTUtils}
 import org.apache.spark.sql.delta.ClassicColumnConversions._
 import org.apache.spark.sql.delta.coordinatedcommits.{CatalogOwnedTableUtils, CommitCoordinatorClient, CommitCoordinatorProvider, CoordinatedCommitsUsageLogs, CoordinatedCommitsUtils, TableCommitCoordinatorClient}
 import org.apache.spark.sql.delta.expressions.EncodeNestedVariantAsZ85String
@@ -236,7 +236,7 @@ class Snapshot(
 
   /** Returns the lastManifestCommit reliably for this snapshot's version. */
   lazy val lastManifestCommitOpt: Option[LastManifestCommit] =
-    Option.when(protocol.isFeatureSupported(AdaptiveMetadataTableFeature)) {
+    Option.when(AMTUtils.amtEnabled(this)) {
       _reconstructedProtocolMetadataICTAndLMC.bestEffortLastManifestCommit.orElse {
         // Only fallback to direct CommitInfo read if there are no trailing deltas.
         // This avoids unnecessary I/O when there isn't any AMT checkpoint yet.
@@ -602,7 +602,7 @@ class Snapshot(
       val localMinSetTransactionRetentionTimestamp = minSetTransactionRetentionTimestamp
       val localTableRoot = deltaLog.dataPath.toString
       val localUseDeletionVectorObjectIdentity =
-        FileAction.useDeletionVectorObjectIdentity(protocol, spark)
+        FileAction.useDeletionVectorObjectIdentity(metadata, protocol, spark)
 
       val canonicalPath = deltaLog.getCanonicalPathUdf()
 
@@ -969,7 +969,7 @@ object Snapshot extends DeltaLogging {
     // AddFile-generation logic cannot handle back references (yet): it writes allFiles into the CRC
     // without them. Only leaf-resident files carry a back reference, so a root-only tree yields a
     // back-reference-free list that matches state reconstruction.
-    if (snapshot.protocol.isFeatureSupported(AdaptiveMetadataTableFeature)) {
+    if (AMTUtils.amtEnabled(snapshot)) {
       val rootOnly =
         effectiveLatestAMTCheckpointAtCommitVersion.exists(_.contentRoot.numLeaves.contains(0L))
       if (!rootOnly) return false

--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -833,12 +833,14 @@ object FileAction {
    * Whether deletion vectors should be reconciled by their normalized object identity for the
    * given table (see [[DeletionVectorDescriptor.uniqueId]]).
    *
+   * @param metadata the table metadata.
    * @param protocol the table protocol.
    */
   def useDeletionVectorObjectIdentity(
+      metadata: Metadata,
       protocol: Protocol,
       spark: SparkSession): Boolean =
-    protocol.isFeatureSupported(AdaptiveMetadataTableFeature) ||
+    AMTUtils.amtEnabled(metadata, protocol) ||
       spark.conf.get(DeltaSQLConf.DELETION_VECTORS_USE_OBJECT_IDENTITY_FOR_NON_AMT)
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTUtils.scala
@@ -16,8 +16,8 @@
 
 package org.apache.spark.sql.delta.amt
 
-import org.apache.spark.sql.delta.{CurrentTransactionInfo, WinningCommitSummary}
-import org.apache.spark.sql.delta.actions.LastManifestCommit
+import org.apache.spark.sql.delta.{AdaptiveMetadataTableFeature, CurrentTransactionInfo, SnapshotDescriptor, WinningCommitSummary}
+import org.apache.spark.sql.delta.actions.{LastManifestCommit, Metadata, Protocol}
 import org.apache.spark.sql.delta.deletionvectors.{RoaringBitmapArray, RoaringBitmapArrayFormat}
 import org.apache.spark.sql.delta.util.DeltaFileOperations
 import org.apache.hadoop.fs.{FileSystem, Path}
@@ -31,6 +31,17 @@ import org.apache.hadoop.fs.{FileSystem, Path}
  * This differs from Delta's `AddFile.path`, which is URL-encoded.
  */
 object AMTUtils {
+  /**
+   * Whether AMT (Adaptive Metadata Tree) writes are enabled for a table with this `protocol` and
+   * `metadata`.
+   */
+  def amtEnabled(metadata: Metadata, protocol: Protocol): Boolean =
+    protocol.isFeatureSupported(AdaptiveMetadataTableFeature)
+
+  /** Whether AMT writes are enabled for `snapshot`. */
+  def amtEnabled(snapshot: SnapshotDescriptor): Boolean =
+    amtEnabled(snapshot.metadata, snapshot.protocol)
+
   private val PathSeparator = "/"
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriterManager.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriterManager.scala
@@ -16,7 +16,7 @@
 
 package org.apache.spark.sql.delta.amt
 
-import org.apache.spark.sql.delta.{AdaptiveMetadataTableFeature, CurrentTransactionInfo, DeltaErrors, DeltaLog, DeltaOperations, LogSegment, MaintenanceOperation, Snapshot}
+import org.apache.spark.sql.delta.{CurrentTransactionInfo, DeltaErrors, DeltaLog, DeltaOperations, LogSegment, MaintenanceOperation, Snapshot}
 import org.apache.spark.sql.delta.actions.{Action, Checkpoint}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.FileNames
@@ -128,7 +128,7 @@ class AMTWriterManager(
       commitVersion: Long,
       currentTransactionInfo: CurrentTransactionInfo,
       preCommitLogSegment: LogSegment): Option[AMTWriteResult] = {
-    if (!amtEnabled(commitVersion)) return None
+    if (!AMTUtils.amtEnabled(readSnapshot)) return None
     val actionsToCommit = currentTransactionInfo.actions
     // Whether this attempt would (re)write a manifest tree.
     val writesTree = initialOperation match {
@@ -253,7 +253,7 @@ class AMTWriterManager(
       postCommitSnapshot: Snapshot): MaintenanceOperation = {
     // if the commit itself was to do a checkpoint, don't schedule any maintenance as part
     // of its post-commit hook.
-    if (!amtEnabled(commitVersion)
+    if (!AMTUtils.amtEnabled(readSnapshot)
         || initialOperation.isInstanceOf[DeltaOperations.OptimizeCheckpoint]) {
       return MaintenanceOperation()
     }
@@ -276,7 +276,7 @@ class AMTWriterManager(
       commitVersion: Long,
       postCommitSnapshot: Snapshot): MaintenanceOperation = {
     // The follow-up OPTIMIZE CHECKPOINT commit itself must never schedule more maintenance.
-    if (!amtEnabled(commitVersion)
+    if (!AMTUtils.amtEnabled(readSnapshot)
         || initialOperation.isInstanceOf[DeltaOperations.OptimizeCheckpoint]) {
       return MaintenanceOperation()
     }
@@ -358,15 +358,6 @@ class AMTWriterManager(
         versionsSinceFull > 0 && versionsSinceFull % checkpointInterval == 0 &&
           versionsSinceFull >= fullRewriteSpan
       }
-  }
-
-  /**
-   * Whether AMT write is possible at all for this commit.
-   * Note: We don't create AMT at commit 0 as of now but this could be relaxed in future.
-   */
-  private def amtEnabled(commitVersion: Long): Boolean = {
-    if (commitVersion <= 0) return false
-    readSnapshot.protocol.isFeatureSupported(AdaptiveMetadataTableFeature)
   }
 
   private def largeCommitActionsCountThresholdForInlineManifestCommit: Long =

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
@@ -476,7 +476,8 @@ class OptimizeExecutor(
         // Note: When checking if the candidate set is the same, we need to consider (Path, DV)
         //       as the key.
         val useObjectIdentity =
-          FileAction.useDeletionVectorObjectIdentity(snapshot.protocol, sparkSession)
+          FileAction.useDeletionVectorObjectIdentity(
+            snapshot.metadata, snapshot.protocol, sparkSession)
         val candidateSetOld = filesToProcess
           .map(f =>
             f.toUniqueFileActionTuple(snapshot.dataPath, useObjectIdentity))

--- a/spark/src/main/scala/org/apache/spark/sql/delta/hooks/CheckpointHook.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/hooks/CheckpointHook.scala
@@ -16,7 +16,8 @@
 
 package org.apache.spark.sql.delta.hooks
 
-import org.apache.spark.sql.delta.{AdaptiveMetadataTableFeature, CommittedTransaction, DeltaOperations}
+import org.apache.spark.sql.delta.{CommittedTransaction, DeltaOperations}
+import org.apache.spark.sql.delta.amt.AMTUtils
 
 import org.apache.spark.sql.SparkSession
 
@@ -29,7 +30,7 @@ object CheckpointHook extends PostCommitHook {
 
     // AMT tables checkpoint by rewriting their manifest tree via a follow-up OPTIMIZE CHECKPOINT
     // commit rather than a standalone checkpoint file.
-    if (txn.postCommitSnapshot.protocol.isFeatureSupported(AdaptiveMetadataTableFeature)) {
+    if (AMTUtils.amtEnabled(txn.postCommitSnapshot)) {
       val triggerMode = txn.maintenanceOperation.amtTriggerModeOpt.getOrElse {
         throw new IllegalStateException(
           "An AMT table scheduled a checkpoint but carries no AMTTriggerMode.")

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogMinorCompactionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogMinorCompactionSuite.scala
@@ -44,12 +44,13 @@ class DeltaLogMinorCompactionSuite extends QueryTest
       startVersion: Long,
       endVersion: Long): Unit = {
     val deltaLog = DeltaLog.forTable(spark, tablePath)
+    val snapshotForReplay = deltaLog.update()
     val logReplay = new InMemoryLogReplay(
       minFileRetentionTimestamp = None,
       minSetTransactionRetentionTimestamp = None,
       tableRoot = deltaLog.dataPath,
       useDeletionVectorObjectIdentity = FileAction.useDeletionVectorObjectIdentity(
-        deltaLog.update().protocol, spark))
+        snapshotForReplay.metadata, snapshotForReplay.protocol, spark))
     val hadoopConf = deltaLog.newDeltaHadoopConf()
 
     (startVersion to endVersion).foreach { versionToRead =>

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTUtilsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTUtilsSuite.scala
@@ -16,6 +16,8 @@
 
 package org.apache.spark.sql.delta.amt
 
+import org.apache.spark.sql.delta.AdaptiveMetadataTableFeature
+import org.apache.spark.sql.delta.actions.{Metadata, Protocol}
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 
@@ -127,5 +129,14 @@ class AMTUtilsSuite extends SparkFunSuite {
     val leaf = new Path("file:/tables/t1/metadata/leaf-1.parquet")
     val relative = AMTUtils.relativizeManifestPathToTableRoot(fs, root, leaf)
     assert(AMTUtils.absolutePathForManifestFile(root, relative) === leaf)
+  }
+
+  test("amtEnabled: true when the protocol supports the AMT feature") {
+    val protocol = Protocol.forTableFeature(AdaptiveMetadataTableFeature)
+    assert(AMTUtils.amtEnabled(Metadata(), protocol))
+  }
+
+  test("amtEnabled: false when the protocol lacks the AMT feature") {
+    assert(!AMTUtils.amtEnabled(Metadata(), Protocol()))
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AdaptiveMetadataTableFeatureSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AdaptiveMetadataTableFeatureSuite.scala
@@ -93,6 +93,8 @@ class AdaptiveMetadataTableFeatureSuite
       val protocol = protocolOf("amt_supported")
       assert(protocol.isFeatureSupported(AdaptiveMetadataTableFeature),
         s"Protocol must record adaptiveMetadata-preview as supported. Got: $protocol")
+      assert(AMTUtils.amtEnabled(metadataOf("amt_supported"), protocol),
+        s"AMTUtils.amtEnabled must report the table as AMT-enabled. Got: $protocol")
       // Every required feature (and their transitive dependencies) must be present.
       dependentFeatures(AdaptiveMetadataTableFeature).foreach { f =>
         assert(protocol.readerAndWriterFeatureNames.contains(f.name),


### PR DESCRIPTION
Introduces `AMTUtils.amtEnabled(metadata, protocol)` — with a `SnapshotDescriptor` overload — as the single way to check whether Adaptive Metadata Tree (AMT) writes are enabled for a table, and routes the existing scattered protocol feature checks through it.

Previously the check `protocol.isFeatureSupported(AdaptiveMetadataTableFeature)` was duplicated across `Snapshot`, `OptimisticTransaction`, `Checksum`, `CheckpointHook`, and `AMTWriterManager` (which kept its own private helper). These now all call `AMTUtils.amtEnabled`, and `AMTWriterManager` no longer special-cases commit version 0.

`FileAction.useDeletionVectorObjectIdentity` also routes through the helper and now takes the table metadata alongside the protocol, matching the shape of the other feature-enablement helpers; its call sites are updated to pass metadata.

Adds unit coverage for `AMTUtils.amtEnabled` and asserts it in the feature-registration test.
