### PR TITLE
[SPARK] Add new expressions to AllowedExpressionAllowlist

### DIFF
--- a/spark/src/main/scala-shims/spark-4.0-4.1/AllowedUserProvidedExpressionsShims.scala
+++ b/spark/src/main/scala-shims/spark-4.0-4.1/AllowedUserProvidedExpressionsShims.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.expressions
+
+/** Additional classes allowed during user-provided expression validation in Spark 4.0 and 4.1. */
+object AllowedUserProvidedExpressionsShims {
+  val additionalExpressions: Set[Class[_]] = Set.empty
+}

--- a/spark/src/main/scala-shims/spark-4.2/AllowedUserProvidedExpressionsShims.scala
+++ b/spark/src/main/scala-shims/spark-4.2/AllowedUserProvidedExpressionsShims.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.expressions
+
+/** Additional classes allowed during user-provided expression validation in Spark 4.2. */
+object AllowedUserProvidedExpressionsShims {
+  val additionalExpressions: Set[Class[_]] = Set(
+    classOf[With],
+    classOf[CommonExpressionDef],
+    classOf[CommonExpressionRef],
+    classOf[TypedNullLiteral],
+    classOf[TimestampAddInterval])
+}

--- a/spark/src/main/scala-shims/spark-4.2/AllowedUserProvidedExpressionsShims.scala
+++ b/spark/src/main/scala-shims/spark-4.2/AllowedUserProvidedExpressionsShims.scala
@@ -19,9 +19,6 @@ package org.apache.spark.sql.catalyst.expressions
 /** Additional classes allowed during user-provided expression validation in Spark 4.2. */
 object AllowedUserProvidedExpressionsShims {
   val additionalExpressions: Set[Class[_]] = Set(
-    classOf[With],
-    classOf[CommonExpressionDef],
-    classOf[CommonExpressionRef],
     classOf[TypedNullLiteral],
     classOf[TimestampAddInterval])
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/AllowedUserProvidedExpressions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/AllowedUserProvidedExpressions.scala
@@ -336,7 +336,7 @@ object AllowedUserProvidedExpressions {
     // Special expressions that are not built-in expressions.
     expression[AttributeReference]("col"),
     expression[Literal]("lit")
-  )
+  ) ++ AllowedUserProvidedExpressionsShims.additionalExpressions
 
   val checkConstraintExpressions: Set[Class[_]] = Set(
     expression[Contains]("contains"),

--- a/spark/src/main/scala/org/apache/spark/sql/delta/AllowedUserProvidedExpressions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/AllowedUserProvidedExpressions.scala
@@ -334,6 +334,9 @@ object AllowedUserProvidedExpressions {
     expression[StructsToCsv]("to_csv"),
 
     // Special expressions that are not built-in expressions.
+    classOf[With],
+    classOf[CommonExpressionDef],
+    classOf[CommonExpressionRef],
     expression[AttributeReference]("col"),
     expression[Literal]("lit")
   ) ++ AllowedUserProvidedExpressionsShims.additionalExpressions

--- a/spark/src/test/scala/org/apache/spark/sql/delta/GeneratedColumnSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/GeneratedColumnSuite.scala
@@ -2229,7 +2229,47 @@ trait GeneratedColumnSuiteBase
       }
     }
   }
+
+  test("validateGeneratedColumns: NULLIF with regexp_extract") {
+    Seq(false, true).foreach { alwaysInlineCommonExpr =>
+      withSQLConf(SQLConf.ALWAYS_INLINE_COMMON_EXPR.key -> alwaysInlineCommonExpr.toString) {
+        val body = StructField("body", StringType)
+        val shortUrlId = withGenerationExpression(
+          StructField("short_url_id", StringType),
+          "NULLIF(regexp_extract(body, 'short/([^ ]+)', 1), '')")
+        validateGeneratedColumns(spark, StructType(Seq(body, shortUrlId)))
+      }
+    }
+  }
+
+  test("OPTIMIZE rewrites files with a NULLIF generated column") {
+    withTableName("nullif_generated_column") { table =>
+      withSQLConf(
+        DeltaSQLConf.DELTA_OPTIMIZE_WRITE_ENABLED.key -> "false",
+        DeltaSQLConf.DELTA_AUTO_COMPACT_ENABLED.key -> "false") {
+        createTable(
+          table,
+          None,
+          "body STRING, short_url_id STRING",
+          Map("short_url_id" -> "NULLIF(regexp_extract(body, 'short/([^ ]+)', 1), '')"),
+          Nil)
+
+        sql(s"INSERT INTO $table (body) VALUES ('short/abc')")
+        sql(s"INSERT INTO $table (body) VALUES ('no-match')")
+
+        val deltaLog = DeltaLog.forTableWithSnapshot(spark, TableIdentifier(table))._1
+        assert(deltaLog.update().numOfFiles > 1)
+        val numFilesAdded = sql(s"OPTIMIZE $table")
+          .select($"metrics.numFilesAdded")
+          .as[Long]
+          .head()
+        assert(numFilesAdded > 0)
+        checkAnswer(
+          sql(s"SELECT body, short_url_id FROM $table"),
+          Seq(Row("short/abc", "abc"), Row("no-match", null)))
+      }
+    }
+  }
 }
 
 class GeneratedColumnSuite extends GeneratedColumnSuiteBase
