### PR TITLE
[Kernel] Add PartitionKeyType to Transaction.getWriteContext for physical-keyed partition values

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/PartitionKeyType.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/PartitionKeyType.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel;
+
+import io.delta.kernel.annotation.Evolving;
+
+/**
+ * Indicates whether the partition-column keys of a {@code partitionValues} map are logical or
+ * physical column names.
+ */
+@Evolving
+public enum PartitionKeyType {
+  LOGICAL,
+  PHYSICAL
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Transaction.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Transaction.java
@@ -254,10 +254,8 @@ public interface Transaction {
   }
 
   /**
-   * Get the context for writing data into a table. The context tells the connector where the data
-   * should be written. For partitioned table context is generated per partition. So, the connector
-   * should call this API for each partition. For un-partitioned table, the context is same for all
-   * the data.
+   * Equivalent to {@link #getWriteContext(Engine, Row, Map, PartitionKeyType)} with {@link
+   * PartitionKeyType#LOGICAL}; {@code partitionValues} keys are logical partition column names.
    *
    * @param engine {@link Engine} instance to use.
    * @param transactionState The transaction state
@@ -269,6 +267,30 @@ public interface Transaction {
    */
   static DataWriteContext getWriteContext(
       Engine engine, Row transactionState, Map<String, Literal> partitionValues) {
+    return getWriteContext(engine, transactionState, partitionValues, PartitionKeyType.LOGICAL);
+  }
+
+  /**
+   * Get the context for writing data into a table. The context tells the connector where the data
+   * should be written. For partitioned table context is generated per partition. So, the connector
+   * should call this API for each partition. For un-partitioned table, the context is same for all
+   * the data.
+   *
+   * @param engine {@link Engine} instance to use.
+   * @param transactionState The transaction state
+   * @param partitionValues The partition values for the data, keyed per {@code partitionKeyType}.
+   *     If the table is un-partitioned, the map should be empty.
+   * @param partitionKeyType whether {@code partitionValues} keys are logical or physical partition
+   *     column names.
+   * @return {@link DataWriteContext} containing metadata about where and how the data for partition
+   *     should be written. The target directory and the returned partition-value keys use the
+   *     physical partition column names.
+   */
+  static DataWriteContext getWriteContext(
+      Engine engine,
+      Row transactionState,
+      Map<String, Literal> partitionValues,
+      PartitionKeyType partitionKeyType) {
     // Column mapping check removed from getWriteContext: connectors that handle column
     // name translation themselves (e.g. using Spark's Parquet writer instead of Kernel's)
     // only need the target directory and partition metadata from this method. The column
@@ -276,15 +298,18 @@ public interface Transaction {
     StructType tableSchema = getLogicalSchema(transactionState);
     List<String> partitionColNames = getPartitionColumnsList(transactionState);
 
-    partitionValues =
-        validateAndSanitizePartitionValues(tableSchema, partitionColNames, partitionValues);
-
-    // The on-disk partition directory and AddFile partition-value keys use physical names, so
-    // translate the column-name list and the value-map keys to physical.
     ColumnMapping.ColumnMappingMode mode = getColumnMappingMode(transactionState);
+    // The on-disk partition directory and AddFile partition-value keys use physical names.
+    // Validate in the caller's key space, then ensure the values are physically keyed.
+    partitionValues =
+        validateAndSanitizePartitionValues(
+            tableSchema, partitionColNames, partitionValues, partitionKeyType);
+    if (partitionKeyType == PartitionKeyType.LOGICAL) {
+      partitionValues =
+          PartitionUtils.toPhysicalPartitionValues(tableSchema, partitionValues, mode);
+    }
     partitionColNames =
         PartitionUtils.toPhysicalPartitionColNames(tableSchema, partitionColNames, mode);
-    partitionValues = PartitionUtils.toPhysicalPartitionValues(tableSchema, partitionValues, mode);
 
     String targetDirectory =
         getTargetDirectory(getTablePath(transactionState), partitionColNames, partitionValues);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/PartitionUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/PartitionUtils.java
@@ -24,6 +24,7 @@ import static io.delta.kernel.internal.util.Preconditions.checkArgument;
 import static io.delta.kernel.internal.util.SchemaUtils.casePreservingPartitionColNames;
 import static java.util.Arrays.asList;
 
+import io.delta.kernel.PartitionKeyType;
 import io.delta.kernel.data.*;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.engine.ExpressionHandler;
@@ -145,9 +146,9 @@ public class PartitionUtils {
   }
 
   /**
-   * Validate {@code partitionValues} contains values for every partition column in the table and
-   * the type of the value is correct. Once validated the partition values are sanitized to match
-   * the case of the partition column names in the table schema and returned
+   * Equivalent to {@link #validateAndSanitizePartitionValues(StructType, List, Map,
+   * PartitionKeyType)} with {@link PartitionKeyType#LOGICAL}; {@code partitionValues} keys are
+   * logical partition column names.
    *
    * @param tableSchema Schema of the table.
    * @param partitionColNames Partition column name. These should be from the table metadata that
@@ -159,13 +160,50 @@ public class PartitionUtils {
       StructType tableSchema,
       List<String> partitionColNames,
       Map<String, Literal> partitionValues) {
+    return validateAndSanitizePartitionValues(
+        tableSchema, partitionColNames, partitionValues, PartitionKeyType.LOGICAL);
+  }
 
-    if (!toLowerCaseSet(partitionColNames).equals(toLowerCaseSet(partitionValues.keySet()))) {
+  /**
+   * Validate {@code partitionValues} contains a value for every partition column and that each
+   * value's type matches its column, then return the values sanitized to the case of the partition
+   * column names.
+   *
+   * @param tableSchema Schema of the table.
+   * @param partitionColNames Logical partition column names, in the same case as in the table
+   *     schema.
+   * @param partitionValues Map of partition column to value given by the connector, keyed per
+   *     {@code partitionKeyType}.
+   * @param partitionKeyType Whether {@code partitionValues} keys are logical or physical column
+   *     names.
+   * @return Sanitized partition values, keyed per {@code partitionKeyType}.
+   */
+  public static Map<String, Literal> validateAndSanitizePartitionValues(
+      StructType tableSchema,
+      List<String> partitionColNames,
+      Map<String, Literal> partitionValues,
+      PartitionKeyType partitionKeyType) {
+
+    // Resolve the partition column names in partitionKeyType's name space, and the field for each
+    // name used to check the value's type.
+    List<String> expectedColNames = new ArrayList<>(partitionColNames.size());
+    Map<String, StructField> colNameToField = new HashMap<>();
+    for (String logicalName : partitionColNames) {
+      StructField field = tableSchema.get(logicalName);
+      String name =
+          partitionKeyType == PartitionKeyType.PHYSICAL
+              ? ColumnMapping.getPhysicalName(field)
+              : logicalName;
+      expectedColNames.add(name);
+      colNameToField.put(name, field);
+    }
+
+    if (!toLowerCaseSet(expectedColNames).equals(toLowerCaseSet(partitionValues.keySet()))) {
       throw new IllegalArgumentException(
           String.format(
               "Partition values provided are not matching the partition columns. "
                   + "Partition columns: %s, Partition values: %s",
-              partitionColNames, partitionValues));
+              expectedColNames, partitionValues));
     }
 
     // Convert the partition column names in given `partitionValues` to schema case. Schema
@@ -175,7 +213,7 @@ public class PartitionUtils {
     // (`partitionValues` in `AddFile`) or generating the target directory for writing the
     // data belonging to a partition.
     Map<String, Literal> schemaCasePartitionValues =
-        casePreservingPartitionColNames(partitionColNames, partitionValues);
+        casePreservingPartitionColNames(expectedColNames, partitionValues);
 
     // validate types are the same
     schemaCasePartitionValues
@@ -184,7 +222,7 @@ public class PartitionUtils {
             entry -> {
               String partColName = entry.getKey();
               Literal partValue = entry.getValue();
-              StructField partColField = tableSchema.get(partColName);
+              StructField partColField = colNameToField.get(partColName);
 
               // this shouldn't happen as we have already validated the partition column names
               checkArgument(

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/TransactionSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/TransactionSuite.scala
@@ -21,6 +21,7 @@ import java.util.Optional
 
 import scala.collection.JavaConverters._
 
+import io.delta.kernel.PartitionKeyType
 import io.delta.kernel.Transaction.{generateAppendActions, getWriteContext, transformLogicalData}
 import io.delta.kernel.data._
 import io.delta.kernel.exceptions.KernelException
@@ -156,6 +157,71 @@ class TransactionSuite extends AnyFunSuite with VectorTestUtils with MockEngineU
         ctx.asInstanceOf[DataWriteContextImpl].getPartitionValues.keySet().asScala
       assert(partitionKeys === Set("col-state", "col-country"))
     }
+  }
+
+  Seq("name", "id").foreach { cmMode =>
+    test(s"getWriteContext: PHYSICAL keys used as-is on column-mapped table: cmMode=$cmMode") {
+      // Physical keys are used as-is: same physical target dir and keys as the LOGICAL path.
+      val ctx = getWriteContext(
+        mockEngine(),
+        testTxnState(columnMappedPartitionSchema, testPartitionColNames, cmMode = cmMode),
+        Map(
+          "col-state" -> Literal.ofString("CA"),
+          "col-country" -> Literal.ofString("USA")).asJava,
+        PartitionKeyType.PHYSICAL)
+
+      assert(ctx.getTargetDirectory.endsWith("/col-state=CA/col-country=USA"))
+      val partitionKeys =
+        ctx.asInstanceOf[DataWriteContextImpl].getPartitionValues.keySet().asScala
+      assert(partitionKeys === Set("col-state", "col-country"))
+    }
+  }
+
+  test("getWriteContext: PHYSICAL rejects a value whose type mismatches the column") {
+    val e = intercept[IllegalArgumentException] {
+      getWriteContext(
+        mockEngine(),
+        testTxnState(columnMappedPartitionSchema, testPartitionColNames, cmMode = "name"),
+        Map(
+          "col-state" -> Literal.ofInt(5), // state is StringType
+          "col-country" -> Literal.ofString("USA")).asJava,
+        PartitionKeyType.PHYSICAL)
+    }
+    assert(
+      e.getMessage ===
+        "Partition column col-state is of type string but the value provided is of type integer")
+  }
+
+  test("getWriteContext: PHYSICAL rejects an unknown physical partition column") {
+    val e = intercept[IllegalArgumentException] {
+      getWriteContext(
+        mockEngine(),
+        testTxnState(columnMappedPartitionSchema, testPartitionColNames, cmMode = "name"),
+        Map(
+          "col-bogus" -> Literal.ofString("CA"),
+          "col-country" -> Literal.ofString("USA")).asJava,
+        PartitionKeyType.PHYSICAL)
+    }
+    assert(
+      e.getMessage ===
+        "Partition values provided are not matching the partition columns. " +
+        "Partition columns: [col-state, col-country], " +
+        "Partition values: {col-bogus=CA, col-country=USA}")
+  }
+
+  test("getWriteContext: PHYSICAL rejects a missing partition column") {
+    val e = intercept[IllegalArgumentException] {
+      getWriteContext(
+        mockEngine(),
+        testTxnState(columnMappedPartitionSchema, testPartitionColNames, cmMode = "name"),
+        Map("col-state" -> Literal.ofString("CA")).asJava, // missing col-country
+        PartitionKeyType.PHYSICAL)
+    }
+    assert(
+      e.getMessage ===
+        "Partition values provided are not matching the partition columns. " +
+        "Partition columns: [col-state, col-country], " +
+        "Partition values: {col-state=CA}")
   }
 
   withIcebergCompatVersions("generateAppendActions: iceberg comaptibily checks") {


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [X] Kernel

## Description

Adds an overload `Transaction.getWriteContext(engine, txnState, partitionValues, PartitionKeyType)`
and a new public enum `PartitionKeyType { LOGICAL, PHYSICAL }` that selects whether `partitionValues`
is keyed by logical or physical (column-mapping) partition column names. The existing 3-arg
`getWriteContext` delegates with `LOGICAL`, so current behavior is unchanged.

Why: connectors that write column-mapped data with their own writer (e.g. Spark) — rather than
Kernel's `transformLogicalData`, which still blocks column-mapped writes — already hold partition
values keyed by *physical* names and only use `getWriteContext` for the target directory and
partition metadata. `PHYSICAL` lets them pass those directly: the values are validated against the
schema and used as-is, with no logical<->physical round-trip.

`PartitionUtils.validateAndSanitizePartitionValues` gains a matching `PartitionKeyType` overload so
both key spaces share one completeness + case + type-compatibility check.

## How was this patch tested?

New unit tests in `TransactionSuite`: `PHYSICAL` keys produce the same physical target directory and
partition-value keys as `LOGICAL` (column mapping `name` and `id`), plus negative cases — value/column
type mismatch, unknown physical column, and missing partition column. Existing logical-path suites
(`TransactionSuite`, `PartitionUtilsSuite`, `DeltaTableWritesSuite`) pass unchanged.

## Does this PR introduce _any_ user-facing changes?

Yes — additive, non-breaking Kernel API: a new `@Evolving` `PartitionKeyType` enum and a new
`Transaction.getWriteContext` overload. Existing signatures and behavior are unchanged.
