### PR TITLE
[Spark] Make deltaAssert accept a DeltaLoggingProvider

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommandBase.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommandBase.scala
@@ -499,7 +499,7 @@ trait MergeIntoCommandBase extends LeafRunnableCommand
       name = "merge.sourceCachedAfterMaterializationStep",
       msg = "Cached source plans must be materialized in MERGE but the source only got cached " +
         "after the decision to materialize was taken.",
-      deltaLog = targetDeltaLog
+      provider = targetDeltaLog
     )
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/metering/DeltaLogging.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/metering/DeltaLogging.scala
@@ -30,7 +30,6 @@ import com.databricks.spark.util.TagDefinitions.{
   TAG_TAHOE_ID,
   TAG_TAHOE_PATH
 }
-import org.apache.spark.sql.delta.DeltaLog
 import org.apache.spark.sql.delta.SnapshotDescriptor
 import org.apache.spark.sql.delta.actions.Metadata
 import org.apache.spark.sql.delta.logging.DeltaLogKeys
@@ -155,7 +154,7 @@ trait DeltaLogging
       check: => Boolean,
       name: String,
       msg: String,
-      deltaLog: DeltaLog = null,
+      provider: DeltaLoggingProvider = null,
       data: AnyRef = null,
       path: Option[Path] = None)
     : Unit = {
@@ -163,7 +162,7 @@ trait DeltaLogging
       assert(check, msg)
     } else if (!check) {
       recordDeltaEvent(
-        provider = deltaLog,
+        provider = provider,
         opType = s"delta.assertions.$name",
         data = data,
         path = path


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Follow-up to #6742: recordDeltaEvent / recordDeltaOperation were switched to take a DeltaLoggingProvider, but deltaAssert still took a DeltaLog and forwarded it as the provider. Have deltaAssert accept a DeltaLoggingProvider directly, update the one named-arg call site, and drop the now-unused DeltaLog import.

## How was this patch tested?

This should be verifiable by CI compiling.

## Does this PR introduce _any_ user-facing changes?

No.