### PR TITLE
[Spark] Skip transient IR nodes in generated column validation

### DIFF
--- a/spark/src/main/scala-shims/spark-4.0-4.1/AllowedExpressionsShim.scala
+++ b/spark/src/main/scala-shims/spark-4.0-4.1/AllowedExpressionsShim.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.catalyst.expressions
+
+/**
+ * Version-specific transient IR allow-listed for user-provided expressions
+ * (see `AllowedUserProvidedExpressions`). Empty on Spark 4.0 / 4.1: `TypedNullLiteral` (used by
+ * NULLIF rewrites) only exists from Spark 4.2.
+ */
+object AllowedExpressionsShim {
+  val transientExpressions: Set[Class[_]] = Set.empty[Class[_]]
+}

--- a/spark/src/main/scala-shims/spark-4.2/AllowedExpressionsShim.scala
+++ b/spark/src/main/scala-shims/spark-4.2/AllowedExpressionsShim.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.catalyst.expressions
+
+/**
+ * Version-specific transient IR allow-listed for user-provided expressions
+ * (see `AllowedUserProvidedExpressions`). Since Spark 4.2 (SPARK-56840) NULLIF rewrites use
+ * `TypedNullLiteral` for the null branch. It is package-private to
+ * `org.apache.spark.sql.catalyst.expressions`, hence this shim lives in that package.
+ */
+object AllowedExpressionsShim {
+  val transientExpressions: Set[Class[_]] = Set(classOf[TypedNullLiteral])
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/AllowedUserProvidedExpressions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/AllowedUserProvidedExpressions.scala
@@ -335,8 +335,15 @@ object AllowedUserProvidedExpressions {
 
     // Special expressions that are not built-in expressions.
     expression[AttributeReference]("col"),
-    expression[Literal]("lit")
-  )
+    expression[Literal]("lit"),
+
+    // Transient "common expression" IR from Spark 4.0+ function rewrites (e.g. NULLIF analyzes to
+    // `With(If(.., <null>, ..), CommonExpressionDef(..))`). Stripped before execution and carry no
+    // user logic of their own; their real children are still validated by the walk.
+    classOf[With],
+    classOf[CommonExpressionDef],
+    classOf[CommonExpressionRef]
+  ) ++ AllowedExpressionsShim.transientExpressions
 
   val checkConstraintExpressions: Set[Class[_]] = Set(
     expression[Contains]("contains"),

--- a/spark/src/main/scala/org/apache/spark/sql/delta/GeneratedColumn.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/GeneratedColumn.scala
@@ -282,6 +282,11 @@ object GeneratedColumn extends DeltaLogging with AnalysisHelper {
         throw DeltaErrors.generatedColumnsNonDeterministicExpression(expr)
       case expr if expr.isInstanceOf[AggregateExpression] =>
         throw DeltaErrors.generatedColumnsAggregateExpression(expr)
+      case expr @ (_: RuntimeReplaceable | _: Unevaluable) =>
+        // Transient IR rewritten away before execution (e.g. NullIf's `With(.., TypedNullLiteral,
+        // ..)`), so never allow-listed; children are still traversed. Match by trait: the
+        // `With`/`CommonExpression*` classes are absent pre-Spark-4.0.
+        expr
       case expr if !AllowedUserProvidedExpressions.expressions.contains(expr.getClass) =>
         throw DeltaErrors.generatedColumnsUnsupportedExpression(expr)
     }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/GeneratedColumn.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/GeneratedColumn.scala
@@ -282,11 +282,6 @@ object GeneratedColumn extends DeltaLogging with AnalysisHelper {
         throw DeltaErrors.generatedColumnsNonDeterministicExpression(expr)
       case expr if expr.isInstanceOf[AggregateExpression] =>
         throw DeltaErrors.generatedColumnsAggregateExpression(expr)
-      case expr @ (_: RuntimeReplaceable | _: Unevaluable) =>
-        // Transient IR rewritten away before execution (e.g. NullIf's `With(.., TypedNullLiteral,
-        // ..)`), so never allow-listed; children are still traversed. Match by trait: the
-        // `With`/`CommonExpression*` classes are absent pre-Spark-4.0.
-        expr
       case expr if !AllowedUserProvidedExpressions.expressions.contains(expr.getClass) =>
         throw DeltaErrors.generatedColumnsUnsupportedExpression(expr)
     }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/GeneratedColumnSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/GeneratedColumnSuite.scala
@@ -838,6 +838,24 @@ trait GeneratedColumnSuiteBase
     }
   }
 
