### PR TITLE
[Spark] Refactor V2 scan E2E tests in Scala

### DIFF
--- a/spark-unified/src/test/scala/io/delta/spark/internal/v2/read/DeltaV2BatchScanAssertions.scala
+++ b/spark-unified/src/test/scala/io/delta/spark/internal/v2/read/DeltaV2BatchScanAssertions.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.spark.internal.v2.read
+
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.execution.{FileSourceScanLike, SparkPlan}
+import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
+import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
+
+private[read] trait DeltaV2BatchScanAssertions {
+  self: AdaptiveSparkPlanHelper =>
+
+  private def deltaV2BatchScans(plan: SparkPlan): Seq[DeltaV2Scan] = collect(plan) {
+    case scan: BatchScanExec if scan.scan.isInstanceOf[DeltaV2Scan] =>
+      scan.scan.asInstanceOf[DeltaV2Scan]
+  }
+
+  protected final def assertDeltaV2BatchScan(df: DataFrame, context: String): Unit = {
+    val plan = df.queryExecution.executedPlan
+    assert(
+      deltaV2BatchScans(plan).nonEmpty,
+      s"expected a Delta V2 BatchScan for $context, got:\n$plan")
+    assert(
+      collect(plan) { case _: FileSourceScanLike => true }.isEmpty,
+      s"expected $context to stay off file-source execution, got:\n$plan")
+  }
+
+  protected final def assertDeltaV2BatchScanCount(
+      df: DataFrame,
+      expected: Int,
+      context: String): Unit = {
+    val plan = df.queryExecution.executedPlan
+    val actual = deltaV2BatchScans(plan).size
+    assert(
+      actual == expected,
+      s"expected $expected Delta V2 BatchScans for $context, got $actual:\n$plan")
+    assert(
+      collect(plan) { case _: FileSourceScanLike => true }.isEmpty,
+      s"expected $context to stay off file-source execution, got:\n$plan")
+  }
+
+  protected final def deltaV2BatchScanReadFieldNames(
+      df: DataFrame,
+      expectedScanCount: Int,
+      context: String): Seq[Seq[String]] = {
+    assertDeltaV2BatchScanCount(df, expectedScanCount, context)
+    deltaV2BatchScans(df.queryExecution.executedPlan)
+      .map(_.getReadDataSchema.fieldNames.toSeq)
+  }
+
+  protected final def assertDeltaV2BatchScanPushedLimit(
+      df: DataFrame,
+      expected: Int,
+      context: String): Unit = {
+    assertDeltaV2BatchScan(df, context)
+    val plan = df.queryExecution.executedPlan
+    val scans = deltaV2BatchScans(plan)
+    val marker = s"PushedLimit: $expected"
+    assert(
+      scans.nonEmpty && scans.forall(_.description().contains(marker)),
+      s"expected every Delta V2 BatchScan for $context to have $marker, " +
+        s"got ${scans.map(_.description()).mkString("[", ", ", "]")}:\n$plan")
+  }
+
+  protected final def assertDeltaV2BatchScanHasNoPushedLimit(
+      df: DataFrame,
+      context: String): Unit = {
+    assertDeltaV2BatchScan(df, context)
+    val plan = df.queryExecution.executedPlan
+    val scans = deltaV2BatchScans(plan)
+    assert(
+      scans.nonEmpty && scans.forall(scan => !scan.description().contains("PushedLimit")),
+      s"expected no Delta V2 BatchScan for $context to have PushedLimit, " +
+        s"got ${scans.map(_.description()).mkString("[", ", ", "]")}:\n$plan")
+  }
+}

