### PR TITLE
[Spark] Add DSv2 table API source tests

### DIFF
--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceTableAPISuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceTableAPISuite.scala
@@ -23,7 +23,7 @@ class DeltaV2SourceTableAPISuite extends DeltaSourceTableAPISuite with V2ForceTe
 
   override protected def assertNoV1Fallback: Boolean = true
 
-  override protected def runSourceDataSetup(f: => Unit): Unit = inV1Mode(f)
+  override protected def withV1Mode(f: => Unit): Unit = inV1Mode(f)
 
   override protected def shouldPassTests: Set[String] =
     DeltaV2SourceTableAPISuite.PassingTests

--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceTableAPISuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceTableAPISuite.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.test
+
+import org.apache.spark.sql.delta.DeltaSourceTableAPISuite
+
+/** Runs the streaming source tests from [[DeltaSourceTableAPISuite]] through the V2 connector. */
+class DeltaV2SourceTableAPISuite extends DeltaSourceTableAPISuite with V2ForceTest {
+
+  override protected def assertNoV1Fallback: Boolean = true
+
+  override protected def runSourceDataSetup(f: => Unit): Unit = inV1Mode(f)
+
+  override protected def shouldPassTests: Set[String] =
+    DeltaV2SourceTableAPISuite.PassingTests
+
+  override protected def shouldFailTests: Set[String] =
+    DeltaV2SourceTableAPISuite.NonSourceTests
+}
+
+object DeltaV2SourceTableAPISuite {
+  val PassingTests: Set[String] = Set(
+    "table API",
+    "table API with database"
+  )
+
+  // These inherited cases test writeStream.toTable. They do not cover the streaming source.
+  val NonSourceTests: Set[String] = Set(
+    "writeStream.table - create new external table",
+    "writeStream.table - create new managed table",
+    "writeStream.table - create new managed table with database",
+    "writeStream.table - create table from existing output",
+    "writeStream.table - fail writing into a view",
+    "writeStream.table - fail due to different schema than existing Delta table",
+    "writeStream.table - fail due to different partitioning on existing Delta table",
+    "writeStream.table - fail writing into an external nonDelta table",
+    "writeStream.table - fail writing into an external nonDelta path"
+  )
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceTableAPISuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceTableAPISuite.scala
@@ -42,15 +42,15 @@ class DeltaSourceTableAPISuite extends StreamTest
 
   import testImplicits._
 
-  /** Runs batch writes that prepare data for a streaming source test. */
-  protected def runSourceDataSetup(f: => Unit): Unit = f
+  /** Runs batch writes that prepare data for a streaming source test through V1. */
+  protected def withV1Mode(f: => Unit): Unit = f
 
   test("table API") {
     withTempDir { tempDir =>
       val tblName = "my_table"
       val dir = tempDir.getAbsolutePath
       withTable(tblName) {
-        runSourceDataSetup {
+        withV1Mode {
           spark.range(3).write.format("delta").option("path", dir).saveAsTable(tblName)
         }
 
@@ -69,7 +69,7 @@ class DeltaSourceTableAPISuite extends StreamTest
       withTempDatabase { db =>
         withTable(tblName) {
           spark.sql(s"USE $db")
-          runSourceDataSetup {
+          withV1Mode {
             spark.range(3).write.format("delta").option("path", dir).saveAsTable(tblName)
           }
           spark.sql(s"USE $DEFAULT_DATABASE")

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceTableAPISuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceTableAPISuite.scala
@@ -41,12 +41,18 @@ class DeltaSourceTableAPISuite extends StreamTest
   }
 
   import testImplicits._
+
+  /** Runs batch writes that prepare data for a streaming source test. */
+  protected def runSourceDataSetup(f: => Unit): Unit = f
+
   test("table API") {
     withTempDir { tempDir =>
       val tblName = "my_table"
       val dir = tempDir.getAbsolutePath
       withTable(tblName) {
-        spark.range(3).write.format("delta").option("path", dir).saveAsTable(tblName)
+        runSourceDataSetup {
+          spark.range(3).write.format("delta").option("path", dir).saveAsTable(tblName)
+        }
 
         testStream(spark.readStream.table(tblName))(
           ProcessAllAvailable(),
@@ -63,7 +69,9 @@ class DeltaSourceTableAPISuite extends StreamTest
       withTempDatabase { db =>
         withTable(tblName) {
           spark.sql(s"USE $db")
-          spark.range(3).write.format("delta").option("path", dir).saveAsTable(tblName)
+          runSourceDataSetup {
+            spark.range(3).write.format("delta").option("path", dir).saveAsTable(tblName)
+          }
           spark.sql(s"USE $DEFAULT_DATABASE")
 
           testStream(spark.readStream.table(s"$db.$tblName"))(


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Adds DSv2 version of the table API suite, starting with just enabling the source tests.

## How was this patch tested?
new tests ran locally.
## Does this PR introduce _any_ user-facing changes?

No, test only.
