### PR TITLE
[Spark] Abstract the AMT manifest deletion-vector bitmap behind a ManifestBitmap trait

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTCheckpointProvider.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTCheckpointProvider.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql.delta.amt
 import org.apache.spark.sql.delta.{CheckpointPolicy, CheckpointProvider, DeltaLog, DeltaLogFileIndex, Snapshot}
 import org.apache.spark.sql.delta.DeltaLogFileIndex.COMMIT_VERSION_COLUMN
 import org.apache.spark.sql.delta.actions.{Action, AddFile, BackReference, Checkpoint, ContentRoot, Metadata, Protocol, RemoveFile, SingleAction}
-import org.apache.spark.sql.delta.deletionvectors.RoaringBitmapArray
 import org.apache.spark.sql.delta.util.DeltaEncoder
 import org.apache.hadoop.fs.{FileStatus, Path}
 
@@ -169,7 +168,7 @@ final class AMTCheckpointProvider(
         AMTCheckpointProvider.liveDataEntryStatuses.toSeq: _*))
       .filter { entryWithLoc =>
         mdvBroadcast.value.get(entryWithLoc.leafPath)
-          .forall(bytes => !RoaringBitmapArray.readFrom(bytes).contains(entryWithLoc.pos))
+          .forall(bytes => !AMTUtils.deserializeMdv(bytes).contains(entryWithLoc.pos))
       }
 
     dataEntries

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTUtils.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.delta.amt
 
 import org.apache.spark.sql.delta.{AdaptiveMetadataTableFeature, CurrentTransactionInfo, SnapshotDescriptor, WinningCommitSummary}
 import org.apache.spark.sql.delta.actions.{LastManifestCommit, Metadata, Protocol}
-import org.apache.spark.sql.delta.deletionvectors.{RoaringBitmapArray, RoaringBitmapArrayFormat}
+import org.apache.spark.sql.delta.deletionvectors.ManifestBitmap
 import org.apache.spark.sql.delta.util.DeltaFileOperations
 import org.apache.hadoop.fs.{FileSystem, Path}
 
@@ -163,10 +163,10 @@ object AMTUtils {
   }
 
   // Serializes a Manifest Deletion Vector to the on-disk byte form carried in `manifest_info.dv`.
-  private[amt] def serializeMdv(mdv: RoaringBitmapArray): Array[Byte] =
-    mdv.serializeAsByteArray(RoaringBitmapArrayFormat.Portable)
+  private[amt] def serializeMdv(mdv: ManifestBitmap): Array[Byte] =
+    mdv.serializeAsByteArray()
 
   // Deserializes a Manifest Deletion Vector previously written by [[serializeMdv]].
-  private[amt] def deserializeMdv(bytes: Array[Byte]): RoaringBitmapArray =
-    RoaringBitmapArray.readFrom(bytes)
+  private[amt] def deserializeMdv(bytes: Array[Byte]): ManifestBitmap =
+    ManifestBitmap.readFrom(bytes)
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriteHelper.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriteHelper.scala
@@ -21,7 +21,7 @@ import java.util.concurrent.TimeUnit.NANOSECONDS
 // scalastyle:off import.ordering.noEmptyLine
 import org.apache.spark.sql.delta.{Checkpoints, DeltaLog, Snapshot}
 import org.apache.spark.sql.delta.actions.{AddFile, Checkpoint, ContentRoot, DomainMetadata, Metadata, Protocol, SetTransaction}
