### PR TITLE
[Spark] Port catalog managed streaming suite for DSv2

### DIFF
--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogManagedStreamingV2Suite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogManagedStreamingV2Suite.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.coordinatedcommits
+
+import org.apache.spark.sql.delta.test.V2ForceTest
+
+/** Runs the catalog-managed streaming tests through the strict Delta V2 connector. */
+class CatalogManagedStreamingV2Suite
+  extends CatalogManagedStreamingSuiteBase
+  with V2ForceTest {
+
+  override protected def assertNoV1Fallback: Boolean = true
+
+  override protected def runDataSetup(f: => Unit): Unit = inV1Mode(f)
+
+  override protected def shouldPassTests: Set[String] =
+    CatalogManagedStreamingV2Suite.PassingTests
+
+  override protected def shouldFailTests: Set[String] =
+    CatalogManagedStreamingV2Suite.FailingTests
+}
+
+object CatalogManagedStreamingV2Suite {
+  val PassingTests: Set[String] = Set(
+    "stream from delta source"
+  )
+
+  val FailingTests: Set[String] = Set(
+    // Delta V2 supports catalog-managed reads but not catalog-managed streaming commits.
+    "stream to delta sink",
+    "stream from delta source to delta sink with shared commit coordinator"
+  )
+}

--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogManagedStreamingV2Suite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogManagedStreamingV2Suite.scala
@@ -25,7 +25,7 @@ class CatalogManagedStreamingV2Suite
 
   override protected def assertNoV1Fallback: Boolean = true
 
-  override protected def runDataSetup(f: => Unit): Unit = inV1Mode(f)
+  override protected def withV1Mode(f: => Unit): Unit = inV1Mode(f)
 
   override protected def shouldPassTests: Set[String] =
     CatalogManagedStreamingV2Suite.PassingTests

--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogManagedStreamingV2Suite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogManagedStreamingV2Suite.scala
@@ -40,7 +40,8 @@ object CatalogManagedStreamingV2Suite {
   )
 
   val FailingTests: Set[String] = Set(
-    // Delta V2 supports catalog-managed reads but not catalog-managed streaming commits.
+    // TODO(#7140): Delta V2 supports catalog-managed reads but not catalog-managed
+    // streaming commits.
     "stream to delta sink",
     "stream from delta source to delta sink with shared commit coordinator"
   )

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogManagedStreamingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogManagedStreamingSuite.scala
@@ -64,6 +64,10 @@ trait CatalogManagedStreamingSuiteBase
     getTrackingClient.foreach(_.reset())
   }
 
+
+  /** Runs test-data setup that is separate from the streaming connector operation. */
+  protected def runDataSetup(f: => Unit): Unit = f
+
   /**
    * Provides a checkpoint location for streaming tests. Defaults to a local temp dir; subclasses
    * can override it to run the same test bodies against a different storage backend.
@@ -90,7 +94,9 @@ trait CatalogManagedStreamingSuiteBase
         testStream(df)(
           StartStream(checkpointLocation = checkpointPath),
           Execute{ _ =>
-            Seq(1, 2).toDF().write.format("delta").mode("append").saveAsTable(sourceTableName)
+            runDataSetup {
+              Seq(1, 2).toDF().write.format("delta").mode("append").saveAsTable(sourceTableName)
+            }
           },
           ProcessAllAvailable(),
           CheckAnswer(1, 2),
@@ -173,7 +179,9 @@ trait CatalogManagedStreamingSuiteBase
           assertNumGetCommitsCalled(expectedNumGetCommits)
 
           try {
-            Seq(1).toDF().write.format("delta").mode("append").saveAsTable(sourceTableName)
+            runDataSetup {
+              Seq(1).toDF().write.format("delta").mode("append").saveAsTable(sourceTableName)
+            }
             query.processAllAvailable()
             // One commit to the source table and one commit to the sink table
             expectedNumCommits += 2
@@ -186,7 +194,9 @@ trait CatalogManagedStreamingSuiteBase
             assertNumCommitsCalled(expectedNumCommits)
             assertNumGetCommitsCalled(expectedNumGetCommits)
 
-            Seq(2).toDF().write.format("delta").mode("append").saveAsTable(sourceTableName)
+            runDataSetup {
+              Seq(2).toDF().write.format("delta").mode("append").saveAsTable(sourceTableName)
+            }
             query.processAllAvailable()
             // One commit to the source table and one commit to the sink table
             expectedNumCommits += 2

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogManagedStreamingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CatalogManagedStreamingSuite.scala
@@ -65,8 +65,8 @@ trait CatalogManagedStreamingSuiteBase
   }
 
 
-  /** Runs test-data setup that is separate from the streaming connector operation. */
-  protected def runDataSetup(f: => Unit): Unit = f
+  /** Runs test-data setup through V1 when a subclass forces Delta V2. */
+  protected def withV1Mode(f: => Unit): Unit = f
 
   /**
    * Provides a checkpoint location for streaming tests. Defaults to a local temp dir; subclasses
@@ -94,7 +94,7 @@ trait CatalogManagedStreamingSuiteBase
         testStream(df)(
           StartStream(checkpointLocation = checkpointPath),
           Execute{ _ =>
-            runDataSetup {
+            withV1Mode {
               Seq(1, 2).toDF().write.format("delta").mode("append").saveAsTable(sourceTableName)
             }
           },
@@ -179,7 +179,7 @@ trait CatalogManagedStreamingSuiteBase
           assertNumGetCommitsCalled(expectedNumGetCommits)
 
           try {
-            runDataSetup {
+            withV1Mode {
               Seq(1).toDF().write.format("delta").mode("append").saveAsTable(sourceTableName)
             }
             query.processAllAvailable()
@@ -194,7 +194,7 @@ trait CatalogManagedStreamingSuiteBase
             assertNumCommitsCalled(expectedNumCommits)
             assertNumGetCommitsCalled(expectedNumGetCommits)
 
-            runDataSetup {
+            withV1Mode {
               Seq(2).toDF().write.format("delta").mode("append").saveAsTable(sourceTableName)
             }
             query.processAllAvailable()


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Updates the `CatalogManagedStreamingSuite` so it can be ran under DSv2 mode. Introduces new DSv2 test for catalog managed streaming tests.

## How was this patch tested?
New and existing tests ran.

## Does this PR introduce _any_ user-facing changes?
No, test only
