### PR TITLE
[Spark] Stop metadata cleanup listing after retention checkpoint

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaHistoryManager.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaHistoryManager.scala
@@ -850,6 +850,7 @@ object DeltaHistoryManager extends DeltaLogging {
     private val maybeDeleteFiles = new mutable.ArrayBuffer[FileStatus]()
     private var lastFile: FileStatus = _
     private var hasNextCalled: Boolean = false
+    private var reachedLastDeletionBoundary: Boolean = false
     // A map to keep track of multi-part checkpoints.
     val checkpointMap = new scala.collection.mutable.HashMap[(Long, Int),
       collection.mutable.Buffer[FileStatus]]()
@@ -918,6 +919,7 @@ object DeltaHistoryManager extends DeltaLogging {
             flushBuffer()
             maybeDeleteFiles.append(currentFile)
             continueBuffering = false
+            reachedLastDeletionBoundary = versionGetter(currentFile.getPath) > maxVersion
           } else {
             // Multi-part checkpoint
             val mpKey = versionGetter(currentFile.getPath) -> numParts.get
@@ -929,6 +931,7 @@ object DeltaHistoryManager extends DeltaLogging {
               partBuffer.foreach(f => maybeDeleteFiles.append(f))
               checkpointMap.remove(mpKey)
               continueBuffering = false
+              reachedLastDeletionBoundary = versionGetter(currentFile.getPath) > maxVersion
             }
           }
         } else {
@@ -940,7 +943,11 @@ object DeltaHistoryManager extends DeltaLogging {
 
     override def hasNext: Boolean = {
       hasNextCalled = true
-      if (filesToDelete.isEmpty) queueFilesInBuffer()
+      // LogStore listings are ordered by path (and therefore version). Once a complete checkpoint
+      // beyond maxVersion has released the preceding buffer, no later file can be deleted. Avoid
+      // consuming the rest of a lazy/paginated listing; timestamps alone are not an early-exit
+      // condition because modification times are not guaranteed to be monotonic.
+      if (filesToDelete.isEmpty && !reachedLastDeletionBoundary) queueFilesInBuffer()
       filesToDelete.nonEmpty
     }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTimeTravelSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTimeTravelSuite.scala
@@ -313,6 +313,79 @@ class DeltaTimeTravelSuite extends QueryTest
     )
   }
 
