### PR TITLE
[Spark] Support conflict resolution when a log commit wins over an inline AMT commit

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriterManager.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriterManager.scala
@@ -137,10 +137,14 @@ class AMTWriterManager(
     }
 
     if (preCommitLogSegment.version > readSnapshot.version) {
-      // A concurrent commit won our target version and we are rebasing. A commit that writes no
-      // tree, and that lost only to commits that wrote no tree, is safe to rebase as-is; anything
-      // else needs the tree and back-reference rebase that is not implemented yet.
-      if (writesTree || winningCommitInstalledNewAMTTree(currentTransactionInfo)) {
+      // A concurrent commit won our target version and we are rebasing. Scenarios handled:
+      //   Winning commit | Losing commit     | Action taken
+      //   Log commit     | Log commit        | usual conflict checking; back references stay valid
+      //   Log commit     | Inline AMT commit | regenerate the inline AMT tree; no back-ref changes
+      // All other scenarios are not handled.
+      val losingOptimizeCheckpoint =
+        initialOperation.isInstanceOf[DeltaOperations.OptimizeCheckpoint]
+      if (losingOptimizeCheckpoint || winningCommitInstalledNewAMTTree(currentTransactionInfo)) {
         throw DeltaErrors.concurrentWriteException(conflictingCommit = None)
       }
     }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointTestBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointTestBase.scala
@@ -498,6 +498,28 @@ trait AMTCheckpointTestBase
       .flatMap(_.incrementalWriteMetrics)
   }
 
+  /**
+   * Like [[trackIncrementalAMTWriteMetrics]] but returns one entry per attempt that made an
+   * incremental write, in attempt order -- a conflict retry materializes the tree more than once,
+   * so this exposes each attempt's shape. `commitVersion` is by-name so callers can pass the final
+   * committed version, which is only known after `commit` runs.
+   */
+  protected def trackIncrementalAMTWriteMetricsPerAttempt(
+      commitVersion: => Long)(commit: => Unit): Seq[IncrementalAMTWriteMetrics] = {
+    val events = Log4jUsageLogger.track {
+      commit
+    }
+    val version = commitVersion
+    events.filter(e => e.metric == MetricDefinitions.EVENT_TAHOE.name &&
+        e.tags.get("opType").contains("delta.commit.stats"))
+      .map(e => JsonUtils.fromJson[CommitStats](e.blob))
+      .find(_.commitVersion == version)
+      .toSeq
+      .flatMap(_.amtWriteMetrics.toSeq)
+      .flatMap(_.attempts)
+      .flatMap(_.incrementalWriteMetrics)
+  }
+
   private def assertAMTCheckpointScenarioInvariants(
       context: AMTCheckpointScenarioContext): Unit = {
     val scenario = context.scenario
@@ -566,11 +588,13 @@ trait AMTCheckpointTestBase
   }
 
   /** Forces every write to inline its AMT incrementally (a low action-count threshold). */
