### PR TITLE
[Spark] Use relative path in DataEntry

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTCheckpointProvider.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTCheckpointProvider.scala
@@ -28,7 +28,6 @@ import org.apache.spark.sql.execution.datasources.FileFormat.{FILE_PATH, METADAT
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
 import org.apache.spark.sql.functions.{col, lit, struct}
 import org.apache.spark.sql.types.StructType
-import org.apache.spark.util.SerializableConfiguration
 
 /**
  * A [[CheckpointProvider]] backed by an AMT (Adaptive Metadata Tree) manifest tree.
@@ -148,7 +147,6 @@ final class AMTCheckpointProvider(
     // provider.
     val localTableRoot = tableRoot
     val encodedRootPath = SparkPath.fromPath(rootManifestAbsolutePath).urlEncoded
-    val serializableConf = new SerializableConfiguration(deltaLog.newDeltaHadoopConf())
     val parentTracking = parentTrackingByManifestPath
 
     val files = rootFile +: liveLeafFiles
@@ -174,7 +172,6 @@ final class AMTCheckpointProvider(
 
     dataEntries
       .mapPartitions { entries =>
-        val fs = localTableRoot.getFileSystem(serializableConf.value)
         entries.map { entryWithLoc =>
           entryWithLoc.entry.unwrap match {
             case data: DataEntry =>
@@ -183,7 +180,7 @@ final class AMTCheckpointProvider(
               } else {
                 val absLeaf = SparkPath.fromUrlString(entryWithLoc.leafPath).toPath
                 val relManifest =
-                  AMTUtils.relativizeManifestPathToTableRoot(fs, localTableRoot, absLeaf)
+                  AMTUtils.relativizeLocation(localTableRoot.toString, absLeaf.toString)
                 Some(BackReference(relManifest, entryWithLoc.pos.toInt))
               }
               // Root entries have nothing above them to inherit from, so they resolve against an

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTUtils.scala
@@ -19,8 +19,7 @@ package org.apache.spark.sql.delta.amt
 import org.apache.spark.sql.delta.{AdaptiveMetadataTableFeature, CurrentTransactionInfo, SnapshotDescriptor, WinningCommitSummary}
 import org.apache.spark.sql.delta.actions.{LastManifestCommit, Metadata, Protocol}
 import org.apache.spark.sql.delta.deletionvectors.ManifestBitmap
-import org.apache.spark.sql.delta.util.DeltaFileOperations
-import org.apache.hadoop.fs.{FileSystem, Path}
+import org.apache.hadoop.fs.Path
 
 /**
  * Path helpers for AMT (Adaptive Metadata Tree) manifest files.
@@ -81,11 +80,11 @@ object AMTUtils {
    * Relativizes a location against a table location. A trailing slash on `tableLocation` is
    * ignored. If `location` starts with the normalized table location immediately followed by `/`,
    * the prefix and separator are removed. Otherwise, `location` is returned as-is.
-   * This is a lightweight string manipulation compared to [[DeltaFileOperations.tryRelativizePath]]
-   * and should be preferred in hot paths.
+   * This is a lightweight string manipulation.
    *
    * Because the relativization is prefix matching based, callers are expected to pass locations in
-   * the same format and encoding. No such checks are performed here.
+   * the same format and encoding (either both raw or both URL-encoded).
+   * No such checks are performed here.
    */
   def relativizeLocation(tableLocation: String, location: String): String = {
     // Strip trailing slash from tableLocation if present.
@@ -106,14 +105,6 @@ object AMTUtils {
       location
     }
   }
-
-  /**
-   * Relativizes an AMT manifest file `path` against `tableRoot`, returning the raw
-   * (non-URL-encoded) string to store in a manifest `location` / `contentRoot.path`. Paths under
-   * the table root become relative; paths elsewhere are returned absolute.
-   */
-  def relativizeManifestPathToTableRoot(fs: FileSystem, tableRoot: Path, path: Path): String =
-    DeltaFileOperations.tryRelativizePath(fs, tableRoot, path).toString
 
   /**
    * Resolves a manifest `location` / `contentRoot.path` back to an absolute [[Path]] against

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriteHelper.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriteHelper.scala
@@ -234,10 +234,10 @@ object AMTWriteHelper extends DeltaLogging {
     val tracking = existingTrackingForDataEntry()
     val tableRootSparkPath = SparkPath.fromPath(tableRoot)
     val metadataDirSparkPath = SparkPath.fromPath(metadataDir)
-
-    val amtDs = addFilesDs.map { add =>
-      DataEntry.fromAddFile(add, tracking, tableRootSparkPath.toPath).wrap
-    }
+    val tableRootPath = tableRootSparkPath.toPath
+    val amtDs = addFilesDs.map(add =>
+      DataEntry.fromAddFile(add, tracking, tableRootPath).wrap
+    )
     val amtWithPartition = AMTPartitionValues.forWrite(amtDs.toDF(), metadata.partitionSchema)
     val amtDf = AMTContentStats.forWrite(amtWithPartition, metadata, protocol)
     val schema = AMTSingleAction.persistedSchema(metadata, protocol)
@@ -280,7 +280,6 @@ object AMTWriteHelper extends DeltaLogging {
             expectedNumParts = desiredNumLeaves,
             rows = countingRows
           )
-          val leafFs = leafFile.getFileSystem(conf)
           // The root pointer to this leaf is newly ADDED, even though the leaf's own DATA entries
           // are EXISTING (the referenced data files already lived in the table), so manifest_info
           // counts every entry and its rows as EXISTING.
@@ -291,8 +290,8 @@ object AMTWriteHelper extends DeltaLogging {
             replacedFileAndRowCount = emptyFileRowCount,
             modifiedFileAndRowCount = emptyFileRowCount)
           Iterator.single(DataManifestEntry(
-            location = AMTUtils.relativizeManifestPathToTableRoot(
-              leafFs, tableRootSparkPath.toPath, leafFile),
+            location = AMTUtils.relativizeLocation(
+              tableRootSparkPath.toPath.toString, leafFile.toString),
             file_format = AMTSingleAction.FileFormatParquet,
             tracking = tracking,
             record_count = entryCount,
@@ -480,7 +479,7 @@ object AMTWriteHelper extends DeltaLogging {
     // manifest_info still counts the DELETED / REPLACED entries and their rows.
     val (tracking, manifestInfo) = addedTrackingForLeaf(entries)
     DataManifestEntry(
-      location = AMTUtils.relativizeManifestPathToTableRoot(fs, tableRoot, leafFile),
+      location = AMTUtils.relativizeLocation(tableRoot.toString, leafFile.toString),
       file_format = AMTSingleAction.FileFormatParquet,
       tracking = tracking,
       // Number of content entries the referenced leaf manifest holds.
@@ -509,7 +508,7 @@ object AMTWriteHelper extends DeltaLogging {
     writeAMTParquet(spark, hadoopConf, rootFile, metadata, protocol, rows)
     val status = fs.getFileStatus(rootFile)
     ContentRoot(
-      path = AMTUtils.relativizeManifestPathToTableRoot(fs, tableRoot, rootFile),
+      path = AMTUtils.relativizeLocation(tableRoot.toString, rootFile.toString),
       sizeInBytes = status.getLen,
       version = version)
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/actions.scala
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.databind.{DeserializationContext, JsonDeserializer}
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import org.apache.hadoop.fs.{FileStatus, Path}
 
+import org.apache.spark.paths.SparkPath
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.execution.datasources.parquet.ParquetUtils
 import org.apache.spark.sql.types.{MetadataBuilder, StructField, StructType}
@@ -488,7 +489,8 @@ case class DataEntry(
     val dv = deletion_vector.map(DeletionVector.toDescriptor(_, tableRoot)).orNull
     val stats = AMTContentStats.toStatsJson(content_stats, record_count)
     AddFile(
-      path = location,
+      // RFC-2396 encoding used by Delta.
+      path = SparkPath.fromPathString(location).urlEncoded,
       partitionValues = partition.getOrElse(Map.empty),
       size = file_size_in_bytes,
       modificationTime = 0L,
@@ -507,7 +509,9 @@ object DataEntry {
   def fromAddFile(add: AddFile, tracking: Tracking, tableRoot: Path): DataEntry = {
     val passthrough = add.amtPassthrough
     DataEntry(
-      location = add.path,
+      // RFC-2396 to Iceberg raw path conversion.
+      location = AMTUtils.relativizeLocation(
+        tableRoot.toString, SparkPath.fromUrlString(add.path).toPath.toString),
       file_format = AMTSingleAction.FileFormatParquet,
       // Round-trip the AddFile's row-tracking fields through the Iceberg tracking envelope so a
       // rowTracking-enabled table can reconstruct them on read.

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTBackReferenceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTBackReferenceSuite.scala
@@ -22,6 +22,7 @@ import org.apache.spark.sql.delta.deletionvectors.RoaringBitmapArray
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.hadoop.fs.Path
 
+import org.apache.spark.paths.SparkPath
 import org.apache.spark.sql.functions.col
 
 class AMTBackReferenceSuite extends AMTCheckpointTestBase with DeletionVectorsTestUtils {
@@ -32,13 +33,12 @@ class AMTBackReferenceSuite extends AMTCheckpointTestBase with DeletionVectorsTe
    *  is, so test assertions compare against the identical value. */
   private def relativeManifest(snapshot: Snapshot, absLeaf: Path): String = {
     val tableRoot = snapshot.deltaLog.dataPath
-    val fs = tableRoot.getFileSystem(snapshot.deltaLog.newDeltaHadoopConf())
-    AMTUtils.relativizeManifestPathToTableRoot(fs, tableRoot, absLeaf)
+    AMTUtils.relativizeLocation(tableRoot.toString, absLeaf.toString)
   }
 
   /**
-   * The (relative leaf manifest, position) -> data-file location map for every live DATA entry
-   * across the snapshot's leaves, read straight from the leaf parquet via `_metadata.row_index`.
+   * The (relative leaf manifest, position) -> Delta AddFile path map for every live DATA entry
+   * across the snapshot's leaves, read from leaf parquet via `_metadata.row_index`.
    */
   private def leafLocationByBackRef(snapshot: Snapshot): Map[(String, Long), String] = {
     val provider = amtProvider(snapshot).getOrElse(fail("expected AMTCheckpointProvider"))
@@ -49,7 +49,10 @@ class AMTBackReferenceSuite extends AMTCheckpointTestBase with DeletionVectorsTe
           .where(col("content_type") === AMTSingleAction.ContentType.Type.Data)
           .select(col("location"), col("_metadata.row_index").as("pos"))
           .collect()
-          .map(row => (relManifest, row.getLong(1)) -> row.getString(0))
+          .map { row =>
+            val deltaPath = SparkPath.fromPathString(row.getString(0)).urlEncoded
+            (relManifest, row.getLong(1)) -> deltaPath
+          }
       }.toMap
     }
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointWriteSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointWriteSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.delta.amt
 import java.io.File
 
 import com.databricks.spark.util.{Log4jUsageLogger, MetricDefinitions}