--- a/spark-unified/src/test/scala/io/delta/spark/internal/v2/read/DeltaV2ColumnPruningE2ESuite.scala
+++ b/spark-unified/src/test/scala/io/delta/spark/internal/v2/read/DeltaV2ColumnPruningE2ESuite.scala
@@ -1,0 +1,165 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.spark.internal.v2.read
+
+import org.apache.spark.sql.Row
+
+private[read] trait DeltaV2ColumnPruningE2ETests {
+  self: DeltaV2ScanE2ETestUtils =>
+
+  // V2ScanColumnPruningIntegrationTest.testSelectSubsetPrunesDataColumns
+  test("selecting a subset prunes unused data columns") {
+    val table = "v2_scan_e2e_pruning_subset"
+    withTable(table) {
+      withV1Mode {
+        sql(s"CREATE TABLE $table (a INT, b INT, c INT) USING $tableProvider")
+        sql(s"INSERT INTO $table VALUES (1, 2, 3), (4, 5, 6)")
+      }
+
+      val df = sql(s"SELECT a FROM $table")
+      checkAnswer(df, Seq(Row(1), Row(4)))
+      val requiredSchemas =
+        expectedScanRequiredFieldNames(df, 1, "subset column-pruning read")
+      assert(
+        requiredSchemas == Seq(Seq("a")),
+        s"expected the scan to read only a, got $requiredSchemas")
+    }
+  }
+
+  // V2ScanColumnPruningIntegrationTest.testFilterPushdownLeavesOnlyProjectedColumns
+  test("a residual filter retains its column and prunes unused columns") {
+    val table = "v2_scan_e2e_pruning_filter"
+    withTable(table) {
+      withV1Mode {
+        sql(s"CREATE TABLE $table (a INT, b INT, c INT) USING $tableProvider")
+        sql(s"INSERT INTO $table VALUES (1, 2, 3), (4, 5, 6)")
+      }
+
+      val df = sql(s"SELECT a FROM $table WHERE b > 3")
+      checkAnswer(df, Seq(Row(4)))
+      val requiredSchemas =
+        expectedScanRequiredFieldNames(df, 1, "residual-filter column-pruning read")
+      assert(
+        requiredSchemas == Seq(Seq("a", "b")),
+        s"expected the scan to read a and b but not c, got $requiredSchemas")
+    }
+  }
+
+  // V2ScanColumnPruningIntegrationTest.testAllColumnsUsedMeansNoPruning
+  test("using every data column leaves the read schema unchanged") {
+    val table = "v2_scan_e2e_pruning_all_columns"
+    withTable(table) {
+      withV1Mode {
+        sql(s"CREATE TABLE $table (a INT, b INT) USING $tableProvider")
+        sql(s"INSERT INTO $table VALUES (1, 2), (3, 4)")
+      }
+
+      val df = sql(s"SELECT a, b FROM $table")
+      checkAnswer(df, Seq(Row(1, 2), Row(3, 4)))
+      val requiredSchemas =
+        expectedScanRequiredFieldNames(df, 1, "all-columns pruning read")
+      assert(
+        requiredSchemas == Seq(Seq("a", "b")),
+        s"expected the scan to read a and b, got $requiredSchemas")
+    }
+  }
+
+  // V2ScanColumnPruningIntegrationTest.testPartitionOnlyQueryHasEmptyReadDataSchema
+  test("a partition-only query has an empty data read schema") {
+    val table = "v2_scan_e2e_pruning_partition_only"
+    withTable(table) {
+      withV1Mode {
+        sql(
+          s"CREATE TABLE $table (a INT, p STRING) USING $tableProvider " +
+            "PARTITIONED BY (p)")
+        sql(s"INSERT INTO $table VALUES (1, 'x'), (2, 'y')")
+      }
+
+      val df = sql(s"SELECT p FROM $table")
+      checkAnswer(df, Seq(Row("x"), Row("y")))
+      val requiredSchemas =
+        expectedScanRequiredFieldNames(df, 1, "partition-only column-pruning read")
+      assert(
+        requiredSchemas == Seq(Seq.empty[String]),
+        s"expected an empty data requiredSchema, got $requiredSchemas")
+    }
+  }
+
+  // V2ScanColumnPruningIntegrationTest.testSubqueryDecorrelation_prunesUnusedColumns
+  test("subquery decorrelation prunes unused columns") {
+    val orders = "v2_scan_e2e_pruning_orders"
+    val vips = "v2_scan_e2e_pruning_vips"
+    withTable(orders, vips) {
+      withV1Mode {
+        sql(
+          s"CREATE TABLE $orders (" +
+            s"order_id INT, customer_id INT, amount INT, status STRING) " +
+            s"USING $tableProvider")
+        sql(
+          s"INSERT INTO $orders VALUES " +
+            "(1, 10, 100, 'open'), (2, 20, 200, 'closed')")
+        sql(s"CREATE TABLE $vips (customer_id INT) USING $tableProvider")
+        sql(s"INSERT INTO $vips VALUES (10), (30)")
+      }
+
+      val df = sql(
+        s"SELECT order_id, amount FROM $orders " +
+          s"WHERE customer_id IN (SELECT customer_id FROM $vips)")
+      checkAnswer(df, Seq(Row(1, 100)))
+      val requiredSchemas =
+        expectedScanRequiredFieldNames(df, 2, "decorrelated subquery column-pruning read")
+      val expectedSchemas = Set(
+        Seq("order_id", "customer_id", "amount"),
+        Seq("customer_id"))
+      assert(
+        requiredSchemas.toSet == expectedSchemas,
+        s"expected orders and VIP required schemas $expectedSchemas, got $requiredSchemas")
+    }
+  }
+
+  // V2ScanColumnPruningIntegrationTest.testJoinPrunesUnreferencedColumns
+  test("a join prunes unreferenced columns from both sides") {
+    val left = "v2_scan_e2e_pruning_join_left"
+    val right = "v2_scan_e2e_pruning_join_right"
+    withTable(left, right) {
+      withV1Mode {
+        sql(s"CREATE TABLE $left (a INT, b INT, c INT) USING $tableProvider")
+        sql(s"INSERT INTO $left VALUES (1, 2, 3), (4, 5, 6)")
+        sql(s"CREATE TABLE $right (x INT, y INT, z INT) USING $tableProvider")
+        sql(s"INSERT INTO $right VALUES (2, 20, 200), (5, 50, 500)")
+      }
+
+      val df =
+        sql(s"SELECT a, y FROM $left t1 JOIN $right t2 ON t1.b = t2.x")
+      checkAnswer(df, Seq(Row(1, 20), Row(4, 50)))
+      val requiredSchemas =
+        expectedScanRequiredFieldNames(df, 2, "join column-pruning read")
+      val expectedSchemas = Set(Seq("a", "b"), Seq("x", "y"))
+      assert(
+        requiredSchemas.toSet == expectedSchemas,
+        s"expected left and right required schemas $expectedSchemas, got $requiredSchemas")
+    }
+  }
+}
+
+/** Covers required-schema and column-pruning contracts shared across Delta V2 scan paths.
+ */
+class DeltaV2ColumnPruningE2ESuite
+  extends DeltaV2ScanE2ETestUtils
+  with DeltaV2ColumnPruningE2ETests
+{
+}