+  test("BufferingLogDeletionIterator: stops listing after the retention checkpoint") {
+    def file(version: Long, timestamp: Long, checkpoint: Boolean = false): FileStatus = {
+      val path = if (checkpoint) {
+        FileNames.checkpointFileSingular(new Path("/foo"), version)
+      } else {
+        FileNames.unsafeDeltaFile(new Path("/foo"), version)
+      }
+      new FileStatus(10L, false, 1, 10L, timestamp, path)
+    }
+
+    def checkpointPart(version: Long, part: Int, numParts: Int, timestamp: Long): FileStatus = {
+      val path = FileNames.checkpointFileWithParts(new Path("/foo"), version, numParts)(part - 1)
+      new FileStatus(10L, false, 1, 10L, timestamp, path)
+    }
+
+    def assertDeletionAndConsumption(
+        files: Seq[FileStatus],
+        maxTimestamp: Long,
+        expectedDeletedVersions: Seq[Long],
+        expectedConsumed: Int): Unit = {
+      var consumed = 0
+      val countingIterator = files.iterator.map { fileStatus =>
+        consumed += 1
+        fileStatus
+      }
+      val iterator = new BufferingLogDeletionIterator(
+        countingIterator,
+        maxTimestamp,
+        maxVersion = 2,
+        versionGetter = FileNames.getFileVersion)
+
+      assert(iterator.map(f => FileNames.getFileVersion(f.getPath)).toSeq ===
+        expectedDeletedVersions)
+      assert(consumed === expectedConsumed)
+    }
+
+    val newerFiles = (4L to 10000L).map(version => file(version, timestamp = 200L))
+
+    // Nothing is expired, but the complete checkpoint still has to be inspected to establish
+    // that preceding commits are safe to retain without consuming the newer listing.
+    assertDeletionAndConsumption(
+      Seq(file(0, 100), file(1, 101), file(2, 102), file(3, 103, checkpoint = true)) ++
+        newerFiles,
+      maxTimestamp = 99,
+      expectedDeletedVersions = Nil,
+      expectedConsumed = 4)
+
+    // Timestamp adjustment is preserved: version 1 anchors version 2's adjusted timestamp. The
+    // checkpoint beyond maxVersion releases the buffer, and files after it cannot be deletable.
+    assertDeletionAndConsumption(
+      Seq(file(0, 5), file(1, 10), file(2, 8), file(3, 20, checkpoint = true)) ++ newerFiles,
+      maxTimestamp = 11,
+      expectedDeletedVersions = Seq(0, 1, 2),
+      expectedConsumed = 4)
+
+    // A multipart checkpoint becomes a stopping boundary only after all of its parts are present.
+    assertDeletionAndConsumption(
+      Seq(file(0, 5), file(1, 6), file(2, 7),
+        checkpointPart(3, 1, 2, 20), checkpointPart(3, 2, 2, 20)) ++ newerFiles,
+      maxTimestamp = 7,
+      expectedDeletedVersions = Seq(0, 1, 2),
+      expectedConsumed = 5)
+
+    // An incomplete checkpoint must not release preceding commits or establish an early-exit
+    // boundary. This intentionally consumes the listing to preserve checkpoint safety.
+    assertDeletionAndConsumption(
+      Seq(file(0, 5), file(1, 6), file(2, 7), checkpointPart(3, 1, 2, 20)) ++
+        newerFiles.take(10),
+      maxTimestamp = 7,
+      expectedDeletedVersions = Nil,
+      expectedConsumed = 14)
+  }
+
   test("BufferingLogDeletionIterator: " +
     "early exit while handling adjusted timestamps due to timestamp") {
     // only should return 5 because 5 < 7


### PR DESCRIPTION
## Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] All JVM projects relying on the Azure/Hadoop LogStore implementation

## Description

Related to #6531.

Metadata cleanup continued consuming the `_delta_log` listing after `BufferingLogDeletionIterator` processed the complete checkpoint beyond the maximum deletable version. At that point, all subsequent files are version-ineligible for deletion.

This change records that boundary and stops consuming the underlying iterator.

The stopping condition is based on ordered log versions. It does not assume that file modification timestamps are monotonic.

## Correctness

The existing timestamp-adjustment and checkpoint-buffering behavior remains unchanged. In particular:

- Files must still satisfy both the timestamp and version retention limits.
- Buffered commits are released only after a complete checkpoint is found.
- A multipart checkpoint becomes a stopping boundary only after all its parts have been observed.
- An incomplete multipart checkpoint does not release buffered commits or establish an early-exit boundary.
- Non-monotonic modification timestamps continue to use the existing timestamp adjustment behavior.
- Single-part and V2 checkpoints continue through the existing checkpoint path.
- Checksum, coordinated commit, unbackfilled commit, and sidecar cleanup logic is unchanged.

An incomplete multipart checkpoint does not establish an early-exit boundary.

## Performance

A deterministic regression test supplies more than 10,000 newer entries after the retention checkpoint.

For the nothing-expired and few-files-expired cases, the iterator consumes only the entries required to reach the complete checkpoint instead of consuming the entire synthetic listing.

## Hadoop and Azure follow-up

This change reduces work when `LogStore.listFrom` provides a genuinely lazy or paginated iterator.

The Hadoop and Azure implementations currently call `listStatus` and materialize/sort the directory contents before returning their iterator. Therefore, this patch does not eliminate the provider-level listing cost for those implementations.

Making Hadoop/Azure listing lazy requires preserving the public `LogStore.listFrom` contract that results are lexicographically sorted. Generic Hadoop `RemoteIterator` APIs do not provide that ordering guarantee. This broader provider/API design is left.

For this reason, this PR is related to #6531 but does not close it.

## Tests

The following focused tests passed:

- `DeltaTimeTravelSuite` filtered to `BufferingLogDeletionIterator`
  - 5 tests passed
  - 0 tests failed
- Existing incomplete multipart checkpoint cleanup test

A broader `DeltaRetentionSuite` run completed with 10 passing and 5 failing tests. The failures occurred during Windows `table_changes_by_path` validation after the relevant cleanup assertions:


## Does this PR introduce _any_ user-facing changes?

No. Metadata retention and deletion semantics are unchanged. The change only avoids consuming log-listing entries that cannot affect the cleanup result.