-import org.apache.spark.sql.delta.{Checkpoints, CommitStats, CurrentTransactionInfo, DeltaOperations, LastCheckpointInfo}
+import org.apache.spark.sql.delta.{Checkpoints, CommitStats, DeltaOperations, LastCheckpointInfo}
 import org.apache.spark.sql.delta.actions.{AddFile, Checkpoint, ContentRoot, RemoveFile}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.{FileNames, JsonUtils}
@@ -363,8 +363,7 @@ class AMTCheckpointWriteSuite extends AMTCheckpointTestBase {
           useRename = false,
           outputSchema = Some(AMTSingleAction.persistedSchema(metadata, protocol)),
           writeAsIcebergManifest = true)
-        val relative = AMTUtils.relativizeManifestPathToTableRoot(
-          file.getFileSystem(hadoopConf), dataPath, file)
+        val relative = AMTUtils.relativizeLocation(dataPath.toString, file.toString)
         assert(relative == s"${FileNames.AMT_METADATA_DIR_NAME}/$fileName" &&
           !relative.contains("%20"),
           s"stored pointer must be raw and table-root-relative; got $relative")
@@ -406,6 +405,82 @@ class AMTCheckpointWriteSuite extends AMTCheckpointTestBase {
       assert(addPaths.toSeq == Seq("part-0.parquet"),
         s"reconstruction from the spaced-manifest tree must surface the DATA entry; got $addPaths")
     }
