### PR TITLE
[SPARK] Disable inferring partition predicates from generated columns in lossy cases

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/GeneratedColumn.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/GeneratedColumn.scala
@@ -19,17 +19,22 @@ package org.apache.spark.sql.delta
 // scalastyle:off import.ordering.noEmptyLine
 import java.util.Locale
 
+import scala.util.control.NonFatal
+
 import org.apache.spark.sql.delta.DataFrameUtils
 import org.apache.spark.sql.delta.ClassicColumnConversions._
 import org.apache.spark.sql.delta.actions.{Metadata, Protocol}
 import org.apache.spark.sql.delta.v2.interop.AbstractProtocol
 import org.apache.spark.sql.delta.files.{TahoeBatchFileIndex, TahoeFileIndex}
+import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.schema.SchemaUtils.quoteIdentifier
 import org.apache.spark.sql.delta.sources.DeltaSourceUtils.GENERATION_EXPRESSION_METADATA_KEY
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.sources.DeltaSQLConf.GeneratedColumnPartitionFilterInferenceMode
 import org.apache.spark.sql.delta.util.AnalysisHelper
 
+import org.apache.spark.internal.MDC
 import org.apache.spark.sql.{AnalysisException, Column, Dataset, SparkSession}
 import org.apache.spark.sql.catalyst.analysis.Analyzer
 import org.apache.spark.sql.catalyst.expressions._
@@ -38,12 +43,13 @@ import org.apache.spark.sql.catalyst.expressions.objects.StaticInvoke
 import org.apache.spark.sql.catalyst.optimizer.CollapseProject
 import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan, Project}
 import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
