### PR TITLE
[Spark] Make insert schema evolution tests run through Spark Connect

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoClassicSchemaEvolutionSuites.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoClassicSchemaEvolutionSuites.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.scalactic.source.Position
+import org.scalatest.Tag
+
+class DeltaInsertIntoSchemaEvolutionSuite
+  extends DeltaInsertIntoTest
+  with DeltaInsertIntoSchemaEvolutionTests
+
+class DeltaInsertIntoVoidEvolutionSuite
+  extends DeltaInsertIntoTest
+  with DeltaInsertIntoVoidEvolutionTests {
+
+
+  override protected def test(testName: String, testTags: Tag*)(testFun: => Any)
+      (implicit pos: Position): Unit = {
+    super.test(testName, testTags: _*) {
+      assume(DeltaTestUtilsBase.nullTypeColumnsSupported)
+      testFun
+    }
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoClassicTest.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoClassicTest.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.{DataFrame, Encoders, QueryTest}
+
+trait DeltaInsertIntoTest
+  extends QueryTest
+  with DeltaDMLTestUtilsPathBased
+  with org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+  with DeltaInsertIntoTestBase {
+
+  override protected def beforeStreamingInsert(): Unit = {
+  }
+
+  override protected def createDataFrameFromTestData(data: TestData): DataFrame = {
+    val json = spark.createDataset(data.data)(Encoders.STRING)
+    spark.read.schema(data.schema).option("mode", "FAILFAST").json(json)
+  }
+
+  override protected def adaptExpectedResult(
+      expectedResult: Any): DeltaInsertIntoTestHarness.ExpectedResult[Any] = {
+    expectedResult match {
+      case ExpectedResult.Success(expected) =>
+        DeltaInsertIntoTestHarness.ExpectedResult.Success(expected)
+      case ExpectedResult.Failure(checkError) =>
+        DeltaInsertIntoTestHarness.ExpectedResult.Failure(checkError)
+      case _ =>
+        super.adaptExpectedResult(expectedResult)
+    }
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoSchemaEvolutionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoSchemaEvolutionSuite.scala
@@ -16,23 +16,25 @@
 
 package org.apache.spark.sql.delta
 
-import org.apache.spark.sql.delta.sources.DeltaSQLConf
-import org.scalactic.source.Position
-import org.scalatest.Tag
+// scalastyle:off funsuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.spark.SparkThrowable
 import org.apache.spark.sql.SaveMode
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 
-trait DeltaInsertIntoEvolutionSuiteBase extends DeltaInsertIntoTest with DeltaTableProvider {
+trait DeltaInsertIntoEvolutionSuiteBase extends DeltaInsertIntoTestBase { self: AnyFunSuite =>
+  protected def setCurrentCatalog(): Unit = {
+    executeSql(s"set catalog $catalogName")
+  }
 
-  override def beforeAll(): Unit = {
-    super.beforeAll()
-    spark.conf.set(SQLConf.ANSI_ENABLED.key, "true")
+  override protected def beforeEach(): Unit = {
+    super.beforeEach()
+    spark.conf.set("spark.sql.ansi.enabled", "true")
   }
 
   test("all test cases are implemented") {
+    assert(supportedInsertTypes.nonEmpty, "At least one insert type must be supported")
     // we don't cover SQL INSERT with an explicit column list in this suite as it's not possible to
     // specify a column that doesn't exist in the target table that way.
     val ignoredTestCases = testCases.map { case (name, _) =>
@@ -51,28 +53,32 @@ trait DeltaInsertIntoEvolutionSuiteBase extends DeltaInsertIntoTest with DeltaTa
  * This suite intends to exhaustively cover all the ways INSERT can be run on a Delta table. See
  * [[DeltaInsertIntoTest]] for a list of these INSERT operations covered.
  */
-class DeltaInsertIntoSchemaEvolutionSuite extends DeltaInsertIntoEvolutionSuiteBase {
+trait DeltaInsertIntoSchemaEvolutionTests
+  extends DeltaInsertIntoEvolutionSuiteBase { self: AnyFunSuite =>
+  import DeltaInsertIntoTestHarness._
 
-  for (enableAutoMergeSQLConf <- BOOLEAN_DOMAIN) {
-    val testMsg = s"enableAutoMergeSQLConf=$enableAutoMergeSQLConf"
-    testInserts("WITH SCHEMA EVOLUTION or .option always take precedence over the SQL Conf, " +
-        testMsg)(
-      initialData = TestData("a int, s struct <x: int>", Seq("""{ "a": 1, "s": { "x": 2 } }""")),
-      partitionBy = Seq("a"),
-      overwriteWhere = "a" -> 1,
-      insertData = TestData("a int, s struct <x: int, y: int>",
-        Seq("""{ "a": 1, "s": { "x": 4, "y": 5 } }""")),
-      expectedResult = ExpectedResult.Success(
-        expected = new StructType()
-          .add("a", IntegerType)
-          .add("s", new StructType()
-            .add("x", IntegerType)
-            .add("y", IntegerType)
-          )),
-      confs = Seq(
-        DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> enableAutoMergeSQLConf.toString),
-      withSchemaEvolution = true
-    )
+  if (supportsRuntimeConfigMutations) {
+    for (enableAutoMerge <- BOOLEAN_DOMAIN) {
+      val testMsg = s"enableAutoMerge=$enableAutoMerge"
+      testInserts("WITH SCHEMA EVOLUTION or .option always take precedence over the SQL Conf, " +
+          testMsg)(
+        initialData = TestData("a int, s struct <x: int>", Seq("""{ "a": 1, "s": { "x": 2 } }""")),
+        partitionBy = Seq("a"),
+        overwriteWhere = "a" -> 1,
+        insertData = TestData("a int, s struct <x: int, y: int>",
+          Seq("""{ "a": 1, "s": { "x": 4, "y": 5 } }""")),
+        expectedResult = ExpectedResult.Success(
+          expected = new StructType()
+            .add("a", IntegerType)
+            .add("s", new StructType()
+              .add("x", IntegerType)
+              .add("y", IntegerType)
+            )),
+        confs = Seq(
+          DeltaSchemaAutoMigrateKey -> enableAutoMerge.toString),
+        withSchemaEvolution = true
+      )
+    }
   }
 
   for (schemaEvolution <- BOOLEAN_DOMAIN) {
@@ -90,7 +96,8 @@ class DeltaInsertIntoSchemaEvolutionSuite extends DeltaInsertIntoEvolutionSuiteB
             .add("c", IntegerType))
       } else {
         ExpectedResult.Failure(ex => {
-          checkError(ex, "DELTA_METADATA_MISMATCH", "42KDG", Map.empty[String, String])
+          checkExpectedError(
+            ex, "DELTA_METADATA_MISMATCH", Some("42KDG"), Map.empty[String, String])
         })
       },
       excludeInserts = Set(
@@ -119,7 +126,8 @@ class DeltaInsertIntoSchemaEvolutionSuite extends DeltaInsertIntoEvolutionSuiteB
             .add("c", IntegerType))
       } else {
         ExpectedResult.Failure(ex => {
-          checkError(ex, "DELTA_METADATA_MISMATCH", "42KDG", Map.empty[String, String])
+          checkExpectedError(
+            ex, "DELTA_METADATA_MISMATCH", Some("42KDG"), Map.empty[String, String])
         })
       },
       excludeInserts = insertsSQL.intersect(insertsByName) ++
@@ -134,7 +142,7 @@ class DeltaInsertIntoSchemaEvolutionSuite extends DeltaInsertIntoEvolutionSuiteB
       overwriteWhere = "a" -> 1,
       insertData = TestData("a int, b long, c int", Seq("""{ "a": 1, "b": 4, "c": 5  }""")),
       expectedResult = ExpectedResult.Failure(ex => {
-        checkError(
+        checkExpectedError(
           ex,
           "DELTA_FAILED_TO_MERGE_FIELDS",
           parameters = Map(
@@ -162,11 +170,11 @@ class DeltaInsertIntoSchemaEvolutionSuite extends DeltaInsertIntoEvolutionSuiteB
             .add("c", IntegerType))
       } else {
         ExpectedResult.Failure(ex => {
-          checkError(
+          checkExpectedError(
             ex,
             "INSERT_COLUMN_ARITY_MISMATCH.TOO_MANY_DATA_COLUMNS",
             parameters = Map(
-              "tableName" -> s"`$catalogName`.`default`.`target`",
+              "tableName" -> s"`$catalogName`.`default`.${quoteIdentifier(targetTableName)}",
               "tableColumns" -> "`a`, `b`",
               "dataColumns" -> "`a`, `b`, `c`"
             ))
@@ -199,40 +207,42 @@ class DeltaInsertIntoSchemaEvolutionSuite extends DeltaInsertIntoEvolutionSuiteB
             ))
       } else {
         ExpectedResult.Failure(ex => {
-          checkError(ex, "DELTA_METADATA_MISMATCH", "42KDG", Map.empty[String, String])
+          checkExpectedError(
+            ex, "DELTA_METADATA_MISMATCH", Some("42KDG"), Map.empty[String, String])
         })
       },
       withSchemaEvolution = schemaEvolution
     )
   }
 
-  for {
-    preserveNullSourceStructs <- BOOLEAN_DOMAIN
-    (inserts: Set[Insert], expectedAnswer) <- Seq(
+  if (supportsRuntimeConfigMutations) {
+    for {
+      preserveNullSourceStructs <- BOOLEAN_DOMAIN
+      (inserts: Set[Insert], expectedAnswer) <- Seq(
       insertsAppend ->
         TestData("a int, s struct <x: int, y: int>",
           Seq("""{ "a": 1, "s": { "x": 2, "y": null } }""", """{ "a": 1, "s": null }""")),
       insertsOverwrite ->
         TestData("a int, s struct <x: int, y: int>",
           Seq("""{ "a": 1, "s": null }"""))
-    )
-  } {
-    testInserts(s"insert with extra nested field, null struct, " +
-        s"preserveNullSourceStructs=$preserveNullSourceStructs")(
-      initialData = TestData("a int, s struct <x: int>",
-        Seq("""{ "a": 1, "s": { "x": 2 } }""")),
-      partitionBy = Seq("a"),
-      overwriteWhere = "a" -> 1,
-      insertData = TestData("a int, s struct <x: int, y: int>",
-        Seq("""{ "a": 1, "s": null }""")),
-      expectedResult = ExpectedResult.Success(expected = expectedAnswer),
-      includeInserts = inserts,
-      confs = Seq(
-        DeltaSQLConf.DELTA_INSERT_PRESERVE_NULL_SOURCE_STRUCTS.key
-          -> preserveNullSourceStructs.toString
-      ),
-      withSchemaEvolution = true
-    )
+      )
+    } {
+      testInserts(s"insert with extra nested field, null struct, " +
+          s"preserveNullSourceStructs=$preserveNullSourceStructs")(
+        initialData = TestData("a int, s struct <x: int>",
+          Seq("""{ "a": 1, "s": { "x": 2 } }""")),
+        partitionBy = Seq("a"),
+        overwriteWhere = "a" -> 1,
+        insertData = TestData("a int, s struct <x: int, y: int>",
+          Seq("""{ "a": 1, "s": null }""")),
+        expectedResult = ExpectedResult.Success(expected = expectedAnswer),
+        includeInserts = inserts,
+        confs = Seq(
+          DeltaInsertPreserveNullSourceStructsKey -> preserveNullSourceStructs.toString
+        ),
+        withSchemaEvolution = true
+      )
+    }
   }
 
   for (schemaEvolution <- BOOLEAN_DOMAIN) {
@@ -256,7 +266,8 @@ class DeltaInsertIntoSchemaEvolutionSuite extends DeltaInsertIntoEvolutionSuiteB
             ))
       } else {
         ExpectedResult.Failure(ex => {
-          checkError(ex, "DELTA_METADATA_MISMATCH", "42KDG", Map.empty[String, String])
+          checkExpectedError(
+            ex, "DELTA_METADATA_MISMATCH", Some("42KDG"), Map.empty[String, String])
         })
       },
       excludeInserts = Set(
@@ -277,7 +288,7 @@ class DeltaInsertIntoSchemaEvolutionSuite extends DeltaInsertIntoEvolutionSuiteB
       insertData = TestData("a int, s struct <x: long, y: int>",
         Seq("""{ "a": 1, "s": { "x": 4, "y": 5 } }""")),
       expectedResult = ExpectedResult.Failure(ex => {
-        checkError(
+        checkExpectedError(
           ex,
           "DELTA_FAILED_TO_MERGE_FIELDS",
           parameters = Map(
@@ -292,38 +303,41 @@ class DeltaInsertIntoSchemaEvolutionSuite extends DeltaInsertIntoEvolutionSuiteB
 
   // When DELTA_INSERT_BY_NAME_SCHEMA_EVOLUTION_ENABLED is disabled, SQL INSERT BY NAME with extra
   // top-level columns should fail even when schema evolution is enabled.
-  test("insert by name with extra top-level column and implicit cast fails " +
-      "when byNameSchemaEvolution is disabled") {
-    withTable("target") {
-      sql(createTableSQL("target", "a INT, b INT"))
-      withSQLConf(
-          DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> "true",
-          DeltaSQLConf.DELTA_INSERT_BY_NAME_SCHEMA_EVOLUTION_ENABLED.key -> "false") {
-        val ex = intercept[SparkThrowable] {
-          sql("INSERT INTO target BY NAME SELECT 1 AS a, 2L AS b, 3 AS c")
+  if (supportsRuntimeConfigMutations &&
+      supportedInsertTypes.contains(SQLInsertByName(SaveMode.Append))) {
+    test("insert by name with extra top-level column and implicit cast fails " +
+        "when byNameSchemaEvolution is disabled") {
+      withTestTables(targetTableName) {
+        val quotedTargetTableName = quoteMultipartIdentifier(targetTableName)
+        executeSql(s"CREATE TABLE $quotedTargetTableName (a INT, b INT) USING DELTA")
+        withRuntimeConf(
+            DeltaSchemaAutoMigrateKey -> "true",
+            DeltaInsertByNameSchemaEvolutionEnabledKey -> "false") {
+          val ex = intercept[SparkThrowable] {
+            executeSql(
+              s"INSERT INTO $quotedTargetTableName BY NAME SELECT 1 AS a, 2L AS b, 3 AS c")
+          }
+          validateInsertFailure(
+            ex,
+            exception =>
+              checkExpectedError(
+                exception,
+                "INSERT_COLUMN_ARITY_MISMATCH.TOO_MANY_DATA_COLUMNS",
+                parameters = Map(
+                  "tableName" ->
+                    s"`$catalogName`.`default`.${quoteIdentifier(targetTableName)}",
+                  "tableColumns" -> "`a`, `b`",
+                  "dataColumns" -> "`a`, `b`, `c`"
+                )))
         }
-        checkError(
-          ex,
-          "INSERT_COLUMN_ARITY_MISMATCH.TOO_MANY_DATA_COLUMNS",
-          parameters = Map(
-            "tableName" -> s"`$catalogName`.`default`.`target`",
-            "tableColumns" -> "`a`, `b`",
-            "dataColumns" -> "`a`, `b`, `c`"
-          ))
       }
     }
   }
 }
 
-class DeltaInsertIntoVoidEvolutionSuite extends DeltaInsertIntoEvolutionSuiteBase {
-
-  override protected def test(testName: String, testTags: Tag*)(testFun: => Any)
-      (implicit pos: Position): Unit = {
-    super.test(testName, testTags: _*) {
-      assume(DeltaTestUtilsBase.nullTypeColumnsSupported)
-      testFun
-    }
-  }
+trait DeltaInsertIntoVoidEvolutionTests
+  extends DeltaInsertIntoEvolutionSuiteBase { self: AnyFunSuite =>
+  import DeltaInsertIntoTestHarness._
 
   for (schemaEvolution <- BOOLEAN_DOMAIN) {
     testInserts(s"insert and evolve void column into int," +
@@ -341,14 +355,18 @@ class DeltaInsertIntoVoidEvolutionSuite extends DeltaInsertIntoEvolutionSuiteBas
             .add("v", IntegerType))
       } else {
         ExpectedResult.Failure(ex => {
-          checkError(ex, "DELTA_METADATA_MISMATCH", "42KDG", Map.empty[String, String])
+          checkExpectedError(
+            ex,
+            "DELTA_METADATA_MISMATCH",
+            Some("42KDG"),
+            Map.empty[String, String])
         })
       },
       withSchemaEvolution = schemaEvolution
     )
   }
 
-  testInserts(s"insert and evolve void column into struct")(
+  testInserts("insert and evolve void column into struct")(
     initialData = TestData("a int, i int, v void", Seq("""{ "a": 1, "i": 1, "v": null }""")),
     partitionBy = Seq("a"),
     overwriteWhere = "a" -> 1,
@@ -363,7 +381,7 @@ class DeltaInsertIntoVoidEvolutionSuite extends DeltaInsertIntoEvolutionSuiteBas
     withSchemaEvolution = true
   )
 
-  testInserts(s"insert and evolve void column into array")(
+  testInserts("insert and evolve void column into array")(
     initialData = TestData("a int, i int, v void", Seq("""{ "a": 1, "i": 1, "v": null }""")),
     partitionBy = Seq("a"),
     overwriteWhere = "a" -> 1,
@@ -380,7 +398,7 @@ class DeltaInsertIntoVoidEvolutionSuite extends DeltaInsertIntoEvolutionSuiteBas
     withSchemaEvolution = true
   )
 
-  testInserts(s"insert and evolve void column into map")(
+  testInserts("insert and evolve void column into map")(
     initialData = TestData("a int, i int, v void", Seq("""{ "a": 1, "i": 1, "v": null }""")),
     partitionBy = Seq("a"),
     overwriteWhere = "a" -> 1,
@@ -398,7 +416,7 @@ class DeltaInsertIntoVoidEvolutionSuite extends DeltaInsertIntoEvolutionSuiteBas
     withSchemaEvolution = true
   )
 
-  testInserts(s"insert and evolve void column in struct into int")(
+  testInserts("insert and evolve void column in struct into int")(
     initialData = TestData("a int, i int, v struct<x:int, y:void>",
       Seq("""{ "a": 1, "i": 1, "v": { "x": 1, "y": null } }""")),
     partitionBy = Seq("a"),
@@ -415,7 +433,7 @@ class DeltaInsertIntoVoidEvolutionSuite extends DeltaInsertIntoEvolutionSuiteBas
     withSchemaEvolution = true
   )
 
-  testInserts(s"insert and evolve void column in struct into struct")(
+  testInserts("insert and evolve void column in struct into struct")(
     initialData = TestData("a int, i int, v struct<x:int, y:void>",
       Seq("""{ "a": 1, "i": 1, "v": { "x": 1, "y": null } }""")),
     partitionBy = Seq("a"),
@@ -433,7 +451,7 @@ class DeltaInsertIntoVoidEvolutionSuite extends DeltaInsertIntoEvolutionSuiteBas
     withSchemaEvolution = true
   )
 
-  testInserts(s"insert and evolve void column in struct into struct with void")(
+  testInserts("insert and evolve void column in struct into struct with void")(
     initialData = TestData("a int, i int, v struct<x:int, y:void>",
       Seq("""{ "a": 1, "i": 1, "v": { "x": 1, "y": null } }""")),
     partitionBy = Seq("a"),
@@ -453,7 +471,7 @@ class DeltaInsertIntoVoidEvolutionSuite extends DeltaInsertIntoEvolutionSuiteBas
     withSchemaEvolution = true
   )
 
-  testInserts(s"insert and evolve void column in struct into struct with void")(
+  testInserts("insert and evolve void column in struct into struct with void")(
     initialData = TestData("a int, i int, v struct<x:int, y:void>",
       Seq("""{ "a": 1, "i": 1, "v": { "x": 1, "y": null } }""")),
     partitionBy = Seq("a"),
@@ -461,13 +479,13 @@ class DeltaInsertIntoVoidEvolutionSuite extends DeltaInsertIntoEvolutionSuiteBas
     insertData = TestData("a int, i int, v struct<x:int, y:struct<f1:int, f2:void>>",
       Seq("""{ "a": 1, "i": 2, "v": { "x": 2, "y": { "f1": 2, "f2": null } } }""")),
     expectedResult = ExpectedResult.Failure(ex => {
-      checkError(ex, "DELTA_NULL_SCHEMA_IN_STREAMING_WRITE")
+      checkExpectedError(ex, "DELTA_NULL_SCHEMA_IN_STREAMING_WRITE")
     }),
     includeInserts = Set(StreamingInsert),
     withSchemaEvolution = true
   )
 
-  testInserts(s"insert and evolve void column in struct into array")(
+  testInserts("insert and evolve void column in struct into array")(
     initialData = TestData("a int, i int, v struct<x:int, y:void>",
       Seq("""{ "a": 1, "i": 1, "v": { "x": 1, "y": null } }""")),
     partitionBy = Seq("a"),
@@ -484,7 +502,7 @@ class DeltaInsertIntoVoidEvolutionSuite extends DeltaInsertIntoEvolutionSuiteBas
     withSchemaEvolution = true
   )
 
-  testInserts(s"insert and evolve void column in struct into map")(
+  testInserts("insert and evolve void column in struct into map")(
     initialData = TestData("a int, i int, v struct<x:int, y:void>",
       Seq("""{ "a": 1, "i": 1, "v": { "x": 1, "y": null } }""")),
     partitionBy = Seq("a"),

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoSchemaEvolutionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoSchemaEvolutionSuite.scala
@@ -17,15 +17,26 @@
 package org.apache.spark.sql.delta
 
 // scalastyle:off funsuite
+import org.scalatest.BeforeAndAfterEach
 import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.spark.SparkThrowable
 import org.apache.spark.sql.SaveMode
 import org.apache.spark.sql.types._
 
-trait DeltaInsertIntoEvolutionSuiteBase extends DeltaInsertIntoTestBase { self: AnyFunSuite =>
+trait DeltaInsertIntoEvolutionSuiteBase
+    extends DeltaInsertIntoTestBase
+    with BeforeAndAfterEach { self: AnyFunSuite =>
+
+  protected val schemaEvolutionBooleanDomain: Seq[Boolean] = Seq(true, false)
+
+  protected val DeltaInsertPreserveNullSourceStructsKey: String =
+    "spark.databricks.delta.insert.preserveNullSourceStructs"
+  protected val DeltaInsertByNameSchemaEvolutionEnabledKey: String =
+    "spark.databricks.delta.insert.byName.schemaEvolution.enabled"
+
   protected def setCurrentCatalog(): Unit = {
-    executeSql(s"set catalog $catalogName")
+    spark.sql(s"set catalog $catalogName")
   }
 
   override protected def beforeEach(): Unit = {
@@ -34,7 +45,6 @@ trait DeltaInsertIntoEvolutionSuiteBase extends DeltaInsertIntoTestBase { self: 
   }
 
   test("all test cases are implemented") {
-    assert(supportedInsertTypes.nonEmpty, "At least one insert type must be supported")
     // we don't cover SQL INSERT with an explicit column list in this suite as it's not possible to
     // specify a column that doesn't exist in the target table that way.
     val ignoredTestCases = testCases.map { case (name, _) =>
@@ -57,31 +67,29 @@ trait DeltaInsertIntoSchemaEvolutionTests
   extends DeltaInsertIntoEvolutionSuiteBase { self: AnyFunSuite =>
   import DeltaInsertIntoTestHarness._
 
-  if (supportsRuntimeConfigMutations) {
-    for (enableAutoMerge <- BOOLEAN_DOMAIN) {
-      val testMsg = s"enableAutoMerge=$enableAutoMerge"
-      testInserts("WITH SCHEMA EVOLUTION or .option always take precedence over the SQL Conf, " +
-          testMsg)(
-        initialData = TestData("a int, s struct <x: int>", Seq("""{ "a": 1, "s": { "x": 2 } }""")),
-        partitionBy = Seq("a"),
-        overwriteWhere = "a" -> 1,
-        insertData = TestData("a int, s struct <x: int, y: int>",
-          Seq("""{ "a": 1, "s": { "x": 4, "y": 5 } }""")),
-        expectedResult = ExpectedResult.Success(
-          expected = new StructType()
-            .add("a", IntegerType)
-            .add("s", new StructType()
-              .add("x", IntegerType)
-              .add("y", IntegerType)
-            )),
-        confs = Seq(
-          DeltaSchemaAutoMigrateKey -> enableAutoMerge.toString),
-        withSchemaEvolution = true
-      )
-    }
+  for (enableAutoMergeSQLConf <- schemaEvolutionBooleanDomain) {
+    val testMsg = s"enableAutoMergeSQLConf=$enableAutoMergeSQLConf"
+    testInserts("WITH SCHEMA EVOLUTION or .option always take precedence over the SQL Conf, " +
+        testMsg)(
+      initialData = TestData("a int, s struct <x: int>", Seq("""{ "a": 1, "s": { "x": 2 } }""")),
+      partitionBy = Seq("a"),
+      overwriteWhere = "a" -> 1,
+      insertData = TestData("a int, s struct <x: int, y: int>",
+        Seq("""{ "a": 1, "s": { "x": 4, "y": 5 } }""")),
+      expectedResult = ExpectedResult.Success(
+        expected = new StructType()
+          .add("a", IntegerType)
+          .add("s", new StructType()
+            .add("x", IntegerType)
+            .add("y", IntegerType)
+          )),
+      confs = Seq(
+        DeltaSchemaAutoMigrateKey -> enableAutoMergeSQLConf.toString),
+      withSchemaEvolution = true
+    )
   }
 
-  for (schemaEvolution <- BOOLEAN_DOMAIN) {
+  for (schemaEvolution <- schemaEvolutionBooleanDomain) {
     // We allow adding new top-level columns with schema evolution for all inserts.
     testInserts(s"insert with extra top-level column, schemaEvolution=$schemaEvolution")(
       initialData = TestData("a int, b int", Seq("""{ "a": 1, "b": 2 }""")),
@@ -215,37 +223,35 @@ trait DeltaInsertIntoSchemaEvolutionTests
     )
   }
 
-  if (supportsRuntimeConfigMutations) {
-    for {
-      preserveNullSourceStructs <- BOOLEAN_DOMAIN
-      (inserts: Set[Insert], expectedAnswer) <- Seq(
+  for {
+    preserveNullSourceStructs <- schemaEvolutionBooleanDomain
+    (inserts: Set[Insert], expectedAnswer) <- Seq(
       insertsAppend ->
         TestData("a int, s struct <x: int, y: int>",
           Seq("""{ "a": 1, "s": { "x": 2, "y": null } }""", """{ "a": 1, "s": null }""")),
       insertsOverwrite ->
         TestData("a int, s struct <x: int, y: int>",
           Seq("""{ "a": 1, "s": null }"""))
-      )
-    } {
-      testInserts(s"insert with extra nested field, null struct, " +
-          s"preserveNullSourceStructs=$preserveNullSourceStructs")(
-        initialData = TestData("a int, s struct <x: int>",
-          Seq("""{ "a": 1, "s": { "x": 2 } }""")),
-        partitionBy = Seq("a"),
-        overwriteWhere = "a" -> 1,
-        insertData = TestData("a int, s struct <x: int, y: int>",
-          Seq("""{ "a": 1, "s": null }""")),
-        expectedResult = ExpectedResult.Success(expected = expectedAnswer),
-        includeInserts = inserts,
-        confs = Seq(
-          DeltaInsertPreserveNullSourceStructsKey -> preserveNullSourceStructs.toString
-        ),
-        withSchemaEvolution = true
-      )
-    }
+    )
+  } {
+    testInserts(s"insert with extra nested field, null struct, " +
+        s"preserveNullSourceStructs=$preserveNullSourceStructs")(
+      initialData = TestData("a int, s struct <x: int>",
+        Seq("""{ "a": 1, "s": { "x": 2 } }""")),
+      partitionBy = Seq("a"),
+      overwriteWhere = "a" -> 1,
+      insertData = TestData("a int, s struct <x: int, y: int>",
+        Seq("""{ "a": 1, "s": null }""")),
+      expectedResult = ExpectedResult.Success(expected = expectedAnswer),
+      includeInserts = inserts,
+      confs = Seq(
+        DeltaInsertPreserveNullSourceStructsKey -> preserveNullSourceStructs.toString
+      ),
+      withSchemaEvolution = true
+    )
   }
 
-  for (schemaEvolution <- BOOLEAN_DOMAIN) {
+  for (schemaEvolution <- schemaEvolutionBooleanDomain) {
     // Adding new nested struct fields with schema evolution is allowed for all inserts, but
     // dataframe inserts by name don't support implicit casting and will fail due to the type
     // mismatch.
@@ -303,33 +309,27 @@ trait DeltaInsertIntoSchemaEvolutionTests
 
   // When DELTA_INSERT_BY_NAME_SCHEMA_EVOLUTION_ENABLED is disabled, SQL INSERT BY NAME with extra
   // top-level columns should fail even when schema evolution is enabled.
-  if (supportsRuntimeConfigMutations &&
-      supportedInsertTypes.contains(SQLInsertByName(SaveMode.Append))) {
-    test("insert by name with extra top-level column and implicit cast fails " +
-        "when byNameSchemaEvolution is disabled") {
-      withTestTables(targetTableName) {
-        val quotedTargetTableName = quoteMultipartIdentifier(targetTableName)
-        executeSql(s"CREATE TABLE $quotedTargetTableName (a INT, b INT) USING DELTA")
-        withRuntimeConf(
-            DeltaSchemaAutoMigrateKey -> "true",
-            DeltaInsertByNameSchemaEvolutionEnabledKey -> "false") {
-          val ex = intercept[SparkThrowable] {
-            executeSql(
-              s"INSERT INTO $quotedTargetTableName BY NAME SELECT 1 AS a, 2L AS b, 3 AS c")
-          }
-          validateInsertFailure(
-            ex,
-            exception =>
-              checkExpectedError(
-                exception,
-                "INSERT_COLUMN_ARITY_MISMATCH.TOO_MANY_DATA_COLUMNS",
-                parameters = Map(
-                  "tableName" ->
-                    s"`$catalogName`.`default`.${quoteIdentifier(targetTableName)}",
-                  "tableColumns" -> "`a`, `b`",
-                  "dataColumns" -> "`a`, `b`, `c`"
-                )))
+  test("insert by name with extra top-level column and implicit cast fails " +
+      "when byNameSchemaEvolution is disabled") {
+    withTestTables(targetTableName) {
+      val quotedTargetTableName = quoteMultipartIdentifier(targetTableName)
+      spark.sql(s"CREATE TABLE $quotedTargetTableName (a INT, b INT) USING DELTA")
+      withRuntimeConf(
+          DeltaSchemaAutoMigrateKey -> "true",
+          DeltaInsertByNameSchemaEvolutionEnabledKey -> "false") {
+        val ex = intercept[SparkThrowable] {
+          spark.sql(
+            s"INSERT INTO $quotedTargetTableName BY NAME SELECT 1 AS a, 2L AS b, 3 AS c")
         }
+        checkExpectedError(
+          ex,
+          "INSERT_COLUMN_ARITY_MISMATCH.TOO_MANY_DATA_COLUMNS",
+          parameters = Map(
+            "tableName" ->
+              s"`$catalogName`.`default`.${quoteIdentifier(targetTableName)}",
+            "tableColumns" -> "`a`, `b`",
+            "dataColumns" -> "`a`, `b`, `c`"
+          ))
       }
     }
   }
@@ -339,7 +339,7 @@ trait DeltaInsertIntoVoidEvolutionTests
   extends DeltaInsertIntoEvolutionSuiteBase { self: AnyFunSuite =>
   import DeltaInsertIntoTestHarness._
 
-  for (schemaEvolution <- BOOLEAN_DOMAIN) {
+  for (schemaEvolution <- schemaEvolutionBooleanDomain) {
     testInserts(s"insert and evolve void column into int," +
       s"schemaEvolution=$schemaEvolution")(
       initialData = TestData("a int, i int, v void", Seq("""{ "a": 1, "i": 1, "v": null }""")),

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoTest.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoTest.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql.delta
 import scala.collection.mutable
 
 // scalastyle:off funsuite
-import org.scalatest.BeforeAndAfterEach
 import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.spark.SparkThrowable
@@ -29,8 +28,6 @@ import org.apache.spark.sql.streaming.{StreamingQueryException, Trigger}
 import org.apache.spark.sql.types.StructType
 
 object DeltaInsertIntoTestHarness {
-  val BOOLEAN_DOMAIN: Seq[Boolean] = Seq(true, false)
-
   sealed trait ExpectedResult[-T]
   object ExpectedResult {
     case class Success[T](expected: T) extends ExpectedResult[T]
@@ -47,8 +44,7 @@ object DeltaInsertIntoTestHarness {
  * Each take a unique path through analysis. The abstractions below captures these different
  * inserts to allow more easily running tests with all or a subset of them.
  */
-trait DeltaInsertIntoTestBase
-  extends BeforeAndAfterEach { self: AnyFunSuite =>
+trait DeltaInsertIntoTestBase { self: AnyFunSuite =>
 
   protected def spark: SparkSession
 
@@ -77,8 +73,6 @@ trait DeltaInsertIntoTestBase
       s"Expected no query context but got ${exception.getQueryContext.toSeq}")
   }
 
-  protected def executeSql(query: String): DataFrame = spark.sql(query)
-
   protected def writeFormat: String
 
   protected val catalogName: String = "spark_catalog"
@@ -89,13 +83,16 @@ trait DeltaInsertIntoTestBase
 
   protected val DeltaSchemaAutoMigrateKey: String =
     "spark.databricks.delta.schema.autoMerge.enabled"
-  protected val DeltaInsertPreserveNullSourceStructsKey: String =
-    "spark.databricks.delta.insert.preserveNullSourceStructs"
-  protected val DeltaInsertByNameSchemaEvolutionEnabledKey: String =
-    "spark.databricks.delta.insert.byName.schemaEvolution.enabled"
 
   private val ReplaceOnDataFrameWriterEnabledKey =
     "spark.databricks.delta.replaceOn.dataframe.writer.enabled"
+
+  private def supportsInsertWithSchemaEvolutionSyntax: Boolean = {
+    val versionParts = spark.version.split('.')
+    val major = versionParts(0).toInt
+    val minor = versionParts(1).toInt
+    major > 4 || (major == 4 && minor >= 2)
+  }
 
   private def targetTablePath: String =
     spark.sql(s"DESCRIBE DETAIL $quotedTargetTableName")
@@ -106,12 +103,10 @@ trait DeltaInsertIntoTestBase
       f
     } finally {
       tableNames.reverse.foreach { tableName =>
-        executeSql(s"DROP TABLE IF EXISTS ${quoteMultipartIdentifier(tableName)}").collect()
+        spark.sql(s"DROP TABLE IF EXISTS ${quoteMultipartIdentifier(tableName)}").collect()
       }
     }
   }
-
-  protected def unsetRuntimeConf(key: String): Unit = spark.conf.unset(key)
 
   protected def withRuntimeConf[T](pairs: (String, String)*)(f: => T): T = {
     val previousValues = pairs.map { case (key, _) => key -> spark.conf.getOption(key) }
@@ -119,7 +114,7 @@ trait DeltaInsertIntoTestBase
     try f finally {
       previousValues.foreach {
         case (key, Some(value)) => spark.conf.set(key, value)
-        case (key, None) => unsetRuntimeConf(key)
+        case (key, None) => spark.conf.unset(key)
       }
     }
   }
@@ -155,12 +150,21 @@ trait DeltaInsertIntoTestBase
     /**
      * Runs a SQL INSERT, enabling Delta schema evolution when [[withSchemaEvolution]] is set.
      *
+     * Spark 4.2 introduced the `INSERT WITH SCHEMA EVOLUTION` syntax. Earlier versions enable
+     * schema evolution through the corresponding SQL configuration instead.
+     *
      * @param buildInsert builds the INSERT statement given the schema evolution clause to splice
      *                    in right after the leading `INSERT` keyword.
      */
     def runInsertSql(withSchemaEvolution: Boolean)(buildInsert: String => String): Unit = {
-      val clause = if (withSchemaEvolution) "WITH SCHEMA EVOLUTION " else ""
-      executeSql(buildInsert(clause))
+      if (supportsInsertWithSchemaEvolutionSyntax) {
+        val clause = if (withSchemaEvolution) "WITH SCHEMA EVOLUTION " else ""
+        spark.sql(buildInsert(clause))
+      } else {
+        withRuntimeConf(DeltaSchemaAutoMigrateKey -> withSchemaEvolution.toString) {
+          spark.sql(buildInsert(""))
+        }
+      }
     }
 
     /** The expected content of the table after the insert. */
@@ -295,7 +299,7 @@ trait DeltaInsertIntoTestBase
         withSchemaEvolution: Boolean): Unit =
       spark.read.table(sourceTableName).write.mode(mode)
         .option("mergeSchema", withSchemaEvolution.toString)
-        .format("delta")
+        .format(writeFormat)
         .insertInto(targetTableName)
   }
 
@@ -311,7 +315,7 @@ trait DeltaInsertIntoTestBase
         withSchemaEvolution: Boolean): Unit = {
       spark.read.table(sourceTableName).write.mode(mode)
         .option("mergeSchema", withSchemaEvolution.toString)
-        .format("delta")
+        .format(writeFormat)
         .saveAsTable(targetTableName)
     }
   }
@@ -328,7 +332,7 @@ trait DeltaInsertIntoTestBase
         withSchemaEvolution: Boolean): Unit = {
       spark.read.table(sourceTableName).write.mode(mode)
         .option("mergeSchema", withSchemaEvolution.toString)
-        .format("delta")
+        .format(writeFormat)
         .save(targetTablePath)
     }
   }
@@ -350,7 +354,7 @@ trait DeltaInsertIntoTestBase
           .option("replaceOn", s"t.$whereCol = $whereValue")
           .option("targetAlias", "t")
           .option("mergeSchema", withSchemaEvolution.toString)
-          .format("delta")
+          .format(writeFormat)
           .insertInto(targetTableName)
       }
     }
@@ -373,7 +377,7 @@ trait DeltaInsertIntoTestBase
           .option("replaceOn", s"t.$whereCol = $whereValue")
           .option("targetAlias", "t")
           .option("mergeSchema", withSchemaEvolution.toString)
-          .format("delta")
+          .format(writeFormat)
           .save(targetTablePath)
       }
     }
@@ -394,7 +398,7 @@ trait DeltaInsertIntoTestBase
         .mode(mode)
         .option("partitionOverwriteMode", "dynamic")
         .option("mergeSchema", withSchemaEvolution.toString)
-        .format("delta")
+        .format(writeFormat)
         .insertInto(targetTableName)
   }
 
@@ -504,18 +508,6 @@ trait DeltaInsertIntoTestBase
       )
     } yield insert).toSet
 
-  protected def supportedInsertTypes: Set[Insert] = allInsertTypes
-
-  protected def supportsUsageLogValidation: Boolean = true
-
-  protected def supportsRuntimeConfigMutations: Boolean = true
-
-  protected def supportsCanonicalInsertFailureErrors: Boolean = true
-
-  protected def validateInsertFailure(
-      exception: SparkThrowable,
-      validation: SparkThrowable => Unit): Unit = validation(exception)
-
   protected def adaptExpectedResult(
       expectedResult: Any): DeltaInsertIntoTestHarness.ExpectedResult[Any] = {
     expectedResult match {
@@ -566,7 +558,7 @@ trait DeltaInsertIntoTestBase
   def checkAllTestCasesImplemented(ignoredTestCases: Map[String, Set[Insert]] = Map.empty): Unit = {
     val ignoredTests = ignoredTestCases.withDefaultValue(Set.empty)
     val missingTests = testCases.map {
-      case (name, inserts) => name -> (supportedInsertTypes -- inserts -- ignoredTests(name))
+      case (name, inserts) => name -> (allInsertTypes -- inserts -- ignoredTests(name))
     }.collect {
       case (name, missingInserts) if missingInserts.nonEmpty =>
         s"Test '$name' is not covering all insert types, missing: $missingInserts"
@@ -593,15 +585,7 @@ trait DeltaInsertIntoTestBase
     } else {
       s"SELECT from_json(CAST(NULL AS STRING), $schemaLiteral) AS parsed"
     }
-    executeSql(s"SELECT parsed.* FROM ($parsedRows) WHERE parsed IS NOT NULL")
-  }
-
-  protected def expectedRows(
-      insert: Insert,
-      initialData: TestData,
-      insertData: TestData,
-      expectedSchema: StructType): Seq[Row] = {
-    insert.expectedResult(initialData.toDF, insertData.toDF).collect().toSeq
+    spark.sql(s"SELECT parsed.* FROM ($parsedRows) WHERE parsed IS NOT NULL")
   }
 
   protected def checkExpectedRows(
@@ -610,7 +594,8 @@ trait DeltaInsertIntoTestBase
       initialData: TestData,
       insertData: TestData,
       expectedSchema: StructType): Unit = {
-    checkAnswer(actual, expectedRows(insert, initialData, insertData, expectedSchema))
+    val expected = insert.expectedResult(initialData.toDF, insertData.toDF).collect().toSeq
+    checkAnswer(actual, expected)
   }
 
   protected def checkExpectedRows(actual: => DataFrame, expectedData: TestData): Unit = {
@@ -621,7 +606,7 @@ trait DeltaInsertIntoTestBase
       tableName: String,
       data: TestData,
       partitionBy: Seq[String] = Seq.empty): Unit = {
-    val writer = data.toDF.write.format("delta")
+    val writer = data.toDF.write.format(writeFormat)
     if (partitionBy.nonEmpty) {
       writer.partitionBy(partitionBy: _*)
     }
@@ -656,20 +641,11 @@ trait DeltaInsertIntoTestBase
       excludeInserts: Set[Insert] = Set.empty,
       confs: Seq[(String, String)] = Seq.empty,
       withSchemaEvolution: Boolean = false): Unit = {
-    val requestedInserts = includeInserts.filterNot(excludeInserts)
-    assert(requestedInserts.nonEmpty, s"Test '$name' doesn't cover any inserts. Please check the " +
+    val inserts = includeInserts.filterNot(excludeInserts)
+    assert(inserts.nonEmpty, s"Test '$name' doesn't cover any inserts. Please check the " +
       "includeInserts/excludeInserts sets and ensure at least one insert is included.")
+    testCases(name) ++= inserts
     val adaptedExpectedResult = adaptExpectedResult(expectedResult)
-    val supportsExpectedResult = adaptedExpectedResult match {
-      case _: DeltaInsertIntoTestHarness.ExpectedResult.Failure[_] =>
-        supportsCanonicalInsertFailureErrors
-      case _ => true
-    }
-    val inserts =
-      if (supportsExpectedResult) requestedInserts.intersect(supportedInsertTypes) else Set.empty
-    if (inserts.nonEmpty) {
-      testCases(name) ++= inserts
-    }
 
     for (insert <- inserts) {
       test(s"${insert.name} - $name") {
@@ -705,6 +681,8 @@ trait DeltaInsertIntoTestBase
                 val target = spark.read.table(targetTableName)
                 assert(target.schema === expectedData.schema)
                 checkExpectedRows(target, expectedData)
+              case DeltaInsertIntoTestHarness.ExpectedResult.Success(expected) =>
+                fail(s"Unsupported expected success type: ${expected.getClass.getName}")
               case DeltaInsertIntoTestHarness.ExpectedResult.Failure(checkError) =>
                 val ex = if (insert == StreamingInsert) {
                   intercept[StreamingQueryException] {
@@ -715,7 +693,7 @@ trait DeltaInsertIntoTestBase
                     runInsert()
                   }
                 }
-                validateInsertFailure(ex, checkError)
+                checkError(ex)
             }
           }
         }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoTest.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoTest.scala
@@ -23,6 +23,7 @@ import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.spark.SparkThrowable
 import org.apache.spark.sql.{DataFrame, Row, SaveMode, SparkSession}
+import org.apache.spark.sql.catalyst.util.QuotingUtils
 import org.apache.spark.sql.functions.{col, lit}
 import org.apache.spark.sql.streaming.{StreamingQueryException, Trigger}
 import org.apache.spark.sql.types.StructType
@@ -258,7 +259,7 @@ trait DeltaInsertIntoTestBase { self: AnyFunSuite =>
         whereCol: String,
         whereValue: Int,
         withSchemaEvolution: Boolean): Unit = {
-      val assignments = columns.filterNot(_ == quoteIdentifier(whereCol)).mkString(", ")
+      val assignments = columns.filterNot(_ == whereCol).mkString(", ")
       runInsertSql(withSchemaEvolution) { clause =>
         s"INSERT ${clause}OVERWRITE $quotedTargetTableName " +
           s"PARTITION ($whereCol = $whereValue) " +
@@ -278,7 +279,7 @@ trait DeltaInsertIntoTestBase { self: AnyFunSuite =>
         whereCol: String,
         whereValue: Int,
         withSchemaEvolution: Boolean): Unit = {
-      val assignments = columns.filterNot(_ == quoteIdentifier(whereCol)).mkString(", ")
+      val assignments = columns.filterNot(_ == whereCol).mkString(", ")
       runInsertSql(withSchemaEvolution) { clause =>
         s"INSERT ${clause}OVERWRITE $quotedTargetTableName " +
           s"PARTITION ($whereCol = $whereValue) ($assignments) " +
@@ -657,7 +658,7 @@ trait DeltaInsertIntoTestBase { self: AnyFunSuite =>
 
           def runInsert(): Unit =
             insert.runInsert(
-              columns = insertData.schema.map(field => quoteIdentifier(field.name)),
+              columns = insertData.schema.map(field => QuotingUtils.quoteIfNeeded(field.name)),
               whereCol = overwriteWhere._1,
               whereValue = overwriteWhere._2,
               withSchemaEvolution = withSchemaEvolution

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoTest.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoTest.scala
@@ -18,17 +18,25 @@ package org.apache.spark.sql.delta
 
 import scala.collection.mutable
 
-import org.apache.spark.sql.delta.sources.DeltaSQLConf
-import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
-import org.apache.hadoop.fs.Path
+// scalastyle:off funsuite
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.funsuite.AnyFunSuite
 
-import org.apache.spark.{DebugFilesystem, SparkThrowable}
-import org.apache.spark.sql.{DataFrame, QueryTest, SaveMode}
-import org.apache.spark.sql.catalyst.TableIdentifier
-import org.apache.spark.sql.catalyst.util.QuotingUtils
+import org.apache.spark.SparkThrowable
+import org.apache.spark.sql.{DataFrame, Row, SaveMode, SparkSession}
 import org.apache.spark.sql.functions.{col, lit}
 import org.apache.spark.sql.streaming.{StreamingQueryException, Trigger}
 import org.apache.spark.sql.types.StructType
+
+object DeltaInsertIntoTestHarness {
+  val BOOLEAN_DOMAIN: Seq[Boolean] = Seq(true, false)
+
+  sealed trait ExpectedResult[-T]
+  object ExpectedResult {
+    case class Success[T](expected: T) extends ExpectedResult[T]
+    case class Failure[T](checkError: SparkThrowable => Unit = _ => ()) extends ExpectedResult[T]
+  }
+}
 
 /**
  * There are **many** different ways to run an insert:
@@ -39,13 +47,82 @@ import org.apache.spark.sql.types.StructType
  * Each take a unique path through analysis. The abstractions below captures these different
  * inserts to allow more easily running tests with all or a subset of them.
  */
-trait DeltaInsertIntoTest
-  extends QueryTest
-  with DeltaDMLTestUtilsPathBased
-  with DeltaSQLCommandTest
-  with DeltaTableProvider {
+trait DeltaInsertIntoTestBase
+  extends BeforeAndAfterEach { self: AnyFunSuite =>
 
-  val catalogName = "spark_catalog"
+  protected def spark: SparkSession
+
+  protected def checkAnswer(actual: => DataFrame, expected: Seq[Row]): Unit
+
+  protected def checkExpectedError(
+      exception: SparkThrowable,
+      condition: String,
+      sqlState: Option[String] = None,
+      parameters: Map[String, String] = Map.empty): Unit = {
+    assert(
+      exception.getCondition == condition,
+      s"Expected condition $condition but got ${exception.getCondition}")
+    sqlState.foreach { expected =>
+      assert(
+        exception.getSqlState == expected,
+        s"Expected SQLSTATE $expected but got ${exception.getSqlState}")
+    }
+    val actualParameters = exception.getMessageParameters
+    assert(
+      actualParameters.size == parameters.size &&
+        parameters.forall { case (key, value) => actualParameters.get(key) == value },
+      s"Expected parameters $parameters but got $actualParameters")
+    assert(
+      exception.getQueryContext.isEmpty,
+      s"Expected no query context but got ${exception.getQueryContext.toSeq}")
+  }
+
+  protected def executeSql(query: String): DataFrame = spark.sql(query)
+
+  protected def writeFormat: String
+
+  protected val catalogName: String = "spark_catalog"
+
+  protected def sourceTableName: String = "source"
+
+  protected def targetTableName: String = "target"
+
+  protected val DeltaSchemaAutoMigrateKey: String =
+    "spark.databricks.delta.schema.autoMerge.enabled"
+  protected val DeltaInsertPreserveNullSourceStructsKey: String =
+    "spark.databricks.delta.insert.preserveNullSourceStructs"
+  protected val DeltaInsertByNameSchemaEvolutionEnabledKey: String =
+    "spark.databricks.delta.insert.byName.schemaEvolution.enabled"
+
+  private val ReplaceOnDataFrameWriterEnabledKey =
+    "spark.databricks.delta.replaceOn.dataframe.writer.enabled"
+
+  private def targetTablePath: String =
+    spark.sql(s"DESCRIBE DETAIL $quotedTargetTableName")
+      .select("location").collect().head.getString(0)
+
+  protected def withTestTables(tableNames: String*)(f: => Unit): Unit = {
+    try {
+      f
+    } finally {
+      tableNames.reverse.foreach { tableName =>
+        executeSql(s"DROP TABLE IF EXISTS ${quoteMultipartIdentifier(tableName)}").collect()
+      }
+    }
+  }
+
+  protected def unsetRuntimeConf(key: String): Unit = spark.conf.unset(key)
+
+  protected def withRuntimeConf[T](pairs: (String, String)*)(f: => T): T = {
+    val previousValues = pairs.map { case (key, _) => key -> spark.conf.getOption(key) }
+    pairs.foreach { case (key, value) => spark.conf.set(key, value) }
+    try f finally {
+      previousValues.foreach {
+        case (key, Some(value)) => spark.conf.set(key, value)
+        case (key, None) => unsetRuntimeConf(key)
+      }
+    }
+  }
 
   /**
    * Represents one way of inserting data into a Delta table.
@@ -78,24 +155,12 @@ trait DeltaInsertIntoTest
     /**
      * Runs a SQL INSERT, enabling Delta schema evolution when [[withSchemaEvolution]] is set.
      *
-     * Spark 4.2 introduced the `INSERT WITH SCHEMA EVOLUTION` syntax. On 4.2+ the clause is
-     * spliced into the statement right after the leading `INSERT` keyword. Earlier versions
-     * cannot parse that syntax, so schema evolution is toggled through
-     * [[DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE]] instead.
-     *
      * @param buildInsert builds the INSERT statement given the schema evolution clause to splice
      *                    in right after the leading `INSERT` keyword.
      */
     def runInsertSql(withSchemaEvolution: Boolean)(buildInsert: String => String): Unit = {
-      if (sparkVersionBucket(spark) == "4.2+") {
-        val clause = if (withSchemaEvolution) "WITH SCHEMA EVOLUTION " else ""
-        sql(buildInsert(clause))
-      } else {
-        withSQLConf(
-            DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> withSchemaEvolution.toString) {
-          sql(buildInsert(""))
-        }
-      }
+      val clause = if (withSchemaEvolution) "WITH SCHEMA EVOLUTION " else ""
+      executeSql(buildInsert(clause))
     }
 
     /** The expected content of the table after the insert. */
@@ -118,7 +183,8 @@ trait DeltaInsertIntoTest
         whereValue: Int,
         withSchemaEvolution: Boolean): Unit = {
       runInsertSql(withSchemaEvolution) { clause =>
-        s"INSERT $clause$intoOrOverwrite target SELECT * FROM source"
+        s"INSERT $clause$intoOrOverwrite $quotedTargetTableName " +
+          s"SELECT * FROM $quotedSourceTableName"
       }
     }
   }
@@ -135,7 +201,8 @@ trait DeltaInsertIntoTest
         withSchemaEvolution: Boolean): Unit = {
       val colList = columns.mkString(", ")
       runInsertSql(withSchemaEvolution) { clause =>
-        s"INSERT $clause$intoOrOverwrite target ($colList) SELECT $colList FROM source"
+        s"INSERT $clause$intoOrOverwrite $quotedTargetTableName ($colList) " +
+          s"SELECT $colList FROM $quotedSourceTableName"
       }
     }
   }
@@ -151,8 +218,8 @@ trait DeltaInsertIntoTest
         whereValue: Int,
         withSchemaEvolution: Boolean): Unit = {
       runInsertSql(withSchemaEvolution) { clause =>
-        s"INSERT $clause$intoOrOverwrite target BY NAME " +
-          s"SELECT ${columns.mkString(", ")} FROM source"
+        s"INSERT $clause$intoOrOverwrite $quotedTargetTableName BY NAME " +
+          s"SELECT ${columns.mkString(", ")} FROM $quotedSourceTableName"
       }
     }
   }
@@ -169,9 +236,9 @@ trait DeltaInsertIntoTest
         whereValue: Int,
         withSchemaEvolution: Boolean): Unit = {
       runInsertSql(withSchemaEvolution) { clause =>
-        s"INSERT ${clause}INTO target " +
+        s"INSERT ${clause}INTO $quotedTargetTableName " +
           s"REPLACE WHERE $whereCol = $whereValue " +
-          s"SELECT ${columns.mkString(", ")} FROM source"
+          s"SELECT ${columns.mkString(", ")} FROM $quotedSourceTableName"
       }
     }
   }
@@ -187,11 +254,11 @@ trait DeltaInsertIntoTest
         whereCol: String,
         whereValue: Int,
         withSchemaEvolution: Boolean): Unit = {
-      val assignments = columns.filterNot(_ == whereCol).mkString(", ")
+      val assignments = columns.filterNot(_ == quoteIdentifier(whereCol)).mkString(", ")
       runInsertSql(withSchemaEvolution) { clause =>
-        s"INSERT ${clause}OVERWRITE target " +
+        s"INSERT ${clause}OVERWRITE $quotedTargetTableName " +
           s"PARTITION ($whereCol = $whereValue) " +
-          s"SELECT $assignments FROM source"
+          s"SELECT $assignments FROM $quotedSourceTableName"
       }
     }
   }
@@ -207,11 +274,11 @@ trait DeltaInsertIntoTest
         whereCol: String,
         whereValue: Int,
         withSchemaEvolution: Boolean): Unit = {
-      val assignments = columns.filterNot(_ == whereCol).mkString(", ")
+      val assignments = columns.filterNot(_ == quoteIdentifier(whereCol)).mkString(", ")
       runInsertSql(withSchemaEvolution) { clause =>
-        s"INSERT ${clause}OVERWRITE target " +
+        s"INSERT ${clause}OVERWRITE $quotedTargetTableName " +
           s"PARTITION ($whereCol = $whereValue) ($assignments) " +
-          s"SELECT $assignments FROM source"
+          s"SELECT $assignments FROM $quotedSourceTableName"
       }
     }
   }
@@ -226,10 +293,10 @@ trait DeltaInsertIntoTest
         whereCol: String,
         whereValue: Int,
         withSchemaEvolution: Boolean): Unit =
-      spark.read.table("source").write.mode(mode)
+      spark.read.table(sourceTableName).write.mode(mode)
         .option("mergeSchema", withSchemaEvolution.toString)
-        .format(writeFormat)
-        .insertInto("target")
+        .format("delta")
+        .insertInto(targetTableName)
   }
 
   /** df.write.mode(mode).saveAsTable() */
@@ -242,10 +309,10 @@ trait DeltaInsertIntoTest
         whereCol: String,
         whereValue: Int,
         withSchemaEvolution: Boolean): Unit = {
-      spark.read.table("source").write.mode(mode)
+      spark.read.table(sourceTableName).write.mode(mode)
         .option("mergeSchema", withSchemaEvolution.toString)
-        .format(writeFormat)
-        .saveAsTable("target")
+        .format("delta")
+        .saveAsTable(targetTableName)
     }
   }
 
@@ -259,11 +326,10 @@ trait DeltaInsertIntoTest
         whereCol: String,
         whereValue: Int,
         withSchemaEvolution: Boolean): Unit = {
-      val deltaLog = DeltaLog.forTable(spark, TableIdentifier("target"))
-      spark.read.table("source").write.mode(mode)
+      spark.read.table(sourceTableName).write.mode(mode)
         .option("mergeSchema", withSchemaEvolution.toString)
-        .format(writeFormat)
-        .save(deltaLog.dataPath.toString)
+        .format("delta")
+        .save(targetTablePath)
     }
   }
 
@@ -278,14 +344,14 @@ trait DeltaInsertIntoTest
         whereCol: String,
         whereValue: Int,
         withSchemaEvolution: Boolean): Unit = {
-      withSQLConf(
-          DeltaSQLConf.REPLACE_ON_OPTION_IN_DATAFRAME_WRITER_ENABLED.key -> "true") {
-        spark.read.table("source").write.mode(mode)
+      withRuntimeConf(
+          ReplaceOnDataFrameWriterEnabledKey -> "true") {
+        spark.read.table(sourceTableName).write.mode(mode)
           .option("replaceOn", s"t.$whereCol = $whereValue")
           .option("targetAlias", "t")
           .option("mergeSchema", withSchemaEvolution.toString)
-          .format(writeFormat)
-          .insertInto("target")
+          .format("delta")
+          .insertInto(targetTableName)
       }
     }
   }
@@ -301,15 +367,14 @@ trait DeltaInsertIntoTest
         whereCol: String,
         whereValue: Int,
         withSchemaEvolution: Boolean): Unit = {
-      withSQLConf(
-          DeltaSQLConf.REPLACE_ON_OPTION_IN_DATAFRAME_WRITER_ENABLED.key -> "true") {
-        val deltaLog = DeltaLog.forTable(spark, TableIdentifier("target"))
-        spark.read.table("source").write.mode(mode)
+      withRuntimeConf(
+          ReplaceOnDataFrameWriterEnabledKey -> "true") {
+        spark.read.table(sourceTableName).write.mode(mode)
           .option("replaceOn", s"t.$whereCol = $whereValue")
           .option("targetAlias", "t")
           .option("mergeSchema", withSchemaEvolution.toString)
-          .format(writeFormat)
-          .save(deltaLog.dataPath.toString)
+          .format("delta")
+          .save(targetTablePath)
       }
     }
   }
@@ -325,12 +390,12 @@ trait DeltaInsertIntoTest
         whereCol: String,
         whereValue: Int,
         withSchemaEvolution: Boolean): Unit =
-      spark.read.table("source").write
+      spark.read.table(sourceTableName).write
         .mode(mode)
         .option("partitionOverwriteMode", "dynamic")
         .option("mergeSchema", withSchemaEvolution.toString)
-        .format(writeFormat)
-        .insertInto("target")
+        .format("delta")
+        .insertInto(targetTableName)
   }
 
   /** df.writeTo.append() */
@@ -344,8 +409,8 @@ trait DeltaInsertIntoTest
         whereCol: String,
         whereValue: Int,
         withSchemaEvolution: Boolean): Unit = {
-      spark.read.table("source")
-        .writeTo("target")
+      spark.read.table(sourceTableName)
+        .writeTo(targetTableName)
         .option("mergeSchema", withSchemaEvolution.toString)
         .append()
     }
@@ -362,8 +427,8 @@ trait DeltaInsertIntoTest
         whereCol: String,
         whereValue: Int,
         withSchemaEvolution: Boolean): Unit = {
-      spark.read.table("source")
-        .writeTo("target")
+      spark.read.table(sourceTableName)
+        .writeTo(targetTableName)
         .option("mergeSchema", withSchemaEvolution.toString)
         .overwrite(col(whereCol) === lit(whereValue))
     }
@@ -380,8 +445,8 @@ trait DeltaInsertIntoTest
         whereCol: String,
         whereValue: Int,
         withSchemaEvolution: Boolean): Unit = {
-      spark.read.table("source")
-        .writeTo("target")
+      spark.read.table(sourceTableName)
+        .writeTo(targetTableName)
         .option("mergeSchema", withSchemaEvolution.toString)
         .overwritePartitions()
     }
@@ -398,16 +463,15 @@ trait DeltaInsertIntoTest
         whereCol: String,
         whereValue: Int,
         withSchemaEvolution: Boolean): Unit = {
-      val tablePath = DeltaLog.forTable(spark, TableIdentifier("target")).dataPath
-      val checkpointLocation = new Path(tablePath, "_checkpoint")
+      val checkpointLocation = s"$targetTablePath/_checkpoint"
       val query = spark.readStream
-        .table("source")
+        .table(sourceTableName)
         .writeStream
-        .option("checkpointLocation", checkpointLocation.toString)
+        .option("checkpointLocation", checkpointLocation)
         .option("mergeSchema", withSchemaEvolution.toString)
         .format(writeFormat)
         .trigger(Trigger.AvailableNow())
-        .toTable("target")
+        .toTable(targetTableName)
       try {
         query.processAllAvailable()
       } finally {
@@ -439,6 +503,30 @@ trait DeltaInsertIntoTest
         DFv1Save(mode)
       )
     } yield insert).toSet
+
+  protected def supportedInsertTypes: Set[Insert] = allInsertTypes
+
+  protected def supportsUsageLogValidation: Boolean = true
+
+  protected def supportsRuntimeConfigMutations: Boolean = true
+
+  protected def supportsCanonicalInsertFailureErrors: Boolean = true
+
+  protected def validateInsertFailure(
+      exception: SparkThrowable,
+      validation: SparkThrowable => Unit): Unit = validation(exception)
+
+  protected def adaptExpectedResult(
+      expectedResult: Any): DeltaInsertIntoTestHarness.ExpectedResult[Any] = {
+    expectedResult match {
+      case result: DeltaInsertIntoTestHarness.ExpectedResult[_] =>
+        result.asInstanceOf[DeltaInsertIntoTestHarness.ExpectedResult[Any]]
+      case result =>
+        fail(s"Unsupported expected result type: ${result.getClass.getName}")
+    }
+  }
+
+  protected def beforeStreamingInsert(): Unit = {}
 
   /** Collects inserts using resolution by name and by position respectively. */
   protected lazy val (insertsByName, insertsByPosition): (Set[Insert], Set[Insert]) =
@@ -478,7 +566,7 @@ trait DeltaInsertIntoTest
   def checkAllTestCasesImplemented(ignoredTestCases: Map[String, Set[Insert]] = Map.empty): Unit = {
     val ignoredTests = ignoredTestCases.withDefaultValue(Set.empty)
     val missingTests = testCases.map {
-      case (name, inserts) => name -> (allInsertTypes -- inserts -- ignoredTests(name))
+      case (name, inserts) => name -> (supportedInsertTypes -- inserts -- ignoredTests(name))
     }.collect {
       case (name, missingInserts) if missingInserts.nonEmpty =>
         s"Test '$name' is not covering all insert types, missing: $missingInserts"
@@ -492,7 +580,52 @@ trait DeltaInsertIntoTest
   /** Convenience wrapper define test data using a SQL schema and a JSON string for each row. */
   case class TestData(schemaDDL: String, data: Seq[String]) {
     val schema: StructType = StructType.fromDDL(schemaDDL)
-    def toDF: DataFrame = readFromJSON(data, schema)
+    def toDF: DataFrame = createDataFrameFromTestData(this)
+  }
+
+  protected def createDataFrameFromTestData(testData: TestData): DataFrame = {
+    val schemaLiteral = quoteStringLiteral(testData.schemaDDL)
+    val parsedRows = if (testData.data.nonEmpty) {
+      val values =
+        testData.data.map(value => s"(${quoteStringLiteral(value)})").mkString(", ")
+        s"SELECT from_json(value, $schemaLiteral) AS parsed " +
+          s"FROM VALUES $values AS json_data(value)"
+    } else {
+      s"SELECT from_json(CAST(NULL AS STRING), $schemaLiteral) AS parsed"
+    }
+    executeSql(s"SELECT parsed.* FROM ($parsedRows) WHERE parsed IS NOT NULL")
+  }
+
+  protected def expectedRows(
+      insert: Insert,
+      initialData: TestData,
+      insertData: TestData,
+      expectedSchema: StructType): Seq[Row] = {
+    insert.expectedResult(initialData.toDF, insertData.toDF).collect().toSeq
+  }
+
+  protected def checkExpectedRows(
+      actual: => DataFrame,
+      insert: Insert,
+      initialData: TestData,
+      insertData: TestData,
+      expectedSchema: StructType): Unit = {
+    checkAnswer(actual, expectedRows(insert, initialData, insertData, expectedSchema))
+  }
+
+  protected def checkExpectedRows(actual: => DataFrame, expectedData: TestData): Unit = {
+    checkAnswer(actual, expectedData.toDF.collect().toSeq)
+  }
+
+  protected def createTableFromTestData(
+      tableName: String,
+      data: TestData,
+      partitionBy: Seq[String] = Seq.empty): Unit = {
+    val writer = data.toDF.write.format("delta")
+    if (partitionBy.nonEmpty) {
+      writer.partitionBy(partitionBy: _*)
+    }
+    writer.saveAsTable(tableName)
   }
 
   /**
@@ -503,7 +636,8 @@ trait DeltaInsertIntoTest
    * @param insertData          Additional data to be inserted.
    * @param overwriteWhere      Where clause for overwrite PARTITION / REPLACE WHERE (as
    *                            colName -> value)
-   * @param expectedResult      Expected result, see [[ExpectedResult]] above.
+   * @param expectedResult      Expected result, see
+   *                            [[DeltaInsertIntoTestHarness.ExpectedResult]] above.
    * @param includeInserts      List of insert types to run the test with.
    *                            Defaults to all inserts.
    * @param excludeInserts      List of insert types to exclude when running the test.
@@ -512,54 +646,66 @@ trait DeltaInsertIntoTest
    *                            operation.
    * @param withSchemaEvolution Whether to enable Automatic Schema Evolution.
    */
-  def testInserts[T](name: String)(
+  def testInserts(name: String)(
       initialData: TestData,
       partitionBy: Seq[String] = Seq.empty,
       insertData: TestData,
       overwriteWhere: (String, Int),
-      expectedResult: ExpectedResult[T],
+      expectedResult: Any,
       includeInserts: Set[Insert] = allInsertTypes,
       excludeInserts: Set[Insert] = Set.empty,
       confs: Seq[(String, String)] = Seq.empty,
       withSchemaEvolution: Boolean = false): Unit = {
-    val inserts = includeInserts.filterNot(excludeInserts)
-    assert(inserts.nonEmpty, s"Test '$name' doesn't cover any inserts. Please check the " +
+    val requestedInserts = includeInserts.filterNot(excludeInserts)
+    assert(requestedInserts.nonEmpty, s"Test '$name' doesn't cover any inserts. Please check the " +
       "includeInserts/excludeInserts sets and ensure at least one insert is included.")
-    testCases(name) ++= inserts
+    val adaptedExpectedResult = adaptExpectedResult(expectedResult)
+    val supportsExpectedResult = adaptedExpectedResult match {
+      case _: DeltaInsertIntoTestHarness.ExpectedResult.Failure[_] =>
+        supportsCanonicalInsertFailureErrors
+      case _ => true
+    }
+    val inserts =
+      if (supportsExpectedResult) requestedInserts.intersect(supportedInsertTypes) else Set.empty
+    if (inserts.nonEmpty) {
+      testCases(name) ++= inserts
+    }
 
     for (insert <- inserts) {
       test(s"${insert.name} - $name") {
-        withTable("source", "target") {
-          val writer = initialData.toDF.write.format(writeFormat)
-          if (partitionBy.nonEmpty) {
-            writer.partitionBy(partitionBy: _*)
-          }
-          writer.saveAsTable("target")
+        withTestTables(sourceTableName, targetTableName) {
+          createTableFromTestData(targetTableName, initialData, partitionBy)
           // Write the data to insert to a table so that we can use it in both SQL and dataframe
           // writer inserts.
-          insertData.toDF.write.format(writeFormat).saveAsTable("source")
+          createTableFromTestData(sourceTableName, insertData)
 
           def runInsert(): Unit =
             insert.runInsert(
-              columns = insertData.schema.map(f => QuotingUtils.quoteIfNeeded(f.name)),
+              columns = insertData.schema.map(field => quoteIdentifier(field.name)),
               whereCol = overwriteWhere._1,
               whereValue = overwriteWhere._2,
               withSchemaEvolution = withSchemaEvolution
             )
 
-          withSQLConf(confs: _*) {
-            expectedResult match {
-              case ExpectedResult.Success(expectedSchema: StructType) =>
+          withRuntimeConf(confs: _*) {
+            adaptedExpectedResult match {
+              case DeltaInsertIntoTestHarness.ExpectedResult.Success(
+                    expectedSchema: StructType) =>
                 runInsert()
-                val target = spark.read.table("target")
+                val target = spark.read.table(targetTableName)
                 assert(target.schema === expectedSchema)
-                checkAnswer(target, insert.expectedResult(initialData.toDF, insertData.toDF))
-              case ExpectedResult.Success(expectedData: TestData) =>
+                checkExpectedRows(
+                  target,
+                  insert,
+                  initialData,
+                  insertData,
+                  expectedSchema)
+              case DeltaInsertIntoTestHarness.ExpectedResult.Success(expectedData: TestData) =>
                 runInsert()
-                val target = spark.read.table("target")
+                val target = spark.read.table(targetTableName)
                 assert(target.schema === expectedData.schema)
-                checkAnswer(spark.read.table("target"), expectedData.toDF)
-              case ExpectedResult.Failure(checkError) =>
+                checkExpectedRows(target, expectedData)
+              case DeltaInsertIntoTestHarness.ExpectedResult.Failure(checkError) =>
                 val ex = if (insert == StreamingInsert) {
                   intercept[StreamingQueryException] {
                     runInsert()
@@ -569,11 +715,24 @@ trait DeltaInsertIntoTest
                     runInsert()
                   }
                 }
-                checkError(ex)
+                validateInsertFailure(ex, checkError)
             }
           }
         }
       }
     }
   }
+
+  private def quotedSourceTableName: String = quoteMultipartIdentifier(sourceTableName)
+
+  private def quotedTargetTableName: String = quoteMultipartIdentifier(targetTableName)
+
+  protected def quoteIdentifier(identifier: String): String =
+    s"`${identifier.replace("`", "``")}`"
+
+  protected def quoteMultipartIdentifier(identifier: String): String =
+    identifier.split("\\.", -1).map(quoteIdentifier).mkString(".")
+
+  private def quoteStringLiteral(value: String): String =
+    s"'${value.replace("'", "''")}'"
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTestUtils.scala
@@ -1032,7 +1032,7 @@ trait DeltaDMLInMemoryTestUtils
 }
 
 trait DeltaDMLTestUtilsPathBased extends DeltaDMLTestUtils {
-  self: SharedSparkSession =>
+  self: SparkFunSuite =>
 
   protected var tempDir: File = _
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Refactor the Delta insert schema evolution test suite into a reusable, client-agnostic harness. The existing classic Spark suites remain as concrete implementations, while shared test traits expose hooks for other Spark clients to exercise the same cases.

## How was this patch tested?


## Does this PR introduce _any_ user-facing changes?

No.