### PR TITLE
[Spark] DeltaV2OptimisticTransaction: Kernel-backed blind-append commit path

### DIFF
--- a/spark-unified/src/main/scala/org/apache/spark/sql/delta/v2/interop/DeltaV2OptimisticTransaction.scala
+++ b/spark-unified/src/main/scala/org/apache/spark/sql/delta/v2/interop/DeltaV2OptimisticTransaction.scala
@@ -16,78 +16,268 @@
 
 package org.apache.spark.sql.delta.v2.interop
 
-import org.apache.spark.sql.delta.{
-  CurrentTransactionInfo,
-  DeltaLog,
-  LogSegment,
-  OptimisticTransaction,
-  VersionChecksum
-}
+// scalastyle:off import.ordering.noEmptyLine
+import java.nio.file.FileAlreadyExistsException
+import java.util.Optional
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable.ArrayBuffer
+import scala.collection.mutable.HashMap
+
+import org.apache.spark.sql.delta.{CurrentTransactionInfo, DeltaLog, LogSegment, OptimisticTransaction, Snapshot, VersionChecksum}
+import org.apache.spark.sql.delta.actions.{AddFile, Checkpoint, CommitInfo, Protocol}
+import org.apache.spark.sql.delta.amt.AMTCheckpointProvider
+import org.apache.spark.sql.delta.hooks.{CheckpointHook, ChecksumHook, HudiConverterHook, IcebergConverterHook, PostCommitHook}
+import org.apache.spark.sql.delta.util.{DeltaFileOperations, FileNames}
 import io.delta.storage.commit.Commit
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
+import io.delta.kernel.{DataWriteContext => KernelDataWriteContext, Operation => KernelOperation, Snapshot => KernelSnapshot, Table => KernelTable, Transaction => KernelTransaction}
+import io.delta.kernel.data.{Row => KernelRow}
+import io.delta.kernel.engine.{Engine => KernelEngine}
+import io.delta.kernel.expressions.{Literal => KernelLiteral}
+import io.delta.kernel.internal.{SnapshotImpl => KernelSnapshotImpl}
+import io.delta.kernel.internal.util.{PartitionUtils => KernelPartitionUtils, Utils => KernelUtils}
+import io.delta.kernel.statistics.{DataFileStatistics => KernelDataFileStatistics}
+import io.delta.kernel.types.{StringType => KernelStringType}
+import io.delta.kernel.utils.{CloseableIterable => KernelCloseableIterable, DataFileStatus => KernelDataFileStatus}
 
