### PR TITLE
[Spark] Make the metrics schema output not nullable

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
@@ -121,7 +121,8 @@ case class DeleteCommand(
 
   override def innerChildren: Seq[QueryPlan[_]] = Seq(target)
 
-  override val output: Seq[Attribute] = Seq(AttributeReference("num_affected_rows", LongType)())
+  override val output: Seq[Attribute] =
+    Seq(AttributeReference("num_affected_rows", LongType, nullable = false)())
 
   override lazy val metrics = createMetrics
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommand.scala
@@ -77,10 +77,10 @@ case class MergeIntoCommand(
   with ClassicMergeExecutor {
 
   override val output: Seq[Attribute] = Seq(
-    AttributeReference("num_affected_rows", LongType)(),
-    AttributeReference("num_updated_rows", LongType)(),
-    AttributeReference("num_deleted_rows", LongType)(),
-    AttributeReference("num_inserted_rows", LongType)())
+    AttributeReference("num_affected_rows", LongType, nullable = false)(),
+    AttributeReference("num_updated_rows", LongType, nullable = false)(),
+    AttributeReference("num_deleted_rows", LongType, nullable = false)(),
+    AttributeReference("num_inserted_rows", LongType, nullable = false)())
 
   protected def runMerge(spark: SparkSession): Seq[Row] = {
     recordDeltaOperation(targetDeltaLog, "delta.dml.merge") {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/UpdateCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/UpdateCommand.scala
@@ -65,7 +65,7 @@ case class UpdateCommand(
   extends LeafRunnableCommand with DeltaCommand {
 
   override val output: Seq[Attribute] = {
-    Seq(AttributeReference("num_affected_rows", LongType)())
+    Seq(AttributeReference("num_affected_rows", LongType, nullable = false)())
   }
 
   override def innerChildren: Seq[QueryPlan[_]] = Seq(target)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeleteMetricsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeleteMetricsSuite.scala
@@ -450,4 +450,14 @@ class DeleteMetricsSuite extends QueryTest
     }
   }
 
+  test("DELETE output metrics schema is not nullable") {
+    withTable("target") {
+      spark.range(10).write.format("delta").saveAsTable("target")
+
+      val schema = spark.sql("DELETE FROM target WHERE id < 3").schema
+
+      assert(schema.forall(!_.nullable))
+    }
+  }
+
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoMetricsBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoMetricsBase.scala
@@ -1337,6 +1337,20 @@ trait MergeIntoMetricsBase
         testConfig = testConfig
       )
    }}
+
+  test("MERGE output metrics schema is not nullable") {
+    withTable("target", "source") {
+      spark.range(10).write.format("delta").saveAsTable("target")
+      spark.range(5, 15).write.format("delta").saveAsTable("source")
+
+      val schema = spark.sql(
+        "MERGE INTO target t USING source s ON t.id = s.id " +
+          "WHEN MATCHED THEN UPDATE SET t.id = s.id " +
+          "WHEN NOT MATCHED THEN INSERT (id) VALUES (s.id)").schema
+
+      assert(schema.forall(!_.nullable))
+    }
+  }
 }
 
 object MergeIntoMetricsBase extends QueryTest with SharedSparkSession {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/UpdateMetricsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/UpdateMetricsSuite.scala
@@ -350,4 +350,14 @@ class UpdateMetricsSuite extends QueryTest
     )
   }
 
+  test("UPDATE output metrics schema is not nullable") {
+    withTable("target") {
+      spark.range(10).write.format("delta").saveAsTable("target")
+
+      val schema = spark.sql("UPDATE target SET id = id + 100 WHERE id < 5").schema
+
+      assert(schema.forall(!_.nullable))
+    }
+  }
+
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Tighten the schema of the output metrics after a DML command to be not nullable.

## How was this patch tested?
New unit tests asserting that the output schema is `nullable = false`.

## Does this PR introduce _any_ user-facing changes?
Yes, the schema of the output metrics changes from `nullable = true` to `nullable = false`. We always emit an actual value so a `null` was never a returned value.