### PR TITLE
Refine the ManifestBitmap API for manifest deletion vectors

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -1191,7 +1191,7 @@ object AddFile {
  */
 case class BackReference(
     manifest: String,
-    pos: Long)
+    pos: Int)
 
 object BackReference {
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTCheckpointProvider.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTCheckpointProvider.scala
@@ -169,7 +169,7 @@ final class AMTCheckpointProvider(
       .where(col("entry.tracking.status").isin(Tracking.Status.liveEntryStatuses.toSeq: _*))
       .filter { entryWithLoc =>
         mdvBroadcast.value.get(entryWithLoc.leafPath)
-          .forall(bytes => !AMTUtils.deserializeMdv(bytes).contains(entryWithLoc.pos))
+          .forall(bytes => !AMTUtils.deserializeMdv(bytes).contains(entryWithLoc.pos.toInt))
       }
 
     dataEntries
@@ -184,7 +184,7 @@ final class AMTCheckpointProvider(
                 val absLeaf = SparkPath.fromUrlString(entryWithLoc.leafPath).toPath
                 val relManifest =
                   AMTUtils.relativizeManifestPathToTableRoot(fs, localTableRoot, absLeaf)
-                Some(BackReference(relManifest, entryWithLoc.pos))
+                Some(BackReference(relManifest, entryWithLoc.pos.toInt))
               }
               // Root entries have nothing above them to inherit from, so they resolve against an
               // empty parent.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTUtils.scala
@@ -168,5 +168,5 @@ object AMTUtils {
 
   // Deserializes a Manifest Deletion Vector previously written by [[serializeMdv]].
   private[amt] def deserializeMdv(bytes: Array[Byte]): ManifestBitmap =
-    ManifestBitmap.readFrom(bytes)
+    ManifestBitmap.fromSerializedByteArray(bytes)
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriteHelper.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriteHelper.scala
@@ -426,15 +426,15 @@ object AMTWriteHelper extends DeltaLogging {
    */
   private[amt] def modifiedOrDeletedTrackingForLeaf(
       oldEntry: DataManifestEntry,
-      mdvPositions: Seq[Long],
-      deletedPositions: Seq[Long],
-      replacedPositions: Seq[Long]): (Tracking, ManifestInfo) = {
+      mdvPositions: Seq[Int],
+      deletedPositions: Seq[Int],
+      replacedPositions: Seq[Int]): (Tracking, ManifestInfo) = {
     val cumulativeMdv = oldEntry.manifest_info.dv
-      .map(AMTUtils.deserializeMdv).getOrElse(ManifestBitmap.empty())
+      .map(AMTUtils.deserializeMdv).getOrElse(ManifestBitmap.fromPositions(Seq.empty))
     mdvPositions.foreach(cumulativeMdv.add)
-    def bitmapOf(positions: Seq[Long]): Option[Array[Byte]] = {
+    def bitmapOf(positions: Seq[Int]): Option[Array[Byte]] = {
       if (positions.isEmpty) None
-      else Some(AMTUtils.serializeMdv(ManifestBitmap(positions: _*)))
+      else Some(AMTUtils.serializeMdv(ManifestBitmap.fromPositions(positions)))
     }
     // Every masked / CDF position indexes an entry within this leaf, so no count can exceed the
     // leaf's entry count; a larger value signals a corrupt bitmap or a double-counted position.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/IncrementalAMTWriter.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/IncrementalAMTWriter.scala
@@ -227,14 +227,14 @@ class IncrementalAMTWriter(spark: SparkSession, deltaLog: DeltaLog) {
       leaves = allLeafPointers,
       includeActionsInCommitJson = true)
     val numOldLeavesUpdated = carriedLeafPointers.count(p =>
-      leafPositions.newMDVPositionsByLeaf.getOrElse(p.location, Set.empty[Long]).nonEmpty)
+      leafPositions.newMDVPositionsByLeaf.getOrElse(p.location, Set.empty[Int]).nonEmpty)
     // Per-status breakdown over every leaf pointer in the new tree (carried + newly spilled).
     val leavesByStatus = allLeafPointers.groupBy(_.tracking.status).map {
       case (status, ps) => status -> ps.size
     }
     val numStaleDeletedLeavesDropped =
       oldAMTCheckpointProvider.leaves.count(_.tracking.status == Tracking.Status.Deleted)
-    def positionCount(byLeaf: Map[String, Set[Long]]): Int = byLeaf.valuesIterator.map(_.size).sum
+    def positionCount(byLeaf: Map[String, Set[Int]]): Int = byLeaf.valuesIterator.map(_.size).sum
     // Per-status breakdown over the new tree's root-resident DATA entries (live + remove entries).
     val rootEntriesByStatus = (rootLiveEntries ++ rootRemoveEntries)
       .groupBy(_.tracking.status).map { case (status, es) => status -> es.size }
@@ -290,7 +290,7 @@ class IncrementalAMTWriter(spark: SparkSession, deltaLog: DeltaLog) {
     // A (leaf, position) can be superseded multiple times, e.g. a leaf file removed, re-added and
     // removed again. We use a Set to dedupe the positions so the count matches the number of bits
     // gained by the MDV or CDF bitmap.
-    def positionsByLeaf(backrefs: Seq[BackReference]): Map[String, Set[Long]] =
+    def positionsByLeaf(backrefs: Seq[BackReference]): Map[String, Set[Int]] =
       backrefs.map(br => br.manifest -> br.pos)
         .groupBy(_._1).map { case (leaf, pairs) => leaf -> pairs.map(_._2).toSet }
     val newMDVPositionsByLeaf = positionsByLeaf(mdvSupersededBackrefs)
@@ -300,11 +300,11 @@ class IncrementalAMTWriter(spark: SparkSession, deltaLog: DeltaLog) {
       if (pointer.tracking.status == Tracking.Status.Deleted) None
       else {
         val newMdvPositions =
-          newMDVPositionsByLeaf.getOrElse(pointer.location, Set.empty[Long]).toSeq
+          newMDVPositionsByLeaf.getOrElse(pointer.location, Set.empty[Int]).toSeq
         val deletedPositions =
-          deletedPositionsByLeaf.getOrElse(pointer.location, Set.empty[Long]).toSeq
+          deletedPositionsByLeaf.getOrElse(pointer.location, Set.empty[Int]).toSeq
         val replacedPositions =
-          replacedPositionsByLeaf.getOrElse(pointer.location, Set.empty[Long]).toSeq
+          replacedPositionsByLeaf.getOrElse(pointer.location, Set.empty[Int]).toSeq
         Some(carryForwardOneLeaf(pointer, newMdvPositions, deletedPositions, replacedPositions))
       }
     }
@@ -315,9 +315,9 @@ class IncrementalAMTWriter(spark: SparkSession, deltaLog: DeltaLog) {
   // Visible for testing.
   private[amt] def carryForwardOneLeaf(
       pointer: DataManifestEntry,
-      newMdvPositions: Seq[Long],
-      deletedPositions: Seq[Long],
-      replacedPositions: Seq[Long]): DataManifestEntry = {
+      newMdvPositions: Seq[Int],
+      deletedPositions: Seq[Int],
+      replacedPositions: Seq[Int]): DataManifestEntry = {
     val liveFileCount = pointer.manifest_info.liveFilesCount
     val tombstoneFileCount = pointer.manifest_info.tombstoneFilesCount
     if (liveFileCount > 0 && tombstoneFileCount > 0) {
@@ -601,6 +601,6 @@ private class ProcessedActions(
 }
 
 private case class MDVAndCDFPositions(
-    newMDVPositionsByLeaf: Map[String, Set[Long]],
-    deleteCDFPositionByLeaf: Map[String, Set[Long]],
-    replaceCDFPositionByLeaf: Map[String, Set[Long]])
+    newMDVPositionsByLeaf: Map[String, Set[Int]],
+    deleteCDFPositionByLeaf: Map[String, Set[Int]],
+    replaceCDFPositionByLeaf: Map[String, Set[Int]])

--- a/spark/src/main/scala/org/apache/spark/sql/delta/deletionvectors/ManifestBitmap.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/deletionvectors/ManifestBitmap.scala
@@ -16,22 +16,19 @@
 
 package org.apache.spark.sql.delta.deletionvectors
 
+import org.apache.spark.util.Utils
+
 /**
- * A mutable bitmap of unsigned positions for the AMT manifest deletion vectors: the masking MDV in
- * `manifest_info.dv` and the CDF `tracking.deleted_positions` / `tracking.replaced_positions`
+ * A mutable bitmap of unsigned positions for the AMT manifest deletion vectors: the masking MDV
+ * in `manifest_info.dv` and the CDF `tracking.deleted_positions` / `tracking.replaced_positions`
  * bitmaps.
- *
- * This trait is the seam over the concrete bitmap format written to disk. The only implementation
- * today is [[RoaringManifestBitmap]] (Roaring portable), so behavior is unchanged; the trait exists
- * so an alternative compressed format can later be dropped in behind the [[ManifestBitmap]] factory
- * and [[ManifestBitmap.readFrom]] without touching the AMT write path.
  */
 trait ManifestBitmap {
   /** Adds `value` to the bitmap. */
-  def add(value: Long): Unit
+  def add(value: Int): Unit
 
   /** Returns `true` if `value` is set. */
-  def contains(value: Long): Boolean
+  def contains(value: Int): Boolean
 
   /** Returns the number of set positions. */
   def cardinality: Long
@@ -39,48 +36,73 @@ trait ManifestBitmap {
   /** Returns `true` if no position is set. */
   def isEmpty: Boolean
 
-  /** Returns the set positions in ascending order. */
-  def toArray: Array[Long]
-
   /** Serializes to the on-disk byte form carried in `manifest_info.dv` / the CDF bitmaps. */
   def serializeAsByteArray(): Array[Byte]
+
+  /** The set positions in ascending order, for tests only. */
+  final def toArrayForTesting: Array[Long] = {
+    assert(Utils.isTesting)
+    toArrayForTestingImpl
+  }
+
+  protected def toArrayForTestingImpl: Array[Long]
+
 }
 
 object ManifestBitmap {
-  /** Returns an empty bitmap. */
-  def empty(): ManifestBitmap = RoaringManifestBitmap.empty()
-
   /** Returns a bitmap of the given positions. */
-  def apply(values: Long*): ManifestBitmap = RoaringManifestBitmap(values: _*)
+  def fromPositions(values: Seq[Int]): ManifestBitmap = RoaringManifestBitmap.fromPositions(values)
 
   /** Deserializes a bitmap previously produced by [[ManifestBitmap.serializeAsByteArray]]. */
-  def readFrom(bytes: Array[Byte]): ManifestBitmap = RoaringManifestBitmap.readFrom(bytes)
+  def fromSerializedByteArray(bytes: Array[Byte]): ManifestBitmap =
+    RoaringManifestBitmap.fromSerializedByteArray(bytes)
 }
 
-/** A [[ManifestBitmap]] backed by a [[RoaringBitmapArray]] serialized in the portable format. */
-final class RoaringManifestBitmap private (private val underlying: RoaringBitmapArray)
+/**
+ * A [[ManifestBitmap]] backed by a [[RoaringBitmapArray]] in the portable format.
+ */
+final class RoaringManifestBitmap private (
+    private val serializedBytesOrPositions: Either[Array[Byte], Seq[Int]])
   extends ManifestBitmap {
 
-  override def add(value: Long): Unit = underlying.add(value)
+  // Materialized on first bit-level use: decoded from the on-disk bytes, or built from the
+  // positions.
+  private lazy val roaringBitmapArray: RoaringBitmapArray =
+    serializedBytesOrPositions match {
+      case Left(bytes) => RoaringBitmapArray.readFrom(bytes)
+      case Right(positions) => RoaringBitmapArray(positions.map(_.toLong): _*)
+    }
 
-  override def contains(value: Long): Boolean = underlying.contains(value)
+  // Set once a position is added, so serialization re-encodes from the decoded (mutated) bitmap
+  // instead of returning the now-stale `serializedBytesOrPositions`.
+  private var mutated = false
 
-  override def cardinality: Long = underlying.cardinality
+  override def add(value: Int): Unit = {
+    mutated = true
+    roaringBitmapArray.add(value.toLong)
+  }
 
-  override def isEmpty: Boolean = underlying.isEmpty
+  override def contains(value: Int): Boolean = roaringBitmapArray.contains(value.toLong)
 
-  override def toArray: Array[Long] = underlying.toArray
+  override def cardinality: Long = roaringBitmapArray.cardinality
+
+  override def isEmpty: Boolean = roaringBitmapArray.isEmpty
+
+  override protected def toArrayForTestingImpl: Array[Long] = roaringBitmapArray.toArray
 
   override def serializeAsByteArray(): Array[Byte] =
-    underlying.serializeAsByteArray(RoaringBitmapArrayFormat.Portable)
+    serializedBytesOrPositions match {
+      // Defensive copy: Don't expose internal buffer for a caller to mutate.
+      case Left(bytes) if !mutated => bytes.clone()
+      case _ => roaringBitmapArray.serializeAsByteArray(RoaringBitmapArrayFormat.Portable)
+    }
+
 }
 
 object RoaringManifestBitmap {
-  def empty(): RoaringManifestBitmap = new RoaringManifestBitmap(new RoaringBitmapArray)
+  def fromPositions(values: Seq[Int]): RoaringManifestBitmap =
+    new RoaringManifestBitmap(Right(values))
 
-  def apply(values: Long*): RoaringManifestBitmap =
-    new RoaringManifestBitmap(RoaringBitmapArray(values: _*))
-
-  def readFrom(bytes: Array[Byte]): RoaringManifestBitmap =
-    new RoaringManifestBitmap(RoaringBitmapArray.readFrom(bytes))
+  def fromSerializedByteArray(serializedBytes: Array[Byte]): RoaringManifestBitmap =
+    new RoaringManifestBitmap(Left(serializedBytes))
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/ActionSerializerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/ActionSerializerSuite.scala
@@ -111,7 +111,7 @@ class ActionSerializerSuite extends QueryTest with SharedSparkSession with Delta
       size = 1,
       modificationTime = 2,
       dataChange = false,
-      backReference = Some(BackReference(manifest = "metadata/leaf-1.parquet", pos = 7L)))
+      backReference = Some(BackReference(manifest = "metadata/leaf-1.parquet", pos = 7)))
     assert(withBackRef.json.contains("\"backReference\":{\"manifest\":" +
       "\"metadata/leaf-1.parquet\",\"pos\":7}"))
     assert(Action.fromJson(withBackRef.json) === withBackRef)
@@ -126,7 +126,7 @@ class ActionSerializerSuite extends QueryTest with SharedSparkSession with Delta
     val withBackRef = RemoveFile(
       path = "a",
       deletionTimestamp = Some(1L),
-      backReference = Some(BackReference(manifest = "metadata/leaf-2.parquet", pos = 3L)))
+      backReference = Some(BackReference(manifest = "metadata/leaf-2.parquet", pos = 3)))
     assert(withBackRef.json.contains("\"backReference\":{\"manifest\":" +
       "\"metadata/leaf-2.parquet\",\"pos\":3}"))
     assert(Action.fromJson(withBackRef.json) === withBackRef)
@@ -137,7 +137,7 @@ class ActionSerializerSuite extends QueryTest with SharedSparkSession with Delta
   }
 
   test("AddFile back reference propagates to removeWithTimestamp and copy") {
-    val backRef = Some(BackReference(manifest = "metadata/leaf-3.parquet", pos = 11L))
+    val backRef = Some(BackReference(manifest = "metadata/leaf-3.parquet", pos = 11))
     val add = AddFile("a", Map.empty, 1, 2, dataChange = true, backReference = backRef)
     // removeWithTimestamp -> tombstone inherits the back reference.
     assert(add.removeWithTimestamp().backReference == backRef)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTBackReferenceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTBackReferenceSuite.scala
@@ -144,7 +144,7 @@ class AMTBackReferenceSuite extends AMTCheckpointTestBase with DeletionVectorsTe
       assert(leafPaths.contains(br.manifest),
         s"Back-ref manifest ${br.manifest} must be one of the tree's leaves $leafPaths.")
       // The back-ref must point at exactly the leaf entry describing this data file.
-      assert(groundTruth.get((br.manifest, br.pos)).contains(add.path),
+      assert(groundTruth.get((br.manifest, br.pos.toLong)).contains(add.path),
         s"Back-ref (${br.manifest}, ${br.pos}) must resolve to the entry for ${add.path}.")
     }
   }
@@ -433,7 +433,7 @@ class AMTBackReferenceSuite extends AMTCheckpointTestBase with DeletionVectorsTe
   test("commit fails when a present file's tombstone carries the wrong back reference") {
     withTable("amt_commit_wrong") {
       val adds = emitStampedAddFiles("amt_commit_wrong")
-      val wrongBr = adds.head.backReference.get.copy(pos = adds.head.backReference.get.pos + 1000L)
+      val wrongBr = adds.head.backReference.get.copy(pos = adds.head.backReference.get.pos + 1000)
       val wrong = adds.head.removeWithTimestamp().copy(backReference = Some(wrongBr))
       val ex = intercept[IllegalStateException] {
         commitActions("amt_commit_wrong", Seq(wrong))

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTIncrementalWriteInvariantSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTIncrementalWriteInvariantSuite.scala
@@ -209,7 +209,7 @@ class AMTIncrementalWriteInvariantSuite extends AMTIncrementalWriteTestBase {
       // there is nothing left to mask.
       val tombstoneOnly = carriedLeafPointer(deletedFiles = 3)
       val ex = intercept[IllegalStateException] {
-        writer.carryForwardOneLeaf(tombstoneOnly, newMdvPositions = Seq(0L),
+        writer.carryForwardOneLeaf(tombstoneOnly, newMdvPositions = Seq(0),
           deletedPositions = Seq.empty, replacedPositions = Seq.empty)
       }
       assert(ex.getMessage.contains("no live file but gained new MDV positions"),

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTIncrementalWriteTestBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTIncrementalWriteTestBase.scala
@@ -221,15 +221,17 @@ abstract class AMTIncrementalWriteTestBase extends AMTCheckpointTestBase {
     (liveAdds, tombstones)
   }
 
+  /** Decodes a manifest bitmap's set positions into a set (empty if the bytes are absent). */
+  private def bitmapPositions(bytes: Array[Byte]): Set[Long] =
+    ManifestBitmap.fromSerializedByteArray(bytes).toArrayForTesting.toSet
+
   /** The per-commit CDF `tracking.deleted_positions` off a leaf pointer (empty if unset). */
   protected def leafDeletedPositions(leaf: DataManifestEntry): Set[Long] =
-    leaf.tracking.deleted_positions
-      .map(ManifestBitmap.readFrom(_).toArray.toSet).getOrElse(Set.empty)
+    leaf.tracking.deleted_positions.map(bitmapPositions).getOrElse(Set.empty)
 
   /** The per-commit CDF `tracking.replaced_positions` off a leaf pointer (empty if unset). */
   protected def leafReplacedPositions(leaf: DataManifestEntry): Set[Long] =
-    leaf.tracking.replaced_positions
-      .map(ManifestBitmap.readFrom(_).toArray.toSet).getOrElse(Set.empty)
+    leaf.tracking.replaced_positions.map(bitmapPositions).getOrElse(Set.empty)
 
   /** The current snapshot's leaf pointers, keyed by relative location. */
   protected def leafPointers(snapshot: Snapshot): Map[String, DataManifestEntry] = {
@@ -456,8 +458,8 @@ abstract class AMTIncrementalWriteTestBase extends AMTCheckpointTestBase {
           .filter { case (status, _) => Tracking.Status.liveEntryStatuses.contains(status) }
           .values.sum
         val mdvDeclaredCardinality = leaf.manifest_info.dv_cardinality.getOrElse(0L)
-        val decoded =
-          leaf.manifest_info.dv.map(ManifestBitmap.readFrom).getOrElse(ManifestBitmap.empty())
+        val decoded = leaf.manifest_info.dv.map(ManifestBitmap.fromSerializedByteArray)
+          .getOrElse(ManifestBitmap.fromPositions(Seq.empty))
         assert(decoded.cardinality == mdvDeclaredCardinality,
           s"Leaf ${leaf.location}: dv_cardinality=$mdvDeclaredCardinality but the decoded MDV " +
             s"has ${decoded.cardinality} bits.")
@@ -465,7 +467,7 @@ abstract class AMTIncrementalWriteTestBase extends AMTCheckpointTestBase {
           s"Leaf ${leaf.location}: MDV cardinality ($mdvDeclaredCardinality) exceeds physical " +
             s"entries " +
             s"($physicalEntries).")
-        decoded.toArray.foreach { pos =>
+        decoded.toArrayForTesting.foreach { pos =>
           assert(pos >= 0 && pos < physicalEntries,
             s"Leaf ${leaf.location}: MDV position $pos is out of range [0, $physicalEntries).")
         }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotSuite.scala
@@ -1305,7 +1305,7 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
 
   /** Serializes a manifest DV bitmap over the given leaf entry positions. */
   private def mdvBytesFor(positions: Long*): Array[Byte] =
-    AMTUtils.serializeMdv(ManifestBitmap(positions: _*))
+    AMTUtils.serializeMdv(ManifestBitmap.fromPositions(positions.map(_.toInt)))
 
   /** An ADDED tracking envelope with no lineage/sequence numbers, matching the AMT writer. */
   private def addedTracking: Tracking = Tracking(


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Refines the `ManifestBitmap` abstraction used for manifest deletion-vector bitmaps.

`RoaringManifestBitmap` is now backed by an `Either[Array[Byte], Seq[Int]]`, so a bitmap can be
constructed either from raw positions (`fromPositions`) or from already-serialized bytes
(`fromSerializedByteArray`). Decoding into a `RoaringBitmapArray` is deferred until the first
bit-level access, so a bitmap that is only carried forward and re-serialized never pays the
decode/encode cost.

`serializeAsByteArray` returns the original bytes when the bitmap was never mutated -- with a
defensive copy so a caller cannot mutate the internal buffer -- and re-encodes from the decoded
bitmap once a position has been added. `BackReference.pos` is narrowed from `Long` to `Int`, and
the manifest write path (`AMTWriteHelper`, `IncrementalAMTWriter`) and the associated tests are
updated to the new API.

## How was this patch tested?

Updated the existing manifest, back-reference, and action-serializer unit tests to exercise the
new API: `ActionSerializerSuite`, `AMTBackReferenceSuite`, `AMTIncrementalWriteInvariantSuite`,
`AMTIncrementalWriteTestBase`, and `AMTSnapshotSuite`.

## Does this PR introduce _any_ user-facing changes?

No.
