### PR TITLE
AMT conflict resolution: winning AMT commit vs losing log or inline-tree commit

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -37,7 +37,7 @@ import org.apache.spark.sql.delta.DeltaGeoSpatial
 import org.apache.spark.sql.delta.DeltaOperations.{ChangeColumn, ChangeColumns, CreateTable, Operation, ReplaceColumns, ReplaceTable, UpdateSchema}
 import org.apache.spark.sql.delta.RowId.RowTrackingMetadataDomain
 import org.apache.spark.sql.delta.actions._
-import org.apache.spark.sql.delta.amt.{AMTCheckpointProvider, AMTUtils, AMTWriteMetrics, AMTWriteResult, AMTWriterManager}
+import org.apache.spark.sql.delta.amt.{AMTCheckpointProvider, AMTMetrics, AMTUtils, AMTWriteResult, AMTWriterManager}
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.commands.DeletionVectorUtils
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
@@ -139,7 +139,7 @@ case class CommitStats(
   numOfDomainMetadatas: Long = 0,
   txnId: Option[String] = None,
   /** Metrics for the inline AMT (Adaptive Metadata Tree) write, if this commit emitted one. */
-  amtWriteMetrics: Option[AMTWriteMetrics] = None
+  amtWriteMetrics: Option[AMTMetrics] = None
 )
 
 /**
@@ -2796,7 +2796,8 @@ trait OptimisticTransactionImpl extends TransactionHelper
             // readFiles or we might rollback the no-data-change transaction and update our actions
             // that we want to commit.
             val (newCommitVersion, newCurrentTransactionInfo) = checkForConflicts(
-              commitVersion, updatedCurrentTransactionInfo, attemptNumber, isolationLevel)
+              commitVersion, updatedCurrentTransactionInfo, attemptNumber, isolationLevel,
+              amtWriterManager)
             // Check if we may have already committed this version but retried due to
             // a transient error. If that's the case, just return success.
             newCurrentTransactionInfo.idempotentCommitAlreadyLandedAt match {
@@ -3066,7 +3067,9 @@ trait OptimisticTransactionImpl extends TransactionHelper
       fileSizeHistogramOpt = postCommitSnapshot.checksumOpt.flatMap(_.fileSizeHistogram),
       commitInfoOpt = committedTransactionInfo.commitInfo,
       commitSizeBytes = commitSizeBytes,
-      amtWriteMetricsOpt = Option.when(amtWriterManager.metrics.attempts.nonEmpty)(
+      amtWriteMetricsOpt = Option.when(
+        amtWriterManager.metrics.writeAttempts.nonEmpty ||
+          amtWriterManager.metrics.backrefRebaseAttempts.nonEmpty)(
         amtWriterManager.metrics),
       isIdempotentRetry = isIdempotentRetry
     )
@@ -3256,7 +3259,8 @@ trait OptimisticTransactionImpl extends TransactionHelper
       checkVersion: Long,
       currentTransactionInfo: CurrentTransactionInfo,
       attemptNumber: Int,
-      commitIsolationLevel: IsolationLevel)
+      commitIsolationLevel: IsolationLevel,
+      amtWriterManager: AMTWriterManager)
     : (Long, CurrentTransactionInfo) = recordDeltaOperation(
         deltaLog,
         "delta.commit.retry.conflictCheck",
@@ -3300,12 +3304,18 @@ trait OptimisticTransactionImpl extends TransactionHelper
           currentTransactionInfo
         }
         else {
-          resolveConflicts(
+          val currentTransactionInfoAfterResolvingConflicts = resolveConflicts(
             currentTransactionInfo = currentTransactionInfo,
             firstWinningVersion = expected.head,
             lastWinningVersion = expected.last,
             conflictingCommitFiles = fileStatuses,
             commitIsolationLevel = commitIsolationLevel)
+          // On an AMT rebase where a winning commit installed a new tree, re-point the writer's
+          // cached AMT provider at the folded tree, then re-derive the committed file actions' back
+          // references against it (a no-op otherwise).
+          amtWriterManager.updatePreCommitLatestAMTCheckpointProvider(
+            currentTransactionInfoAfterResolvingConflicts)
+          amtWriterManager.rebaseBackReferences(currentTransactionInfoAfterResolvingConflicts)
         }
       }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTCheckpointProvider.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTCheckpointProvider.scala
@@ -18,7 +18,8 @@ package org.apache.spark.sql.delta.amt
 
 import org.apache.spark.sql.delta.{CheckpointPolicy, CheckpointProvider, DeltaLog, DeltaLogFileIndex, Snapshot}
 import org.apache.spark.sql.delta.DeltaLogFileIndex.COMMIT_VERSION_COLUMN
-import org.apache.spark.sql.delta.actions.{Action, AddFile, BackReference, Checkpoint, ContentRoot, Metadata, Protocol, RemoveFile, SingleAction}
+import org.apache.spark.sql.delta.actions.{Action, AddFile, BackReference, Checkpoint, ContentRoot, FileAction, Metadata, Protocol, RemoveFile, SingleAction}
+import org.apache.spark.sql.delta.actions.FileAction.UniqueFileActionTuple
 import org.apache.spark.sql.delta.util.DeltaEncoder
 import org.apache.hadoop.fs.{FileStatus, Path}
 
@@ -231,23 +232,28 @@ final class AMTCheckpointProvider(
     // Key by (path, dv) so a same-path replace is handled: the removed (path, oldDv) is checked
     // against the AMT, while the re-added (path, newDv) is a distinct key absent from the tree.
     val committedFiles = committedActions.collect {
-      case a: AddFile => (a.path, a.getLegacyDeletionVectorUniqueId) -> a.backReference
-      case r: RemoveFile => (r.path, r.getLegacyDeletionVectorUniqueId) -> r.backReference
+      case a: AddFile =>
+        a.toUniqueFileActionTuple(tableRoot, useObjectIdentity = true) -> a.backReference
+      case r: RemoveFile =>
+        r.toUniqueFileActionTuple(tableRoot, useObjectIdentity = true) -> r.backReference
     }
     if (committedFiles.isEmpty) return
 
     val expectedKeyToBackreferenceMap =
       liveAddSingleActions(spark, deltaLog)
         .collect()
-        .map(sa => (sa.add.path, sa.add.getLegacyDeletionVectorUniqueId) -> sa.add.backReference)
+        .map { singleAction =>
+          singleAction.add.toUniqueFileActionTuple(tableRoot, useObjectIdentity = true) ->
+            singleAction.add.backReference
+        }
         .toMap
 
     // Keys an intermediate commit (after this AMT) already re-committed. The first superseding
     // add/remove must carry a back reference; a 2nd superseding one of the same key need not.
     val intermediateCommittedKeys =
       deltaLog.getChanges(checkpointVersion + 1).flatMap(_._2).collect {
-        case a: AddFile => (a.path, a.getLegacyDeletionVectorUniqueId)
-        case r: RemoveFile => (r.path, r.getLegacyDeletionVectorUniqueId)
+        case a: AddFile => a.toUniqueFileActionTuple(tableRoot, useObjectIdentity = true)
+        case r: RemoveFile => r.toUniqueFileActionTuple(tableRoot, useObjectIdentity = true)
       }.toSet
 
     committedFiles.foreach { case (key, actual) =>
@@ -255,19 +261,115 @@ final class AMTCheckpointProvider(
         case Some(expected)
             if actual != expected && !(intermediateCommittedKeys.contains(key) && actual.isEmpty) =>
           throw new IllegalStateException(
-            s"AMT back reference for file '${key._1}' does not match the AMT. " +
+            s"AMT back reference for file '${key.fileURI}' does not match the AMT. " +
             s"Expected $expected but the committed action carried $actual.")
         case None if actual.isDefined =>
           throw new IllegalStateException(
-            s"File '${key._1}' carries a back reference $actual but is not present in the AMT " +
-            "tree, so it must not carry one.")
+            s"File '${key.fileURI}' carries a back reference $actual but is not present in " +
+            "the AMT tree, so it must not carry one.")
         case _ => // Matching, omitted after a window supersession, or absent+empty: as expected.
       }
     }
   }
+
+  private def getBackreferencesForFilePaths(
+      spark: SparkSession,
+      deltaLog: DeltaLog,
+      filePaths: Set[String]): Map[UniqueFileActionTuple, Option[BackReference]] =
+    liveAddSingleActions(spark, deltaLog)
+      .where(col("add.path").isin(filePaths.toSeq: _*))
+      .collect()
+      .map { singleAction =>
+        singleAction.add.toUniqueFileActionTuple(tableRoot, useObjectIdentity = true) ->
+          singleAction.add.backReference
+      }
+      .toMap
+
+  /**
+   * Re-derives file actions' back references to match this (the latest) tree.
+   * The actions which have backreferences corresponding to leaves which
+   * hasn't changed (Same old leaf is still present with the new tree and MDV
+   * also hasn't changed) doesn't need to be re-calculated as the old
+   * backreferences are still valid.
+   */
+  private[delta] def reStampBackReferences(
+      spark: SparkSession,
+      deltaLog: DeltaLog,
+      actions: Seq[Action]): AMTCheckpointProvider.ReStampedBackReferences = {
+    def existingBackReference(action: Action): Option[BackReference] = action match {
+      case a: AddFile => a.backReference
+      case r: RemoveFile => r.backReference
+      case _ => None
+    }
+    def isFileAction(action: Action): Boolean = action match {
+      case _: AddFile | _: RemoveFile => true
+      case _ => false
+    }
+    // An `isMasked(pos)` test over each referenced leaf's manifest DV (a leaf with no DV masks
+    // nothing), keyed by the leaf `location` a back reference's `manifest` holds. Only the leaves
+    // some back reference points at are deserialized.
+    val referencedManifests =
+      actions.iterator.flatMap(existingBackReference).map(_.manifest).toSet
+    val isMaskedByLocation: Map[String, Int => Boolean] = liveLeaves.iterator
+      .filter(leaf => referencedManifests.contains(leaf.location))
+      .map { leaf =>
+        val isMasked: Int => Boolean = leaf.manifestDV match {
+          case Some((dvBytes, _)) =>
+            val mdv = AMTUtils.deserializeMdv(dvBytes)
+            pos => mdv.contains(pos)
+          case None => _ => false
+        }
+        leaf.location -> isMasked
+      }.toMap
+    // A back reference is still valid iff its leaf is present in this tree and its position there
+    // is not MDV-masked. If an action has no back reference against the older tree, we recalculate
+    // it too, as the entry might have spilled from the root to a new leaf in the latest tree.
+    def stillValid(backReference: Option[BackReference]): Boolean =
+      backReference.exists { case BackReference(manifest, pos) =>
+        isMaskedByLocation.get(manifest).exists(isMasked => !isMasked(pos))
+      }
+    def needsReStamp(action: Action): Boolean = action match {
+      case a: AddFile => !stillValid(a.backReference)
+      case r: RemoveFile => !stillValid(r.backReference)
+      case _ => false
+    }
+    if (!actions.exists(needsReStamp)) {
+      return AMTCheckpointProvider.ReStampedBackReferences(
+        actions,
+        numActionsReusingBackref = actions.count(isFileAction),
+        numActionsRegeneratingBackref = 0)
+    }
+    val pathsToReStamp: Set[String] = actions.iterator.collect {
+      case a: AddFile if needsReStamp(a) => a.path
+      case r: RemoveFile if needsReStamp(r) => r.path
+    }.toSet
+    val keyToBackRef = getBackreferencesForFilePaths(spark, deltaLog, pathsToReStamp)
+    def backRefFor(action: FileAction): Option[BackReference] =
+      keyToBackRef.getOrElse(
+        action.toUniqueFileActionTuple(tableRoot, useObjectIdentity = true), None)
+    val restamped = actions.map {
+      case a: AddFile if needsReStamp(a) => a.copy(backReference = backRefFor(a))
+      case r: RemoveFile if needsReStamp(r) => r.copy(backReference = backRefFor(r))
+      case other => other
+    }
+    AMTCheckpointProvider.ReStampedBackReferences(
+      restamped,
+      numActionsReusingBackref = actions.count(a => isFileAction(a) && !needsReStamp(a)),
+      numActionsRegeneratingBackref = actions.count(needsReStamp))
+  }
 }
 
 object AMTCheckpointProvider {
+
+  /**
+   * @param actions                       the actions with re-derived back references where needed.
+   * @param numActionsReusingBackref      file actions whose existing back reference stayed valid.
+   * @param numActionsRegeneratingBackref file actions whose back reference was re-derived.
+   */
+  case class ReStampedBackReferences(
+      actions: Seq[Action],
+      numActionsReusingBackref: Int,
+      numActionsRegeneratingBackref: Int)
 
   /**
    * An [[AMTSingleAction]] entry paired with its physical read location in its manifest parquet.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriterManager.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriterManager.scala
@@ -16,8 +16,10 @@
 
 package org.apache.spark.sql.delta.amt
 
+import java.util.concurrent.TimeUnit
+
 import org.apache.spark.sql.delta.{CurrentTransactionInfo, DeltaErrors, DeltaLog, DeltaOperations, LogSegment, MaintenanceOperation, Snapshot}
-import org.apache.spark.sql.delta.actions.{Action, Checkpoint}
+import org.apache.spark.sql.delta.actions.{Action, Checkpoint, FileAction}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.FileNames
 
@@ -53,9 +55,18 @@ object AMTTriggerMode {
     isIncremental = true)
 }
 
-/** Metrics describing an AMT (Adaptive Metadata Tree) write, one entry per attempt. */
-case class AMTWriteMetrics(
-    private[delta] var attempts: Seq[SingleAMTWriteMetrics] = Seq.empty)
+/** Aggregated AMT metrics collected across all attempts of a single [[AMTWriterManager]]. */
+case class AMTMetrics(
+    private[delta] var writeAttempts: Seq[SingleAMTWriteMetrics] = Seq.empty,
+    private[delta] var backrefRebaseAttempts: Seq[BackRefRebaseMetrics] = Seq.empty)
+
+/** Metrics for one back-reference rebase pass (see [[AMTWriterManager.rebaseBackReferences]]). */
+case class BackRefRebaseMetrics(
+    oldAMTVersion: Long,
+    newAMTVersion: Long,
+    totalTimeTakenMs: Long,
+    numActionsReusingBackref: Int,
+    numActionsRegeneratingBackref: Int)
 
 /** Metrics for a single AMT write attempt (one per commit attempt that materializes a tree). */
 case class SingleAMTWriteMetrics(
@@ -102,6 +113,21 @@ case class AMTWriteResult(
     leaves: Seq[DataManifestEntry],
     includeActionsInCommitJson: Boolean)
 
+/** A lazily-materialized [[AMTCheckpointProvider]] for `checkpointOpt`. */
+class LazyAMTCheckpointProvider(
+    checkpointOpt: Option[Checkpoint],
+    readSnapshot: Snapshot,
+    manifestCommitVersion: Long) {
+  lazy val providerOpt: Option[AMTCheckpointProvider] = checkpointOpt.map { checkpoint =>
+    readSnapshot.checkpointProvider match {
+      case amt: AMTCheckpointProvider if amt.checkpointAction.version == checkpoint.version => amt
+      case _ =>
+        AMTCheckpointProvider.fromCheckpoint(
+          readSnapshot.deltaLog, checkpoint, manifestCommitVersion)
+    }
+  }
+}
+
 /**
  * Orchestrates write of an AMT for a given transaction (including reattempts on a conflict).
  */
@@ -112,8 +138,28 @@ class AMTWriterManager(
   private def spark: SparkSession = SparkSession.active
   private def deltaLog: DeltaLog = readSnapshot.deltaLog
 
-  val metrics = AMTWriteMetrics()
+  val metrics = AMTMetrics()
   private var lastAMTWriteResultOpt: Option[AMTWriteResult] = None
+
+  /** The read snapshot's own AMT checkpoint, if it is AMT-backed. */
+  private def readSnapshotAMTCheckpointOpt: Option[Checkpoint] = {
+    if (!AMTUtils.amtEnabled(readSnapshot)) return None
+    readSnapshot.checkpointProvider match {
+      case amt: AMTCheckpointProvider => Some(amt.checkpointAction)
+      case _ => None
+    }
+  }
+
+  /**
+   * The AMT Checkpoint Provider corresponding to the last manifest commit corresponding to
+   * OptimisticTransaction.preCommitLogSegment.
+   * This is updated after every round of [[ConflictChecker]] rebase.
+   */
+  private var preCommitLatestAMTCheckpointProvider: LazyAMTCheckpointProvider =
+    new LazyAMTCheckpointProvider(readSnapshotAMTCheckpointOpt, readSnapshot, readSnapshot.version)
+
+  /** The folded AMT tree version the committed actions were last re-stamped against. */
+  private var lastRebasedAMTVersion: Option[Long] = None
 
   /**
    * Builds the AMT write for a commit attempt, or `None` when no AMT should be written. Serves both
@@ -137,14 +183,18 @@ class AMTWriterManager(
     }
 
     if (preCommitLogSegment.version > readSnapshot.version) {
-      // A concurrent commit won our target version and we are rebasing. Scenarios handled:
-      //   Winning commit | Losing commit     | Action taken
-      //   Log commit     | Log commit        | usual conflict checking; back references stay valid
-      //   Log commit     | Inline AMT commit | regenerate the inline AMT tree; no back-ref changes
+      // A concurrent commit won our target version and we are rebasing. In the table below a
+      // "new-tree commit" is a winner that installed a new AMT tree (an OPTIMIZE checkpoint or a
+      // large inline commit); scenarios handled:
+      //   Winning commit  | Losing commit     | Action taken
+      //   Log commit      | Log commit        | usual conflict checking; back refs stay valid
+      //   Log commit      | Inline AMT commit | rebuild the inline tree; back refs stay valid
+      //   New-tree commit | Log commit        | rebase onto the new tree; re-derive back refs
+      //   New-tree commit | Inline AMT commit | re-seat + rebuild; re-derive back refs
       // All other scenarios are not handled.
       val losingOptimizeCheckpoint =
         initialOperation.isInstanceOf[DeltaOperations.OptimizeCheckpoint]
-      if (losingOptimizeCheckpoint || winningCommitInstalledNewAMTTree(currentTransactionInfo)) {
+      if (losingOptimizeCheckpoint) {
         throw DeltaErrors.concurrentWriteException(conflictingCommit = None)
       }
     }
@@ -185,9 +235,7 @@ class AMTWriterManager(
     actionsToCommit.size.toLong >= largeCommitActionsCountThresholdForInlineManifestCommit &&
       AMTWriteHelper.previousAMTContentRoot(readSnapshot).isDefined
 
-  /**
-   * True when conflict resolution folded in a winning commit that installed a new AMT tree.
-   */
+  /** True when there was a winning manifest commit concurrent to this transaction */
   private def winningCommitInstalledNewAMTTree(
       currentTransactionInfo: CurrentTransactionInfo): Boolean = {
     val readSnapshotAMTVersion = readSnapshot.lastManifestCommitOpt.map(_.contentRootVersion)
@@ -215,10 +263,13 @@ class AMTWriterManager(
       preCommitLogSegment: LogSegment,
       incremental: Boolean,
       trigger: String): AMTWriteResult = {
-    val amtProviderOpt = readSnapshot.checkpointProvider match {
-      case amt: AMTCheckpointProvider => Some(amt)
-      case _ => None
-    }
+    val amtProviderOpt = preCommitLatestAMTCheckpointProvider.providerOpt
+    assert(
+      amtProviderOpt.map(_.checkpointAction.version) ==
+        currentTransactionInfo.preCommitLatestAMTCheckpointOpt.map(_.version),
+      s"Cached AMT provider ${amtProviderOpt.map(_.checkpointAction.version)} is out of sync " +
+        "with preCommitLatestAMTCheckpointOpt " +
+        s"${currentTransactionInfo.preCommitLatestAMTCheckpointOpt.map(_.version)}.")
     val (result, singleMetric) =
       if (incremental && amtProviderOpt.isDefined) {
         val amtProvider = amtProviderOpt.get
@@ -244,7 +295,7 @@ class AMTWriterManager(
           postCommitMetadata = currentTransactionInfo.metadata,
           trigger = trigger)
       }
-    metrics.attempts :+= singleMetric
+    metrics.writeAttempts :+= singleMetric
     result
   }
 
@@ -371,4 +422,78 @@ class AMTWriterManager(
   private def fullRewriteCheckpointIntervalMultiplier: Int =
     spark.sessionState.conf.getConf(
       DeltaSQLConf.AMT_FULL_REWRITE_CHECKPOINT_INTERVAL_MULTIPLIER)
+
+  /**
+   * Updates the pre-commit AMTCheckpointProvider after resolving conflicts via [[ConflictChecker]].
+   */
+  def updatePreCommitLatestAMTCheckpointProvider(
+      currentTransactionInfo: CurrentTransactionInfo): Unit = {
+    val manifestCommitVersion = currentTransactionInfo.commitInfo
+      .flatMap(_.lastManifestCommit).map(_.version)
+      .orElse(currentTransactionInfo.preCommitLatestAMTCheckpointOpt.map(_.version)).getOrElse(0L)
+    preCommitLatestAMTCheckpointProvider = new LazyAMTCheckpointProvider(
+      currentTransactionInfo.preCommitLatestAMTCheckpointOpt, readSnapshot, manifestCommitVersion)
+  }
+
+  /**
+   * Re-derives the file actions' back references against the AMT this attempt builds on. Only runs
+   * on a rebase where a winning commit installed a new tree; `reStampBackReferences` re-derives
+   * each file action whose back reference that tree invalidated (a leaf it dropped or a position it
+   * newly MDV-masked because the file moved or was removed) and leaves the rest -- those still
+   * pointing at a live leaf entry -- unchanged. A blind append is skipped entirely: it only adds
+   * brand-new files, so none of its actions can point at a leaf the winner's tree invalidated.
+   */
+  def rebaseBackReferences(
+      currentTransactionInfo: CurrentTransactionInfo): CurrentTransactionInfo = {
+    val actions = currentTransactionInfo.actions
+    if (!AMTUtils.amtEnabled(readSnapshot) ||
+        !winningCommitInstalledNewAMTTree(currentTransactionInfo)) {
+      return currentTransactionInfo
+    }
+    // A blind append only adds brand-new files and reads or removes nothing, so none of its actions
+    // reference a leaf the winner's tree could have dropped or MDV-masked. Those new files are
+    // absent from the winner's tree and get a fresh back reference when this attempt's own tree
+    // folds them in, so skip the re-stamp rather than re-deriving back references that do not exist
+    // in the winner's tree.
+    if (currentTransactionInfo.commitInfo.flatMap(_.isBlindAppend).getOrElse(false)) {
+      return currentTransactionInfo
+    }
+    // A commit with no file actions has no back references to re-derive, so short-circuit before
+    // materializing the winning tree's (potentially expensive) AMT provider.
+    if (!actions.exists(_.isInstanceOf[FileAction])) {
+      return currentTransactionInfo
+    }
+    val foldedAMTVersion = currentTransactionInfo.preCommitLatestAMTCheckpointOpt.map(_.version)
+    if (foldedAMTVersion == lastRebasedAMTVersion) {
+      // No new tree was installed since the last rebase, so the actions are already re-stamped
+      // against it -- nothing to re-derive.
+      return currentTransactionInfo
+    }
+    // The tree the actions were last stamped against: the previous rebase target, or -- on the
+    // first rebase -- the read snapshot's own tree, which is what the writer originally stamped.
+    val oldAMTVersion = lastRebasedAMTVersion
+      .orElse(readSnapshot.lastManifestCommitOpt.map(_.contentRootVersion))
+      .getOrElse(0L)
+    val foldedContentRootVersion =
+      currentTransactionInfo.preCommitLatestAMTCheckpointOpt.map(_.contentRoot.version)
+    val providerContentRootVersion =
+      preCommitLatestAMTCheckpointProvider.providerOpt.map(_.checkpointAction.contentRoot.version)
+    assert(foldedContentRootVersion == providerContentRootVersion,
+      "the cached AMT provider must correspond to the transaction's folded AMT checkpoint.")
+    val startNs = System.nanoTime()
+    val restampedActions = preCommitLatestAMTCheckpointProvider.providerOpt match {
+      case Some(provider) =>
+        val result = provider.reStampBackReferences(spark, deltaLog, actions)
+        metrics.backrefRebaseAttempts :+= BackRefRebaseMetrics(
+          oldAMTVersion = oldAMTVersion,
+          newAMTVersion = foldedAMTVersion.getOrElse(oldAMTVersion),
+          totalTimeTakenMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNs),
+          numActionsReusingBackref = result.numActionsReusingBackref,
+          numActionsRegeneratingBackref = result.numActionsRegeneratingBackref)
+        result.actions
+      case None => actions
+    }
+    lastRebasedAMTVersion = foldedAMTVersion
+    currentTransactionInfo.copy(actions = restampedActions)
+  }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/TransactionHelper.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/TransactionHelper.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.delta.{CatalogOwnedTableFeature, CommitStats, Commit
 import org.apache.spark.sql.delta.DeltaOperations.Operation
 import org.apache.spark.sql.delta.RowId.RowTrackingMetadataDomain
 import org.apache.spark.sql.delta.actions.{Action, AddCDCFile, AddFile, CommitInfo, DomainMetadata, FileAction, Metadata, Protocol, RemoveFile, SetTransaction}
-import org.apache.spark.sql.delta.amt.AMTWriteMetrics
+import org.apache.spark.sql.delta.amt.AMTMetrics
 import org.apache.spark.sql.delta.coordinatedcommits.{CatalogOwnedTableUtils, TableCommitCoordinatorClient}
 import org.apache.spark.sql.delta.hooks.PostCommitHook
 import org.apache.spark.sql.delta.logging.DeltaLogKeys
@@ -384,7 +384,7 @@ trait TransactionHelper extends DeltaLogging {
         fileSizeHistogramOpt: Option[FileSizeHistogram],
         commitInfoOpt: Option[CommitInfo],
         commitSizeBytes: Long,
-        amtWriteMetricsOpt: Option[AMTWriteMetrics] = None,
+        amtWriteMetricsOpt: Option[AMTMetrics] = None,
         isIdempotentRetry: Boolean = false): Unit = {
       assertStateBeforeFinalization()
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTBackReferenceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTBackReferenceSuite.scala
@@ -442,6 +442,59 @@ class AMTBackReferenceSuite extends AMTCheckpointTestBase with DeletionVectorsTe
     }
   }
 
+  test("reStampBackReferences drops an MDV-masked back reference and keeps a live one") {
+    withTable("amt_restamp_mdv") {
+      val name = "amt_restamp_mdv"
+      // A tree with three full leaves; every seeded file is stamped with a leaf back reference.
+      val adds = emitStampedAddFiles(name)
+      val deltaLog = deltaLogForName(name)
+      val originalLeafLocations = amtProvider(deltaLog.update())
+        .getOrElse(fail("expected AMTCheckpointProvider")).leaves.map(_.location).toSet
+      val victim = adds.head
+      val keeper = adds.last
+      val victimBr = victim.backReference.getOrElse(fail("victim must be leaf-resident."))
+      val keeperBr = keeper.backReference.getOrElse(fail("keeper must be leaf-resident."))
+
+      // Remove the victim whole, then fold the removal into the tree with an incremental
+      // checkpoint. Its leaf keeps nine live entries, so it is carried forward at the SAME
+      // location with the victim's position MDV-masked -- the case a leaf-location-only gate
+      // would wrongly skip.
+      commitActions(name, Seq(victim.removeWithTimestamp()))
+      commitCheckpoint(deltaLog, incremental = true)
+
+      val winnerSnapshot = deltaLog.update()
+      val winner = amtProvider(winnerSnapshot).getOrElse(fail("expected AMTCheckpointProvider"))
+      assert(winner.leaves.map(_.location).toSet == originalLeafLocations,
+        "precondition: the winning tree must carry the leaves forward at the same locations.")
+      assert(winner.leaves.exists(_.location == victimBr.manifest),
+        "precondition: the victim's leaf must still be present (carried forward) in the winner.")
+      val livePaths = liveAddFiles(winnerSnapshot).map(_.path).toSet
+      assert(!livePaths.contains(victim.path),
+        "precondition: the victim's leaf entry must be MDV-masked (no longer live).")
+      assert(livePaths.contains(keeper.path),
+        "precondition: the keeper must still be live at its stamped leaf position.")
+
+      // Re-stamping tombstones for both against the winner tree: the victim's stale back reference
+      // must be dropped (its entry moved out of the leaf), the keeper's must be preserved.
+      val restamped = winner.reStampBackReferences(
+        spark, deltaLog, Seq(victim.removeWithTimestamp(), keeper.removeWithTimestamp())).actions
+      val backRefByPath =
+        restamped.collect { case r: RemoveFile => r.path -> r.backReference }.toMap
+      assert(backRefByPath(victim.path).isEmpty,
+        s"the MDV-masked victim's stale back reference must be dropped, was " +
+          s"${backRefByPath(victim.path)}.")
+      assert(backRefByPath(keeper.path).contains(keeperBr),
+        s"the still-live keeper's back reference must be preserved as $keeperBr, was " +
+          s"${backRefByPath(keeper.path)}.")
+
+      // When every back reference is still valid, the batch is returned untouched -- no live map is
+      // built and no action is re-stamped.
+      val keeperOnly = Seq(keeper.removeWithTimestamp())
+      assert(winner.reStampBackReferences(spark, deltaLog, keeperOnly).actions eq keeperOnly,
+        "a batch whose back references are all still valid must be returned as-is.")
+    }
+  }
+
   /**
    * Builds an AMT source with stamped files, runs `clone(src, tgt)`, then asserts every AddFile
    * committed to the target carries no back reference.

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointPolicySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointPolicySuite.scala
@@ -62,7 +62,7 @@ class AMTCheckpointPolicySuite extends AMTCheckpointTestBase {
       .map(e => JsonUtils.fromJson[CommitStats](e.blob))
       .find(_.commitVersion == version)
       .flatMap(_.amtWriteMetrics)
-      .flatMap(_.attempts.headOption)
+      .flatMap(_.writeAttempts.headOption)
       .getOrElse(fail(s"No AMT write metrics logged for version $version."))
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointTestBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointTestBase.scala
@@ -507,7 +507,7 @@ trait AMTCheckpointTestBase
       .map(e => JsonUtils.fromJson[CommitStats](e.blob))
       .find(_.commitVersion == commitVersion)
       .flatMap(_.amtWriteMetrics)
-      .flatMap(_.attempts.headOption)
+      .flatMap(_.writeAttempts.headOption)
       .flatMap(_.incrementalWriteMetrics)
   }
 
@@ -529,8 +529,29 @@ trait AMTCheckpointTestBase
       .find(_.commitVersion == version)
       .toSeq
       .flatMap(_.amtWriteMetrics.toSeq)
-      .flatMap(_.attempts)
+      .flatMap(_.writeAttempts)
       .flatMap(_.incrementalWriteMetrics)
+  }
+
+  /**
+   * Runs `commit` and returns the [[BackRefRebaseMetrics]] logged for the commit at
+   * `commitVersion` -- one entry per conflict round that re-derived back references against a
+   * newly installed tree. `commitVersion` is by-name so callers can pass the final committed
+   * version, which is only known after `commit` runs.
+   */
+  protected def trackBackrefRebaseMetricsAt(
+      commitVersion: => Long)(commit: => Unit): Seq[BackRefRebaseMetrics] = {
+    val events = Log4jUsageLogger.track {
+      commit
+    }
+    val version = commitVersion
+    events.filter(e => e.metric == MetricDefinitions.EVENT_TAHOE.name &&
+        e.tags.get("opType").contains("delta.commit.stats"))
+      .map(e => JsonUtils.fromJson[CommitStats](e.blob))
+      .find(_.commitVersion == version)
+      .toSeq
+      .flatMap(_.amtWriteMetrics.toSeq)
+      .flatMap(_.backrefRebaseAttempts)
   }
 
   private def assertAMTCheckpointScenarioInvariants(

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointWriteSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTCheckpointWriteSuite.scala
@@ -531,10 +531,11 @@ class AMTCheckpointWriteSuite extends AMTCheckpointTestBase {
       val v3Stats = allStats.find(_.commitVersion == 3).getOrElse(fail("No stats for v3."))
       val metrics = v3Stats.amtWriteMetrics
         .getOrElse(fail("The follow-up commit's stats should carry AMT write metrics."))
-      assert(metrics.attempts.size == 1, s"Expected one AMT write attempt, got ${metrics.attempts}")
+      assert(metrics.writeAttempts.size == 1,
+        s"Expected one AMT write attempt, got ${metrics.writeAttempts}")
       // The first AMT has no prior tree to build on, so it is always a full rewrite.
-      assert(metrics.attempts.head.trigger == AMTTriggerMode.CheckpointIntervalFull.name)
-      assert(metrics.attempts.head.materializeDurationMs >= 0L)
+      assert(metrics.writeAttempts.head.trigger == AMTTriggerMode.CheckpointIntervalFull.name)
+      assert(metrics.writeAttempts.head.materializeDurationMs >= 0L)
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTConflictResolutionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTConflictResolutionSuite.scala
@@ -43,9 +43,20 @@ class AMTConflictResolutionSuite
     Array.empty
   }
 
+  /** A transaction body that commits a full-rewrite OPTIMIZE CHECKPOINT (a brand-new AMT tree). */
+  private def fullCheckpointTxn(deltaLog: DeltaLog): () => Array[Row] = () => {
+    commitCheckpoint(deltaLog, incremental = false)
+    Array.empty
+  }
+
   /** A transaction body that appends `id` as a plain (log-only, no tree) business commit. */
   private def appendTxn(tableName: String, id: Int): () => Array[Row] = () => {
     spark.sql(s"INSERT INTO $tableName VALUES ($id)").collect()
+  }
+
+  /** A transaction body that deletes `id` -- a non-blind commit. */
+  private def deleteTxn(tableName: String, id: Int): () => Array[Row] = () => {
+    spark.sql(s"DELETE FROM $tableName WHERE id = $id").collect()
   }
 
   /**
@@ -137,22 +148,33 @@ class AMTConflictResolutionSuite
     }
   }
 
-  test("Winning Commit [Manifest Commit] vs Losing commit [inline-incremental commit]" +
-    " - FAILS") {
+  test("Winning Commit [Incremental checkpoint commit] vs Losing commit " +
+    "[inline-incremental commit] - Success") {
     withTable("amt_conflict_inline_vs_tree_winner") {
       val name = "amt_conflict_inline_vs_tree_winner"
       val deltaLog = setupAMTTable(name)
+      val liveIdsBefore = spark.sql(s"SELECT id FROM $name").collect().map(_.getInt(0)).toSet
 
       // A's 10-file insert inlines a tree; B installs a new tree (OPTIMIZE CHECKPOINT) and wins A's
-      // target version. The winner's tree moves A's base, so A hard-fails until the base re-seat
-      // lands.
+      // target version. A must re-seat its incremental write onto B's tree and rebuild its own tree
+      // on top (re-deriving back references if B's leaf set moved), rather than hard-failing.
       withInlineThreshold(6) {
         val (futureA, futureB) = runTxnsWithOrder__A_Start__B__A_End(
           () => { appendRowsAsSeparateFiles(name, numFiles = 10, startId = 100); Array.empty },
           optimizeCheckpointTxn(deltaLog))
         ThreadUtils.awaitResult(futureB, Duration.Inf)
-        assertConcurrentWriteFailure(futureA)
+        ThreadUtils.awaitResult(futureA, Duration.Inf)
       }
+
+      val liveIdsAfter = spark.sql(s"SELECT id FROM $name").collect().map(_.getInt(0)).toSet
+      assert(liveIdsAfter == liveIdsBefore ++ (100 to 109).toSet,
+        s"A's files must survive the rebase onto the winner's tree; before=$liveIdsBefore " +
+          s"after=$liveIdsAfter")
+      // A's rebased commit rode an inline AMT checkpoint built on the winner's tree.
+      val latest = deltaLog.update()
+      assert(checkpointAt(deltaLog, latest.version).isDefined,
+        "the rebased inline commit must carry an AMT checkpoint at its version.")
+      assert(amtProvider(latest).isDefined, "the table must remain AMT-backed after the rebase.")
     }
   }
 
@@ -182,39 +204,95 @@ class AMTConflictResolutionSuite
     }
   }
 
-  test("Winning Commit [Manifest Commit] vs Losing commit [Log commit] - FAILS") {
+  test("Winning Commit [Incremental checkpoint commit] vs Losing commit [log commit] - " +
+    "Success") {
     withTable("amt_conflict_log_vs_tree_winner") {
       val name = "amt_conflict_log_vs_tree_winner"
       val deltaLog = setupAMTTable(name)
+      val liveIdsBefore = spark.sql(s"SELECT id FROM $name").collect().map(_.getInt(0)).toSet
 
-      // A is a plain (blind) append, so its AddFiles carry no back references. B writes a new
-      // tree (OPTIMIZE CHECKPOINT) and wins A's target version.
-      val (futureA, futureB) = runTxnsWithOrder__A_Start__B__A_End(
-        appendTxn(name, id = 100),
-        optimizeCheckpointTxn(deltaLog))
+      // A is a non-blind DELETE (it removes id 1's file); B installs a new tree (OPTIMIZE
+      // CHECKPOINT) and wins A's target version. A must rebase past the new tree -- re-deriving its
+      // RemoveFile's back reference against it when the tree's leaf set moved -- rather than
+      // hard-failing.
+      val rebaseMetrics = trackBackrefRebaseMetricsAt(deltaLog.update().version) {
+        val (futureA, futureB) = runTxnsWithOrder__A_Start__B__A_End(
+          deleteTxn(name, id = 1),
+          optimizeCheckpointTxn(deltaLog))
+        ThreadUtils.awaitResult(futureB, Duration.Inf)
+        ThreadUtils.awaitResult(futureA, Duration.Inf)
+      }
 
-      // B commits its tree; A loses and hard-fails. Every commit that lost to a tree-installing
-      // winner is blocked for now -- regardless of back references -- because re-seating it onto
-      // the winner's tree is a later milestone.
-      ThreadUtils.awaitResult(futureB, Duration.Inf)
-      assertConcurrentWriteFailure(futureA)
+      val liveIdsAfter = spark.sql(s"SELECT id FROM $name").collect().map(_.getInt(0)).toSet
+      assert(liveIdsAfter == liveIdsBefore - 1,
+        s"A's delete must survive the rebase onto the winner's tree; before=$liveIdsBefore " +
+          s"after=$liveIdsAfter")
+      assert(amtProvider(deltaLog.update()).isDefined,
+        "the table must remain AMT-backed after the rebase.")
+      // The rebase really ran: one round re-derived A's RemoveFile back reference against B's tree.
+      assert(rebaseMetrics.size == 1 && rebaseMetrics.head.numActionsRegeneratingBackref >= 1,
+        s"A must record one back-ref rebase that re-derived its RemoveFile; got $rebaseMetrics")
     }
   }
 
-  test("Winning Commit [Manifest Commit] vs Losing commit [Manifest Commit] - FAILS") {
-    withTable("amt_conflict_tree_vs_tree") {
-      val name = "amt_conflict_tree_vs_tree"
+  test("Winning Commit [Full checkpoint commit] vs Losing commit [log commit] - Success") {
+    withTable("amt_conflict_log_vs_full_tree_winner") {
+      val name = "amt_conflict_log_vs_full_tree_winner"
       val deltaLog = setupAMTTable(name)
+      val liveIdsBefore = spark.sql(s"SELECT id FROM $name").collect().map(_.getInt(0)).toSet
 
-      // Both A and B are OPTIMIZE CHECKPOINTs (tree writers). B wins A's target version; A loses
-      // and, because it (re)writes a tree, still hard-fails -- rebasing a losing tree writer is a
-      // later milestone.
-      val (futureA, futureB) = runTxnsWithOrder__A_Start__B__A_End(
-        optimizeCheckpointTxn(deltaLog),
-        optimizeCheckpointTxn(deltaLog))
+      // A is a non-blind DELETE (it removes id 1's file); B installs a brand-new FULL-rewrite tree
+      // (OPTIMIZE CHECKPOINT, incremental = false) and wins A's target version. A full rewrite
+      // moves every leaf position, so A's RemoveFile back reference is re-derived from scratch
+      // against B's tree before A commits, rather than hard-failing.
+      val rebaseMetrics = trackBackrefRebaseMetricsAt(deltaLog.update().version) {
+        val (futureA, futureB) = runTxnsWithOrder__A_Start__B__A_End(
+          deleteTxn(name, id = 1),
+          fullCheckpointTxn(deltaLog))
+        ThreadUtils.awaitResult(futureB, Duration.Inf)
+        ThreadUtils.awaitResult(futureA, Duration.Inf)
+      }
 
-      ThreadUtils.awaitResult(futureB, Duration.Inf)
-      assertConcurrentWriteFailure(futureA)
+      val liveIdsAfter = spark.sql(s"SELECT id FROM $name").collect().map(_.getInt(0)).toSet
+      assert(liveIdsAfter == liveIdsBefore - 1,
+        s"A's delete must survive the rebase onto the full-rewrite winner's tree; " +
+          s"before=$liveIdsBefore after=$liveIdsAfter")
+      assert(amtProvider(deltaLog.update()).isDefined,
+        "the table must remain AMT-backed after the rebase.")
+      // The rebase really ran: the full rewrite forced A's RemoveFile back reference to be
+      // re-derived against B's tree.
+      assert(rebaseMetrics.size == 1 && rebaseMetrics.head.numActionsRegeneratingBackref >= 1,
+        s"A must record one back-ref rebase that re-derived its RemoveFile; got $rebaseMetrics")
     }
   }
+
+  test("Winning Commit [Full checkpoint commit] vs Losing commit " +
+    "[inline-incremental commit] - Success") {
+    withTable("amt_conflict_inline_vs_full_tree_winner") {
+      val name = "amt_conflict_inline_vs_full_tree_winner"
+      val deltaLog = setupAMTTable(name)
+      val liveIdsBefore = spark.sql(s"SELECT id FROM $name").collect().map(_.getInt(0)).toSet
+
+      // A's 10-file insert inlines a tree; B installs a brand-new FULL-rewrite tree and wins A's
+      // target version. A must re-seat its incremental write onto B's full tree and rebuild its
+      // own tree on top, re-deriving all its back references, rather than hard-failing.
+      withInlineThreshold(6) {
+        val (futureA, futureB) = runTxnsWithOrder__A_Start__B__A_End(
+          () => { appendRowsAsSeparateFiles(name, numFiles = 10, startId = 100); Array.empty },
+          fullCheckpointTxn(deltaLog))
+        ThreadUtils.awaitResult(futureB, Duration.Inf)
+        ThreadUtils.awaitResult(futureA, Duration.Inf)
+      }
+
+      val liveIdsAfter = spark.sql(s"SELECT id FROM $name").collect().map(_.getInt(0)).toSet
+      assert(liveIdsAfter == liveIdsBefore ++ (100 to 109).toSet,
+        s"A's files must survive the rebase onto the full-rewrite winner's tree; " +
+          s"before=$liveIdsBefore after=$liveIdsAfter")
+      val latest = deltaLog.update()
+      assert(checkpointAt(deltaLog, latest.version).isDefined,
+        "the rebased inline commit must carry an AMT checkpoint at its version.")
+      assert(amtProvider(latest).isDefined, "the table must remain AMT-backed after the rebase.")
+    }
+  }
+
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTWriterManagerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTWriterManagerSuite.scala
@@ -78,7 +78,8 @@ class AMTWriterManagerSuite extends AMTCheckpointTestBase {
         // The commit carries no user actions, so the tree describes state as of the read version.
         assert(result.contentRootVersion == snapshot.version)
         // The metric records the trigger name carried on the operation.
-        assert(manager.metrics.attempts.head.trigger == AMTTriggerMode.CheckpointIntervalFull.name)
+        assert(manager.metrics.writeAttempts.head.trigger ==
+          AMTTriggerMode.CheckpointIntervalFull.name)
       }
     }
   }
@@ -129,7 +130,7 @@ class AMTWriterManagerSuite extends AMTCheckpointTestBase {
     }
   }
 
-  test("writeAMT hard-fails a log-only commit when the winner installed a new tree") {
+  test("writeAMT writes no tree for a log-only commit rebasing past a tree-installing winner") {
     withTable("amt_conflict_log_vs_tree") {
       val name = "amt_conflict_log_vs_tree"
       createAMTTable(name, checkpointInterval = 2)
@@ -138,17 +139,19 @@ class AMTWriterManagerSuite extends AMTCheckpointTestBase {
       val (manager, snapshot) = managerFor(name)
       val baseTree = amtProvider(snapshot).map(_.checkpointAction).getOrElse(
         fail("the table must be AMT-backed for this case."))
-      // A winner installed a newer tree than the read snapshot's, so a log-only commit's back
-      // references are stale and it must hard-fail until they are re-derived (a later milestone).
+      // A winner installed a newer tree than the read snapshot's. writeAMT for a log-only commit no
+      // longer hard-fails on this -- it writes no tree; re-deriving the file actions' back
+      // references against the winner tree happens in doCommit's rebaseBackReferences, exercised
+      // end-to-end in AMTConflictResolutionSuite.
       val winnerTree = baseTree.copy(version = baseTree.version + 1)
       val retrySegment = snapshot.logSegment.copy(version = snapshot.version + 1)
-      intercept[ConcurrentWriteException] {
-        manager.writeAMT(
-          commitVersion = snapshot.version + 2,
-          currentTransactionInfo = txnInfoFor(
-            snapshot, actions = Seq.empty, preCommitLatestAMTCheckpointOpt = Some(winnerTree)),
-          preCommitLogSegment = retrySegment)
-      }
+      val result = manager.writeAMT(
+        commitVersion = snapshot.version + 2,
+        currentTransactionInfo = txnInfoFor(
+          snapshot, actions = Seq.empty, preCommitLatestAMTCheckpointOpt = Some(winnerTree)),
+        preCommitLogSegment = retrySegment)
+      assert(result.isEmpty,
+        "a log-only commit rebasing past a winner tree writes no AMT (re-derivation is elsewhere).")
     }
   }
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Handles optimistic-concurrency conflict resolution for AMT-backed commits.

When a transaction loses a conflict and rebases onto the winning commit, the back references
of its committed file actions may need to be re-derived against the tree the winner installed.
`AMTWriterManager` now tracks the `AMTCheckpointProvider` for the last manifest commit and
refreshes it after each `ConflictChecker` rebase round, then re-stamps the committed actions'
back references against the folded tree only when a winning commit actually installed a new tree
(an OPTIMIZE checkpoint or a large inline commit). The log-commit and inline-AMT losing-commit
cases keep their back references valid without a rebuild.

The four winner/loser combinations are enumerated in `AMTWriterManager`:

- log winner / log loser -- usual conflict checking; back references stay valid.
- log winner / inline-AMT loser -- rebuild the inline tree; back references stay valid.
- new-tree winner / log loser -- rebase onto the new tree; re-derive back references.
- new-tree winner / inline-AMT loser -- re-seat and rebuild; re-derive back references.

`OptimisticTransaction` re-points the cached provider at the folded tree before re-deriving back
references (a no-op when no new tree was installed). A metrics type aggregated across commit
attempts, plus a per-rebase-pass metric, is threaded through `CommitStats`.

## How was this patch tested?

Extends the AMT conflict-resolution and back-reference suites: `AMTConflictResolutionSuite` (the
winner/loser tree combinations, including an inline-AMT losing commit), `AMTBackReferenceSuite`,
`AMTWriterManagerSuite`, and the shared `AMTCheckpointTestBase` helpers.

## Does this PR introduce _any_ user-facing changes?

No.