--- a/spark-unified/src/test/scala/io/delta/spark/internal/v2/read/DeltaV2LimitPushdownE2ESuite.scala
+++ b/spark-unified/src/test/scala/io/delta/spark/internal/v2/read/DeltaV2LimitPushdownE2ESuite.scala
@@ -1,0 +1,354 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.spark.internal.v2.read
+
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+
+import org.apache.spark.sql.Row
+
+private[read] trait DeltaV2LimitPushdownE2ETests {
+  self: DeltaV2ScanE2ETestUtils =>
+
+  // V2LimitPushdownTest.testLimitBasic.
+  test("a basic LIMIT returns the requested rows and reaches the scan") {
+    val table = "v2_scan_e2e_limit_basic"
+    withTable(table) {
+      withV1Mode {
+        sql(s"CREATE TABLE $table (id INT, name STRING) USING $tableProvider")
+        sql(
+          s"INSERT INTO $table VALUES " +
+            "(1, 'a'), (2, 'b'), (3, 'c'), (4, 'd'), (5, 'e')")
+      }
+
+      val df = sql(s"SELECT * FROM $table LIMIT 3")
+      assert(df.count() == 3L, "LIMIT 3 should return exactly 3 rows")
+      assertExpectedPushedLimit(df, 3, "basic LIMIT read")
+    }
+  }
+
+  // V2LimitPushdownTest.testLimitLargerThanTable.
+  test("a LIMIT larger than the table returns every row and reaches the scan") {
+    val table = "v2_scan_e2e_limit_larger_than_table"
+    withTable(table) {
+      withV1Mode {
+        sql(s"CREATE TABLE $table (id INT) USING $tableProvider")
+        sql(s"INSERT INTO $table VALUES (1), (2), (3)")
+      }
+
+      val df = sql(s"SELECT * FROM $table LIMIT 100")
+      checkAnswer(df, Seq(Row(1), Row(2), Row(3)))
+      assertExpectedPushedLimit(df, 100, "LIMIT larger than table")
+    }
+  }
+
+  // V2LimitPushdownTest.testLimit1.
+  test("LIMIT one returns one row and reaches the scan") {
+    val table = "v2_scan_e2e_limit_one"
+    withTable(table) {
+      withV1Mode {
+        sql(s"CREATE TABLE $table (id INT) USING $tableProvider")
+        sql(s"INSERT INTO $table VALUES (1), (2), (3)")
+      }
+
+      val df = sql(s"SELECT * FROM $table LIMIT 1")
+      assert(df.count() == 1L, "LIMIT 1 should return exactly 1 row")
+      assertExpectedPushedLimit(df, 1, "LIMIT one read")
+    }
+  }
+
+  // V2LimitPushdownTest.testLimitEmptyTable.
+  test("LIMIT on an empty table returns no rows and reaches the scan") {
+    val table = "v2_scan_e2e_limit_empty"
+    withTable(table) {
+      withV1Mode {
+        sql(s"CREATE TABLE $table (id INT) USING $tableProvider")
+      }
+
+      val df = sql(s"SELECT * FROM $table LIMIT 10")
+      checkAnswer(df, Seq.empty)
+      assertExpectedPushedLimit(df, 10, "LIMIT on empty table")
+    }
+  }
+
+  // V2LimitPushdownTest.testLimitWithDeletionVectors.
+  test("LIMIT with deletion vectors returns live rows and reaches the scan") {
+    val table = "v2_scan_e2e_limit_dv"
+    withTable(table) {
+      withV1Mode {
+        sql(
+          s"CREATE TABLE $table (id LONG, value STRING) USING $tableProvider " +
+            "TBLPROPERTIES ('delta.enableDeletionVectors' = 'true')")
+        spark
+          .range(1000)
+          .selectExpr("id", "cast(id as string) as value")
+          .write
+          .mode("append")
+          .insertInto(table)
+        sql(s"DELETE FROM $table WHERE id % 2 = 0")
+      }
+
+      val query = s"SELECT * FROM $table LIMIT 50"
+      assertAnySelectedFileHasDeletionVector(
+        sql(query),
+        "LIMIT read with deletion vectors")
+      val df = sql(query)
+      val rows = df.collect().toSeq
+      assert(rows.length == 50, "LIMIT 50 with DVs should return exactly 50 rows")
+      assert(
+        rows.forall(_.getLong(0) % 2 == 1),
+        s"LIMIT 50 with DVs returned a deleted even id: ${rows.mkString(", ")}")
+      assertExpectedPushedLimit(df, 50, "LIMIT read with deletion vectors")
+      assertExpectedScan(df, "LIMIT read with deletion vectors")
+    }
+  }
+
+  // V2LimitPushdownTest.testLimitWithHeavyDVs.
+  test("LIMIT with heavy deletion vectors spans enough live rows") {
+    val table = "v2_scan_e2e_limit_heavy_dv"
+    withTable(table) {
+      withV1Mode {
+        sql(
+          s"CREATE TABLE $table (id LONG, value STRING) USING $tableProvider " +
+            "TBLPROPERTIES ('delta.enableDeletionVectors' = 'true')")
+        spark
+          .range(0, 100)
+          .selectExpr("id", "cast(id as string) as value")
+          .coalesce(1)
+          .write
+          .mode("append")
+          .insertInto(table)
+        spark
+          .range(100, 200)
+          .selectExpr("id", "cast(id as string) as value")
+          .coalesce(1)
+          .write
+          .mode("append")
+          .insertInto(table)
+        sql(
+          s"DELETE FROM $table WHERE " +
+            "(id >= 40 AND id < 100) OR (id >= 140 AND id < 200)")
+      }
+
+      val numFiles = fileCount(table)
+      assert(numFiles == 2L)
+      val query = s"SELECT * FROM $table LIMIT 50"
+      assertAllSelectedFilesHaveDeletionVectors(
+        sql(query),
+        "LIMIT read with heavy deletion vectors")
+      val df = sql(query)
+      val rows = df.collect().toSeq
+      assert(rows.length == 50, "LIMIT 50 with heavy DVs should return exactly 50 rows")
+      assert(
+        rows.forall { row =>
+          val id = row.getLong(0)
+          (id >= 0 && id < 40) || (id >= 100 && id < 140)
+        },
+        s"LIMIT 50 with heavy DVs returned a deleted id: ${rows.mkString(", ")}")
+      assertExpectedPushedLimit(df, 50, "LIMIT read with heavy deletion vectors")
+      assertExpectedScan(df, "LIMIT read with heavy deletion vectors")
+      assertRouteSpecificInputFileCount(
+        df,
+        expected = 2,
+        context = "LIMIT 50 must select both heavy-DV files")
+    }
+  }
+
+  // V2LimitPushdownTest.testLimitWithPartitionFilter.
+  test("a partition filter with LIMIT returns matching rows") {
+    val table = "v2_scan_e2e_limit_partition_filter"
+    withTable(table) {
+      withV1Mode {
+        sql(
+          s"CREATE TABLE $table (id INT, part STRING) USING $tableProvider " +
+            "PARTITIONED BY (part)")
+        sql(
+          s"INSERT INTO $table VALUES " +
+            "(1, 'a'), (2, 'a'), (3, 'a'), (4, 'b'), (5, 'b')")
+      }
+
+      val df = sql(s"SELECT * FROM $table WHERE part = 'a' LIMIT 2")
+      val rows = df.collect().toSeq
+      assert(rows.length == 2, "Partition filter + LIMIT should return 2 rows")
+      assert(
+        rows.forall(_.getString(1) == "a"),
+        s"Partition filter + LIMIT returned a non-matching row: ${rows.mkString(", ")}")
+    }
+  }
+
+  // V2LimitPushdownTest.testLimitWithDataFilter.
+  test("a data filter with LIMIT returns matching rows without pushdown") {
+    val table = "v2_scan_e2e_limit_data_filter"
+    withTable(table) {
+      withV1Mode {
+        sql(s"CREATE TABLE $table (id INT, name STRING) USING $tableProvider")
+        sql(
+          s"INSERT INTO $table VALUES " +
+            "(1, 'a'), (2, 'b'), (3, 'c'), (4, 'd'), (5, 'e')")
+      }
+
+      val df = sql(s"SELECT * FROM $table WHERE id > 2 LIMIT 2")
+      val rows = df.collect().toSeq
+      assert(rows.length == 2, "Data filter + LIMIT should return 2 rows")
+      assert(
+        rows.forall(_.getInt(0) > 2),
+        s"Data filter + LIMIT returned an id <= 2: ${rows.mkString(", ")}")
+      assertExpectedNoPushedLimit(df, "data filter with LIMIT")
+    }
+  }
+
+  // V2LimitPushdownTest.testLimitWithColumnProjection.
+  test("a projected LIMIT returns only the requested column and reaches the scan") {
+    val table = "v2_scan_e2e_limit_projection"
+    withTable(table) {
+      withV1Mode {
+        sql(
+          s"CREATE TABLE $table (id INT, name STRING, value DOUBLE) USING $tableProvider")
+        sql(
+          s"INSERT INTO $table VALUES " +
+            "(1, 'a', 1.0), (2, 'b', 2.0), (3, 'c', 3.0)")
+      }
+
+      val df = sql(s"SELECT name FROM $table LIMIT 2")
+      val rows = df.collect().toSeq
+      assert(rows.length == 2, "Column projection + LIMIT should return 2 rows")
+      assert(df.columns.toSeq == Seq("name"), "projected result should contain only name")
+      val expectedNames = Set("a", "b", "c")
+      assert(
+        rows.forall(row => !row.isNullAt(0) && expectedNames.contains(row.getString(0))),
+        s"Column projection + LIMIT returned an unexpected value: ${rows.mkString(", ")}")
+      assertExpectedPushedLimit(df, 2, "projected LIMIT read")
+    }
+  }
+
+  // V2LimitPushdownTest.testLimitWithMultipleFiles.
+  test("LIMIT over multiple files returns the requested rows and reaches the scan") {
+    val table = "v2_scan_e2e_limit_multiple_files"
+    withTable(table) {
+      withV1Mode {
+        sql(s"CREATE TABLE $table (id INT) USING $tableProvider")
+        // Preserve the source's deterministic one-row-per-file layout.
+        (0 until 20).foreach { id =>
+          sql(s"INSERT INTO $table VALUES ($id)")
+        }
+      }
+
+      val numFiles = fileCount(table)
+      assert(numFiles == 20L, s"expected 20 source files, got $numFiles")
+
+      val df = sql(s"SELECT * FROM $table LIMIT 3")
+      assert(df.count() == 3L, "LIMIT 3 over 20 single-row files should return 3 rows")
+      assertExpectedPushedLimit(df, 3, "LIMIT read over multiple files")
+      assertRouteSpecificInputFileCount(
+        df,
+        expected = 3,
+        context = "LIMIT 3 route-specific input-file count")
+    }
+  }
+
+  // DeltaV2ScanTest.testLimitPushdown_missingNumRecordsPlansAllFiles.
+  test("LIMIT pushdown retains files without numRecords") {
+    val table = "v2_scan_e2e_limit_missing_num_records"
+    withTable(table) {
+      withV1Mode {
+        withSQLConf(DeltaSQLConf.DELTA_COLLECT_STATS.key -> "false") {
+          sql(
+            s"CREATE TABLE $table (id INT) USING $tableProvider " +
+              "TBLPROPERTIES ('delta.enableRowTracking' = 'false')")
+          sql(s"INSERT INTO $table VALUES (1)")
+          sql(s"INSERT INTO $table VALUES (2)")
+        }
+      }
+
+      val numFiles = fileCount(table)
+      assert(numFiles == 2L, s"expected two source files, got $numFiles")
+
+      val df = sql(s"SELECT * FROM $table LIMIT 1")
+      val rows = df.collect().toSeq
+      assert(rows.length == 1, s"expected one row, got ${rows.length}")
+      assert(Set(Row(1), Row(2)).contains(rows.head), s"unexpected source row ${rows.head}")
+      assertExpectedPushedLimit(df, 1, "LIMIT read with missing numRecords")
+      assertExpectedScan(df, "LIMIT read with missing numRecords")
+      assertRouteSpecificInputFileCount(
+        df,
+        expected = 2,
+        // With file statistics disabled, neither file counts toward the pushed limit.
+        context = "LIMIT 1 must retain files without numRecords")
+    }
+  }
+
+  // V2LimitPushdownTest.testLimitWithNonDeterministicFilterIsNotPushed.
+  test("a non-deterministic filter prevents LIMIT pushdown") {
+    val table = "v2_scan_e2e_limit_nondeterministic_filter"
+    withTable(table) {
+      withV1Mode {
+        sql(s"CREATE TABLE $table (id INT) USING $tableProvider")
+        spark
+          .range(100)
+          .selectExpr("cast(id as int) as id")
+          .write
+          .mode("append")
+          .insertInto(table)
+      }
+
+      val df = sql(s"SELECT * FROM $table WHERE rand(0) > 0.5 LIMIT 5")
+      assert(df.count() == 5L)
+      assertExpectedNoPushedLimit(df, "non-deterministic filter with LIMIT")
+    }
+  }
+
+  // V2LimitPushdownTest.testLimitWithOffsetPushesCombinedRowRequirement.
+  test("LIMIT with OFFSET pushes the combined row requirement") {
+    val table = "v2_scan_e2e_limit_offset"
+    withTable(table) {
+      withV1Mode {
+        sql(s"CREATE TABLE $table (id INT) USING $tableProvider")
+        sql(s"INSERT INTO $table VALUES (1), (2), (3), (4), (5)")
+      }
+
+      val df = sql(s"SELECT * FROM $table LIMIT 2 OFFSET 1")
+      assert(df.count() == 2L)
+      assertExpectedPushedLimit(df, 3, "LIMIT with OFFSET read")
+    }
+  }
+
+  // V2LimitPushdownTest.testLimitOrderBy.
+  test("ORDER BY with LIMIT returns ordered rows without pushdown") {
+    val table = "v2_scan_e2e_limit_order_by"
+    withTable(table) {
+      withV1Mode {
+        sql(s"CREATE TABLE $table (id INT, name STRING) USING $tableProvider")
+        sql(
+          s"INSERT INTO $table VALUES " +
+            "(3, 'c'), (1, 'a'), (5, 'e'), (2, 'b'), (4, 'd')")
+      }
+
+      val df = sql(s"SELECT * FROM $table ORDER BY id LIMIT 3")
+      checkAnswer(df, Seq(Row(1, "a"), Row(2, "b"), Row(3, "c")))
+      assertExpectedNoPushedLimit(df, "ORDER BY with LIMIT")
+    }
+  }
+}
+
+
+/** Covers LIMIT correctness and pushdown semantics shared across Delta V2 scan paths.
+ * Path-specific DPP and column-mapping gaps are kept in their corresponding test traits.
+ */
+class DeltaV2LimitPushdownE2ESuite
+  extends DeltaV2ScanE2ETestUtils
+  with DeltaV2LimitPushdownE2ETests
+{
+}