-import org.apache.spark.sql.catalyst.util.{quoteIfNeeded, CaseInsensitiveMap, CharVarcharCodegenUtils}
+import org.apache.spark.sql.catalyst.util.{quoteIfNeeded, CaseInsensitiveMap, CharVarcharCodegenUtils, DateTimeUtils}
 import org.apache.spark.sql.execution.SQLExecution
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.types.{Metadata => FieldMetadata}
+import org.apache.spark.unsafe.types.UTF8String
 /**
  * Provide utility methods to implement Generated Columns for Delta. Users can use the following
  * SQL syntax to create a table with generated columns.
@@ -502,6 +508,136 @@ object GeneratedColumn extends DeltaLogging with AnalysisHelper {
     }
   }
 
+  private case class PartitionFilterCandidate(
+      expression: Expression,
+      descriptor: OptimizablePartitionExpression,
+      sourceDataType: DataType,
+      sourcePredicate: Expression) {
+
+    val sourceLiteral: Option[Literal] = sourcePredicate match {
+      case comparison: BinaryComparison => comparison.right match {
+        case literal: Literal => Some(literal)
+        case _ => None
+      }
+      case _ => None
+    }
+
+    val operatorName: String = sourcePredicate.getClass.getSimpleName
+  }
+
+  private case class PartitionFilterCandidateSummary(
+      descriptor: String,
+      sourceDataType: String,
+      partitionDataTypes: Seq[String],
+      literalDataType: Option[String],
+      operator: String,
+      hasKnownRisk: Boolean,
+      count: Int = 1)
+
+  private case class PartitionFilterInferenceEvent(
+      candidateSignatures: Seq[PartitionFilterCandidateSummary])
+
+  /** Returns the partition-column data types referenced by a candidate expression. */
+  private def partitionDataTypes(candidate: PartitionFilterCandidate): Seq[String] = {
+    candidate.expression.references.toSeq
+      .map(_.dataType.catalogString)
+      .distinct
+      .sorted
+  }
+
+  /** Returns whether a literal is compatible with string-to-date conversion. */
+  private def stringLiteralCanCastToDate(literal: Literal): Boolean = {
+    literal.dataType match {
+      case _: StringType =>
+        DateTimeUtils.stringToDate(literal.value.asInstanceOf[UTF8String]).isDefined
+      case _ => true
+    }
+  }
+
+  /**
+   * Returns whether a candidate inference is unsafe.
+   *
+   * String `TRUNC` inference is unsafe when its generated date predicate does not preserve the
+   * source predicate. Date truncation changes range ordering, while an unparseable equality literal
+   * may fail under ANSI evaluation even though the original comparison is between strings.
+   */
+  private def isUnsafeInference(candidate: PartitionFilterCandidate): Boolean = {
+    // Match the source predicates used by `OptimizablePartitionExpression` to generate candidates.
+    val isStringTrunc = candidate.descriptor.isInstanceOf[TruncDatePartitionExpr] &&
+      candidate.sourceDataType == StringType
+    isStringTrunc && (candidate.sourcePredicate match {
+      case _: LessThan | _: LessThanOrEqual | _: GreaterThan | _: GreaterThanOrEqual => true
+      case _: EqualTo =>
+        // Date parsing accepts single-digit month and day components, so values such as
+        // `2024-4-1` normalize to `2024-04-01` and remain safe.
+        candidate.sourceLiteral.exists(value => !stringLiteralCanCastToDate(value))
+      case _ => false
+    })
+  }
+
+  /** Returns whether the candidate matches a known inference risk. */
+  private def hasKnownInferenceRisk(candidate: PartitionFilterCandidate): Boolean = {
+    isUnsafeInference(candidate)
+  }
+
+  /** Builds the telemetry signature for an inferred predicate. */
+  private def candidateSignature(
+      candidate: PartitionFilterCandidate): PartitionFilterCandidateSummary = {
+    val partitionTypes = partitionDataTypes(candidate)
+    PartitionFilterCandidateSummary(
+      descriptor = candidate.descriptor.getClass.getSimpleName,
+      sourceDataType = candidate.sourceDataType.catalogString,
+      partitionDataTypes = partitionTypes,
+      literalDataType = candidate.sourceLiteral.map(_.dataType.catalogString),
+      operator = candidate.operatorName,
+      hasKnownRisk = hasKnownInferenceRisk(candidate))
+  }
+
+  /** Records predicate signatures and their occurrence counts in a Delta event. */
+  private def recordPartitionFilterInferenceCandidates(
+      snapshot: SnapshotDescriptor,
+      candidates: Seq[PartitionFilterCandidate]): Unit = {
+    val signatureCounts = candidates.map(candidateSignature).groupBy(identity).toSeq
+      .map { case (signature, matching) =>
+        signature.copy(count = matching.size)
+      }
+      .sortBy(_.toString)
+    recordDeltaEvent(
+      snapshot,
+      "delta.generatedColumns.partitionFilterInference",
+      data = PartitionFilterInferenceEvent(signatureCounts))
+  }
+
+  /**
+   * Applies the configured rollout mode to candidate inferences.
+   *
+   * LOG_ONLY / ASSERT modes record telemetry, and ASSERT also filters candidates classified by
+   * `isUnsafeInference`.
+   */
+  private def applyPartitionFilterInferenceRollout(
+      spark: SparkSession,
+      snapshot: SnapshotDescriptor,
+      candidates: Seq[PartitionFilterCandidate]): Seq[PartitionFilterCandidate] = {
+    if (candidates.isEmpty) return candidates
+
+    val conf = spark.sessionState.conf
+    val mode = GeneratedColumnPartitionFilterInferenceMode.fromConf(conf)
+    if (mode == GeneratedColumnPartitionFilterInferenceMode.OFF) {
+      return candidates
+    }
+
+    val suppressUnsafeInference = mode == GeneratedColumnPartitionFilterInferenceMode.ASSERT
+    try {
+      recordPartitionFilterInferenceCandidates(snapshot, candidates)
+      if (suppressUnsafeInference) candidates.filterNot(isUnsafeInference) else candidates
+    } catch {
+      case NonFatal(e) =>
+        logWarning(log"Failed to apply generated-column partition-filter inference rollout: " +
+          log"${MDC(DeltaLogKeys.EXCEPTION, e)}")
+        candidates
+    }
+  }
+
   def partitionFilterOptimizationEnabled(spark: SparkSession): Boolean = {
     spark.sessionState.conf
       .getConf(DeltaSQLConf.GENERATED_COLUMN_PARTITION_FILTER_OPTIMIZATION_ENABLED)
@@ -557,37 +693,63 @@ object GeneratedColumn extends DeltaLogging with AnalysisHelper {
      */
     def toPartitionFilter(
         nameParts: Seq[String],
-        func: (OptimizablePartitionExpression) => Option[Expression]): Seq[Expression] = {
+        sourceDataType: DataType,
+        sourcePredicate: Expression,
+        func: (OptimizablePartitionExpression) => Option[Expression])
+        : Seq[PartitionFilterCandidate] = {
       optimizablePartitionExpressions.get(createFieldPath(nameParts)).toSeq.flatMap { exprs =>
-        exprs.flatMap(expr => func(expr))
+        exprs.flatMap { descriptor =>
+          func(descriptor).map { expression =>
+            PartitionFilterCandidate(
+              expression,
+              descriptor,
+              sourceDataType,
+              sourcePredicate)
+          }
+        }
       }
     }
 
-    val partitionFilters = dataFilters.flatMap { filter =>
+    val partitionFilterCandidates = dataFilters.flatMap { filter =>
       preprocess(filter) match {
-        case LessThan(ExtractBaseColumn(nameParts, _), lit: Literal) =>
-          toPartitionFilter(nameParts, _.lessThan(lit))
-        case LessThanOrEqual(ExtractBaseColumn(nameParts, _), lit: Literal) =>
-          toPartitionFilter(nameParts, _.lessThanOrEqual(lit))
-        case EqualTo(ExtractBaseColumn(nameParts, _), lit: Literal) =>
-          toPartitionFilter(nameParts, _.equalTo(lit))
-        case GreaterThan(ExtractBaseColumn(nameParts, _), lit: Literal) =>
-          toPartitionFilter(nameParts, _.greaterThan(lit))
-        case GreaterThanOrEqual(ExtractBaseColumn(nameParts, _), lit: Literal) =>
-          toPartitionFilter(nameParts, _.greaterThanOrEqual(lit))
-        case IsNull(ExtractBaseColumn(nameParts, _)) =>
-          toPartitionFilter(nameParts, _.isNull())
+        case predicate @ LessThan(ExtractBaseColumn(nameParts, sourceType), lit: Literal) =>
+          toPartitionFilter(nameParts, sourceType, predicate,
+            _.lessThan(lit))
+        case predicate @ LessThanOrEqual(
+            ExtractBaseColumn(nameParts, sourceType), lit: Literal) =>
+          toPartitionFilter(nameParts, sourceType, predicate,
+            _.lessThanOrEqual(lit))
+        case predicate @ EqualTo(ExtractBaseColumn(nameParts, sourceType), lit: Literal) =>
+          toPartitionFilter(nameParts, sourceType, predicate,
+            _.equalTo(lit))
+        case predicate @ GreaterThan(ExtractBaseColumn(nameParts, sourceType), lit: Literal) =>
+          toPartitionFilter(nameParts, sourceType, predicate,
+            _.greaterThan(lit))
+        case predicate @ GreaterThanOrEqual(
+            ExtractBaseColumn(nameParts, sourceType), lit: Literal) =>
+          toPartitionFilter(nameParts, sourceType, predicate,
+            _.greaterThanOrEqual(lit))
+        case predicate @ IsNull(ExtractBaseColumn(nameParts, sourceType)) =>
+          toPartitionFilter(nameParts, sourceType, predicate, _.isNull())
         case _ => Nil
       }
     }
 
-    val resolvedPartitionFilters = resolveReferencesForExpressions(spark, partitionFilters, delta)
+    val resolvedExpressions = resolveReferencesForExpressions(
+      spark, partitionFilterCandidates.map(_.expression), delta)
+    val resolvedCandidates = partitionFilterCandidates.zip(resolvedExpressions)
+      .map { case (candidate, resolvedExpression) =>
+        candidate.copy(expression = resolvedExpression)
+      }
+    val retainedCandidates = applyPartitionFilterInferenceRollout(
+      spark, snapshot, resolvedCandidates)
+    val resolvedPartitionFilters = retainedCandidates.map(_.expression)
 
     if (log.isDebugEnabled) {
       logDebug("User provided data filters:")
       dataFilters.foreach(f => logDebug(f.sql))
       logDebug("Auto generated partition filters:")
-      partitionFilters.foreach(f => logDebug(f.sql))
+      partitionFilterCandidates.foreach(candidate => logDebug(candidate.expression.sql))
       logDebug("Resolved generated partition filters:")
       resolvedPartitionFilters.foreach(f => logDebug(f.sql))
     }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -2173,6 +2173,20 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .booleanConf
       .createWithDefault(true)
 
+  object GeneratedColumnPartitionFilterInferenceMode extends
+    DeltaBreakingChangeEnum(GENERATED_COLUMN_PARTITION_FILTER_INFERENCE_MODE)
+
+  val GENERATED_COLUMN_PARTITION_FILTER_INFERENCE_MODE =
+    buildConf("generatedColumn.partitionFilterInference.mode")
+      .internal()
+      .doc("Controls telemetry and suppression for generated-column partition filter " +
+        "inferences. LOG_ONLY records candidate signatures while retaining all inferred " +
+        "filters. ASSERT also suppresses candidates covered by the current safety policy.")
+      .stringConf
+      .transform(_.toUpperCase(Locale.ROOT))
+      .checkValues(DeltaBreakingChangeEnum.validValues)
+      .createWithDefault(DeltaBreakingChangeEnum.LOG_ONLY)
+
   val GENERATED_COLUMN_ALLOW_NULLABLE =
     buildConf("generatedColumn.allowNullableIngest.enabled")
       .internal()

--- a/spark/src/test/scala/org/apache/spark/sql/delta/perf/OptimizeGeneratedColumnSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/perf/OptimizeGeneratedColumnSuite.scala
@@ -20,19 +20,24 @@ import java.sql.Timestamp
 import java.util.Locale
 import java.util.concurrent.{CountDownLatch, TimeUnit}
 
+import scala.collection.JavaConverters._
 import scala.util.matching.Regex
 
 // scalastyle:off import.ordering.noEmptyLine
+import com.databricks.spark.util.Log4jUsageLogger
 import org.apache.spark.sql.delta._
 
 import org.apache.spark.sql.delta.sources.DeltaSQLConf.{DELTA_COLLECT_STATS, GENERATED_COLUMN_PARTITION_FILTER_OPTIMIZATION_ENABLED}
+import org.apache.spark.sql.delta.sources.DeltaSQLConf.GENERATED_COLUMN_PARTITION_FILTER_INFERENCE_MODE
 import org.apache.spark.sql.delta.stats.PrepareDeltaScanBase
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
+import org.apache.spark.sql.delta.util.JsonUtils
 
-import org.apache.spark.sql.{DataFrame, Row}
+import org.apache.spark.sql.{AnalysisException, DataFrame, Row}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.execution.{FileSourceScanLike, QueryExecution}
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.TimestampType
 import org.apache.spark.util.ThreadUtils
 import org.apache.spark.util.Utils
@@ -52,6 +57,107 @@ class OptimizeGeneratedColumnSuite extends GeneratedColumnTest {
   protected def insertInto(path: String, df: DataFrame) = {
     df.write.format("delta").mode("append").save(path)
   }
+
+  private case class LoggedInferenceCandidate(
+      descriptor: String,
+      sourceDataType: String,
+      partitionDataTypes: Seq[String],
+      literalDataType: Option[String],
+      operator: String,
+      hasKnownRisk: Boolean,
+      count: Int = 1)
+
+
+  private def inferenceConfs(
+      mode: String,
+      timeZone: Option[String] = None): Seq[(String, String)] = {
+    Seq(
+      GENERATED_COLUMN_PARTITION_FILTER_INFERENCE_MODE.key -> mode) ++
+      timeZone.map(SQLConf.SESSION_LOCAL_TIMEZONE.key -> _)
+  }
+
+  private def trackPartitionFilterInference(
+      body: => Unit): Seq[LoggedInferenceCandidate] = {
+    Log4jUsageLogger.track(body)
+      .filter(_.tags.getOrElse("opType", "") ==
+        "delta.generatedColumns.partitionFilterInference")
+      .flatMap { record =>
+        JsonUtils.mapper.readTree(record.blob).path("candidateSignatures").elements().asScala
+          .map { candidate =>
+            LoggedInferenceCandidate(
+              descriptor = candidate.path("descriptor").asText(),
+              sourceDataType = candidate.path("sourceDataType").asText(),
+              partitionDataTypes = candidate.path("partitionDataTypes").elements().asScala
+                .map(_.asText()).toSeq,
+              literalDataType = Option(candidate.get("literalDataType")).map(_.asText()),
+              operator = candidate.path("operator").asText(),
+              hasKnownRisk = candidate.path("hasKnownRisk").asBoolean(),
+              count = candidate.path("count").asInt())
+          }
+      }
+      .distinct
+  }
+
+  private def getFiltersAndInferenceCandidates(
+      relation: DataFrame): (Seq[Expression], Seq[LoggedInferenceCandidate]) = {
+    var filters = Seq.empty[Expression]
+    val candidates = trackPartitionFilterInference {
+      filters = getPushedPartitionFilters(relation.queryExecution)
+    }
+    filters -> candidates
+  }
+
+  private def assertInferenceCandidates(
+      actual: Seq[LoggedInferenceCandidate],
+      expected: LoggedInferenceCandidate*): Unit = {
+    assert(actual.size === expected.size)
+    assert(actual.toSet === expected.toSet)
+  }
+
+  private def comparisonCandidate(
+      descriptor: String,
+      sourceDataType: String,
+      partitionDataType: String,
+      operator: String,
+      hasKnownRisk: Boolean,
+      count: Int = 1): LoggedInferenceCandidate = {
+    LoggedInferenceCandidate(
+      descriptor,
+      sourceDataType,
+      Seq(partitionDataType),
+      Some(sourceDataType),
+      operator,
+      hasKnownRisk,
+      count)
+  }
+
+  private def hasFilterFor(filters: Seq[Expression], column: String): Boolean = {
+    filters.exists(_.references.exists(_.name == column))
+  }
+
+  private val unsafeTruncPartitionColumns = Seq("date", "dateCopy")
+
+  private def withUnsafeStringTruncTable(testCode: String => Unit): Unit = {
+    withTableName("unsafe_string_trunc_partition_filter") { table =>
+      createTable(
+        table,
+        None,
+        "eventDateStr STRING, date DATE, dateCopy DATE, prefix STRING",
+        Map(
+          "date" -> "trunc(eventDateStr, 'quarter')",
+          "dateCopy" -> "trunc(eventDateStr, 'quarter')",
+          "prefix" -> "substring(eventDateStr, 1, 4)"),
+        unsafeTruncPartitionColumns :+ "prefix")
+      withSQLConf(
+          DELTA_COLLECT_STATS.key -> "false",
+          SQLConf.ANSI_ENABLED.key -> "false") {
+        sql(s"""INSERT INTO $table (eventDateStr) VALUES
+          |('10000-01-01'), ('2022-04-01'), ('not-a-date')""".stripMargin)
+      }
+      testCode(table)
+    }
+  }
+
 
   /**
    * Verify we can recognize an `OptimizablePartitionExpression` and generate corresponding
@@ -1175,6 +1281,244 @@ class OptimizeGeneratedColumnSuite extends GeneratedColumnTest {
         Seq("(date IS NULL)")
     )
   )
+
+  test("ASSERT retains string TRUNC inference for valid equality literals") {
+    withUnsafeStringTruncTable { table =>
+      withSQLConf(inferenceConfs("ASSERT"): _*) {
+        Seq(
+          "eventDateStr = '2022-04-01'",
+          "'2022-04-01' = eventDateStr").foreach { predicate =>
+          val filters = getPushedPartitionFilters(
+            sql(s"SELECT eventDateStr FROM $table WHERE $predicate").queryExecution)
+          (unsafeTruncPartitionColumns :+ "prefix").foreach { column =>
+            assert(hasFilterFor(filters, column),
+              s"Expected inferred equality filter for $predicate: ${filters.map(_.sql)}")
+          }
+        }
+
+        checkAnswer(
+          sql(s"SELECT eventDateStr FROM $table WHERE eventDateStr = '2022-04-01'"),
+          Row("2022-04-01"))
+      }
+    }
+  }
+
+  test("ASSERT does not over-prune non-zero-padded string equality literals") {
+    withUnsafeStringTruncTable { table =>
+      val value = "2026-4-1"
+      sql(s"INSERT INTO $table (eventDateStr) VALUES ('$value')")
+
+      Seq(false, true).foreach { ansiEnabled =>
+        val confs = inferenceConfs("ASSERT") :+
+          (SQLConf.ANSI_ENABLED.key -> ansiEnabled.toString)
+        withSQLConf(confs: _*) {
+          val predicate = s"eventDateStr = '$value'"
+          val relation = sql(s"SELECT eventDateStr FROM $table WHERE $predicate")
+          val filters = getPushedPartitionFilters(relation.queryExecution)
+          unsafeTruncPartitionColumns.foreach { column =>
+            assert(hasFilterFor(filters, column),
+              s"Expected inferred equality filter for $predicate: ${filters.map(_.sql)}")
+          }
+          checkAnswer(relation, Row(value))
+        }
+      }
+    }
+  }
+
+  test("ASSERT suppresses unsafe string TRUNC inference") {
+    withUnsafeStringTruncTable { table =>
+      val rangePredicates = Seq(
+        "eventDateStr < '2022-04-01'",
+        "eventDateStr <= '2022-04-01'",
+        "eventDateStr > '2022-04-01'",
+        "eventDateStr >= '2022-04-01'",
+        "'2022-04-01' > eventDateStr",
+        "'2022-04-01' >= eventDateStr",
+        "'2022-04-01' < eventDateStr",
+        "'2022-04-01' <= eventDateStr")
+
+      withSQLConf(inferenceConfs("ASSERT"): _*) {
+        rangePredicates.foreach { predicate =>
+          val filters = getPushedPartitionFilters(
+            sql(s"SELECT eventDateStr FROM $table WHERE $predicate").queryExecution)
+          unsafeTruncPartitionColumns.foreach { column =>
+            assert(!hasFilterFor(filters, column),
+              s"Unexpected inferred filter for $predicate: ${filters.map(_.sql)}")
+          }
+          assert(hasFilterFor(filters, "prefix"),
+            s"Expected safe substring filter for $predicate: ${filters.map(_.sql)}")
+        }
+
+        val nullRelation = sql(s"SELECT * FROM $table WHERE eventDateStr IS NULL")
+        val (nullFilters, nullCandidates) = getFiltersAndInferenceCandidates(nullRelation)
+        (unsafeTruncPartitionColumns :+ "prefix").foreach { column =>
+          assert(hasFilterFor(nullFilters, column))
+        }
+        assertInferenceCandidates(
+          nullCandidates,
+          LoggedInferenceCandidate(
+            "SubstringPartitionExpr", "string", Seq("string"), None, "IsNull", false),
+          LoggedInferenceCandidate(
+            "TruncDatePartitionExpr", "string", Seq("date"), None, "IsNull", false, 2))
+
+        checkAnswer(
+          sql(s"SELECT eventDateStr FROM $table WHERE eventDateStr < '2022-04-01'"),
+          Row("10000-01-01"))
+
+        withSQLConf(SQLConf.ANSI_ENABLED.key -> "true") {
+          val relation = sql(s"SELECT * FROM $table WHERE eventDateStr = 'not-a-date'")
+          val (filters, candidates) = getFiltersAndInferenceCandidates(relation)
+          unsafeTruncPartitionColumns.foreach(column => assert(!hasFilterFor(filters, column)))
+          assert(hasFilterFor(filters, "prefix"))
+          assertInferenceCandidates(
+            candidates,
+            comparisonCandidate(
+              "SubstringPartitionExpr", "string", "string", "EqualTo", false),
+            comparisonCandidate(
+              "TruncDatePartitionExpr", "string", "date", "EqualTo", true, 2))
+          checkAnswer(relation.select("eventDateStr"), Row("not-a-date"))
+        }
+      }
+    }
+  }
+
+  test("typed string predicates only infer filters after string coercion") {
+    withUnsafeStringTruncTable { table =>
+      withSQLConf(inferenceConfs("ASSERT"): _*) {
+        Seq(
+          "eventDateStr < 20",
+          "eventDateStr < DATE '2022-04-01'",
+          "eventDateStr < TIMESTAMP '2022-04-01 00:00:00'").foreach { predicate =>
+          val relation = sql(s"SELECT eventDateStr FROM $table WHERE $predicate")
+          val (filters, candidates) = getFiltersAndInferenceCandidates(relation)
+          assert(filters.isEmpty,
+            s"Unexpected inferred filter for $predicate: ${filters.map(_.sql)}")
+          assert(candidates.isEmpty)
+        }
+
+        withSQLConf(
+            SQLConf.ANSI_ENABLED.key -> "false",
+            SQLConf.LEGACY_CAST_DATETIME_TO_STRING.key -> "true") {
+          Seq(
+            "eventDateStr < DATE '2022-04-01'",
+            "eventDateStr < TIMESTAMP '2022-04-01 00:00:00'").foreach { predicate =>
+            val relation = sql(s"SELECT eventDateStr FROM $table WHERE $predicate")
+            val (filters, candidates) = getFiltersAndInferenceCandidates(relation)
+            unsafeTruncPartitionColumns.foreach { column =>
+              assert(!hasFilterFor(filters, column),
+                s"Unexpected inferred filter for $predicate: ${filters.map(_.sql)}")
+            }
+            assert(hasFilterFor(filters, "prefix"),
+              s"Expected safe substring filter for $predicate: ${filters.map(_.sql)}")
+            assertInferenceCandidates(
+              candidates,
+              comparisonCandidate(
+                "SubstringPartitionExpr", "string", "string", "LessThan", false),
+              comparisonCandidate(
+                "TruncDatePartitionExpr", "string", "date", "LessThan", true, 2))
+          }
+        }
+      }
+    }
+  }
+
+  test("partition filter inference flags behaves correctly") {
+    withUnsafeStringTruncTable { table =>
+      Seq("OFF", "LOG_ONLY", "ASSERT").foreach { mode =>
+        withSQLConf(inferenceConfs(mode): _*) {
+          val relation = sql(s"SELECT * FROM $table WHERE eventDateStr < '2022-04-01'")
+          val (filters, candidates) = getFiltersAndInferenceCandidates(relation)
+
+          if (mode == "ASSERT") {
+            unsafeTruncPartitionColumns.foreach(column => assert(!hasFilterFor(filters, column)))
+          } else {
+            unsafeTruncPartitionColumns.foreach(column => assert(hasFilterFor(filters, column)))
+          }
+          assert(hasFilterFor(filters, "prefix"))
+
+          if (mode == "OFF") {
+            assert(candidates.isEmpty)
+          } else {
+            assertInferenceCandidates(
+              candidates,
+              comparisonCandidate(
+                "SubstringPartitionExpr", "string", "string", "LessThan", false),
+              comparisonCandidate(
+                "TruncDatePartitionExpr", "string", "date", "LessThan", true, 2))
+          }
+        }
+      }
+    }
+  }
+
+  test("ASSERT retains safe temporal partition filter inference") {
+    Seq(
+      ("eventDate DATE", "date DATE", "trunc(eventDate, 'month')",
+        "eventDate", "date", "date", "TruncDatePartitionExpr"),
+      ("eventDate DATE", "year INT", "year(eventDate)",
+        "eventDate", "year", "int", "YearPartitionExpr"),
+      ("eventDate DATE", "formatted STRING", "date_format(eventDate, 'yyyy-MM')",
+        "eventDate", "formatted", "string", "DateFormatPartitionExpr")
+    ).foreach {
+      case (sourceSchema, partitionSchema, generationExpression, sourceColumn,
+          partitionColumn, partitionDataType, descriptor) =>
+      withTableName("temporal_trunc_partition_filter") { table =>
+        createTable(
+          table,
+          None,
+          s"$sourceSchema, $partitionSchema",
+          Map(partitionColumn -> generationExpression),
+          Seq(partitionColumn))
+        withSQLConf(inferenceConfs("ASSERT"): _*) {
+          val relation = sql(s"SELECT * FROM $table WHERE $sourceColumn < '2022-04-01'")
+          val (filters, candidates) = getFiltersAndInferenceCandidates(relation)
+          assert(hasFilterFor(filters, partitionColumn))
+          assertInferenceCandidates(
+            candidates,
+            comparisonCandidate(
+              descriptor, "date", partitionDataType, "LessThan", false))
+        }
+      }
+    }
+  }
+
+  test("unsupported conversions do not produce partition filter inference") {
+    Seq(
+      ("value STRING", "intPart INT", "CAST(value AS INT)", "value < '20'"),
+      ("value STRING", "datePart DATE", "CAST(value AS DATE)",
+        "value < '2022-04-01'"),
+      ("value STRING", "timestampPart TIMESTAMP", "CAST(value AS TIMESTAMP)",
+        "value < '2022-04-01'"),
+      ("value STRING", "timestampPart TIMESTAMP", "DATE_TRUNC('YEAR', value)",
+        "value < '2022-04-01'"),
+      ("value INT", "doublePart DOUBLE", "CAST(value AS DOUBLE)", "value < 20"),
+      ("value BIGINT", "doublePart DOUBLE", "CAST(value AS DOUBLE)",
+        "value < CAST(20 AS BIGINT)"),
+      ("value DECIMAL(20, 0)", "doublePart DOUBLE", "CAST(value AS DOUBLE)",
+        "value < CAST(20 AS DECIMAL(20, 0))"))
+      .zipWithIndex
+      .foreach { case ((sourceSchema, partitionSchema, generationExpression, predicate), index) =>
+        withTableName(s"unsupported_conversion_partition_filter_$index") { table =>
+          val partitionColumn = partitionSchema.takeWhile(_ != ' ')
+          createTable(
+            table,
+            None,
+            s"$sourceSchema, $partitionSchema",
+            Map(partitionColumn -> generationExpression),
+            Seq(partitionColumn))
+
+          val metadata = DeltaLog.forTable(spark, TableIdentifier(table)).update().metadata
+          assert(!metadata.optimizablePartitionExpressions.contains("value"))
+          withSQLConf(inferenceConfs("LOG_ONLY"): _*) {
+            val relation = sql(s"SELECT * FROM $table WHERE $predicate")
+            val (filters, candidates) = getFiltersAndInferenceCandidates(relation)
+            assert(filters.isEmpty)
+            assert(candidates.isEmpty)
+          }
+        }
+      }
+  }
+
 
   test("five digits year in a year month day partition column") {
     withTempDir { tempDir =>


### PR DESCRIPTION


<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Spark can infer partition filters from predicates on source columns used by generated partition columns. For example:

event_date DATE GENERATED ALWAYS AS (TRUNC(event_date_str, 'quarter'))
For a predicate such as: event_date_str < '2022-04-01'

The source predicate uses string ordering, while the inferred partition predicate uses date ordering. These semantics differ for values such as '10000-01-01', which can cause Delta to incorrectly skip matching data.

This PR:

- Tracks the datatype and expression metadata for inferred partition-filter candidates.
- Adds aggregated, literal-free telemetry through delta.generatedColumns.partitionFilterInference.
- Adds an internal OFF/LOG_ONLY/ASSERT flag to control the inference blocking behavior.
In ASSERT mode, it suppresses the proven-unsafe TRUNC(STRING) cases:
- Range comparisons.
- Equality comparisons whose string literal cannot be parsed as a date.
- Preserves valid string equality, IS NULL, substring inference, and other existing inference types.

OFF emits no telemetry. LOG_ONLY emits telemetry without changing inference behavior. ASSERT emits telemetry and suppresses the proven-unsafe candidates.
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
New UTs
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No