### PR TITLE
[Spark] Preserve DV metrics when deletion vector creation is disabled

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotState.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotState.scala
@@ -86,24 +86,6 @@ trait SnapshotStateManager extends DeltaLogging { self: Snapshot =>
   protected def deletedRecordCountsHistogramEnabled: Boolean =
     spark.sessionState.conf.getConf(DeltaSQLConf.DELTA_DELETED_RECORD_COUNTS_HISTOGRAM_ENABLED)
 
-  /**
-   * Whether [[aggregationsToComputeState]] computes the deletion vector metrics
-   * (`numDeletedRecordsOpt` / `numDeletionVectorsOpt`, and with
-   * [[deletedRecordCountsHistogramEnabled]] also `deletedRecordCountsHistogramOpt`); when it does
-   * not, those aggregates are `null` and the corresponding fields end up as [[None]].
-   *
-   * The accessors that read these fields from the checksum gate on this very same predicate, so
-   * that a value served from the checksum is exactly the value the aggregation would have
-   * produced. Note this is deliberately the *writable* predicate used by the aggregation, which
-   * is stricter than the *readable* one used when deciding what to persist into the checksum.
-   * That divergence is tracked by https://github.com/delta-io/delta/issues/7507; when it is
-   * resolved, this single definition has to keep covering both the aggregation and the accessors
-   * so the two cannot disagree again.
-   */
-  protected def checksumDVMetricsComputed: Boolean =
-    spark.sessionState.conf.getConf(DeltaSQLConf.DELTA_CHECKSUM_DV_METRICS_ENABLED) &&
-      DeletionVectorUtils.deletionVectorsWritable(this)
-
   /** Whether computedState is already computed or not */
   @volatile protected var _computedStateTriggered: Boolean = false
 
@@ -178,9 +160,8 @@ trait SnapshotStateManager extends DeltaLogging { self: Snapshot =>
    * A Map of alias to aggregations which needs to be done to calculate the `computedState`
    */
   protected def aggregationsToComputeState: Map[String, Column] = {
-    val computeChecksumDVMetrics = checksumDVMetricsComputed
     val persistentDVsAggs =
-      if (computeChecksumDVMetrics) {
+      if (deletionVectorsReadableAndMetricsEnabled) {
         Map(
           "numDeletedRecordsOpt" -> sum(coalesce(col("add.deletionVector.cardinality"), lit(0L))),
           "numDeletionVectorsOpt" -> count(col("add.deletionVector")))
@@ -188,7 +169,7 @@ trait SnapshotStateManager extends DeltaLogging { self: Snapshot =>
         Map("numDeletedRecordsOpt" -> lit(null), "numDeletionVectorsOpt" -> lit(null))
       }
 
-    val histogramDVsAggExpr = if (computeChecksumDVMetrics && deletedRecordCountsHistogramEnabled) {
+    val histogramDVsAggExpr = if (deletionVectorsReadableAndHistogramEnabled) {
       DeletedRecordCountsHistogramUtils.histogramAggregate(
         when(col("add").isNotNull, coalesce(col("add.deletionVector.cardinality"), lit(0L))))
     } else {
@@ -255,15 +236,15 @@ trait SnapshotStateManager extends DeltaLogging { self: Snapshot =>
   protected[delta] def domainMetadatasIfKnown: Option[Seq[DomainMetadata]] = Some(domainMetadata)
   def numDeletedRecordsOpt: Option[Long] =
     fetchFromChecksumIfAvailable { checksum =>
-      Option.when(checksumDVMetricsComputed)(checksum.numDeletedRecordsOpt).flatten
+      Option.when(deletionVectorsReadableAndMetricsEnabled)(checksum.numDeletedRecordsOpt).flatten
     }.orElse(computedState.numDeletedRecordsOpt)
   def numDeletionVectorsOpt: Option[Long] =
     fetchFromChecksumIfAvailable { checksum =>
-      Option.when(checksumDVMetricsComputed)(checksum.numDeletionVectorsOpt).flatten
+      Option.when(deletionVectorsReadableAndMetricsEnabled)(checksum.numDeletionVectorsOpt).flatten
     }.orElse(computedState.numDeletionVectorsOpt)
   def deletedRecordCountsHistogramOpt: Option[DeletedRecordCountsHistogram] =
     fetchFromChecksumIfAvailable { checksum =>
-      Option.when(checksumDVMetricsComputed && deletedRecordCountsHistogramEnabled)(
+      Option.when(deletionVectorsReadableAndHistogramEnabled)(
         checksum.deletedRecordCountsHistogramOpt).flatten
     }.orElse(computedState.deletedRecordCountsHistogramOpt)
 
@@ -287,6 +268,11 @@ trait SnapshotStateManager extends DeltaLogging { self: Snapshot =>
     checksumOpt.flatMap(field)
   }
 
+  /**
+   * Shared eligibility for reconstructed and checksum-backed DV metrics. Disabling DV creation
+   * does not remove existing deletion vectors, so these metrics depend on readability rather
+   * than writability.
+   */
   protected def deletionVectorsReadableAndMetricsEnabled: Boolean = {
     val checksumDVMetricsEnabled =
       spark.sessionState.conf.getConf(DeltaSQLConf.DELTA_CHECKSUM_DV_METRICS_ENABLED)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
@@ -899,7 +899,10 @@ object DeletionVectorsTableFeature
    */
   override def validateDropInvariants(table: DeltaTableV2, snapshot: Snapshot): Boolean = {
     val dvsWritable = DeletionVectorUtils.deletionVectorsWritable(snapshot)
-    val dvsExist = snapshot.numDeletionVectorsOpt.getOrElse(0L) > 0
+    val dvsExist = snapshot.numDeletionVectorsOpt.map(_ > 0).getOrElse {
+      // Metrics may be disabled; their absence does not mean the table is DV-free.
+      !DeletionVectorUtils.isTableDVFree(snapshot)
+    }
 
     !(dvsWritable || dvsExist)
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/ChecksumDVMetricsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/ChecksumDVMetricsSuite.scala
@@ -198,11 +198,9 @@ class ChecksumDVMetricsSuite
         // to take advantage any recent snapshot reconstruction and harvest the stats from there.
         // In the opposite scenario, disabling DVs midway, we maintain the previously computed
         // statistics so we do not lose incrementality if DVs are enabled again.
-        // When incremental commit is disabled, both enabling and disabling DVs
-        // midway is not an issue. When DVs are enabled we produce results and when DVs are
-        // disabled we do not.
-        validateChecksum(targetLog.update(),
-          statisticsExpected = !(enableDVCreation && !enableIncrementalCommit))
+        // With incremental commit disabled, reconstruction also produces metrics as long as
+        // DVs are readable, even if creation has been disabled.
+        validateChecksum(targetLog.update())
       }
     }
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/ChecksumSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/ChecksumSuite.scala
@@ -24,6 +24,7 @@ import org.apache.spark.sql.delta.DeltaTestUtils._
 import org.apache.spark.sql.delta.actions.{LastManifestCommit, Metadata, Protocol}
 import org.apache.spark.sql.delta.coordinatedcommits.CatalogOwnedTestBaseSuite
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.stats.DeletedRecordCountsHistogramUtils
 import org.apache.spark.sql.delta.test.{DeltaSQLCommandTest, DeltaSQLTestUtils}
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 import org.apache.spark.sql.delta.util.{FileNames, JsonUtils}
@@ -522,47 +523,90 @@ class ChecksumSuite
     }
   }
 
-  test("DV metrics are only served from the CRC when the aggregation would have computed them") {
+  for (writeChecksum <- BOOLEAN_DOMAIN)
+  test(s"DV metrics remain available after disabling DV creation: writeChecksum=$writeChecksum") {
     withCrcTable { tableName =>
-      // Table with deletion vectors enabled, so the CRC carries the DV metrics.
-      sql(s"CREATE TABLE $tableName (id LONG) USING delta " +
-        s"TBLPROPERTIES ('delta.enableDeletionVectors' = 'true')")
-      sql(s"INSERT INTO $tableName SELECT * FROM range(10)")
-      sql(s"DELETE FROM $tableName WHERE id = 1")
+      withSQLConf(
+        DeltaSQLConf.DELTA_WRITE_CHECKSUM_ENABLED.key -> writeChecksum.toString,
+        DeltaSQLConf.DELTA_CHECKSUM_DV_METRICS_ENABLED.key -> "true",
+        DeltaSQLConf.DELTA_DELETED_RECORD_COUNTS_HISTOGRAM_ENABLED.key -> "true",
+        DeltaSQLConf.DELETE_USE_PERSISTENT_DELETION_VECTORS.key -> "true"
+      ) {
+        sql(s"CREATE TABLE $tableName (id LONG) USING delta " +
+          s"TBLPROPERTIES ('delta.enableDeletionVectors' = 'true')")
+        spark.range(10).coalesce(1).write.format("delta").mode("append").saveAsTable(tableName)
+        sql(s"DELETE FROM $tableName WHERE id = 1")
+        val expectedHistogram = DeletedRecordCountsHistogramUtils.emptyHistogram
+        expectedHistogram.insert(1L)
 
-      withSQLConf(DeltaSQLConf.USE_SNAPSHOT_STATE_FROM_CHECKSUM_ENABLED.key -> "true") {
-        val s = freshSnapshot(tableName)
-        assert(s.checksumOpt.flatMap(_.numDeletedRecordsOpt).contains(1L),
-          "test setup should produce a CRC carrying the DV metrics")
-        assert(s.numDeletedRecordsOpt.contains(1L))
-        assert(s.numDeletionVectorsOpt.contains(1L))
-        assert(!s.stateReconstructionTriggered,
-          "DV metrics present in the CRC must not trigger state reconstruction")
-      }
+        for (dvCreationEnabled <- Seq(true, false)) {
+          if (!dvCreationEnabled) {
+            sql(s"ALTER TABLE $tableName SET TBLPROPERTIES " +
+              s"('delta.enableDeletionVectors' = 'false')")
+          }
+          for (readFromChecksum <- BOOLEAN_DOMAIN) {
+            withSQLConf(
+              DeltaSQLConf.USE_SNAPSHOT_STATE_FROM_CHECKSUM_ENABLED.key ->
+                readFromChecksum.toString) {
+              val snapshot = freshSnapshot(tableName)
+              assert(snapshot.checksumOpt.isDefined == writeChecksum)
+              snapshot.checksumOpt.foreach { checksum =>
+                assert(checksum.numDeletedRecordsOpt.contains(1L))
+                assert(checksum.numDeletionVectorsOpt.contains(1L))
+                assert(checksum.deletedRecordCountsHistogramOpt.contains(expectedHistogram))
+              }
 
-      // Disabling DV creation makes the aggregation stop computing the DV metrics (it gates on
-      // deletionVectorsWritable). The accessors must follow the aggregation rather than the
-      // still-populated CRC, otherwise the fast path would change the returned value.
-      sql(s"ALTER TABLE $tableName SET TBLPROPERTIES ('delta.enableDeletionVectors' = 'false')")
-      withSQLConf(DeltaSQLConf.USE_SNAPSHOT_STATE_FROM_CHECKSUM_ENABLED.key -> "true") {
-        val s = freshSnapshot(tableName)
-        val fromCrc = withSQLConf(
-          DeltaSQLConf.USE_SNAPSHOT_STATE_FROM_CHECKSUM_ENABLED.key -> "false") {
-          val baseline = freshSnapshot(tableName)
-          (baseline.numDeletedRecordsOpt, baseline.numDeletionVectorsOpt)
+              // Existing DVs are still readable when creation is disabled. Both access paths
+              // must report them, including their deleted-record histogram (delta-io/delta#7507).
+              assert(snapshot.numDeletedRecordsOpt.contains(1L))
+              assert(snapshot.numDeletionVectorsOpt.contains(1L))
+              assert(snapshot.deletedRecordCountsHistogramOpt.contains(expectedHistogram))
+              assert(snapshot.stateReconstructionTriggered == !(writeChecksum && readFromChecksum),
+                s"writeChecksum=$writeChecksum, readFromChecksum=$readFromChecksum, " +
+                  s"dvCreationEnabled=$dvCreationEnabled")
+              assert(snapshot.validateChecksum())
+            }
+          }
         }
-        assert(s.numDeletedRecordsOpt == fromCrc._1)
-        assert(s.numDeletionVectorsOpt == fromCrc._2)
+      }
+    }
+  }
 
-        // Canary. Today these accessors reach the value through state reconstruction, because
-        // the aggregation does not compute the DV metrics while DV creation is disabled. If the
-        // readable/writable divergence is ever reconciled
-        // (https://github.com/delta-io/delta/issues/7507), the CRC becomes able to serve them
-        // and this assertion starts failing. When that happens, update `checksumDVMetricsComputed`
-        // along with the aggregation so these fields are served from the CRC again instead of
-        // silently falling back to state reconstruction forever.
-        assert(s.stateReconstructionTriggered,
-          "DV metrics currently fall back to state reconstruction when DV creation is disabled")
+  for {
+    metricsEnabled <- BOOLEAN_DOMAIN
+    histogramEnabled <- BOOLEAN_DOMAIN
+    if !metricsEnabled || !histogramEnabled
+  }
+  test(s"DV metrics respect collection configs: " +
+      s"metricsEnabled=$metricsEnabled, histogramEnabled=$histogramEnabled") {
+    withCrcTable { tableName =>
+      withSQLConf(
+        DeltaSQLConf.DELTA_CHECKSUM_DV_METRICS_ENABLED.key -> "true",
+        DeltaSQLConf.DELTA_DELETED_RECORD_COUNTS_HISTOGRAM_ENABLED.key -> "true",
+        DeltaSQLConf.DELETE_USE_PERSISTENT_DELETION_VECTORS.key -> "true"
+      ) {
+        sql(s"CREATE TABLE $tableName (id LONG) USING delta " +
+          s"TBLPROPERTIES ('delta.enableDeletionVectors' = 'true')")
+        spark.range(10).coalesce(1).write.format("delta").mode("append").saveAsTable(tableName)
+        sql(s"DELETE FROM $tableName WHERE id = 1")
+        sql(s"ALTER TABLE $tableName SET TBLPROPERTIES ('delta.enableDeletionVectors' = 'false')")
+
+        for (readFromChecksum <- BOOLEAN_DOMAIN) {
+          withSQLConf(
+            DeltaSQLConf.USE_SNAPSHOT_STATE_FROM_CHECKSUM_ENABLED.key ->
+              readFromChecksum.toString,
+            DeltaSQLConf.DELTA_CHECKSUM_DV_METRICS_ENABLED.key -> metricsEnabled.toString,
+            DeltaSQLConf.DELTA_DELETED_RECORD_COUNTS_HISTOGRAM_ENABLED.key ->
+              histogramEnabled.toString
+          ) {
+            val snapshot = freshSnapshot(tableName)
+            assert(snapshot.checksumOpt.flatMap(_.numDeletionVectorsOpt).contains(1L))
+            assert(snapshot.checksumOpt.flatMap(_.deletedRecordCountsHistogramOpt).nonEmpty)
+            assert(snapshot.numDeletedRecordsOpt == Option.when(metricsEnabled)(1L))
+            assert(snapshot.numDeletionVectorsOpt == Option.when(metricsEnabled)(1L))
+            assert(snapshot.deletedRecordCountsHistogramOpt.isEmpty)
+          }
+        }
       }
     }
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaFastDropFeatureSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaFastDropFeatureSuite.scala
@@ -627,6 +627,44 @@ class DeltaFastDropFeatureSuite
       !protocol.readerFeatureNames.contains(DeletionVectorsTableFeature.name))
   }
 
+  for {
+    readFromChecksum <- BOOLEAN_DOMAIN
+    metricsEnabled <- BOOLEAN_DOMAIN
+  }
+  test(s"DV drop invariants reject existing vectors after DV creation is disabled: " +
+      s"readFromChecksum=$readFromChecksum, metricsEnabled=$metricsEnabled") {
+    withTempPath { dir =>
+      withSQLConf(DeltaSQLConf.DELTA_CHECKSUM_DV_METRICS_ENABLED.key -> "true") {
+        val deltaLog = DeltaLog.forTable(spark, dir.getAbsolutePath)
+        createTableWithDeletionVectors(deltaLog)
+        sql(s"ALTER TABLE delta.`${dir.getAbsolutePath}` SET TBLPROPERTIES " +
+          s"('delta.enableDeletionVectors' = 'false')")
+      }
+
+      withSQLConf(
+        DeltaSQLConf.USE_SNAPSHOT_STATE_FROM_CHECKSUM_ENABLED.key -> readFromChecksum.toString,
+        DeltaSQLConf.DELTA_CHECKSUM_DV_METRICS_ENABLED.key -> metricsEnabled.toString
+      ) {
+        DeltaLog.clearCache()
+        val table = DeltaTableV2(spark, new Path(dir.getAbsolutePath))
+        val snapshot = table.initialSnapshot
+        assert(!DeltaConfigs.ENABLE_DELETION_VECTORS_CREATION.fromMetaData(snapshot.metadata))
+        assert(snapshot.allFiles.filter(col("deletionVector").isNotNull).count() == 2L)
+        assert(snapshot.numDeletionVectorsOpt == Option.when(metricsEnabled)(2L))
+        assert(!DeletionVectorsTableFeature.validateDropInvariants(table, snapshot))
+
+        sql(s"REORG TABLE delta.`${dir.getAbsolutePath}` APPLY (PURGE)")
+        val purgedSnapshot = table.update()
+        assert(purgedSnapshot.allFiles.filter(col("deletionVector").isNotNull).isEmpty)
+        assert(purgedSnapshot.numDeletionVectorsOpt == Option.when(metricsEnabled)(0L))
+        assert(DeletionVectorsTableFeature.validateDropInvariants(table, purgedSnapshot))
+
+        dropDeletionVectors(table.deltaLog)
+        assert(spark.read.format("delta").load(dir.getAbsolutePath).count() == 80L)
+      }
+    }
+  }
+
   private def validateTombstones(
       log: DeltaLog,
       expectedDVTombstoneCount: Option[Int] = None): Unit = {


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Fixes https://github.com/delta-io/delta/issues/7507. This follows the [DV metric predicate discussion](https://github.com/delta-io/delta/pull/6929#discussion_r3833837203) with @dhruvarya-db in delta-io/delta#6929. That PR preserved the existing aggregation behavior; this follow-up resolves the underlying readable-versus-writable divergence. \+ @timothyw553

Disabling `delta.enableDeletionVectors` prevents creating new deletion vectors but does not remove existing ones. Snapshot reconstruction currently gates DV metrics on writability, so it returns `None` after DV creation is disabled even when the table still contains DVs and its checksum retains their metrics.

This PR aligns reconstruction and checksum-backed accessors on the existing `deletionVectorsReadableAndMetricsEnabled` and `deletionVectorsReadableAndHistogramEnabled` predicates. Both paths report existing DV counts and the deleted-record histogram regardless of whether DV creation is enabled, while continuing to respect the metric collection configs. The redundant `checksumDVMetricsComputed` wrapper is removed.

`DeletionVectorsTableFeature.validateDropInvariants` also stops treating an unavailable DV count as zero. When metrics are unavailable, it uses `DeletionVectorUtils.isTableDVFree` to check active files. This keeps the drop validation meaningful when metric collection is disabled; known counts continue to avoid the additional scan.

## How was this patch tested?

Added and updated regression coverage in `ChecksumSuite`, `ChecksumDVMetricsSuite`, and `DeltaFastDropFeatureSuite`, including CatalogOwned checksum coverage:

- DV counts and histograms remain correct before and after disabling DV creation, with and without a CRC and with checksum-backed reads enabled or disabled.
- Available CRC metrics avoid state reconstruction, and the metric/histogram collection configs remain respected.
- Incremental and reconstructed checksums retain correct DV metrics after creation is disabled.
- Feature-drop validation rejects snapshots with remaining DVs, including when metrics are disabled, and permits dropping the feature after `REORG ... APPLY (PURGE)` removes them.

The new regression cases reproduced the failures against the base implementation and pass with the fix.

## Does this PR introduce _any_ user-facing changes?

Yes. When existing DVs remain after `delta.enableDeletionVectors` is disabled, snapshot metric accessors report their actual counts and histogram when metric collection is enabled, rather than returning `None`. Feature-drop validation also detects leftover DVs when metric collection is disabled.
