### PR TITLE
Allow raising a bare Delta error class when subclasses exist

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaThrowableHelper.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaThrowableHelper.scala
@@ -79,9 +79,22 @@ object DeltaThrowableHelper
    */
   def getMessage(errorClass: String, messageParameters: Array[String]): String = {
     validateParameterValues(errorClass, errorSubClass = null, messageParameters)
-    val template = errorClassReader.getMessageTemplate(errorClass)
+    val template = getMessageTemplate(errorClass)
     val message = formatMessage(errorClass, messageParameters, template)
     s"[$errorClass] $message"
+  }
+
+  /**
+   * This is a temporary workaround for SPARK-58999. It bypasses a limitation in Spark, and allows
+   * us to raise an error that uses only the main error class, even if the given error class has
+   * available subclasses.
+   */
+  private[delta] def getMessageTemplate(errorClass: String): String = {
+    if (errorClass.contains(".")) {
+      errorClassReader.getMessageTemplate(errorClass)
+    } else {
+      getMainMessageTemplate(errorClass)
+    }
   }
 
   private def formatMessage(
@@ -174,7 +187,7 @@ object DeltaThrowableHelper
     } else {
       errorClass + "." + errorSubClass
     }
-    val parameterizedMessage = errorClassReader.getMessageTemplate(wholeErrorClass)
+    val parameterizedMessage = getMessageTemplate(wholeErrorClass)
     parsePrameterNamesFromParameterizedMessage(parameterizedMessage)
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -3006,6 +3006,33 @@ trait DeltaErrorsSuiteBase
     }
   }
 
+  test("raising error class without subclass when subclasses exist") {
+    // DELTA_METADATA_MISMATCH defines subclasses, so a fully-qualified subclass extends the
+    // main-class template. This guards that the test exercises the has-subclasses scenario.
+    val mainTemplate = DeltaThrowableHelper.getMainMessageTemplate("DELTA_METADATA_MISMATCH")
+    val subTemplate =
+      DeltaThrowableHelper.getSubMessageTemplate("DELTA_METADATA_MISMATCH.SCHEMA_MISMATCH")
+    assert(subTemplate.nonEmpty)
+    assert(DeltaThrowableHelper.getMessageTemplate("DELTA_METADATA_MISMATCH") == mainTemplate)
+    assert(DeltaThrowableHelper.getMessageTemplate("DELTA_METADATA_MISMATCH.SCHEMA_MISMATCH") ==
+      mainTemplate + " " + subTemplate)
+
+    val e = intercept[DeltaIllegalArgumentException] {
+      throw new DeltaIllegalArgumentException(errorClass = "DELTA_METADATA_MISMATCH")
+    }
+    assert(e.getErrorClass == "DELTA_METADATA_MISMATCH")
+    // Assert getMessage directly rather than via checkError: the point is to verify that getMessage
+    // itself renders a bare class that has subclasses, which checkError does not exercise.
+    assert(e.getMessage == "[DELTA_METADATA_MISMATCH] " + mainTemplate)
+
+    // getParameterNames must also resolve for a bare main class that has subclasses. Use
+    // DELTA_CONCURRENT_APPEND, whose main template and subclass both carry parameters.
+    assert(DeltaThrowableHelper.getParameterNames("DELTA_CONCURRENT_APPEND", errorSubClass = null)
+      .toSeq == Seq("operation", "tableName", "version"))
+    assert(DeltaThrowableHelper.getParameterNames("DELTA_CONCURRENT_APPEND", "WITH_PARTITION_HINT")
+      .toSeq == Seq("operation", "tableName", "version", "partitionValues", "docLink"))
+  }
+
   test("throwChangelogReadFailed preserves SparkThrowable cause and wraps others") {
     // A cause that already carries a Spark error class is rethrown unchanged.
     val sparkThrowableCause = new DeltaAnalysisException(


### PR DESCRIPTION
## Description

`DeltaThrowableHelper` routed a bare main error class straight into `ErrorClassesJsonReader.getMessageTemplate`, whose assertion requires a sub-class whenever the main class defines sub-classes. As a result, an error could not be raised with only its main error class when that class defines sub-classes.

This adds a `getMessageTemplate` helper that returns just the main-class message template for a bare `MAIN_CLASS` (a workaround for SPARK-58999), while `MAIN_CLASS.SUB_CLASS` still goes through the reader, and uses it in `getMessage` and `getParameterNames`.

## How was this patch tested?

Added a `DeltaErrorsSuite` unit test covering message-template resolution, `getMessage`, and `getParameterNames` for a bare error class that defines sub-classes.

## Does this PR introduce _any_ user-facing changes?

No.