--- a/spark-unified/src/test/scala/io/delta/spark/internal/v2/read/DeltaV2MetadataReadE2ESuite.scala
+++ b/spark-unified/src/test/scala/io/delta/spark/internal/v2/read/DeltaV2MetadataReadE2ESuite.scala
@@ -1,0 +1,195 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.spark.internal.v2.read
+
+import java.net.URI
+import java.sql.Timestamp
+
+import org.apache.spark.sql.{DataFrame, Row}
+import org.apache.spark.sql.execution.datasources.FileFormat
+import org.apache.spark.sql.types.StructType
+
+private[read] trait DeltaV2MetadataReadE2ETests {
+  self: DeltaV2ScanE2ETestUtils =>
+
+  private val baseMetadataFieldNames =
+    FileFormat.BASE_METADATA_FIELDS.map(_.name)
+
+  private def withMetadataTable(
+      table: String,
+      rowTrackingEnabled: Boolean)(body: String => Unit): Unit = {
+    withTable(table) {
+      withV1Mode {
+        sql(
+          s"CREATE TABLE $table (id LONG, name STRING) USING $tableProvider " +
+            s"TBLPROPERTIES ('delta.enableRowTracking' = '$rowTrackingEnabled')")
+        withSQLConf("spark.sql.leafNodeDefaultParallelism" -> "1") {
+          sql(s"INSERT INTO $table VALUES (1, 'Alice'), (2, 'Bob'), (3, 'Charlie')")
+        }
+      }
+      val tableLocation = withV1Mode {
+        sql(s"DESCRIBE DETAIL $table").select("location").head().getString(0)
+      }
+      body(tableLocation)
+    }
+  }
+
+  private def assertFileBelongsToTable(filePath: String, tableLocation: String): Unit = {
+    val normalizedFileUri = new URI(filePath).normalize()
+    val normalizedTableUri = new URI(tableLocation).normalize()
+    assert(
+      Option(normalizedFileUri.getScheme) == Option(normalizedTableUri.getScheme),
+      s"expected file URI scheme to match table location $tableLocation, got $filePath")
+    assert(
+      Option(normalizedFileUri.getAuthority) == Option(normalizedTableUri.getAuthority),
+      s"expected file URI authority to match table location $tableLocation, got $filePath")
+    val normalizedTablePath = normalizedTableUri.getPath.stripSuffix("/")
+    assert(
+      normalizedFileUri.getPath.startsWith(s"$normalizedTablePath/"),
+      s"expected file path under table location $tableLocation, got $filePath")
+  }
+
+  private def assertMetadataValueShape(
+      fieldName: String,
+      value: Any,
+      tableLocation: String): Unit = {
+    assert(value != null, s"expected _metadata.$fieldName to be populated")
+    fieldName match {
+      case "file_path" =>
+        val filePath = value.asInstanceOf[String]
+        assert(filePath.startsWith("file:"), s"expected file URI, got $filePath")
+        assert(filePath.endsWith(".parquet"), s"expected Parquet path, got $filePath")
+        assertFileBelongsToTable(filePath, tableLocation)
+      case "file_name" =>
+        val fileName = value.asInstanceOf[String]
+        assert(fileName.endsWith(".parquet"), s"expected Parquet file name, got $fileName")
+        assert(!fileName.contains("/"), s"expected a leaf file name, got $fileName")
+      case "file_size" =>
+        assert(value.asInstanceOf[Long] > 0L, s"expected positive file size, got $value")
+      case "file_block_start" =>
+        assert(value.asInstanceOf[Long] >= 0L, s"expected non-negative block start, got $value")
+      case "file_block_length" =>
+        assert(value.asInstanceOf[Long] > 0L, s"expected positive block length, got $value")
+      case "file_modification_time" =>
+        val modificationTime = value.asInstanceOf[Timestamp]
+        assert(
+          modificationTime.getTime > 0L,
+          s"expected positive file modification epoch, got $modificationTime")
+    }
+  }
+
+  private def assertSingleFileMetadataRows(
+      df: DataFrame,
+      valueOrdinal: Int,
+      fieldName: String,
+      tableLocation: String): Unit = {
+    val rows = df.collect().toSeq
+    assert(rows.length == 3, s"expected three rows, got ${rows.length}")
+    rows.foreach { row =>
+      assertMetadataValueShape(fieldName, row.get(valueOrdinal), tableLocation)
+    }
+    val values = rows.map(_.get(valueOrdinal))
+    assert(
+      values.distinct.size == 1,
+      s"expected one source file for _metadata.$fieldName, got ${values.distinct}")
+  }
+
+  private def assertMetadataStruct(metadata: Row, tableLocation: String): Unit = {
+    assert(metadata != null, "expected _metadata to be populated")
+    baseMetadataFieldNames.zipWithIndex.foreach { case (fieldName, ordinal) =>
+      assertMetadataValueShape(fieldName, metadata.get(ordinal), tableLocation)
+    }
+  }
+
+  Seq(true, false).foreach { rowTrackingEnabled =>
+    test(s"file_path is available when row tracking is $rowTrackingEnabled") {
+      val table = s"v2_scan_e2e_metadata_path_$rowTrackingEnabled"
+      withMetadataTable(table, rowTrackingEnabled) { tableLocation =>
+        val df =
+          sql(s"SELECT id, _metadata.file_path FROM $table ORDER BY id")
+        assert(df.schema.fieldNames.toSeq == Seq("id", "file_path"))
+        assert(df.collect().map(_.getLong(0)).toSeq == Seq(1L, 2L, 3L))
+        assertSingleFileMetadataRows(
+          df,
+          valueOrdinal = 1,
+          fieldName = "file_path",
+          tableLocation = tableLocation)
+        assertExpectedScan(df, s"file_path read with row tracking $rowTrackingEnabled")
+      }
+    }
+  }
+
+  baseMetadataFieldNames.foreach { fieldName =>
+    test(s"base metadata field $fieldName has the expected shape") {
+      val table = s"v2_scan_e2e_metadata_${fieldName}_field"
+      withMetadataTable(table, rowTrackingEnabled = false) { tableLocation =>
+        val query =
+          s"SELECT id, _metadata.$fieldName AS metadata_value FROM $table ORDER BY id"
+        val df = sql(query)
+        assert(df.schema.fieldNames.toSeq == Seq("id", "metadata_value"))
+        assertSingleFileMetadataRows(
+          df,
+          valueOrdinal = 1,
+          fieldName = fieldName,
+          tableLocation = tableLocation)
+        if (fieldName == "file_modification_time") {
+          val v1Rows = withV1Mode {
+            sql(query).collect().toSeq
+          }
+          checkAnswer(df, v1Rows)
+        }
+        assertExpectedScan(df, s"$fieldName metadata read")
+      }
+    }
+  }
+
+  test("the whole metadata struct contains every base field") {
+    val table = "v2_scan_e2e_metadata_whole"
+    withMetadataTable(table, rowTrackingEnabled = false) { tableLocation =>
+      val df = sql(s"SELECT _metadata FROM $table")
+      assert(df.schema.fieldNames.toSeq == Seq("_metadata"))
+      val metadataType = df.schema("_metadata").dataType.asInstanceOf[StructType]
+      assert(metadataType.fieldNames.toSeq == baseMetadataFieldNames)
+      val rows = df.collect().toSeq
+      assert(rows.length == 3, s"expected three rows, got ${rows.length}")
+      rows.foreach(row => assertMetadataStruct(row.getStruct(0), tableLocation))
+      assertExpectedScan(df, "whole metadata struct read")
+    }
+  }
+
+  test("metadata alongside star preserves metadata and data columns") {
+    val table = "v2_scan_e2e_metadata_star"
+    withMetadataTable(table, rowTrackingEnabled = false) { tableLocation =>
+      val df = sql(s"SELECT _metadata, * FROM $table ORDER BY id")
+      assert(df.schema.fieldNames.toSeq == Seq("_metadata", "id", "name"))
+      val rows = df.collect().toSeq
+      assert(rows.map(_.getLong(1)) == Seq(1L, 2L, 3L))
+      assert(rows.map(_.getString(2)) == Seq("Alice", "Bob", "Charlie"))
+      rows.foreach(row => assertMetadataStruct(row.getStruct(0), tableLocation))
+      assertExpectedScan(df, "metadata alongside star read")
+    }
+  }
+}
+
+/** Covers Spark base `_metadata` field values and schemas shared across Delta V2 scan paths.
+ * Row-tracking-only metadata fields stay outside this suite.
+ */
+class DeltaV2MetadataReadE2ESuite
+  extends DeltaV2ScanE2ETestUtils
+  with DeltaV2MetadataReadE2ETests
+{
+}

