### PR TITLE
[Spark] Convert KernelEngineFactory from Java to Scala

### DIFF
--- a/spark/v2/src/main/scala/io/delta/spark/internal/v2/kernel/KernelEngineFactory.scala
+++ b/spark/v2/src/main/scala/io/delta/spark/internal/v2/kernel/KernelEngineFactory.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (2025) The Delta Lake Project Authors.
+ * Copyright (2026) The Delta Lake Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,17 @@
  * limitations under the License.
  */
 
-package io.delta.spark.internal.v2.kernel;
+package io.delta.spark.internal.v2.kernel
 
-import io.delta.kernel.defaults.engine.DefaultEngine;
-import io.delta.kernel.engine.Engine;
-import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.conf.Configuration
+import io.delta.kernel.defaults.engine.{DefaultEngine => KernelDefaultEngine}
+import io.delta.kernel.engine.{Engine => KernelEngine}
 
-/** Factory for creating the default Kernel {@link Engine} used by the DSv2 connector. */
-public final class KernelEngineFactory {
-
-  private KernelEngineFactory() {}
+/** Factory for creating the default Kernel [[KernelEngine]] used by the DSv2 connector. */
+object KernelEngineFactory {
 
   /** Builds the backend-appropriate default engine. */
-  public static Engine createDefaultEngine(Configuration hadoopConf) {
-    return DefaultEngine.create(hadoopConf);
+  def createDefaultEngine(hadoopConf: Configuration): KernelEngine = {
+    KernelDefaultEngine.create(hadoopConf)
   }
 }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Converts `KernelEngineFactory` -- the factory for the default Kernel engine used by the Spark DataSource V2 (DSv2) connector -- from Java to Scala.

The Java `final class` with a private constructor becomes a Scala `object`, and the static `createDefaultEngine(Configuration)` method becomes a `def` returning the default Kernel `Engine`. Behavior is unchanged: it still delegates to `DefaultEngine.create(hadoopConf)`.

## How was this patch tested?

Mechanical, language-level conversion with no behavior change. The converted object exposes the same `createDefaultEngine` method and delegates to `DefaultEngine.create`, so existing DSv2 connector code and tests that obtain the default engine continue to exercise it.

## Does this PR introduce _any_ user-facing changes?

No.
