### PR TITLE
[Spark] Negotiate the UC Delta API protocol version

### DIFF
--- a/project/scripts/setup_unitycatalog_main.sh
+++ b/project/scripts/setup_unitycatalog_main.sh
@@ -83,8 +83,10 @@ set -euo pipefail
 # The pin. Bump both lines together if UC's version.sbt changed at the new SHA. build.sbt's
 # `unityCatalogVersion` is obtained by running this script with `--print-version`, so these two
 # values are the single source of truth.
-UC_PIN_SHA=b11188d2a92c9bf1395d03be4235706af26b2c45
-UC_BASE_VERSION=0.6.0-SNAPSHOT
+UC_PIN_SHA=3780832600477c47c21815a02dc5d7b84fd7c218
+UC_BASE_VERSION=0.7.0-SNAPSHOT
+# Temporary fetch ref for https://github.com/unitycatalog/unitycatalog/pull/1827.
+UC_PIN_FETCH_REF=refs/pull/1827/head
 # ---------------------------------------------------------------------------------------------
 
 UC_DIR="${UC_DIR:-/tmp/unitycatalog}"
@@ -151,7 +153,9 @@ mkdir -p "$UC_DIR"
 git -C "$UC_DIR" init --quiet
 git -C "$UC_DIR" remote add origin "$UC_REPO"
 # Full fetch (not --depth=1) so merge-base --is-ancestor can verify the pin.
-if [[ "$UC_REF" == "$UC_PIN_SHA" || "$UC_REF" == "main" ]]; then
+if [[ "$UC_REF" == "$UC_PIN_SHA" && -n "$UC_PIN_FETCH_REF" ]]; then
+  git -C "$UC_DIR" fetch --quiet origin "$UC_PIN_FETCH_REF"
+elif [[ "$UC_REF" == "$UC_PIN_SHA" || "$UC_REF" == "main" ]]; then
   git -C "$UC_DIR" fetch --quiet origin main
 else
   git -C "$UC_DIR" fetch --quiet origin "$UC_REF"
@@ -162,7 +166,8 @@ cd "$UC_DIR"
 # Safety check: the pinned SHA must be reachable from UC main. Local `merge-base --is-ancestor`
 # on the history we just fetched - no GitHub API, no token needed. Only applies when UC_REF is
 # the pinned SHA; UC_REF=main is trivially on main. Skipped in release mode.
-if [[ "$DELTA_RELEASE_MODE" != "1" && "$UC_REF" == "$UC_PIN_SHA" ]]; then
+if [[ "$DELTA_RELEASE_MODE" != "1" && "$UC_REF" == "$UC_PIN_SHA" &&
+      -z "$UC_PIN_FETCH_REF" ]]; then
   if ! git merge-base --is-ancestor "$UC_PIN_SHA" origin/main 2>/dev/null; then
     echo "ERROR: UC_PIN_SHA=$UC_PIN_SHA is not reachable from unitycatalog/unitycatalog main." >&2
     echo "       Pin must reference a commit on https://github.com/unitycatalog/unitycatalog/commits/main" >&2

--- a/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClient.java
@@ -39,9 +39,11 @@ import io.unitycatalog.client.ApiClientBuilder;
 import io.unitycatalog.client.ApiException;
 import io.unitycatalog.client.api.MetastoresApi;
 import io.unitycatalog.client.auth.TokenProvider;
+import io.unitycatalog.client.delta.api.DeltaConfigurationApi;
 import io.unitycatalog.client.delta.api.DeltaTablesApi;
 import io.unitycatalog.client.delta.model.DeltaAddCommitUpdate;
 import io.unitycatalog.client.delta.model.DeltaAssertTableUUID;
+import io.unitycatalog.client.delta.model.DeltaCatalogConfig;
 import io.unitycatalog.client.delta.model.DeltaClusteringDomainMetadata;
 import io.unitycatalog.client.delta.model.DeltaCommit;
 import io.unitycatalog.client.delta.model.DeltaCreateStagingTableRequest;
@@ -81,11 +83,13 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.Supplier;
 
@@ -107,7 +111,9 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
   private static final int HTTP_BAD_REQUEST = 400;
   private static final int HTTP_CONFLICT = 409;
   private static final int HTTP_NOT_FOUND = 404;
+  private static final String DELTA_API_PROTOCOL_VERSION = "1.0";
 
+  private DeltaConfigurationApi deltaConfigurationApi;
   private DeltaTablesApi deltaTablesApi;
   private MetastoresApi metastoresApi;
   private final ApiClient apiClient;
@@ -118,6 +124,7 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
   private final boolean credentialRenewalEnabled;
   private final boolean credentialScopedFsEnabled;
   private final Supplier<Configuration> hadoopConfSupplier;
