### PR TITLE
[Spark] Support decoding SetTransaction (TXN) actions from Delta Kernel

### DIFF
--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/v2/kernel/KernelActionUtilsSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/v2/kernel/KernelActionUtilsSuite.scala
@@ -36,6 +36,7 @@ import io.delta.kernel.internal.actions.{Format => KernelFormat}
 import io.delta.kernel.internal.actions.{Metadata => KernelMetadata}
 import io.delta.kernel.internal.actions.{Protocol => KernelProtocol}
 import io.delta.kernel.internal.actions.{RemoveFile => KernelRemoveFile}
+import io.delta.kernel.internal.actions.{SetTransaction => KernelSetTransaction}
 import io.delta.kernel.internal.data.GenericColumnVector
 import io.delta.kernel.internal.data.GenericRow
 import io.delta.kernel.internal.util.{Utils => KernelUtils}
@@ -247,6 +248,25 @@ class KernelActionUtilsSuite extends SparkFunSuite {
   }
   // scalastyle:on removeFile
 
+  test("setTransactionFromKernel preserves all fields") {
+    val setTransaction = KernelActionUtils.setTransactionFromKernel(
+      new KernelSetTransaction(
+        "app-id", java.lang.Long.valueOf(7L), Optional.of(java.lang.Long.valueOf(12345L))))
+
+    assert(setTransaction.appId === "app-id")
+    assert(setTransaction.version === 7L)
+    assert(setTransaction.lastUpdated === Some(12345L))
+  }
+
+  test("setTransactionFromKernel maps an absent lastUpdated") {
+    val setTransaction = KernelActionUtils.setTransactionFromKernel(
+      new KernelSetTransaction("app-id", java.lang.Long.valueOf(7L), Optional.empty()))
+
+    assert(setTransaction.appId === "app-id")
+    assert(setTransaction.version === 7L)
+    assert(setTransaction.lastUpdated === None)
+  }
+
   test("addFileFromKernel preserves all populated fields") {
     val kernelDv = new KernelDeletionVectorDescriptor(
       "u", "storage-path", Optional.of(java.lang.Integer.valueOf(10)), 128, 5L)
@@ -390,7 +410,7 @@ class KernelActionUtilsSuite extends SparkFunSuite {
   test("readActions fails loud on an action type with no decoder (hand-built commit batch)") {
     val presentColumn = new GenericColumnVector(
       java.util.Collections.singletonList("present"), StringType.STRING)
-    Seq(KernelDeltaAction.TXN, KernelDeltaAction.DOMAINMETADATA, KernelDeltaAction.CDC)
+    Seq(KernelDeltaAction.DOMAINMETADATA, KernelDeltaAction.CDC)
       .foreach { action =>
         val e = intercept[UnsupportedOperationException] {
           KernelActionUtils.readActions(singleColumnCommitActions(action.colName, presentColumn))

--- a/spark/v2/src/main/scala/org/apache/spark/sql/delta/v2/kernel/KernelActionUtils.scala
+++ b/spark/v2/src/main/scala/org/apache/spark/sql/delta/v2/kernel/KernelActionUtils.scala
@@ -29,7 +29,8 @@ import org.apache.spark.sql.delta.actions.{
   Format,
   Metadata,
   Protocol,
-  RemoveFile
+  RemoveFile,
+  SetTransaction
 }
 import io.delta.kernel.{CommitActions => KernelCommitActions}
 import io.delta.kernel.data.{ColumnarBatch => KernelColumnarBatch}
@@ -44,6 +45,7 @@ import io.delta.kernel.internal.actions.{
 import io.delta.kernel.internal.actions.{Metadata => KernelMetadata}
 import io.delta.kernel.internal.actions.{Protocol => KernelProtocol}
 import io.delta.kernel.internal.actions.{RemoveFile => KernelRemoveFile}
+import io.delta.kernel.internal.actions.{SetTransaction => KernelSetTransaction}
 import io.delta.kernel.internal.data.{StructRow => KernelStructRow}
 import io.delta.kernel.internal.util.{VectorUtils => KernelVectorUtils}
 
@@ -110,6 +112,9 @@ private[v2] object KernelActionUtils {
     case KernelDeltaAction.COMMITINFO =>
       commitInfoFromKernel(
         KernelCommitInfo.fromColumnVector(columnVector, rowId))
+    case KernelDeltaAction.TXN =>
+      setTransactionFromKernel(
+        KernelSetTransaction.fromColumnVector(columnVector, rowId))
     case other =>
       throw new UnsupportedOperationException(
         s"No V1 action from Kernel decoder for a '${other.colName}' action yet")
@@ -213,6 +218,16 @@ private[v2] object KernelActionUtils {
       engineInfo = commitInfo.getEngineInfo.toScala,
       txnId = commitInfo.getTxnId.toScala,
       lastManifestCommit = None)
+  }
+
+  /**
+   * Converts a Kernel [[KernelSetTransaction]] into a V1 [[SetTransaction]].
+   */
+  def setTransactionFromKernel(txn: KernelSetTransaction): SetTransaction = {
+    SetTransaction(
+      appId = txn.getAppId,
+      version = txn.getVersion,
+      lastUpdated = txn.getLastUpdated.toScala.map(_.longValue()))
   }
 
   private def deletionVectorFromKernel(


### PR DESCRIPTION
## Description

The Kernel-to-Delta action decoder in `KernelActionUtils` did not handle the
`SetTransaction` (TXN) action: `readActions` threw an
`UnsupportedOperationException` when it encountered a `TXN` action in a commit
batch.

This change adds `setTransactionFromKernel`, which converts a Kernel
`SetTransaction` into a `SetTransaction` action (mapping `appId`, `version`, and
the optional `lastUpdated`), and wires the `TXN` case into `readActions`.

## How was this patch tested?

New unit tests in `KernelActionUtilsSuite`:
- `setTransactionFromKernel preserves all fields` (populated `lastUpdated`)
- `setTransactionFromKernel maps an absent lastUpdated` (empty `lastUpdated`)

The existing "readActions fails loud on an action type with no decoder" test was
updated to drop `TXN` from the set of actions expected to be unsupported, since
`TXN` now has a decoder.

## Does this PR introduce _any_ user-facing changes?

No.
