### PR TITLE
[Spark] AMT: field-id manifest reads survive column rename; write timestamps as Iceberg TIMESTAMP_MICROS

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
@@ -1313,11 +1313,11 @@ object Checkpoints
    *                  (the default, classic-checkpoint behavior) it is `df.schema.asNullable` (fully
    *                  nullable). The AMT manifest writer passes its id-carrying schema. The resolved
    *                  schema is the value returned to the caller.
-   * @param useDeltaParquetWriteSupport When true, hooks in [[DeltaParquetWriteSupport]] as the
-   *                  Parquet write support class so that list-element / map key-value field ids
-   *                  carried on `outputSchema` via `parquet.field.nested.ids` are emitted to the
-   *                  file's Parquet schema (the stock `ParquetWriteSupport` does not). Needed for
-   *                  the AMT Iceberg-V4 manifest schema. Default false uses the standard support.
+   * @param writeAsIcebergManifest When true, applies the Iceberg-V4 manifest write settings via
+   *                  [[configureIcebergManifestParquetWrite]]: list-element / map key-value field
+   *                  ids (carried on `outputSchema` via `parquet.field.nested.ids`, which the stock
+   *                  `ParquetWriteSupport` omits) and int64 `TIMESTAMP(MICROS)` timestamps. Needed
+   *                  for the AMT manifest schema. Default false uses the standard parquet write.
    * @return The schema actually written.
    */
   def writeAtomicCheckpointParquetFile(
@@ -1327,17 +1327,17 @@ object Checkpoints
       hadoopConf: Configuration,
       useRename: Boolean,
       outputSchema: Option[StructType] = None,
-      useDeltaParquetWriteSupport: Boolean = false): StructType =
+      writeAsIcebergManifest: Boolean = false): StructType =
       recordFrameProfile(
         "Checkpoints", "writeAtomicCheckpointParquetFile") {
     val schema = outputSchema.getOrElse(df.schema.asNullable)
     val format = new ParquetFileFormat()
     val job = Job.getInstance(hadoopConf)
     val factory = format.prepareWrite(spark, job, Map.empty, schema)
-    if (useDeltaParquetWriteSupport) {
-      // Emit nested (list-element / map key-value) field ids, which the stock ParquetWriteSupport
-      // does not. Set after prepareWrite so it overrides the write-support class prepareWrite set.
-      ParquetOutputFormat.setWriteSupportClass(job, classOf[DeltaParquetWriteSupport])
+    if (writeAsIcebergManifest) {
+      // Write as an Iceberg-V4 manifest (nested field ids + int64 micros timestamps). Applied after
+      // prepareWrite so it overrides what prepareWrite put on the job.
+      configureIcebergManifestParquetWrite(job)
     }
     val serConf = new SerializableConfiguration(job.getConfiguration)
     val finalSparkPath = SparkPath.fromPath(finalPath)
@@ -1372,6 +1372,22 @@ object Checkpoints
         Iterator(status)
       }.collect()
     schema
+  }
+
+  /**
+   * Applies the extra Parquet write settings an AMT Iceberg-V4 manifest needs, on top of what
+   * `ParquetFileFormat.prepareWrite` sets. Call after `prepareWrite` and before the job's
+   * `Configuration` is snapshotted for executors, so these override the defaults. Keep in sync with
+   * the Iceberg write behaviors in `DeltaParquetFileFormatBase.prepareWrite`:
+   *   - timestamps as int64 `TIMESTAMP(MICROS)` (Iceberg-legal; Spark's default is `INT96`);
+   *   - list-element / map key-value field ids via [[DeltaParquetWriteSupport]] (the stock
+   *     `ParquetWriteSupport` omits them).
+   */
+  private[delta] def configureIcebergManifestParquetWrite(job: Job): Unit = {
+    job.getConfiguration.set(
+      SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key,
+      SQLConf.ParquetOutputTimestampType.TIMESTAMP_MICROS.toString)
+    ParquetOutputFormat.setWriteSupportClass(job, classOf[DeltaParquetWriteSupport])
   }
 
   // scalastyle:off argcount

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriteHelper.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriteHelper.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.delta.amt
 import java.util.concurrent.TimeUnit.NANOSECONDS
 
 // scalastyle:off import.ordering.noEmptyLine
-import org.apache.spark.sql.delta.{Checkpoints, DeltaLog, DeltaParquetWriteSupport, Snapshot}
+import org.apache.spark.sql.delta.{Checkpoints, DeltaLog, Snapshot}
 import org.apache.spark.sql.delta.actions.{AddFile, Checkpoint, ContentRoot, DomainMetadata, Metadata, Protocol, SetTransaction}
 import org.apache.spark.sql.delta.deletionvectors.RoaringBitmapArray
 import org.apache.spark.sql.delta.metering.DeltaLogging
@@ -28,7 +28,6 @@ import org.apache.spark.sql.delta.util.FileNames
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.hadoop.mapreduce.Job
-import org.apache.parquet.hadoop.ParquetOutputFormat
 
 import org.apache.spark.TaskContext
 import org.apache.spark.paths.SparkPath
@@ -247,9 +246,9 @@ object AMTWriteHelper extends DeltaLogging {
       val format = new ParquetFileFormat()
       val job = Job.getInstance(hadoopConf)
       val f = format.prepareWrite(spark, job, Map.empty, schema)
-      // Emit nested (list-element / map key-value) field ids, which the stock ParquetWriteSupport
-      // does not. Set after prepareWrite (before snapshotting the conf) so it flows to executors.
-      ParquetOutputFormat.setWriteSupportClass(job, classOf[DeltaParquetWriteSupport])
+      // Write as an Iceberg-V4 manifest (nested field ids + int64 micros timestamps). Applied after
+      // prepareWrite (before snapshotting the conf) so it flows to executors.
+      Checkpoints.configureIcebergManifestParquetWrite(job)
       (f, new SerializableConfiguration(job.getConfiguration))
     }
 
