### PR TITLE
[Spark] Prepare Delta tests for SessionQueryTest

### DIFF
--- a/iceberg/src/test/scala/org/apache/spark/sql/delta/ConvertIcebergToDeltaSuite.scala
+++ b/iceberg/src/test/scala/org/apache/spark/sql/delta/ConvertIcebergToDeltaSuite.scala
@@ -73,17 +73,17 @@ trait ConvertIcebergToDeltaUtils extends SharedSparkSession {
     .filterNot(identity).map(_ => "NO STATISTICS").getOrElse("")
 
 
-  override def beforeAll(): Unit = {
+  override protected def beforeAll(): Unit = {
     warehousePath = Utils.createTempDir()
     super.beforeAll()
   }
 
-  override def afterAll(): Unit = {
+  override protected def afterAll(): Unit = {
     super.afterAll()
     if (warehousePath != null) Utils.deleteRecursively(warehousePath)
   }
 
-  override def afterEach(): Unit = {
+  override protected def afterEach(): Unit = {
     sql(s"DROP TABLE IF EXISTS $table")
     super.afterEach()
   }

--- a/sharing/src/test/scala/io/delta/sharing/spark/DeltaFormatSharingSourceSuite.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/DeltaFormatSharingSourceSuite.scala
@@ -55,8 +55,8 @@ import org.apache.spark.sql.types.{
 }
 
 class DeltaFormatSharingSourceSuite
-    extends StreamTest
-    with DeltaSQLCommandTest
+    extends DeltaSQLCommandTest
+    with StreamTest
     with DeltaSharingTestSparkUtils
     with DeltaSharingDataSourceDeltaTestUtils {
 

--- a/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingDataSourceCMSuite.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingDataSourceCMSuite.scala
@@ -30,13 +30,15 @@ import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.sharing.DeltaSharingTestSparkUtils
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.streaming.{StreamingQueryException, StreamTest, Trigger}
+import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{IntegerType, StringType, StructType}
 
 // Unit tests to verify that delta format sharing support column mapping (CM).
 class DeltaSharingDataSourceCMSuite
-    extends StreamTest
+    extends SharedSparkSession
     with DeltaSQLCommandTest
     with DeltaSharingTestSparkUtils
+    with StreamTest
     with DeltaSharingDataSourceDeltaTestUtils {
 
   import testImplicits._

--- a/spark-unified/src/test/scala/io/delta/internal/ApplyV2ReadOptionsSuite.scala
+++ b/spark-unified/src/test/scala/io/delta/internal/ApplyV2ReadOptionsSuite.scala
@@ -40,8 +40,9 @@ import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorClient
 import org.apache.spark.sql.connector.catalog.Identifier
 import org.apache.spark.sql.execution.datasources.DataSource
 import org.apache.spark.sql.types.{StringType, StructType}
+import org.apache.spark.sql.test.SharedSparkSession
 
-class ApplyV2ReadOptionsSuite extends DeltaSQLCommandTest {
+class ApplyV2ReadOptionsSuite extends DeltaSQLCommandTest with SharedSparkSession {
 
   // Mirrors the rule order in DeltaSparkSessionExtension: ApplyV2Streaming runs first to produce
   // a StreamingRelationV2, then ApplyV2ReadOptions plumbs read options into the table.

--- a/spark-unified/src/test/scala/io/delta/internal/ApplyV2StreamingSuite.scala
+++ b/spark-unified/src/test/scala/io/delta/internal/ApplyV2StreamingSuite.scala
@@ -36,9 +36,10 @@ import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.execution.datasources.DataSource
 import org.apache.spark.sql.connector.catalog.Identifier
 import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
-class ApplyV2StreamingSuite extends DeltaSQLCommandTest {
+class ApplyV2StreamingSuite extends DeltaSQLCommandTest with SharedSparkSession {
 
   private def applyRule(plan: LogicalPlan): LogicalPlan = {
     new ApplyV2Streaming(spark).apply(plan)

--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/catalog/DeltaCatalogSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/catalog/DeltaCatalogSuite.scala
@@ -16,12 +16,14 @@
 
 package org.apache.spark.sql.delta.catalog
 
-import io.delta.spark.internal.v2.catalog.DeltaV2Table
-import org.apache.spark.sql.delta.sources.DeltaSQLConf
-import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
-
 import java.io.File
 import java.util.Locale
+
+import io.delta.spark.internal.v2.catalog.DeltaV2Table
+
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.test.SharedSparkSession
 
 /**
  * Unit tests for DeltaCatalog's V2 connector routing logic.
@@ -31,7 +33,7 @@ import java.util.Locale
  * - STRICT mode: Kernel's DeltaV2Table (V2 connector)
  * - NONE mode (default): DeltaTableV2 (V1 connector)
  */
-class DeltaCatalogSuite extends DeltaSQLCommandTest {
+class DeltaCatalogSuite extends DeltaSQLCommandTest with SharedSparkSession {
 
   private val modeTestCases = Seq(
     ("STRICT", classOf[DeltaV2Table], "Kernel DeltaV2Table"),

--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/V2ForceTest.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/V2ForceTest.scala
@@ -121,13 +121,10 @@ trait V2ForceTest extends DeltaSQLCommandTest with AdaptiveSparkPlanHelper {
    * Run an arbitrary action through the V1 connector by temporarily setting V2_ENABLE_MODE to
    * NONE. Useful for setup/DDL/DML that V2 doesn't support.
    */
-  protected def inV1Mode[T](f: => T): T =
+  protected def inV1Mode[T](f: => T): T = {
     withSQLConf(DeltaSQLConf.V2_ENABLE_MODE.key -> "NONE")(f)
+  }
 
   /** Run a SQL statement through the V1 connector. */
-  protected def executeInV1Mode(sqlText: String): Unit = inV1Mode(sql(sqlText))
-
-  override def afterAll(): Unit = {
-    super.afterAll()
-  }
+  protected def executeInV1Mode(sqlText: String): Unit = inV1Mode(spark.sql(sqlText))
 }

--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/v2/interop/DeltaV2SnapshotSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/v2/interop/DeltaV2SnapshotSuite.scala
@@ -27,6 +27,7 @@ import io.delta.kernel.TableManager
 import io.delta.kernel.engine.Engine
 import io.delta.kernel.internal.{SnapshotImpl => KernelSnapshot}
 
+import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTable, CatalogTableType}
 
@@ -36,7 +37,9 @@ import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTable
  * (`metadata`, `protocol`, `allFiles`, `timestamp`, ...), and the V1 state-reconstruction members
  * that remain unsupported and throw [[UnsupportedOperationException]].
  */
-class DeltaV2SnapshotSuite extends DeltaSQLCommandTest {
+class DeltaV2SnapshotSuite
+  extends DeltaSQLCommandTest
+  with SharedSparkSession {
 
   // scalastyle:off deltahadoopconfiguration
   // No DeltaLog in this test (the snapshot is loaded via Kernel), so use the session Hadoop conf.

--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/v2/interop/KernelSnapshotUtilsSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/v2/interop/KernelSnapshotUtilsSuite.scala
@@ -29,7 +29,9 @@ import io.delta.kernel.TableManager
 import io.delta.kernel.engine.Engine
 import io.delta.kernel.internal.SnapshotImpl
 
-class KernelSnapshotUtilsSuite extends DeltaSQLCommandTest {
+import org.apache.spark.sql.catalyst.SQLConfHelper
+
+class KernelSnapshotUtilsSuite extends DeltaSQLCommandTest with SQLConfHelper {
 
   // scalastyle:off deltahadoopconfiguration
   private def engine: Engine =
@@ -147,7 +149,7 @@ class KernelSnapshotUtilsSuite extends DeltaSQLCommandTest {
       withTempDir { dir =>
         val path = dir.getAbsolutePath
         spark.range(10).repartition(1).write.format("delta").save(path)
-        sql(s"DELETE FROM delta.`$path` WHERE id = 0")
+        spark.sql(s"DELETE FROM delta.`$path` WHERE id = 0")
         val (kernelFiles, v1Files) = allFilesFor(path)
 
         assert(v1Files.exists(_.deletionVector != null))

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCDCStreamSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCDCStreamSuite.scala
@@ -38,8 +38,10 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.streaming.{StreamingQuery, StreamingQueryException, StreamTest, Trigger}
 import org.apache.spark.sql.types.StructType
 
-trait DeltaCDCStreamSuiteBase extends StreamTest with DeltaSQLCommandTest
+trait DeltaCDCStreamSuiteBase
+  extends DeltaSQLCommandTest
   with DeltaSourceSuiteBase
+  with StreamTest
   with DeltaColumnMappingTestUtils {
 
   import testImplicits._

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoColumnOrderSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoColumnOrderSuite.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.internal.SQLConf
  */
 class DeltaInsertIntoColumnOrderSuite extends DeltaInsertIntoTest {
 
-  override def beforeAll(): Unit = {
+  override protected def beforeAll(): Unit = {
     super.beforeAll()
     spark.conf.set(SQLConf.ANSI_ENABLED.key, "true")
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoImplicitCastSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoImplicitCastSuite.scala
@@ -33,7 +33,7 @@ import org.apache.spark.sql.types._
  * [[DeltaInsertIntoTest]] for a list of these INSERT operations covered.
  */
 trait DeltaInsertIntoImplicitCastBase extends DeltaInsertIntoTest {
-  override def beforeAll(): Unit = {
+  override protected def beforeAll(): Unit = {
     super.beforeAll()
     // Enable the null expansion fix by preserving NULL source structs in INSERT operations.
     // Without this fix, NULL source structs are incorrectly expanded to structs with NULL fields.

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoMissingColumnSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoMissingColumnSuite.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.types._
  */
 class DeltaInsertIntoMissingColumnSuite extends DeltaInsertIntoTest {
 
-  override def beforeAll(): Unit = {
+  override protected def beforeAll(): Unit = {
     super.beforeAll()
     spark.conf.set(SQLConf.ANSI_ENABLED.key, "true")
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoSchemaEvolutionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoSchemaEvolutionSuite.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.types._
 
 trait DeltaInsertIntoEvolutionSuiteBase extends DeltaInsertIntoTest with DeltaTableProvider {
 
-  override def beforeAll(): Unit = {
+  override protected def beforeAll(): Unit = {
     super.beforeAll()
     spark.conf.set(SQLConf.ANSI_ENABLED.key, "true")
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoTest.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoTest.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.{DebugFilesystem, SparkThrowable}
-import org.apache.spark.sql.{DataFrame, QueryTest, SaveMode}
+import org.apache.spark.sql.{DataFrame, SaveMode}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.util.QuotingUtils
 import org.apache.spark.sql.functions.{col, lit}
@@ -40,9 +40,8 @@ import org.apache.spark.sql.types.StructType
  * inserts to allow more easily running tests with all or a subset of them.
  */
 trait DeltaInsertIntoTest
-  extends QueryTest
+  extends DeltaSQLCommandTest
   with DeltaDMLTestUtilsPathBased
-  with DeltaSQLCommandTest
   with DeltaTableProvider {
 
   val catalogName = "spark_catalog"

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSinkSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSinkSuite.scala
@@ -45,8 +45,8 @@ import org.apache.spark.sql.types._
 import org.apache.spark.util.Utils
 
 abstract class DeltaSinkTest
-  extends StreamTest
-  with DeltaSQLCommandTest {
+  extends DeltaSQLCommandTest
+  with StreamTest {
 
   override val streamingTimeout = 60.seconds
   import testImplicits._

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceDeletionVectorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceDeletionVectorsSuite.scala
@@ -29,9 +29,10 @@ import org.scalatest.concurrent.PatienceConfiguration.Timeout
 import org.apache.spark.sql.streaming.{StreamTest, Trigger}
 import org.apache.spark.sql.streaming.util.StreamManualClock
 
-trait DeltaSourceDeletionVectorTests extends StreamTest
-  with DeletionVectorsTestUtils {
-  self: DeltaSourceConnectorTrait =>
+trait DeltaSourceDeletionVectorTests
+  extends DeltaSQLCommandTest
+  with DeletionVectorsTestUtils
+  with StreamTest { self: DeltaSourceConnectorTrait =>
 
   import testImplicits._
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceRowTrackingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceRowTrackingSuite.scala
@@ -21,6 +21,7 @@ import java.util.Locale
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 
 import org.apache.spark.sql.streaming.StreamTest
+import org.apache.spark.sql.test.SharedSparkSession
 
 /**
  * Streaming regression tests for row-tracking metadata and CDC combination scenarios.
@@ -28,9 +29,11 @@ import org.apache.spark.sql.streaming.StreamTest
  * The base suite runs through the DSv1 connector; DeltaV2SourceRowTrackingSuite
  * re-runs the same tests through the DSv2 connector via V2ForceTest.
  */
-trait DeltaSourceRowTrackingSuiteBase extends StreamTest
+trait DeltaSourceRowTrackingSuiteBase
+  extends SharedSparkSession
   with DeltaSourceSuiteBase
-  with DeltaColumnMappingTestUtils {
+  with DeltaColumnMappingTestUtils
+  with StreamTest {
 
   import testImplicits._
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSchemaEvolutionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSchemaEvolutionSuite.scala
@@ -41,8 +41,11 @@ import org.apache.spark.sql.streaming.{StreamingQueryException, Trigger}
 import org.apache.spark.sql.types.{StringType, StructType}
 import org.apache.spark.util.Utils
 
-trait StreamingSchemaEvolutionSuiteBase extends ColumnMappingStreamingTestUtils
-  with DeltaSourceSuiteBase with DeltaColumnMappingSelectedTestMixin with DeltaSQLCommandTest {
+trait StreamingSchemaEvolutionSuiteBase
+  extends DeltaSQLCommandTest
+  with DeltaSourceSuiteBase
+  with DeltaColumnMappingSelectedTestMixin
+  with ColumnMappingStreamingTestUtils {
 
   override protected def runOnlyTests: Seq[String] = Seq(
     "schema log initialization with additive schema changes",

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
@@ -52,9 +52,10 @@ import org.apache.spark.sql.types.{IntegerType, LongType, NullType, StringType, 
 import org.apache.spark.unsafe.types.UTF8String
 import org.apache.spark.util.{ManualClock, Utils}
 
-class DeltaSourceSuite extends DeltaSourceSuiteBase
+class DeltaSourceSuite
+  extends DeltaSQLCommandTest
   with DeltaColumnMappingTestUtils
-  with DeltaSQLCommandTest {
+  with DeltaSourceSuiteBase {
 
   // Many tests in this suite deliberately delete commit JSON files to exercise streaming's own
   // missing-commit-file / failOnDataLoss handling. The DeltaLog.getChangeLogFiles version-gap

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuiteBase.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.delta.coordinatedcommits.CatalogOwnedTestBaseSuite
 import org.apache.spark.sql.delta.schema.{SchemaMergingUtils, SchemaUtils}
 import org.apache.spark.sql.delta.test.DeltaSQLTestUtils
 
-import org.apache.spark.sql.{Column, DataFrame}
+import org.apache.spark.sql.{Column, DataFrame, SparkSessionProvider}
 import org.apache.spark.sql.streaming.StreamTest
 import org.apache.spark.sql.types.StructType
 import org.scalactic.source.Position
@@ -32,8 +32,7 @@ import org.scalatest.Tag
 /**
  * Trait that provides abstraction for testing both DSv1 and DSv2 connectors.
  */
-trait DeltaSourceConnectorTrait {
-  self: DeltaSQLTestUtils =>
+trait DeltaSourceConnectorTrait extends SparkSessionProvider {
 
   protected def useDsv2: Boolean = false
 
@@ -49,7 +48,8 @@ trait DeltaSourceConnectorTrait {
   }
 }
 
-trait DeltaSourceSuiteBase extends StreamTest
+trait DeltaSourceSuiteBase
+  extends StreamTest
   with DeltaSQLTestUtils
   with CatalogOwnedTestBaseSuite
   with DeltaSourceConnectorTrait {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceTableAPISuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceTableAPISuite.scala
@@ -31,14 +31,10 @@ import org.apache.spark.sql.execution.streaming._
 import org.apache.spark.sql.streaming.{StreamingQuery, StreamTest}
 import org.apache.spark.util.Utils
 
-class DeltaSourceTableAPISuite extends StreamTest
-  with DeltaSQLCommandTest
+class DeltaSourceTableAPISuite
+  extends DeltaSQLCommandTest
+  with StreamTest
   with CatalogOwnedTestBaseSuite {
-
-  override def beforeAll(): Unit = {
-    super.beforeAll()
-
-  }
 
   import testImplicits._
   test("table API") {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTestUtils.scala
@@ -47,6 +47,7 @@ import org.scalatest.{BeforeAndAfterEach, Tag}
 import org.apache.spark.{SparkConf, SparkContext, SparkFunSuite, SparkThrowable}
 import org.apache.spark.scheduler.{JobFailed, SparkListener, SparkListenerJobEnd, SparkListenerJobStart}
 import org.apache.spark.sql.{AnalysisException, DataFrame, DataFrameWriter, SparkSession}
+import org.apache.spark.sql.catalyst.SQLConfHelper
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
@@ -68,7 +69,7 @@ object DeltaTestUtilsBase {
   def nullTypeColumnsSupported: Boolean = !org.apache.spark.SPARK_VERSION.startsWith("4.0")
 }
 
-trait CDCTestMixin extends SharedSparkSession {
+trait CDCTestMixin {
   // Setting the spark Conf is left to the test implementation.
 
   def computeCDC(
@@ -81,7 +82,11 @@ trait CDCTestMixin extends SharedSparkSession {
   }
 }
 
-trait ChangelogV2CDCUtilMixin extends CDCTestMixin with ChangelogSyntaxSupportedShim {
+trait ChangelogV2CDCUtilMixin
+  extends SharedSparkSession
+  with CDCTestMixin
+  with ChangelogSyntaxSupportedShim
+  with SQLConfHelper {
 
   // Tests skipped on the V2 changelog read path.
   protected def excludedV2Exact: Set[String] = Set(
@@ -812,7 +817,6 @@ trait DeltaDMLTestUtils
   with DeltaTableProvider
   with BeforeAndAfterEach
   with CDCTestMixin {
-  self: SharedSparkSession =>
 
   import testImplicits._
 
@@ -903,11 +907,11 @@ trait DeltaDMLTestUtils
       spark.read
         .schema(schema)
         .option("mode", FailFastMode.name)
-        .json(data.toDS)
+        .json(spark.createDataset(data))
     } else {
       spark.read
         .option("mode", FailFastMode.name)
-        .json(data.toDS)
+        .json(spark.createDataset(data))
     }
   }
 
@@ -1032,7 +1036,6 @@ trait DeltaDMLInMemoryTestUtils
 }
 
 trait DeltaDMLTestUtilsPathBased extends DeltaDMLTestUtils {
-  self: SharedSparkSession =>
 
   protected var tempDir: File = _
 
@@ -1065,8 +1068,7 @@ trait DeltaDMLTestUtilsPathBased extends DeltaDMLTestUtils {
  */
 case object NameBasedAccessIncompatible extends Tag("NameBasedAccessIncompatible")
 
-trait DeltaDMLTestUtilsNameBased extends DeltaDMLTestUtils {
-  self: SharedSparkSession =>
+trait DeltaDMLTestUtilsNameBased extends DeltaDMLTestUtils with SharedSparkSession {
 
   override protected def test(testName: String, testTags: Tag*)(testFun: => Any)(
       implicit pos: Position): Unit = {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoMaterializeSourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoMaterializeSourceSuite.scala
@@ -50,7 +50,7 @@ trait MergeIntoMaterializeSourceMixin
     with DeltaSQLTestUtils
     with DeltaTestUtilsBase {
 
-  override def beforeAll(): Unit = {
+  override protected def beforeAll(): Unit = {
     super.beforeAll()
     // trigger source materialization in all tests
     spark.conf.set(DeltaSQLConf.MERGE_MATERIALIZE_SOURCE.key, "all")

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSchemaEvolutionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSchemaEvolutionSuite.scala
@@ -33,7 +33,7 @@ import org.apache.spark.util.Utils
  * Trait collecting schema evolution test runner methods and other helpers.
  */
 trait MergeIntoSchemaEvolutionMixin extends QueryTest {
-  self: SharedSparkSession with MergeIntoTestUtils =>
+  self: MergeIntoTestUtils =>
 
   protected implicit def strToJsonSeq(str: String): Seq[String] = {
     str.split("\n").filter(_.trim.length > 0)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoTestUtils.scala
@@ -29,7 +29,6 @@ import org.apache.spark.sql.test.SharedSparkSession
  * or Scala API resp.
  */
 trait MergeIntoTestUtils extends DeltaDMLTestUtils with MergeHelpers {
-  self: SharedSparkSession =>
 
   protected def executeMerge(
       target: String,
@@ -56,7 +55,6 @@ trait MergeIntoTestUtils extends DeltaDMLTestUtils with MergeHelpers {
 }
 
 trait MergeIntoSQLTestUtils extends DeltaSQLTestUtils with MergeIntoTestUtils {
-  self: SharedSparkSession =>
 
   protected def basicMergeStmt(
       cte: Option[String] = None,
@@ -120,7 +118,6 @@ trait MergeIntoSQLTestUtils extends DeltaSQLTestUtils with MergeIntoTestUtils {
 }
 
 trait MergeIntoScalaTestUtils extends MergeIntoTestUtils {
-  self: SharedSparkSession =>
 
   override protected def executeMerge(
       target: String,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/commands/DeltaCommandInvariantsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/commands/DeltaCommandInvariantsSuite.scala
@@ -20,7 +20,8 @@ import scala.util.{Failure, Success, Try}
 
 import com.databricks.spark.util.Log4jUsageLogger
 
-import org.apache.spark.{SparkFunSuite, SparkThrowable}
+import org.apache.spark.SparkThrowable
+import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.delta.DeltaLog
 import org.apache.spark.sql.delta.DeltaTestUtils.BOOLEAN_DOMAIN
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
@@ -28,7 +29,7 @@ import org.apache.spark.sql.delta.DeltaOperations.EmptyCommit
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.util.JsonUtils
 
-class DeltaCommandInvariantsSuite extends SparkFunSuite with DeltaSQLCommandTest {
+class DeltaCommandInvariantsSuite extends SharedSparkSession with DeltaSQLCommandTest {
 
   for {
     shouldSucceed <- BOOLEAN_DOMAIN

--- a/spark/src/test/scala/org/apache/spark/sql/delta/concurrency/TransactionExecutionTestMixin.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/concurrency/TransactionExecutionTestMixin.scala
@@ -28,11 +28,12 @@ import org.apache.spark.sql.delta.fuzzer.{OptimisticTransactionPhases, PhaseLock
 import org.apache.spark.SparkException
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.Row
+import org.apache.spark.sql.SparkSessionProvider
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.util.ThreadUtils
 
 trait TransactionExecutionTestMixin {
-  self: PhaseLockingTestMixin with SharedSparkSession with Logging =>
+  self: PhaseLockingTestMixin with SparkSessionProvider with Logging =>
 
   /**
    * Timeout used when waiting for individual phases of instrumented operations to complete.

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogManagedStreamingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogManagedStreamingSuite.scala
@@ -30,9 +30,9 @@ import org.apache.spark.sql.streaming.StreamTest
  * on the tracking client will not be deterministic.
  */
 trait CatalogManagedStreamingSuiteBase
-  extends StreamTest
+  extends DeltaSQLCommandTest
+  with StreamTest
   with DeltaSQLTestUtils
-  with DeltaSQLCommandTest
   with CatalogOwnedTestBaseSuite {
 
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowTrackingMergeSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowTrackingMergeSuite.scala
@@ -43,7 +43,7 @@ trait RowTrackingMergeSuiteBase extends RowIdTestUtils
       .write.format("delta").saveAsTable(tableName)
   }
 
-  override def beforeAll(): Unit = {
+  override protected def beforeAll(): Unit = {
     super.beforeAll()
     spark.conf.set(DeltaConfigs.ROW_TRACKING_ENABLED.defaultTablePropertyKey, value = "true")
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/skipping/clustering/ClusteredTableDDLSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/skipping/clustering/ClusteredTableDDLSuite.scala
@@ -42,12 +42,12 @@ trait ClusteredTableCreateOrReplaceDDLSuiteBase extends QueryTest
   with SharedSparkSession
   with ClusteredTableTestUtils {
 
-  override def beforeAll(): Unit = {
+  override protected def beforeAll(): Unit = {
     super.beforeAll()
     spark.conf.set(DeltaSQLConf.DELTA_UPDATE_CATALOG_ENABLED.key, "true")
   }
 
-  override def afterAll(): Unit = {
+  override protected def afterAll(): Unit = {
     // Reset UpdateCatalog's thread pool to ensure it is re-initialized in the next test suite.
     // This is necessary because the [[SparkThreadLocalForwardingThreadPoolExecutor]]
     // retains a reference to the SparkContext. Without resetting, the new test suite would

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningAlterTableNestedSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningAlterTableNestedSuite.scala
@@ -32,6 +32,7 @@ class TypeWideningAlterTableNestedSuite
     with TypeWideningTestMixin
     with DeltaDMLTestUtilsNameBased
     with TypeWideningAlterTableNestedTests
+    with org.apache.spark.sql.test.SharedSparkSession
 
 trait TypeWideningAlterTableNestedTests {
   self: QueryTest with ParquetTest with TypeWideningTestMixin =>

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningAlterTableSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningAlterTableSuite.scala
@@ -36,6 +36,7 @@ class TypeWideningAlterTableSuite
     with ParquetTest
     with TypeWideningTestMixin
     with DeltaDMLTestUtilsNameBased
+    with org.apache.spark.sql.test.SharedSparkSession
 
 trait TypeWideningAlterTableTests extends QueryTest
     with QueryErrorsBase

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningStreamingSourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningStreamingSourceSuite.scala
@@ -30,7 +30,7 @@ import org.apache.spark.SparkArithmeticException
 import org.apache.spark.sql.{DataFrame, Row, SaveMode}
 import org.apache.spark.sql.functions.{col, count, lit}
 import org.apache.spark.sql.streaming._
-import org.apache.spark.sql.test.SQLTestUtils
+import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
 
 /**
@@ -70,14 +70,14 @@ trait TypeWideningStreamingSourceTestMixin
   /** Unblocks the stream after a widening type change. */
   protected def withUnblockedTypeChanges(fn: => Unit): Unit
 
-  override def beforeAll(): Unit = {
+  override protected def beforeAll(): Unit = {
     super.beforeAll()
     spark.sessionState.conf.setConf(
       DeltaSQLConf.DELTA_TYPE_WIDENING_ENABLE_STREAMING_SCHEMA_TRACKING, schemaTrackingEnabled)
     spark.udf.register("scala_udf", (x: Int) => x + 1)
   }
 
-  override def afterAll(): Unit = {
+  override protected def afterAll(): Unit = {
     // The scala UDF is a temporary function, no need to drop it.
     super.afterAll()
   }
@@ -160,9 +160,9 @@ trait TypeWideningStreamingSourceTestMixin
  * Can run both with and without schema tracking.
  */
 trait TypeWideningStreamingSourceTests
-  extends StreamTest
-  with SQLTestUtils
-  with TypeWideningStreamingSourceTestMixin {
+  extends SharedSparkSession
+  with TypeWideningStreamingSourceTestMixin
+  with StreamTest {
 
   import testImplicits._
 
@@ -525,9 +525,9 @@ trait TypeWideningStreamingSourceTests
 
 /** Tests that specifically cover type widening without schema tracking. */
 trait TypeWideningStreamingSourceWithoutSchemaTrackingTests
-  extends StreamTest
-  with SQLTestUtils
-  with TypeWideningStreamingSourceTestMixin {
+  extends SharedSparkSession
+  with TypeWideningStreamingSourceTestMixin
+  with StreamTest {
 
   import testImplicits._
 
@@ -601,9 +601,9 @@ trait TypeWideningStreamingSourceWithoutSchemaTrackingTests
 
 /** Tests that specifically cover schema tracking for type widening. */
 trait TypeWideningStreamingSourceSchemaTrackingTests
-  extends StreamTest
-  with SQLTestUtils
-  with TypeWideningStreamingSourceTestMixin {
+  extends SharedSparkSession
+  with TypeWideningStreamingSourceTestMixin
+  with StreamTest {
 
   import testImplicits._
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningTestCases.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningTestCases.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.types._
 /**
  * Trait collecting supported and unsupported type change test cases.
  */
-trait TypeWideningTestCases extends SQLTestUtils { self: SharedSparkSession =>
+trait TypeWideningTestCases extends SQLTestUtils {
   import testImplicits._
 
   /**


### PR DESCRIPTION
Align test suite session ownership so the same Delta tests can run with classic Spark and Spark Connect.

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Reducing the usage of `SharedSparkSession` and introducing `SessionQueryTest` in order to be able to test with a Spark connect session

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

CI

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No, only testing changes
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