--- a/spark-unified/src/test/scala/io/delta/spark/internal/v2/read/DeltaV2ReadE2ESuite.scala
+++ b/spark-unified/src/test/scala/io/delta/spark/internal/v2/read/DeltaV2ReadE2ESuite.scala
@@ -1,0 +1,312 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.spark.internal.v2.read
+
+import org.apache.spark.sql.Row
+
+private[read] trait DeltaV2ReadE2ETests {
+  self: DeltaV2ScanE2ETestUtils =>
+
+  test("plain catalog read preserves the requested schema and rows") {
+    withDeltaTable("v2_scan_e2e_plain") {
+      checkRead("plain catalog read")(sql("SELECT id, value FROM v2_scan_e2e_plain")) { df =>
+        assert(df.schema.fieldNames.toSeq == Seq("id", "value"))
+        checkAnswer(df, Seq(Row(1L, "a"), Row(2L, "b"), Row(3L, "c")))
+      }
+    }
+  }
+
+  test("partition-filtered read returns matching partition rows") {
+    withTable("v2_scan_e2e_partitioned") {
+      withV1Mode {
+        sql(
+          s"CREATE TABLE v2_scan_e2e_partitioned (id LONG, part STRING) " +
+            s"USING $tableProvider PARTITIONED BY (part)")
+        sql("INSERT INTO v2_scan_e2e_partitioned VALUES (1, 'x'), (2, 'y'), (3, 'x')")
+      }
+      checkRead("partition-filtered read") {
+        sql("SELECT id, part FROM v2_scan_e2e_partitioned WHERE part = 'x'")
+      } { df =>
+        checkAnswer(df, Seq(Row(1L, "x"), Row(3L, "x")))
+      }
+    }
+  }
+
+  test("projection with a residual data filter returns matching rows") {
+    withDeltaTable("v2_scan_e2e_projection") {
+      checkRead("projected residual-filtered read") {
+        sql("SELECT value FROM v2_scan_e2e_projection WHERE id > 1")
+      } { df =>
+        checkAnswer(df, Seq(Row("b"), Row("c")))
+      }
+    }
+  }
+
+  test("a deletion-vector-capable table without selected vectors preserves live rows") {
+    withDeltaTable(
+        "v2_scan_e2e_dv_unused",
+        "TBLPROPERTIES ('delta.enableDeletionVectors' = 'true')") {
+      checkRead("deletion-vector-capable read without selected vectors") {
+        sql("SELECT id, value FROM v2_scan_e2e_dv_unused")
+      } { df =>
+        checkAnswer(df, Seq(Row(1L, "a"), Row(2L, "b"), Row(3L, "c")))
+      }
+    }
+  }
+
+  test("a selected deletion vector preserves only live rows") {
+    val table = "v2_scan_e2e_dv"
+    withDeltaTable(table, "TBLPROPERTIES ('delta.enableDeletionVectors' = 'true')") {
+      withV1Mode {
+        sql(s"DELETE FROM $table WHERE id = 2")
+      }
+      val query = s"SELECT id, value FROM $table"
+      assertAnySelectedFileHasDeletionVector(
+        sql(query),
+        "selected deletion-vector read")
+      val df = sql(query)
+      checkAnswer(df, Seq(Row(1L, "a"), Row(3L, "c")))
+      assertExpectedScan(df, "selected deletion-vector read")
+    }
+  }
+
+  test("mixed deletion-vector and plain files preserve only live rows") {
+    val table = "v2_scan_e2e_dv_mixed"
+    withDeltaTable(table, "TBLPROPERTIES ('delta.enableDeletionVectors' = 'true')") {
+      withV1Mode {
+        sql(s"INSERT INTO $table VALUES (4, 'd'), (5, 'e')")
+        sql(s"DELETE FROM $table WHERE id = 2")
+      }
+      val query = s"SELECT id, value FROM $table"
+      assertMixedSelectedFileDeletionVectors(
+        sql(query),
+        "mixed deletion-vector and plain read")
+      val df = sql(query)
+      checkAnswer(df, Seq(Row(1L, "a"), Row(3L, "c"), Row(4L, "d"), Row(5L, "e")))
+      assertExpectedScan(df, "mixed deletion-vector and plain read")
+    }
+  }
+
+  test("partitioned deletion vectors preserve live rows and partition pruning") {
+    val table = "v2_scan_e2e_dv_partitioned"
+    withTable(table) {
+      withV1Mode {
+        sql(
+          s"CREATE TABLE $table (id LONG, part STRING) USING $tableProvider " +
+            "PARTITIONED BY (part) " +
+            "TBLPROPERTIES ('delta.enableDeletionVectors' = 'true')")
+        sql(s"INSERT INTO $table VALUES (1, 'x'), (2, 'x'), (3, 'y'), (4, 'y')")
+        sql(s"DELETE FROM $table WHERE id IN (2, 3)")
+      }
+      val numFiles = fileCount(table)
+      assert(numFiles == 2L)
+      val query = s"SELECT id, part FROM $table"
+      assertAllSelectedFilesHaveDeletionVectors(
+        sql(query),
+        "partitioned deletion-vector read")
+      val df = sql(query)
+      checkAnswer(df, Seq(Row(1L, "x"), Row(4L, "y")))
+      assertExpectedScan(df, "partitioned deletion-vector read")
+
+      val pruned = sql(s"SELECT id, part FROM $table WHERE part = 'y'")
+      checkAnswer(pruned, Seq(Row(4L, "y")))
+      assertExpectedScan(pruned, "partitioned deletion-vector read with partition filter")
+    }
+  }
+
+  test("a second delete on the same file reads through the rewritten vector") {
+    val table = "v2_scan_e2e_dv_rewritten"
+    withDeltaTable(table, "TBLPROPERTIES ('delta.enableDeletionVectors' = 'true')") {
+      withV1Mode {
+        sql(s"DELETE FROM $table WHERE id = 1")
+        sql(s"DELETE FROM $table WHERE id = 2")
+      }
+      val query = s"SELECT id, value FROM $table"
+      assertAnySelectedFileHasDeletionVector(
+        sql(query),
+        "rewritten deletion-vector read")
+      val df = sql(query)
+      checkAnswer(df, Seq(Row(3L, "c")))
+      assertExpectedScan(df, "rewritten deletion-vector read")
+    }
+  }
+
+  test("row-tracking protocol and deletion vectors preserve ordinary-column rows") {
+    val table = "v2_scan_e2e_dv_row_tracking"
+    withDeltaTable(
+        table,
+        "TBLPROPERTIES ('delta.enableDeletionVectors' = 'true', " +
+          "'delta.enableRowTracking' = 'true')") {
+      withV1Mode {
+        sql(s"DELETE FROM $table WHERE id = 2")
+      }
+      val query = s"SELECT id, value FROM $table"
+      assertAnySelectedFileHasDeletionVector(
+        sql(query),
+        "row-tracking protocol DV read")
+      val df = sql(query)
+      checkAnswer(df, Seq(Row(1L, "a"), Row(3L, "c")))
+      assertExpectedScan(df, "row-tracking protocol DV read")
+    }
+  }
+
+  test("a row-tracking table preserves ordinary-column rows") {
+    withDeltaTable(
+        "v2_scan_e2e_row_tracking",
+        "TBLPROPERTIES ('delta.enableRowTracking' = 'true')") {
+      checkRead("row-tracking table ordinary-column read") {
+        sql("SELECT id, value FROM v2_scan_e2e_row_tracking")
+      } { df =>
+        checkAnswer(df, Seq(Row(1L, "a"), Row(2L, "b"), Row(3L, "c")))
+      }
+    }
+  }
+
+  test("partition column in the middle preserves DDL schema order") {
+    withPartitionColumnInMiddleTable("v2_scan_e2e_partition_middle") {
+      checkRead("partition column in the middle") {
+        sql("SELECT * FROM v2_scan_e2e_partition_middle ORDER BY id")
+      } { df =>
+        assert(df.schema.fieldNames.toSeq == Seq("id", "part", "col3"))
+        checkAnswer(
+          df,
+          Seq(Row(1L, 10L, 100), Row(2L, 20L, 200), Row(3L, 30L, 300)))
+      }
+    }
+  }
+
+  // V2ReadTest.testBatchReadPartitionColumnInMiddleWithPruning.
+  test("partition column in the middle preserves pruned projections") {
+    val table = "v2_scan_e2e_partition_middle_pruning"
+    withPartitionColumnInMiddleTable(table) {
+      checkRead("reordered partition and data projection") {
+        sql(s"SELECT part, id FROM $table ORDER BY id")
+      } { df =>
+        assert(df.schema.fieldNames.toSeq == Seq("part", "id"))
+        checkAnswer(df, Seq(Row(10L, 1L), Row(20L, 2L), Row(30L, 3L)))
+      }
+
+      checkRead("partition-only projection") {
+        sql(s"SELECT part FROM $table ORDER BY part")
+      } { df =>
+        assert(df.schema.fieldNames.toSeq == Seq("part"))
+        checkAnswer(df, Seq(Row(10L), Row(20L), Row(30L)))
+      }
+
+      checkRead("data-only projection") {
+        sql(s"SELECT col3 FROM $table ORDER BY col3")
+      } { df =>
+        assert(df.schema.fieldNames.toSeq == Seq("col3"))
+        checkAnswer(df, Seq(Row(100), Row(200), Row(300)))
+      }
+    }
+  }
+
+  // V2ReadTest.testBatchReadPartitionColumnAtEnd.
+  test("partition column at the end preserves DDL schema order") {
+    val table = "v2_scan_e2e_partition_end"
+    withTable(table) {
+      withV1Mode {
+        sql(
+          s"CREATE TABLE $table (id LONG, col3 INT, part LONG) USING $tableProvider " +
+            "PARTITIONED BY (part)")
+        sql(
+          s"INSERT INTO $table VALUES " +
+            "(1, 100, 10), (2, 200, 20), (3, 300, 30)")
+      }
+      checkRead("partition column at the end") {
+        sql(s"SELECT * FROM $table ORDER BY id")
+      } { df =>
+        assert(df.schema.fieldNames.toSeq == Seq("id", "col3", "part"))
+        checkAnswer(
+          df,
+          Seq(Row(1L, 100, 10L), Row(2L, 200, 20L), Row(3L, 300, 30L)))
+      }
+    }
+  }
+
+  // V2ReadTest.testBatchReadMultiplePartitionColumns.
+  test("multiple interleaved partition columns preserve DDL schema order") {
+    val table = "v2_scan_e2e_multiple_partitions"
+    withTable(table) {
+      withV1Mode {
+        sql(
+          s"CREATE TABLE $table (a LONG, p1 STRING, b INT, p2 STRING, c DOUBLE) " +
+            s"USING $tableProvider PARTITIONED BY (p2, p1)")
+        sql(
+          s"INSERT INTO $table VALUES " +
+            "(1, 'x', 10, 'y', 1.5), " +
+            "(2, 'x', 20, 'z', 2.5), " +
+            "(3, 'w', 30, 'y', 3.5)")
+      }
+      checkRead("multiple interleaved partition columns") {
+        sql(s"SELECT * FROM $table ORDER BY a")
+      } { df =>
+        assert(df.schema.fieldNames.toSeq == Seq("a", "p1", "b", "p2", "c"))
+        checkAnswer(
+          df,
+          Seq(
+            Row(1L, "x", 10, "y", 1.5),
+            Row(2L, "x", 20, "z", 2.5),
+            Row(3L, "w", 30, "y", 3.5)))
+      }
+    }
+  }
+
+  // V2ReadTest.testBatchReadWithDeletionVectorAndPartitionColumnInMiddle.
+  test("deletion vectors with a middle partition column preserve rows and DDL order") {
+    val table = "v2_scan_e2e_dv_partition_middle"
+    withTable(table) {
+      withV1Mode {
+        sql(
+          s"CREATE TABLE $table (id LONG, part LONG, val INT) USING $tableProvider " +
+            "PARTITIONED BY (part) " +
+            "TBLPROPERTIES ('delta.enableDeletionVectors' = 'true')")
+        spark
+          .range(2000)
+          .selectExpr("id", "id % 2 AS part", "cast(id * 10 AS INT) AS val")
+          .write
+          .mode("append")
+          .insertInto(table)
+        sql(s"DELETE FROM $table WHERE id < 100")
+      }
+
+      val query = s"SELECT * FROM $table ORDER BY id"
+      assertAnySelectedFileHasDeletionVector(
+        sql(query),
+        "deletion-vector read with a middle partition column")
+      val df = sql(query)
+      assert(df.schema.fieldNames.toSeq == Seq("id", "part", "val"))
+      val rows = df.collect()
+      assert(rows.length == 1900, "expected 1900 surviving rows after delete")
+      assert(rows.head == Row(100L, 0L, 1000))
+      assertExpectedScan(
+        df,
+        "deletion-vector read with a middle partition column")
+    }
+  }
+}
+
+
+/** Covers ordinary read, schema, and deletion-vector semantics shared across Delta V2 scan paths.
+ * Path-specific fallback and gap cases are kept in their corresponding test traits.
+ */
+class DeltaV2ReadE2ESuite
+  extends DeltaV2ScanE2ETestUtils
+  with DeltaV2ReadE2ETests
+{
+}