+  test("generation expression allows NULLIF (create, write and OPTIMIZE)") {
+    // NullIf's replacement is transient IR not in the allow-list; validation must not reject it.
+    // CREATE covers the metadata path; ASSERT makes the write path (INSERT/OPTIMIZE) fatal too.
+    withSQLConf(DeltaSQLConf.GENERATED_COLUMN_VALIDATE_ON_WRITE.key ->
+        GeneratedColumnValidateOnWriteMode.ASSERT.toString) {
+      withTableName("nullif_gen_col") { table =>
+        createTable(table, None, "c1 INT, c2 INT, g INT", Map("g" -> "NULLIF(c1, c2)"), Nil)
+        sql(s"INSERT INTO $table (c1, c2) VALUES (1, 1)")
+        sql(s"INSERT INTO $table (c1, c2) VALUES (2, 3)")
+        sql(s"OPTIMIZE $table")
+        checkAnswer(
+          sql(s"SELECT c1, c2, g FROM $table"),
+          Row(1, 1, null) :: Row(2, 3, 2) :: Nil
+        )
+      }
+    }
+  }
+
   test("complex type extractors") {
     withTableName("struct_field") { table =>
       createTable(

--- a/spark/src/test/scala/org/apache/spark/sql/delta/schema/CheckConstraintsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/schema/CheckConstraintsSuite.scala
@@ -233,6 +233,20 @@ class CheckConstraintsSuite extends QueryTest
     }
   }
 
+  testQuietly("check constraint allows NULLIF") {
+    // NULLIF analyzes to transient IR (With/CommonExpression*, TypedNullLiteral on 4.2+), which
+    // validation must allow. `NULLIF(num, 0) IS NOT NULL` means `num != 0`; existing rows satisfy
+    // it, so the constraint is added and then enforced on writes.
+    withTestTable { table =>
+      sql(s"ALTER TABLE $table ADD CONSTRAINT numNotZero CHECK (NULLIF(num, 0) IS NOT NULL)")
+      sql(s"INSERT INTO $table VALUES (7, 'g')")
+      val e = intercept[InvariantViolationException] {
+        sql(s"INSERT INTO $table VALUES (0, 'h')")
+      }
+      assert(e.getMessage.contains("CHECK constraint numnotzero"))
+    }
+  }
+
   test("drop constraint that doesn't exist throws an exception") {
     withTestTable { table =>
       intercept[AnalysisException] {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->
Resolves #7626

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
On Spark 4.x, a `NULLIF(...)` generated column fails on `CREATE` (and on `OPTIMIZE`/writes under `ASSERT` write-validation) with `DELTA_UNSUPPORTED_EXPRESSION_GENERATED_COLUMN`.

`validateGeneratedColumns` walks the analyzed plan and rejects any expression class not in `AllowedUserProvidedExpressions`. Since Spark 4.0, `NullIf`'s replacement is `With(If(.., TypedNullLiteral, ..), ..)`, transient `RuntimeReplaceable` / `Unevaluable` IR that `ReplaceExpressions` / `RewriteWithExpression` strip before execution and that can never be allow-listed (`TypedNullLiteral` was added in [SPARK-56840](https://issues.apache.org/jira/browse/SPARK-56840); the `With` common-expression wrapper is a separate Spark 4.0 feature and is the node that actually trips the walk). This PR skips those nodes; their real children are still traversed, so UDF / non-deterministic / aggregate sub-expressions are still rejected. Matched by trait, since the `With` / `CommonExpression*` classes don't exist before Spark 4.0.


## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Added a regression test to `GeneratedColumnSuite` covering CREATE + INSERT + OPTIMIZE of a `NULLIF` generated column (write path forced to `ASSERT`).

build/sbt "spark/testOnly org.apache.spark.sql.delta.GeneratedColumnSuite"

116/116 tests pass with the fix; the new test fails (1/116) without it. `git diff --check` passes.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. `NULLIF` generated columns now work on Spark 4.x; previously they failed with `DELTA_UNSUPPORTED_EXPRESSION_GENERATED_COLUMN`.