+  }
+
+  private val eAcute: Char = 0xE9.toChar
+
+  testAcrossAMTCheckpointScenarios(
+      "AddFile and DataEntry conversions use correct encoding of Delta and Iceberg specs",
+      "amt_data_entry_raw_location")(
+      setup = name => {
+        val deltaLog = deltaLogForName(name)
+        val inTableAbsolute =
+          deltaLog.dataPath.toUri.toString + s"/dir/part%20with%25percent(3)${eAcute}.parquet"
+        deltaLog.startTransaction().commit(
+          Seq(
+            // Relative.
+            AddFile(
+              path = s"dir/part%20with%25percent(1)${eAcute}.parquet",
+              partitionValues = Map.empty,
+              size = 128L,
+              modificationTime = 0L,
+              dataChange = true,
+              stats = s"""{"numRecords":1}"""),
+            // Out-of-root absolute.
+            AddFile(
+              path = s"file:/other-root/table/part%20with%25percent(2)${eAcute}.parquet",
+              partitionValues = Map.empty,
+              size = 128L,
+              modificationTime = 0L,
+              dataChange = true,
+              stats = s"""{"numRecords":1}"""),
+            // In table root absolute.
+            AddFile(
+              path = inTableAbsolute,
+              partitionValues = Map.empty,
+              size = 128L,
+              modificationTime = 0L,
+              dataChange = true,
+              stats = s"""{"numRecords":1}""")),
+          DeltaOperations.ManualUpdate)
+      }) { context =>
+    // According to RFC-2396:
+    // %20: whitespace
+    // %25: percent sign
+    // (: unreserved in RFC-2396 (in contrast to RFC-3986), left literal
+    // ): same above
+    // e-acute(U+00E9): non-ASCII, left literal
+    val expectedRawLocations = Set(
+      s"dir/part with%percent(1)${eAcute}.parquet",
+      s"file:/other-root/table/part with%percent(2)${eAcute}.parquet",
+      s"dir/part with%percent(3)${eAcute}.parquet")
+    val expectedDeltaPaths = Set(
+      s"dir/part%20with%25percent(1)${eAcute}.parquet",
+      s"file:/other-root/table/part%20with%25percent(2)${eAcute}.parquet",
+      s"dir/part%20with%25percent(3)${eAcute}.parquet")
+    val rootPath = context.checkpoint.contentRoot.getAbsolutePath(context.provider.tableRoot)
+    val dataLocations = allowReadWithinDeltaLog {
+      spark.read.parquet(rootPath.toString)
+        .where(col("content_type") === AMTSingleAction.ContentType.Type.Data)
+        .select("location")
+        .as[String]
+        .collect()
+        .toSet
+    }
+    assert(dataLocations == expectedRawLocations,
+      s"AMT DATA locations must be raw; got $dataLocations.")
+
+    val reconstructedPaths = context.provider
+      .loadActionsForStateReconstruction(spark, context.postCheckpointSnapshot.deltaLog)
+      .getOrElse(fail("AMT provider must contribute reconstructed actions."))
+      .where("add is not null")
+      .select("add.path")
+      .as[String]
+      .collect()
+      .toSet
+    assert(reconstructedPaths == expectedDeltaPaths,
+      s"Reconstructed AddFile paths must stay Delta-encoded; got $reconstructedPaths.")
+    assertReconstructsLiveFileSet(context)
   }
 
   test("no emission on a vanilla (non-AMT) table") {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTIncrementalWriteTrackingMDVSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTIncrementalWriteTrackingMDVSuite.scala
@@ -174,11 +174,9 @@ class AMTIncrementalWriteTrackingMDVSuite extends AMTIncrementalWriteTestBase {
 
   test("incremental AMT writes handles paths with spaces correctly") {
     withTempDir { baseDir =>
-      // A leaf pointer's `location` is relativized against the table root as a URI, so a space in
-      // the root becomes %20 there. The MDV update matches a remove's stamped
-      // `backReference.manifest` to that `location` by string equality, and a mismatch would
-      // silently no-op the MDV -- leaving the removed file live, which the live-set oracle inside
-      // createIncrementalAMTAndValidate catches.
+      // A leaf pointer's `location` and a remove's stamped `backReference.manifest` are both raw,
+      // table-root-relative AMT paths. A mismatch here would silently no-op the MDV, leaving the
+      // removed file live, which createIncrementalAMTAndValidate's live-set oracle catches.
       val tableRoot = new java.io.File(baseDir, "amt tbl")
       withTables(amtTableLocation = Some(tableRoot.toString)) {
           (baselineDeltaLog, amtDeltaLog) =>

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTInheritanceReadSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTInheritanceReadSuite.scala
@@ -60,7 +60,7 @@ class AMTInheritanceReadSuite extends AMTCheckpointTestBase {
       AMTWriteHelper.writeAMTParquet(
         spark, hadoopConf, file, base.metaData, base.protocol, rows)
       val fs = file.getFileSystem(hadoopConf)
-      val location = AMTUtils.relativizeManifestPathToTableRoot(fs, deltaLog.dataPath, file)
+      val location = AMTUtils.relativizeLocation(deltaLog.dataPath.toString, file.toString)
       (location, fs.getFileStatus(file).getLen)
     }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSingleActionSerializerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSingleActionSerializerSuite.scala
@@ -108,11 +108,60 @@ class AMTSingleActionSerializerSuite extends QueryTest with SharedSparkSession {
     val add = sampleAddFile
     val entry = AMTSingleAction.fromAddFile(add, addedTracking, tableRoot)
     assert(entry.content_type == AMTSingleAction.ContentType.Type.Data)
-    assert(entry.location == add.path)
+    assert(entry.location == "part-00000.parquet")
     assert(entry.record_count == add.numPhysicalRecords.get)
     assert(entry.file_size_in_bytes == add.size)
     assert(entry.manifest_info.isEmpty)
     assert(entry.tracking == addedTracking)
+  }
+
+  test("fromAddFile decodes Delta paths into raw DATA locations") {
+    val add = sampleAddFile.copy(path = "dir/part%20with%25percent.parquet")
+    val entry = AMTSingleAction.fromAddFile(add, addedTracking, tableRoot)
+    assert(entry.location == "dir/part with%percent.parquet")
+  }
+
+  test("toAddFile encodes raw DATA locations into Delta paths") {
+    val add = DataEntry(
+      location = "dir/part with%percent.parquet",
+      file_format = AMTSingleAction.FileFormatParquet,
+      tracking = addedTracking,
+      record_count = 10L,
+      file_size_in_bytes = 100L).toAddFile(tableRoot)
+    assert(add.path == "dir/part%20with%25percent.parquet")
+  }
+
+  test("fromAddFile relativizes absolute in-table Delta paths") {
+    val deltaPath = "file:/tmp/amt-test-table/dir/part%20with%20space.parquet"
+    val entry = AMTSingleAction.fromAddFile(
+      sampleAddFile.copy(path = deltaPath),
+      addedTracking,
+      tableRoot
+    )
+    assert(entry.location == "dir/part with space.parquet")
+    assert(entry.unwrap.asInstanceOf[DataEntry].toAddFile(tableRoot).path ==
+      "dir/part%20with%20space.parquet")
+  }
+
+  test("toAddFile keeps a relative in-table location relative") {
+    val add = DataEntry(
+      location = "dir/part with space.parquet",
+      file_format = AMTSingleAction.FileFormatParquet,
+      tracking = addedTracking,
+      record_count = 10L,
+      file_size_in_bytes = 100L).toAddFile(tableRoot)
+    assert(add.path == "dir/part%20with%20space.parquet")
+  }
+
+  test("DATA location conversion preserves out-of-root absolute Delta paths") {
+    val deltaPath = "file:/tmp/other-table/dir/part%20with%20space.parquet"
+    val entry = AMTSingleAction.fromAddFile(
+      sampleAddFile.copy(path = deltaPath),
+      addedTracking,
+      tableRoot
+    )
+    assert(entry.location == "file:/tmp/other-table/dir/part with space.parquet")
+    assert(entry.unwrap.asInstanceOf[DataEntry].toAddFile(tableRoot).path == deltaPath)
   }
 
   test("DataManifestEntry wraps to a DATA_MANIFEST root entry") {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTSnapshotSuite.scala
@@ -26,6 +26,7 @@ import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.FileNames
 import org.apache.hadoop.fs.Path
 
+import org.apache.spark.paths.SparkPath
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.execution.datasources.LogicalRelation
 import org.apache.spark.sql.functions.col
@@ -1295,12 +1296,16 @@ class AMTSnapshotSuite extends AMTCheckpointTestBase with DeletionVectorsTestUti
       .getOrElse(fail("AMT provider must contribute leaf-derived file actions."))
       .where("add is not null").select("add.path").as[String].collect().toSet
 
-  /** Maps a leaf's parquet row positions to their entry `location`s (bypasses the format check). */
+  /** Maps a leaf's parquet row positions to the encoded AddFile paths they reconstruct as. */
   private def leafPosToLoc(leaf: DataManifestEntry, tableRoot: Path): Map[Long, String] =
     allowReadWithinDeltaLog {
       spark.read.parquet(leaf.getAbsolutePath(tableRoot).toString)
         .select(col("_metadata.row_index").as("pos"), col("location"))
-        .as[(Long, String)].collect().toMap
+        .as[(Long, String)]
+        .collect()
+        .map { case (pos, location) =>
+          pos -> SparkPath.fromPathString(location).urlEncoded
+        }.toMap
     }
 
   /** Serializes a manifest DV bitmap over the given leaf entry positions. */

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTUtilsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTUtilsSuite.scala
@@ -18,15 +18,11 @@ package org.apache.spark.sql.delta.amt
 
 import org.apache.spark.sql.delta.AdaptiveMetadataTableFeature
 import org.apache.spark.sql.delta.actions.{Metadata, Protocol}
-import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.SparkFunSuite
 
 class AMTUtilsSuite extends SparkFunSuite {
-
-  private val tableRoot = new Path("file:/tables/t1")
-  private val fs = tableRoot.getFileSystem(new Configuration())
 
   test("hasScheme: follows URI scheme grammar") {
     assert(AMTUtils.hasScheme("s3://bucket/path"))
@@ -90,26 +86,6 @@ class AMTUtilsSuite extends SparkFunSuite {
       "data/00000-0.parquet")
   }
 
-  test("relativizeManifestPathToTableRoot: a file under the table root becomes relative") {
-    val leaf = new Path("file:/tables/t1/metadata/leaf-1.parquet")
-    assert(AMTUtils.relativizeManifestPathToTableRoot(fs, tableRoot, leaf) ===
-      "metadata/leaf-1.parquet")
-  }
-
-  test("relativizeManifestPathToTableRoot: a file outside the table root stays absolute") {
-    val outside = new Path("file:/other/metadata/leaf-1.parquet")
-    assert(AMTUtils.relativizeManifestPathToTableRoot(fs, tableRoot, outside) ===
-      "file:/other/metadata/leaf-1.parquet")
-  }
-
-  test("relativizeManifestPathToTableRoot: result is raw, not URL-encoded") {
-    val leaf = new Path("file:/tables/t1/metadata/leaf a.parquet")
-    val relative = AMTUtils.relativizeManifestPathToTableRoot(fs, tableRoot, leaf)
-    assert(relative === "metadata/leaf a.parquet",
-      s"space must stay raw, not percent-encoded; got $relative")
-    assert(!relative.contains("%20"))
-  }
-
   test("absolutePathForManifestFile: a relative location joins raw onto the table root") {
     val resolved = AMTUtils.absolutePathForManifestFile(
       new Path("s3://bucket/tables/t1"), "metadata/leaf a.parquet")
@@ -127,7 +103,7 @@ class AMTUtilsSuite extends SparkFunSuite {
   test("relativize then absolutize round-trips a file under the table root") {
     val root = new Path("file:/tables/t1")
     val leaf = new Path("file:/tables/t1/metadata/leaf-1.parquet")
-    val relative = AMTUtils.relativizeManifestPathToTableRoot(fs, root, leaf)
+    val relative = AMTUtils.relativizeLocation(root.toString, leaf.toString)
     assert(AMTUtils.absolutePathForManifestFile(root, relative) === leaf)
   }
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Updates the file paths written to `DataEntry` records in manifests. When a
data file resides within the table root, its path is now stored relative to
the table root instead of as an absolute path.

## How was this patch tested?

Existing and new unit tests.

## Does this PR introduce _any_ user-facing changes?

No.