### PR TITLE
[Storage] Synchronize local HDFS log writes across instances

### DIFF
--- a/flink/src/test/java/io/delta/flink/table/AbstractKernelTableTest.java
+++ b/flink/src/test/java/io/delta/flink/table/AbstractKernelTableTest.java
@@ -384,6 +384,8 @@ class AbstractKernelTableTest extends TestHelper {
           CyclicBarrier snapshotBarrier = new CyclicBarrier(2);
           ExecutorService executor = Executors.newFixedThreadPool(2);
 
+          // Concurrent commits use separate HDFSLogStore instances, exercising cross-instance
+          // locking.
           try (BarrierLocalFileSystemTable first =
                   new BarrierLocalFileSystemTable(
                       dir.toURI(), properties, initialSchema, snapshotBarrier);

--- a/storage/src/main/java/io/delta/storage/HDFSLogStore.java
+++ b/storage/src/main/java/io/delta/storage/HDFSLogStore.java
@@ -42,6 +42,7 @@ import org.slf4j.LoggerFactory;
  */
 public class HDFSLogStore extends HadoopFileSystemLogStore {
     private static final Logger LOG = LoggerFactory.getLogger(HDFSLogStore.class);
+    private static final Object LOCAL_FS_WRITE_LOCK = new Object();
     public static final String NO_ABSTRACT_FILE_SYSTEM_EXCEPTION_MESSAGE = "No AbstractFileSystem";
 
     public HDFSLogStore(Configuration hadoopConf) {
@@ -58,8 +59,9 @@ public class HDFSLogStore extends HadoopFileSystemLogStore {
         if (isLocalFs) {
             // We need to add `synchronized` for RawLocalFileSystem as its rename will not throw an
             // exception when the target file exists. Hence we must make sure `exists + rename` in
-            // `writeInternal` for RawLocalFileSystem is atomic in our tests.
-            synchronized(this) {
+            // `writeInternal` for RawLocalFileSystem is atomic across log store instances in our
+            // tests.
+            synchronized(LOCAL_FS_WRITE_LOCK) {
                 writeInternal(path, actions, overwrite, hadoopConf);
             }
         } else {


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [x] Flink
- [ ] Kernel
- [x] Other (Delta Storage)

## Description

Every Delta commit has a version number. Only one writer can commit a specific version. For example, if one writer commits version 2, another writer must not also commit version 2. The other writer must detect a conflict.

HDFSLogStore writes a commit in two steps:

1. Check that the file for the new version does not exist.
2. Rename a temporary file to the new version file.

RawLocalFileSystem can replace the target file during a rename. Therefore, HDFSLogStore must hold one lock during both steps.

### What was wrong?

Before this change, each HDFSLogStore object had its own lock. Two Flink table updates can use two different HDFSLogStore objects. Thus, the two updates also used two different locks. The locks did not block each other.

This race could occur:

1. Writer A checks for version 2. The file does not exist.
2. Writer B checks for version 2. The file still does not exist.
3. Writer A writes version 2.
4. Writer B replaces the same version 2 file.
5. Both writers report success.

Only one version 2 file remains. One writer loses its schema change, but it still reports success.

This race caused the test error: expected 1 but was 0. The test starts two different schema updates. One update must fail with a conflict. The test found zero failures because both updates reported success.

### How does this change fix the problem?

This change uses one static lock for all HDFSLogStore objects that use RawLocalFileSystem.

Writer A now holds the shared lock while it checks and writes version 2. Writer B must wait. When Writer B gets the lock, it finds the version 2 file and detects the conflict.

This change does not affect HDFS writes. The Flink regression test also states that it uses separate HDFSLogStore objects.

## How was this patch tested?

- Ran AbstractKernelTableTest.testConcurrentSchemaUpdatesDoNotMergeDifferentTargets 20 times with Flink 2.3.0. All 20 runs passed.
- Ran all 24 tests in AbstractKernelTableTest with Flink 2.3.0. All tests passed.
- Ran all Flink 2.3.0 tests. All tests passed.
- Ran the Flink Java format checks. All checks passed.
- Generated the Flink API documentation. The command passed.

## Does this PR introduce _any_ user-facing changes?

No.