+  private final Set<String> negotiatedCatalogs = new HashSet<>();
 
   /**
    * Creates an instance by parsing all configuration from a flat config map.
@@ -157,6 +164,7 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
     });
 
     this.apiClient = builder.build();
+    this.deltaConfigurationApi = new DeltaConfigurationApi(this.apiClient);
     this.deltaTablesApi = new DeltaTablesApi(this.apiClient);
     this.metastoresApi = new MetastoresApi(this.apiClient);
     this.baseUri = baseUri;
@@ -215,9 +223,32 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
   }
 
   private void ensureOpen() {
-    if (deltaTablesApi == null || metastoresApi == null) {
+    if (deltaConfigurationApi == null || deltaTablesApi == null || metastoresApi == null) {
       throw new IllegalStateException("UCDeltaTokenBasedRestClient has been closed.");
     }
+  }
+
+  private synchronized void ensureProtocolNegotiated(String catalog) throws IOException {
+    if (negotiatedCatalogs.contains(catalog)) {
+      return;
+    }
+
+    DeltaCatalogConfig config;
+    try {
+      config = deltaConfigurationApi.getConfig(catalog, DELTA_API_PROTOCOL_VERSION);
+    } catch (ApiException e) {
+      throw new IOException(
+          String.format("Failed to negotiate the Delta API protocol for catalog %s (HTTP %s): %s",
+              catalog, e.getCode(), e.getResponseBody()),
+          e);
+    }
+
+    if (!DELTA_API_PROTOCOL_VERSION.equals(config.getProtocolVersion())) {
+      throw new IOException(
+          String.format("UC selected unsupported Delta API protocol version %s for catalog %s",
+              config.getProtocolVersion(), catalog));
+    }
+    negotiatedCatalogs.add(catalog);
   }
 
   // ===========================
@@ -255,6 +286,7 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
     Objects.requireNonNull(tableId, "tableId must not be null");
     Objects.requireNonNull(transactionDomainMetadata, "transactionDomainMetadata must not be null");
     ResolvedTableName name = requireThreePartName(tableIdentifier);
+    ensureProtocolNegotiated(name.catalog);
 
     DeltaUpdateTableRequest request = new DeltaUpdateTableRequest();
     request.addRequirementsItem(new DeltaAssertTableUUID()
@@ -309,6 +341,7 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
     Objects.requireNonNull(endVersion, "endVersion must not be null");
 
     ResolvedTableName name = requireThreePartName(tableIdentifier);
+    ensureProtocolNegotiated(name.catalog);
 
     // The UC loadTable endpoint does not support server-side filtering by version range, so
     // we fetch the full unbackfilled commit window and filter client-side below. The server
@@ -395,6 +428,16 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
     Objects.requireNonNull(properties, "properties must not be null");
     Objects.requireNonNull(domainMetadata, "domainMetadata must not be null");
 
+    try {
+      ensureProtocolNegotiated(catalogName);
+    } catch (IOException e) {
+      throw new CommitFailedException(
+          false /* retryable */,
+          false /* conflict */,
+          e.getMessage(),
+          e);
+    }
+
     DeltaCreateTableRequest sdkRequest = new DeltaCreateTableRequest()
         .name(tableName)
         .location(storageLocation)
@@ -435,6 +478,7 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
 
   @Override
   public void close() throws IOException {
+    this.deltaConfigurationApi = null;
     this.deltaTablesApi = null;
     this.metastoresApi = null;
   }