+// scalastyle:on import.ordering.noEmptyLine
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.util.{Clock, SystemClock}
 
 /**
- * OptimisticTransaction backed by Delta Kernel.
- *
- * Extends V1 [[org.apache.spark.sql.delta.OptimisticTransaction]] directly.
- * Constructed with `deltaLog = null`: the transaction must not depend on the V1 DeltaLog,
- * so any missed V1 reach surfaces loudly instead of silently using V1 state.
- *
- * This is a skeleton: it wires up only the construction path so the transaction can be built and
- * its read state (`readVersion`, `metadata`, `protocol`, `snapshot`) resolved from the Kernel
- * snapshot. The commit lifecycle ([[writeCommitFile]] and the rest of the Kernel commit path) is
- * intentionally left unimplemented and fails loudly; it is a follow-up.
+ * OptimisticTransaction backed by Delta Kernel, extending
+ * [[org.apache.spark.sql.delta.OptimisticTransaction]] with `deltaLog = null` (a
+ * guardrail): every DeltaLog reach is either overridden by a
+ * Kernel-backed seam or neutralized by skipping registration (e.g. the checkpoint and checksum
+ * post-commit hooks), so any missed dependency surfaces loudly instead of silently reading
+ * DeltaLog-derived state.
  */
 private[v2] class DeltaV2OptimisticTransaction(
     catalogTable: Option[CatalogTable],
-    val deltaV2Snapshot: DeltaV2Snapshot)
+    // `deltaV2Snapshot` and `kernelEngine` are intentionally private, which is internal
+    // implementation details we do not expose in the public API.
+    private val deltaV2Snapshot: DeltaV2Snapshot,
+    private val kernelEngine: KernelEngine)
   extends OptimisticTransaction(
     null.asInstanceOf[DeltaLog],
     catalogTable,
     deltaV2Snapshot) {
 
-  // Opt in to the base null-deltaLog guardrail: this transaction legitimately has no V1 DeltaLog
+  /**
+   * Opt in to the base null-deltaLog guardrail: this transaction legitimately has no V1 DeltaLog.
+   */
   override protected def allowNullDeltaLog: Boolean = true
 
-  // Kernel-sourced path / conf.
+  /** Kernel-sourced path / conf. */
   override def dataPath: Path = deltaV2Snapshot.dataPath
 
   override def logPath: Path = deltaV2Snapshot.logPath
 
-  // No V1 deltaLog to source a Hadoop conf from, so use the session Hadoop conf.
+  /** No V1 deltaLog to source a Hadoop conf from, so use the session Hadoop conf. */
   // scalastyle:off deltahadoopconfiguration
   override def newDeltaHadoopConf(): Configuration = spark.sessionState.newHadoopConf()
   // scalastyle:on deltahadoopconfiguration
 
-  // A Kernel-backed transaction maintains no V1 incremental-commit CRC state currently.
+  /** A Kernel-backed transaction maintains no V1 incremental-commit CRC state currently. */
   override protected def computeIncrementalCommitEnabled: Boolean = false
   override protected def computeShouldVerifyIncrementalCommit: Boolean = false
 
-  // A Kernel-backed transaction has no V1 LogSegment (its snapshot's `logSegment` is null), so
-  // seed the pre-commit segment as null
+  /**
+   * A Kernel-backed transaction has no V1 LogSegment (its snapshot's `logSegment` is null), so
+   * seed the pre-commit segment as null.
+   */
   override protected def initialPreCommitLogSegment: LogSegment = null
 
-  // Kernel snapshots have no V1 segment or commits to backfill.
-  // TODO: Before supporting coordinated commits or FsToCC, add Kernel recovery for interrupted
-  // CC->FS downgrades to prevent gaps in the backfilled commit sequence.
+  /**
+   * Kernel snapshots have no V1 segment or commits to backfill.
+   *
+   * Before supporting coordinated commits or FsToCC, add Kernel recovery for interrupted
+   * CC->FS downgrades to prevent gaps in the backfilled commit sequence.
+   */
   override protected def maybeBackfillOnConstruction(): Unit = ()
 
-  // A Kernel-backed transaction has no V1 DeltaLog to source a clock from; use a system clock
+  /** A Kernel-backed transaction has no V1 DeltaLog to source a clock from; use a system clock. */
   override def clock: Clock = new SystemClock
 
 
+  /** No log store implemented, emit empty. */
+  override protected def commitLogStoreClassName: String = ""
+  override protected[delta] def commitLogStoreClassNameForTag: String = ""
+
+
+  override def registerPostCommitHook(hook: PostCommitHook): Unit = {
+    val isUnsupported =
+        hook == ChecksumHook ||
+        hook == CheckpointHook ||
+        hook == IcebergConverterHook ||
+        hook == HudiConverterHook
+    if (!isUnsupported) {
+      super.registerPostCommitHook(hook)
+    }
+  }
+
   /**
-   * Commit-IO seam. Not implemented in this skeleton yet.
+   * The per-table commit lock serializes concurrent same-table commits within one driver JVM; V1
+   * borrows it from the DeltaLog `snapshotLock`, for which a Kernel-backed transaction has no
+   * equivalent yet. Left disabled until the connector decides where to surface it.
+   */
+  override private[delta] def isCommitLockEnabled: Boolean = false
+
+
+  /**
+   * V1 checkpointing is disabled for a Kernel-backed transaction because there is no equivalent
+   * Kernel implementation yet.
+   */
+  override protected def isCheckpointNeeded(
+      committedVersion: Long, postCommitSnapshot: Snapshot): Boolean = false
+
+  /**
+   * Return None because a [[DeltaV2Snapshot]]'s checkpoint provider is unimplemented.
+   */
+  override protected def amtCheckpointProviderOpt: Option[AMTCheckpointProvider] = None
+
+  /**
+   * Commit-stats telemetry: the table id is sourced from the Kernel snapshot.
+   */
+  override protected def commitTableId: String = snapshot.metadata.id
+
+  /**
+   * Kernel validated the table's protocol when it loaded the snapshot; protocol-CHANGING commits
+   * are a kernel wrapper gap and must fail loudly.
+   */
+  override protected def validateProtocolWrite(protocol: Protocol): Unit = {
+    if (protocol != snapshot.protocol) {
+      throw new UnsupportedOperationException(
+        "DeltaV2OptimisticTransaction cannot commit protocol changes yet (kernel wrapper gap)")
+    }
+  }
+
+  /**
+   * Resolves the post-commit snapshot after a successful commit-file write.
+   */
+  override protected def resolvePostCommitSnapshot(
+      committedVersion: Long,
+      commitOpt: Option[Commit],
+      newChecksumOpt: Option[VersionChecksum],
+      catalogTableOpt: Option[CatalogTable],
+      amtCheckpointWrittenInCommitOpt: Option[Checkpoint],
+      isIdempotentRetry: Boolean): Snapshot = {
+    // TODO: Use Kernel's incremental snapshot load API to build the post-commit snapshot from the
+    // pre-commit snapshot plus this commit, instead of a full reload that replays the log. It is
+    // supported in Rust but not yet exposed on the Java wrapper.
+    val kernelPostCommitSnapshot = KernelTable
+      .forPath(kernelEngine, dataPath.toString)
+      .getLatestSnapshot(kernelEngine)
+      .asInstanceOf[KernelSnapshotImpl]
+    require(
+      kernelPostCommitSnapshot.getVersion >= committedVersion,
+      s"Kernel reload returned version ${kernelPostCommitSnapshot.getVersion}, older than the " +
+        s"just-committed version $committedVersion")
+    new DeltaV2Snapshot(kernelPostCommitSnapshot)
+  }
+
+  /**
+   * Commit-IO seam: write the commit through Kernel.
+   *
+   * Translates staged [[Action]]s into Kernel action rows and commits through `Transaction.commit`,
+   * returning a [[Commit]] at the version Kernel reports.
    */
   override protected[interop] def writeCommitFile(
       attemptVersion: Long,
       jsonActions: Iterator[String],
       currentTransactionInfo: CurrentTransactionInfo)
-      : (Option[VersionChecksum], Commit, CurrentTransactionInfo) =
-    throw new UnsupportedOperationException(
-      "DeltaV2OptimisticTransaction commit is not implemented yet")
+      : (Option[VersionChecksum], Commit, CurrentTransactionInfo) = {
+    val actions = currentTransactionInfo.finalActionsToCommit
+    val addFiles = new ArrayBuffer[AddFile]()
+    actions.foreach {
+      case a: AddFile => addFiles += a
+      case _: CommitInfo => // Kernel generates its own; V1 operation provenance is an JNR gap.
+      case other =>
+        throw new UnsupportedOperationException(
+          "DeltaV2OptimisticTransaction only supports AddFile actions yet; cannot commit action " +
+            s"${other.getClass.getSimpleName} (kernel wrapper gap)")
+    }
+
+    val kernelSnapshotForCommit = KernelTable
+      .forPath(kernelEngine, dataPath.toString)
+      .getLatestSnapshot(kernelEngine)
+    if (kernelSnapshotForCommit.getVersion != attemptVersion - 1) {
+      throw new FileAlreadyExistsException(
+        s"Cannot commit version $attemptVersion through Kernel: the log is already at version " +
+          s"${kernelSnapshotForCommit.getVersion}; deferring to V1 conflict resolution")
+    }
+
+    val kernelTxn = kernelSnapshotForCommit
+      .buildUpdateTableTransaction("DeltaV2OptimisticTransaction", KernelOperation.WRITE)
+      .build(kernelEngine)
+    try {
+      val kernelTxnState = kernelTxn.getTransactionState(kernelEngine)
+      val kernelCommitResult = kernelTxn.commit(
+        kernelEngine,
+        kernelAppendActionsIterable(
+          addFiles, kernelTxnState, kernelSnapshotForCommit, dataPath.toString))
+      val committedVersion = kernelCommitResult.getVersion
+      val deltaFile = FileNames.unsafeDeltaFile(logPath, committedVersion)
+      val fs = deltaFile.getFileSystem(newDeltaHadoopConf())
+      val fileStatus = fs.getFileStatus(deltaFile)
+      (None, new Commit(committedVersion, fileStatus, fileStatus.getModificationTime),
+        currentTransactionInfo)
+    } finally {
+    }
+  }
+
+  /**
+   * Translates staged [[AddFile]]s into iterable Kernel append-action rows.
+   */
+  private def kernelAppendActionsIterable(
+      addFiles: Iterable[AddFile],
+      kernelTxnState: KernelRow,
+      kernelSnapshot: KernelSnapshot,
+      dataPathStr: String): KernelCloseableIterable[KernelRow] = {
+    val kernelSchema = kernelSnapshot.getSchema
+    val partitionColNames = kernelSnapshot.getPartitionColumnNames.asScala
+    val partitionColumnDataTypesByName = kernelSchema.fields().asScala
+      .filter(f => partitionColNames.exists(_.equalsIgnoreCase(f.getName)))
+      .map(f => f.getName -> f.getDataType).toMap
+
+    def generateKernelWriteContext(
+        partitionValues: Map[String, String]): KernelDataWriteContext = {
+      val kernelLiteralPartitionValues: java.util.Map[String, KernelLiteral] =
+        partitionValues.map { case (name, value) =>
+          val kernelDataType =
+            partitionColumnDataTypesByName.getOrElse(name, KernelStringType.STRING)
+          name -> KernelPartitionUtils.literalForPartitionValue(kernelDataType, value)
+        }.asJava
+      KernelTransaction.getWriteContext(kernelEngine, kernelTxnState, kernelLiteralPartitionValues)
+    }
+
+    def kernelDataFileStatusFor(addFile: AddFile): KernelDataFileStatus =
+      new KernelDataFileStatus(
+        DeltaFileOperations.absolutePath(dataPathStr, addFile.path).toString,
+        addFile.size,
+        addFile.modificationTime,
+        Option(addFile.stats).map(KernelDataFileStatistics.deserializeFromJson(_, kernelSchema))
+          .getOrElse(Optional.empty[KernelDataFileStatistics]()))
+
+    new KernelCloseableIterable[KernelRow] {
+      override def iterator() = {
+        val writeContextByPartition =
+          new HashMap[Map[String, String], KernelDataWriteContext]()
+        KernelUtils.toCloseableIterator(addFiles.iterator.asJava).flatMap {
+          (addFile: AddFile) =>
+            val kernelWriteContext = writeContextByPartition.getOrElseUpdate(
+              addFile.partitionValues, generateKernelWriteContext(addFile.partitionValues))
+            KernelTransaction.generateAppendActions(
+              kernelEngine,
+              kernelTxnState,
+              KernelUtils.singletonCloseableIterator(kernelDataFileStatusFor(addFile)),
+              kernelWriteContext)
+        }
+      }
+
+      override def close(): Unit = {}
+    }
+  }
 }

