### PR TITLE
[Spark] AMT tests: reuse shared manifest-read helpers

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTBackReferenceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTBackReferenceSuite.scala
@@ -42,6 +42,7 @@ class AMTBackReferenceSuite extends AMTCheckpointTestBase with DeletionVectorsTe
    */
   private def leafLocationByBackRef(snapshot: Snapshot): Map[(String, Long), String] = {
     val provider = amtProvider(snapshot).getOrElse(fail("expected AMTCheckpointProvider"))
+    allowReadWithinDeltaLog {
       provider.liveLeafManifestAbsolutePaths.flatMap { leafPath =>
         val relManifest = relativeManifest(snapshot, leafPath)
         spark.read.parquet(leafPath.toString)
@@ -50,6 +51,7 @@ class AMTBackReferenceSuite extends AMTCheckpointTestBase with DeletionVectorsTe
           .collect()
           .map(row => (relManifest, row.getLong(1)) -> row.getString(0))
       }.toMap
+    }
   }
 
   /** All actions committed after `afterVersion`, up to the latest version. */

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointTestBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointTestBase.scala
@@ -639,14 +639,18 @@ trait AMTCheckpointTestBase
    * this can exceed the live file count. To assert the tree captures exactly the live file set,
    * call [[assertReconstructsLiveFileSet]] instead.
    */
