### PR TITLE
Resolve the inherited file sequence number in the AMT reader

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTCheckpointProvider.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTCheckpointProvider.scala
@@ -63,8 +63,13 @@ final class AMTCheckpointProvider(
 
   /** The live leaf pointers which must have all the live [[DataEntry]]s. */
   private lazy val liveLeaves: Seq[DataManifestEntry] =
-    leaves.filter(l =>
-      AMTCheckpointProvider.liveDataManifestEntryStatuses.contains(l.tracking.status))
+    leaves.filter(l => Tracking.Status.liveEntryStatuses.contains(l.tracking.status))
+
+  /** The tracking to inherit from. */
+  private lazy val parentTrackingByManifestPath: Map[String, InheritableTracking] =
+    liveLeaves.map { leaf =>
+      SparkPath.fromPath(leaf.getAbsolutePath(tableRoot)).urlEncoded -> InheritableTracking(leaf)
+    }.toMap
 
   /** Absolute [[Path]]s to the live leaf manifest parquet files, resolved against the root. */
   lazy val liveLeafManifestAbsolutePaths: Seq[Path] = liveLeaves.map(_.getAbsolutePath(tableRoot))
@@ -119,10 +124,6 @@ final class AMTCheckpointProvider(
    * The full action set of this checkpoint as a distributed [[Dataset]] of [[SingleAction]]: the
    * live file `AddFile`s reconstructed from the AMT(root + leaves), unioned with the inline
    * non-content actions (protocol, metadata, domain metadata, txns) built on the driver.
-   *
-   * Note: Iceberg metadata inheritance (manifest entries inheriting fields such as partition
-   * values, sequence numbers, or snapshot id from the parent manifest) is not supported yet;
-   * entries are read as fully materialized rows.
    */
   private def allActions(spark: SparkSession, deltaLog: DeltaLog): Dataset[SingleAction] = {
     import org.apache.spark.sql.delta.implicits._
@@ -144,11 +145,12 @@ final class AMTCheckpointProvider(
   private def liveAddSingleActions(
       spark: SparkSession, deltaLog: DeltaLog): Dataset[SingleAction] = {
     import org.apache.spark.sql.delta.implicits._
-    // Bind to a local so the `mapPartitions` closure captures it, not the (non-serializable)
+    // Bind to locals so the `mapPartitions` closure captures them, not the (non-serializable)
     // provider.
     val localTableRoot = tableRoot
     val encodedRootPath = SparkPath.fromPath(rootManifestAbsolutePath).urlEncoded
     val serializableConf = new SerializableConfiguration(deltaLog.newDeltaHadoopConf())
+    val parentTracking = parentTrackingByManifestPath
 
     val files = rootFile +: liveLeafFiles
     val fmt = DeltaLogFileIndex.CHECKPOINT_FILE_FORMAT_PARQUET
@@ -165,8 +167,7 @@ final class AMTCheckpointProvider(
     val dataEntries = AMTCheckpointProvider.loadEntriesWithLocation(
       deltaLog, index, checkpointAction.metaData, checkpointAction.protocol)
       .where(col("entry.content_type") === lit(AMTSingleAction.ContentType.Type.Data))
-      .where(col("entry.tracking.status").isin(
-        AMTCheckpointProvider.liveDataEntryStatuses.toSeq: _*))
+      .where(col("entry.tracking.status").isin(Tracking.Status.liveEntryStatuses.toSeq: _*))
       .filter { entryWithLoc =>
         mdvBroadcast.value.get(entryWithLoc.leafPath)
           .forall(bytes => !RoaringBitmapArray.readFrom(bytes).contains(entryWithLoc.pos))
@@ -186,7 +187,16 @@ final class AMTCheckpointProvider(
                   AMTUtils.relativizeManifestPathToTableRoot(fs, localTableRoot, absLeaf)
                 Some(BackReference(relManifest, entryWithLoc.pos))
               }
-              val add = data.toAddFile(localTableRoot).copy(backReference = backReference)
+              // Root entries have nothing above them to inherit from, so they resolve against an
+              // empty parent.
+              val resolvedTracking = Tracking.resolve(
+                childTracking = data.tracking,
+                parentTracking =
+                  parentTracking.getOrElse(entryWithLoc.leafPath, InheritableTracking.none),
+                childEntryLocationForLogging = data.location)
+              val add = data.copy(tracking = resolvedTracking)
+                .toAddFile(localTableRoot)
+                .copy(backReference = backReference)
               SingleAction(add = add)
             case other => throw new IllegalStateException(
               s"Expected a DATA entry after filtering, got ${other.getClass.getSimpleName}.")
@@ -304,14 +314,6 @@ object AMTCheckpointProvider {
       tableRoot = tableRoot)
   }
 
-  /** Tracking Status representing the live [[DataEntry]] in an AMT. */
-  private[amt] val liveDataEntryStatuses: Set[Int] =
-    Set(Tracking.Status.Existing, Tracking.Status.Added, Tracking.Status.Modified)
-
-  /** All Tracking Status for leafs which may have any live files. */
-  private[amt] val liveDataManifestEntryStatuses: Set[Int] =
-    Set(Tracking.Status.Added, Tracking.Status.Existing, Tracking.Status.Modified)
-
   /** Reads the AMT root and returns the live [[DataEntry]]s tracked by root. */
   private[amt] def readLiveRootDataEntries(
       deltaLog: DeltaLog,
@@ -324,7 +326,7 @@ object AMTCheckpointProvider {
       .collect().toSeq
       .filter(_.content_type == AMTSingleAction.ContentType.Type.Data)
       .map(_.unwrap.asInstanceOf[DataEntry])
-      .filter(e => liveDataEntryStatuses.contains(e.tracking.status))
+      .filter(e => Tracking.Status.liveEntryStatuses.contains(e.tracking.status))
       .map(_.toAddFile(tableRoot))
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriteHelper.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriteHelper.scala
@@ -546,7 +546,7 @@ object AMTWriteHelper extends DeltaLogging {
   /**
    * Writes a sequence of AMTSingleActions to a Parquet file.
    */
-  private def writeAMTParquet(
+  private[amt] def writeAMTParquet(
       spark: SparkSession,
       hadoopConf: Configuration,
       finalPath: Path,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/actions.scala
@@ -496,7 +496,7 @@ case class DataEntry(
       stats = stats,
       deletionVector = dv,
       baseRowId = tracking.first_row_id,
-      defaultRowCommitVersion = tracking.sequence_number,
+      defaultRowCommitVersion = tracking.file_sequence_number,
       tags = tags.orNull,
       amtPassthrough = AMTPassthrough.fromDataEntry(this))
   }
@@ -513,7 +513,7 @@ object DataEntry {
       // rowTracking-enabled table can reconstruct them on read.
       tracking = tracking.copy(
         first_row_id = add.baseRowId,
-        sequence_number = add.defaultRowCommitVersion),
+        file_sequence_number = add.defaultRowCommitVersion),
       // Iceberg field 103 is the physical record count of the file, not the live/logical
       // count after deletes; throw rather than guess when the AddFile carries no stats.
       record_count = add.numPhysicalRecords.getOrElse(
@@ -768,6 +768,25 @@ case class Tracking(
     s"Unsupported tracking status: $status.")
 }
 
+/**
+ * A leaf manifest may be written before the commit version is assigned, so the tracking fields that
+ * depend on the commit could be written null. The root `DATA_MANIFEST` entry pointing at that
+ * leaf is written at commit time with explicit values, and a reader recovers each leaf entry's
+ * tracking by filling its nulls from that parent. This lets a leaf be written once and reused
+ * across commit retries, since only the root has to be rewritten.
+ *
+ * Every `status` named below is the child [[DataEntry]]'s status, not the parent
+ * `DATA_MANIFEST` entry's status. The inheritable fields are:
+ *
+ *  - `file_sequence_number` (4): inherited when null and the status is `ADDED`.
+ *  - `first_row_id` (142): inherited when null, whatever the status, but not by simply copying the
+ *    parent's value down. An entry takes the parent's `first_row_id` plus the summed
+ *    `record_count` of the entries physically before it in the same leaf that were themselves
+ *    null.
+ *
+ * The `ADDED` restriction keeps the file sequence number correct. Leaf entries with `EXISTING`
+ * status must have an explicit `file_sequence_number` instead of inheriting.
+ */
 object Tracking {
   /**
    * Closed set of `status` values, matching Iceberg V4 integer codes.
@@ -785,7 +804,98 @@ object Tracking {
     val Replaced: Int = 3
     val Modified: Int = 4
     val all: Set[Int] = Set(Existing, Added, Deleted, Replaced, Modified)
+
+    /**
+     * Statuses that keep an entry in the active table state, for both entry kinds: on a
+     * [[DataEntry]] the data file is still part of the table, and on a [[DataManifestEntry]] the
+     * leaf may still hold live [[DataEntry]]s, so a scan has to read it.
+     */
+    val liveEntryStatuses: Set[Int] = Set(Existing, Added, Modified)
+
+    /** The spec name of a `status` code, for error messages. */
+    def nameOf(status: Int): String = status match {
+      case Existing => "EXISTING"
+      case Added => "ADDED"
+      case Deleted => "DELETED"
+      case Replaced => "REPLACED"
+      case Modified => "MODIFIED"
+      case other => s"UNKNOWN($other)"
+    }
   }
+
+  /**
+   * Fills the null tracking fields of a leaf entry from the root `DATA_MANIFEST` entry that
+   * references its leaf.
+   *
+   * @param childTracking The leaf entry's tracking, as read off disk.
+   * @param parentTracking The inheritable values of the root entry referencing this leaf.
+   * @param childEntryLocationForLogging The child entry's `location`, used only to describe a
+   *                                     malformed entry.
+   */
+  def resolve(
+      childTracking: Tracking,
+      parentTracking: InheritableTracking,
+      childEntryLocationForLogging: String): Tracking = {
+    if (parentTracking.isEmpty) {
+      childTracking
+    } else {
+      val parentFileSequenceNumber = parentTracking.file_sequence_number.getOrElse(
+        throw new IllegalStateException(
+          "tracking.file_sequence_number must not be null in AMT root DATA_MANIFEST entries."))
+      childTracking.copy(
+        file_sequence_number = inheritFileSequenceNumberOnAdded(
+          fieldValueInChild = childTracking.file_sequence_number,
+          parentFileSequenceNumber = parentFileSequenceNumber,
+          dataEntryStatus = childTracking.status,
+          childEntryLocationForLogging = childEntryLocationForLogging))
+    }
+  }
+
+  /**
+   * Resolves `file_sequence_number`, which the child leaf entry inherits when its own status is
+   * `ADDED`.
+   */
+  private def inheritFileSequenceNumberOnAdded(
+      fieldValueInChild: Option[Long],
+      parentFileSequenceNumber: Long,
+      dataEntryStatus: Int,
+      childEntryLocationForLogging: String): Option[Long] =
+    fieldValueInChild.orElse {
+      if (dataEntryStatus == Status.Added) {
+        Some(parentFileSequenceNumber)
+      } else {
+        throw new IllegalStateException(
+          s"Malformed AMT data entry '$childEntryLocationForLogging': " +
+            "tracking.file_sequence_number is null " +
+            s"but the entry's status is ${Status.nameOf(dataEntryStatus)}. Only ADDED entries " +
+            "inherit a file sequence number from the root DATA_MANIFEST entry; every other " +
+            "status must materialize it.")
+      }
+    }
+}
+
+/**
+ * The subset of a root `DATA_MANIFEST` entry's [[Tracking]] that the entries of the leaf it
+ * points at can inherit.
+ *
+ * Projecting the parent down to these values keeps the per-leaf parent map small enough
+ * to capture in a scan closure.
+ *
+ * @param file_sequence_number Parent's file sequence number.
+ */
+case class InheritableTracking(file_sequence_number: Option[Long]) {
+
+  /** True when the parent declares no value that any child could inherit. */
+  def isEmpty: Boolean = file_sequence_number.isEmpty
+}
+
+object InheritableTracking {
+  /** A parent that supplies nothing. */
+  val none: InheritableTracking = InheritableTracking(None)
+
+  /** The inheritable projection of a root `DATA_MANIFEST` entry. */
+  def apply(parent: DataManifestEntry): InheritableTracking =
+    InheritableTracking(file_sequence_number = parent.tracking.file_sequence_number)
 }
 
 /**

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTIncrementalWriteTestBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTIncrementalWriteTestBase.scala
@@ -216,7 +216,7 @@ abstract class AMTIncrementalWriteTestBase extends AMTCheckpointTestBase {
         provider.checkpointAction.contentRoot.getAbsolutePath(provider.tableRoot).toString)
     val liveAdds =
       byStatus.filter { case (status, _) =>
-        AMTCheckpointProvider.liveDataEntryStatuses.contains(status) }.values.sum
+        Tracking.Status.liveEntryStatuses.contains(status) }.values.sum
     val tombstones = tombstoneTrackingStatuses.toSeq.map(byStatus.getOrElse(_, 0L)).sum
     (liveAdds, tombstones)
   }
@@ -440,8 +440,8 @@ abstract class AMTIncrementalWriteTestBase extends AMTCheckpointTestBase {
     val statusToCountMap = trackingStatusToAddFileCountMap(rootPath)
     val rootLiveAdds =
       statusToCountMap
-        .filter { case (status, _) =>
-          AMTCheckpointProvider.liveDataEntryStatuses.contains(status) }.values.sum
+        .filter { case (status, _) => Tracking.Status.liveEntryStatuses.contains(status) }
+        .values.sum
 
     // Leaves: each pointer's MDV must be internally consistent, and the unmasked LIVE entries are
     // the leaf's live contribution. A tombstone-only leaf (born ADDED but holding no live entry)
@@ -453,8 +453,7 @@ abstract class AMTIncrementalWriteTestBase extends AMTCheckpointTestBase {
         val statusToCountMapForLeaf = trackingStatusToAddFileCountMap(leafPath)
         val physicalEntries = statusToCountMapForLeaf.values.sum
         val livePhysicalEntries = statusToCountMapForLeaf
-          .filter { case (status, _) =>
-            AMTCheckpointProvider.liveDataEntryStatuses.contains(status) }
+          .filter { case (status, _) => Tracking.Status.liveEntryStatuses.contains(status) }
           .values.sum
         val mdvDeclaredCardinality = leaf.manifest_info.dv_cardinality.getOrElse(0L)
         val decoded =

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTInheritanceReadSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTInheritanceReadSuite.scala
@@ -1,0 +1,298 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.amt
+
+import org.apache.spark.sql.delta.DeltaLog
+import org.apache.spark.sql.delta.actions.{Checkpoint, ContentRoot}
+import org.apache.spark.sql.delta.implicits.amtSingleActionEncoder
+import org.apache.spark.sql.delta.util.FileNames
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.sql.functions.col
+
+/**
+ * The AMT writer materializes every leaf value today, so no tree it produces exercises
+ * inheritance. These tests therefore hand-build manifest trees with deliberately null leaf
+ * tracking.
+ */
+class AMTInheritanceReadSuite extends AMTCheckpointTestBase {
+
+  import testImplicits._
+
+  /** File sequence number assigned on the root pointer in inheritance scenarios. */
+  private val inheritedFileSequenceNumber = 42L
+
+  /** The row-tracking view of one file the reader reconstructed from a manifest tree. */
+  private case class ReconstructedFile(
+      path: String,
+      baseRowId: Option[Long],
+      defaultRowCommitVersion: Option[Long])
+
+  /** A leaf manifest written to disk, with the entries it was written from. */
+  private case class WrittenLeaf(location: String, sizeInBytes: Long, entries: Seq[DataEntry])
+
+  /**
+   * An AMT table whose manifest tree a test replaces with a hand-built one.
+   *
+   * @param deltaLog The table's log.
+   * @param base A real emitted checkpoint action, whose protocol and metadata the synthetic trees
+   *             reuse so only the `contentRoot` differs.
+   */
+  private case class SyntheticTree(deltaLog: DeltaLog, base: Checkpoint) {
+
+    /** Writes `rows` as a single manifest parquet, returning its stored location and size. */
+    private def writeManifest(file: Path, rows: Seq[AMTSingleAction]): (String, Long) = {
+      val hadoopConf = deltaLog.newDeltaHadoopConf()
+      AMTWriteHelper.writeAMTParquet(
+        spark, hadoopConf, file, base.metaData, base.protocol, rows)
+      val fs = file.getFileSystem(hadoopConf)
+      val location = AMTUtils.relativizeManifestPathToTableRoot(fs, deltaLog.dataPath, file)
+      (location, fs.getFileStatus(file).getLen)
+    }
+
+    /** Writes `entries` to a fresh leaf manifest, in the order given. */
+    def writeLeaf(entries: Seq[DataEntry]): WrittenLeaf = {
+      val metadataDir = FileNames.amtMetadataDirPath(deltaLog.dataPath)
+      val leafFile = FileNames.newAMTLeafManifestFile(metadataDir)
+      val (location, sizeInBytes) = writeManifest(leafFile, entries.map(_.wrap))
+      // A row's inherited row id depends on the entries physically before it, so tests that state
+      // expected row ids are only meaningful if the rows landed in the order they were written.
+      val onDisk = allowReadWithinDeltaLog {
+        spark.read.parquet(leafFile.toString)
+          .orderBy(col("_metadata.row_index"))
+          .select(col("location")).as[String].collect().toSeq
+      }
+      assert(onDisk == entries.map(_.location),
+        s"leaf rows must keep the order they were written in; got $onDisk")
+      WrittenLeaf(location, sizeInBytes, entries)
+    }
+
+    /**
+     * Writes `rootEntries` as the root manifest and returns the files a reader reconstructs from
+     * the resulting tree.
+     */
+    def reconstruct(rootEntries: Seq[AMTSingleAction]): Map[String, ReconstructedFile] = {
+      val metadataDir = FileNames.amtMetadataDirPath(deltaLog.dataPath)
+      val (location, sizeInBytes) =
+        writeManifest(FileNames.newAMTRootManifestFile(metadataDir), rootEntries)
+      val checkpoint =
+        base.copy(contentRoot = ContentRoot(path = location, sizeInBytes = sizeInBytes))
+      val provider = AMTCheckpointProvider.fromCheckpoint(
+        deltaLog, checkpoint, manifestCommitVersion = checkpoint.version)
+      provider.loadActionsForStateReconstruction(spark, deltaLog)
+        .getOrElse(fail("AMT provider must contribute reconstructed actions."))
+        .where("add is not null")
+        .select(col("add.path"), col("add.baseRowId"), col("add.defaultRowCommitVersion"))
+        .as[(String, Option[Long], Option[Long])]
+        .collect()
+        .map { case (path, baseRowId, commitVersion) =>
+          path -> ReconstructedFile(path, baseRowId, commitVersion)
+        }
+        .toMap
+    }
+  }
+
+  /**
+   * Creates an AMT table with a real emitted tree, then hands `body` the fixture it
+   * uses to replace that tree with a hand-built one.
+   */
+  private def withSyntheticTree(tableName: String)(body: SyntheticTree => Unit): Unit = {
+    withTable(tableName) {
+      createAMTTable(tableName, checkpointInterval = 2)
+      sql(s"INSERT INTO $tableName VALUES (1)")
+      // Emits a real AMT checkpoint action, whose non-content state the synthetic trees reuse.
+      sql(s"INSERT INTO $tableName VALUES (2)")
+      val deltaLog = deltaLogForName(tableName)
+      val checkpointAction = amtProvider(deltaLog.update())
+        .getOrElse(fail("expected an AMT-backed checkpoint provider"))
+        .checkpointAction
+      body(SyntheticTree(deltaLog, checkpointAction))
+    }
+  }
+
+  /** Tracking with nothing assigned, as a writer records it before the commit version is known. */
+  private def unassignedTracking(status: Int = Tracking.Status.Added): Tracking = Tracking(
+    status = status,
+    snapshot_id = None,
+    dv_snapshot_id = None,
+    sequence_number = None,
+    file_sequence_number = None,
+    first_row_id = None,
+    deleted_positions = None,
+    replaced_positions = None)
+
+  /**
+   * Tracking for a root `DATA_MANIFEST` pointer, which is written at commit time and so carries
+   * the explicit values its leaf's entries inherit.
+   */
+  private def pointerTracking(fileSequenceNumber: Option[Long]): Tracking =
+    unassignedTracking().copy(
+      file_sequence_number = fileSequenceNumber,
+      first_row_id = Some(1000L))
+
+  /** A leaf DATA entry for a data file of `recordCount` physical rows. */
+  private def dataEntry(
+      path: String,
+      recordCount: Long,
+      tracking: Tracking = unassignedTracking()): DataEntry = DataEntry(
+    location = path,
+    file_format = AMTSingleAction.FileFormatParquet,
+    tracking = tracking,
+    record_count = recordCount,
+    file_size_in_bytes = 128L)
+
+  /** A root pointer to `leaf`. */
+  private def leafPointer(leaf: WrittenLeaf, tracking: Tracking): DataManifestEntry =
+    DataManifestEntry(
+      location = leaf.location,
+      file_format = AMTSingleAction.FileFormatParquet,
+      tracking = tracking,
+      record_count = leaf.entries.size.toLong,
+      file_size_in_bytes = leaf.sizeInBytes,
+      manifest_info = ManifestInfo(
+        added_files_count = leaf.entries.size,
+        existing_files_count = 0,
+        deleted_files_count = 0,
+        replaced_files_count = 0,
+        modified_files_count = 0,
+        added_rows_count = leaf.entries.map(_.record_count).sum,
+        existing_rows_count = 0L,
+        deleted_rows_count = 0L,
+        replaced_rows_count = 0L,
+        modified_rows_count = 0L,
+        min_sequence_number = 0L,
+        dv = None,
+        dv_cardinality = None))
+
+  /** The messages of `error` and of every exception it wraps. */
+  private def causeMessages(error: Throwable): String =
+    Iterator.iterate(Option(error))(_.flatMap(e => Option(e.getCause)))
+      .takeWhile(_.isDefined)
+      .flatten
+      .map(e => String.valueOf(e.getMessage))
+      .mkString("\n")
+
+  test("leaf entries inherit the file sequence number of their root pointer") {
+    withSyntheticTree("amt_inherit_all") { tree =>
+      val leaf = tree.writeLeaf(Seq(
+        dataEntry("data/a.parquet", recordCount = 10L),
+        dataEntry("data/b.parquet", recordCount = 20L),
+        dataEntry("data/c.parquet", recordCount = 30L)))
+      val files = tree.reconstruct(Seq(
+        leafPointer(leaf, pointerTracking(Some(inheritedFileSequenceNumber))).wrap))
+
+      assert(files.keySet == Set("data/a.parquet", "data/b.parquet", "data/c.parquet"))
+      assert(files.values.forall(_.defaultRowCommitVersion.contains(inheritedFileSequenceNumber)),
+        s"every entry must inherit the pointer's file sequence number; got ${files.values}")
+      assert(files.values.forall(_.baseRowId.isEmpty),
+        s"first_row_id is not inherited yet; got ${files.values}")
+    }
+  }
+
+  test("each leaf inherits from its own root pointer") {
+    withSyntheticTree("amt_inherit_two_leaves") { tree =>
+      val first = tree.writeLeaf(Seq(
+        dataEntry("data/a.parquet", recordCount = 10L),
+        dataEntry("data/b.parquet", recordCount = 20L)))
+      val second = tree.writeLeaf(Seq(
+        dataEntry("data/c.parquet", recordCount = 5L),
+        dataEntry("data/d.parquet", recordCount = 7L)))
+      val files = tree.reconstruct(Seq(
+        leafPointer(first, pointerTracking(Some(inheritedFileSequenceNumber))).wrap,
+        leafPointer(second, pointerTracking(Some(99L))).wrap))
+
+      assert(files("data/b.parquet").defaultRowCommitVersion.contains(inheritedFileSequenceNumber))
+      assert(files("data/d.parquet").defaultRowCommitVersion.contains(99L))
+    }
+  }
+
+  test("a root pointer that declares no tracking leaves its leaf entries unresolved") {
+    withSyntheticTree("amt_inherit_nothing") { tree =>
+      // What today's AMT writer emits: no leaf entry inherits, and the tree reads back verbatim.
+      val leaf = tree.writeLeaf(Seq(
+        dataEntry("data/a.parquet", recordCount = 10L),
+        dataEntry("data/b.parquet", recordCount = 20L)))
+      val files = tree.reconstruct(Seq(leafPointer(leaf, unassignedTracking()).wrap))
+
+      assert(files.keySet == Set("data/a.parquet", "data/b.parquet"))
+      assert(files.values.forall(_.baseRowId.isEmpty),
+        s"nothing may be inherited from an unassigned pointer; got ${files.values}")
+      assert(files.values.forall(_.defaultRowCommitVersion.isEmpty))
+    }
+  }
+
+  test("root-resident entries are read verbatim") {
+    withSyntheticTree("amt_inherit_root_entries") { tree =>
+      val leaf = tree.writeLeaf(Seq(dataEntry("data/leaf.parquet", recordCount = 10L)))
+      // A root DATA entry has nothing above it to inherit from, so it keeps its own tracking even
+      // while a sibling pointer hands values down to its leaf.
+      val files = tree.reconstruct(Seq(
+        dataEntry("data/inline.parquet", recordCount = 4L).wrap,
+        leafPointer(leaf, pointerTracking(Some(inheritedFileSequenceNumber))).wrap))
+
+      assert(files("data/inline.parquet").defaultRowCommitVersion.isEmpty)
+      assert(files("data/leaf.parquet").defaultRowCommitVersion
+        .contains(inheritedFileSequenceNumber))
+    }
+  }
+
+  test("a live entry that is not ADDED and has no file sequence number is rejected") {
+    withSyntheticTree("amt_inherit_malformed") { tree =>
+      // Only an ADDED entry may leave its file sequence number to inheritance. An EXISTING entry
+      // predates the tree, so there is no value it could correctly inherit.
+      val leaf = tree.writeLeaf(Seq(
+        dataEntry("data/a.parquet", recordCount = 10L,
+          tracking = unassignedTracking(Tracking.Status.Existing))))
+      val error = intercept[Exception] {
+        tree.reconstruct(Seq(
+          leafPointer(leaf, pointerTracking(Some(inheritedFileSequenceNumber))).wrap))
+      }
+      val messages = causeMessages(error)
+      assert(messages.contains("tracking.file_sequence_number is null"), messages)
+      assert(messages.contains("EXISTING"), messages)
+    }
+  }
+
+  test("a materialized file_sequence_number on a leaf entry is read without inheriting") {
+    Tracking.Status.liveEntryStatuses.foreach { status =>
+      withSyntheticTree(s"amt_materialized_leaf_${Tracking.Status.nameOf(status)}") { tree =>
+        val materialized = 77L
+        val leaf = tree.writeLeaf(Seq(
+          dataEntry("data/a.parquet", recordCount = 10L,
+            tracking = unassignedTracking(status).copy(file_sequence_number = Some(materialized)))))
+        val files = tree.reconstruct(Seq(
+          leafPointer(leaf, pointerTracking(Some(inheritedFileSequenceNumber))).wrap))
+        assert(files("data/a.parquet").defaultRowCommitVersion.contains(materialized),
+          s"${Tracking.Status.nameOf(status)} must keep its materialized value")
+      }
+    }
+  }
+
+  test("a materialized file_sequence_number on a root-resident entry is read without inheriting") {
+    Tracking.Status.liveEntryStatuses.foreach { status =>
+      withSyntheticTree(s"amt_materialized_root_${Tracking.Status.nameOf(status)}") { tree =>
+        val materialized = 55L
+        val files = tree.reconstruct(Seq(
+          dataEntry("data/inline.parquet", recordCount = 4L,
+            tracking = unassignedTracking(status).copy(file_sequence_number = Some(materialized)))
+            .wrap))
+        assert(files("data/inline.parquet").defaultRowCommitVersion.contains(materialized),
+          s"${Tracking.Status.nameOf(status)} must keep its materialized value")
+      }
+    }
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTInheritanceReadSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTInheritanceReadSuite.scala
@@ -90,7 +90,8 @@ class AMTInheritanceReadSuite extends AMTCheckpointTestBase {
       val (location, sizeInBytes) =
         writeManifest(FileNames.newAMTRootManifestFile(metadataDir), rootEntries)
       val checkpoint =
-        base.copy(contentRoot = ContentRoot(path = location, sizeInBytes = sizeInBytes))
+        base.copy(contentRoot =
+          ContentRoot(path = location, sizeInBytes = sizeInBytes, version = base.version))
       val provider = AMTCheckpointProvider.fromCheckpoint(
         deltaLog, checkpoint, manifestCommitVersion = checkpoint.version)
       provider.loadActionsForStateReconstruction(spark, deltaLog)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTInheritanceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTInheritanceSuite.scala
@@ -1,0 +1,140 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.amt
+
+import org.apache.spark.SparkFunSuite
+
+/**
+ * Unit tests for the Iceberg V4 tracking inheritance rules.
+ */
+class AMTInheritanceSuite extends SparkFunSuite {
+
+  /** The statuses an entry can carry that are not `ADDED`. */
+  private val nonAddedStatuses: Seq[Int] = (Tracking.Status.all - Tracking.Status.Added).toSeq
+
+  /** A root `DATA_MANIFEST` parent that declares a file sequence number. */
+  private val fullParent = InheritableTracking(file_sequence_number = Some(42L))
+
+  private def childTracking(
+      status: Int = Tracking.Status.Added,
+      snapshotId: Option[Long] = None,
+      dvSnapshotId: Option[Long] = None,
+      sequenceNumber: Option[Long] = None,
+      fileSequenceNumber: Option[Long] = None,
+      firstRowId: Option[Long] = None,
+      deletedPositions: Option[Array[Byte]] = None,
+      replacedPositions: Option[Array[Byte]] = None): Tracking = Tracking(
+    status = status,
+    snapshot_id = snapshotId,
+    dv_snapshot_id = dvSnapshotId,
+    sequence_number = sequenceNumber,
+    file_sequence_number = fileSequenceNumber,
+    first_row_id = firstRowId,
+    deleted_positions = deletedPositions,
+    replaced_positions = replacedPositions)
+
+  private def resolve(
+      child: Tracking,
+      parent: InheritableTracking = fullParent): Tracking =
+    Tracking.resolve(child, parent, childEntryLocationForLogging = "data/part-0.parquet")
+
+  /** A root `DATA_MANIFEST` entry carrying the given tracking. */
+  private def parentPointer(tracking: Tracking): DataManifestEntry = DataManifestEntry(
+    location = "_delta_log/_amt/leaf-0.parquet",
+    file_format = AMTSingleAction.FileFormatParquet,
+    tracking = tracking,
+    record_count = 1L,
+    file_size_in_bytes = 1L,
+    manifest_info = ManifestInfo(
+      added_files_count = 1,
+      existing_files_count = 0,
+      deleted_files_count = 0,
+      replaced_files_count = 0,
+      modified_files_count = 0,
+      added_rows_count = 1L,
+      existing_rows_count = 0L,
+      deleted_rows_count = 0L,
+      replaced_rows_count = 0L,
+      modified_rows_count = 0L,
+      min_sequence_number = 0L,
+      dv = None,
+      dv_cardinality = None))
+
+  test("an ADDED entry with a null file_sequence_number inherits it from its parent") {
+    val resolved = resolve(childTracking())
+    assert(resolved.file_sequence_number.contains(42L))
+    assert(resolved.sequence_number.isEmpty)
+  }
+
+  test("a materialized child file_sequence_number is kept in preference to the parent's") {
+    val resolved = resolve(childTracking(fileSequenceNumber = Some(3L)))
+    assert(resolved.file_sequence_number.contains(3L))
+  }
+
+  test("file_sequence_number is inherited only by ADDED entries") {
+    val added = resolve(childTracking(status = Tracking.Status.Added))
+    assert(added.file_sequence_number.contains(42L))
+    nonAddedStatuses.foreach { status =>
+      val resolved = resolve(childTracking(status = status, fileSequenceNumber = Some(8L)))
+      assert(resolved.file_sequence_number.contains(8L))
+    }
+  }
+
+  test("status and the CDF position bitmaps pass through untouched") {
+    val deleted = Array[Byte](1, 2, 3)
+    val replaced = Array[Byte](4, 5)
+    val resolved = resolve(childTracking(
+      status = Tracking.Status.Added,
+      deletedPositions = Some(deleted),
+      replacedPositions = Some(replaced)))
+    assert(resolved.status == Tracking.Status.Added)
+    assert(resolved.deleted_positions.contains(deleted))
+    assert(resolved.replaced_positions.contains(replaced))
+  }
+
+  test("a parent that declares nothing leaves the child unchanged") {
+    assert(InheritableTracking.none.isEmpty)
+    Tracking.Status.all.foreach { status =>
+      val child = childTracking(status = status)
+      assert(resolve(child, InheritableTracking.none) == child)
+    }
+  }
+
+  test("a null file_sequence_number on a non-ADDED entry is rejected") {
+    nonAddedStatuses.foreach { status =>
+      val error = intercept[IllegalStateException] {
+        resolve(childTracking(status = status))
+      }
+      assert(error.getMessage.contains("tracking.file_sequence_number is null"))
+      assert(error.getMessage.contains(Tracking.Status.nameOf(status)))
+      assert(error.getMessage.contains("data/part-0.parquet"))
+    }
+  }
+
+  test("InheritableTracking projects only the inheritable fields of a parent") {
+    val parent = parentPointer(Tracking(
+      status = Tracking.Status.Existing,
+      snapshot_id = Some(7L),
+      dv_snapshot_id = Some(8L),
+      sequence_number = Some(42L),
+      file_sequence_number = Some(43L),
+      first_row_id = Some(1000L),
+      deleted_positions = Some(Array[Byte](1)),
+      replaced_positions = Some(Array[Byte](2))))
+    assert(InheritableTracking(parent) == InheritableTracking(file_sequence_number = Some(43L)))
+  }
+}


### PR DESCRIPTION
## Description

Leaf entries in an AMT tree can be written once with `null` tracking fields and reused
across commit retries, with only the root `DATA_MANIFEST` entry rewritten. On read, a leaf
entry recovers its tracking by inheriting values from the root entry that references its leaf.

This change implements the reader-side resolution of the inherited `file_sequence_number`:

- Adds `Tracking.resolve(...)`, which fills a leaf entry's null tracking fields from the
  inheritable values of its parent root entry.
- A leaf entry inherits `file_sequence_number` from the parent only when its own status is
  `ADDED`. A leaf with any other status (e.g. `EXISTING`) must carry an explicit
  `file_sequence_number`; a null there is treated as malformed and raises a clear error.
- Adds `Status.liveEntryStatuses` and `Status.nameOf` helpers, and documents the inheritance
  contract on the tracking types.

## How was this patch tested?

New unit tests in `AMTInheritanceReadSuite` and `AMTInheritanceSuite` cover inheritance of the
file sequence number for `ADDED` leaves, the explicit-value requirement for non-`ADDED` leaves,
and the malformed-entry error path. Existing AMT write/read tests continue to pass.

## Does this PR introduce _any_ user-facing change?

No.