--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/v2/interop/DeltaV2OptimisticTransactionSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/v2/interop/DeltaV2OptimisticTransactionSuite.scala
@@ -17,40 +17,59 @@
 package org.apache.spark.sql.delta.v2.interop
 
 import java.io.File
+import java.nio.file.{Files, StandardCopyOption}
 
-import org.apache.spark.sql.delta.DeltaLog
+import org.apache.spark.sql.delta.DeltaOperations
+import org.apache.spark.sql.delta.actions.{AddFile, SetTransaction}
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import io.delta.spark.internal.v2.kernel.KernelEngineFactory
 import io.delta.kernel.Table
-import io.delta.kernel.defaults.engine.DefaultEngine
 import io.delta.kernel.internal.SnapshotImpl
 
 import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.LongType
 import org.apache.spark.util.SystemClock
 
 /**
- * Tests for the [[DeltaV2OptimisticTransaction]] skeleton. This suite exercises the construction
- * path only: a transaction can be built over a Kernel snapshot (with a null V1 `deltaLog`) and its
- * read state (`readVersion`, `metadata`, `protocol`, `snapshot`) resolves from the wrapped
- * [[DeltaV2Snapshot]]. The commit lifecycle is not yet implemented and must fail loudly.
+ * Tests for [[DeltaV2OptimisticTransaction]]. Two groups:
+ *  - Construction: a transaction builds over a Kernel snapshot (with a null V1 `deltaLog`) and its
+ *    read state (`readVersion`, `metadata`, `protocol`, `snapshot`) resolves from the wrapped
+ *    [[DeltaV2Snapshot]].
+ *  - Commit: [[AddFile]] actions commit through Kernel's `Transaction.commit` while the surrounding
+ *    commit machinery runs unchanged; the durable log is asserted by re-loading the table through
+ *    Kernel as a [[DeltaV2Snapshot]]. Non-AddFile actions fail loudly.
  */
 class DeltaV2OptimisticTransactionSuite
     extends QueryTest
     with SharedSparkSession
     with DeltaSQLCommandTest {
 
+  import testImplicits._
+
   /** Builds a Kernel-backed transaction over the latest snapshot of the table at `dir`. */
   private def startKernelTxn(dir: File): DeltaV2OptimisticTransaction = {
     // scalastyle:off deltahadoopconfiguration
     // No DeltaLog here (the snapshot is loaded via Kernel), so use the session Hadoop conf.
-    val engine = DefaultEngine.create(spark.sessionState.newHadoopConf())
+    val engine = KernelEngineFactory.createDefaultEngine(spark.sessionState.newHadoopConf())
     // scalastyle:on deltahadoopconfiguration
     val kernelSnap = Table
       .forPath(engine, dir.getCanonicalPath)
       .getLatestSnapshot(engine)
       .asInstanceOf[SnapshotImpl]
     val deltaV2Snapshot = new DeltaV2Snapshot(kernelSnap)
-    new DeltaV2OptimisticTransaction(catalogTable = None, deltaV2Snapshot)
+    new DeltaV2OptimisticTransaction(catalogTable = None, deltaV2Snapshot, engine)
+  }
+
+  private def latestKernelSnapshot(dir: File): DeltaV2Snapshot = {
+    // scalastyle:off deltahadoopconfiguration
+    val engine = KernelEngineFactory.createDefaultEngine(spark.sessionState.newHadoopConf())
+    // scalastyle:on deltahadoopconfiguration
+    val kernelSnap = Table
+      .forPath(engine, dir.getCanonicalPath)
+      .getLatestSnapshot(engine)
+      .asInstanceOf[SnapshotImpl]
+    new DeltaV2Snapshot(kernelSnap)
   }
 
   /** Seeds a simple (unpartitioned) V1 Delta table at `dir`. */
@@ -70,21 +89,25 @@ class DeltaV2OptimisticTransactionSuite
     }
   }
 
