### PR TITLE
Abstract IncrementalAMTWriter old-AMT inputs behind an actions provider

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTActionsProvider.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTActionsProvider.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.amt
+
+import org.apache.spark.sql.delta.DeltaLog
+import org.apache.spark.sql.delta.actions.{AddFile, DomainMetadata, Metadata, Protocol, SetTransaction}
+
+/**
+ * The previous-AMT state that an incremental write builds the next manifest tree on top of.
+ *
+ * This is everything [[IncrementalAMTWriter]] needs from the "old" tree.
+ *
+ * @param metadata                          the old AMT's inline table metadata.
+ * @param protocol                          the old AMT's inline table protocol.
+ * @param setTransactions                   the old AMT's inline `SetTransaction` actions.
+ * @param domainMetadatas                   the old AMT's inline `DomainMetadata` actions.
+ * @param fileActionsFromRoot               the live root-resident file actions (leaf-resident files
+ *                                          are carried forward by pointer, not materialized here).
+ * @param allLeafs                          the root's `DATA_MANIFEST` leaf pointers, one per leaf.
+ * @param version                           the table version the old AMT describes.
+ * @param lastManifestCommitWithFullRewrite the last-full-rewrite marker carried forward into the
+ *                                          new tree's `ContentRoot`.
+ */
+case class BaseAMTActionsResult(
+    metadata: Metadata,
+    protocol: Protocol,
+    setTransactions: Seq[SetTransaction],
+    domainMetadatas: Seq[DomainMetadata],
+    fileActionsFromRoot: Seq[AddFile],
+    allLeafs: Seq[DataManifestEntry],
+    version: Long,
+    lastManifestCommitWithFullRewrite: Option[Long])
+
+/**
+ * Loads the previous-AMT state that [[IncrementalAMTWriter]] extends. Abstracting the source lets
+ * the writer build on top of any old-AMT representation, not just a resolved checkpoint provider.
+ */
+trait BaseAMTActionsProvider {
+  def load(): BaseAMTActionsResult
+}
+
+/** A [[BaseAMTActionsProvider]] backed by an already-resolved [[AMTCheckpointProvider]]. */
+class BaseAMTCheckpointActionsProvider(
+    deltaLog: DeltaLog,
+    checkpointProvider: AMTCheckpointProvider) extends BaseAMTActionsProvider {
+  override def load(): BaseAMTActionsResult = {
+    val checkpoint = checkpointProvider.checkpointAction
+    BaseAMTActionsResult(
+      metadata = checkpoint.metaData,
+      protocol = checkpoint.protocol,
+      setTransactions = checkpoint.txns,
+      domainMetadatas = checkpoint.domainMetadata,
+      fileActionsFromRoot = AMTCheckpointProvider.readLiveRootDataEntries(deltaLog, checkpoint),
+      allLeafs = checkpointProvider.leaves,
+      version = checkpoint.contentRoot.version,
+      lastManifestCommitWithFullRewrite = checkpoint.contentRoot.lastManifestCommitWithFullRewrite)
+  }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriterManager.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriterManager.scala
@@ -221,13 +221,13 @@ class AMTWriterManager(
     }
     val (result, singleMetric) =
       if (incremental && amtProviderOpt.isDefined) {
-        val oldAMTVersion = amtProviderOpt.get.checkpointAction.contentRoot.version
+        val amtProvider = amtProviderOpt.get
+        val oldAMTVersion = amtProvider.checkpointAction.contentRoot.version
         // The commits written after the old AMT, up to the last committed version.
         val intermediateLogCommits = preCommitLogSegment.deltas
           .filter(f => FileNames.getFileVersion(f) > oldAMTVersion)
         new IncrementalAMTWriter(spark, deltaLog).writeIncremental(
-          oldAMTVersion = oldAMTVersion,
-          oldAMTCheckpointProvider = amtProviderOpt.get,
+          oldAMTActionsProvider = new BaseAMTCheckpointActionsProvider(deltaLog, amtProvider),
           intermediateLogCommits = intermediateLogCommits,
           attemptVersion = commitVersion,
           actionsToCommit = currentTransactionInfo.actions,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/IncrementalAMTWriter.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/IncrementalAMTWriter.scala
@@ -90,8 +90,8 @@ class IncrementalAMTWriter(spark: SparkSession, deltaLog: DeltaLog) {
    * Materializes the incremental manifest for `attemptVersion` and returns the inline
    * [[Checkpoint]] write result plus its metrics.
    *
-   * @param oldAMTVersion             version the previous AMT checkpoint describes.
-   * @param oldAMTCheckpointProvider  provider for the previous AMT (root, leaves, inline state).
+   * @param oldAMTActionsProvider     provider for the previous AMT (version, root files, leaves,
+   *                                  inline state); loaded once at the start of this write.
    * @param intermediateLogCommits    the commit log files written after the old AMT and up to the
    *                                  last committed version (the window between the old AMT and
    *                                  this commit), in commit order.
@@ -101,14 +101,14 @@ class IncrementalAMTWriter(spark: SparkSession, deltaLog: DeltaLog) {
    * @param trigger                   trigger name recorded in metrics.
    */
   def writeIncremental(
-      oldAMTVersion: Long,
-      oldAMTCheckpointProvider: AMTCheckpointProvider,
+      oldAMTActionsProvider: BaseAMTActionsProvider,
       intermediateLogCommits: Seq[FileStatus],
       attemptVersion: Long,
       actionsToCommit: Seq[Action],
       trigger: String): (AMTWriteResult, SingleAMTWriteMetrics) = {
     val startNanos = System.nanoTime()
-    val oldCheckpoint = oldAMTCheckpointProvider.checkpointAction
+    val oldAMT = oldAMTActionsProvider.load()
+    val oldAMTVersion = oldAMT.version
 
     // ---- Step 0: validate the window is contiguous and lines up with our assumptions. ----
     // The intermediate commits after the old AMT must contiguously cover
@@ -118,11 +118,10 @@ class IncrementalAMTWriter(spark: SparkSession, deltaLog: DeltaLog) {
     // ---- Step 1: gather the actions of all three parts and process them. ----
     // 1.a: old AMT root -- its live root-resident files, plus its inline non-content state
     // (protocol, metadata, setTxns, domainMetadata). Leaf-resident files are NOT read here.
-    val fileActionsFromOldRoot = AMTCheckpointProvider.readLiveRootDataEntries(
-      deltaLog, oldCheckpoint)
+    val fileActionsFromOldRoot = oldAMT.fileActionsFromRoot
     val nonContentFromOldCheckpoint: Seq[Action] =
-      Seq[Action](oldCheckpoint.protocol, oldCheckpoint.metaData) ++
-        oldCheckpoint.txns ++ oldCheckpoint.domainMetadata
+      Seq[Action](oldAMT.protocol, oldAMT.metadata) ++
+        oldAMT.setTransactions ++ oldAMT.domainMetadatas
     // 1.b: the log commits / minor compactions committed after the old AMT, read in parallel (the
     // MinorCompactionHook primitive). Each segment delta file becomes a SingleCommit keyed by its
     // version (a compacted delta's version is its endVersion, via getFileVersion).
@@ -145,7 +144,7 @@ class IncrementalAMTWriter(spark: SparkSession, deltaLog: DeltaLog) {
     // ---- Step 2: carry the old leaf pointers forward, patching MDV + CDF positions. ----
     val (carriedLeafPointers, leafPositions) =
       carryForwardLeaves(
-        oldAMTCheckpointProvider,
+        oldAMT.allLeafs,
         processedActions.mdvSupersededBackrefs,
         processedActions.cdfDeletedBackrefs,
         processedActions.cdfReplacedBackrefs)
@@ -204,8 +203,8 @@ class IncrementalAMTWriter(spark: SparkSession, deltaLog: DeltaLog) {
 
     // ---- Step 6: generate the Checkpoint action. ----
     // An incremental rewrite carries forward the previous tree's last-full-rewrite marker.
-    val lastFullRewriteVersion = oldCheckpoint.contentRoot
-      .lastManifestCommitWithFullRewrite.getOrElse(contentStateVersion)
+    val lastFullRewriteVersion =
+      oldAMT.lastManifestCommitWithFullRewrite.getOrElse(contentStateVersion)
     val contentRoot = ContentRoot(
       path = contentRootBase.path,
       sizeInBytes = contentRootBase.sizeInBytes,
@@ -233,7 +232,7 @@ class IncrementalAMTWriter(spark: SparkSession, deltaLog: DeltaLog) {
       case (status, ps) => status -> ps.size
     }
     val numStaleDeletedLeavesDropped =
-      oldAMTCheckpointProvider.leaves.count(_.tracking.status == Tracking.Status.Deleted)
+      oldAMT.allLeafs.count(_.tracking.status == Tracking.Status.Deleted)
     def positionCount(byLeaf: Map[String, Set[Int]]): Int = byLeaf.valuesIterator.map(_.size).sum
     // Per-status breakdown over the new tree's root-resident DATA entries (live + remove entries).
     val rootEntriesByStatus = (rootLiveEntries ++ rootRemoveEntries)
@@ -282,7 +281,7 @@ class IncrementalAMTWriter(spark: SparkSession, deltaLog: DeltaLog) {
    * Returns the carried-forward pointers and an [[MDVAndCDFPositions]] that has been set per-leaf.
    */
   private def carryForwardLeaves(
-      provider: AMTCheckpointProvider,
+      oldLeaves: Seq[DataManifestEntry],
       mdvSupersededBackrefs: Seq[BackReference],
       cdfDeletedBackrefs: Seq[BackReference],
       cdfReplacedBackrefs: Seq[BackReference])
@@ -296,7 +295,7 @@ class IncrementalAMTWriter(spark: SparkSession, deltaLog: DeltaLog) {
     val newMDVPositionsByLeaf = positionsByLeaf(mdvSupersededBackrefs)
     val deletedPositionsByLeaf = positionsByLeaf(cdfDeletedBackrefs)
     val replacedPositionsByLeaf = positionsByLeaf(cdfReplacedBackrefs)
-    val pointers = provider.leaves.flatMap { pointer =>
+    val pointers = oldLeaves.flatMap { pointer =>
       if (pointer.tracking.status == Tracking.Status.Deleted) None
       else {
         val newMdvPositions =

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTIncrementalWriteInvariantSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTIncrementalWriteInvariantSuite.scala
@@ -52,8 +52,7 @@ class AMTIncrementalWriteInvariantSuite extends AMTIncrementalWriteTestBase {
         // hole -> the Step-0 coverage assert must fire.
         intercept[AssertionError] {
           new IncrementalAMTWriter(spark, amtDeltaLog).writeIncremental(
-            oldAMTVersion = oldAMTVersion,
-            oldAMTCheckpointProvider = provider,
+            oldAMTActionsProvider = new BaseAMTCheckpointActionsProvider(amtDeltaLog, provider),
             intermediateLogCommits = intermediateLogCommits,
             attemptVersion = snapshot.version + 5,
             actionsToCommit = Seq.empty,


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

`IncrementalAMTWriter.writeIncremental` previously took the previous manifest tree as two
parameters -- the old AMT version and the resolved `AMTCheckpointProvider` -- and read the pieces it
needed directly off the checkpoint action: the inline non-content state (protocol, metadata, set
transactions, domain metadata), the live root-resident file actions, the leaf pointers to carry
forward, and the two version markers (the version the old tree describes and the last-full-rewrite
marker). This tied the incremental writer to a resolved `AMTCheckpointProvider` as the only possible
source of that state.

This PR introduces `AMTActionsProvider`, a small abstraction over the previous-AMT state an
incremental write builds on. `AMTActionsProvider.load()` returns an `AMTActionsResult` carrying
exactly what the writer consumes -- `metadata`, `protocol`, `setTransactions`, `domainMetadatas`,
`fileActionsFromRoot`, `allLeafs`, `version`, and `lastManifestCommitWithFullRewrite` -- and
`writeIncremental` now takes a single `AMTActionsProvider`. The writer calls `load()` once and
sources every old-AMT value off the result, so it no longer depends on how that state was produced.
The existing behavior is preserved by `AMTCheckpointActionsProvider`, whose `load()` reads the live
root DATA entries from the root manifest parquet and copies the inline non-content state, leaf
pointers, and version markers off the checkpoint action exactly as before. This is a pure refactor
with no behavioral change.

## How was this patch tested?

Existing AMT incremental-write coverage exercises this path unchanged, including
`AMTIncrementalWriteInvariantSuite` (updated to construct the writer through
`AMTCheckpointActionsProvider`). The refactored writer produces the identical result and metrics as
before, since the checkpoint-backed provider returns exactly the values the writer previously read
inline.

## Does this PR introduce _any_ user-facing changes?

No. This is an internal refactor of the incremental manifest writer's input plumbing; there is no
change to any public API or observable behavior.