-

--- a/spark/src/test/scala/org/apache/spark/sql/delta/schema/CheckConstraintsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/schema/CheckConstraintsSuite.scala
@@ -636,6 +636,40 @@ class CheckConstraintsSuite extends QueryTest
     }
   }
 
+  test("check constraints with timestamp + interval (TimestampAddInterval) expression") {
+    assume(
+      sparkVersionBucket(spark) == "4.2+",
+      "TimestampAddInterval is only allowlisted in Spark 4.2")
+    withSQLConf(DeltaSQLConf.VALIDATE_CHECK_CONSTRAINTS.key ->
+      ValidateCheckConstraintsMode.ASSERT.toString) {
+      val testTable = "time_add_test"
+      withTable(testTable) {
+        sql(createTableSQL(testTable, "id INT, event_ts TIMESTAMP",
+          props = Map("delta.feature.checkConstraints" -> "supported")))
+        sql(s"ALTER TABLE $testTable ADD CONSTRAINT c_time_add " +
+          "CHECK (event_ts > CAST('2020-01-01' AS TIMESTAMP) + INTERVAL 1 DAY)")
+        sql(s"INSERT INTO $testTable VALUES (1, '2025-06-15 10:00:00')")
+        checkAnswer(
+          sql(s"SELECT id FROM $testTable"),
+          Seq(Row(1)))
+      }
+    }
+  }
+
+  test("CREATE TABLE with a NULLIF check constraint succeeds") {
+    withSQLConf(DeltaSQLConf.VALIDATE_CHECK_CONSTRAINTS.key ->
+      ValidateCheckConstraintsMode.ASSERT.toString) {
+      val tableName = "test_create_nullif_constraint"
+      withTable(tableName) {
+        sql(createTableSQL(
+          tableName,
+          "id INT, value STRING",
+          props = Map("delta.constraints.nullif_value" -> "NULLIF(value, value) IS NULL")))
+        sql(s"INSERT INTO $tableName VALUES (1, '')")
+      }
+    }
+  }
+
   test("check constraints with array_size and array_compact expressions") {
     withSQLConf(DeltaSQLConf.VALIDATE_CHECK_CONSTRAINTS.key ->
       ValidateCheckConstraintsMode.ASSERT.toString) {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/schema/CheckConstraintsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/schema/CheckConstraintsSuite.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.delta.schema
 
 import scala.collection.JavaConverters._
 
-import org.apache.spark.sql.delta.{AllowedUserProvidedExpressions, DeltaConfigs, DeltaLog, DeltaTableProvider}
+import org.apache.spark.sql.delta.{AllowedUserProvidedExpressions, DeltaConfigs, DeltaLog, DeltaTableProvider, DeltaTestUtils}
 import org.apache.spark.sql.delta.constraints.CharVarcharConstraint
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.sources.DeltaSQLConf.ValidateCheckConstraintsMode
@@ -638,7 +638,7 @@ class CheckConstraintsSuite extends QueryTest
 
   test("check constraints with timestamp + interval (TimestampAddInterval) expression") {
     assume(
-      sparkVersionBucket(spark) == "4.2+",
+      DeltaTestUtils.sparkVersionBucket(spark) == "4.2+",
       "TimestampAddInterval is only allowlisted in Spark 4.2")
     withSQLConf(DeltaSQLConf.VALIDATE_CHECK_CONSTRAINTS.key ->
       ValidateCheckConstraintsMode.ASSERT.toString) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
`NULLIF` is already allowed in Delta generated columns and check constraints. In Spark 4.2, its analyzed replacement contains With, CommonExpressionDef, CommonExpressionRef, and TypedNullLiteral. Delta validates the completely analyzed expression tree, but these internal expressions were missing from its allowlist. Consequently, valid uses of `NULLIF` could fail validation, including when OPTIMIZE revalidates a table's generated columns.

This PR introduces Spark version specific expression allowlist shims. The Spark 4.0-4.1 shim adds no expressions, while the Spark 4.2 shim adds the internal NULLIF expansion expressions and `TimestampAddInterval`. A Boolean shim method also lets the existing TimestampAddInterval test cancel on Spark versions where that expression is not allowlisted.

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
UTs
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