-  test("metadata and protocol resolve from the Kernel snapshot and match V1") {
+  test("metadata and protocol resolve from the Kernel snapshot") {
     withTempDir { dir =>
       seedTable(dir)
       val txn = startKernelTxn(dir)
-      val log = DeltaLog.forTable(spark, dir.getCanonicalPath)
-      val v1 = log.update()
 
-      assert(txn.metadata.id === v1.metadata.id)
-      assert(txn.metadata.schemaString === v1.metadata.schemaString)
-      assert(txn.metadata.partitionColumns === v1.metadata.partitionColumns)
-      assert(txn.protocol === v1.protocol)
+      // Read state reflects the seeded table: a single LONG `id` column, unpartitioned.
+      assert(txn.metadata.schema.fieldNames.toSeq === Seq("id"))
+      assert(txn.metadata.schema("id").dataType === LongType)
+      assert(txn.metadata.partitionColumns.isEmpty)
+      assert(txn.metadata.id.nonEmpty)
 
-      // The Kernel-sourced path overrides match the V1 DeltaLog's paths.
-      assert(txn.dataPath === log.dataPath)
-      assert(txn.logPath === log.logPath)
+      // A basic table resolves a protocol with at least the minimum supported versions.
+      assert(txn.protocol.minReaderVersion >= 1)
+      assert(txn.protocol.minWriterVersion >= 2)
+
+      // Kernel-sourced path overrides point at the table directory and its `_delta_log` child.
+      assert(txn.dataPath.getName === dir.getName)
+      assert(txn.logPath.getName === "_delta_log")
+      assert(txn.logPath.getParent.getName === dir.getName)
     }
   }
 
@@ -112,25 +135,283 @@ class DeltaV2OptimisticTransactionSuite
         .write.format("delta").partitionBy("p").save(dir.getCanonicalPath)
 
       val txn = startKernelTxn(dir)
-      assert(txn.snapshot eq txn.deltaV2Snapshot)
-      assert(txn.deltaV2Snapshot.isInstanceOf[DeltaV2Snapshot])
+      assert(txn.snapshot.isInstanceOf[DeltaV2Snapshot])
       assert(txn.metadata.partitionColumns === Seq("p"))
     }
   }
 
