### PR TITLE
[Spark][4.3] Backport staged commit listing and maintenance checks

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/CatalogManagedTableMaintenanceOperation.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/CatalogManagedTableMaintenanceOperation.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+object CatalogManagedTableMaintenanceOperation {
+  /**
+   * Deletes data files that no retained table version needs. It deletes the files only after the
+   * retention period.
+   */
+  val DATA_CLEANUP = "DATA_CLEANUP"
+
+  /**
+   * Rewrites data files that the current table version uses. It changes how the files store and
+   * group the data. It does not change the table's current rows.
+   */
+  val DATA_REORGANIZATION = "DATA_REORGANIZATION"
+
+  /**
+   * Deletes expired files from `_delta_log`. It keeps the files that are necessary to read retained
+   * table versions.
+   */
+  val METADATA_CLEANUP = "METADATA_CLEANUP"
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -4087,6 +4087,15 @@ trait DeltaErrorsBase
       messageParameters = Array(operation))
   }
 
+  def checkCatalogManagedTableOperationAllowed(
+      operation: String,
+      snapshot: SnapshotDescriptor,
+      catalogTableOpt: Option[CatalogTable]): Unit = {
+    if (snapshot.isCatalogOwned) {
+      throw operationBlockedOnCatalogManagedTable(operation)
+    }
+  }
+
   def deltaCannotCreateCatalogManagedTable(): Throwable = {
     new DeltaUnsupportedOperationException(
       errorClass = "DELTA_UNSUPPORTED_CATALOG_MANAGED_TABLE_CREATION",

--- a/spark/src/main/scala/org/apache/spark/sql/delta/MetadataCleanup.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/MetadataCleanup.scala
@@ -67,6 +67,14 @@ trait MetadataCleanup extends DeltaLogging {
       snapshotToCleanup: Snapshot,
       catalogTableOpt: Option[CatalogTable]): Unit = {
     if (enableExpiredLogCleanup(unsafeVolatileSnapshot.metadata)) {
+      try {
+        DeltaErrors.checkCatalogManagedTableOperationAllowed(
+          CatalogManagedTableMaintenanceOperation.METADATA_CLEANUP,
+          snapshotToCleanup,
+          catalogTableOpt)
+      } catch {
+        case _: DeltaUnsupportedOperationException => return
+      }
       cleanUpExpiredLogs(snapshotToCleanup, catalogTableOpt)
     }
   }
@@ -77,6 +85,11 @@ trait MetadataCleanup extends DeltaLogging {
       catalogTableOpt: Option[CatalogTable] = None,
       deltaRetentionMillisOpt: Option[Long] = None,
       cutoffTruncationGranularity: TruncationGranularity = DAY): Unit = {
+    DeltaErrors.checkCatalogManagedTableOperationAllowed(
+      CatalogManagedTableMaintenanceOperation.METADATA_CLEANUP,
+      snapshotToCleanup,
+      catalogTableOpt)
+
     recordDeltaOperation(this, "delta.log.cleanup") {
       val retentionMillis =
         deltaRetentionMillisOpt.getOrElse(deltaRetentionMillis(unsafeVolatileSnapshot.metadata))

--- a/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
@@ -126,7 +126,10 @@ trait SnapshotManagement { self: DeltaLog =>
     val files =
       filesOpt.map {
       _.flatMap {
-        case DeltaFile(f, fileVersion) =>
+        // Use BackfilledDeltaFile, not the permissive DeltaFile: a raw listing must not promote
+        // staged commits (`_staged_commits/N.<uuid>.json`) to commits. They are ratified by the
+        // commit coordinator (getCommits), and enter the log segment separately via the caller.
+        case BackfilledDeltaFile(f, fileVersion) =>
           Some((f, FileType.DELTA, fileVersion))
         case CompactedDeltaFile(f, startVersion, endVersion)
             if includeMinorCompactions && versionToLoad.forall(endVersion <= _) =>

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeltaReorgTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeltaReorgTableCommand.scala
@@ -16,7 +16,11 @@
 
 package org.apache.spark.sql.delta.commands
 
-import org.apache.spark.sql.delta.{DeltaColumnMapping, DeltaErrors, SnapshotDescriptor}
+import org.apache.spark.sql.delta.{
+  CatalogManagedTableMaintenanceOperation,
+  DeltaColumnMapping,
+  DeltaErrors,
+  SnapshotDescriptor}
 import org.apache.spark.sql.delta.actions.AddFile
 
 import org.apache.spark.sql.{Row, SparkSession}
@@ -75,9 +79,10 @@ case class DeltaReorgTableCommand(
       optimizeByReorg(sparkSession)
     case DeltaReorgTableSpec(DeltaReorgTableMode.UNIFORM_ICEBERG, Some(icebergCompatVersion)) =>
       val table = getDeltaTable(target, "REORG")
-      if (table.update().isCatalogOwned) {
-        throw DeltaErrors.operationBlockedOnCatalogManagedTable("REORG")
-      }
+      DeltaErrors.checkCatalogManagedTableOperationAllowed(
+        CatalogManagedTableMaintenanceOperation.DATA_REORGANIZATION,
+        table.update(),
+        table.catalogTable)
       upgradeUniformIcebergCompatVersion(table, sparkSession, icebergCompatVersion)
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
@@ -162,9 +162,10 @@ case class OptimizeTableCommand(
       throw DeltaErrors.notADeltaTableException(table.deltaLog.dataPath.toString)
     }
 
-    if (snapshot.isCatalogOwned) {
-      throw DeltaErrors.operationBlockedOnCatalogManagedTable("OPTIMIZE")
-    }
+    DeltaErrors.checkCatalogManagedTableOperationAllowed(
+      CatalogManagedTableMaintenanceOperation.DATA_REORGANIZATION,
+      snapshot,
+      table.catalogTable)
 
     val isClusteredTable = ClusteredTableUtils.isSupported(snapshot.protocol)
     if (isClusteredTable) {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/VacuumCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/VacuumCommand.scala
@@ -41,7 +41,6 @@ import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.internal.MDC
 import org.apache.spark.paths.SparkPath
 import org.apache.spark.sql.{Column, DataFrame, Dataset, Encoder, SparkSession}
-import org.apache.spark.sql.catalyst.catalog.CatalogTableType
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.execution.metric.SQLMetrics.createMetric
 import org.apache.spark.sql.functions.{col, count, lit, replace, startswith, substr, sum}
@@ -167,16 +166,10 @@ object VacuumCommand extends VacuumCommandImpl with Serializable {
       val snapshot = table.update()
       deltaLog.protocolWrite(snapshot.protocol)
 
-      if (snapshot.isCatalogOwned) {
-        table.catalogTable.foreach { catalogTable =>
-          assert(
-            catalogTable.tableType == CatalogTableType.MANAGED,
-            s"All Catalog Owned tables should be MANAGED tables, " +
-              s"but found ${catalogTable.tableType} for table ${catalogTable.identifier}."
-          )
-        }
-        throw DeltaErrors.operationBlockedOnCatalogManagedTable("VACUUM")
-      }
+      DeltaErrors.checkCatalogManagedTableOperationAllowed(
+        CatalogManagedTableMaintenanceOperation.DATA_CLEANUP,
+        snapshot,
+        table.catalogTable)
 
       // By default, we will do full vacuum unless LITE vacuum conf is set
       val isLiteVacuumEnabled = spark.sessionState.conf.getConf(DeltaSQLConf.LITE_VACUUM_ENABLED)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
@@ -158,6 +158,12 @@ case class WriteIntoDelta(
         clusterBySpecOpt
       }
     val rearrangeOnly = options.rearrangeOnly
+    if (rearrangeOnly) {
+      DeltaErrors.checkCatalogManagedTableOperationAllowed(
+        CatalogManagedTableMaintenanceOperation.DATA_REORGANIZATION,
+        txn.snapshot,
+        txn.catalogTable)
+    }
     val charPadding = sparkSession.conf.get(SQLConf.READ_SIDE_CHAR_PADDING)
     val charAsVarchar = sparkSession.conf.get(SQLConf.CHAR_AS_VARCHAR)
     val dataSchema = if (!charAsVarchar && charPadding) {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/columnmapping/RemoveColumnMappingCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/columnmapping/RemoveColumnMappingCommand.scala
@@ -41,6 +41,11 @@ class RemoveColumnMappingCommand(
    */
   def run(spark: SparkSession, removeColumnMappingTableProperty: Boolean): Unit = {
     deltaLog.withNewTransaction(catalogOpt) { txn =>
+      DeltaErrors.checkCatalogManagedTableOperationAllowed(
+        CatalogManagedTableMaintenanceOperation.DATA_REORGANIZATION,
+        txn.snapshot,
+        txn.catalogTable)
+
       val originalFiles = txn.filterFiles()
       val originalData = buildDataFrame(txn, originalFiles)
       val originalSchema = txn.snapshot.schema

--- a/spark/src/main/scala/org/apache/spark/sql/delta/hooks/AutoCompact.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/hooks/AutoCompact.scala
@@ -98,6 +98,15 @@ trait AutoCompactBase extends PostCommitHook with DeltaLogging {
   }
 
   override def run(spark: SparkSession, txn: CommittedTransaction): Unit = {
+    try {
+      DeltaErrors.checkCatalogManagedTableOperationAllowed(
+        CatalogManagedTableMaintenanceOperation.DATA_REORGANIZATION,
+        txn.postCommitSnapshot,
+        txn.catalogTable)
+    } catch {
+      case _: DeltaUnsupportedOperationException => return
+    }
+
     val conf = spark.sessionState.conf
     val autoCompactTypeOpt = getAutoCompactType(conf, txn.postCommitSnapshot.metadata)
     // Skip Auto Compact if current transaction is not qualified or the table is not qualified

--- a/spark/src/main/scala/org/apache/spark/sql/delta/hooks/GenerateSymlinkManifest.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/hooks/GenerateSymlinkManifest.scala
@@ -72,6 +72,15 @@ trait GenerateSymlinkManifestImpl extends PostCommitHook with DeltaLogging with 
   override val name: String = "Generate Symlink Format Manifest"
 
   override def run(spark: SparkSession, txn: CommittedTransaction): Unit = {
+    try {
+      DeltaErrors.checkCatalogManagedTableOperationAllowed(
+        "GENERATE_SYMLINK_FORMAT_MANIFEST",
+        txn.postCommitSnapshot,
+        txn.catalogTable)
+    } catch {
+      case _: DeltaUnsupportedOperationException => return
+    }
+
     generateIncrementalManifest(spark, txn, txn.postCommitSnapshot)
   }
 
@@ -183,6 +192,10 @@ trait GenerateSymlinkManifestImpl extends PostCommitHook with DeltaLogging with 
       deltaLog: DeltaLog,
       catalogTableOpt: Option[CatalogTable]): Unit = {
     val snapshot = deltaLog.update(catalogTableOpt = catalogTableOpt)
+    DeltaErrors.checkCatalogManagedTableOperationAllowed(
+      "GENERATE_SYMLINK_FORMAT_MANIFEST",
+      snapshot,
+      catalogTableOpt)
     assertTableIsDVFree(spark, snapshot)
     generateFullManifestWithSnapshot(spark, deltaLog, snapshot)
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/AutoCompactSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/AutoCompactSuite.scala
@@ -162,6 +162,29 @@ class AutoCompactExecutionSuite extends
 
   import testImplicits._
 
+  test("auto compact is skipped for a catalog-managed table") {
+    withCatalogManagedTable() { tableName =>
+      val deltaLog = DeltaLog.forTable(spark, TableIdentifier(tableName))
+      val versionBefore = deltaLog.update().version
+
+      val usageLogs = withSQLConf(
+          DeltaSQLConf.DELTA_AUTO_COMPACT_ENABLED.key -> "true",
+          DeltaSQLConf.DELTA_AUTO_COMPACT_MIN_NUM_FILES.key -> "0") {
+        captureOptimizeLogs(AutoCompact.OP_TYPE) {
+          spark.range(10)
+            .selectExpr("CAST(id AS INT) AS id")
+            .write
+            .mode("append")
+            .insertInto(tableName)
+        }
+      }
+
+      assert(usageLogs.isEmpty)
+      assert(deltaLog.update().version === versionBefore + 1)
+      assert(spark.table(tableName).count() === 10)
+    }
+  }
+
   test("auto compact event log: inline AC") {
     withTempDir { dir =>
       withSQLConf(

--- a/spark/src/test/scala/org/apache/spark/sql/delta/CheckpointsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CheckpointsSuite.scala
@@ -26,7 +26,7 @@ import scala.concurrent.duration._
 import com.databricks.spark.util.{Log4jUsageLogger, MetricDefinitions, UsageRecord}
 import org.apache.spark.sql.delta.DeltaTestUtils.createTestAddFile
 import org.apache.spark.sql.delta.actions._
-import org.apache.spark.sql.delta.coordinatedcommits.CatalogOwnedTestBaseSuite
+import org.apache.spark.sql.delta.coordinatedcommits.{CatalogManagedMaintenanceIncompatible, CatalogOwnedTestBaseSuite}
 import org.apache.spark.sql.delta.deletionvectors.DeletionVectorsSuite
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.storage.LocalLogStore
@@ -1156,7 +1156,9 @@ class CheckpointsSuite
     }
   }
 
-  test("validate metadata cleanup is not called with createCheckpointAtVersion API") {
+  test(
+      "validate metadata cleanup is not called with createCheckpointAtVersion API",
+      CatalogManagedMaintenanceIncompatible) {
     withTempDir { dir =>
       val usageRecords1 = Log4jUsageLogger.track {
         spark.range(10).write.format("delta").save(dir.getAbsolutePath)
@@ -1976,4 +1978,3 @@ class CheckpointsWithCatalogOwnedBatch2Suite extends CheckpointsSuite {
 class CheckpointsWithCatalogOwnedBatch100Suite extends CheckpointsSuite {
   override def catalogOwnedCoordinatorBackfillBatchSize: Option[Int] = Some(100)
 }
-

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaColumnMappingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaColumnMappingSuite.scala
@@ -2282,6 +2282,33 @@ class DeltaColumnMappingSuite extends QueryTest
     }
   }
 
+  test("column-mapping removal is blocked for a catalog-managed table") {
+    withSQLConf(DeltaSQLConf.ALLOW_COLUMN_MAPPING_REMOVAL.key -> "true") {
+      withCatalogManagedTable() { tableName =>
+        spark.sql(
+          s"ALTER TABLE $tableName SET TBLPROPERTIES " +
+            s"('${DeltaConfigs.COLUMN_MAPPING_MODE.key}' = 'name')")
+        spark.sql(s"INSERT INTO $tableName VALUES (1)")
+        val deltaLog = DeltaLog.forTable(spark, TableIdentifier(tableName))
+        val snapshotBefore = deltaLog.update()
+
+        checkError(
+          intercept[DeltaUnsupportedOperationException] {
+            spark.sql(
+              s"ALTER TABLE $tableName SET TBLPROPERTIES " +
+                s"('${DeltaConfigs.COLUMN_MAPPING_MODE.key}' = 'none')")
+          },
+          "DELTA_UNSUPPORTED_CATALOG_MANAGED_TABLE_OPERATION",
+          parameters = Map("operation" -> "DATA_REORGANIZATION"))
+
+        val snapshotAfter = deltaLog.update()
+        assert(snapshotAfter.version === snapshotBefore.version)
+        assert(snapshotAfter.metadata === snapshotBefore.metadata)
+        assert(snapshotAfter.allFiles.collect().toSet === snapshotBefore.allFiles.collect().toSet)
+      }
+    }
+  }
+
   test("enabling column mapping disallowed if column mapping metadata already exists") {
     withSQLConf(
       // enabling this fixes the issue of committing invalid metadata in the first place

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaGenerateSymlinkManifestSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaGenerateSymlinkManifestSuite.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.delta.DeltaOperations.Delete
 import org.apache.spark.sql.delta.commands.DeltaGenerateCommand
 import org.apache.spark.sql.delta.hooks.GenerateSymlinkManifest
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
-import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.delta.test.{DeltaSQLCommandTest, DeltaSQLTestUtils}
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 import org.apache.spark.sql.delta.util.DeltaFileOperations
 import org.apache.hadoop.conf.Configuration
@@ -45,6 +45,7 @@ class DeltaGenerateSymlinkManifestSuite
 
 trait DeltaGenerateSymlinkManifestSuiteBase
   extends DeltaGenerateSymlinkManifestTestHelper
+  with DeltaSQLTestUtils
   with DeletionVectorsTestUtils
   with DeltaTestUtilsForTempViews {
 
@@ -75,6 +76,35 @@ trait DeltaGenerateSymlinkManifestSuiteBase
 
       spark.sql(s"GENERATE symlink_ForMat_Manifest FOR TABLE $tableName")
       assertManifest(tableName, expectSameFiles = true, expectedNumFiles = 7)
+    }
+  }
+
+  test("symlink manifest generation is blocked for a catalog-managed table") {
+    withCatalogManagedTable(createTable = false) { tableName =>
+      spark.sql(s"CREATE TABLE $tableName (id INT) USING delta TBLPROPERTIES " +
+        s"('delta.feature.${CatalogOwnedTableFeature.name}' = 'supported', " +
+        "'delta.enableDeletionVectors' = 'false')")
+      assertManifest(tableName, expectSameFiles = false, expectedNumFiles = 0)
+
+      checkError(
+        intercept[DeltaUnsupportedOperationException] {
+          spark.sql(s"GENERATE symlink_format_manifest FOR TABLE $tableName")
+        },
+        "DELTA_UNSUPPORTED_CATALOG_MANAGED_TABLE_OPERATION",
+        parameters = Map("operation" -> "GENERATE_SYMLINK_FORMAT_MANIFEST"))
+      assertManifest(tableName, expectSameFiles = false, expectedNumFiles = 0)
+
+      spark.sql(
+        s"ALTER TABLE $tableName SET TBLPROPERTIES " +
+          s"('${DeltaConfigs.SYMLINK_FORMAT_MANIFEST_ENABLED.key}' = 'true')")
+      val deltaLog = DeltaLog.forTable(spark, TableIdentifier(tableName))
+      val versionBefore = deltaLog.update().version
+
+      spark.sql(s"INSERT INTO $tableName VALUES (1)")
+
+      assert(deltaLog.update().version === versionBefore + 1)
+      assertManifest(tableName, expectSameFiles = false, expectedNumFiles = 0)
+      checkAnswer(spark.table(tableName), Row(1))
     }
   }
 
@@ -874,4 +904,3 @@ class SymlinkManifestFailureTestFileSystem extends RawLocalFileSystem {
 object SymlinkManifestFailureTestFileSystem {
   val SCHEME = "testScheme"
 }
-

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuite.scala
@@ -21,8 +21,10 @@ import java.io.File
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
+import com.databricks.spark.util.Log4jUsageLogger
 import org.apache.spark.sql.delta.DeltaTestUtils.createTestAddFile
 import org.apache.spark.sql.delta.actions.{Action, AddFile, RemoveFile, SetTransaction}
+import org.apache.spark.sql.delta.coordinatedcommits.CatalogManagedMaintenanceIncompatible
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.test.DeltaSQLTestUtils
@@ -33,6 +35,7 @@ import org.apache.hadoop.fs.{FileStatus, FileSystem, Path, RawLocalFileSystem}
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.util.ManualClock
 
 // scalastyle:off: removeFile
@@ -56,7 +59,45 @@ class DeltaRetentionSuite extends QueryTest
     }
   }
 
-  test("delete expired logs") {
+  test("direct metadata cleanup is blocked for catalog-managed tables") {
+    withCatalogManagedTable() { tableName =>
+      val log = DeltaLog.forTable(spark, TableIdentifier(tableName))
+      val logPath = new File(log.logPath.toUri)
+      val filesBeforeCleanup = getLogFiles(logPath).map(_.getCanonicalPath).toSet
+
+      checkError(
+        intercept[DeltaUnsupportedOperationException] {
+          log.cleanUpExpiredLogs(log.update())
+        },
+        "DELTA_UNSUPPORTED_CATALOG_MANAGED_TABLE_OPERATION",
+        parameters = Map("operation" -> "METADATA_CLEANUP"))
+      assert(getLogFiles(logPath).map(_.getCanonicalPath).toSet === filesBeforeCleanup)
+    }
+  }
+
+  test("checkpoint does not clean up catalog-managed table metadata") {
+    withCatalogManagedTable() { tableName =>
+      spark.sql(s"ALTER TABLE $tableName SET TBLPROPERTIES " +
+        "('delta.enableExpiredLogCleanup' = 'true')")
+      spark.sql(s"INSERT INTO $tableName VALUES (1)")
+      val log = DeltaLog.forTable(spark, TableIdentifier(tableName))
+      val snapshot = log.update()
+      val firstCommit = FileNames.unsafeDeltaFile(log.logPath, 0)
+      val fs = firstCommit.getFileSystem(log.newDeltaHadoopConf())
+      assert(fs.exists(firstCommit))
+      fs.setTimes(firstCommit, 0L, -1L)
+
+      val usageRecords = Log4jUsageLogger.track {
+        log.checkpoint(snapshot)
+      }
+
+      assert(log.readLastCheckpointFile().exists(_.version == snapshot.version))
+      assert(DeltaTestUtils.filterUsageRecords(usageRecords, "delta.log.cleanup").isEmpty)
+      assert(fs.exists(firstCommit))
+    }
+  }
+
+  test("delete expired logs", CatalogManagedMaintenanceIncompatible) {
     withTempDir { tempDir =>
       val startTime = getStartTimeForRetentionTest
       val clock = new ManualClock(startTime)
@@ -107,7 +148,9 @@ class DeltaRetentionSuite extends QueryTest
     }
   }
 
-  test("log files being already deleted shouldn't fail log deletion job") {
+  test(
+      "log files being already deleted shouldn't fail log deletion job",
+      CatalogManagedMaintenanceIncompatible) {
     withTempDir { tempDir =>
       val startTime = getStartTimeForRetentionTest
       val clock = new ManualClock(startTime)
@@ -282,7 +325,9 @@ class DeltaRetentionSuite extends QueryTest
     }
   }
 
-  test("the checkpoint and checksum for version 0 should be cleaned") {
+  test(
+      "the checkpoint and checksum for version 0 should be cleaned",
+      CatalogManagedMaintenanceIncompatible) {
     withTempDir { tempDir =>
       val clock = new ManualClock(getStartTimeForRetentionTest)
       val log = DeltaLog.forTable(spark, new Path(tempDir.getCanonicalPath), clock)
@@ -372,7 +417,9 @@ class DeltaRetentionSuite extends QueryTest
   }
 
   for (v2CheckpointFormat <- V2Checkpoint.Format.ALL_AS_STRINGS)
-  test(s"sidecar file cleanup [v2CheckpointFormat: $v2CheckpointFormat]") {
+  test(
+      s"sidecar file cleanup [v2CheckpointFormat: $v2CheckpointFormat]",
+      CatalogManagedMaintenanceIncompatible) {
     val checkpointPolicy = CheckpointPolicy.V2.name
     withSQLConf((DeltaSQLConf.CHECKPOINT_V2_TOP_LEVEL_FILE_FORMAT.key -> v2CheckpointFormat)) {
       withTempDir { tempDir =>
@@ -483,7 +530,8 @@ class DeltaRetentionSuite extends QueryTest
   for (v2CheckpointFormat <- V2Checkpoint.Format.ALL_AS_STRINGS)
   test(
     s"compat file created with metadata cleanup when checkpoints are deleted" +
-      s" [v2CheckpointFormat: $v2CheckpointFormat]") {
+      s" [v2CheckpointFormat: $v2CheckpointFormat]",
+    CatalogManagedMaintenanceIncompatible) {
     val checkpointPolicy = CheckpointPolicy.V2.name
     withSQLConf((DeltaSQLConf.CHECKPOINT_V2_TOP_LEVEL_FILE_FORMAT.key -> v2CheckpointFormat)) {
       withTempDir { tempDir =>
@@ -555,7 +603,7 @@ class DeltaRetentionSuite extends QueryTest
       }
   }.flatten).foreach { case (chkConfigName, chkConfig) =>
   test(s"cleanup does not delete the checkpoint if it is required by non-expired versions. " +
-    s"Config: $chkConfigName.") {
+    s"Config: $chkConfigName.", CatalogManagedMaintenanceIncompatible) {
     withSQLConf(chkConfig: _*) {
       // Disable the following check as the test relies on time travel beyond
       // deletedFileRetentionDuration
@@ -692,7 +740,9 @@ class DeltaRetentionSuite extends QueryTest
   }
   }
 
-  test(s"cleanup does not delete the JSON logs if the multi-part checkpoint is incomplete.") {
+  test(
+    s"cleanup does not delete the JSON logs if the multi-part checkpoint is incomplete.",
+    CatalogManagedMaintenanceIncompatible) {
     withSQLConf(DeltaSQLConf.DELTA_CHECKPOINT_PART_SIZE.key -> "1") {
     withTempDir { tempDir =>
       val startTime = getStartTimeForRetentionTest
@@ -775,7 +825,9 @@ class DeltaRetentionSuite extends QueryTest
     }
   }
 
-  test("Metadata cleanup respects requireCheckpointProtectionBeforeVersion") {
+  test(
+      "Metadata cleanup respects requireCheckpointProtectionBeforeVersion",
+      CatalogManagedMaintenanceIncompatible) {
     withSQLConf(
         DeltaSQLConf.ALLOW_METADATA_CLEANUP_WHEN_ALL_PROTOCOLS_SUPPORTED.key -> "false",
         DeltaSQLConf.ALLOW_METADATA_CLEANUP_CHECKPOINT_EXISTENCE_CHECK_DISABLED.key -> "true") {
@@ -915,7 +967,9 @@ class DeltaRetentionSuite extends QueryTest
     }
   }
 
-  test("Cleanup is allowed if a checkpoint already exists at the boundary") {
+  test(
+      "Cleanup is allowed if a checkpoint already exists at the boundary",
+      CatalogManagedMaintenanceIncompatible) {
     withSQLConf(DeltaSQLConf.ALLOW_METADATA_CLEANUP_WHEN_ALL_PROTOCOLS_SUPPORTED.key -> "false") {
       testRequireCheckpointProtectionBeforeVersion(
         createNumCommitsOutsideRetentionPeriod = 8,
@@ -929,7 +983,9 @@ class DeltaRetentionSuite extends QueryTest
     }
   }
 
-  test("Metadata cleanup protocol validation positive tests.") {
+  test(
+      "Metadata cleanup protocol validation positive tests.",
+      CatalogManagedMaintenanceIncompatible) {
     withSQLConf(
         DeltaSQLConf.ALLOW_METADATA_CLEANUP_CHECKPOINT_EXISTENCE_CHECK_DISABLED.key -> "true") {
       // In all tests below, we cannot satisfy the version requirement and thus fallback
@@ -995,7 +1051,9 @@ class DeltaRetentionSuite extends QueryTest
     }
   }
 
-  test("Metadata cleanup protocol validation negative tests.") {
+  test(
+      "Metadata cleanup protocol validation negative tests.",
+      CatalogManagedMaintenanceIncompatible) {
     withSQLConf(
         DeltaSQLConf.ALLOW_METADATA_CLEANUP_CHECKPOINT_EXISTENCE_CHECK_DISABLED.key -> "true") {
       // In all tests below, we cannot satisfy the version requirement and thus fallback
@@ -1070,7 +1128,9 @@ class DeltaRetentionSuite extends QueryTest
     }
   }
 
-  test("Metadata cleanup protocol validation with incomplete CRCs.") {
+  test(
+      "Metadata cleanup protocol validation with incomplete CRCs.",
+      CatalogManagedMaintenanceIncompatible) {
     withSQLConf(
         DeltaSQLConf.ALLOW_METADATA_CLEANUP_CHECKPOINT_EXISTENCE_CHECK_DISABLED.key -> "true") {
       // We fall back to protocol validations which cannot be completed due to missing
@@ -1133,7 +1193,9 @@ class DeltaRetentionWithCatalogOwnedBatch2Suite
    *
    * Note: This test is too slow for batchSize = 100 and wouldn't necessarily work for batchSize = 1
    */
-  test("unbackfilled expired commits are always retained") {
+  test(
+      "unbackfilled expired commits are always retained",
+      CatalogManagedMaintenanceIncompatible) {
     withTempDir { tempDir =>
       val startTime = getStartTimeForRetentionTest
       val clock = new ManualClock(startTime)
@@ -1183,4 +1245,3 @@ class DeltaRetentionWithCatalogOwnedBatch2Suite
     }
   }
 }
-

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
@@ -29,6 +29,7 @@ import org.apache.spark.sql.delta.DataFrameUtils
 import org.apache.spark.sql.delta.DeltaTestUtils.{modifyCommitTimestamp, modifyCommitTimestamps}
 import org.apache.spark.sql.delta.Relocated
 import org.apache.spark.sql.delta.actions.{AddFile, Protocol}
+import org.apache.spark.sql.delta.coordinatedcommits.CatalogManagedMaintenanceIncompatible
 import org.apache.spark.sql.delta.sources.{DeltaDataSource, DeltaSQLConf, DeltaSource, DeltaSourceOffset}
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
@@ -1079,7 +1080,8 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
   }
 
   test(
-      "can delete old files of a snapshot without update"
+      "can delete old files of a snapshot without update",
+    CatalogManagedMaintenanceIncompatible
   ) {
     withTempDir { inputDir =>
       val deltaLog = DeltaLog.forTable(spark, new Path(inputDir.toURI))

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.delta.DeltaTestUtils.BOOLEAN_DOMAIN
 import org.apache.spark.sql.delta.actions.{Action, TableFeatureProtocolUtils}
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
-import org.apache.spark.sql.delta.coordinatedcommits.{CatalogOwnedTableUtils, CatalogOwnedTestBaseSuite}
+import org.apache.spark.sql.delta.coordinatedcommits.{CatalogManagedMaintenanceIncompatible, CatalogOwnedTableUtils, CatalogOwnedTestBaseSuite}
 import org.apache.spark.sql.delta.files.TahoeLogFileIndex
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
@@ -399,7 +399,7 @@ class DeltaSuite extends QueryTest
     }
   }
 
-  test("replaceWhere with rearrangeOnly") {
+  test("replaceWhere with rearrangeOnly", CatalogManagedMaintenanceIncompatible) {
     withTempDir { dir =>
       Seq(1, 2, 3, 4).toDF()
         .withColumn("is_odd", $"value" % 2 =!= 0)
@@ -433,6 +433,32 @@ class DeltaSuite extends QueryTest
       checkAnswer(
         spark.read.format("delta").load(dir.toString),
         Seq(2, 4, 9).toDF().withColumn("is_odd", $"value" % 2 =!= 0))
+    }
+  }
+
+  test("rearrange-only write is blocked for a catalog-managed table") {
+    withCatalogManagedTable() { tableName =>
+      spark.sql(s"INSERT INTO $tableName VALUES (1)")
+      val deltaLog = DeltaLog.forTable(spark, TableIdentifier(tableName))
+      val snapshotBefore = deltaLog.update()
+
+      checkError(
+        intercept[DeltaUnsupportedOperationException] {
+          Seq(2).toDF("id")
+            .write
+            .format("delta")
+            .mode("overwrite")
+            .option(DeltaOptions.REPLACE_WHERE_OPTION, "id = 1")
+            .option(DeltaOptions.DATA_CHANGE_OPTION, "false")
+            .save(deltaLog.dataPath.toString)
+        },
+        "DELTA_UNSUPPORTED_CATALOG_MANAGED_TABLE_OPERATION",
+        parameters = Map("operation" -> "DATA_REORGANIZATION"))
+
+      val snapshotAfter = deltaLog.update()
+      assert(snapshotAfter.version === snapshotBefore.version)
+      assert(snapshotAfter.allFiles.collect().toSet === snapshotBefore.allFiles.collect().toSet)
+      checkAnswer(spark.table(tableName), Row(1))
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaVacuumSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaVacuumSuite.scala
@@ -1540,20 +1540,27 @@ class DeltaVacuumSuite extends DeltaVacuumSuiteBase with DeltaSQLCommandTest {
 
   test("running vacuum on a catalog managed table should fail") {
     withCatalogManagedTable() { tableName =>
+      val deltaLog = DeltaLog.forTable(spark, TableIdentifier(tableName))
+      val untrackedFile = new Path(deltaLog.dataPath, "untracked-file")
+      val fs = untrackedFile.getFileSystem(deltaLog.newDeltaHadoopConf())
+      fs.create(untrackedFile).close()
+
       checkError(
         intercept[DeltaUnsupportedOperationException] {
           spark.sql(s"VACUUM $tableName")
         },
         "DELTA_UNSUPPORTED_CATALOG_MANAGED_TABLE_OPERATION",
-        parameters = Map("operation" -> "VACUUM")
+        parameters = Map("operation" -> "DATA_CLEANUP")
       )
+      assert(fs.exists(untrackedFile))
       checkError(
         intercept[DeltaUnsupportedOperationException] {
           spark.sql(s"VACUUM $tableName DRY RUN")
         },
         "DELTA_UNSUPPORTED_CATALOG_MANAGED_TABLE_OPERATION",
-        parameters = Map("operation" -> "VACUUM")
+        parameters = Map("operation" -> "DATA_CLEANUP")
       )
+      assert(fs.exists(untrackedFile))
     }
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsTestUtils.scala
@@ -34,12 +34,17 @@ import io.delta.storage.commit.actions.{AbstractMetadata, AbstractProtocol}
 import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorClient
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
+import org.scalactic.source.Position
+import org.scalatest.Tag
 import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.sql.{QueryTest, Row, SparkSession}
 import org.apache.spark.sql.catalyst.{TableIdentifier => CatalystTableIdentifier}
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.test.SharedSparkSession
+
+case object CatalogManagedMaintenanceIncompatible
+  extends Tag("CatalogManagedMaintenanceIncompatible")
 
 // This trait is built to serve as a base trait for tests built for both CatalogOwned
 // and commit-coordinators table feature.
@@ -166,6 +171,17 @@ trait CatalogOwnedTestBaseSuite
       if (oldConfig.isDefined) {
         spark.conf.set(defaultCatalogOwnedFeatureEnabledKey, oldConfig.get)
       }
+    }
+  }
+
+  override protected def test(testName: String, testTags: Tag*)(testFun: => Any)(
+      implicit pos: Position): Unit = {
+    super.test(testName, testTags: _*) {
+      if (catalogOwnedDefaultCreationEnabledInTests &&
+          testTags.contains(CatalogManagedMaintenanceIncompatible)) {
+        cancel("Maintenance operation is not supported for catalog-managed tables")
+      }
+      testFun
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/StagedCommitListingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/StagedCommitListingSuite.scala
@@ -1,0 +1,248 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.spark.sql.delta.coordinatedcommits
+
+import java.io.File
+
+import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.DeltaTestUtils.verifyUnbackfilled
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.storage.LocalLogStore
+import org.apache.spark.sql.delta.storage.LogStore.logStoreClassConfKey
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.delta.util.FileNames
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileStatus, Path}
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.QueryTest
+
+/**
+ * On a Catalog Owned table the fs listing must not promote a staged-commit file
+ * (`_staged_commits/N.<uuid>.json`) to a commit. [[RecursiveListingLocalLogStore]] reproduces a
+ * recursive-listing LogStore hermetically (no real object store).
+ */
+class StagedCommitListingSuite extends QueryTest
+    with CatalogOwnedTestBaseSuite
+    with DeltaSQLCommandTest {
+
+  override def catalogOwnedCoordinatorBackfillBatchSize: Option[Int] = Some(100)
+
+  override protected def sparkConf: SparkConf =
+    super.sparkConf.set(logStoreClassConfKey, classOf[RecursiveListingLocalLogStore].getName)
+
+  /** Runs `f` with Catalog Owned (CCv2) enabled by default for new tables. */
+  private def withCatalogOwnedCommits(f: => Unit): Unit = {
+    withDefaultCCTableFeature {
+      withSQLConf(
+        // Keep checkpoints/minor-compactions out of the picture; these tests reason about versions.
+        DeltaSQLConf.DELTALOG_MINOR_COMPACTION_USE_FOR_READS.key -> "false") {
+        f
+      }
+    }
+  }
+
+  private def logDir(path: String): File = new File(path, "_delta_log")
+
+  private def stagedCommitsDir(path: String): File =
+    new File(logDir(path), FileNames.COMMIT_SUBDIR)
+
+  private def stagedCommitFiles(path: String): Seq[File] =
+    Option(stagedCommitsDir(path).listFiles()).getOrElse(Array.empty)
+      .filter(_.getName.endsWith(".json"))
+      .sortBy(_.getName)
+      .toSeq
+
+  private def backfilledDeltaFile(path: String, version: Long): File =
+    new File(FileNames.unsafeDeltaFile(new Path(logDir(path).toString), version).toString)
+
+  /** The [[InMemoryCommitCoordinator]] backing the builder, for manipulating its ledger. */
+  private def getInMemoryCoordinator: InMemoryCommitCoordinator = {
+    val client = getCatalogOwnedCommitCoordinatorClient(
+      CatalogOwnedTableUtils.DEFAULT_CATALOG_NAME_FOR_TESTING)
+    client match {
+      case tracking: TrackingCommitCoordinatorClient =>
+        tracking.delegatingCommitCoordinatorClient.asInstanceOf[InMemoryCommitCoordinator]
+      case inMemory: InMemoryCommitCoordinator => inMemory
+      case other =>
+        throw new IllegalStateException(
+          s"Unexpected commit coordinator client type: ${other.getClass.getName}")
+    }
+  }
+
+  // Sanity check: the harness actually surfaces staged files, else the tests below pass vacuously.
+  test("test harness: recursive listing surfaces _staged_commits files") {
+    withCatalogOwnedCommits {
+      withTempDir { tempDir =>
+        val path = tempDir.getCanonicalPath
+        spark.range(0, 10).write.format("delta").save(path)
+        // Append v1; with batch size 100 it stays staged (un-backfilled).
+        spark.range(10, 20).write.format("delta").mode("append").save(path)
+
+        assert(stagedCommitFiles(path).nonEmpty,
+          "expected at least one staged commit file to exist on disk")
+
+        val deltaLog = DeltaLog.forTable(spark, path)
+        val logPath = deltaLog.logPath
+        val listed = deltaLog.store
+          .listFrom(FileNames.listingPrefix(logPath, 0L), deltaLog.newDeltaHadoopConf())
+          .map(_.getPath)
+          .toSeq
+        assert(listed.exists(p => p.getParent.getName == FileNames.COMMIT_SUBDIR),
+          s"recursive listing should surface _staged_commits files, but listed: $listed")
+      }
+    }
+  }
+
+  test("backfilled + staged copy of the same version does not throw NOT_CONTIGUOUS") {
+    withCatalogOwnedCommits {
+      withTempDir { tempDir =>
+        val path = tempDir.getCanonicalPath
+        spark.range(0, 10).write.format("delta").save(path) // v0
+        spark.range(10, 20).write.format("delta").mode("append").save(path) // v1 (staged)
+
+        // Also materialise the backfilled `00...01.json` so v1 exists both backfilled and staged.
+        val staged = stagedCommitFiles(path)
+        assert(staged.nonEmpty, "expected a staged commit for v1")
+        val stagedV1 = staged.find(f => FileNames.deltaVersion(new Path(f.getName)) == 1L).get
+        val backfilledV1 = backfilledDeltaFile(path, 1L)
+        if (!backfilledV1.exists()) {
+          java.nio.file.Files.copy(stagedV1.toPath, backfilledV1.toPath)
+        }
+        assert(backfilledV1.exists() && stagedV1.exists(),
+          "v1 must exist both backfilled and staged for this scenario")
+
+        DeltaLog.invalidateCache(spark, new Path(path))
+
+        // Before the fix this threw DELTA_VERSIONS_NOT_CONTIGUOUS (versions [0, 1, 1]).
+        val snapshot = DeltaLog.forTable(spark, path).update()
+        assert(snapshot.version == 1L)
+        checkAnswer(
+          spark.read.format("delta").load(path).orderBy("id"),
+          (0 until 20).map(i => org.apache.spark.sql.Row(i.toLong)))
+      }
+    }
+  }
+
+  test("orphaned staged commit (not in getCommits) is not read") {
+    withCatalogOwnedCommits {
+      withTempDir { tempDir =>
+        val path = tempDir.getCanonicalPath
+        spark.range(0, 10).write.format("delta").save(path) // v0
+        // Write a genuine, well-formed v1 commit. With batch size 100 it stays staged.
+        spark.range(10, 20).write.format("delta").mode("append").save(path) // v1 (staged)
+
+        val deltaLog = DeltaLog.forTable(spark, path)
+        val logPath = deltaLog.logPath
+
+        // Orphan v1: drop it from the coordinator and delete any backfilled copy, leaving only the
+        // well-formed staged file under `_staged_commits/`.
+        val coordinator = getInMemoryCoordinator
+        coordinator.removeCommitTestOnly(logPath, commitVersion = 1L)
+        val backfilledV1 = backfilledDeltaFile(path, 1L)
+        if (backfilledV1.exists()) assert(backfilledV1.delete())
+        assert(stagedCommitFiles(path).exists(f =>
+          FileNames.deltaVersion(new Path(f.getName)) == 1L),
+          "the orphaned staged v1 file must still be present on disk")
+
+        DeltaLog.invalidateCache(spark, new Path(path))
+
+        val snapshot = DeltaLog.forTable(spark, path).update()
+        assert(snapshot.version == 0L,
+          s"orphaned staged commit must not advance the snapshot; got v${snapshot.version}")
+        checkAnswer(
+          spark.read.format("delta").load(path).orderBy("id"),
+          (0 until 10).map(i => org.apache.spark.sql.Row(i.toLong)))
+      }
+    }
+  }
+
+  test("ratified, not-yet-backfilled staged commit is still read via the coordinator") {
+    withCatalogOwnedCommits {
+      withTempDir { tempDir =>
+        val path = tempDir.getCanonicalPath
+        spark.range(0, 10).write.format("delta").save(path) // v0
+        spark.range(10, 20).write.format("delta").mode("append").save(path) // v1 (ratified, staged)
+
+        // v1 is ratified by the coordinator but, with batch size 100, still only exists staged.
+        val staged = stagedCommitFiles(path)
+        assert(staged.exists(f => FileNames.deltaVersion(new Path(f.getName)) == 1L),
+          "v1 should be present as a staged commit")
+        assert(!backfilledDeltaFile(path, 1L).exists(),
+          "v1 should NOT be backfilled yet (batch size is large)")
+
+        DeltaLog.invalidateCache(spark, new Path(path))
+        val deltaLog = DeltaLog.forTable(spark, path)
+
+        // Channel check: the raw fs listing must NOT surface v1 (else we wouldn't be testing the
+        // coordinator path).
+        val (fsListingOpt, _) = deltaLog.listFromFileSystemInternal(
+          startVersion = 0L,
+          versionToLoad = None,
+          includeMinorCompactions = false)
+        val fsDeltaVersions = fsListingOpt.getOrElse(Array.empty)
+          .collect { case (f, FileNames.FileType.DELTA, v) => v }.toSeq
+        assert(!fsDeltaVersions.contains(1L),
+          s"raw fs listing must not surface staged v1 as a delta; got $fsDeltaVersions")
+
+        val snapshot = deltaLog.update()
+        assert(snapshot.version == 1L,
+          s"ratified staged v1 must be read via the coordinator; got v${snapshot.version}")
+        // The v1 delta is the staged (unbackfilled) file, i.e. it came from the coordinator.
+        val v1Delta = snapshot.logSegment.deltas
+          .find(f => FileNames.deltaVersion(f.getPath) == 1L)
+          .getOrElse(fail("v1 delta missing from the log segment"))
+        verifyUnbackfilled(v1Delta)
+
+        checkAnswer(
+          spark.read.format("delta").load(path).orderBy("id"),
+          (0 until 20).map(i => org.apache.spark.sql.Row(i.toLong)))
+      }
+    }
+  }
+}
+
+/**
+ * A [[LocalLogStore]] whose `listFrom` recurses into subdirectories, reproducing a recursive
+ * LogStore that surfaces `_staged_commits/` files (the default [[LocalLogStore]] lists only
+ * immediate children and masks the bug). Top-level so it can be set via the logStore class conf.
+ */
+class RecursiveListingLocalLogStore(sparkConf: SparkConf, hadoopConf: Configuration)
+    extends LocalLogStore(sparkConf, hadoopConf) {
+
+  override def listFrom(path: Path, hadoopConf: Configuration): Iterator[FileStatus] = {
+    val fs = path.getFileSystem(hadoopConf)
+    val parent = path.getParent
+    if (!fs.exists(parent)) {
+      throw DeltaErrors.fileOrDirectoryNotFoundException(s"$parent")
+    }
+    // Recursively collect leaf files under the parent (mirrors a no-delimiter prefix listing).
+    val collected = scala.collection.mutable.ArrayBuffer.empty[FileStatus]
+    def recurse(dir: Path): Unit = {
+      fs.listStatus(dir).foreach { st =>
+        if (st.isDirectory) recurse(st.getPath) else collected += st
+      }
+    }
+    recurse(parent)
+    // Return files with name >= the start name, sorted by leaf name (as the S3 log store does).
+    collected
+      .filter(_.getPath.getName >= path.getName)
+      .sortBy(_.getPath.getName)
+      .iterator
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/optimize/DeltaReorgSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/optimize/DeltaReorgSuite.scala
@@ -303,13 +303,20 @@ class DeltaReorgSuite extends QueryTest
 
   test("reorg on a catalog managed table should fail") {
     withCatalogManagedTable() { tableName =>
+      spark.sql(s"INSERT INTO $tableName VALUES (1)")
+      val snapshotBefore = getSnapshot(tableName)
+
       checkError(
         intercept[DeltaUnsupportedOperationException] {
           spark.sql(s"REORG TABLE $tableName APPLY (PURGE)")
         },
         "DELTA_UNSUPPORTED_CATALOG_MANAGED_TABLE_OPERATION",
-        parameters = Map("operation" -> "OPTIMIZE")
+        parameters = Map("operation" -> "DATA_REORGANIZATION")
       )
+
+      val snapshotAfter = getSnapshot(tableName)
+      assert(snapshotAfter.version === snapshotBefore.version)
+      assert(snapshotAfter.allFiles.collect().toSet === snapshotBefore.allFiles.collect().toSet)
     }
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/optimize/OptimizeCompactionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/optimize/OptimizeCompactionSuite.scala
@@ -642,13 +642,20 @@ trait OptimizeCompactionSuiteBase extends QueryTest
 
   test("optimize on a catalog managed table should fail") {
     withCatalogManagedTable() { tableName =>
+      spark.sql(s"INSERT INTO $tableName VALUES (1)")
+      val snapshotBefore = getSnapshot(tableName)
+
       checkError(
         intercept[DeltaUnsupportedOperationException] {
           spark.sql(s"OPTIMIZE $tableName")
         },
         "DELTA_UNSUPPORTED_CATALOG_MANAGED_TABLE_OPERATION",
-        parameters = Map("operation" -> "OPTIMIZE")
+        parameters = Map("operation" -> "DATA_REORGANIZATION")
       )
+
+      val snapshotAfter = getSnapshot(tableName)
+      assert(snapshotAfter.version === snapshotBefore.version)
+      assert(snapshotAfter.allFiles.collect().toSet === snapshotBefore.allFiles.collect().toSet)
     }
   }
 

--- a/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaUtilityTest.java
+++ b/spark/unitycatalog/src/test/java/io/sparkuctest/UCDeltaUtilityTest.java
@@ -150,15 +150,15 @@ public class UCDeltaUtilityTest extends UCDeltaTableIntegrationBaseTest {
 
           assertThatThrownBy(() -> sql("OPTIMIZE %s", tableName))
               .hasMessageContaining("DELTA_UNSUPPORTED_CATALOG_MANAGED_TABLE_OPERATION")
-              .hasMessageContaining("OPTIMIZE");
+              .hasMessageContaining("DATA_REORGANIZATION");
 
           assertThatThrownBy(() -> sql("VACUUM %s", tableName))
               .hasMessageContaining("DELTA_UNSUPPORTED_CATALOG_MANAGED_TABLE_OPERATION")
-              .hasMessageContaining("VACUUM");
+              .hasMessageContaining("DATA_CLEANUP");
 
           assertThatThrownBy(() -> sql("REORG TABLE %s APPLY (PURGE)", tableName))
               .hasMessageContaining("DELTA_UNSUPPORTED_CATALOG_MANAGED_TABLE_OPERATION")
-              .hasMessageContaining("OPTIMIZE");
+              .hasMessageContaining("DATA_REORGANIZATION");
         });
   }
 }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This backports #7550 and #7525 to `branch-4.3`.

A recursive filesystem listing can return files from `_delta_log/_staged_commits`. For example, an unratified staged version could look like a committed version, or a staged and backfilled copy could return the same version twice. This change accepts only backfilled Delta files from raw filesystem listings. Ratified staged commits still enter through the commit coordinator.

Catalog-managed tables require catalog permission before destructive maintenance. This change uses one shared permission check for data cleanup, data reorganization, and log cleanup. Direct operations fail before changing the table. Automatic post-commit maintenance is skipped, so the write that started the hook can still succeed.

## How was this patch tested?

- Four staged-commit listing tests passed.
- Seven focused maintenance tests passed.
- Scala formatting, Scala style, Checkstyle, and Java formatting passed during compilation.

All 11 focused tests passed with 0 failures.

## Does this PR introduce _any_ user-facing changes?

Yes. Delta no longer reads unratified staged commits from recursive filesystem listings. It also blocks unsupported destructive maintenance on catalog-managed tables and skips unsupported automatic maintenance. Other tables keep their current behavior.