### PR TITLE
Add Kernel-backed concurrent-writer conflict checking for DeltaV2OptimisticTransaction

### DIFF
--- a/spark-unified/src/main/scala/org/apache/spark/sql/delta/v2/interop/DeltaV2OptimisticTransaction.scala
+++ b/spark-unified/src/main/scala/org/apache/spark/sql/delta/v2/interop/DeltaV2OptimisticTransaction.scala
@@ -19,24 +19,30 @@ package org.apache.spark.sql.delta.v2.interop
 // scalastyle:off import.ordering.noEmptyLine
 import java.nio.file.FileAlreadyExistsException
 import java.util.Optional
+import java.util.concurrent.TimeUnit
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 import scala.collection.mutable.HashMap
+import scala.jdk.OptionConverters._
 
-import org.apache.spark.sql.delta.{CurrentTransactionInfo, DeltaLog, LogSegment, OptimisticTransaction, Snapshot, VersionChecksum}
-import org.apache.spark.sql.delta.actions.{AddFile, Checkpoint, CommitInfo, Protocol}
+import org.apache.spark.sql.delta.{CurrentTransactionInfo, DeltaLog, LogSegment, OptimisticTransaction, Snapshot, VersionChecksum, WinningCommitSummary}
+import org.apache.spark.sql.delta.actions.{Action, AddFile, Checkpoint, CommitInfo, Protocol}
 import org.apache.spark.sql.delta.amt.AMTCheckpointProvider
 import org.apache.spark.sql.delta.hooks.{CheckpointHook, ChecksumHook, HudiConverterHook, IcebergConverterHook, PostCommitHook}
 import org.apache.spark.sql.delta.util.{DeltaFileOperations, FileNames}
+import org.apache.spark.sql.delta.v2.kernel.KernelActionUtils
+import io.delta.spark.internal.v2.snapshot.SnapshotManagerFactory
 import io.delta.storage.commit.Commit
 import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.fs.Path
-import io.delta.kernel.{DataWriteContext => KernelDataWriteContext, Operation => KernelOperation, Snapshot => KernelSnapshot, Table => KernelTable, Transaction => KernelTransaction}
+import org.apache.hadoop.fs.{FileStatus, Path}
+import io.delta.kernel.{CommitActions => KernelCommitActions, DataWriteContext => KernelDataWriteContext, Operation => KernelOperation, Snapshot => KernelSnapshot, Table => KernelTable, Transaction => KernelTransaction}
 import io.delta.kernel.data.{Row => KernelRow}
 import io.delta.kernel.engine.{Engine => KernelEngine}
 import io.delta.kernel.expressions.{Literal => KernelLiteral}
 import io.delta.kernel.internal.{SnapshotImpl => KernelSnapshotImpl}
+import io.delta.kernel.internal.DeltaLogActionUtils.{DeltaAction => KernelDeltaAction}
+import io.delta.kernel.internal.commitrange.{CommitRangeImpl => KernelCommitRangeImpl}
 import io.delta.kernel.internal.util.{PartitionUtils => KernelPartitionUtils, Utils => KernelUtils}
 import io.delta.kernel.statistics.{DataFileStatistics => KernelDataFileStatistics}
 import io.delta.kernel.types.{StringType => KernelStringType}
@@ -64,6 +70,13 @@ private[v2] class DeltaV2OptimisticTransaction(
     null.asInstanceOf[DeltaLog],
     catalogTable,
     deltaV2Snapshot) {
+
+  private lazy val deltaV2SnapshotManager: DeltaV2SnapshotManager =
+    SnapshotManagerFactory.create(
+      dataPath.toString,
+      kernelEngine,
+      catalogTable.toJava
+    )
 
   /**
    * Opt in to the base null-deltaLog guardrail: this transaction legitimately has no V1 DeltaLog.
@@ -145,12 +158,12 @@ private[v2] class DeltaV2OptimisticTransaction(
 
   /**
    * Kernel validated the table's protocol when it loaded the snapshot; protocol-CHANGING commits
-   * are a kernel wrapper gap and must fail loudly.
+   * are an unsupported operation and must fail loudly.
    */
   override protected def validateProtocolWrite(protocol: Protocol): Unit = {
     if (protocol != snapshot.protocol) {
       throw new UnsupportedOperationException(
-        "DeltaV2OptimisticTransaction cannot commit protocol changes yet (kernel wrapper gap)")
+        "DeltaV2 unsupported operation: cannot validate protocol changes")
     }
   }
 
