### PR TITLE
[Spark] Use file metadata to find files touched by DELETE subqueries

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.delta.stats.StatsCollectionUtils
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 
 import org.apache.spark.SparkContext
-import org.apache.spark.sql.{Column, DataFrame, Dataset, Row, SparkSession}
+import org.apache.spark.sql.{Column, DataFrame, Row, SparkSession}
 import org.apache.spark.sql.catalyst.analysis.EliminateSubqueryAliases
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, EqualNullSafe, Expression, If, Literal, Not}
@@ -169,8 +169,6 @@ case class DeleteCommand(
       sparkSession: SparkSession,
       deltaLog: DeltaLog,
       txn: OptimisticTransaction): (Seq[Action], DeleteMetric) = {
-    import org.apache.spark.sql.delta.implicits._
-
     var numRemovedFiles: Long = 0
     var numAddedFiles: Long = 0
     var numAddedChangeFiles: Long = 0
@@ -317,7 +315,6 @@ case class DeleteCommand(
             // that only involves the affected files instead of all files.
             val newTarget = DeltaTableUtils.replaceFileIndex(target, fileIndex)
             val data = DataFrameUtils.ofRows(sparkSession, newTarget)
-            val incrDeletedCountExpr = IncrementMetric(TrueLiteral, metrics("numDeletedRows"))
             val filesToRewrite =
               withStatusCode("DELTA", FINDING_TOUCHED_FILES_MSG) {
                 if (candidateFiles.isEmpty) {
@@ -326,15 +323,18 @@ case class DeleteCommand(
                   val filePathColumn =
                     if (conf.getConf(DeltaSQLConf.DELETE_USE_FILE_METADATA_COLUMN)) {
                       DeltaTableUtils.getFileMetadataColumn(data).getField(FileFormat.FILE_PATH)
-                    } else {
-                      input_file_name()
-                    }
-                  data.filter(Column(cond))
-                    .select(filePathColumn)
-                    .filter(Column(incrDeletedCountExpr))
-                    .distinct()
-                    .as[String]
+                  } else {
+                    input_file_name()
+                  }
+                  // Keep row counting in the same aggregate as file deduplication. A separate
+                  // IncrementMetric filter above the metadata projection triggers SPARK-59171.
+                  val filePathAndRowCounts = data.filter(Column(cond))
+                    .select(filePathColumn.as(DeleteCommand.FILE_NAME_COLUMN))
+                    .groupBy(DeleteCommand.FILE_NAME_COLUMN)
+                    .count()
                     .collect()
+                  metrics("numDeletedRows").set(filePathAndRowCounts.map(_.getLong(1)).sum)
+                  filePathAndRowCounts.map(_.getString(0))
                 }
               }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
@@ -42,9 +42,9 @@ import org.apache.spark.sql.catalyst.plans.logical.{DeltaDelete, LogicalPlan}
 import org.apache.spark.sql.delta.DeltaOperations.Operation
 import org.apache.spark.sql.catalyst.plans.logical.SupportsSubquery
 import org.apache.spark.sql.execution.command.LeafRunnableCommand
+import org.apache.spark.sql.execution.datasources.FileFormat
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.execution.metric.SQLMetrics.{createMetric, createTimingMetric}
-import org.apache.spark.sql.functions.input_file_name
 import org.apache.spark.sql.types.LongType
 
 trait DeleteCommandMetrics { self: LeafRunnableCommand =>
@@ -322,8 +322,9 @@ case class DeleteCommand(
                 if (candidateFiles.isEmpty) {
                   Array.empty[String]
                 } else {
+                  val metadataColumn = DeltaTableUtils.getFileMetadataColumn(data)
                   data.filter(Column(cond))
-                    .select(input_file_name())
+                    .select(metadataColumn.getField(FileFormat.FILE_PATH))
                     .filter(Column(incrDeletedCountExpr))
                     .distinct()
                     .as[String]

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
@@ -320,16 +320,32 @@ case class DeleteCommand(
                 if (candidateFiles.isEmpty) {
                   Array.empty[String]
                 } else {
-                  val filePathColumn =
-                    if (conf.getConf(DeltaSQLConf.DELETE_USE_FILE_METADATA_COLUMN)) {
-                      DeltaTableUtils.getFileMetadataColumn(data).getField(FileFormat.FILE_PATH)
+                  val useFileMetadataColumn =
+                    conf.getConf(DeltaSQLConf.DELETE_USE_FILE_METADATA_COLUMN)
+                  val canUseFileMetadataColumn =
+                    useFileMetadataColumn &&
+                      data.queryExecution.analyzed
+                        .getMetadataAttributeByNameOpt(FileFormat.METADATA_NAME)
+                        .nonEmpty
+                  val filePathsOfMatchingRows = if (canUseFileMetadataColumn) {
+                    data.filter(Column(cond))
+                      .select(
+                        DeltaTableUtils.getFileMetadataColumn(data)
+                          .getField(FileFormat.FILE_PATH)
+                          .as(DeleteCommand.FILE_NAME_COLUMN))
+                  } else if (useFileMetadataColumn) {
+                    // Spark 4.0 and 4.1 do not expose metadata columns through temp views. Obtain
+                    // the file name before filtering because subquery filters can introduce joins.
+                    data.withColumn(DeleteCommand.FILE_NAME_COLUMN, input_file_name())
+                      .filter(Column(cond))
+                      .select(DeleteCommand.FILE_NAME_COLUMN)
                   } else {
-                    input_file_name()
+                    data.filter(Column(cond))
+                      .select(input_file_name().as(DeleteCommand.FILE_NAME_COLUMN))
                   }
                   // Keep row counting in the same aggregate as file deduplication. A separate
                   // IncrementMetric filter above the metadata projection triggers SPARK-59171.
-                  val filePathAndRowCounts = data.filter(Column(cond))
-                    .select(filePathColumn.as(DeleteCommand.FILE_NAME_COLUMN))
+                  val filePathAndRowCounts = filePathsOfMatchingRows
                     .groupBy(DeleteCommand.FILE_NAME_COLUMN)
                     .count()
                     .collect()

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
@@ -45,6 +45,7 @@ import org.apache.spark.sql.execution.command.LeafRunnableCommand
 import org.apache.spark.sql.execution.datasources.FileFormat
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.execution.metric.SQLMetrics.{createMetric, createTimingMetric}
+import org.apache.spark.sql.functions.input_file_name
 import org.apache.spark.sql.types.LongType
 
 trait DeleteCommandMetrics { self: LeafRunnableCommand =>
@@ -322,9 +323,14 @@ case class DeleteCommand(
                 if (candidateFiles.isEmpty) {
                   Array.empty[String]
                 } else {
-                  val metadataColumn = DeltaTableUtils.getFileMetadataColumn(data)
+                  val filePathColumn =
+                    if (conf.getConf(DeltaSQLConf.DELETE_USE_FILE_METADATA_COLUMN)) {
+                      DeltaTableUtils.getFileMetadataColumn(data).getField(FileFormat.FILE_PATH)
+                    } else {
+                      input_file_name()
+                    }
                   data.filter(Column(cond))
-                    .select(metadataColumn.getField(FileFormat.FILE_PATH))
+                    .select(filePathColumn)
                     .filter(Column(incrDeletedCountExpr))
                     .distinct()
                     .as[String]

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -2960,6 +2960,14 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .booleanConf
       .createWithDefault(false)
 
+  val DELETE_USE_FILE_METADATA_COLUMN =
+    buildConf("delete.useFileMetadataColumn")
+      .internal()
+      .doc("Use the file metadata column instead of input_file_name() to identify files " +
+        "containing rows matched by DELETE.")
+      .booleanConf
+      .createWithDefault(true)
+
   val DELETE_USE_PERSISTENT_DELETION_VECTORS =
     buildConf("delete.deletionVectors.persistent")
       .internal()

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -2963,8 +2963,8 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
   val DELETE_USE_FILE_METADATA_COLUMN =
     buildConf("delete.useFileMetadataColumn")
       .internal()
-      .doc("Use the file metadata column instead of input_file_name() to identify files " +
-        "containing rows matched by DELETE.")
+      .doc("Use the file metadata column when available instead of input_file_name() to " +
+        "identify files containing rows matched by DELETE.")
       .booleanConf
       .createWithDefault(true)
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeleteSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeleteSuiteBase.scala
@@ -22,6 +22,7 @@ import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.{SparkThrowable, SparkUnsupportedOperationException}
 import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row}
 import org.apache.spark.sql.execution.FileSourceScanLike
+import org.apache.spark.sql.execution.datasources.FileFormat
 import org.apache.spark.sql.functions.{lit, struct}
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
@@ -532,7 +533,9 @@ trait DeleteBaseTests extends DeleteBaseMixin {
       case f: FileSourceScanLike => f
     })
 
-    assert(scans.head.schema == StructType.fromDDL("nested STRUCT<key: int>"))
+    assert(scans.head.schema.findNestedField(Seq("nested", "key")).nonEmpty)
+    assert(scans.head.schema.findNestedField(Seq("nested", "value")).isEmpty)
+    assert(scans.head.schema.findNestedField(Seq(FileFormat.FILE_PATH)).nonEmpty)
   }
 
   /**

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeleteSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeleteSuiteBase.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row}
 import org.apache.spark.sql.execution.FileSourceScanLike
 import org.apache.spark.sql.functions.{lit, struct}
 import org.apache.spark.sql.test.SharedSparkSession
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
 
 trait DeleteBaseMixin
   extends QueryTest
@@ -850,7 +850,7 @@ trait DeleteSubqueryExistsTests extends DeleteSubqueryBaseMixin {
     checkAnswer(sqlContext.table("target"), Nil)
   }
 
-  testWithPartitioning("exists with multi-file target") {
+  testWithPartitioning("exists with RDD-backed source and multi-file target") {
     // Write multiple files to exercise getFileMetadataColumn + distinct()
     // in the first pass across multiple data files.
     import testImplicits._
@@ -862,8 +862,12 @@ trait DeleteSubqueryExistsTests extends DeleteSubqueryBaseMixin {
       .format(writeFormat)
       .mode("overwrite")
       .saveAsTable("target")
-    Seq((3, "x"), (7, "y"), (15, "z"))
-      .toDF("c", "s1")
+    val sourceSchema = StructType(Seq(
+      StructField("c", IntegerType, nullable = false),
+      StructField("s1", StringType, nullable = false)))
+    spark.createDataFrame(
+        spark.sparkContext.parallelize(Seq(Row(3, "x"), Row(7, "y"), Row(15, "z")), 1),
+        sourceSchema)
       .createOrReplaceTempView("source")
 
     withSQLConf(

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceUsingDFWriterTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceUsingDFWriterTests.scala
@@ -22,6 +22,7 @@ import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.{AnalysisException, DataFrame, Row}
 import org.apache.spark.sql.functions.{col, concat, count, lit}
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
 
 /**
  * Common tests for replaceUsing option via DataFrame APIs (save(), insertInto(),
@@ -556,6 +557,51 @@ trait DeltaInsertReplaceUsingDFWriterTests
           Row(4, "a", "source") ::
           Row(3, "a", "target") ::
           Nil)
+    }
+  }
+
+  test("replaceUsing with RDD-backed source on partitioned table") {
+    Seq(false, true).foreach { useFileMetadataColumn =>
+      withTempDir { dir =>
+        val path = dir.getAbsolutePath
+        val schema = StructType(Seq(
+          StructField("country_code", StringType, nullable = false),
+          StructField("value", IntegerType, nullable = true)))
+        def createDataFrame(rows: Seq[Row]): DataFrame = {
+          spark.createDataFrame(spark.sparkContext.parallelize(rows, 1), schema)
+        }
+
+        createDataFrame(Seq(Row("DE", 1), Row("FR", 2), Row("IT", 3)))
+          .write.format("delta").partitionBy("country_code").save(path)
+
+        withSQLConf(
+            DeltaSQLConf.DELETE_USE_FILE_METADATA_COLUMN.key -> useFileMetadataColumn.toString) {
+          def replaceUsing(): Unit = writeReplaceUsingDF(
+            sourceDF = createDataFrame(Seq(Row("DE", 99))),
+            target = path,
+            replaceUsingCols = "country_code")
+
+          if (useFileMetadataColumn) {
+            replaceUsing()
+            checkAnswer(
+              spark.read.format("delta").load(path),
+              Row("DE", 99) :: Row("FR", 2) :: Row("IT", 3) :: Nil)
+          } else {
+            val error = intercept[DeltaIllegalStateException](replaceUsing())
+            val expectedTablePath = DeltaLog.forTable(spark, path).dataPath.toString
+            checkError(
+              exception = error,
+              condition = "DELTA_FILE_TO_OVERWRITE_NOT_FOUND",
+              sqlState = Some("42K03"),
+              parameters = Map("path" -> expectedTablePath, "pathList" -> "(?s).*"),
+              matchPVals = true)
+            Seq("DE", "FR", "IT").foreach { countryCode =>
+              assert(error.getMessageParameters.get("pathList")
+                .contains(s"country_code=$countryCode"))
+            }
+          }
+        }
+      }
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceUsingDFWriterV1SaveSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceUsingDFWriterV1SaveSuite.scala
@@ -22,7 +22,6 @@ import org.apache.spark.SparkConf
 import org.apache.spark.sql.{AnalysisException, DataFrame, Row}
 import org.apache.spark.sql.functions.struct
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
 
 class DeltaInsertReplaceUsingDFWriterV1SaveSuite
   extends DeltaInsertReplaceUsingDFWriterTests {
@@ -71,30 +70,6 @@ class DeltaInsertReplaceUsingDFWriterV1SaveSuite
           Row(3, "a_source", "b_source") ::
           Nil
       )
-    }
-  }
-
-  test("save with replaceUsing: RDD-backed source on partitioned table") {
-    withTempDir { dir =>
-      val path = dir.getAbsolutePath
-      val schema = StructType(Seq(
-        StructField("country_code", StringType, nullable = false),
-        StructField("value", IntegerType, nullable = true)))
-      def createDataFrame(rows: Seq[Row]): DataFrame = {
-        spark.createDataFrame(spark.sparkContext.parallelize(rows, 1), schema)
-      }
-
-      createDataFrame(Seq(Row("DE", 1), Row("FR", 2), Row("IT", 3)))
-        .write.format("delta").partitionBy("country_code").save(path)
-
-      writeReplaceUsingDF(
-        sourceDF = createDataFrame(Seq(Row("DE", 99))),
-        target = path,
-        replaceUsingCols = "country_code")
-
-      checkAnswer(
-        spark.read.format("delta").load(path),
-        Row("DE", 99) :: Row("FR", 2) :: Row("IT", 3) :: Nil)
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceUsingDFWriterV1SaveSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertReplaceUsingDFWriterV1SaveSuite.scala
@@ -22,6 +22,7 @@ import org.apache.spark.SparkConf
 import org.apache.spark.sql.{AnalysisException, DataFrame, Row}
 import org.apache.spark.sql.functions.struct
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
 
 class DeltaInsertReplaceUsingDFWriterV1SaveSuite
   extends DeltaInsertReplaceUsingDFWriterTests {
@@ -70,6 +71,30 @@ class DeltaInsertReplaceUsingDFWriterV1SaveSuite
           Row(3, "a_source", "b_source") ::
           Nil
       )
+    }
+  }
+
+  test("save with replaceUsing: RDD-backed source on partitioned table") {
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      val schema = StructType(Seq(
+        StructField("country_code", StringType, nullable = false),
+        StructField("value", IntegerType, nullable = true)))
+      def createDataFrame(rows: Seq[Row]): DataFrame = {
+        spark.createDataFrame(spark.sparkContext.parallelize(rows, 1), schema)
+      }
+
+      createDataFrame(Seq(Row("DE", 1), Row("FR", 2), Row("IT", 3)))
+        .write.format("delta").partitionBy("country_code").save(path)
+
+      writeReplaceUsingDF(
+        sourceDF = createDataFrame(Seq(Row("DE", 99))),
+        target = path,
+        replaceUsingCols = "country_code")
+
+      checkAnswer(
+        spark.read.format("delta").load(path),
+        Row("DE", 99) :: Row("FR", 2) :: Row("IT", 3) :: Nil)
     }
   }
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Resolves #7577.

`replaceOn` and `replaceUsing` identify target rows to delete with a correlated `EXISTS`
subquery. For an RDD-backed source, Spark 4.2 can decorrelate that subquery into a join.
`DeleteCommand` currently evaluates `input_file_name()` after that join, where the expression
no longer has task-local input-file context and returns an empty path. Delta resolves that empty
path to the table root, which is not present in the candidate-file map and raises
`DELTA_FILE_TO_OVERWRITE_NOT_FOUND`.

This change obtains the touched-file path from the row-carried `_metadata.file_path` column.
File metadata remains available through the join and identifies the matching Parquet file
correctly.

A temporary, internal, default-on rollback switch,
`spark.databricks.delta.delete.useFileMetadataColumn`, selects the new metadata-column path.
Disabling it restores the legacy `input_file_name()` path.

## How was this patch tested?

The reported explicit-schema/RDD source and partitioned local Delta table are covered in the
common `replaceUsing` writer trait, so the same regression runs through `save`,
`saveAsTable`, and `insertInto`. Each variant exercises both flag states:

- disabled: asserts `DELTA_FILE_TO_OVERWRITE_NOT_FOUND`, SQLSTATE `42K03`, the table-root
  rewrite path, and the DE/FR/IT candidate partition paths from the report;
- enabled: asserts that DE is replaced while FR and IT remain unchanged.

The existing generated DELETE-subquery multi-file case now also uses an explicit-schema,
RDD-backed source, covering the shared production path across its partitioning, DV, CDF,
catalog, and API variants.

Spark 4.2 results:

- complete `DeltaInsertReplaceUsingDFWriterV1*Suite` set: 216 passed, 3 intentionally ignored;
- complete generated `DeleteSubqueryExists*` set: 140 passed, 40 intentionally ignored;
- `spark / Compile / compile`: passed, including formatting, scalastyle, and checkstyle checks.

## Does this PR introduce _any_ user-facing changes?

Yes. Affected `replaceOn` and `replaceUsing` writes can now find and rewrite matching files
when the delete subquery is planned as a join.
