### PR TITLE
[Spark] Retain the snapshot used for Delta V2 scan planning

### DIFF
--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2Scan.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/read/DeltaV2Scan.java
@@ -105,6 +105,7 @@ class DeltaV2Scan extends DeltaV2JavaLogging
   private long totalRows = 0L;
   // true iff every AddFile in the scan had numRecords in its stats JSON.
   private boolean rowCountKnown = false;
+  private org.apache.spark.sql.delta.Snapshot plannedSnapshot = null;
   private volatile boolean planned = false;
 
   // Runtime predicates applied after planning (using Set for order-independent comparison)
@@ -441,6 +442,9 @@ class DeltaV2Scan extends DeltaV2JavaLogging
    * size statistics.
    */
   private void materializeSelectedFiles(DeltaScan deltaScan, String tablePath) {
+    plannedSnapshot =
+        Objects.requireNonNull(
+            deltaScan.scannedSnapshot(), "deltaScan.scannedSnapshot returned null");
     rowCountKnown = arePlanStatsEnabled();
     final List<org.apache.spark.sql.delta.actions.AddFile> scanFiles =
         scala.jdk.javaapi.CollectionConverters.asJava(deltaScan.files());
@@ -555,6 +559,11 @@ class DeltaV2Scan extends DeltaV2JavaLogging
   private void ensurePlanned() {
     // Pass null to indicate no runtime predicate should be applied - just perform the scan planning
     ensurePlanned(null);
+  }
+
+  org.apache.spark.sql.delta.Snapshot plannedSnapshot() {
+    ensurePlanned();
+    return Objects.requireNonNull(plannedSnapshot, "plannedSnapshot is null after planning");
   }
 
   public StructType getDataSchema() {

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2ScanTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/read/DeltaV2ScanTest.java
@@ -31,6 +31,7 @@ import org.apache.spark.sql.connector.read.Scan;
 import org.apache.spark.sql.connector.read.ScanBuilder;
 import org.apache.spark.sql.connector.read.Statistics;
 import org.apache.spark.sql.connector.read.colstats.ColumnStatistics;
+import org.apache.spark.sql.delta.Snapshot;
 import org.apache.spark.sql.execution.datasources.PartitionedFile;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
@@ -565,6 +566,21 @@ public class DeltaV2ScanTest extends DeltaV2TestBase {
     assertTrue(
         filteredSelectedFiles.stream().allMatch(file -> file.getPath().contains("city=hz")),
         "selected files should be pruned with runtime partition filters");
+  }
+
+  @Test
+  public void testPlannedSnapshotTriggersPlanningAndReturnsSameSnapshot() throws Exception {
+    DeltaV2ScanBuilder builder = (DeltaV2ScanBuilder) table.newScanBuilder(options);
+    DeltaV2Scan scan = (DeltaV2Scan) builder.build();
+    assertFalse(getPlanned(scan), "build() should leave file planning lazy");
+
+    Snapshot plannedSnapshot = scan.plannedSnapshot();
+
+    assertTrue(getPlanned(scan), "plannedSnapshot() should trigger file planning");
+    assertSame(
+        plannedSnapshot,
+        scan.plannedSnapshot(),
+        "repeated plannedSnapshot() calls should return the same planned snapshot");
   }
 
   private static long getTotalBytes(DeltaV2Scan scan) throws Exception {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Retain the snapshot associated with planned scan files so selected files and snapshot state remain tied to the same table version. Verify that lazy initialization returns a stable reference.

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

Added new tests and CI

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No