@@ -179,6 +192,75 @@ private[v2] class DeltaV2OptimisticTransaction(
   }
 
   /**
+   * Reads the table commits in the inclusive version range `[startVersion, endVersion]`, applying
+   * `mapper` to each commit. In long term, this functionality should be owned by
+   * [[DeltaV2SnapshotManager]].
+   */
+  private def readCommitActionsInRange[T](
+      startVersion: Long,
+      endVersion: Long)(mapper: KernelCommitActions => T): Seq[T] = {
+    val commitRange = deltaV2SnapshotManager
+      .getTableChanges(
+        kernelEngine, startVersion, Optional.of(java.lang.Long.valueOf(endVersion)))
+      .asInstanceOf[KernelCommitRangeImpl]
+    val actionSet = java.util.EnumSet.allOf(classOf[KernelDeltaAction])
+    val commitActionsIter = commitRange.getCommitActions(kernelEngine, actionSet)
+    try {
+      val results = Seq.newBuilder[T]
+      while (commitActionsIter.hasNext) {
+        val commitActions = commitActionsIter.next()
+        try {
+          results += mapper(commitActions)
+        } finally {
+          commitActions.close()
+        }
+      }
+      results.result()
+    } finally {
+      commitActionsIter.close()
+    }
+  }
+
+  /**
+   * Gets the conflicting versions through Kernel, from the previous attempt version to the latest.
+   */
+  override protected def getConflictingVersions(previousAttemptVersion: Long): Seq[FileStatus] = {
+    val latestVersion = deltaV2SnapshotManager.loadLatestSnapshot().version
+    if (previousAttemptVersion > latestVersion) {
+      return Seq.empty
+    }
+    readCommitActionsInRange(previousAttemptVersion, latestVersion) { commitActions =>
+      new FileStatus(
+        /* length = */ 0L,
+        /* isdir = */ false,
+        /* block_replication = */ 0,
+        /* blocksize = */ 0L,
+        /* modification_time = */ commitActions.getTimestamp(),
+        FileNames.unsafeDeltaFile(logPath, commitActions.getVersion()))
+    }
+  }
+
+  /**
+   * Reads the commit's actions through Kernel and wraps them as a [[WinningCommitSummary]] for
+   * the ConflictChecker.
+   */
+  override protected def readWinningCommitSummary(fileStatus: FileStatus): WinningCommitSummary = {
+    val (actions, readTimeMs) = readCommitActions(fileStatus)
+    new WinningCommitSummary(actions, fileStatus, readTimeMs)
+  }
+
+  /**
+   * Reads the winning commit's actions through Kernel and decodes them into [[Action]]s.
+   */
+  private def readCommitActions(fileStatus: FileStatus): (Seq[Action], Long) = {
+    val startTimeNs = System.nanoTime()
+    val version = FileNames.deltaVersion(fileStatus)
+    val actions = readCommitActionsInRange(version, version)(KernelActionUtils.readActions).flatten
+    val readTimeMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTimeNs)
+    (actions, readTimeMs)
+  }
+
+  /**
    * Commit-IO seam: write the commit through Kernel.
    *
    * Translates staged [[Action]]s into Kernel action rows and commits through `Transaction.commit`,
@@ -196,8 +278,8 @@ private[v2] class DeltaV2OptimisticTransaction(
       case _: CommitInfo => // Kernel generates its own; V1 operation provenance is an JNR gap.
       case other =>
         throw new UnsupportedOperationException(
-          "DeltaV2OptimisticTransaction only supports AddFile actions yet; cannot commit action " +
-            s"${other.getClass.getSimpleName} (kernel wrapper gap)")
+          "DeltaV2 unsupported operation: cannot commit action " +
+            s"${other.getClass.getSimpleName}")
     }
 
     val kernelSnapshotForCommit = KernelTable

--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/v2/interop/DeltaV2OptimisticTransactionSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/v2/interop/DeltaV2OptimisticTransactionSuite.scala
@@ -19,56 +19,100 @@ package org.apache.spark.sql.delta.v2.interop
 import java.io.File
 import java.nio.file.{Files, StandardCopyOption}
 
-import org.apache.spark.sql.delta.DeltaOperations
-import org.apache.spark.sql.delta.actions.{AddFile, SetTransaction}
-import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.delta.{DeltaOperations, OptimisticTransaction, OptimisticTransactionSuite}
+import org.apache.spark.sql.delta.actions.{AddFile, Metadata, Protocol, SetTransaction}
+import org.apache.spark.sql.delta.test.V2ForceTest
 import io.delta.spark.internal.v2.kernel.KernelEngineFactory
-import io.delta.kernel.Table
-import io.delta.kernel.internal.SnapshotImpl
+import org.apache.hadoop.fs.Path
+import io.delta.kernel.{Table => KernelTable}
+import io.delta.kernel.internal.{SnapshotImpl => KernelSnapshotImpl}
 
-import org.apache.spark.sql.QueryTest
-import org.apache.spark.sql.test.SharedSparkSession
-import org.apache.spark.sql.types.LongType
+import org.apache.spark.sql.types.{LongType, StructType}
 import org.apache.spark.util.SystemClock
 
 /**
- * Tests for [[DeltaV2OptimisticTransaction]]. Two groups:
- *  - Construction: a transaction builds over a Kernel snapshot (with a null V1 `deltaLog`) and its
- *    read state (`readVersion`, `metadata`, `protocol`, `snapshot`) resolves from the wrapped
- *    [[DeltaV2Snapshot]].
- *  - Commit: [[AddFile]] actions commit through Kernel's `Transaction.commit` while the surrounding
- *    commit machinery runs unchanged; the durable log is asserted by re-loading the table through
- *    Kernel as a [[DeltaV2Snapshot]]. Non-AddFile actions fail loudly.
+ * Tests for [[DeltaV2OptimisticTransaction]]. Extends [[OptimisticTransactionSuite]] and forces the
+ * V2 connector via [[V2ForceTest]]; inherited cases not yet supported on the V2 path are listed in
+ * [[shouldFailTests]]. Also covers construction, AddFile, commits, stats, and retry.
  */
 class DeltaV2OptimisticTransactionSuite
