### PR TITLE
[Spark] Support AMT deletion vectors in shallow clone

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/DeletionVectorDescriptor.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/DeletionVectorDescriptor.scala
@@ -224,6 +224,49 @@ case class DeletionVectorDescriptor(
   }
 
   /**
+   * Like [[normalizedTableRelativeObjectId]] but identifies the physical DV file rather than the
+   * individual DV within it and returns the normalized (storageType, path) with no offset. Today
+   * this is only used for table clone.
+   */
+  private[delta] def normalizedTableRelativeObjectFile(tableRoot: Path): (String, String) = {
+    storageType match {
+      case INLINE_DV_MARKER =>
+        (INLINE_DV_MARKER, pathOrInlineDv)
+      case UUID_DV_MARKER =>
+        val (randomPrefix, uuid) = getRandomPrefixAndUuid.get
+        val fileName = assembleDeletionVectorFileName(uuid)
+        val relativePath = if (randomPrefix.isEmpty) fileName else s"$randomPrefix/$fileName"
+        (RELATIVE_DV_MARKER, relativePath)
+      case RELATIVE_DV_MARKER =>
+        (RELATIVE_DV_MARKER, pathOrInlineDv)
+      case PATH_DV_MARKER =>
+        val path = SparkPath.fromUrlString(pathOrInlineDv).toPath.toString
+        val relativePath = AMTUtils.relativizeLocation(tableRoot.toString, path)
+        if (AMTUtils.isAbsoluteLocation(relativePath)) {
+          (PATH_DV_MARKER, pathOrInlineDv)
+        } else {
+          (RELATIVE_DV_MARKER, relativePath)
+        }
+      case _ =>
+        throw new IllegalArgumentException(
+          s"Unsupported deletion vector storage type: $storageType")
+    }
+  }
+
+  /**
+   * Computes a normalized absolute object identity for this descriptor.
+   * Today this is only used for table clone.
+   */
+  private[delta] def normalizedAbsoluteObjectId(tableRoot: Path): String = {
+    val (normalizedStorageType, normalizedPathOrInlineDv) = if (isInline) {
+      (INLINE_DV_MARKER, pathOrInlineDv)
+    } else {
+      (PATH_DV_MARKER, urlEncodedPath(tableRoot))
+    }
+    formatIdentity(normalizedStorageType, normalizedPathOrInlineDv, offset)
+  }
+
+  /**
    * Produce a copy of this DV, but using an absolute path.
    *
    * If the DV already has an absolute path or is inline, then this is just a normal copy.

--- a/spark/src/test/scala/org/apache/spark/sql/delta/CloneTableTestMixin.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CloneTableTestMixin.scala
@@ -103,12 +103,18 @@ trait CloneTableTestMixin extends DeltaColumnMappingTestUtils
   }
 
   // Extracted function so it can be overriden in subclasses.
-  protected def uniqueFileActionGroupBy(action: FileAction): String = {
+  protected def uniqueFileActionGroupBy(
+      action: FileAction, tableRoot: Path, useObjectIdentity: Boolean): String = {
     val filePath = action.pathAsUri.toString
     val dvId = action match {
-      case add: AddFile => Option(add.deletionVector).map(_.legacyUniqueId).getOrElse("")
+      case add: AddFile =>
+        Option(add.deletionVector)
+          .map(_.uniqueId(tableRoot, useObjectIdentity))
+          .getOrElse("")
       case remove: RemoveFile =>
-        Option(remove.deletionVector).map(_.legacyUniqueId).getOrElse("")
+        Option(remove.deletionVector)
+          .map(_.uniqueId(tableRoot, useObjectIdentity))
+          .getOrElse("")
       case _ => ""
     }
     filePath + dvId
@@ -251,7 +257,13 @@ trait CloneTableTestMixin extends DeltaColumnMappingTestUtils
         case _ => None
       }
     }
-    assert(filePaths.groupBy(uniqueFileActionGroupBy(_)).forall(_._2.length === 1),
+    val useObjectIdentity = FileAction.useDeletionVectorObjectIdentity(
+      targetLog.unsafeVolatileSnapshot.metadata,
+      targetLog.unsafeVolatileSnapshot.protocol,
+      spark
+    )
+    assert(filePaths.groupBy(uniqueFileActionGroupBy(_, targetLog.dataPath, useObjectIdentity))
+      .forall(_._2.length === 1),
       "A file was added and removed in the same commit")
     // Check whether the resulting datasets are the same
     val targetDf = DataFrameUtils.ofRows(

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotSuite.scala
@@ -18,7 +18,8 @@ package org.apache.spark.sql.delta.amt
 
 import org.apache.spark.sql.delta.{Checkpoints, DeletionVectorsTestUtils, DeltaLog, DeltaOperations, Snapshot}
 import org.apache.spark.sql.delta.DeltaTestUtils.createTestAddFile
-import org.apache.spark.sql.delta.actions.{AddFile, Checkpoint, ContentRoot, DeletionVectorDescriptor}
+import org.apache.spark.sql.delta.actions.{AddFile, Checkpoint, ContentRoot}
+import org.apache.spark.sql.delta.actions.DeletionVectorDescriptor
 import org.apache.spark.sql.delta.deletionvectors.ManifestBitmap
 import org.apache.spark.sql.delta.deletionvectors.RoaringBitmapArray
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
@@ -922,7 +923,6 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
     withSQLConf(DeltaSQLConf.DELTA_HISTORY_METRICS_ENABLED.key -> "false") {
       withTable("amt_dv_clone_src", "amt_dv_clone_tgt") {
         val src = "amt_dv_clone_src"
-        // The source needs no AMT of its own, the clone reads its files.
         createAMTTable(src, checkpointInterval = 100)
         Seq(1, 2).toDF("id").coalesce(1).write.mode("append").insertInto(src)
         val srcLog = deltaLogForName(src)
@@ -931,12 +931,38 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
         val dvActions = writeFileWithDVOnDisk(srcLog, srcFile.head, RoaringBitmapArray(0L))
         srcLog.startTransaction().commit(dvActions, DeltaOperations.Delete(predicate = Seq.empty))
 
+        val sourceJsonFiles = srcLog.update().allFiles.collect()
+        assert(sourceJsonFiles.length == 1)
+        assert(sourceJsonFiles.head.deletionVector != null)
+        assert(sourceJsonFiles.head.deletionVector.storageType ==
+          DeletionVectorDescriptor.UUID_DV_MARKER)
+
+        // Materialize the source's AMT before cloning. AMT stores an in-root DV location as a
+        // relative path, so source allFiles reconstructs the on-disk DV as an r descriptor.
+        commitCheckpoint(srcLog, incremental = false)
+        val sourceAMTSnapshot = srcLog.update()
+        amtProvider(sourceAMTSnapshot).getOrElse(
+          fail("the clone source must have an AMTCheckpointProvider."))
+        val sourceAMTFiles = sourceAMTSnapshot.allFiles.collect()
+        assert(sourceAMTFiles.length == 1)
+        assert(sourceAMTFiles.head.deletionVector != null)
+        assert(sourceAMTFiles.head.deletionVector.storageType ==
+          DeletionVectorDescriptor.RELATIVE_DV_MARKER)
+
         val tgt = "amt_dv_clone_tgt"
         sql(s"CREATE TABLE $tgt SHALLOW CLONE $src")
-        // Materialize the target's AMT.
-        commitCheckpoint(deltaLogForName(tgt), incremental = false)
 
         val tgtLog = deltaLogForName(tgt)
+        val clonedFiles = tgtLog.update().allFiles.collect()
+        assert(clonedFiles.length == 1)
+        val clonedDv = clonedFiles.head.deletionVector
+        assert(clonedDv != null)
+        assert(clonedDv.storageType == DeletionVectorDescriptor.PATH_DV_MARKER,
+          "A shallow-cloned AMT DV must be stored as an absolute p DV")
+
+        // Materialize the target's AMT.
+        commitCheckpoint(tgtLog, incremental = false)
+
         val snapshot = tgtLog.update()
         amtProvider(snapshot).getOrElse(
           fail("the clone target must have an AMTCheckpointProvider."))


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Updates shallow clone to correctly handle the deletion vectors used by the Adaptive Metadata Tree (AMT).

Adds two helpers to `DeletionVectorDescriptor`:
- `normalizedTableRelativeObjectFile`, which identifies the physical deletion vector file, returning the normalized `(storageType, path)` with no offset.
- `normalizedAbsoluteObjectId`, which computes a normalized absolute object identity for the deletion vector.

Clone's file-action deduplication now compares deletion vectors by their object identity instead of the legacy unique id, so a deletion vector is recognized as the same physical file whether it is referenced in its table-relative (`r`) or absolute-path (`p`) form. This ensures a source table whose deletion vectors are stored as AMT relative deletion vectors clones correctly, with the target referencing them as absolute-path deletion vectors.

## How was this patch tested?

Added a unit test in `AMTSnapshotSuite` that shallow-clones a source table whose on-disk deletion vectors are materialized (via the source's AMT) as relative (`r`) deletion vectors, and asserts the cloned target stores them as absolute-path (`p`) deletion vectors.

## Does this PR introduce _any_ user-facing changes?

No.