--- a/spark-unified/src/test/scala/io/delta/spark/internal/v2/read/DeltaV2ScanE2ETestUtils.scala
+++ b/spark-unified/src/test/scala/io/delta/spark/internal/v2/read/DeltaV2ScanE2ETestUtils.scala
@@ -1,0 +1,175 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.spark.internal.v2.read
+
+import scala.jdk.CollectionConverters._
+
+import org.apache.spark.sql.delta.DeltaTableProvider
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.test.{DeltaSQLCommandTest, DeltaSQLTestUtils}
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.{DataFrame, QueryTest}
+import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2ScanRelation
+
+/** Provides shared table fixtures and path-neutral plan hooks for Delta V2 E2E suites.
+ * Concrete suites combine these utilities with reusable tests and path-specific overrides.
+ */
+private[read] trait DeltaV2ScanE2ETestUtils
+  extends QueryTest
+  with DeltaSQLCommandTest
+  with DeltaSQLTestUtils
+  with DeltaTableProvider
+  with AdaptiveSparkPlanHelper
+  with DeltaV2BatchScanAssertions {
+
+  protected def configureE2ESparkConf(conf: SparkConf): SparkConf = conf
+
+  abstract override protected def sparkConf: SparkConf =
+    configureE2ESparkConf(
+      super.sparkConf.set(DeltaSQLConf.V2_ENABLE_MODE.key, "STRICT"))
+
+  protected def withV1Mode[T](body: => T): T =
+    withSQLConf(DeltaSQLConf.V2_ENABLE_MODE.key -> "NONE")(body)
+
+  protected def withDeltaTable(
+      name: String,
+      properties: String = "")(body: => Unit): Unit = {
+    withTable(name) {
+      withV1Mode {
+        sql(s"CREATE TABLE $name (id LONG, value STRING) USING $tableProvider $properties")
+        sql(s"INSERT INTO $name VALUES (1, 'a'), (2, 'b'), (3, 'c')")
+      }
+      body
+    }
+  }
+
+  protected def withPartitionColumnInMiddleTable(
+      name: String,
+      properties: String = "")(body: => Unit): Unit = {
+    withTable(name) {
+      withV1Mode {
+        sql(
+          s"CREATE TABLE $name (id LONG, part LONG, col3 INT) USING $tableProvider " +
+            s"PARTITIONED BY (part) $properties")
+        sql(
+          s"INSERT INTO $name VALUES " +
+            "(1, 10, 100), (2, 20, 200), (3, 30, 300)")
+      }
+      body
+    }
+  }
+
+  protected def fileCount(table: String): Long = {
+    withV1Mode {
+      sql(s"DESCRIBE DETAIL $table")
+        .selectExpr("CAST(numFiles AS BIGINT)")
+        .head()
+        .getLong(0)
+    }
+  }
+
+  protected def withDeltaV2ScanForSelectedFiles[T](
+      query: => DataFrame,
+      context: String)(body: DeltaV2Scan => T): T = {
+    val df = query
+    val plan = df.queryExecution.optimizedPlan
+    val scans = plan.collect {
+      case relation: DataSourceV2ScanRelation
+          if relation.scan.isInstanceOf[DeltaV2Scan] =>
+        relation.scan.asInstanceOf[DeltaV2Scan]
+    }
+    assert(
+      scans.length == 1,
+      s"expected one optimized DeltaV2Scan for $context, got " +
+        s"${scans.length}:\n$plan")
+    body(scans.head)
+  }
+
+  private def selectedFileDeletionVectorFlags(
+      query: => DataFrame,
+      context: String): Seq[Boolean] = {
+    withDeltaV2ScanForSelectedFiles(query, context) { scan =>
+      scan.getSelectedFiles.asScala.map(_.getDeletionVector.isPresent).toSeq
+    }
+  }
+
+  protected def assertAnySelectedFileHasDeletionVector(
+      query: => DataFrame,
+      context: String): Unit = {
+    val hasDeletionVectors = selectedFileDeletionVectorFlags(query, context)
+    assert(
+      hasDeletionVectors.contains(true),
+      s"expected a selected file with a deletion vector for $context")
+  }
+
+  protected def assertMixedSelectedFileDeletionVectors(
+      query: => DataFrame,
+      context: String): Unit = {
+    val hasDeletionVectors = selectedFileDeletionVectorFlags(query, context)
+    assert(
+      hasDeletionVectors.contains(true) && hasDeletionVectors.contains(false),
+      s"expected selected files with and without deletion vectors for $context")
+  }
+
+  protected def assertAllSelectedFilesHaveDeletionVectors(
+      query: => DataFrame,
+      context: String): Unit = {
+    val hasDeletionVectors = selectedFileDeletionVectorFlags(query, context)
+    assert(
+      hasDeletionVectors.nonEmpty && hasDeletionVectors.forall(identity),
+      s"expected all selected files to have deletion vectors for $context")
+  }
+
+  protected def assertExpectedScan(df: DataFrame, context: String): Unit =
+    assertDeltaV2BatchScan(df, context)
+
+  protected def assertExpectedScanCount(
+      df: DataFrame,
+      expected: Int,
+      context: String): Unit =
+    assertDeltaV2BatchScanCount(df, expected, context)
+
+  protected def expectedScanRequiredFieldNames(
+      df: DataFrame,
+      expectedScanCount: Int,
+      context: String): Seq[Seq[String]] =
+    deltaV2BatchScanReadFieldNames(df, expectedScanCount, context)
+
+  protected def assertExpectedPushedLimit(
+      df: DataFrame,
+      expected: Int,
+      context: String): Unit =
+    assertDeltaV2BatchScanPushedLimit(df, expected, context)
+
+  protected def assertExpectedNoPushedLimit(df: DataFrame, context: String): Unit =
+    assertDeltaV2BatchScanHasNoPushedLimit(df, context)
+
+  protected def assertRouteSpecificInputFileCount(
+      df: DataFrame,
+      expected: Int,
+      context: String): Unit = {}
+
+  protected def checkRead(context: String)(
+      query: => DataFrame)(
+      assertions: DataFrame => Unit): Unit = {
+    val df = query
+    assertions(df)
+    assertExpectedScan(df, context)
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Add reusable Scala suites for V2 reads, LIMIT pushdown, column pruning, and metadata reads. Centralize table setup and BatchScan assertions while preserving the behavior covered by the existing Java tests.

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

Added new tests (tests refactor) + CI

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No