### PR TITLE
[Spark] Make Delta DSV2 initialOffset idempotent

### DIFF
--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2MicroBatchStream.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2MicroBatchStream.java
@@ -476,7 +476,7 @@ class DeltaV2MicroBatchStream
 
     cachedInitialOffset =
         DeltaSourceOffset.apply(
-        tableId, version, DeltaSourceOffset.BASE_INDEX(), isInitialSnapshot);
+            tableId, version, DeltaSourceOffset.BASE_INDEX(), isInitialSnapshot);
     return cachedInitialOffset;
   }
 

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2MicroBatchStream.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2MicroBatchStream.java
@@ -178,8 +178,8 @@ class DeltaV2MicroBatchStream
    *
    * <p>- First batch: initialOffset() -> latestOffset(Offset, ReadLimit) - Set `isFirstBatch` to
    * true in initialOffset() - in latestOffset(Offset, ReadLimit), use `isFirstBatch` to determine
-   * whether to return null vs previousOffset (when no data is available) - keep `isFirstBatch`
-   * true until a non-null offset is returned - Subsequent batches: latestOffset(Offset, ReadLimit)
+   * whether to return null vs previousOffset (when no data is available) - keep `isFirstBatch` true
+   * until a non-null offset is returned - Subsequent batches: latestOffset(Offset, ReadLimit)
    */
   private boolean isFirstBatch = false;
 

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2MicroBatchStream.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2MicroBatchStream.java
@@ -170,13 +170,16 @@ class DeltaV2MicroBatchStream
   /** Handler for non-additive schema evolution (rename/drop/type widening). */
   private final MetadataEvolutionHandler metadataEvolutionHandler;
 
+  // Spark can call initialOffset multiple times while constructing and executing the first batch.
+  private DeltaSourceOffset cachedInitialOffset;
+
   /**
    * Tracks whether this is the first batch for this stream (no checkpointed offset).
    *
    * <p>- First batch: initialOffset() -> latestOffset(Offset, ReadLimit) - Set `isFirstBatch` to
    * true in initialOffset() - in latestOffset(Offset, ReadLimit), use `isFirstBatch` to determine
-   * whether to return null vs previousOffset (when no data is available) - set `isFirstBatch` to
-   * false - Subsequent batches: latestOffset(Offset, ReadLimit)
+   * whether to return null vs previousOffset (when no data is available) - keep `isFirstBatch`
+   * true until a non-null offset is returned - Subsequent batches: latestOffset(Offset, ReadLimit)
    */
   private boolean isFirstBatch = false;
 
@@ -452,6 +455,10 @@ class DeltaV2MicroBatchStream
    */
   @Override
   public Offset initialOffset() {
+    if (cachedInitialOffset != null) {
+      return cachedInitialOffset;
+    }
+
     Optional<Long> startingVersionOpt = getStartingVersion();
     long version;
     boolean isInitialSnapshot;
@@ -467,8 +474,10 @@ class DeltaV2MicroBatchStream
       isInitialSnapshot = true;
     }
 
-    return DeltaSourceOffset.apply(
+    cachedInitialOffset =
+        DeltaSourceOffset.apply(
         tableId, version, DeltaSourceOffset.BASE_INDEX(), isInitialSnapshot);
+    return cachedInitialOffset;
   }
 
   @Override
@@ -494,7 +503,9 @@ class DeltaV2MicroBatchStream
       initForTriggerAvailableNowIfNeeded(deltaStartOffset);
       // Return null when no data is available for this batch.
       DeltaSourceOffset endOffset = latestOffsetInternal(deltaStartOffset, limit).orElse(null);
-      isFirstBatch = false;
+      if (endOffset != null) {
+        isFirstBatch = false;
+      }
       return endOffset;
     } catch (Exception e) {
       // Kernel's DefaultJsonHandler wraps ClosedByInterruptException (thrown by NIO

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2MicroBatchStreamTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2MicroBatchStreamTest.java
@@ -143,6 +143,58 @@ public class DeltaV2MicroBatchStreamTest extends DeltaV2TestBase {
   }
 
   @Test
+  public void testInitialOffset_doesNotResetFirstBatchState(@TempDir File tempDir)
+      throws Exception {
+    String testTablePath = tempDir.getAbsolutePath();
+    String testTableName = "test_idempotent_initial_offset_" + System.nanoTime();
+    createEmptyTestTable(testTablePath, testTableName);
+    insertVersions(
+        testTableName,
+        /* numVersions= */ 1,
+        /* rowsPerVersion= */ 1,
+        /* includeEmptyVersion= */ false);
+
+    Configuration hadoopConf = new Configuration();
+    PathBasedSnapshotManager snapshotManager =
+        new PathBasedSnapshotManager(testTablePath, hadoopConf);
+    DeltaV2MicroBatchStream stream =
+        createTestStreamWithDefaults(snapshotManager, hadoopConf, emptyDeltaOptions());
+
+    Offset initialOffset = stream.initialOffset();
+    Offset firstEndOffset = stream.latestOffset(initialOffset, ReadLimit.allAvailable());
+    assertNotNull(firstEndOffset);
+
+    // MicroBatchExecution calls initialOffset again while constructing the first batch's scan.
+    assertEquals(initialOffset, stream.initialOffset());
+
+    // With no new data, a subsequent batch returns its start offset rather than null.
+    assertEquals(firstEndOffset, stream.latestOffset(firstEndOffset, ReadLimit.allAvailable()));
+  }
+
+  @Test
+  public void testInitialOffset_noDataRemainsFirstBatch(@TempDir File tempDir) throws Exception {
+    String testTablePath = tempDir.getAbsolutePath();
+    String testTableName = "test_initial_offset_no_data_" + System.nanoTime();
+    createEmptyTestTable(testTablePath, testTableName);
+
+    scala.collection.immutable.Map<String, String> scalaOptions =
+        Map$.MODULE$.<String, String>empty().updated("startingVersion", "latest");
+    DeltaOptions options = new DeltaOptions(scalaOptions, spark.sessionState().conf());
+    Configuration hadoopConf = new Configuration();
+    PathBasedSnapshotManager snapshotManager =
+        new PathBasedSnapshotManager(testTablePath, hadoopConf);
+    DeltaV2MicroBatchStream stream =
+        createTestStreamWithDefaults(snapshotManager, hadoopConf, options);
+
+    Offset initialOffset = stream.initialOffset();
+    assertNull(stream.latestOffset(initialOffset, ReadLimit.allAvailable()));
+
+    Offset cachedInitialOffset = stream.initialOffset();
+    assertEquals(initialOffset, cachedInitialOffset);
+    assertNull(stream.latestOffset(cachedInitialOffset, ReadLimit.allAvailable()));
+  }
+
+  @Test
   public void testDeserializeOffset_ValidJson(@TempDir File tempDir) throws Exception {
     String tablePath = tempDir.getAbsolutePath();
     DeltaV2MicroBatchStream stream = createTestStream(tempDir);


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Spark can call `MicroBatchStream.initialOffset()` more than once while constructing and executing
the first batch. Cache the Delta DSV2 source's computed initial offset so repeated calls return the
same value without resetting first-batch state.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

Added `testInitialOffset_doesNotResetFirstBatchState` to cover the
`initialOffset -> latestOffset -> initialOffset -> latestOffset` call sequence. Not run locally; CI
will run the test coverage.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No. This only makes internal streaming source initialization idempotent.