-import org.apache.spark.sql.delta.deletionvectors.RoaringBitmapArray
+import org.apache.spark.sql.delta.deletionvectors.ManifestBitmap
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.FileNames
@@ -430,11 +430,11 @@ object AMTWriteHelper extends DeltaLogging {
       deletedPositions: Seq[Long],
       replacedPositions: Seq[Long]): (Tracking, ManifestInfo) = {
     val cumulativeMdv = oldEntry.manifest_info.dv
-      .map(AMTUtils.deserializeMdv).getOrElse(new RoaringBitmapArray)
+      .map(AMTUtils.deserializeMdv).getOrElse(ManifestBitmap.empty())
     mdvPositions.foreach(cumulativeMdv.add)
     def bitmapOf(positions: Seq[Long]): Option[Array[Byte]] = {
       if (positions.isEmpty) None
-      else Some(AMTUtils.serializeMdv(RoaringBitmapArray(positions: _*)))
+      else Some(AMTUtils.serializeMdv(ManifestBitmap(positions: _*)))
     }
     // Every masked / CDF position indexes an entry within this leaf, so no count can exceed the
     // leaf's entry count; a larger value signals a corrupt bitmap or a double-counted position.
@@ -516,7 +516,7 @@ object AMTWriteHelper extends DeltaLogging {
 
   // Returns a copy of a carried-forward leaf's ManifestInfo with `mdv` recorded as its Manifest
   // Deletion Vector.
-  private[amt] def withUpdatedMdv(base: ManifestInfo, mdv: RoaringBitmapArray): ManifestInfo = {
+  private[amt] def withUpdatedMdv(base: ManifestInfo, mdv: ManifestBitmap): ManifestInfo = {
     if (mdv.isEmpty) {
       base.copy(dv = None, dv_cardinality = None)
     } else {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/IncrementalAMTWriter.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/IncrementalAMTWriter.scala
@@ -23,7 +23,6 @@ import scala.collection.mutable.ArrayBuffer
 import org.apache.spark.sql.delta.{DeltaFileProviderUtils, DeltaLog, SingleCommit}
 import org.apache.spark.sql.delta.actions.{Action, AddFile, BackReference, Checkpoint, ContentRoot, DomainMetadata, FileAction, InMemoryLogReplay, Metadata, Protocol, RemoveFile, SetTransaction}
 import org.apache.spark.sql.delta.actions.FileAction.UniqueFileActionTuple
-import org.apache.spark.sql.delta.deletionvectors.RoaringBitmapArray
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.FileNames
 import org.apache.hadoop.fs.{FileStatus, Path}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/deletionvectors/ManifestBitmap.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/deletionvectors/ManifestBitmap.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.deletionvectors
+
+/**
+ * A mutable bitmap of unsigned positions for the AMT manifest deletion vectors: the masking MDV in
+ * `manifest_info.dv` and the CDF `tracking.deleted_positions` / `tracking.replaced_positions`
+ * bitmaps.
+ *
+ * This trait is the seam over the concrete bitmap format written to disk. The only implementation
+ * today is [[RoaringManifestBitmap]] (Roaring portable), so behavior is unchanged; the trait exists
+ * so an alternative compressed format can later be dropped in behind the [[ManifestBitmap]] factory
+ * and [[ManifestBitmap.readFrom]] without touching the AMT write path.
+ */
+trait ManifestBitmap {
+  /** Adds `value` to the bitmap. */
+  def add(value: Long): Unit
+
+  /** Returns `true` if `value` is set. */
+  def contains(value: Long): Boolean
+
+  /** Returns the number of set positions. */
+  def cardinality: Long
+
+  /** Returns `true` if no position is set. */
+  def isEmpty: Boolean
+
+  /** Returns the set positions in ascending order. */
+  def toArray: Array[Long]
+
+  /** Serializes to the on-disk byte form carried in `manifest_info.dv` / the CDF bitmaps. */
+  def serializeAsByteArray(): Array[Byte]
+}
+
+object ManifestBitmap {
+  /** Returns an empty bitmap. */
+  def empty(): ManifestBitmap = RoaringManifestBitmap.empty()
+
+  /** Returns a bitmap of the given positions. */
+  def apply(values: Long*): ManifestBitmap = RoaringManifestBitmap(values: _*)
+
+  /** Deserializes a bitmap previously produced by [[ManifestBitmap.serializeAsByteArray]]. */
+  def readFrom(bytes: Array[Byte]): ManifestBitmap = RoaringManifestBitmap.readFrom(bytes)
+}
+
+/** A [[ManifestBitmap]] backed by a [[RoaringBitmapArray]] serialized in the portable format. */
+final class RoaringManifestBitmap private (private val underlying: RoaringBitmapArray)
+  extends ManifestBitmap {
+
+  override def add(value: Long): Unit = underlying.add(value)
+
+  override def contains(value: Long): Boolean = underlying.contains(value)
+
+  override def cardinality: Long = underlying.cardinality
+
+  override def isEmpty: Boolean = underlying.isEmpty
+
+  override def toArray: Array[Long] = underlying.toArray
+
+  override def serializeAsByteArray(): Array[Byte] =
+    underlying.serializeAsByteArray(RoaringBitmapArrayFormat.Portable)
+}
+
+object RoaringManifestBitmap {
+  def empty(): RoaringManifestBitmap = new RoaringManifestBitmap(new RoaringBitmapArray)
+
+  def apply(values: Long*): RoaringManifestBitmap =
+    new RoaringManifestBitmap(RoaringBitmapArray(values: _*))
+
+  def readFrom(bytes: Array[Byte]): RoaringManifestBitmap =
+    new RoaringManifestBitmap(RoaringBitmapArray.readFrom(bytes))
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTIncrementalWriteTestBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTIncrementalWriteTestBase.scala
@@ -20,7 +20,7 @@ import java.util.UUID
 
 import org.apache.spark.sql.delta.{DeltaLog, DeltaOperations, Snapshot}
 import org.apache.spark.sql.delta.actions.{Action, AddFile, DeletionVectorDescriptor, RemoveFile}
-import org.apache.spark.sql.delta.deletionvectors.RoaringBitmapArray
+import org.apache.spark.sql.delta.deletionvectors.ManifestBitmap
 
 import org.apache.spark.sql.SaveMode
 import org.apache.spark.sql.functions.col
@@ -224,12 +224,12 @@ abstract class AMTIncrementalWriteTestBase extends AMTCheckpointTestBase {
   /** The per-commit CDF `tracking.deleted_positions` off a leaf pointer (empty if unset). */
   protected def leafDeletedPositions(leaf: DataManifestEntry): Set[Long] =
     leaf.tracking.deleted_positions
-      .map(RoaringBitmapArray.readFrom(_).toArray.toSet).getOrElse(Set.empty)
+      .map(ManifestBitmap.readFrom(_).toArray.toSet).getOrElse(Set.empty)
 
   /** The per-commit CDF `tracking.replaced_positions` off a leaf pointer (empty if unset). */
   protected def leafReplacedPositions(leaf: DataManifestEntry): Set[Long] =
     leaf.tracking.replaced_positions
-      .map(RoaringBitmapArray.readFrom(_).toArray.toSet).getOrElse(Set.empty)
+      .map(ManifestBitmap.readFrom(_).toArray.toSet).getOrElse(Set.empty)
 
   /** The current snapshot's leaf pointers, keyed by relative location. */
   protected def leafPointers(snapshot: Snapshot): Map[String, DataManifestEntry] = {
@@ -458,7 +458,7 @@ abstract class AMTIncrementalWriteTestBase extends AMTCheckpointTestBase {
           .values.sum
         val mdvDeclaredCardinality = leaf.manifest_info.dv_cardinality.getOrElse(0L)
         val decoded =
-          leaf.manifest_info.dv.map(RoaringBitmapArray.readFrom).getOrElse(new RoaringBitmapArray)
+          leaf.manifest_info.dv.map(ManifestBitmap.readFrom).getOrElse(ManifestBitmap.empty())
         assert(decoded.cardinality == mdvDeclaredCardinality,
           s"Leaf ${leaf.location}: dv_cardinality=$mdvDeclaredCardinality but the decoded MDV " +
             s"has ${decoded.cardinality} bits.")

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.delta.amt
 import org.apache.spark.sql.delta.{Checkpoints, DeletionVectorsTestUtils, DeltaLog, DeltaOperations, Snapshot}
 import org.apache.spark.sql.delta.DeltaTestUtils.createTestAddFile
 import org.apache.spark.sql.delta.actions.{AddFile, Checkpoint, ContentRoot, DeletionVectorDescriptor}
+import org.apache.spark.sql.delta.deletionvectors.ManifestBitmap
 import org.apache.spark.sql.delta.deletionvectors.RoaringBitmapArray
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.FileNames
@@ -1278,7 +1279,7 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
 
   /** Serializes a manifest DV bitmap over the given leaf entry positions. */
   private def mdvBytesFor(positions: Long*): Array[Byte] =
-    AMTUtils.serializeMdv(RoaringBitmapArray(positions: _*))
+    AMTUtils.serializeMdv(ManifestBitmap(positions: _*))
 
   /** An ADDED tracking envelope with no lineage/sequence numbers, matching the AMT writer. */
   private def addedTracking: Tracking = Tracking(


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Introduces a `ManifestBitmap` abstraction over the bitmap format used by the AMT (Adaptive Metadata Tree) manifest deletion vectors: the masking MDV stored in `manifest_info.dv` and the CDF `tracking.deleted_positions` / `tracking.replaced_positions` bitmaps.

`ManifestBitmap` is a small trait (`add` / `contains` / `cardinality` / `isEmpty` / `toArray` / `serializeAsByteArray`, plus `empty` / `apply` / `readFrom` factory methods), and `RoaringManifestBitmap` is its only implementation, delegating to a `RoaringBitmapArray` serialized in the portable format -- exactly what the AMT write path did before. `AMTUtils.serializeMdv` / `deserializeMdv`, their `AMTWriteHelper` callers, and the manifest-DV read in `AMTCheckpointProvider` now go through `ManifestBitmap` instead of referencing `RoaringBitmapArray` directly. File-level deletion vectors continue to use `RoaringBitmapArray`.

This is a pure refactor with no behavioral or on-disk change. The seam lets an alternative compressed bitmap format be introduced behind the `ManifestBitmap` factory without further churn in the AMT write path.

## How was this patch tested?

Existing AMT manifest-DV suites pass unchanged (the AMT incremental-write suites and `AMTSnapshotSuite` exercise manifest-DV write / read / decay), confirming the abstraction is behavior-preserving.

## Does this PR introduce _any_ user-facing changes?

No.