-  protected def currentLeafDataEntries(snapshot: Snapshot): Long = {
-    val provider = amtProvider(snapshot)
-      .getOrElse(fail("Snapshot has no AMTCheckpointProvider."))
-      provider.liveLeafManifestAbsolutePaths.map { leafPath =>
-        spark.read.parquet(leafPath.toString)
-          .where(col("content_type") === AMTSingleAction.ContentType.Type.Data)
-          .count()
-      }.sum
+  protected def leafLiveDataEntryCount(snapshot: Snapshot): Long =
+    leafLiveDataEntryCount(amtProvider(snapshot)
+      .getOrElse(fail("Snapshot has no AMTCheckpointProvider.")))
+
+  /**
+   * Total DATA (content_type=0) entry rows across `provider`'s live leaves, 0 when the tree is
+   * leafless. Like the [[Snapshot]]-based overload but driven by a provider a test built directly
+   * (e.g. from a checkpoint), where no owning [[Snapshot]] exists.
+   */
+  protected def leafLiveDataEntryCount(provider: AMTCheckpointProvider): Long = {
+    val leaves = provider.liveLeafManifestAbsolutePaths.map(_.toString)
+    if (leaves.isEmpty) 0L else withManifestDataEntries(leaves)(_.count())
   }
 
 
@@ -654,7 +658,7 @@ trait AMTCheckpointTestBase
    * The number of live files the CURRENT snapshot's AMT reconstructs across the WHOLE tree -- root
    * and leaves. Goes through the provider's own reconstruction, which drops MDV-masked leaf entries
    * and `tracking=removed` root tombstones, so it equals `snapshot.allFiles.count()` on both full
-   * and incremental trees. Unlike [[currentLeafDataEntries]], it counts live files stored directly
+   * and incremental trees. Unlike [[leafLiveDataEntryCount]], it counts live files stored directly
    * in the root too (as an incremental commit does below the spill threshold).
    *
    * Prefer [[assertReconstructsLiveFileSet]] when the test runs through

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointWriteSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointWriteSuite.scala
@@ -18,7 +18,6 @@ package org.apache.spark.sql.delta.amt
 
 import java.io.File
 
-// scalastyle:off import.ordering.noEmptyLine
 import com.databricks.spark.util.{Log4jUsageLogger, MetricDefinitions}
 import org.apache.spark.sql.delta.{Checkpoints, CommitStats, CurrentTransactionInfo, DeltaOperations, LastCheckpointInfo}
 import org.apache.spark.sql.delta.actions.{AddFile, Checkpoint, ContentRoot, RemoveFile}
@@ -26,7 +25,6 @@ import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.{FileNames, JsonUtils}
 import org.apache.hadoop.fs.Path
 
-import org.apache.spark.SparkConf
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.execution.datasources.parquet.ParquetUtils
 import org.apache.spark.sql.functions.col
@@ -132,13 +130,9 @@ class AMTCheckpointWriteSuite extends AMTCheckpointTestBase {
         sql(s"INSERT INTO $name VALUES (1)")
         sql(s"INSERT INTO $name VALUES (2)")
       }) { context =>
-    val rootDataEntries = {
-      spark.read
-        .parquet(context.checkpoint.contentRoot.getAbsolutePath(context.provider.tableRoot)
-          .toString)
-        .where(col("content_type") === AMTSingleAction.ContentType.Type.Data)
-        .count()
-    }
+    val rootDataEntries = withManifestDataEntries(
+      Seq(context.checkpoint.contentRoot.getAbsolutePath(context.provider.tableRoot).toString)
+    )(_.count())
 
     assert(context.provider.leaves.isEmpty, "The root must contain no leaf pointers.")
     assert(rootDataEntries == 2L, "Both live files must be reachable as DATA entries in the root.")
@@ -165,18 +159,20 @@ class AMTCheckpointWriteSuite extends AMTCheckpointTestBase {
              |SELECT $cols
              |FROM range(${leafPackedFiles - 1}, $leafPackedFiles)""".stripMargin)
       }) { context =>
-    val leafDf = spark.read.parquet(
-      context.provider.liveLeafManifestAbsolutePaths.map(_.toString): _*)
-    val partitionSchema = context.postCheckpointSnapshot.metadata.partitionSchema
-    val partition = leafDf.schema("partition")
-    assert(partition.nullable)
-    val expectedSchema = AMTPartitionValues.persistedSchema(partitionSchema)
-    assert(
-      fieldIdShape(partition.dataType.asInstanceOf[StructType]) == fieldIdShape(expectedSchema),
-      s"persisted partition schema did not match the expected typed shape\n" +
-        s"  actual=${partition.dataType}\n  expected=$expectedSchema")
-    assert(leafDf.select("partition.p_int").collect().map(_.getInt(0)).toSet ==
-      (0 until leafPackedFiles).toSet)
+    allowReadWithinDeltaLog {
+      val leafDf = spark.read.parquet(
+        context.provider.liveLeafManifestAbsolutePaths.map(_.toString): _*)
+      val partitionSchema = context.postCheckpointSnapshot.metadata.partitionSchema
+      val partition = leafDf.schema("partition")
+      assert(partition.nullable)
+      val expectedSchema = AMTPartitionValues.persistedSchema(partitionSchema)
+      assert(
+        fieldIdShape(partition.dataType.asInstanceOf[StructType]) == fieldIdShape(expectedSchema),
+        s"persisted partition schema did not match the expected typed shape\n" +
+          s"  actual=${partition.dataType}\n  expected=$expectedSchema")
+      assert(leafDf.select("partition.p_int").collect().map(_.getInt(0)).toSet ==
+        (0 until leafPackedFiles).toSet)
+    }
 
     // Every physical-name -> string partition entry must come back exactly as the log recorded it;
     // a cast that disagrees with Delta's own serialization would corrupt these silently.
@@ -199,7 +195,7 @@ class AMTCheckpointWriteSuite extends AMTCheckpointTestBase {
         context.provider.liveLeafManifestAbsolutePaths.map(_.toString))
     assert(manifests.nonEmpty, "Expected at least a root manifest.")
     manifests.foreach { manifest =>
-      val columns = {
+      val columns = allowReadWithinDeltaLog {
         spark.read.parquet(manifest).columns.toSeq
       }
       assert(!columns.contains("partition"),
@@ -219,7 +215,9 @@ class AMTCheckpointWriteSuite extends AMTCheckpointTestBase {
     val snapshot = context.postCheckpointSnapshot
 
     val manifest = context.provider.topLevelFiles.map(_.getPath.toString).head
-    val contentStats = spark.read.parquet(manifest).schema("content_stats")
+    val contentStats = allowReadWithinDeltaLog {
+      spark.read.parquet(manifest).schema("content_stats")
+    }
     assert(contentStats.nullable)
     val expectedSchema = AMTContentStats.persistedSchema(snapshot.metadata, snapshot.protocol)
     assert(
@@ -254,7 +252,7 @@ class AMTCheckpointWriteSuite extends AMTCheckpointTestBase {
     assert(isRootFileName(new File(rootPointer).getName))
 
     // Every leaf pointer stored in the root manifest is likewise table-root-relative.
-    val leafLocations = {
+    val leafLocations = allowReadWithinDeltaLog {
       spark.read.parquet(new File(new File(tablePath(name),
         FileNames.AMT_METADATA_DIR_NAME), new File(rootPointer).getName).toString)
         .where(col("content_type") === AMTSingleAction.ContentType.Type.DataManifest)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTIncrementalWriteInlineSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTIncrementalWriteInlineSuite.scala
@@ -82,7 +82,7 @@ class AMTIncrementalWriteInlineSuite extends AMTIncrementalWriteTestBase with Gr
           initialIdRangeInLeaf = 1 to 30).map(_.location).toSet
         assert(leavesBefore.size >= 2,
           s"Need a tree-shaped bootstrap; got ${leavesBefore.size} leaves.")
-        val physicalEntriesBefore = currentLeafDataEntries(amtDeltaLog.update())
+        val physicalEntriesBefore = leafLiveDataEntryCount(amtDeltaLog.update())
         assert(physicalEntriesBefore == 30,
           "Every bootstrap file is spread across the AMT's leaves.")
 
@@ -100,7 +100,7 @@ class AMTIncrementalWriteInlineSuite extends AMTIncrementalWriteTestBase with Gr
           inlineAMTCommitActions = Some(Seq(removeOf(amtDeltaLog, 1))))
         assert(leafPointers(amtDeltaLog.update()).keySet == leavesBefore,
           "The delete must carry every leaf forward, not rewrite or drop one.")
-        assert(currentLeafDataEntries(amtDeltaLog.update()) == physicalEntriesBefore,
+        assert(leafLiveDataEntryCount(amtDeltaLog.update()) == physicalEntriesBefore,
           "The carried leaf keeps every physical entry; a delete only sets the MDV.")
       }
     }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTIncrementalWriteTestBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTIncrementalWriteTestBase.scala
@@ -101,10 +101,8 @@ abstract class AMTIncrementalWriteTestBase extends AMTCheckpointTestBase {
    * Physical DATA-row counts of a manifest parquet keyed by `tracking.status`.
    */
   protected def trackingStatusToAddFileCountMap(absManifestPath: String): Map[Int, Long] =
-    allowReadWithinDeltaLog {
-      spark.read.parquet(absManifestPath)
-        .where(col("content_type") === AMTSingleAction.ContentType.Type.Data)
-        .groupBy(col("tracking.status").as("status")).count()
+    withManifestDataEntries(Seq(absManifestPath)) { entries =>
+      entries.groupBy(col("tracking.status").as("status")).count()
         .as[(Int, Long)].collect().toMap
     }
 
@@ -113,10 +111,8 @@ abstract class AMTIncrementalWriteTestBase extends AMTCheckpointTestBase {
    * `tracking.status`. Lets a test assert *which* file carries each status, not just the counts.
    */
   protected def trackingStatusToLocationsMap(absManifestPath: String): Map[Int, Set[String]] =
-    allowReadWithinDeltaLog {
-      spark.read.parquet(absManifestPath)
-        .where(col("content_type") === AMTSingleAction.ContentType.Type.Data)
-        .select(col("tracking.status").as("status"), col("location"))
+    withManifestDataEntries(Seq(absManifestPath)) { entries =>
+      entries.select(col("tracking.status").as("status"), col("location"))
         .as[(Int, String)].collect()
         .groupBy(_._1).map { case (status, rows) => status -> rows.map(_._2).toSet }
     }
@@ -137,7 +133,7 @@ abstract class AMTIncrementalWriteTestBase extends AMTCheckpointTestBase {
 
   /** The live AddFiles of a table's latest snapshot, for building real removes. */
   protected def liveAddFilesInLatestSnapshot(deltaLog: DeltaLog): Seq[AddFile] =
-    deltaLog.update().allFiles.collect().toSeq
+    liveAddFiles(deltaLog.update())
 
   /**
    * The leaf-resident live files of the AMT table grouped by their leaf's relative location, read

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotSuite.scala
@@ -1270,7 +1270,7 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
 
   /** Maps a leaf's parquet row positions to their entry `location`s (bypasses the format check). */
   private def leafPosToLoc(leaf: DataManifestEntry, tableRoot: Path): Map[Long, String] =
-    {
+    allowReadWithinDeltaLog {
       spark.read.parquet(leaf.getAbsolutePath(tableRoot).toString)
         .select(col("_metadata.row_index").as("pos"), col("location"))
         .as[(Long, String)].collect().toMap


### PR DESCRIPTION
## Description

Several AMT checkpoint test suites carried their own inline logic for reading
manifest DATA-entry rows and counting live leaf entries. This test-only change
routes those call sites through the shared helpers already provided by the
common AMT test base:

- `withManifestDataEntries(...)` for reading a manifest's DATA-entry rows.
- `leafLiveDataEntryCount(...)` for counting DATA entries across a provider's
  live leaves. This replaces the former `currentLeafDataEntries`, now an
  overload accepting either a `Snapshot` or an `AMTCheckpointProvider`.

Remaining direct manifest reads are wrapped consistently, and one call site now
reuses the existing `liveAddFiles` helper. No production code is changed.

## How was this patch tested?

Existing AMT checkpoint test suites (`AMTCheckpointWriteSuite`,
`AMTBackReferenceSuite`, `AMTSnapshotSuite`, `AMTIncrementalWriteInlineSuite`).

## Does this PR introduce any user-facing change?

No.
