### PR TITLE
[Spark] Make the AdaptiveMetadata table feature removable

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/PreDowngradeTableFeatureCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/PreDowngradeTableFeatureCommand.scala
@@ -343,6 +343,15 @@ case class DeletionVectorsPreDowngradeCommand(table: DeltaTableV2)
   }
 }
 
+case class AdaptiveMetadataPreDowngradeCommand(table: DeltaTableV2)
+  extends PreDowngradeTableFeatureCommand {
+
+  override def removeFeatureTracesIfNeeded(spark: SparkSession): PreDowngradeStatus = {
+    throw new UnsupportedOperationException(
+      s"Dropping the ${AdaptiveMetadataTableFeature.name} table feature is not yet supported.")
+  }
+}
+
 case class V2CheckpointPreDowngradeCommand(table: DeltaTableV2)
   extends PreDowngradeTableFeatureCommand
   with DeltaLogging {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
@@ -920,7 +920,8 @@ object DeletionVectorsTableFeature
 }
 
 object AdaptiveMetadataTableFeature
-  extends ReaderWriterFeature(name = "adaptiveMetadata-preview") {
+  extends ReaderWriterFeature(name = "adaptiveMetadata-preview")
+  with RemovableFeature {
 
   // The [[AdaptiveMetadataTableFeature]] relies on the following features:
   //  - catalogManaged: adaptive metadata tables are catalog managed (CCv2) only.
@@ -936,6 +937,13 @@ object AdaptiveMetadataTableFeature
     DomainMetadataTableFeature,
     DeletionVectorsTableFeature,
     ColumnMappingTableFeature)
+
+  override def preDowngradeCommand(table: DeltaTableV2): PreDowngradeTableFeatureCommand =
+    AdaptiveMetadataPreDowngradeCommand(table)
+
+  override def validateDropInvariants(table: DeltaTableV2, snapshot: Snapshot): Boolean = true
+
+  override def actionUsesFeature(action: Action): Boolean = false
 }
 
 object RowTrackingFeature extends WriterFeature(name = "rowTracking")

--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/DeletionVectorDescriptor.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/DeletionVectorDescriptor.scala
@@ -449,19 +449,19 @@ object DeletionVectorDescriptor {
       cardinality = cardinality)
 
   /**
-   * Returns whether the path points to a deletion vector file.
-   * Note, external writers are no enforced to create DV files with the same naming convertions.
-   * This function is intended for testing. */
-  private[delta] def isDeletionVectorPath(path: Path): Boolean =
+   * Returns whether the path points to a deletion vector file written by this Spark
+   * implementation. This function is intended for testing. Use at your own risk.
+   */
+  private[delta] def isSparkImplDeletionVectorPath(path: Path): Boolean =
     deletionVectorFileNamePattern.matcher(path.getName).matches()
 
-  /** Only for testing. */
-  private[delta] def isDeletionVectorPath(path: String): Boolean =
-    isDeletionVectorPath(new Path(path))
+  /** This function is intended for testing. Use at your own risk. */
+  private[delta] def isSparkImplDeletionVectorPath(path: String): Boolean =
+    isSparkImplDeletionVectorPath(new Path(path))
 
-  /** Same as above but as a column expression. Only for testing. */
-  private[delta] def isDeletionVectorPath(pathCol: Column): Column =
-    DeltaUDF.booleanFromString(isDeletionVectorPath)(pathCol)
+  /** Same as above but as a column expression. Use at your own risk. */
+  private[delta] def isSparkImplDeletionVectorPath(pathCol: Column): Column =
+    DeltaUDF.booleanFromString(isSparkImplDeletionVectorPath)(pathCol)
 
   /** Returns a boolean column that corresponds to whether each deletion vector is inline. */
   def isInline(dv: Column): Column =

--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -1280,7 +1280,8 @@ case class RemoveFile(
 
   /** Only for testing. */
   @JsonIgnore
-  private [delta] def isDVTombstone: Boolean = DeletionVectorDescriptor.isDeletionVectorPath(new Path(path))
+  private [delta] def isDVTombstone: Boolean =
+    DeletionVectorDescriptor.isSparkImplDeletionVectorPath(new Path(path))
 
 }
 // scalastyle:on

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaFastDropFeatureSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaFastDropFeatureSuite.scala
@@ -635,7 +635,7 @@ class DeltaFastDropFeatureSuite
     val snapshot = log.update()
     val dvPath = DeletionVectorDescriptor
       .urlEncodedRelativePathIfExists(col("deletionVector"), log.dataPath)
-    val isDVTombstone = DeletionVectorDescriptor.isDeletionVectorPath(col("path"))
+    val isDVTombstone = DeletionVectorDescriptor.isSparkImplDeletionVectorPath(col("path"))
     val isInlineDeletionVector = DeletionVectorDescriptor.isInline(col("deletionVector"))
 
     val uniqueDvsFromParquetRemoveFiles = snapshot

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AdaptiveMetadataTableFeatureSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AdaptiveMetadataTableFeatureSuite.scala
@@ -64,9 +64,9 @@ class AdaptiveMetadataTableFeatureSuite
   private def protocolOf(tableName: String) =
     DeltaLog.forTableWithSnapshot(spark, new TableIdentifier(tableName))._2.protocol
 
-  test("feature is a ReaderWriterFeature and is NOT a RemovableFeature") {
+  test("feature is a ReaderWriterFeature and a RemovableFeature") {
     assert(AdaptiveMetadataTableFeature.isReaderWriterFeature)
-    assert(!AdaptiveMetadataTableFeature.isInstanceOf[RemovableFeature])
+    assert(AdaptiveMetadataTableFeature.isInstanceOf[RemovableFeature])
   }
 
   test("feature is not automatically enabled by metadata") {


### PR DESCRIPTION
## Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This makes the `AdaptiveMetadataTableFeature` a `RemovableFeature`:

- `AdaptiveMetadataTableFeature` now mixes in `RemovableFeature` and defines
  `preDowngradeCommand`, `validateDropInvariants`, and `actionUsesFeature`.
- The associated `AdaptiveMetadataPreDowngradeCommand` currently throws
  `UnsupportedOperationException`, because actually dropping the feature is not
  yet supported. This establishes the removability contract without enabling a
  drop.

It also renames the test-only helper
`DeletionVectorDescriptor.isDeletionVectorPath` (and its overloads and callers)
to `isSparkImplDeletionVectorPath`, to make explicit that it only recognizes
deletion vector files written by this Spark implementation.

## How was this patch tested?

Updated `AdaptiveMetadataTableFeatureSuite` to assert the feature is now a
`RemovableFeature`, and updated `DeltaFastDropFeatureSuite` for the renamed
helper.

## Does this PR introduce _any_ user-facing change?

No.
