### PR TITLE
[Spark] Foundation for Concurrent Identity Columns: metadata key, error classes

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -771,6 +771,54 @@
     },
     "sqlState" : "2D521"
   },
+  "DELTA_CONCURRENT_IDENTITY_COLUMN_CONVERSION_INCOMPLETE" : {
+    "message" : [
+      "Identity column <columnName> on table <tableId> is missing its sequence service pointer. Re-run the feature opt-in conversion to repair it."
+    ],
+    "sqlState" : "XXKDS"
+  },
+  "DELTA_CONCURRENT_IDENTITY_COLUMN_DISABLED" : {
+    "message" : [
+      "Cannot <operation> table <tableId>: concurrent identity columns are disabled."
+    ],
+    "sqlState" : "0A000"
+  },
+  "DELTA_CONCURRENT_IDENTITY_COLUMN_EMPTY_RESERVE_RANGE" : {
+    "message" : [
+      "Concurrent identity column reservation returned an empty range for sequence <sequenceId> on table <tableId>."
+    ],
+    "sqlState" : "XXKDS"
+  },
+  "DELTA_CONCURRENT_IDENTITY_COLUMN_METADATA_MISMATCH" : {
+    "message" : [
+      "Identity column <property> mismatch: service value <grantedStep> (sequence <sequenceId>) vs schema value <columnStep>."
+    ],
+    "sqlState" : "XXKDS"
+  },
+  "DELTA_CONCURRENT_IDENTITY_COLUMN_SEQUENCE_NOT_FOUND" : {
+    "message" : [
+      "Identity column <columnName> on table <tableId> references sequence <sequenceId>, which no longer exists. Run SYNC IDENTITY to repair the column."
+    ],
+    "sqlState" : "XXKDS"
+  },
+  "DELTA_CONCURRENT_IDENTITY_COLUMN_SERVICE_TIMEOUT" : {
+    "message" : [
+      "The identity sequence operation for table <tableId> timed out after <timeoutMs> ms."
+    ],
+    "sqlState" : "XXKDS"
+  },
+  "DELTA_CONCURRENT_IDENTITY_COLUMN_TOO_MANY_COLUMNS" : {
+    "message" : [
+      "Table <tableId> would have <numColumns> concurrent identity columns, which exceeds the maximum of <maxColumns>. Reduce the number of identity columns."
+    ],
+    "sqlState" : "54011"
+  },
+  "DELTA_CONCURRENT_IDENTITY_COLUMN_USING_WRONG_GENERATOR" : {
+    "message" : [
+      "Write failed due to an identity column version mismatch for column(s) <columnNames> on table <tableId>."
+    ],
+    "sqlState" : "XXKDS"
+  },
   "DELTA_CONCURRENT_TRANSACTION" : {
     "message" : [
       "ConcurrentTransactionException: This error occurs when multiple streaming queries are using the same checkpoint to write into this table. Did you run multiple instances of the same streaming query at the same time?<conflictingCommit>\nRefer to <docLink> for more details."

--- a/spark/src/main/scala/org/apache/spark/sql/delta/ConcurrentIdentityColumnErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ConcurrentIdentityColumnErrors.scala
@@ -1,0 +1,147 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+/**
+ * Thrown by the Concurrent Identity Column (CIC) service-backed reservation guards when a
+ * write would emit identity values outside a reserved range. It is a [[DeltaThrowable]] carrying
+ * one of the `DELTA_CONCURRENT_IDENTITY_COLUMN_*` error classes, so driver call sites and tests
+ * can match on the type or the error class instead of message prose.
+ *
+ * The executor-side generator guard throws this across the Spark task boundary, so it reaches the
+ * driver wrapped in a `SparkException`; tests exercising that path match the error-class token on
+ * the cause chain rather than the type.
+ */
+class ConcurrentIdentityColumnReservationException(
+    errorClass: String,
+    messageParameters: Array[String] = Array.empty)
+  extends IllegalStateException(
+    DeltaThrowableHelper.getMessage(errorClass, messageParameters))
+    with DeltaThrowable {
+  override def getErrorClass: String = errorClass
+
+  override def getMessageParameters: java.util.Map[String, String] =
+    DeltaThrowableHelper.getMessageParameters(errorClass, errorSubClass = null, messageParameters)
+}
+
+/**
+ * Builders for the CIC reservation-guard errors. The message text lives in the Delta
+ * error-classes JSON under the `DELTA_CONCURRENT_IDENTITY_COLUMN_*` classes; each
+ * builder only names its error class and supplies the parameters, in the order the placeholders
+ * appear in the template.
+ */
+object ConcurrentIdentityColumnErrors {
+  // Builders are ordered to match the alphabetical class order in the Delta error-classes JSON.
+
+  /** The column is missing its sequence service pointer; re-run the feature opt-in conversion. */
+  def conversionIncomplete(
+      columnName: String,
+      tableId: String): ConcurrentIdentityColumnReservationException =
+    new ConcurrentIdentityColumnReservationException(
+      "DELTA_CONCURRENT_IDENTITY_COLUMN_CONVERSION_INCOMPLETE",
+      Array(columnName, tableId))
+
+  /**
+   * The CIC feature is disabled, blocking the attempted operation. Covers identity-generating
+   * writes to service-backed tables, CREATE TABLE with CIC, the feature opt-in conversion and
+   * SYNC IDENTITY repair.
+   */
+  def concurrentIdentityColumnsDisabled(
+      operation: String,
+      tableId: String): ConcurrentIdentityColumnReservationException =
+    new ConcurrentIdentityColumnReservationException(
+      "DELTA_CONCURRENT_IDENTITY_COLUMN_DISABLED",
+      Array(operation, tableId))
+
+  /**
+   * A CIC pull granted an empty range. The driver should never return zero values; this guards
+   * the executor generator against a no-progress retry spin.
+   */
+  def emptyReserveRange(
+      sequenceId: String,
+      tableId: String): ConcurrentIdentityColumnReservationException =
+    new ConcurrentIdentityColumnReservationException(
+      "DELTA_CONCURRENT_IDENTITY_COLUMN_EMPTY_RESERVE_RANGE",
+      Array(sequenceId, tableId))
+
+  /**
+   * Service-returned metadata disagrees with the schema-declared metadata. Generalized from the
+   * old STEP_MISMATCH so the same class covers start/other metadata drift later: the `property`
+   * param names which one drifted (value "step" today).
+   */
+  def metadataMismatch(
+      grantedStep: Long,
+      sequenceId: String,
+      columnStep: Long): ConcurrentIdentityColumnReservationException =
+    new ConcurrentIdentityColumnReservationException(
+      "DELTA_CONCURRENT_IDENTITY_COLUMN_METADATA_MISMATCH",
+      Array("step", grantedStep.toString, sequenceId, columnStep.toString))
+
+  /**
+   * A schema-stamped sequenceId is gone from the service. Not recoverable on the write path:
+   * reseeding a fresh counter could hand out values colliding with already-written rows, so
+   * the table needs deliberate repair.
+   */
+  def sequenceNotFound(
+      sequenceId: String,
+      columnName: String,
+      tableId: String): ConcurrentIdentityColumnReservationException =
+    new ConcurrentIdentityColumnReservationException(
+      "DELTA_CONCURRENT_IDENTITY_COLUMN_SEQUENCE_NOT_FOUND",
+      Array(columnName, tableId, sequenceId))
+
+  /**
+   * A single call to the UC identity-sequence service exceeded the bounded wait
+   * (`spark.databricks.delta.identityColumn.concurrent.uc.timeoutMs`) before it returned. The
+   * service is likely temporarily unavailable (e.g. disabled), which the managed-catalog client
+   * would otherwise retry for minutes; we fail fast instead so the caller is not blocked.
+   */
+  def serviceTimeout(
+      tableId: String,
+      timeoutMs: Long): ConcurrentIdentityColumnReservationException =
+    new ConcurrentIdentityColumnReservationException(
+      "DELTA_CONCURRENT_IDENTITY_COLUMN_SERVICE_TIMEOUT",
+      Array(tableId, timeoutMs.toString))
+
+  /**
+   * A CIC table would carry more service-backed identity columns than the configured maximum
+   * (`spark.databricks.delta.identityColumn.concurrent.maxColumnsPerTable`). Thrown by the
+   * CREATE/REPLACE stamping hook and the feature opt-in conversion before any sequence is minted.
+   */
+  def tooManyColumns(
+      tableId: String,
+      numColumns: Int,
+      maxColumns: Int): ConcurrentIdentityColumnReservationException =
+    new ConcurrentIdentityColumnReservationException(
+      "DELTA_CONCURRENT_IDENTITY_COLUMN_TOO_MANY_COLUMNS",
+      Array(tableId, numColumns.toString, maxColumns.toString))
+
+  /**
+   * Defends against an unexpected write path that reaches the legacy high-water-mark
+   * generator on a service-backed (sequence-stamped) table. Every wired write path
+   * (INSERT, all three MERGE variants) reserves from the service before writing, so this
+   * is a backstop: if a future or otherwise-unhandled path skipped the reservation, its
+   * legacy generator would silently emit duplicate identity values, so we abort before
+   * any data is written rather than corrupt the table.
+   */
+  def usingWrongGenerator(
+      columnNames: Seq[String],
+      tableId: String): ConcurrentIdentityColumnReservationException =
+    new ConcurrentIdentityColumnReservationException(
+      "DELTA_CONCURRENT_IDENTITY_COLUMN_USING_WRONG_GENERATOR",
+      Array(columnNames.mkString(", "), tableId))
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/ConcurrentIdentityColumnSchema.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ConcurrentIdentityColumnSchema.scala
@@ -1,0 +1,132 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.delta.actions.Metadata
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import io.delta.storage.commit.uccommitcoordinator.UCCommitCoordinatorClient
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.types.{MetadataBuilder, StructField, StructType}
+
+/**
+ * Schema-metadata for Concurrent Identity Columns (CIC), persisted on identity column
+ * StructFields.
+ *
+ * A CIC column carries a single extra key, the sequence ID
+ * `delta.identity.concurrent.sequenceId`, alongside the standard
+ * `delta.identity.{start, step, allowExplicitInsert}` keys. Those standard keys remain the
+ * source of truth for start/step (read via [[IdentityColumn.getIdentityInfo]]); we do not
+ * duplicate them here. The key name is the cross-system contract with Unity Catalog: UC's
+ * registration hook extracts this exact key from the schema it processes, so it must match
+ * the catalog side verbatim.
+ *
+ * Presence of [[SEQUENCE_ID]] is the canonical signal that a column is backed by a
+ * service-allocated sequence. The reservation path reads it from here.
+ */
+object ConcurrentIdentityColumnSchema {
+  val SEQUENCE_ID = "delta.identity.concurrent.sequenceId"
+
+  /**
+   * The table id under which this table's sequences live in the sequence service. For a
+   * catalog-owned (UC coordinated-commits) table this is the UC table id, stamped into the
+   * table configuration at creation ([[UCCommitCoordinatorClient.UC_TABLE_ID_KEY]]).
+   * The `metadata.id` fallback below is test-only, as CIC requires a table to be managed.
+   */
+  def sequenceServiceTableId(metadata: Metadata): String =
+    metadata.configuration.getOrElse(UCCommitCoordinatorClient.UC_TABLE_ID_KEY, metadata.id)
+
+  /**
+   * Rejects a CIC table with more identity columns than
+   * [[DeltaSQLConf.CONCURRENT_IDENTITY_COLUMN_MAX_COLUMNS_PER_TABLE]]. Called by both producers of
+   * service-backed columns (the CREATE/REPLACE stamping hook and the feature opt-in conversion)
+   * before any sequence is minted, so the bound holds regardless of which path adds the columns.
+   */
+  def checkColumnLimit(
+      sparkSession: SparkSession,
+      metadata: Metadata,
+      identityColumnCount: Int): Unit = {
+    val maxCicColumnsPerTable =
+      sparkSession.conf.get(DeltaSQLConf.CONCURRENT_IDENTITY_COLUMN_MAX_COLUMNS_PER_TABLE)
+    if (identityColumnCount > maxCicColumnsPerTable) {
+      throw ConcurrentIdentityColumnErrors.tooManyColumns(
+        metadata.id, identityColumnCount, maxCicColumnsPerTable)
+    }
+  }
+
+  /** True iff this column carries the sequence ID. */
+  def hasConcurrentSequenceMetadata(field: StructField): Boolean =
+    field.metadata.contains(SEQUENCE_ID)
+
+  /** True iff any column in `schema` carries the sequence ID. */
+  def hasConcurrentSequenceMetadata(schema: StructType): Boolean =
+    schema.exists(hasConcurrentSequenceMetadata)
+
+  /** The driver-generated sequence id for this column, if present. */
+  def getSequenceId(field: StructField): Option[String] =
+    if (hasConcurrentSequenceMetadata(field)) Some(field.metadata.getString(SEQUENCE_ID)) else None
+
+  /**
+   * Names of the columns in `schema` that carry the sequence ID. Non-empty only
+   * on a table stamped with sequence IDs; empty on a stock-identity table. Used by
+   * the reservation downgrade guard to refuse a flag-off write that would otherwise pick the
+   * wrong backend.
+   */
+  def stampedSequenceColumnNames(schema: StructType): Seq[String] =
+    schema.filter(hasConcurrentSequenceMetadata).map(_.name)
+
+  /**
+   * Returns a copy of `metadata` with the sequence ID stripped from every
+   * identity column. Use this before invoking the create-table stamping hook on a path
+   * where the input schema may carry over a stale sequence ID (e.g. REPLACE TABLE), so the
+   * hook's idempotency short-circuit cannot reuse a sequenceId minted for a different
+   * table id. SYNC's downgrade path also uses it to drop a dangling sequence ID.
+   */
+  def stripConcurrentSequenceMetadata(metadata: Metadata): Metadata = {
+    val schema = metadata.schema
+    val stripped = schema.map { field =>
+      if (!hasConcurrentSequenceMetadata(field)) {
+        field
+      } else {
+        withoutConcurrentSequenceMetadata(field)
+      }
+    }
+    val anyStripped = stripped.zip(schema).exists { case (out, in) => out ne in }
+    if (!anyStripped) {
+      metadata
+    } else {
+      metadata.copy(schemaString = schema.copy(fields = stripped.toArray).json)
+    }
+  }
+
+  /** Returns a copy of `field` with the sequence ID removed. */
+  def withoutConcurrentSequenceMetadata(field: StructField): StructField =
+    field.copy(metadata = new MetadataBuilder()
+      .withMetadata(field.metadata)
+      .remove(SEQUENCE_ID)
+      .build())
+
+  /**
+   * Returns a copy of `field` with the sequence ID attached. Existing
+   * metadata is preserved, including the standard `delta.identity.*` keys.
+   */
+  def withConcurrentSequenceMetadata(field: StructField, sequenceId: String): StructField =
+    field.copy(metadata = new MetadataBuilder()
+      .withMetadata(field.metadata)
+      .putString(SEQUENCE_ID, sequenceId)
+      .build())
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -3432,6 +3432,17 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .booleanConf
       .createWithDefault(false)
 
+  val CONCURRENT_IDENTITY_COLUMN_MAX_COLUMNS_PER_TABLE =
+    buildConf("identityColumn.concurrent.maxColumnsPerTable")
+      .internal()
+      .doc("Maximum number of concurrent (service-backed) identity columns allowed on a single " +
+        "table. Enforced when the table opts into the feature: CREATE/REPLACE with the CIC " +
+        "feature and the feature opt-in conversion reject a table whose identity-column count " +
+        "exceeds this, before any sequence is minted.")
+      .intConf
+      .checkValue(_ > 0, "maxColumnsPerTable must be positive")
+      .createWithDefault(50)
+
   //////////////////
   // GeoSpatial
   //////////////////

--- a/spark/src/test/scala/org/apache/spark/sql/delta/ConcurrentIdentityColumnErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/ConcurrentIdentityColumnErrorsSuite.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.SparkFunSuite
+
+/**
+ * Unit tests for the internal CIC reservation-guard error builders in
+ * [[ConcurrentIdentityColumnErrors]]. EMPTY_RESERVE_RANGE, METADATA_MISMATCH, and
+ * USING_WRONG_GENERATOR are invariants/backstops that a wired write path is not expected to hit,
+ * so they are verified directly on the builder output with `checkError` (error class, SQLSTATE,
+ * and parameters , never the message prose). The user-triggerable variants
+ * (CONVERSION_INCOMPLETE, DISABLED, SEQUENCE_NOT_FOUND) are exercised through their real paths in
+ * ConcurrentIdentityColumnServiceBackendSuite and ConcurrentIdentityColumnConversionSuite.
+ */
+class ConcurrentIdentityColumnErrorsSuite extends SparkFunSuite {
+
+  test("emptyReserveRange reports EMPTY_RESERVE_RANGE with its parameters") {
+    checkError(
+      ConcurrentIdentityColumnErrors.emptyReserveRange(sequenceId = "seq-1", tableId = "tbl-1"),
+      condition = "DELTA_CONCURRENT_IDENTITY_COLUMN_EMPTY_RESERVE_RANGE",
+      sqlState = "XXKDS",
+      parameters = Map("sequenceId" -> "seq-1", "tableId" -> "tbl-1"))
+  }
+
+  test("metadataMismatch reports METADATA_MISMATCH with its parameters") {
+    checkError(
+      ConcurrentIdentityColumnErrors.metadataMismatch(
+        grantedStep = 7L, sequenceId = "seq-1", columnStep = 3L),
+      condition = "DELTA_CONCURRENT_IDENTITY_COLUMN_METADATA_MISMATCH",
+      sqlState = "XXKDS",
+      parameters = Map(
+        "property" -> "step",
+        "grantedStep" -> "7",
+        "sequenceId" -> "seq-1",
+        "columnStep" -> "3"))
+  }
+
+  test("usingWrongGenerator reports USING_WRONG_GENERATOR with its parameters") {
+    checkError(
+      ConcurrentIdentityColumnErrors.usingWrongGenerator(
+        columnNames = Seq("c1", "c2"), tableId = "tbl-1"),
+      condition = "DELTA_CONCURRENT_IDENTITY_COLUMN_USING_WRONG_GENERATOR",
+      sqlState = "XXKDS",
+      parameters = Map("columnNames" -> "c1, c2", "tableId" -> "tbl-1"))
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
This PR is the first out of a stack of six PRs in total. 
The combined stack adds support for the Concurrent Identity Column (CIC) feature following the RFC [here](https://github.com/delta-io/delta/pull/7272). 
The TLDR for this RFC/feature: It allows for two concurrent 'inserters' to both succeed by adding an identity sequence service that hands out disjoint ranges of id values. This way the two writers do not conflict and can both commit.

**_Stack overview:_** 
1. Foundation <- this PR
    (#7618)
2. Service abstraction + In-Memory one
    (#7619)
3. Transport and buffering for the service requests 
    (#7620)
4. Table feature and the insert path
    (#7621)
5. DDL integration 
    (#7622)
6. Merge support
    (#7623)


This PR introduces no behaviour changes, just scaffolding. It adds:
  - `ConcurrentIdentityColumnSchema`: the `delta.identity.concurrent.sequenceId` column-metadata key that marks a column as a CIC.
  - `ConcurrentIdentityColumnErrors` + 8 DELTA_CONCURRENT_IDENTITY_COLUMN_* error classes (disabled, too-many-columns, sequence-not-found, metadata-mismatch, empty-reserve-range, service-timeout, conversion-incomplete, using-wrong-generator).
  - Config `spark.databricks.delta.identityColumn.concurrent.maxColumnsPerTable`

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
The ConcurrentIdentityColumnErrorsSuite adds three tests for the `EMPTY_RESERVE_RANGE`, `METADATA_MISMATCH`, and `USING_WRONG_GENERATOR` errors. The tests are only added for these errors because these errors can not occur 'naturally' in the code and are therefore tested this way. 


## Does this PR introduce _any_ user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No