-  protected def withInline[T](body: => T): T =
+  protected def withInline[T](body: => T): T = withInlineThreshold(1)(body)
+
+  /** Runs `body` with the inline-manifest threshold at `n` actions. */
+  protected def withInlineThreshold[T](n: Int)(body: => T): T =
     withSQLConf(
-      DeltaSQLConf.AMT_LARGE_COMMIT_ACTIONS_COUNT_THRESHOLD_FOR_INLINE_MANIFEST_COMMIT.key -> "1") {
-      body
-    }
+      DeltaSQLConf.AMT_LARGE_COMMIT_ACTIONS_COUNT_THRESHOLD_FOR_INLINE_MANIFEST_COMMIT.key
+        -> n.toString)(body)
 
   /**
    * Runs the test with inline writes forced (a low action-count threshold).

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTConflictResolutionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTConflictResolutionSuite.scala
@@ -83,14 +83,76 @@ class AMTConflictResolutionSuite
       val name = "amt_conflict_tree_writer_loses"
       val deltaLog = setupAMTTable(name)
 
-      // A writes a tree (OPTIMIZE CHECKPOINT); B is a plain append that wins A's target version.
+      // A is an OPTIMIZE checkpoint (a maintenance tree write); B is a plain append that wins A's
+      // target version. Rebasing a losing maintenance checkpoint is deferred (it can be rescheduled
+      // against the new snapshot instead), so A still hard-fails.
       val (futureA, futureB) = runTxnsWithOrder__A_Start__B__A_End(
         optimizeCheckpointTxn(deltaLog),
         appendTxn(name, id = 100))
-
-      // B commits cleanly; A loses and, because it (re)writes a tree, still hard-fails.
       ThreadUtils.awaitResult(futureB, Duration.Inf)
       assertConcurrentWriteFailure(futureA)
+    }
+  }
+
+  test("Winning Commit [Log Commit] vs Losing commit [inline-incremental commit] - Success") {
+    withTable("amt_conflict_inline_rebase") {
+      val name = "amt_conflict_inline_rebase"
+      val deltaLog = setupAMTTable(name)
+      val liveIdsBefore = spark.sql(s"SELECT id FROM $name").collect().map(_.getInt(0)).toSet
+
+      // Threshold 6: A's 10-file insert inlines its AMT tree, while B's single-file append (a
+      // couple of actions) stays log-only. So A is a tree writer losing to a log-only winner -- it
+      // must rebase and rebuild its tree with B folded into the incremental window rather than
+      // hard-failing. Capture A's per-attempt AMT write metrics to inspect the window growth.
+      val perAttempt = trackIncrementalAMTWriteMetricsPerAttempt(deltaLog.update().version) {
+        withInlineThreshold(6) {
+          val (futureA, futureB) = runTxnsWithOrder__A_Start__B__A_End(
+            () => { appendRowsAsSeparateFiles(name, numFiles = 10, startId = 100); Array.empty },
+            appendTxn(name, id = 200))
+          ThreadUtils.awaitResult(futureB, Duration.Inf)
+          ThreadUtils.awaitResult(futureA, Duration.Inf)
+        }
+      }
+
+      // Reading the live set back goes through A's rebased inline tree, so a correct id set proves
+      // the tree folded the winning append.
+      val liveIdsAfter = spark.sql(s"SELECT id FROM $name").collect().map(_.getInt(0)).toSet
+      assert(liveIdsAfter == liveIdsBefore ++ (100 to 109).toSet ++ Set(200),
+        s"both commits must survive the rebase; before=$liveIdsBefore after=$liveIdsAfter")
+      // A's commit rode an inline AMT checkpoint, confirming it took the tree-writing rebase path.
+      val latest = deltaLog.update()
+      assert(checkpointAt(deltaLog, latest.version).isDefined,
+        "the rebased inline commit must carry an AMT checkpoint at its version.")
+      assert(amtProvider(latest).isDefined, "the table must remain AMT-backed after the rebase.")
+
+      // A materialized its tree exactly twice -- once on its first attempt and once on the rebase
+      // -- and the rebase's incremental window folds in exactly one extra commit, the winning
+      // append, so its numIntermediateCommits is precisely one more than the first attempt's.
+      val numIntermediateCommits = perAttempt.map(_.numIntermediateCommits)
+      assert(numIntermediateCommits.size == 2,
+        s"A must materialize exactly twice (first attempt + rebase); got $numIntermediateCommits")
+      assert(numIntermediateCommits(1) == numIntermediateCommits(0) + 1,
+        "the rebase must fold exactly one more intermediate commit (the winning append) than the " +
+          s"first attempt; got $numIntermediateCommits")
+    }
+  }
+
+  test("Winning Commit [Manifest Commit] vs Losing commit [inline-incremental commit]" +
+    " - FAILS") {
+    withTable("amt_conflict_inline_vs_tree_winner") {
+      val name = "amt_conflict_inline_vs_tree_winner"
+      val deltaLog = setupAMTTable(name)
+
+      // A's 10-file insert inlines a tree; B installs a new tree (OPTIMIZE CHECKPOINT) and wins A's
+      // target version. The winner's tree moves A's base, so A hard-fails until the base re-seat
+      // lands.
+      withInlineThreshold(6) {
+        val (futureA, futureB) = runTxnsWithOrder__A_Start__B__A_End(
+          () => { appendRowsAsSeparateFiles(name, numFiles = 10, startId = 100); Array.empty },
+          optimizeCheckpointTxn(deltaLog))
+        ThreadUtils.awaitResult(futureB, Duration.Inf)
+        assertConcurrentWriteFailure(futureA)
+      }
     }
   }
 


### PR DESCRIPTION
Extends AMT (Adaptive Metadata Tree) conflict resolution during commit rebase.

When a concurrent log commit wins the target version, a losing commit that wrote an incremental inline AMT tree can now be rebased by regenerating the inline tree (its back references remain valid), instead of hard-failing the transaction. The scenarios are:

| Winning commit | Losing commit     | Action |
|----------------|-------------------|--------|
| Log commit     | Log commit        | usual conflict checking; back references stay valid |
| Log commit     | Inline AMT commit | regenerate the inline AMT tree; no back-reference changes |

All other scenarios still hard-fail: a losing OPTIMIZE-checkpoint commit, or a case where the winning commit installed a new AMT tree.

Also adds a `trackIncrementalAMTWriteMetricsPerAttempt` test helper that returns one incremental-write-metrics entry per attempt (a conflict retry materializes the tree more than once, so each attempt's shape is exposed), and extends the conflict-resolution suite with coverage for the log-wins-over-inline case.