@@ -565,6 +564,6 @@ object AMTWriteHelper extends DeltaLogging {
       hadoopConf = hadoopConf,
       useRename = false,
       outputSchema = Some(AMTSingleAction.persistedSchema(metadata, protocol)),
-      useDeltaParquetWriteSupport = true)
+      writeAsIcebergManifest = true)
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointTestBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointTestBase.scala
@@ -31,7 +31,7 @@ import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.util.{FileNames, JsonUtils}
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.{DataFrame, QueryTest}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.types.{ArrayType, BinaryType, BooleanType, ByteType, DataType, DateType, DecimalType, DoubleType, FloatType, IntegerType, LongType, ShortType, StringType, StructField, StructType, TimestampNTZType, TimestampType}
@@ -71,6 +71,19 @@ trait AMTCheckpointTestBase
     snapshot.checkpointProvider match {
       case amt: AMTCheckpointProvider => Some(amt)
       case _ => None
+    }
+
+  /**
+   * Runs `body` on the DATA (content_type=0) entry rows across `paths`, read straight off disk
+   * (pass a provider's manifest paths -- its root and/or live leaves). The read runs with the
+   * path-based Delta format check disabled, and `body` runs inside that scope, so its terminal
+   * action reads under the disabled check.
+   */
+  protected def withManifestDataEntries[T](paths: Seq[String])(body: DataFrame => T): T =
+    allowReadWithinDeltaLog {
+      body(
+        spark.read.parquet(paths: _*)
+          .where(col("content_type") === AMTSingleAction.ContentType.Type.Data))
     }
 
   /** The [[DeltaLog]] for a catalog-managed table accessed by name. */

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointWriteSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointWriteSuite.scala
@@ -365,7 +365,7 @@ class AMTCheckpointWriteSuite extends AMTCheckpointTestBase {
           hadoopConf,
           useRename = false,
           outputSchema = Some(AMTSingleAction.persistedSchema(metadata, protocol)),
-          useDeltaParquetWriteSupport = true)
+          writeAsIcebergManifest = true)
         val relative = AMTUtils.relativizeManifestPathToTableRoot(
           file.getFileSystem(hadoopConf), dataPath, file)
         assert(relative == s"${FileNames.AMT_METADATA_DIR_NAME}/$fileName" &&

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTContentStatsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTContentStatsSuite.scala
@@ -143,9 +143,7 @@ class AMTContentStatsSuite extends AMTCheckpointTestBase {
 
       // forRead reconstructs the Delta stats JSON from the leaves' DATA entries; compare as parsed
       // JSON trees so field order and formatting do not matter.
-      val reconstructed = allowReadWithinDeltaLog {
-        val entries = spark.read.parquet(leaves: _*)
-          .where(col("content_type") === AMTSingleAction.ContentType.Type.Data)
+      val reconstructed = withManifestDataEntries(leaves) { entries =>
         AMTContentStats.forRead(entries, metadata, protocol)
           .select(col("content_stats"))
           .as[String].collect()

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTFieldSpecSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTFieldSpecSuite.scala
@@ -21,14 +21,19 @@ import java.io.File
 import scala.collection.JavaConverters._
 
 import org.apache.spark.sql.delta.DeltaColumnMapping
+import org.apache.spark.sql.delta.DeltaLog
+import org.apache.spark.sql.delta.actions.Metadata
 import org.apache.spark.sql.delta.util.JsonUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.parquet.format.converter.ParquetMetadataConverter
 import org.apache.parquet.hadoop.ParquetFileReader
-import org.apache.parquet.schema.GroupType
+import org.apache.parquet.schema.{GroupType, LogicalTypeAnnotation, MessageType, PrimitiveType, Type}
 
+import org.apache.spark.SparkRuntimeException
+import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.execution.datasources.parquet.ParquetUtils
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{StructField, StructType}
 
 /**
@@ -39,49 +44,79 @@ import org.apache.spark.sql.types.{StructField, StructType}
  */
 class AMTFieldSpecSuite extends AMTCheckpointTestBase {
 
+  private val tsExpr = allTypeColumns("ts").valueExpr
+  private val tsNtzExpr = allTypeColumns("ts_ntz").valueExpr
+
   /**
-   * Collects field-id assignments from a Parquet footer as dotted paths. Intermediate LIST/MAP
-   * groups (`list`, `key_value`) are omitted so paths match Spark/Iceberg names
+   * Every field of a Parquet footer keyed by its dotted path. Intermediate LIST/MAP groups
+   * (`list`, `key_value`) are omitted from the path so it matches Spark/Iceberg names
    * (e.g. `split_offsets.element`).
    */
-  private def actualFieldIdByName(group: GroupType): Map[String, Int] = {
-    def collect(current: GroupType, prefix: Seq[String]): Map[String, Int] =
-      current.getFields.asScala.foldLeft(Map.empty[String, Int]) { (acc, field) =>
+  private def typesByPath(group: GroupType): Map[String, Type] = {
+    def collect(current: GroupType, prefix: Seq[String]): Map[String, Type] =
+      current.getFields.asScala.foldLeft(Map.empty[String, Type]) { (acc, field) =>
         val skipInPath = field.getName == "list" || field.getName == "key_value"
         val path = if (skipInPath) prefix else prefix :+ field.getName
-        val withOwn = Option(field.getId).map(_.intValue()) match {
-          case Some(id) if !skipInPath => acc + (path.mkString(".") -> id)
-          case _ => acc
-        }
-        if (field.isPrimitive) withOwn
-        else withOwn ++ collect(field.asGroupType(), path)
+        val withOwn = if (skipInPath) acc else acc + (path.mkString(".") -> field)
+        if (field.isPrimitive) withOwn else withOwn ++ collect(field.asGroupType(), path)
       }
 
     collect(group, Seq.empty)
   }
 
+  /** The Parquet footer schema of `file`. */
+  private def footerSchema(hadoopConf: Configuration, file: File): MessageType =
+    ParquetFileReader.readFooter(
+      hadoopConf, new Path(file.getAbsolutePath), ParquetMetadataConverter.NO_FILTER)
+      .getFileMetaData.getSchema
+
+  /**
+   * The [[StructType]] of manifest column `column`, read bare off the root manifest (the schema is
+   * uniform across the tree, so the always-present root suffices).
+   */
+  private def onDiskColumnSchema(provider: AMTCheckpointProvider, column: String): StructType =
+    allowReadWithinDeltaLog {
+      spark.read.parquet(provider.topLevelFiles.map(_.getPath.toString): _*)
+        .schema(column).dataType.asInstanceOf[StructType]
+    }
+
+  /**
+   * Reconstructs the live AddFiles through the production read path, but under a checkpoint whose
+   * metadata is `metadata` (so the read derives its requested, field-id-stamped schema from
+   * `metadata` rather than the checkpoint's own). Returns the rows with a non-null `add`.
+   */
+  private def reconstructAddFiles(
+      provider: AMTCheckpointProvider, deltaLog: DeltaLog, metadata: Metadata): DataFrame =
+    new AMTCheckpointProvider(
+        manifestCommitVersion = provider.manifestCommitVersion,
+        checkpointAction = provider.checkpointAction.copy(metaData = metadata),
+        leaves = provider.leaves,
+        tableRoot = provider.tableRoot)
+      .loadActionsForStateReconstruction(spark, deltaLog)
+      .getOrElse(fail("expected reconstructed actions"))
+      .where("add is not null")
+
   private def assertFieldIds(
       hadoopConf: Configuration,
       file: File,
       label: String,
-      expected: Map[String, Int]): Unit = {
-    val schema = ParquetFileReader.readFooter(
-      hadoopConf, new Path(file.getAbsolutePath), ParquetMetadataConverter.NO_FILTER)
-      .getFileMetaData.getSchema
-    val actual = actualFieldIdByName(schema)
+      expectedIdByPath: Map[String, Int]): Unit = {
+    val actualIdByPath = typesByPath(footerSchema(hadoopConf, file)).flatMap { case (path, field) =>
+      Option(field.getId).map(id => path -> id.intValue())
+    }
     assert(
-      actual.values.toSet.size == actual.size,
-      s"$label contains duplicate field ids: $actual")
+      actualIdByPath.values.toSet.size == actualIdByPath.size,
+      s"$label contains duplicate field ids: $actualIdByPath")
     assert(
-      actual == expected,
+      actualIdByPath == expectedIdByPath,
       s"$label field ids did not match the schema the writer derived\n" +
-        s"  missing=${expected.toSet.diff(actual.toSet)}\n" +
-        s"  unexpected=${actual.toSet.diff(expected.toSet)}")
+        s"  missing=${expectedIdByPath.toSet.diff(actualIdByPath.toSet)}\n" +
+        s"  unexpected=${actualIdByPath.toSet.diff(expectedIdByPath.toSet)}")
   }
 
   /**
    * Collects the field-id assignments actually stamped on `AMTSingleAction.persistedSchema` as
-   * dotted paths, mirroring [[actualFieldIdByName]]'s convention: a scalar/struct id comes from the
+   * dotted paths, mirroring [[typesByPath]]'s convention: a scalar/struct id comes from the
    * field's own `parquet.field.id`; list-element and map key/value ids come from the parent's
    * `parquet.field.nested.ids` (keyed `<field>.element` / `values.key` / `values.value`).
    */
@@ -218,14 +253,8 @@ class AMTFieldSpecSuite extends AMTCheckpointTestBase {
       def contentStatsNames(): Seq[String] = {
         val snapshot = deltaLog.update()
         val provider = amtProvider(snapshot).getOrElse(fail("expected AMTCheckpointProvider"))
-        val manifestPaths =
-          (provider.topLevelFiles.map(_.getPath.toString) ++
-            provider.liveLeafManifestAbsolutePaths.map(_.toString)).distinct
-        allowReadWithinDeltaLog {
-          val manifestDf = spark.read.parquet(manifestPaths: _*)
-          manifestDf.schema("content_stats").dataType.asInstanceOf[StructType]
-            .fieldNames.toSeq.map(_.replaceAll("_\\d+$", ""))
-        }
+        onDiskColumnSchema(provider, "content_stats").fieldNames.toSeq
+          .map(_.replaceAll("_\\d+$", ""))
       }
 
       // The pre-rename checkpoint names the sub-struct by the original logical name.
@@ -241,6 +270,268 @@ class AMTFieldSpecSuite extends AMTCheckpointTestBase {
       // sub-struct picks up the new logical name (same field id).
       commitCheckpoint(deltaLog, incremental = false)
       assert(contentStatsNames() == Seq("c_renamed"))
+    }
+  }
+
+  testAcrossAMTCheckpointScenarios(
+      "content stats survive a column rename (field-id-based read)",
+      "amt_rename",
+      tableSchema = "col_to_be_renamed STRING, col_no_rename STRING")(
+      setup = name => appendRowsAsSeparateFiles(
+        name,
+        numFiles = 2,
+        columnExprs = Seq(
+          "CONCAT('renamedVal', CAST(id AS STRING))",
+          "CONCAT('keptVal', CAST(id AS STRING))")),
+      inlineCheckpointTriggerActionsOrSQL = Some(name => Right(
+        s"""INSERT INTO $name SELECT CONCAT('renamedVal', CAST(id AS STRING)),
+           |CONCAT('keptVal', CAST(id AS STRING)) FROM range(2, 3)""".stripMargin))) { context =>
+    val deltaLog = context.postCheckpointSnapshot.deltaLog
+    val provider = context.provider
+
+    // Reconstruct the live AddFiles under a checkpoint whose metadata is `meta`, projecting the
+    // stats each file carries.
+    def reconstructStats(meta: Metadata): Seq[String] =
+      reconstructAddFiles(provider, deltaLog, meta)
+        .select("add.stats").collect()
+        .map(r => if (r.isNullAt(0)) "null" else r.getString(0)).toSeq
+
+    // The sub-structs on disk are named `<pre-rename logical name>_<field id>` (a bare read
+    // reflects the physical layout verbatim; content_stats keys each sub-struct by column id).
+    val preRenameMeta = deltaLog.update().metadata
+    val onDisk = onDiskColumnSchema(provider, "content_stats")
+    val expectedSubStructs = preRenameMeta.dataSchema
+      .map(f => s"${f.name}_${DeltaColumnMapping.getColumnId(f)}").toSet
+    assert(onDisk.fieldNames.toSet == expectedSubStructs,
+      s"on-disk sub-structs ${onDisk.fieldNames.toSet} != expected $expectedSubStructs")
+
+    // Before the rename, reconstruction carries every file's stats for both columns.
+    val statsBefore = reconstructStats(deltaLog.update().metadata)
+    assert(statsBefore.nonEmpty && statsBefore.forall(_.contains("minValues")))
+    assert(
+      statsBefore.exists(_.contains("renamedVal")) && statsBefore.exists(_.contains("keptVal")),
+      s"expected both columns' stats before rename: $statsBefore")
+
+    // After the rename (same id and physical name, new logical name), the field-id read remaps
+    // the on-disk `col_to_be_renamed` sub-struct onto the current `col_renamed`, so it still
+    // succeeds -- identical for both columns (the stats JSON is keyed by physical name,
+    // unchanged).
+    sql(s"ALTER TABLE ${context.tableName} RENAME COLUMN col_to_be_renamed TO col_renamed")
+    val statsAfter = reconstructStats(deltaLog.update().metadata)
+    assert(statsAfter.sorted == statsBefore.sorted,
+      s"stats changed across rename: $statsBefore -> $statsAfter")
+
+    // Field-id read is what makes this work. With it off, the read falls back to
+    // name-matching: the on-disk `content_stats` struct still matches by name, but its renamed
+    // `col_to_be_renamed` sub-struct no longer matches the new `col_renamed`, so only that
+    // column's stats are lost -- `col_no_rename` still resolves by name.
+    val degraded = withSQLConf(SQLConf.PARQUET_FIELD_ID_READ_ENABLED.key -> "false") {
+      reconstructStats(deltaLog.update().metadata)
+    }
+    assert(degraded.exists(_.contains("keptVal")),
+      s"the un-renamed `col_no_rename` column's stats should survive name-matching: $degraded")
+    assert(degraded.forall(!_.contains("renamedVal")),
+      s"the renamed column's stats should be lost without field-id read: $degraded")
+  }
+
+  testAcrossAMTCheckpointScenarios(
+      "partition values survive a column rename (field-id-based read)",
+      "amt_part_rename",
+      tableSchema = "id LONG, p STRING, keep_p STRING",
+      partitionColumns = Seq("p", "keep_p"))(
+      setup = name => appendRowsAsSeparateFiles(
+        name,
+        numFiles = 2,
+        columnExprs = Seq(
+          "CAST(id AS LONG)",
+          "CONCAT('pRenamedVal', CAST(id AS STRING))",
+          "CONCAT('pKeptVal', CAST(id AS STRING))")),
+      inlineCheckpointTriggerActionsOrSQL = Some(name => Right(
+        s"""INSERT INTO $name SELECT CAST(id AS LONG),
+           |CONCAT('pRenamedVal', CAST(id AS STRING)),
+           |CONCAT('pKeptVal', CAST(id AS STRING)) FROM range(2, 3)""".stripMargin))) { context =>
+    val deltaLog = context.postCheckpointSnapshot.deltaLog
+    val provider = context.provider
+
+    // Reconstruct the live AddFiles under a checkpoint whose metadata is `meta`, projecting the
+    // partition values each file carries.
+    def reconstructPartitions(meta: Metadata): Seq[Map[String, String]] =
+      reconstructAddFiles(provider, deltaLog, meta)
+        .select("add.partitionValues").collect().toSeq
+        .map(r =>
+          if (r.isNullAt(0)) Map.empty[String, String]
+          else r.getMap[String, String](0).toMap)
+
+    // The on-disk partition fields are still named by the pre-rename logical column names.
+    val onDisk = onDiskColumnSchema(provider, "partition")
+    assert(onDisk.fieldNames.toSet == Set("p", "keep_p"))
+
+    // Before the rename, reconstruction carries every file's partition values for both columns.
+    val before = reconstructPartitions(deltaLog.update().metadata)
+    assert(before.nonEmpty && before.forall(m => m.size == 2 && m.values.forall(_ != null)))
+    val beforeValues = before.flatMap(_.values).toSet
+    assert(beforeValues.exists(_.startsWith("pRenamedVal")) &&
+      beforeValues.exists(_.startsWith("pKeptVal")),
+      s"expected both partition columns' values before rename: $before")
+
+    // After the rename (same id and physical name, new logical name), the field-id read remaps
+    // the on-disk `p` field onto the current `p_renamed`, so reconstruction still succeeds --
+    // identical for both columns (the value map is keyed by physical name, unchanged).
+    sql(s"ALTER TABLE ${context.tableName} RENAME COLUMN p TO p_renamed")
+    val after = reconstructPartitions(deltaLog.update().metadata)
+    assert(
+      after.sortBy(_.toString) == before.sortBy(_.toString),
+      s"partition values changed across rename: $before -> $after")
+
+    // Field-id read is what makes this work (see the content-stats test): with it off, the
+    // read falls back to name-matching, so only the renamed `p` field is lost -- it reads null
+    // under the new `p_renamed` name -- while `keep_p` still resolves by name.
+    val degraded = withSQLConf(SQLConf.PARQUET_FIELD_ID_READ_ENABLED.key -> "false") {
+      reconstructPartitions(deltaLog.update().metadata)
+    }
+    val degradedNonNull = degraded.flatMap(_.values).filter(_ != null).toSet
+    assert(degradedNonNull.exists(_.startsWith("pKeptVal")),
+      s"the un-renamed `keep_p` value should survive name-matching: $degraded")
+    assert(!degradedNonNull.exists(_.startsWith("pRenamedVal")),
+      s"the renamed partition value should be lost without field-id read: $degraded")
+    assert(degraded.exists(_.values.exists(_ == null)),
+      s"the renamed partition value should read null without field-id read: $degraded")
+  }
+
+  testAcrossAMTCheckpointScenarios(
+      "manifest writes timestamps as int64 TIMESTAMP_MICROS, not INT96",
+      "amt_ts",
+      tableSchema =
+        "d_ts TIMESTAMP, d_ts_ntz TIMESTAMP_NTZ, p_ts TIMESTAMP, p_ts_ntz TIMESTAMP_NTZ",
+      partitionColumns = Seq("p_ts", "p_ts_ntz"))(
+      setup = name => appendRowsAsSeparateFiles(
+        name,
+        numFiles = 2,
+        columnExprs = Seq(tsExpr, tsNtzExpr, tsExpr, tsNtzExpr)),
+      inlineCheckpointTriggerActionsOrSQL = Some(name => Right(
+        s"""INSERT INTO $name SELECT $tsExpr, $tsNtzExpr, $tsExpr, $tsNtzExpr
+           |FROM range(2, 3)""".stripMargin))) {
+    context =>
+    val deltaLog = context.postCheckpointSnapshot.deltaLog
+    val provider = context.provider
+    val hadoopConf = deltaLog.newDeltaHadoopConf()
+    // This small table is not leaf-packed, so it is a single root-resident manifest; reading the
+    // root covers every persisted timestamp value.
+    val files = provider.topLevelFiles.map(f => new File(f.getPath.toUri))
+    assert(files.nonEmpty, "Expected at least one manifest file.")
+
+    // content_stats names each sub-struct `<column>_<field id>`; derive that suffix here.
+    val tsMeta = deltaLog.update().metadata
+    def cs(column: String): String =
+      s"content_stats.${column}_${DeltaColumnMapping.getColumnId(tsMeta.schema(column))}"
+
+    files.foreach { file =>
+      val primitives = typesByPath(footerSchema(hadoopConf, file)).collect {
+        case (path, field) if field.isPrimitive => path -> field.asPrimitiveType()
+      }
+      def assertTimestampMicros(name: String, adjustToUtc: Boolean): Unit = {
+        val prim =
+          primitives.getOrElse(name, fail(s"no primitive at '$name' in ${file.getName}"))
+        assert(
+          prim.getPrimitiveTypeName == PrimitiveType.PrimitiveTypeName.INT64,
+          s"'$name' should be int64 micros, got ${prim.getPrimitiveTypeName} in ${file.getName}")
+        prim.getLogicalTypeAnnotation match {
+          case ts: LogicalTypeAnnotation.TimestampLogicalTypeAnnotation =>
+            assert(
+              ts.getUnit == LogicalTypeAnnotation.TimeUnit.MICROS,
+              s"'$name' should be MICROS, got ${ts.getUnit} in ${file.getName}")
+            assert(
+              ts.isAdjustedToUTC == adjustToUtc,
+              s"'$name' adjustToUtc should be $adjustToUtc in ${file.getName}")
+          case other =>
+            fail(s"'$name' should carry a timestamp annotation, got $other in ${file.getName}")
+        }
+      }
+      // TimestampType -> adjust-to-utc; TimestampNTZType -> not. content_stats keys each
+      // sub-struct by `<column>_<field id>`; partition keys by logical name.
+      assertTimestampMicros(s"${cs("d_ts")}.lower_bound", adjustToUtc = true)
+      assertTimestampMicros(s"${cs("d_ts")}.upper_bound", adjustToUtc = true)
+      assertTimestampMicros(s"${cs("d_ts_ntz")}.lower_bound", adjustToUtc = false)
+      assertTimestampMicros("partition.p_ts", adjustToUtc = true)
+      assertTimestampMicros("partition.p_ts_ntz", adjustToUtc = false)
+    }
+  }
+
+  test("field-id read recovers a renamed static manifest_info column on the root") {
+    withTable("amt_static_rename") {
+      withSQLConf(leafPackingConfs: _*) {
+        createAMTTable("amt_static_rename", checkpointInterval = Int.MaxValue)
+        appendRowsAsSeparateFiles("amt_static_rename", numFiles = leafPackedFiles)
+        val deltaLog = deltaLogForName("amt_static_rename")
+        commitCheckpoint(deltaLog, incremental = false)
+        val provider = amtProvider(deltaLog.update())
+          .getOrElse(fail("expected AMTCheckpointProvider"))
+        assert(provider.leaves.nonEmpty, "Expected leaf pointers in the root.")
+        val checkpoint = provider.checkpointAction
+        val persistedSchema =
+          AMTSingleAction.persistedSchema(checkpoint.metaData, checkpoint.protocol)
+
+        // Read the root's physical columns verbatim (the persisted schema carries the field ids),
+        // then rewrite the root with its static `manifest_info` struct renamed to
+        // `manifest_info_new`, keeping the same Iceberg field id. A reader that matched columns by
+        // name would now miss it entirely.
+        val rootPath = provider.topLevelFiles.head.getPath.toString
+        val rootRows = allowReadWithinDeltaLog {
+          spark.read.schema(persistedSchema).parquet(rootPath).collect().toSeq
+        }
+        val renamedSchema = StructType(persistedSchema.map { field =>
+          if (field.name == "manifest_info") field.copy(name = "manifest_info_new") else field
+        })
+        withTempDir { dir =>
+          val rewrittenDir = new File(dir, "root-1-dash")
+          withSQLConf(SQLConf.PARQUET_FIELD_ID_WRITE_ENABLED.key -> "true") {
+            spark.createDataFrame(rootRows.asJava, renamedSchema)
+              .coalesce(1).write.parquet(rewrittenDir.getAbsolutePath)
+          }
+          val rewrittenFile = Option(rewrittenDir.listFiles()).toSeq.flatten
+            .find(_.getName.endsWith(".parquet"))
+            .getOrElse(fail("no rewritten root parquet produced"))
+
+          // The field really is renamed on disk (so a name-based read could not recover it).
+          val rewrittenSchema = footerSchema(deltaLog.newDeltaHadoopConf(), rewrittenFile)
+          assert(
+            rewrittenSchema.containsField("manifest_info_new") &&
+              !rewrittenSchema.containsField("manifest_info"),
+            s"rewritten root should rename manifest_info: $rewrittenSchema")
+
+          // Reading the rewritten root through the production path recovers every leaf pointer
+          // unchanged: `manifest_info` is resolved by its Iceberg field id, not its name. (If it
+          // were not, the DATA_MANIFEST rows would unwrap with a missing `manifest_info`.)
+          val rewrittenCheckpoint = checkpoint.copy(
+            contentRoot = checkpoint.contentRoot.copy(
+              path = rewrittenFile.getAbsolutePath,
+              sizeInBytes = rewrittenFile.length()))
+          val rewrittenProvider = AMTCheckpointProvider.fromCheckpoint(
+            deltaLog, rewrittenCheckpoint, provider.manifestCommitVersion)
+          assertLeavesEqual(rewrittenProvider.leaves, provider.leaves)
+
+          // Field-id read is what makes this work: with it off, the read falls back to
+          // name-matching, so the requested `manifest_info` no longer matches the on-disk
+          // `manifest_info_new` and reads null. Decoding the manifest pointer then fails when
+          // `AMTSingleAction.validate` rejects a DATA_MANIFEST entry with no `manifest_info`, and
+          // the row decode surfaces it as EXPRESSION_DECODING_FAILED wrapping that requirement.
+          withSQLConf(SQLConf.PARQUET_FIELD_ID_READ_ENABLED.key -> "false") {
+            val error = intercept[SparkRuntimeException] {
+              AMTCheckpointProvider.fromCheckpoint(
+                deltaLog, rewrittenCheckpoint, provider.manifestCommitVersion)
+            }
+            assert(error.getCondition == "EXPRESSION_DECODING_FAILED",
+              s"Expected an EXPRESSION_DECODING_FAILED error, got ${error.getCondition}.")
+            assert(error.getCause.isInstanceOf[IllegalArgumentException],
+              s"Expected the decode to fail on the validate requirement, got ${error.getCause}.")
+            assert(
+              error.getCause.getMessage.contains(
+                "manifest_info must be set iff content_type is a manifest pointer"),
+              s"Expected a missing manifest_info requirement failure, " +
+                s"got ${error.getCause.getMessage}.")
+          }
+        }
+      }
     }
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTPartitionValuesSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTPartitionValuesSuite.scala
@@ -16,13 +16,12 @@
 
 package org.apache.spark.sql.delta.amt
 
-import org.apache.spark.sql.delta.DeltaColumnMapping
 import org.apache.spark.sql.delta.actions.AddFile
 import org.apache.hadoop.fs.Path
 
-import org.apache.spark.sql.Row
+import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.functions.col
-import org.apache.spark.sql.types.{BooleanType, DataType, DateType, DecimalType, IntegerType, LongType, MapType, MetadataBuilder, StringType, StructField, StructType, TimestampType}
+import org.apache.spark.sql.types.{BinaryType, BooleanType, ByteType, DataType, DateType, DecimalType, DoubleType, FloatType, IntegerType, LongType, MapType, ShortType, StringType, StructField, StructType, TimestampNTZType, TimestampType}
 
 /**
  * Tests for [[AMTPartitionValues]], the converter between Delta's physical-name partition string
@@ -60,92 +59,52 @@ class AMTPartitionValuesSuite extends AMTCheckpointTestBase {
     Seq(sampleAddFile.copy(partitionValues = partitionValues))
       .map(DataEntry.fromAddFile(_, addedTracking, tableRoot).wrap).toDS().toDF()
 
-  /** A partition column whose physical name differs from its logical one, as column mapping
-   *  assigns them. */
-  private def partitionColumn(logical: String, physical: String, dataType: DataType) =
-    StructField(logical, dataType, nullable = true,
-      new MetadataBuilder()
-        .putString(DeltaColumnMapping.COLUMN_MAPPING_PHYSICAL_NAME_KEY, physical)
-        .build())
-
-  test("partition adapter writes typed logical values and restores the physical-name map") {
-    val partitionSchema = StructType(Seq(
-      partitionColumn("region", "col-1", IntegerType),
-      partitionColumn("day", "col-2", DateType),
-      partitionColumn("name", "col-3", StringType),
-      partitionColumn("count", "col-4", LongType),
-      partitionColumn("active", "col-5", BooleanType),
-      partitionColumn("amount", "col-6", DecimalType(9, 3)),
-      partitionColumn("at", "col-7", TimestampType)))
-    // The values a Delta log would hold for these columns. `col-7` is already UTC-normalized
-    // because that is the form `literalToNormalizedString` writes a timestamp in; the round trip
-    // below is only lossless for the form the writer actually produces.
-    val logged = Map(
-      "col-1" -> "7",
-      "col-2" -> "2026-07-25",
-      "col-3" -> "us-west-2",
-      "col-4" -> "9007199254740993",
-      "col-5" -> "true",
-      "col-6" -> "1.250",
-      "col-7" -> "2026-07-25T08:02:03.456000Z")
-    val input = entryWith(logged)
-
-    // The persisted struct is keyed by *logical* name and typed, while the source map was keyed by
-    // physical name with string values.
-    val persistedDF = AMTPartitionValues.forWrite(input, partitionSchema)
-    assert(persistedDF.schema("partition").dataType.asInstanceOf[StructType]
-      .map(f => f.name -> f.dataType) == partitionSchema.map(f => f.name -> f.dataType))
-
-    val partition = persistedDF.select("partition.*").head()
-    assert(partition.getInt(0) == 7)
-    assert(partition.getDate(1).toString == "2026-07-25")
-    assert(partition.getString(2) == "us-west-2")
-    // Wider than a Double can hold exactly, so this also shows the value is not going through one.
-    assert(partition.getLong(3) == 9007199254740993L)
-    assert(partition.getBoolean(4))
-    assert(partition.getDecimal(5) == new java.math.BigDecimal("1.250"))
-    assert(partition.getTimestamp(6).toInstant.toString == "2026-07-25T08:02:03.456Z")
-
-    // The whole struct collects as a nested Row of typed values, not as a map of strings.
-    val persistedRow = persistedDF.select("partition").collect().head.getStruct(0)
-    assert(persistedRow.schema.fieldNames.toSeq == partitionSchema.map(_.name))
-    assert(persistedRow.getInt(0) == 7)
-
-    // Reading it back restores exactly the physical-name string map the Delta log held.
-    val restoredDF = AMTPartitionValues.forRead(persistedDF, partitionSchema)
-    assert(restoredDF.select("partition").collect().toSeq == Seq(Row(logged)))
-    val restored = restoredDF.select(col("partition")).as[Map[String, String]].head()
-    assert(restored == logged)
-  }
-
-  test("partition adapter rejects an invalid non-null typed value") {
-    val schema = StructType(Seq(StructField("p", IntegerType)))
-    val input = entryWith(Map("p" -> "not-an-int"))
-
-    // `forWrite` casts with ANSI on, so an unparseable value fails the write rather than silently
-    // persisting a null partition value.
-    val error = intercept[Exception] {
-      AMTPartitionValues.forWrite(input, schema).collect()
-    }
-    assert(error.toString.contains("CAST_INVALID_INPUT"))
-  }
-
   /**
-   * The physical-name partition-value maps `forRead` reconstructs from the manifest tree's DATA
-   * entries.
+   * Asserts the persisted `partition` field for column `name` has exactly the `expected` Iceberg
+   * type and the string form of its value.
    */
-  private def reconstructPartitionValues(
-      manifests: Seq[String],
-      partitionSchema: StructType): Set[Map[String, String]] =
-    allowReadWithinDeltaLog {
-      val entries = spark.read.parquet(manifests: _*)
-        .where(col("content_type") === AMTSingleAction.ContentType.Type.Data)
-      AMTPartitionValues.forRead(entries, partitionSchema)
-        .select(col("partition"))
-        .collect()
-        .map(_.getMap[String, String](0).toMap)
-        .toSet
+  private def assertPartitionField(
+      persisted: DataFrame,
+      name: String,
+      expected: (DataType, String)): Unit = {
+    val field = persisted.schema("partition").dataType.asInstanceOf[StructType](name)
+    val row = persisted.select(s"partition.$name").head()
+    val actual = (field.dataType, String.valueOf(row.get(0)))
+    assert(actual == expected, s"partition.$name\n  expected=$expected\n  actual=$actual")
+  }
+
+  test("forWrite persists partition values as the typed struct, keyed by logical name") {
+    withAllTypesTable("amt_partition_write", numFiles = 1) { deltaLog =>
+      val snapshot = deltaLog.update()
+      val partitionSchema = snapshot.metadata.partitionSchema
+      val add = liveAddFiles(snapshot).head
+      val entry = DataEntry.fromAddFile(
+        add, AMTWriteHelper.addedTrackingForDataEntry(), deltaLog.dataPath)
+      val input = Seq(entry.wrap).toDS().toDF()
+      val persisted = AMTPartitionValues.forWrite(input, partitionSchema)
+
+      // The struct keeps the partition columns' *logical* names, though the source map is keyed by
+      // physical name -- an Iceberg reader resolves them by field id, so the name is informational.
+      val partition = persisted.schema("partition").dataType.asInstanceOf[StructType]
+      assert(partition.fieldNames.toSeq == partitionableTestColumns.map("p_" + _.name))
+
+      assertPartitionField(persisted, "p_int", (IntegerType, "0"))
+      assertPartitionField(persisted, "p_long", (LongType, "0"))
+      assertPartitionField(persisted, "p_short", (ShortType, "0"))
+      assertPartitionField(persisted, "p_byte", (ByteType, "0"))
+      assertPartitionField(persisted, "p_str", (StringType, "row0"))
+      assertPartitionField(persisted, "p_date", (DateType, "2026-07-25"))
+      assertPartitionField(persisted, "p_ts", (TimestampType, "2026-07-25 01:02:03.456"))
+      assertPartitionField(persisted, "p_ts_ntz", (TimestampNTZType, "2026-07-25T01:02:03.456"))
+      assertPartitionField(persisted, "p_dec", (DecimalType(9, 3), "0.000"))
+      assertPartitionField(persisted, "p_bool", (BooleanType, "false"))
+      assertPartitionField(persisted, "p_float", (FloatType, "0.0"))
+      assertPartitionField(persisted, "p_double", (DoubleType, "0.0"))
+      // Binary's string form is not stable, so assert only that it keeps its type.
+      assert(partition("p_binary").dataType == BinaryType,
+        s"p_binary should stay binary: ${partition("p_binary")}")
     }
+  }
 
   test("forRead reproduces the partition values the delta log holds, for every type") {
     withAllTypesTable("amt_partition_roundtrip", numFiles = leafPackedFiles) { deltaLog =>
@@ -153,11 +112,8 @@ class AMTPartitionValuesSuite extends AMTCheckpointTestBase {
       val snapshot = deltaLog.update()
       val provider = amtProvider(snapshot).getOrElse(fail("expected AMTCheckpointProvider"))
       val partitionSchema = snapshot.metadata.partitionSchema
-      // A full rewrite can hash every file into one Spark partition. In that valid representation,
-      // the sole leaf is promoted to the root and there are no leaf pointers to read.
-      val manifests = provider.topLevelFiles.map(_.getPath.toString) ++
-        provider.liveLeafManifestAbsolutePaths.map(_.toString)
-      assert(manifests.nonEmpty, "Expected at least a root manifest.")
+      val leaves = provider.liveLeafManifestAbsolutePaths.map(_.toString)
+      assert(leaves.nonEmpty, "Expected at least one leaf manifest.")
 
       // Read the commit json directly rather than going through the snapshot: an AMT snapshot
       // reconstructs its AddFiles through `forRead`, so comparing against it would compare
@@ -175,10 +131,29 @@ class AMTPartitionValuesSuite extends AMTCheckpointTestBase {
       assert(logged.size == leafPackedFiles,
         s"Expected one logged add per file, got ${logged.size}.")
 
-      val reconstructed = reconstructPartitionValues(manifests, partitionSchema)
+      // forRead reconstructs the physical-name partition-value map from the leaves' DATA entries.
+      val reconstructed = withManifestDataEntries(leaves) { entries =>
+        AMTPartitionValues.forRead(entries, partitionSchema)
+          .select(col("partition"))
+          .collect()
+          .map(_.getMap[String, String](0).toMap)
+          .toSet
+      }
       assert(reconstructed == logged,
         s"forRead did not reproduce the logged partition values.\n" +
           s"  logged=$logged\n  reconstructed=$reconstructed")
     }
+  }
+
+  test("partition adapter rejects an invalid non-null typed value") {
+    val schema = StructType(Seq(StructField("p", IntegerType)))
+    val input = entryWith(Map("p" -> "not-an-int"))
+
+    // `forWrite` casts with ANSI on, so an unparseable value fails the write rather than silently
+    // persisting a null partition value.
+    val error = intercept[Exception] {
+      AMTPartitionValues.forWrite(input, schema).collect()
+    }
+    assert(error.toString.contains("CAST_INVALID_INPUT"))
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotSuite.scala
@@ -1314,7 +1314,7 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
       hadoopConf,
       useRename,
       outputSchema = Some(AMTSingleAction.persistedSchema(metadata, protocol)),
-      useDeltaParquetWriteSupport = true)
+      writeAsIcebergManifest = true)
     val size = rootFile.getFileSystem(hadoopConf).getFileStatus(rootFile).getLen
     base.copy(contentRoot = ContentRoot(
       path = rootFile.toString, sizeInBytes = size, version = base.version))


### PR DESCRIPTION
## Description

Two robustness/spec-compliance improvements for AMT (adaptive metadata tree) manifests:

1. **Field-id-based manifest reads survive a column rename.** A manifest's `content_stats` and
   `partition` values are resolved by their Iceberg field id rather than by column name, so
   reconstructing a checkpoint's live files keeps working after a column is renamed: the on-disk
   sub-struct keeps its pre-rename name but the same field id, and the read remaps it. With
   field-id read disabled, the reader falls back to name matching and the renamed column's stats /
   partition value are dropped -- this change makes the rename transparent.

2. **Manifest timestamps are written as Iceberg-legal `TIMESTAMP(MICROS)`.** AMT manifests
   previously inherited the default `INT96` timestamp encoding, which is not Iceberg-spec-legal and
   cannot express the `timestamp` vs `timestamptz` (adjust-to-UTC) distinction. Both AMT manifest
   write paths (root and leaf) now force int64 `TIMESTAMP(MICROS)` and stamp nested (list/map)
   field ids, matching the Iceberg V4 manifest spec.

## How was this patch tested?

New unit tests in `AMTFieldSpecSuite`:
- the persisted manifest schema stamps a field id on every mapped field;
- content-stats reconstruction and partition-value reconstruction each survive a column rename
  (and degrade as expected when field-id read is turned off);
- a renamed static `manifest_info` column on the root is still resolved by field id;
- manifest timestamps are written as int64 `TIMESTAMP(MICROS)` with the correct adjust-to-UTC flag
  for `TIMESTAMP` vs `TIMESTAMP_NTZ` data and partition columns.

## Does this PR introduce _any_ user-facing change?

No.
