### PR TITLE
[Spark] Preserve catalog table in DeltaV2Snapshot

### DIFF
--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/v2/interop/DeltaV2SnapshotSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/v2/interop/DeltaV2SnapshotSuite.scala
@@ -27,6 +27,9 @@ import io.delta.kernel.TableManager
 import io.delta.kernel.engine.Engine
 import io.delta.kernel.internal.{SnapshotImpl => KernelSnapshot}
 
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTable, CatalogTableType}
+
 /**
  * Tests for [[DeltaV2Snapshot]] focusing on the construction surface that is wired to the
  * underlying Kernel snapshot: `path` / `version`, the data members read from Kernel
@@ -64,6 +67,23 @@ class DeltaV2SnapshotSuite extends DeltaSQLCommandTest {
       val snapshot2 = new DeltaV2Snapshot(kernelSnapshot2)
       assert(snapshot2.version === 2L)
       assert(snapshot2.version === kernelSnapshot2.getVersion)
+    }
+  }
+
+  test("catalog table is preserved when provided") {
+    withTempDir { dir =>
+      val path = dir.getCanonicalPath
+      spark.range(1).write.format("delta").save(path)
+      val kernelSnapshot = loadKernelSnapshot(path)
+      val catalogTable = CatalogTable(
+        identifier = TableIdentifier("test_table"),
+        tableType = CatalogTableType.EXTERNAL,
+        storage = CatalogStorageFormat.empty.copy(locationUri = Some(dir.toURI)),
+        schema = spark.range(0).schema)
+
+      assert(new DeltaV2Snapshot(kernelSnapshot).catalogTable.isEmpty)
+      assert(new DeltaV2Snapshot(kernelSnapshot, Some(catalogTable)).catalogTable.contains(
+        catalogTable))
     }
   }
 

--- a/spark/v2/src/main/scala/org/apache/spark/sql/delta/v2/interop/DeltaV2Snapshot.scala
+++ b/spark/v2/src/main/scala/org/apache/spark/sql/delta/v2/interop/DeltaV2Snapshot.scala
@@ -21,17 +21,18 @@ import scala.jdk.OptionConverters._
 
 import io.delta.kernel.engine.Engine
 import io.delta.kernel.internal.{SnapshotImpl => KernelSnapshot}
-import org.apache.spark.sql.delta.v2.kernel.KernelActionUtils
 import io.delta.spark.internal.v2.kernel.KernelEngineFactory
 
 import org.apache.spark.sql.delta.{CheckpointProvider, DeltaColumnMappingMode, DeltaLogFileIndex, Snapshot, VersionChecksum}
 import org.apache.spark.sql.delta.actions.{AddFile, DomainMetadata, Metadata, Protocol, RemoveFile, SingleAction}
 import org.apache.spark.sql.delta.coordinatedcommits.TableCommitCoordinatorClient
 import org.apache.spark.sql.delta.stats.{DeltaStatsColumnSpec, FileSizeHistogram, StatisticsCollection}
+import org.apache.spark.sql.delta.v2.kernel.KernelActionUtils
 
 import com.databricks.spark.util.TagDefinition
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.{DataFrame, Dataset}
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
 
 /**
  * A [[Snapshot]] backed by a Delta Kernel snapshot, for the v2 Connector. It extends the V1
@@ -59,6 +60,15 @@ class DeltaV2Snapshot(
       logSegment = null,
       deltaLog = null,
       checksumOpt = None) {
+
+  private[this] var resolvedCatalogTableOpt: Option[CatalogTable] = None
+
+  def this(
+      kernelSnapshot: KernelSnapshot,
+      catalogTableOpt: Option[CatalogTable]) = {
+    this(kernelSnapshot)
+    resolvedCatalogTableOpt = catalogTableOpt
+  }
 
   // scalastyle:off deltahadoopconfiguration
   private def kernelEngine: Engine =
@@ -112,6 +122,8 @@ class DeltaV2Snapshot(
   // This snapshot has no DeltaLog from which to derive usage-log tags, so emit none.
   override def getCommonTags: Map[TagDefinition, String] = Map.empty
 
+  // The catalog table this snapshot was resolved from, if the connector supplied one.
+  def catalogTable: Option[CatalogTable] = Option(resolvedCatalogTableOpt).flatten
   // --- SnapshotDescriptor / state surface ----------------------------------------------------
 
   override lazy val metadata: Metadata =


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Allow `DeltaV2Snapshot` to retain an optional `CatalogTable` supplied at construction time and
expose it through `catalogTable`. This preserves resolved catalog context for consumers of
Kernel-backed snapshots.

## How was this patch tested?

- Added a regression test covering snapshots constructed with and without catalog metadata.
- Applied Scalafmt to the changed `DeltaV2Snapshot` source. The full module format check currently
  also reports three unchanged files from `master`; none are part of this pull request.
- Full test execution is delegated to pull-request CI.

## Does this PR introduce _any_ user-facing changes?

No.