### PR TITLE
[Spark] Assert no V1 fallback in DeltaV2SourceRowTrackingSuite

### DIFF
--- a/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceRowTrackingSuite.scala
+++ b/spark-unified/src/test/scala/org/apache/spark/sql/delta/test/DeltaV2SourceRowTrackingSuite.scala
@@ -28,16 +28,16 @@ class DeltaV2SourceRowTrackingSuite
 
   override protected def useDsv2: Boolean = true
 
+  override protected def assertNoV1Fallback: Boolean = true
+
   override protected def shouldPassTests: Set[String] = Set(
     "CDC stream on row-tracking table works when _metadata not selected",
     "CDC stream on row-tracking column-mapped table rejects _metadata.row_id"
   )
 
   override protected def shouldFailTests: Set[String] = Set(
-    // TODO: Requires Spark PR apache/spark#56133, which adds pruneColumns() to
-    // MicroBatchExecution for SupportsPushDownRequiredColumns sources. Without it
-    // _metadata is not added to requiredDataSchema, causing AIOOBE at executor
-    // runtime when codegen reads position N from an N-column batch.
+    // This inherited test expects _metadata.row_id to be unavailable, but the V2 connector
+    // exposes row-tracking metadata in streaming. Keep the V1-specific assertion ignored in V2.
     "_metadata.row_id is not available in streaming"
   )
 }


### PR DESCRIPTION
## Description

`DeltaV2SourceRowTrackingSuite` runs `DeltaSourceRowTrackingSuiteBase` through the DSv2 connector. This enables `assertNoV1Fallback` so that each passing test additionally verifies its executed plan contains no V1 Delta file-source scan, ensuring the covered streaming row-tracking paths genuinely run through the DSv2 connector rather than silently falling back to V1.

It also updates the comment on the excluded `_metadata.row_id is not available in streaming` case in `shouldFailTests` to state the actual reason it is excluded under V2: the inherited case asserts that `_metadata.row_id` is unavailable in streaming, but the DSv2 connector exposes row-tracking metadata in streaming, so the V1-specific assertion does not apply.

## How was this patch tested?

Test-only change to the existing `DeltaV2SourceRowTrackingSuite`; the enabled assertion runs as part of the suite's passing tests. No functional change.

## Does this PR introduce _any_ user-facing changes?

No.