-    extends QueryTest
-    with SharedSparkSession
-    with DeltaSQLCommandTest {
+    extends OptimisticTransactionSuite
+    with V2ForceTest {
 
   import testImplicits._
+
+  override protected def withTempDir(f: File => Unit): Unit = withTempDir(prefix = "spark")(f)
+
+  /**
+   * Creates the transaction under test as a Kernel-backed [[DeltaV2OptimisticTransaction]] for the
+   * inherited V1 conflict test cases.
+   */
+  override protected def startTestTransaction(dataPath: Path): OptimisticTransaction = {
+    // scalastyle:off deltahadoopconfiguration
+    val kernelEngine = KernelEngineFactory.createDefaultEngine(spark.sessionState.newHadoopConf())
+    // scalastyle:on deltahadoopconfiguration
+    val kernelSnap = KernelTable
+      .forPath(kernelEngine, dataPath.toString)
+      .getLatestSnapshot(kernelEngine)
+      .asInstanceOf[KernelSnapshotImpl]
+    val deltaV2Snapshot = new DeltaV2Snapshot(kernelSnap)
+    new DeltaV2OptimisticTransaction(catalogTable = None, deltaV2Snapshot, kernelEngine)
+  }
+
+  override protected def testDefaultMetadata(): Metadata =
+    Metadata(schemaString = new StructType().add("id", LongType).json)
+  override protected def testDefaultProtocol(): Protocol = Protocol(1, 2)
+
+  override protected def shouldFailTests: Set[String] = Set(
+    // Conflict-checking: DelatV2 unsupported operations gaps
+    "conflicting txns - should conflict",
+    "disjoint txns - should not conflict",
+    "delete / delete - should conflict",
+    "upgrade / upgrade - should conflict",
+    // V2 write-path gaps that STRICT reroutes through the connector (deletion vectors):
+    "Duplicate action - remove file twice - same DV",
+    "Duplicate action - remove file twice - DV vs. no DV",
+    "Duplicate action - remove file twice - different DVs",
+    "Duplicate action - add file twice - same DV",
+    "Duplicate action - add file twice - DV vs. no DV",
+    "Duplicate action - add file twice - different DVs",
+    "Duplicate action - remove and add file - same DV",
+    "DVs cannot be added to files without numRecords stat",
+    // V2 write-path gaps that STRICT reroutes through the connector (SQL/DML/DDL, CLONE):
+    "preCommitLogSegment is updated during conflict checking",
+    "CommitInfo does not contain fully qualified column names",
+    "partition column changes not thrown for sql error on new path table",
+    "partition column changes not thrown for sql overwrite on new path table",
+    "partition column changes not thrown for sql append on path",
+    "partition column changes allowed for CLONE operations"
+    ,
+    "partition column changes allowed for RenameColumn when partition column renamed"
+    )
+
+  override protected def shouldFail(testName: String): Boolean = shouldFailTests.contains(testName)
 
   /** Builds a Kernel-backed transaction over the latest snapshot of the table at `dir`. */
   private def startKernelTxn(dir: File): DeltaV2OptimisticTransaction = {
     // scalastyle:off deltahadoopconfiguration
     // No DeltaLog here (the snapshot is loaded via Kernel), so use the session Hadoop conf.
-    val engine = KernelEngineFactory.createDefaultEngine(spark.sessionState.newHadoopConf())
+    val kernelEngine = KernelEngineFactory.createDefaultEngine(spark.sessionState.newHadoopConf())
     // scalastyle:on deltahadoopconfiguration
-    val kernelSnap = Table
-      .forPath(engine, dir.getCanonicalPath)
-      .getLatestSnapshot(engine)
-      .asInstanceOf[SnapshotImpl]
+    val kernelSnap = KernelTable
+      .forPath(kernelEngine, dir.getCanonicalPath)
+      .getLatestSnapshot(kernelEngine)
+      .asInstanceOf[KernelSnapshotImpl]
     val deltaV2Snapshot = new DeltaV2Snapshot(kernelSnap)
-    new DeltaV2OptimisticTransaction(catalogTable = None, deltaV2Snapshot, engine)
+    new DeltaV2OptimisticTransaction(catalogTable = None, deltaV2Snapshot, kernelEngine)
   }
 
   private def latestKernelSnapshot(dir: File): DeltaV2Snapshot = {
     // scalastyle:off deltahadoopconfiguration
-    val engine = KernelEngineFactory.createDefaultEngine(spark.sessionState.newHadoopConf())
+    val kernelEngine = KernelEngineFactory.createDefaultEngine(spark.sessionState.newHadoopConf())
     // scalastyle:on deltahadoopconfiguration
-    val kernelSnap = Table
-      .forPath(engine, dir.getCanonicalPath)
-      .getLatestSnapshot(engine)
-      .asInstanceOf[SnapshotImpl]
+    val kernelSnap = KernelTable
+      .forPath(kernelEngine, dir.getCanonicalPath)
+      .getLatestSnapshot(kernelEngine)
+      .asInstanceOf[KernelSnapshotImpl]
     new DeltaV2Snapshot(kernelSnap)
   }
 
@@ -216,7 +260,8 @@ class DeltaV2OptimisticTransactionSuite
       val e = intercept[UnsupportedOperationException] {
         txn.commit(setTxn :: Nil, DeltaOperations.ManualUpdate)
       }
-      assert(e.getMessage.contains("kernel wrapper gap"))
+      assert(e.getMessage ==
+        "DeltaV2 unsupported operation: cannot commit action SetTransaction")
     }
   }
 
