### PR TITLE
[Spark] Add KernelContext for deferred Hadoop configuration

### DIFF
--- a/spark/v2/src/main/scala/io/delta/spark/internal/v2/KernelContext.scala
+++ b/spark/v2/src/main/scala/io/delta/spark/internal/v2/KernelContext.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.spark.internal.v2
+
+import org.apache.spark.sql.SparkSession
+
+/**
+ * Immutable, cache-safe value for deferred Hadoop configuration materialization.
+ *
+ * It retains only session-invariant filesystem options. When filesystem I/O begins, it binds those
+ * options to the active Spark session so session-derived settings and credentials are not retained
+ * by reusable connector state.
+ */
+private[v2] final class KernelContext(val sessionInvariantFsOptions: Map[String, String]) {
+  require(sessionInvariantFsOptions != null, "sessionInvariantFsOptions must not be null")
+
+  private[v2] def materializeHadoopConf() =
+    SparkSession.active.sessionState.newHadoopConfWithOptions(sessionInvariantFsOptions)
+}
+
+private[v2] object KernelContext {
+  val empty: KernelContext = new KernelContext(Map.empty)
+
+  def apply(): KernelContext = empty
+
+  def apply(sessionInvariantFsOptions: Map[String, String]): KernelContext = {
+    require(sessionInvariantFsOptions != null, "sessionInvariantFsOptions must not be null")
+    if (sessionInvariantFsOptions.isEmpty) empty else new KernelContext(sessionInvariantFsOptions)
+  }
+}

--- a/spark/v2/src/test/scala/io/delta/spark/internal/v2/KernelContextSuite.scala
+++ b/spark/v2/src/test/scala/io/delta/spark/internal/v2/KernelContextSuite.scala
@@ -1,0 +1,119 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.spark.internal.v2
+
+import java.util.concurrent.FutureTask
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.test.SharedSparkSession
+
+class KernelContextSuite extends SparkFunSuite with SharedSparkSession {
+
+  private val hadoopConfKey = "kernel.context.test"
+  private val invariantHadoopConfKey = "kernel.context.invariant.test"
+
+  test("an empty context uses the active session Hadoop configuration") {
+    withSQLConf(hadoopConfKey -> "session-value") {
+      assert(KernelContext.empty.materializeHadoopConf().get(hadoopConfKey) == "session-value")
+    }
+  }
+
+  test("session-invariant filesystem options override the active session configuration") {
+    withSQLConf(hadoopConfKey -> "session-value") {
+      val context = KernelContext(Map(hadoopConfKey -> "context-value"))
+
+      assert(context.materializeHadoopConf().get(hadoopConfKey) == "context-value")
+    }
+  }
+
+  test("materializeHadoopConf resolves the active Spark session on every call") {
+    val originalSession = SparkSession.active
+    val otherSession = spark.newSession()
+    originalSession.conf.set(hadoopConfKey, "original-session")
+    otherSession.conf.set(hadoopConfKey, "other-session")
+    val context = KernelContext.empty
+
+    try {
+      SparkSession.setActiveSession(originalSession)
+      assert(context.materializeHadoopConf().get(hadoopConfKey) == "original-session")
+
+      SparkSession.setActiveSession(otherSession)
+      assert(context.materializeHadoopConf().get(hadoopConfKey) == "other-session")
+    } finally {
+      SparkSession.setActiveSession(originalSession)
+      originalSession.conf.unset(hadoopConfKey)
+      otherSession.conf.unset(hadoopConfKey)
+    }
+  }
+
+  test("child threads inherit the active session without changing the shared KernelContext") {
+    val originalSession = SparkSession.active
+    val sessionA = spark.newSession()
+    val sessionB = spark.newSession()
+    val invariantOptions = Map(invariantHadoopConfKey -> "context-value")
+    val context = KernelContext(invariantOptions)
+
+    try {
+      sessionA.conf.set(hadoopConfKey, "session-a")
+      SparkSession.setActiveSession(sessionA)
+      val parentAConf = context.materializeHadoopConf()
+      val childATask = new FutureTask[(SparkSession, String, String)](() => {
+        val hadoopConf = context.materializeHadoopConf()
+        (SparkSession.active, hadoopConf.get(hadoopConfKey), hadoopConf.get(invariantHadoopConfKey))
+      })
+      new Thread(childATask).start()
+      val (childASession, childASessionValue, childAInvariantValue) = childATask.get()
+
+      assert(childASession eq sessionA)
+      assert(childASessionValue == parentAConf.get(hadoopConfKey))
+      assert(childAInvariantValue == parentAConf.get(invariantHadoopConfKey))
+
+      sessionB.conf.set(hadoopConfKey, "session-b")
+      SparkSession.setActiveSession(sessionB)
+      val parentBConf = context.materializeHadoopConf()
+      val childBTask = new FutureTask[(SparkSession, String, String)](() => {
+        val hadoopConf = context.materializeHadoopConf()
+        (SparkSession.active, hadoopConf.get(hadoopConfKey), hadoopConf.get(invariantHadoopConfKey))
+      })
+      new Thread(childBTask).start()
+      val (childBSession, childBSessionValue, childBInvariantValue) = childBTask.get()
+
+      assert(childBSession eq sessionB)
+      assert(childBSessionValue == parentBConf.get(hadoopConfKey))
+      assert(childBSessionValue != childASessionValue)
+      assert(childBInvariantValue == parentBConf.get(invariantHadoopConfKey))
+      assert(childBInvariantValue == childAInvariantValue)
+      assert(context.sessionInvariantFsOptions == invariantOptions)
+    } finally {
+      SparkSession.setActiveSession(originalSession)
+      sessionA.conf.unset(hadoopConfKey)
+      sessionB.conf.unset(hadoopConfKey)
+    }
+  }
+
+  test("constructing a context with null session-invariant filesystem options throws") {
+    Seq[() => KernelContext](
+      () => new KernelContext(null),
+      () => KernelContext(null)).foreach { createContext =>
+      val error = intercept[IllegalArgumentException] {
+        createContext()
+      }
+      assert(error.getMessage == "requirement failed: sessionInvariantFsOptions must not be null")
+    }
+  }
+}


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Adds an immutable `KernelContext` that retains session-invariant filesystem options and
materializes a Hadoop configuration from the active Spark session when needed.

This prevents reusable connector state from retaining session-specific settings or credentials.

## How was this patch tested?

- Added direct configuration-overlay and active-session tests.
- Added child-thread tests for inherited active sessions.
- `build/sbt sparkV2/compile`

## Does this PR introduce _any_ user-facing changes?

No.
