### PR TITLE
Move hard-coded messages of DELTA_UNIVERSAL_FORMAT_CONVERSION_FAILED into error subclasses

### DIFF
--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergTransactionUtils.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergTransactionUtils.scala
@@ -218,8 +218,8 @@ object IcebergTransactionUtils
             getMicrosSinceEpoch(utcInstant)
         }
       case _ =>
-        throw DeltaErrors.universalFormatConversionFailedException(
-          version, "iceberg", "Unexpected partition data type " + elemType)
+        throw DeltaErrors.universalFormatConversionFailedUnexpectedPartitionDataTypeException(
+          version, "iceberg", elemType)
     }
   }
 

--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -3189,8 +3189,21 @@
   },
   "DELTA_UNIVERSAL_FORMAT_CONVERSION_FAILED" : {
     "message" : [
-      "Failed to convert the table version <version> to the universal format <format>. <message>"
+      "Failed to convert the table version <version> to the universal format <format>."
     ],
+    "subClass" : {
+      "CAUSED_BY_ERROR" : {
+        "message" : [
+          "<causeErrorMessage>",
+          ""
+        ]
+      },
+      "UNEXPECTED_PARTITION_DATA_TYPE" : {
+        "message" : [
+          "Unexpected partition data type <dataType>."
+        ]
+      }
+    },
     "sqlState" : "KD00E"
   },
   "DELTA_UNIVERSAL_FORMAT_VIOLATION" : {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -37,6 +37,7 @@ import org.apache.spark.sql.delta.schema.{DeltaInvariantViolationException, Inva
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.JsonUtils
 import io.delta.exceptions
+import org.apache.commons.lang3.exception.ExceptionUtils
 import org.apache.hadoop.fs.{ChecksumException, Path}
 
 import org.apache.spark.{SparkConf, SparkEnv, SparkException, SparkThrowable}
@@ -3987,10 +3988,20 @@ trait DeltaErrorsBase
   def universalFormatConversionFailedException(
       failedOnCommitVersion: Long,
       format: String,
-      errorMessage: String): Throwable = {
+      error: Throwable): Throwable = {
     new DeltaRuntimeException(
-      errorClass = "DELTA_UNIVERSAL_FORMAT_CONVERSION_FAILED",
-      messageParameters = Array(s"$failedOnCommitVersion", format, errorMessage)
+      errorClass = "DELTA_UNIVERSAL_FORMAT_CONVERSION_FAILED.CAUSED_BY_ERROR",
+      messageParameters = Array(s"$failedOnCommitVersion", format, ExceptionUtils.getMessage(error))
+    ).initCause(error)
+  }
+
+  def universalFormatConversionFailedUnexpectedPartitionDataTypeException(
+      failedOnCommitVersion: Long,
+      format: String,
+      dataType: DataType): Throwable = {
+    new DeltaRuntimeException(
+      errorClass = "DELTA_UNIVERSAL_FORMAT_CONVERSION_FAILED.UNEXPECTED_PARTITION_DATA_TYPE",
+      messageParameters = Array(s"$failedOnCommitVersion", format, dataType.toString)
     )
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/hooks/IcebergConverterHook.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/hooks/IcebergConverterHook.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql.delta.hooks
 import org.apache.spark.sql.delta.{CommittedTransaction, DeltaErrors, UniversalFormat, UniversalFormatConverter}
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.sources.DeltaSQLConf.DELTA_UNIFORM_ICEBERG_SYNC_CONVERT_ENABLED
-import org.apache.commons.lang3.exception.ExceptionUtils
 
 import org.apache.spark.sql.SparkSession
 
@@ -48,7 +47,7 @@ trait IcebergConverterHook extends PostCommitHook with DeltaLogging {
   override def handleError(spark: SparkSession, error: Throwable, version: Long): Unit = {
     logError(error.getMessage, error)
     throw DeltaErrors.universalFormatConversionFailedException(
-      version, "iceberg", ExceptionUtils.getMessage(error))
+      version, "iceberg", error)
   }
 
   def triggerIcebergConversion(


### PR DESCRIPTION
## Description

The `DELTA_UNIVERSAL_FORMAT_CONVERSION_FAILED` error class took a free-text `message` parameter whose value was hard-coded English assembled in Scala. Injecting message text through a parameter makes the error hard to audit and impossible to localize.

This reshapes the error class so that all message text lives in `delta-error-classes.json`. The parent message keeps only the `version` and `format` parameters, and each distinct case becomes a subclass:

- `CAUSED_BY_ERROR` — carries the message of the underlying exception that caused the conversion to fail (used by the Iceberg conversion hook).
- `UNEXPECTED_PARTITION_DATA_TYPE` — carries the unsupported partition column data type.

`universalFormatConversionFailedException` now takes the causing `Throwable` (rendering its message via `ExceptionUtils.getMessage` and setting it as the exception cause), and a new `universalFormatConversionFailedUnexpectedPartitionDataTypeException` takes the `DataType`. The `sqlState` (`KD00E`) is unchanged.

## How was this patch tested?

Existing tests. The error-classes JSON structure is validated by `DeltaThrowableSuite`.

## Does this PR introduce _any_ user-facing changes?

Errors previously reported under the condition `DELTA_UNIVERSAL_FORMAT_CONVERSION_FAILED` are now reported under a subclass (`DELTA_UNIVERSAL_FORMAT_CONVERSION_FAILED.<SUBCLASS>`). The `SQLSTATE` (`KD00E`) and the situations that raise each error are unchanged; the rendered message text is materially the same.