-  test("commit path is not implemented and fails loudly") {
+  test("blind append of a synthetic AddFile commits through Kernel") {
     withTempDir { dir =>
       seedTable(dir)
       val txn = startKernelTxn(dir)
-      // Call the commit chokepoint directly: going through txn.commit(...) would first reach the
-      // V1 prepareCommit machinery, which NPEs on the null deltaLog before this seam.
-      val e = intercept[UnsupportedOperationException] {
-        txn.writeCommitFile(
-          attemptVersion = txn.readVersion + 1L,
-          jsonActions = Iterator.empty,
-          currentTransactionInfo = null)
+      assert(txn.readVersion === 0L)
+
+      val add = AddFile(
+        path = "synthetic-file",
+        partitionValues = Map.empty,
+        size = 1L,
+        modificationTime = 1L,
+        dataChange = true)
+      txn.commit(add :: Nil, DeltaOperations.ManualUpdate)
+
+      val post = latestKernelSnapshot(dir)
+      assert(post.version === 1L)
+      assert(post.allFiles.collect().map(_.path).contains("synthetic-file"))
+    }
+  }
+
+  test("appended parquet file is readable end to end") {
+    withTempDir { dir =>
+      seedTable(dir)
+
+      // Stage a real parquet file with the table's schema in a sibling directory (writing
+      // format("parquet") under the table root trips DELTA_INVALID_FORMAT validation), then copy
+      // it into the table dir, mirroring how OptimisticTransactionSuite drives commits at the
+      // file-action level.
+      val staging = new File(dir.getParentFile, s"${dir.getName}-staging")
+      spark.range(5, 7).toDF("id").coalesce(1)
+        .write.parquet(staging.getCanonicalPath)
+      val parquetFile = staging.listFiles()
+        .filter(f => f.getName.endsWith(".parquet") && !f.getName.startsWith("_"))
+        .head
+      val targetName = s"part-kernel-poc-${parquetFile.getName}"
+      val target = new File(dir, targetName)
+      Files.copy(parquetFile.toPath, target.toPath, StandardCopyOption.REPLACE_EXISTING)
+
+      val txn = startKernelTxn(dir)
+      val add = AddFile(
+        path = targetName,
+        partitionValues = Map.empty,
+        size = target.length(),
+        modificationTime = target.lastModified(),
+        dataChange = true)
+      txn.commit(add :: Nil, DeltaOperations.ManualUpdate)
+
+      checkAnswer(
+        spark.read.format("delta").load(dir.getCanonicalPath),
+        Seq(0L, 1L, 2L, 3L, 4L, 5L, 6L).toDF("id"))
+    }
+  }
+
+  test("consecutive kernel commits advance the version") {
+    withTempDir { dir =>
+      seedTable(dir)
+      (1 to 3).foreach { i =>
+        val txn = startKernelTxn(dir)
+        assert(txn.readVersion === (i - 1).toLong)
+        val add = AddFile(s"synthetic-$i", Map.empty, 1L, 1L, dataChange = true)
+        txn.commit(add :: Nil, DeltaOperations.ManualUpdate)
       }
-      assert(e.getMessage.contains("not implemented"))
+      val post = latestKernelSnapshot(dir)
+      assert(post.version === 3L)
+      assert(post.allFiles.collect().map(_.path).count(_.startsWith("synthetic-")) === 3)
+    }
+  }
+
+  test("unsupported actions fail loudly") {
+    withTempDir { dir =>
+      seedTable(dir)
+      val txn = startKernelTxn(dir)
+      val setTxn = SetTransaction("test-app", 1L, Some(1L))
+      val e = intercept[UnsupportedOperationException] {
+        txn.commit(setTxn :: Nil, DeltaOperations.ManualUpdate)
+      }
+      assert(e.getMessage.contains("kernel wrapper gap"))
+    }
+  }
+
+  /**
+   * Commits a synthetic [[AddFile]] carrying `statsJson` through Kernel. Used by the stats tests
+   * below to drive `kernelStatistics` with a chosen stats payload.
+   */
+  private def commitWithStats(dir: File, statsJson: String): Unit = {
+    val txn = startKernelTxn(dir)
+    val add = AddFile(
+      path = "synthetic-stats-file",
+      partitionValues = Map.empty,
+      size = 1L,
+      modificationTime = 1L,
+      dataChange = true,
+      stats = statsJson)
+    txn.commit(add :: Nil, DeltaOperations.ManualUpdate)
+  }
+
+  test("full stats JSON round-trips into the kernel add action") {
+    withTempDir { dir =>
+      seedTable(dir)
+      commitWithStats(
+        dir,
+        """{"numRecords":3,"minValues":{"id":1},"maxValues":{"id":9},"nullCount":{"id":0}}""")
+
+      val post = latestKernelSnapshot(dir)
+      assert(post.version === 1L)
+      val committed = post.allFiles.collect().find(_.path == "synthetic-stats-file").get
+      // Only numRecords is asserted: the native (JNR) FFI add-file path (ActionRowConverter)
+      // intentionally carries numRecords only, so min/max/nullCount are not populated.
+      assert(committed.stats.contains("\"numRecords\":3"))
+    }
+  }
+
+  test("stats-less AddFile commits with empty stats rather than failing") {
+    withTempDir { dir =>
+      seedTable(dir)
+      // stats defaults to null on AddFile; absent stats are legitimate and must not error.
+      commitWithStats(dir, statsJson = null)
+      assert(latestKernelSnapshot(dir).version === 1L)
+    }
+  }
+
+  test("numRecords-only stats JSON commits (no min/max to parse)") {
+    withTempDir { dir =>
+      seedTable(dir)
+      commitWithStats(dir, """{"numRecords":7}""")
+
+      val post = latestKernelSnapshot(dir)
+      val committed = post.allFiles.collect().find(_.path == "synthetic-stats-file").get
+      assert(committed.stats.contains("\"numRecords\":7"))
+    }
+  }
+
+  test("malformed stats JSON fails the commit instead of silently dropping stats") {
+    withTempDir { dir =>
+      seedTable(dir)
+      // Truncated JSON: the previous implementation swallowed this and committed
+      // numRecords-only (here, no stats at all), losing data-skipping stats silently.
+      val e = intercept[Exception] {
+        commitWithStats(dir, """{"numRecords":3,"minValues":{"id":""")
+      }
+      assert(
+        e.getMessage != null && e.getMessage.contains("Failed to parse JSON"),
+        s"expected a JSON parse failure, got: ${e.getMessage}")
+      // The bad write did not land.
+      assert(latestKernelSnapshot(dir).version === 0L)
+    }
+  }
+
+  test("stats JSON whose value type contradicts the schema fails the commit") {
+    withTempDir { dir =>
+      seedTable(dir)
+      // `id` is a LONG; a string min value is a real stats/schema inconsistency.
+      val e = intercept[Exception] {
+        commitWithStats(
+          dir,
+          """{"numRecords":3,"minValues":{"id":"not-a-number"},"maxValues":{"id":9}}""")
+      }
+      assert(e.getMessage != null, "expected a typed-parse failure with a message")
+      assert(latestKernelSnapshot(dir).version === 0L)
+    }
+  }
+
+  /**
+   * Seeds a table partitioned by a single column `p` of `partitionType`, inserts one row with
+   * `partitionValueSql`, then commits a synthetic [[AddFile]] through Kernel reusing the seeded
+   * row's serialized partition values. Asserts the commit succeeds and advances the version.
+   *
+   * This exercises the partition-value typing in `generateKernelAppendActionRows`: Kernel's
+   * `getWriteContext` validates each literal's type against the partition schema with exact
+   * type-equality, so a non-string partition column would fail if values were still typed as
+   * strings.
+   */
+  private def checkTypedPartitionAppend(
+      partitionType: String, partitionValueSql: String): Unit = {
+    withTempDir { dir =>
+      val path = dir.getCanonicalPath
+      spark.sql(
+        s"""CREATE TABLE delta.`$path` (id LONG, p $partitionType)
+           |USING delta PARTITIONED BY (p)""".stripMargin)
+      spark.sql(s"INSERT INTO delta.`$path` VALUES (1, $partitionValueSql)")
+
+      val base = latestKernelSnapshot(dir)
+      val baseVersion = base.version
+      val sample = base.allFiles.collect().head
+
+      val txn = startKernelTxn(dir)
+      val add = AddFile(
+        path = s"synthetic-${sample.path}",
+        partitionValues = sample.partitionValues,
+        size = 1L,
+        modificationTime = 1L,
+        dataChange = true)
+      txn.commit(add :: Nil, DeltaOperations.ManualUpdate)
+
+      val post = latestKernelSnapshot(dir)
+      assert(post.version === baseVersion + 1)
+      assert(post.allFiles.collect().map(_.path).exists(_.startsWith("synthetic-")))
+    }
+  }
+
+  test("append to int-partitioned table types the partition literal") {
+    checkTypedPartitionAppend("INT", "5")
+  }
+
+  test("append to date-partitioned table types the partition literal") {
+    checkTypedPartitionAppend("DATE", "DATE'2024-03-11'")
+  }
+
+  test("append to timestamp-partitioned table types the partition literal") {
+    checkTypedPartitionAppend("TIMESTAMP", "TIMESTAMP'2024-03-11 11:00:00.123456'")
+  }
+
+  test("append to decimal-partitioned table types the partition literal") {
+    checkTypedPartitionAppend("DECIMAL(10,2)", "CAST(12.34 AS DECIMAL(10,2))")
+  }
+
+  test("append to boolean-partitioned table types the partition literal") {
+    checkTypedPartitionAppend("BOOLEAN", "true")
+  }
+
+  test("append with a null partition value types the null literal") {
+    checkTypedPartitionAppend("INT", "NULL")
+  }
+
+  test("append to string-partitioned table still works") {
+    checkTypedPartitionAppend("STRING", "'foo'")
+  }
+
+  test("multiple AddFiles per partition all commit through Kernel") {
+    withTempDir { dir =>
+      val path = dir.getCanonicalPath
+      spark.sql(
+        s"""CREATE TABLE delta.`$path` (id LONG, p INT)
+           |USING delta PARTITIONED BY (p)""".stripMargin)
+      // Two partitions (p=0, p=1), each with a real data file so we can reuse their serialized
+      // partition values below.
+      spark.sql(s"INSERT INTO delta.`$path` VALUES (1, 0), (2, 1)")
+
+      val base = latestKernelSnapshot(dir)
+      val baseVersion = base.version
+      // partitionValues keyed by partition -> one representative file per partition.
+      val samplesByPartition =
+        base.allFiles.collect().groupBy(_.partitionValues).map {
+          case (partitionValues, files) => partitionValues -> files.head
+        }
+      assert(samplesByPartition.size === 2, "expected one file per partition to reuse")
+
+      // Stage two synthetic AddFiles per partition (four total) so the per-partition grouping in
+      // generateKernelAppendActionRows must emit multiple append action rows for the same write
+      // context, not just one.
+      val adds = samplesByPartition.toSeq.flatMap { case (partitionValues, sample) =>
+        (1 to 2).map { i =>
+          AddFile(
+            path = s"synthetic-p${partitionValues.values.head}-$i-${sample.path}",
+            partitionValues = partitionValues,
+            size = 1L,
+            modificationTime = 1L,
+            dataChange = true)
+        }
+      }
+      assert(adds.size === 4)
+
+      val txn = startKernelTxn(dir)
+      txn.commit(adds.toList, DeltaOperations.ManualUpdate)
+
+      val post = latestKernelSnapshot(dir)
+      assert(post.version === baseVersion + 1)
+      val committedPaths = post.allFiles.collect().map(_.path)
+      // All four synthetic files landed, spread across both partitions.
+      adds.foreach(add => assert(committedPaths.contains(add.path), s"missing ${add.path}"))
+      assert(committedPaths.count(_.startsWith("synthetic-p0")) === 2)
+      assert(committedPaths.count(_.startsWith("synthetic-p1")) === 2)
     }
   }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -1924,10 +1924,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
           case other => other
         }
       }
