### PR TITLE
[Kernel] Make data skipping column lookups case-insensitive

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/StatsSchemaHelper.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/StatsSchemaHelper.java
@@ -153,10 +153,17 @@ public class StatsSchemaHelper {
   //////////////////////////////////////////////////////////////////////////////////
 
   private final StructType dataSchema;
-  /* Map of all leaf columns from logical to physical names */
-  private final Map<Column, Column> logicalToPhysicalColumn;
-  /* Map of all leaf logical columns to their data type */
-  private final Map<Column, DataType> logicalToDataType;
+  /*
+   * Map of all leaf columns from logical to physical names, keyed by the case-folded logical
+   * column path. Delta column names are case-insensitive (protocol requires uniqueness
+   * regardless of casing), but Column#equals/hashCode are case-sensitive by design since Column
+   * is used broadly for exact-name resolution elsewhere in the kernel. Folding the key here,
+   * rather than in Column itself, keeps that case-insensitive matching scoped to stats/skipping
+   * lookups instead of changing Column's contract everywhere it's used.
+   */
+  private final Map<List<String>, Column> logicalToPhysicalColumn;
+  /* Map of all leaf logical columns to their data type, keyed the same way as above. */
+  private final Map<List<String>, DataType> logicalToDataType;
 
   public StatsSchemaHelper(StructType dataSchema) {
     this.dataSchema = dataSchema;
@@ -166,13 +173,14 @@ public class StatsSchemaHelper {
         logicalToPhysicalColumnAndDataType.entrySet().stream()
             .collect(
                 Collectors.toMap(
-                    Map.Entry::getKey, e -> e.getValue()._1 // map to just the column
+                    e -> caseFoldedPath(e.getKey()), e -> e.getValue()._1 // map to just the column
                     ));
     this.logicalToDataType =
         logicalToPhysicalColumnAndDataType.entrySet().stream()
             .collect(
                 Collectors.toMap(
-                    Map.Entry::getKey, e -> e.getValue()._2 // map to just the data type
+                    e -> caseFoldedPath(e.getKey()),
+                    e -> e.getValue()._2 // map to just the data type
                     ));
   }
 
@@ -213,7 +221,7 @@ public class StatsSchemaHelper {
         column,
         collationIdentifier.isPresent() ? (" for collation " + collationIdentifier) : "",
         dataSchema);
-    DataType dataType = logicalToDataType.get(column);
+    DataType dataType = logicalToDataType.get(caseFoldedPath(column));
     Column maxColumn = getStatsColumn(column, MAX, collationIdentifier);
 
     // If this is a column of type Timestamp or TimestampNTZ
@@ -254,8 +262,9 @@ public class StatsSchemaHelper {
    * column exists, is a leaf column, and is of a skipping-eligible data-type.
    */
   public boolean isSkippingEligibleMinMaxColumn(Column column) {
-    return logicalToDataType.containsKey(column)
-        && isSkippingEligibleDataType(logicalToDataType.get(column));
+    List<String> key = caseFoldedPath(column);
+    return logicalToDataType.containsKey(key)
+        && isSkippingEligibleDataType(logicalToDataType.get(key));
   }
 
   /**
@@ -263,7 +272,7 @@ public class StatsSchemaHelper {
    * the column exists and is a leaf column as we only collect stats for leaf columns.
    */
   public boolean isSkippingEligibleNullCountColumn(Column column) {
-    return logicalToPhysicalColumn.containsKey(column);
+    return logicalToPhysicalColumn.containsKey(caseFoldedPath(column));
   }
 
   //////////////////////////////////////////////////////////////////////////////////
@@ -389,12 +398,13 @@ public class StatsSchemaHelper {
    */
   private Column getStatsColumn(
       Column column, String statType, Optional<CollationIdentifier> collationIdentifier) {
+    List<String> key = caseFoldedPath(column);
     checkArgument(
-        logicalToPhysicalColumn.containsKey(column),
+        logicalToPhysicalColumn.containsKey(key),
         "%s is not a valid leaf column for data schema: %s",
         column,
         dataSchema);
-    Column physicalColumn = logicalToPhysicalColumn.get(column);
+    Column physicalColumn = logicalToPhysicalColumn.get(key);
     // Use binary stats if collation is not specified or if it is the default Spark collation.
     if (collationIdentifier.isPresent()
         && collationIdentifier.get() != CollationIdentifier.SPARK_UTF8_BINARY) {
@@ -435,6 +445,18 @@ public class StatsSchemaHelper {
       }
     }
     return result;
+  }
+
+  /**
+   * Returns a case-folded form of the given column's path, suitable for use as a map key when
+   * looking up a logical column without regard to casing. Delta column names are case-insensitive
+   * (the protocol requires uniqueness regardless of casing), so a schema can never contain two leaf
+   * columns whose paths fold to the same key.
+   */
+  private static List<String> caseFoldedPath(Column column) {
+    return Arrays.stream(column.getNames())
+        .map(name -> name.toLowerCase(Locale.ROOT))
+        .collect(Collectors.toList());
   }
 
   /** Returns the provided column as a child column nested under {@code parentName} */

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/skipping/StatsSchemaHelperSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/skipping/StatsSchemaHelperSuite.scala
@@ -15,8 +15,11 @@
  */
 package io.delta.kernel.internal.skipping
 
+import java.util.Optional
+
 import scala.collection.JavaConverters.setAsJavaSetConverter
 
+import io.delta.kernel.expressions.Column
 import io.delta.kernel.types.{ArrayType, BinaryType, BooleanType, ByteType, CollationIdentifier, DateType, DecimalType, DoubleType, FloatType, IntegerType, LongType, MapType, ShortType, StringType, StructType, TimestampNTZType, TimestampType}
 
 import org.scalatest.funsuite.AnyFunSuite
@@ -424,5 +427,71 @@ class StatsSchemaHelperSuite extends AnyFunSuite {
 
     val statsSchema = StatsSchemaHelper.getStatsSchema(dataSchema, collations.asJava)
     assert(statsSchema == expectedStatsSchema)
+  }
+
+  ///////////////////////////////////////////////////////////////////////////////////////////
+  // Column lookups must be case-insensitive, per the protocol's requirement that column
+  // names be unique regardless of casing. See https://github.com/delta-io/delta/issues/6247.
+  ///////////////////////////////////////////////////////////////////////////////////////////
+
+  test("column lookups match a mixed-case schema column regardless of query casing") {
+    val dataSchema = new StructType().add("Value", IntegerType.INTEGER)
+    val helper = new StatsSchemaHelper(dataSchema)
+
+    // Query using a different casing than the schema ("value" vs. "Value").
+    val queryColumn = new Column("value")
+
+    assert(helper.isSkippingEligibleMinMaxColumn(queryColumn))
+    assert(helper.isSkippingEligibleNullCountColumn(queryColumn))
+
+    // The resolved stats column should reflect the schema's actual casing ("Value"), not the
+    // query's casing.
+    assert(
+      helper.getMinColumn(queryColumn, Optional.empty())._1.getNames.toSeq ==
+        Seq(StatsSchemaHelper.MIN, "Value"))
+    assert(
+      helper.getMaxColumn(queryColumn, Optional.empty())._1.getNames.toSeq ==
+        Seq(StatsSchemaHelper.MAX, "Value"))
+    assert(
+      helper.getNullCountColumn(queryColumn).getNames.toSeq ==
+        Seq(StatsSchemaHelper.NULL_COUNT, "Value"))
+  }
+
+  test("column lookups match a lowercase schema column when queried with mixed case") {
+    // Same as above, with the casings reversed, to confirm the match isn't one-directional.
+    val dataSchema = new StructType().add("value", IntegerType.INTEGER)
+    val helper = new StatsSchemaHelper(dataSchema)
+
+    val queryColumn = new Column("Value")
+
+    assert(helper.isSkippingEligibleMinMaxColumn(queryColumn))
+    assert(helper.isSkippingEligibleNullCountColumn(queryColumn))
+    assert(
+      helper.getMinColumn(queryColumn, Optional.empty())._1.getNames.toSeq ==
+        Seq(StatsSchemaHelper.MIN, "value"))
+  }
+
+  test("column lookups are case-insensitive for nested columns") {
+    val dataSchema = new StructType()
+      .add("A", new StructType().add("B", IntegerType.INTEGER))
+    val helper = new StatsSchemaHelper(dataSchema)
+
+    // Every level of the path is queried with different casing than the schema.
+    val queryColumn = new Column(Array("a", "b"))
+
+    assert(helper.isSkippingEligibleMinMaxColumn(queryColumn))
+    assert(
+      helper.getMinColumn(queryColumn, Optional.empty())._1.getNames.toSeq ==
+        Seq(StatsSchemaHelper.MIN, "A", "B"))
+  }
+
+  test("column lookups still reject a genuinely nonexistent column") {
+    val dataSchema = new StructType().add("Value", IntegerType.INTEGER)
+    val helper = new StatsSchemaHelper(dataSchema)
+
+    val nonexistentColumn = new Column("other")
+
+    assert(!helper.isSkippingEligibleMinMaxColumn(nonexistentColumn))
+    assert(!helper.isSkippingEligibleNullCountColumn(nonexistentColumn))
   }
 }


### PR DESCRIPTION
## Description

Fixes the bug described in #6247: Java Kernel's `StatsSchemaHelper`
matched columns for data skipping using `Column`'s own `equals`/
`hashCode`, which are case-sensitive by design. A predicate like
`col > 5` would silently fail to match a schema column named `Col`,
so data skipping just wouldn't apply, no error, just a missed
optimization. This is inconsistent with the protocol, which requires
column names be unique regardless of casing, and with Delta Spark,
which already handles this correctly via `equalsIgnoreCase`.

## How

Rather than changing `Column`'s equality (it's intentionally
case-sensitive and used broadly elsewhere in the kernel for exact-name
resolution), `StatsSchemaHelper`'s two internal lookup maps are now
keyed by a case-folded form of the column's path instead of by
`Column` directly. This scopes the case-insensitive matching to just
the stats/skipping lookups. It mirrors the fix already merged on the
Rust kernel side (delta-kernel-rs#2055), which takes the same
case-fold-the-lookup-key approach rather than touching column-name
equality globally.

## This PR does NOT:
- Change `Column`'s `equals`/`hashCode` or its case-sensitivity
  elsewhere in the kernel
- Change the on-disk format or any public API signature

## How was this patch tested?

Added test cases to `StatsSchemaHelperSuite`:
- A mixed-case schema column (`Value`) matched by a lowercase query
  (`value`), and the same in reverse
- A nested column matched case-insensitively at every path segment
- Confirmation that a genuinely nonexistent column is still correctly
  rejected (no false positives from the case-folding)

Verified each new test fails against the pre-fix code with the exact
mismatch the issue describes, and passes with the fix. Ran the full
`skipping` package test suite (15 tests, `StatsSchemaHelperSuite` +
`DataSkippingUtilsSuite`), all passing.

## Does this PR introduce _any_ user-facing changes?

No public API or on-disk format changes. Behavior change only: data
skipping now applies correctly for predicates that reference a column
using different casing than the schema, matching Delta Spark's
existing behavior.