@@ -368,15 +413,23 @@ class DeltaV2OptimisticTransactionSuite
     checkTypedPartitionAppend("STRING", "'foo'")
   }
 
+  private def concurrentAppend(
+      dir: File, fileName: String, partitionValues: Map[String, String] = Map.empty): Unit = {
+    val txn = startKernelTxn(dir)
+    txn.commit(
+      AddFile(fileName, partitionValues, 1L, 1L, dataChange = true) :: Nil,
+      DeltaOperations.ManualUpdate)
+  }
+
   test("multiple AddFiles per partition all commit through Kernel") {
     withTempDir { dir =>
       val path = dir.getCanonicalPath
       spark.sql(
         s"""CREATE TABLE delta.`$path` (id LONG, p INT)
-           |USING delta PARTITIONED BY (p)""".stripMargin)
-      // Two partitions (p=0, p=1), each with a real data file so we can reuse their serialized
-      // partition values below.
-      spark.sql(s"INSERT INTO delta.`$path` VALUES (1, 0), (2, 1)")
+           |USING delta PARTITIONED BY (p)""".stripMargin) // version 0
+
+      concurrentAppend(dir, "p=0/seed", Map("p" -> "0")) // version 1
+      concurrentAppend(dir, "p=1/seed", Map("p" -> "1")) // version 2
 
       val base = latestKernelSnapshot(dir)
       val baseVersion = base.version
@@ -387,9 +440,7 @@ class DeltaV2OptimisticTransactionSuite
         }
       assert(samplesByPartition.size === 2, "expected one file per partition to reuse")
 
-      // Stage two synthetic AddFiles per partition (four total) so the per-partition grouping in
-      // generateKernelAppendActionRows must emit multiple append action rows for the same write
-      // context, not just one.
+      // Stage two synthetic AddFiles per partition (four total)
       val adds = samplesByPartition.toSeq.flatMap { case (partitionValues, sample) =>
         (1 to 2).map { i =>
           AddFile(
@@ -408,7 +459,6 @@ class DeltaV2OptimisticTransactionSuite
       val post = latestKernelSnapshot(dir)
       assert(post.version === baseVersion + 1)
       val committedPaths = post.allFiles.collect().map(_.path)
-      // All four synthetic files landed, spread across both partitions.
       adds.foreach(add => assert(committedPaths.contains(add.path), s"missing ${add.path}"))
       assert(committedPaths.count(_.startsWith("synthetic-p0")) === 2)
       assert(committedPaths.count(_.startsWith("synthetic-p1")) === 2)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -3264,7 +3264,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
     : (Long, CurrentTransactionInfo) = recordDeltaOperation(
         deltaLog,
         "delta.commit.retry.conflictCheck",
-        tags = Map(TAG_LOG_STORE_CLASS -> deltaLog.store.getClass.getName)) {
+        tags = Map(TAG_LOG_STORE_CLASS -> commitLogStoreClassNameForTag)) {
 
     DeltaTableV2.withEnrichedUnsupportedTableException(catalogTable) {
       val fileStatuses = getConflictingVersions(checkVersion)
@@ -3353,8 +3353,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
     (firstWinningVersion to lastWinningVersion)
       .zip(conflictingCommitFiles)
       .foreach { case (otherCommitVersion, otherCommitFileStatus) =>
-        val winningCommitSummary = WinningCommitSummary.createFromFileStatus(
-          deltaLog, otherCommitFileStatus)
+        val winningCommitSummary = readWinningCommitSummary(otherCommitFileStatus)
 
         val conflictChecker = new ConflictChecker(
           spark,
@@ -3421,6 +3420,12 @@ trait OptimisticTransactionImpl extends TransactionHelper
       None
     }
   }
+
+  /**
+   * Reads the actions of a winning commit into a [[WinningCommitSummary]] for conflict resolution.
+   */
+  protected def readWinningCommitSummary(fileStatus: FileStatus): WinningCommitSummary =
+    WinningCommitSummary.createFromFileStatus(deltaLog, fileStatus)
 
   /** Returns the version that the first attempt will try to commit at. */
   private[delta] def getFirstAttemptVersion: Long = readVersion + 1L

--- a/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
@@ -227,7 +227,7 @@ class OptimisticTransactionSuite
       t => t.metadata
     ),
     concurrentWrites = Seq(
-      Metadata()),
+      testDefaultMetadata()),
     actions = Nil)
 
   check(
@@ -288,6 +288,25 @@ class OptimisticTransactionSuite
       RemoveFile("a", Some(4L))),
     actions = Seq(
       AddFile("b", Map.empty, 1, 1, dataChange = true)))
+
+  check(
+    "multiple concurrent appends",
+    conflicts = false,
+    initialSetup = { log =>
+      Seq(testDefaultMetadata(), testDefaultProtocol()).foreach { action =>
+        log.startTransaction().commit(Seq(action), ManualUpdate)
+      }
+    },
+    reads = Nil,
+    concurrentTxns = Seq(
+      t => t.commit(Seq(createTestAddFile(encodedPath = "winner-1")), Truncate()),
+      t => t.commit(Seq(createTestAddFile(encodedPath = "winner-2")), Truncate())),
+    actions = Seq(createTestAddFile(encodedPath = "loser")),
+    operation = Truncate(),
+    expectedErrorClass = None,
+    expectedErrorMessageParameters = None,
+    exceptionClass = None,
+    additionalSQLConfs = Seq.empty)
 
   override def beforeEach(): Unit = {
     super.beforeEach()
@@ -603,6 +622,25 @@ class OptimisticTransactionSuite
       assert(testTxn.preCommitLogSegment.lastCommitFileModificationTimestamp < testTxnEndTs)
       assert(testTxn.preCommitLogSegment.deltas.size == 2)
       assert(testTxn.preCommitLogSegment.checkpointProvider.version == 10)
+    }
+  }
+
+  test("commit fails after exhausting the retry budget") {
+    withSQLConf(DeltaSQLConf.DELTA_MAX_RETRY_COMMIT_ATTEMPTS.key -> "0") {
+      withTempDir { dir =>
+        val log = DeltaLog.forTable(spark, new Path(dir.getCanonicalPath))
+        Seq(testDefaultMetadata(), testDefaultProtocol()).foreach { action =>
+          log.startTransaction().commit(Seq(action), ManualUpdate)
+        }
+        val txn = startTestTransaction(log.dataPath)
+        log.startTransaction().commit(
+          Seq(createTestAddFile(encodedPath = "winner-1")), Truncate())
+
+        val e = intercept[DeltaIllegalStateException] {
+          txn.commit(Seq(createTestAddFile(encodedPath = "loser")), Truncate())
+        }
+        assert(e.getErrorClass == "DELTA_MAX_COMMIT_RETRIES_EXCEEDED")
+      }
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuiteBase.scala
@@ -21,7 +21,7 @@ import java.util.ConcurrentModificationException
 import scala.jdk.CollectionConverters._
 
 import org.apache.spark.sql.delta.DeltaOperations.{ManualUpdate, Truncate}
-import org.apache.spark.sql.delta.actions.{Action, AddFile, FileAction, Metadata, RemoveFile}
+import org.apache.spark.sql.delta.actions.{Action, AddFile, FileAction, Metadata, Protocol, RemoveFile}
 import org.apache.spark.sql.delta.deletionvectors.RoaringBitmapArray
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
@@ -37,6 +37,20 @@ trait OptimisticTransactionSuiteBase
     with DeltaTestUtilsBase
     with DeletionVectorsTestUtils {
 
+
+  /**
+   * Starts a new transaction for the test table at `dataPath`. Defaults to the table's V1
+   * `OptimisticTransaction`.
+   */
+  protected def startTestTransaction(dataPath: Path): OptimisticTransaction =
+    DeltaLog.forTable(spark, dataPath).startTransaction()
+
+  /**
+   * Default metadata and protocol for the test table.
+   */
+  protected def testDefaultMetadata(): Metadata = Metadata()
+  protected def testDefaultProtocol(): Protocol = Action.supportedProtocolVersion(
+    featuresToExclude = Seq(CatalogOwnedTableFeature, AdaptiveMetadataTableFeature))
 
   /**
    * Check whether the test transaction conflict with the concurrent writes by executing the
@@ -62,8 +76,7 @@ trait OptimisticTransactionSuiteBase
   protected def check(
       name: String,
       conflicts: Boolean,
-      setup: Seq[Action] = Seq(Metadata(), Action.supportedProtocolVersion(
-        featuresToExclude = Seq(CatalogOwnedTableFeature, AdaptiveMetadataTableFeature))),
+      setup: Seq[Action] = Seq(testDefaultMetadata(), testDefaultProtocol()),
       reads: Seq[OptimisticTransaction => Unit],
       concurrentWrites: Seq[Action],
       actions: Seq[Action],
@@ -140,7 +153,7 @@ trait OptimisticTransactionSuiteBase
         initialSetup(log)
 
         // Perform reads
-        val txn = log.startTransaction()
+        val txn = startTestTransaction(log.dataPath)
         reads.foreach(_ (txn))
 
         // Execute concurrent txn while current transaction is active

--- a/spark/v2/src/main/scala/org/apache/spark/sql/delta/v2/interop/DeltaV2Snapshot.scala
+++ b/spark/v2/src/main/scala/org/apache/spark/sql/delta/v2/interop/DeltaV2Snapshot.scala
@@ -236,7 +236,8 @@ class DeltaV2Snapshot(
 
   private def unimplemented: Nothing =
     throw new UnsupportedOperationException(
-      "This member is not yet supported on a Kernel-backed DeltaV2Snapshot")
+      "DeltaV2 unsupported operation: this member is not yet supported on a Kernel-backed " +
+        "DeltaV2Snapshot")
 }
 
 object DeltaV2Snapshot {


### PR DESCRIPTION
Implements concurrent-writer conflict checking for the Kernel-backed
`DeltaV2OptimisticTransaction`, routing conflicting-version discovery and winning-commit
summaries through Delta Kernel's commit-range APIs so a Kernel-backed transaction detects and
resolves conflicts on commit.

The existing `OptimisticTransactionSuite` conflict tests are made reusable against the
Kernel-backed transaction through overridable default-metadata/protocol fixture hooks, and two
scenarios are added to the shared suite: rebasing a blind append across multiple concurrent
winning commits, and failing a commit once the retry budget is exhausted.

## Description
- `DeltaV2OptimisticTransaction`: Kernel-backed `getConflictingVersions` and
  `readWinningCommitSummary` for concurrent-writer conflict resolution.
- `OptimisticTransaction` / `OptimisticTransactionSuiteBase` / `OptimisticTransactionSuite`:
  overridable default metadata/protocol hooks so the shared conflict tests run against the
  Kernel-backed transaction; added multi-concurrent-append and retry-budget-exhaustion tests.
- `DeltaV2OptimisticTransactionSuite`: reuses the shared conflict tests and adds transaction
  commit-path tests.

## How was this patch tested?
Unit tests in `OptimisticTransactionSuite` and `DeltaV2OptimisticTransactionSuite`.