-      val preCommitLatestAMTCheckpointOpt = snapshot.checkpointProvider match {
-        case amt: AMTCheckpointProvider => Some(amt.checkpointAction)
-        case _ => None
-      }
+      val preCommitLatestAMTCheckpointOpt = amtCheckpointProviderOpt.map(_.checkpointAction)
       val currentTransactionInfo = CurrentTransactionInfo(
         txnId = txnId,
         readPredicates = readPredicates.asScala.toVector,
@@ -2161,7 +2158,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
               toProtocol = p,
               isCreatingNewTable)
             DeltaTableV2.withEnrichedUnsupportedTableException(catalogTable) {
-              deltaLog.protocolWrite(p)
+              validateProtocolWrite(p)
             }
           case _ =>
         }
@@ -2174,7 +2171,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
 
       // Validate protocol support, specifically writer features.
       DeltaTableV2.withEnrichedUnsupportedTableException(catalogTable) {
-        deltaLog.protocolWrite(snapshot.protocol)
+        validateProtocolWrite(snapshot.protocol)
       }
 
       allActions = RowId.assignFreshRowIds(spark, protocol, snapshot, allActions, op)
@@ -2556,7 +2553,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
         isCreatingNewTable,
         operationNameOpt = Some(op.name))
       DeltaTableV2.withEnrichedUnsupportedTableException(catalogTable) {
-        deltaLog.protocolWrite(p)
+        validateProtocolWrite(p)
       }
     }
 