@@ -447,6 +491,7 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
   public TableInfo loadTable(TableIdentifier tableIdentifier) throws IOException {
     ensureOpen();
     ResolvedTableName name = requireThreePartName(tableIdentifier);
+    ensureProtocolNegotiated(name.catalog);
 
     try {
       return toTableInfo(
@@ -478,6 +523,7 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
       throws IOException {
     ensureOpen();
     ResolvedTableName name = requireThreePartName(tableIdentifier);
+    ensureProtocolNegotiated(name.catalog);
     try {
       DeltaCreateStagingTableRequest request =
           new DeltaCreateStagingTableRequest().name(name.table);
@@ -508,6 +554,7 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
     Objects.requireNonNull(protocol, "protocol must not be null");
     Objects.requireNonNull(domainMetadata, "domainMetadata must not be null");
     ResolvedTableName name = requireThreePartName(tableIdentifier);
+    ensureProtocolNegotiated(name.catalog);
     String schemaJson = metadata.getSchemaString();
     Objects.requireNonNull(schemaJson, "metadata.schemaString must not be null");
 
@@ -557,6 +604,7 @@ public class UCDeltaTokenBasedRestClient implements UCDeltaClient {
     Objects.requireNonNull(tableId, "tableId must not be null");
     Objects.requireNonNull(report, "report must not be null");
     ResolvedTableName name = requireThreePartName(tableIdentifier);
+    ensureProtocolNegotiated(name.catalog);
     try {
       DeltaReportMetricsRequest sdkRequest = new DeltaReportMetricsRequest()
           .tableId(UUID.fromString(tableId))

--- a/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClientSuite.scala
+++ b/storage/src/test/scala/io/delta/storage/commit/uccommitcoordinator/UCDeltaTokenBasedRestClientSuite.scala
@@ -20,6 +20,7 @@ import java.net.{InetSocketAddress, URI}
 import java.nio.charset.StandardCharsets
 import java.util.{Collections, Optional, Set => JSet, UUID}
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
 
 import scala.jdk.CollectionConverters._
 
@@ -49,6 +50,9 @@ class UCDeltaTokenBasedRestClientSuite
 
   private var server: HttpServer = _
   private var serverUri: String = _
+  private var configJson: String = _
+  private val configRequests = new AtomicInteger()
+  private val configQuery = new AtomicReference[String]()
   private var deltaHandler: (HttpExchange, String) => Unit = _
   private val objectMapper = new ObjectMapper()
 
@@ -62,6 +66,10 @@ class UCDeltaTokenBasedRestClientSuite
       val path = exchange.getRequestURI.getPath
       if (path.contains("/metastore_summary")) {
         sendJson(exchange, HttpStatus.SC_OK, metastoreJson)
+      } else if (path.endsWith("/delta/v1/config")) {
+        configRequests.incrementAndGet()
+        configQuery.set(exchange.getRequestURI.getRawQuery)
+        sendJson(exchange, HttpStatus.SC_OK, configJson)
       } else if (deltaHandler != null) {
         deltaHandler(exchange, body)
       } else {
@@ -75,7 +83,12 @@ class UCDeltaTokenBasedRestClientSuite
   }
 
   override def afterAll(): Unit = if (server != null) server.stop(0)
-  override def beforeEach(): Unit = { deltaHandler = null }
+  override def beforeEach(): Unit = {
+    configJson = """{"endpoints":[],"protocol-version":"1.0"}"""
+    configRequests.set(0)
+    configQuery.set(null)
+    deltaHandler = null
+  }
 
   // --------------- helpers ---------------
 
@@ -203,6 +216,47 @@ class UCDeltaTokenBasedRestClientSuite
 
   test("getMetastoreId returns ID on success") {
     withClient(c => assert(c.getMetastoreId() === testMetastoreId))
+  }
+
+  // --------------- protocol negotiation ---------------
+
+  test("negotiates protocol once before the first Delta API operation") {
+    deltaHandler = (exchange, _) => {
+      if (exchange.getRequestURI.getPath.endsWith("/staging-tables")) {
+        sendJson(exchange, HttpStatus.SC_OK,
+          s"""{"table-id":"$testTableId","table-type":"MANAGED",""" +
+            """"location":"s3://bucket/staging"}""")
+      } else {
+        sendJson(exchange, HttpStatus.SC_OK, loadTableJson())
+      }
+    }
+
+    val config = clientConfig
+    config.put("credentialVending.enabled", "false")
+    val client = new UCDeltaTokenBasedRestClient(config, null)
+    try {
+      client.createStagingTable(testIdentifier)
+      client.loadTable(testIdentifier)
+    } finally {
+      client.close()
+    }
+
+    assert(configRequests.get() === 1)
+    assert(configQuery.get().contains(s"catalog=$testCatalog"))
+    assert(configQuery.get().contains("protocol-versions=1.0"))
+  }
+
+  test("rejects an unsupported or malformed selected protocol version") {
+    Seq("1.1", "invalid").foreach { selectedVersion =>
+      configJson = s"""{"endpoints":[],"protocol-version":"$selectedVersion"}"""
+      withClient { client =>
+        val e = intercept[java.io.IOException] {
+          client.loadTable(testIdentifier)
+        }
+        assert(e.getMessage.contains("unsupported Delta API protocol version"))
+        assert(e.getMessage.contains(selectedVersion))
+      }
+    }
   }
 
   // --------------- loadTable ---------------


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other

## Description

The UC Delta client called table endpoints without first negotiating an API version. A future server could select a version that this client does not support, but the client would continue to call the table endpoints.

This change calls the Delta configuration endpoint before the first Delta API operation for each catalog. The client sends version 1.0, requires the server to select version 1.0, and caches a successful result. This applies when load, create, commit, or another Delta operation is the first request. Later operations for the same catalog do not repeat the configuration request.

The generated SDK still owns the endpoint paths. This change validates the selected version but does not add a new endpoint-routing layer.

The Unity Catalog integration setup is temporarily pinned to unitycatalog/unitycatalog#1827 at commit 3780832600477c47c21815a02dc5d7b84fd7c218. That PR adds the server-side negotiation used by these tests.

## How was this patch tested?

- build/sbt javafmtAll
- build/sbt "storage/testOnly io.delta.storage.commit.uccommitcoordinator.UCDeltaTokenBasedRestClientSuite"
- build/sbt "sparkUnityCatalog/testOnly io.sparkuctest.UCDeltaTableDeltaAPITest"
- bash -n project/scripts/setup_unitycatalog_main.sh

The storage suite passed 44 tests. The UC Delta integration suite passed 16 tests.

## Does this PR introduce _any_ user-facing changes?

Yes. Delta Spark now makes one configuration request per catalog before its first UC Delta API operation. It fails early if the server selects a protocol version other than 1.0. Current version 1.0 servers continue to work.