@@ -2655,8 +2652,8 @@ trait OptimisticTransactionImpl extends TransactionHelper
     }
 
     DeltaTableV2.withEnrichedUnsupportedTableException(catalogTable) {
-      newProtocol.foreach(deltaLog.protocolWrite)
-      deltaLog.protocolWrite(snapshot.protocol)
+      newProtocol.foreach(validateProtocolWrite)
+      validateProtocolWrite(snapshot.protocol)
     }
 
     finalActions = RowId.assignFreshRowIds(
@@ -2692,10 +2689,10 @@ trait OptimisticTransactionImpl extends TransactionHelper
    */
   private def verifyAmtBackReferences(finalActions: Seq[Action]): Unit = {
     if (!DeltaUtils.isTesting) return
-    snapshot.checkpointProvider match {
-      case amt: AMTCheckpointProvider =>
+    amtCheckpointProviderOpt match {
+      case Some(amt) =>
         amt.verifyCommitBackReferences(spark, deltaLog, finalActions)
-      case _ =>
+      case None =>
         // Not an AMT-backed table: no file action may carry a back reference.
         finalActions.foreach {
           case a: AddFile if a.backReference.isDefined =>
@@ -3007,11 +3004,10 @@ trait OptimisticTransactionImpl extends TransactionHelper
 
     executionObserver.beginPostCommit()
     val catalogTableForPostCommitSnapshot = catalogTable
-    val postCommitSnapshot = deltaLog.updateAfterCommit(
+    val postCommitSnapshot = resolvePostCommitSnapshot(
       attemptVersion,
       commitOpt,
       newChecksumOpt,
-      preCommitLogSegment,
       catalogTableForPostCommitSnapshot,
       amtCheckpointWrittenInCommitOpt = amtWriteResultOpt.map(_.checkpoint),
       isIdempotentRetry = isIdempotentRetry)
@@ -3047,7 +3043,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
     // Add to commit stats and consume the returned iterator.
     commitStatsComputer.addToCommitStats(actions.toIterator).foreach(_ => ())
     partitionsAddedToOpt = Some(commitStatsComputer.getPartitionsAddedByTransaction)
-    collectAutoOptimizeStatsAndFinalize(actions, deltaLog.unsafeVolatileTableId)
+    collectAutoOptimizeStatsAndFinalize(actions, commitTableId)
     val commitSizeBytes: Long = jsonActions.map(_.length.toLong).sum
     commitStatsComputer.finalizeAndEmitCommitStats(
       spark,
@@ -3415,6 +3411,42 @@ trait OptimisticTransactionImpl extends TransactionHelper
 
   /** Returns the version that the first attempt will try to commit at. */
   private[delta] def getFirstAttemptVersion: Long = readVersion + 1L
+
+  /**
+   * Validates that this client may write with the given protocol.
+   */
+  protected def validateProtocolWrite(protocol: Protocol): Unit =
+    deltaLog.protocolWrite(protocol)
+
+  /**
+   * Resolves the post-commit snapshot after a successful commit-file write. It resolves it and
+   * installs it as the DeltaLog's current snapshot.
+   */
+  protected def resolvePostCommitSnapshot(
+      committedVersion: Long,
+      commitOpt: Option[Commit],
+      newChecksumOpt: Option[VersionChecksum],
+      catalogTableOpt: Option[CatalogTable],
+      amtCheckpointWrittenInCommitOpt: Option[Checkpoint] = None,
+      isIdempotentRetry: Boolean = false): Snapshot =
+    deltaLog.updateAfterCommit(
+      committedVersion, commitOpt, newChecksumOpt, preCommitLogSegment, catalogTableOpt,
+      amtCheckpointWrittenInCommitOpt = amtCheckpointWrittenInCommitOpt,
+      isIdempotentRetry = isIdempotentRetry)
+
+  /**
+   * The table id used for auto-optimize commit stats. V1 uses `deltaLog.unsafeVolatileTableId`
+   */
+  protected def commitTableId: String = deltaLog.unsafeVolatileTableId
+
+  /**
+   * The read snapshot's [[AMTCheckpointProvider]], or None if the table is not AMT-backed.
+   */
+  protected def amtCheckpointProviderOpt: Option[AMTCheckpointProvider] =
+    snapshot.checkpointProvider match {
+      case amt: AMTCheckpointProvider => Some(amt)
+      case _ => None
+    }
 
   /** Returns the conflicting commit information */
   protected def getConflictingVersions(previousAttemptVersion: Long): Seq[FileStatus] = {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/TransactionHelper.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/TransactionHelper.scala
@@ -55,6 +55,12 @@ trait TransactionHelper extends DeltaLogging {
   /** The Hadoop [[Configuration]] used to access the Delta log. */
   def newDeltaHadoopConf(): Configuration = deltaLog.newDeltaHadoopConf()
 
+  /** Canonical name of the commit log store class for commit-stats telemetry. */
+  protected def commitLogStoreClassName: String = deltaLog.store.getClass.getCanonicalName
+
+  /** Value used for the `TAG_LOG_STORE_CLASS` operation tag. */
+  protected[delta] def commitLogStoreClassNameForTag: String = deltaLog.store.getClass.getName
+
   def catalogTable: Option[CatalogTable]
   def snapshot: Snapshot
 


### PR DESCRIPTION
Implement single-writer blind appends of `AddFile` actions for `DeltaV2OptimisticTransaction`, committing through Delta Kernel's `Transaction.commit`. The surrounding commit machinery (prepareCommit, retry loop, post-commit install) runs unchanged via overridable seams re-pointed at Kernel:

- `writeCommitFile` commits through Kernel's `Transaction.commit`; staged `AddFile`s (grouped per partition, with full statistics) are translated to Kernel action rows. Non-AddFile actions and protocol changes fail loudly.
- `installPostCommitSnapshot` reloads through Kernel into a `DeltaV2Snapshot`.

Concurrent-writer conflict resolution is intentionally out of scope here and is a follow-up.

## How was this patch tested?

New unit tests in `DeltaV2OptimisticTransactionSuite`: blind append + end-to-end read-back, consecutive-commit version advance, unsupported-action fail-loud, stats-JSON round-trip, and typed-partition appends (int/date/timestamp/decimal/boolean/null/string).