### PR TITLE
Pull commit-preparation logic out of OptimisticTransaction.doCommit

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -91,6 +91,38 @@ case class CoordinatedCommitsStats(
   commitCoordinatorName: String,
   commitCoordinatorConf: Map[String, String])
 
+/**
+ * Metrics gathered while preparing a commit attempt, carried through to the
+ * final [[CommitStats]].
+ */
+case class CommitPrepMetrics(
+    amtMetrics: AMTMetrics = AMTMetrics(),
+    icebergMetadataGenerationDurationMsOpt: Option[Long] = None)
+
+/**
+ * The prepared state of one commit attempt, ready for the write step. Produced by
+ * [[OptimisticTransaction.prepareCommit]] on the first attempt and by
+ * [[OptimisticTransaction.rebaseCurrentTransactionInfo]] on a conflict retry -- the only two places
+ * that edit the [[CurrentTransactionInfo]] once a commit attempt begins.
+ *
+ * @param commitVersion the version this attempt targets (the rebased version on a retry)
+ * @param currentTransactionInfo the fully prepared txn info (Uniform + AMT checkpoint ref applied)
+ * @param currentTransactionInfoBeforePreparedResult the txn info before this attempt's preparation
+ *        (conflict-resolved, but without the Uniform/AMT edits). The retry loop feeds this -- not
+ *        the prepared `currentTransactionInfo` -- into the next `checkForConflicts`, so prepared
+ *        state never leaks into a later conflict check.
+ * @param actionsToWriteInLogFile the final actions to persist, incl. the inline AMT checkpoint
+ * @param amtWriteResultForLastCheckpointOpt the AMT write result, for the _last_checkpoint write
+ * @param prepMetrics metrics gathered during preparation
+ */
+case class PrepareCommitResult(
+    commitVersion: Long,
+    currentTransactionInfo: CurrentTransactionInfo,
+    currentTransactionInfoBeforePreparedResult: CurrentTransactionInfo,
+    actionsToWriteInLogFile: Seq[Action],
+    amtWriteResultForLastCheckpointOpt: Option[AMTWriteResult],
+    prepMetrics: CommitPrepMetrics)
+
 /** Record metrics about a successful commit. */
 case class CommitStats(
   /** The version read by the txn when it starts. */
@@ -655,7 +687,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
 
   /**
    * Do the actual checks and works to update the metadata and save it into the `newMetadata`
-   * field, which will be added to the actions to commit in [[prepareCommit]].
+   * field, which will be added to the actions to commit in [[prepareInitialActions]].
    */
   protected def updateMetadataInternal(
       proposedNewMetadata: Metadata,
@@ -1854,14 +1886,14 @@ trait OptimisticTransactionImpl extends TransactionHelper
 
       val identityOnlyMetadataUpdate = isIdentityOnlyMetadataUpdate()
       // Update schema for IDENTITY column writes if necessary. This has to be called before
-      // `prepareCommit` because it might change metadata and `prepareCommit` is responsible for
-      // converting updated metadata into a `Metadata` action.
+      // `prepareInitialActions` because it might change metadata and `prepareInitialActions` is
+      // responsible for converting updated metadata into a `Metadata` action.
       precommitUpdateSchemaWithIdentityHighWaterMarks()
 
       // Try to commit at the next version.
       var preparedActions =
         executionObserver.preparingCommit {
-          prepareCommit(finalActions, op)
+          prepareInitialActions(finalActions, op)
         }
 
       validateActionsAddFileInvariants(preparedActions, metadata)
@@ -2499,7 +2531,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
    * Prepare for a commit by doing all necessary pre-commit checks and modifications to the actions.
    * @return The finalized set of actions.
    */
-  protected def prepareCommit(
+  protected def prepareInitialActions(
       actions: Seq[Action],
       op: DeltaOperations.Operation): Seq[Action] = {
 
@@ -2771,7 +2803,10 @@ trait OptimisticTransactionImpl extends TransactionHelper
       deltaLog, "delta.commit.allAttempts") {
     lockCommitIfEnabled {
       var commitVersion = attemptVersion
-      var updatedCurrentTransactionInfo = currentTransactionInfo
+      // The [[CurrentTransactionInfo]] with everything except the prepareCommit (Uniform/AMT)
+      // edits. This is the logical set of actions we want to commit, and it is what gets fed to
+      // the ConflictChecker in case of a conflict.
+      var updatedUnpreparedCurrentTransactionInfo = currentTransactionInfo
       val amtWriterManager = new AMTWriterManager(snapshot, currentTransactionInfo.op)
       val isFsToCcCommit =
         snapshot.metadata.coordinatedCommitsCoordinatorName.isEmpty &&
@@ -2781,26 +2816,41 @@ trait OptimisticTransactionImpl extends TransactionHelper
         spark.conf.get(DeltaSQLConf.DELTA_MAX_NON_CONFLICT_RETRY_COMMIT_ATTEMPTS)
       var nonConflictAttemptNumber = 0
       var shouldCheckForConflicts = false
+      // Idempotent handling: sometimes the commit RPC fails but the commit actually landed. We
+      // discover that in the next iteration during rebase. Once we establish that our commit from
+      // the previous attempt really succeeded, we finalize it by invoking performPostCommitActions
+      // with this lastPreparedCommitResult (the exact actions, metrics, and AMT write result of the
+      // attempt that landed) rather than re-reading them back.
+      var lastPreparedCommitResult: Option[PrepareCommitResult] = None
 
       for (attemptNumber <- 0 to maxRetryAttempts) {
         try {
           val (postCommitSnapshot, committedTransactionInfo) = if (!shouldCheckForConflicts) {
+            val prepareCommitResult = prepareCommit(
+              commitVersion,
+              updatedUnpreparedCurrentTransactionInfo,
+              amtWriterManager)
+            lastPreparedCommitResult = Some(prepareCommitResult)
             doCommit(
-              commitVersion, updatedCurrentTransactionInfo, attemptNumber, isolationLevel,
+              prepareCommitResult.commitVersion,
+              prepareCommitResult.currentTransactionInfo,
+              prepareCommitResult.actionsToWriteInLogFile,
+              prepareCommitResult.amtWriteResultForLastCheckpointOpt,
+              prepareCommitResult.prepMetrics,
+              attemptNumber,
+              isolationLevel)
+          } else recordDeltaOperation(deltaLog, "delta.commit.retry") {
+            val rebaseResult = rebaseCurrentTransactionInfo(
+              commitVersion,
+              updatedUnpreparedCurrentTransactionInfo,
+              attemptNumber,
+              isolationLevel,
+              lastPreparedCommitResult,
               amtWriterManager
             )
-          } else recordDeltaOperation(deltaLog, "delta.commit.retry") {
-            // The [[CurrentTransactionInfo]] might keep on getting updated while resolving
-            // conflicts against the already committed concurrent transactions. This can happen
-            // when we resolve conflicts against no-data-change transaction - we might map our
-            // readFiles or we might rollback the no-data-change transaction and update our actions
-            // that we want to commit.
-            val (newCommitVersion, newCurrentTransactionInfo) = checkForConflicts(
-              commitVersion, updatedCurrentTransactionInfo, attemptNumber, isolationLevel,
-              amtWriterManager)
             // Check if we may have already committed this version but retried due to
             // a transient error. If that's the case, just return success.
-            newCurrentTransactionInfo.idempotentCommitAlreadyLandedAt match {
+            rebaseResult.currentTransactionInfo.idempotentCommitAlreadyLandedAt match {
               case Some(committedVersion) =>
                 // The idempotent self-commit is expected to land at exactly the version we were
                 // attempting. If it landed at a different version, surface it.
@@ -2809,36 +2859,44 @@ trait OptimisticTransactionImpl extends TransactionHelper
                     s"Idempotent self-commit landed at version $committedVersion but the " +
                       s"transaction was attempting version $commitVersion.")
                 }
-                // newCurrentTransactionInfo carries the actions read back from the commit file
-                // that actually landed (adopted in resolveConflicts on the idempotent path), so
-                // post-commit stats and the resulting CommittedTransaction reflect exactly what
-                // was committed rather than the pre-doCommit action set
-                val actions = newCurrentTransactionInfo.finalActionsToCommit
+                // rebaseResult is the prepared result from the attempt that already landed (the
+                // commit RPC failed but the write succeeded); it was validated against the landed
+                // commit inside rebaseCurrentTransactionInfo. Finalize it directly -- its actions,
+                // metrics, and AMT write result are exactly what was committed.
+                val actions = rebaseResult.actionsToWriteInLogFile
                 val jsonActions = actions.map(_.json)
                 val (postCommitSnapshot, txnInfo) = performPostCommitActions(
                   committedVersion,
                   actions,
                   jsonActions,
-                  newCurrentTransactionInfo,
+                  rebaseResult.currentTransactionInfo,
                   isolationLevel,
                   fsWriteStartNanoOpt = None,
-                  amtWriterManager = amtWriterManager,
+                  prepMetrics = rebaseResult.prepMetrics,
                   newChecksumOpt = None,
-                  amtWriteResultOpt = None,
+                  amtWriteResultOpt = rebaseResult.amtWriteResultForLastCheckpointOpt,
                   commitOpt = None,
                   isIdempotentRetry = true
                 )
                 return (committedVersion, postCommitSnapshot, txnInfo)
               case None => // fall through to the normal retry commit below
             }
-            commitVersion = newCommitVersion
-            updatedCurrentTransactionInfo = newCurrentTransactionInfo
+            commitVersion = rebaseResult.commitVersion
+            // Feed the unprepared (conflict-resolved) txn info -- not this attempt's Uniform/AMT
+            // edits -- into any later retry's conflict check.
+            updatedUnpreparedCurrentTransactionInfo =
+              rebaseResult.currentTransactionInfoBeforePreparedResult
+            lastPreparedCommitResult = Some(rebaseResult)
             doCommit(
-              commitVersion, updatedCurrentTransactionInfo, attemptNumber, isolationLevel,
-              amtWriterManager
-            )
+              rebaseResult.commitVersion,
+              rebaseResult.currentTransactionInfo,
+              rebaseResult.actionsToWriteInLogFile,
+              rebaseResult.amtWriteResultForLastCheckpointOpt,
+              rebaseResult.prepMetrics,
+              attemptNumber,
+              isolationLevel)
           }
-          return (commitVersion, postCommitSnapshot, updatedCurrentTransactionInfo)
+          return (commitVersion, postCommitSnapshot, updatedUnpreparedCurrentTransactionInfo)
         } catch {
           case _: FileAlreadyExistsException if isFsToCcCommit =>
             // Don't retry if this commit tries to upgrade the table from filesystem to managed
@@ -2875,25 +2933,54 @@ trait OptimisticTransactionImpl extends TransactionHelper
         maxRetryAttempts + 1,
         commitVersion,
         attemptVersion,
-        updatedCurrentTransactionInfo.finalActionsToCommit.length,
+        updatedUnpreparedCurrentTransactionInfo.finalActionsToCommit.length,
         totalCommitAttemptTime)
     }
   }
 
   /**
-   * Commit `actions` using `attemptVersion` version number. Throws a FileAlreadyExistsException
-   * if any conflicts are detected.
-   *
-   * @param amtWriterManager the AMT writer for this commit, shared across all attempts.
-   * @return the post-commit snapshot and transaction info used by the successful commit.
+   * If we believe that this is an idempotent self-commit, the actions that we read from the
+   * winning commit should match exactly with what we were trying to write. Note that the
+   * conflict checking logic injects a `version` in the winning commit's CommitInfo (see
+   * [[WinningCommitSummary]]), which we explicitly ignore during the comparison.
    */
-  protected def doCommit(
+  private def validateIdempotentCommitInvariants(
+      prepared: PrepareCommitResult,
+      landedActions: Seq[Action]): Unit = {
+    // Comparing the full action lists has a performance cost, so this validation is gated behind a
+    // flag and is intended to be removed once the idempotent self-commit finalization path is
+    // proven.
+    if (!spark.conf.get(
+        DeltaSQLConf.DELTA_COMMIT_IDEMPOTENCY_CHECK_VALIDATE_PREPARED_ACTIONS_ENABLED)) {
+      return
+    }
+    val clearCommitInfoVersion: Action => Action = {
+      case ci: CommitInfo => ci.copy(version = None)
+      case other => other
+    }
+    val msg = "Prepared commit actions do not match the actions read back from the landed " +
+      "idempotent self-commit (ignoring CommitInfo.version)."
+    deltaAssertAndThrow(
+      prepared.actionsToWriteInLogFile.map(clearCommitInfoVersion) ==
+        landedActions.map(clearCommitInfoVersion),
+      name = "idempotentCommitPreparedActionsMismatch",
+      msg = msg,
+      throwable = new IllegalStateException(msg),
+      deltaLog = deltaLog)
+  }
+
+  /**
+   * Prepares one commit attempt:
+   *   - generates Uniform/Iceberg metadata
+   *   - handles writing Adaptive metadata tree
+   * Invoked directly on the first attempt;
+   * On a conflict retry, [[rebaseCurrentTransactionInfo]] invokes it after conflict resolution.
+   *
+   */
+  protected def prepareCommit(
       attemptVersion: Long,
       currentTransactionInfo: CurrentTransactionInfo,
-      attemptNumber: Int,
-      isolationLevel: IsolationLevel,
-      amtWriterManager: AMTWriterManager
-  ): (Snapshot, CurrentTransactionInfo) = {
+      amtWriterManager: AMTWriterManager): PrepareCommitResult = {
     val targetCatalogTable = catalogTable
     // If the table requires atomic Iceberg metadata generation
     // , generate iceberg metadata and update the transaction info.
@@ -2949,6 +3036,85 @@ trait OptimisticTransactionImpl extends TransactionHelper
           currentCommitAttemptAMTCheckpointOpt = Some(amtCheckpoint))
       case None => updatedCurrentTransactionInfo
     }
+    PrepareCommitResult(
+      commitVersion = attemptVersion,
+      currentTransactionInfo = txnInfoForCommit,
+      currentTransactionInfoBeforePreparedResult = currentTransactionInfo,
+      actionsToWriteInLogFile = actions,
+      amtWriteResultForLastCheckpointOpt = amtWriteResultOpt,
+      prepMetrics = CommitPrepMetrics(
+        amtMetrics = amtWriterManager.metrics.copy(),
+        icebergMetadataGenerationDurationMsOpt = icebergMetadataGenerationDurationMsOpt))
+  }
+
+  /**
+   * Resolves conflicts against the winning commits and re-prepares this transaction on top of them.
+   * Runs on a conflict retry: resolves conflicts, updates the post-conflict metrics, then re-runs
+   * the Uniform + AMT preparation via [[prepareCommit]]. Together with [[prepareCommit]]
+   * (used on the first attempt) it is the only place that edits the [[CurrentTransactionInfo]] once
+   * a commit attempt has begun.
+   *
+   * On the idempotent self-commit path (our commit already landed under a transient-error retry)
+   * returns the last prepared result directly.
+   *
+   */
+  protected def rebaseCurrentTransactionInfo(
+      commitVersion: Long,
+      currentTransactionInfo: CurrentTransactionInfo,
+      attemptNumber: Int,
+      isolationLevel: IsolationLevel,
+      lastPreparedCommitResult: Option[PrepareCommitResult],
+      amtWriterManager: AMTWriterManager): PrepareCommitResult = {
+    // The [[CurrentTransactionInfo]] might keep on getting updated while resolving
+    // conflicts against the already committed concurrent transactions. This can happen
+    // when we resolve conflicts against no-data-change transaction - we might map our
+    // readFiles or we might rollback the no-data-change transaction and update our actions
+    // that we want to commit.
+    val (newCommitVersion, newCurrentTransactionInfo) = checkForConflicts(
+      commitVersion,
+      currentTransactionInfo,
+      attemptNumber,
+      isolationLevel,
+      amtWriterManager)
+    newCurrentTransactionInfo.idempotentCommitAlreadyLandedAt match {
+      case Some(landedVersion) =>
+        // Our commit from a previous attempt already landed (the commit RPC failed but the write
+        // succeeded), so there is nothing new to prepare.
+        val prepared = lastPreparedCommitResult.getOrElse(
+          throw new IllegalStateException(
+            "Idempotent self-commit detected but no prior prepared commit result is " +
+              "available to finalize it."))
+        validateIdempotentCommitInvariants(
+          prepared, newCurrentTransactionInfo.finalActionsToCommit)
+        return prepared.copy(
+          currentTransactionInfo = prepared.currentTransactionInfo.copy(
+            idempotentCommitAlreadyLandedAt = Some(landedVersion)))
+      case None => // nothing landed yet; prepare this attempt normally below
+    }
+    var rebasedTransactionInfo = newCurrentTransactionInfo
+    prepareCommit(
+      newCommitVersion,
+      rebasedTransactionInfo,
+      amtWriterManager)
+  }
+
+  /**
+   * Persists a prepared commit attempt: writes the commit file and runs the post-commit actions.
+   * Throws a FileAlreadyExistsException if any conflicts are detected. The [[PrepareCommitResult]]
+   * carries everything to persist -- all [[CurrentTransactionInfo]] preparation happened in
+   * [[prepareCommit]] / [[rebaseCurrentTransactionInfo]] before this is called.
+   *
+   * @return the post-commit snapshot and transaction info used by the successful commit.
+   */
+  protected def doCommit(
+      attemptVersion: Long,
+      txnInfoForCommit: CurrentTransactionInfo,
+      actions: Seq[Action],
+      amtWriteResultForLastCheckpointOpt: Option[AMTWriteResult],
+      prepMetrics: CommitPrepMetrics,
+      attemptNumber: Int,
+      isolationLevel: IsolationLevel): (Snapshot, CurrentTransactionInfo) = {
+    val targetCatalogTable = catalogTable
     logInfo(
       log"Attempting to commit version ${MDC(DeltaLogKeys.VERSION, attemptVersion)} with " +
       log"${MDC(DeltaLogKeys.NUM_ACTIONS, actions.size.toLong)} actions with " +
@@ -2980,9 +3146,9 @@ trait OptimisticTransactionImpl extends TransactionHelper
       committedTransactionInfo,
       isolationLevel,
       Some(fsWriteStartNano),
-      amtWriterManager,
+      prepMetrics,
       newChecksumOpt,
-      amtWriteResultOpt,
+      amtWriteResultForLastCheckpointOpt,
       commitOpt = Some(commit)
     )
   }
@@ -2995,7 +3161,7 @@ trait OptimisticTransactionImpl extends TransactionHelper
       committedTransactionInfo: CurrentTransactionInfo,
       isolationLevel: IsolationLevel,
       fsWriteStartNanoOpt: Option[Long],
-      amtWriterManager: AMTWriterManager,
+      prepMetrics: CommitPrepMetrics,
       newChecksumOpt: Option[VersionChecksum],
       amtWriteResultOpt: Option[AMTWriteResult],
       commitOpt: Option[Commit],
@@ -3024,7 +3190,8 @@ trait OptimisticTransactionImpl extends TransactionHelper
       // The AMT writer did not write inline, so schedule a follow-up OPTIMIZE CHECKPOINT commit
       // (issued by the post-commit checkpoint hook)
       // if needed.
-      amtWriterManager.planMaintenance(attemptVersion, postCommitSnapshot)
+      AMTWriterManager.planMaintenance(
+        spark, snapshot, committedTransactionInfo.op, attemptVersion, postCommitSnapshot)
     } else {
       // The _last_checkpoint file must be updated here rather than the checkpoint hook, because the
       // hook does not know about the new AMT checkpoint emitted in this commit.
@@ -3041,7 +3208,8 @@ trait OptimisticTransactionImpl extends TransactionHelper
       // the commit JSON, and skipping it would push those actions back inline and bloat the commit
       // JSON -- exactly what the inline path avoids. The rare double materialization is the
       // accepted cost of never writing a very large commit JSON.
-      amtWriterManager.planMaintenanceAfterInlineWrite(attemptVersion, postCommitSnapshot)
+      AMTWriterManager.planMaintenanceAfterInlineWrite(
+        spark, snapshot, committedTransactionInfo.op, attemptVersion, postCommitSnapshot)
     }
     val commitStatsComputer = new CommitStatsComputer()
     // Add to commit stats and consume the returned iterator.
@@ -3068,9 +3236,9 @@ trait OptimisticTransactionImpl extends TransactionHelper
       commitInfoOpt = committedTransactionInfo.commitInfo,
       commitSizeBytes = commitSizeBytes,
       amtWriteMetricsOpt = Option.when(
-        amtWriterManager.metrics.writeAttempts.nonEmpty ||
-          amtWriterManager.metrics.backrefRebaseAttempts.nonEmpty)(
-        amtWriterManager.metrics),
+        prepMetrics.amtMetrics.writeAttempts.nonEmpty ||
+          prepMetrics.amtMetrics.backrefRebaseAttempts.nonEmpty)(
+        prepMetrics.amtMetrics),
       isIdempotentRetry = isIdempotentRetry
     )
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/TransactionExecutionObserver.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TransactionExecutionObserver.scala
@@ -65,7 +65,7 @@ trait TransactionExecutionObserver
    * These are called from within the transaction object.
    */
 
-  /** Wraps `prepareCommit`. */
+  /** Wraps `prepareInitialActions`. */
   def preparingCommit[T](f: => T): T
 
   /*

--- a/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriterManager.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/amt/AMTWriterManager.scala
@@ -299,129 +299,9 @@ class AMTWriterManager(
     result
   }
 
-  /**
-   * The maintenance work a committed transaction should schedule for after it commits.
-   * The maintenance work will be done by CheckpointHook
-   */
-  def planMaintenance(
-      commitVersion: Long,
-      postCommitSnapshot: Snapshot): MaintenanceOperation = {
-    // if the commit itself was to do a checkpoint, don't schedule any maintenance as part
-    // of its post-commit hook.
-    if (!AMTUtils.amtEnabled(readSnapshot)
-        || initialOperation.isInstanceOf[DeltaOperations.OptimizeCheckpoint]) {
-      return MaintenanceOperation()
-    }
-
-
-    val amtTriggerModeOpt = followUpTriggerMode(commitVersion, postCommitSnapshot)
-    MaintenanceOperation(
-      shouldCheckpoint = amtTriggerModeOpt.isDefined,
-      amtTriggerModeOpt = amtTriggerModeOpt)
-  }
-
-  /**
-   * The maintenance work to schedule after a large commit wrote its AMT inline.
-   *
-   * An inline write is always incremental. If a table keeps getting inline AMTs, we still want it
-   * to get a full AMT once in a while when the last full AMT was older than
-   * checkpointInterval * fullRewriteCheckpointIntervalMultiplier.
-   */
-  def planMaintenanceAfterInlineWrite(
-      commitVersion: Long,
-      postCommitSnapshot: Snapshot): MaintenanceOperation = {
-    // The follow-up OPTIMIZE CHECKPOINT commit itself must never schedule more maintenance.
-    if (!AMTUtils.amtEnabled(readSnapshot)
-        || initialOperation.isInstanceOf[DeltaOperations.OptimizeCheckpoint]) {
-      return MaintenanceOperation()
-    }
-    val checkpointInterval = deltaLog.checkpointInterval(postCommitSnapshot.metadata)
-    if (isFullCheckpointOverdue(commitVersion, postCommitSnapshot, checkpointInterval)) {
-      MaintenanceOperation(
-        shouldCheckpoint = true,
-        amtTriggerModeOpt = Some(AMTTriggerMode.CheckpointIntervalFull))
-    } else {
-      MaintenanceOperation()
-    }
-  }
-
-  /** [[AMTTriggerMode]] for a followup AMT Checkpoint commit if any. */
-  private def followUpTriggerMode(
-      commitVersion: Long,
-      postCommitSnapshot: Snapshot): Option[AMTTriggerMode] = {
-    val checkpointInterval = deltaLog.checkpointInterval(postCommitSnapshot.metadata)
-    // -- case-1 --
-    // Assume v0 has an AMT. This is to make sure future AMTs land on even boundaries
-    // e.g. 10/20/30 instead of 9/19/29 (as classic checkpoints do).
-    val lastCheckpointVersion = postCommitSnapshot.logSegment.checkpointProvider.version
-    val lastAMTVersion = math.max(0L, lastCheckpointVersion)
-    val versionDiff = commitVersion - lastAMTVersion
-    // Emit only on the exact interval boundary (versionDiff a positive multiple of the interval),
-    // not >= the interval. This is what CheckpointTrigger does: if v10's follow-up AMT has not
-    // landed yet, a racing v11 still sees lastAMTVersion == 0, but 11 % 10 != 0 so it does not
-    // re-trigger; only v10, v20, ... do.
-    if (versionDiff > 0 && versionDiff % checkpointInterval == 0) {
-      // If checkpointInterval is 200 and fullRewriteCheckpointIntervalMultiplier is 5
-      // Then if 10220 is full tree, then 10420, 10620, 10820, 11020 will be incremental
-      // and then 11220 will be full tree again.
-      val fullRewriteSpan = checkpointInterval.toLong * fullRewriteCheckpointIntervalMultiplier
-      val needsFullRewrite = AMTWriteHelper.previousAMTContentRoot(postCommitSnapshot)
-        .flatMap(_.lastManifestCommitWithFullRewrite)
-        .forall(lastFull => commitVersion - lastFull >= fullRewriteSpan)
-      return Some(
-        if (needsFullRewrite) {
-          AMTTriggerMode.CheckpointIntervalFull
-        } else {
-          AMTTriggerMode.CheckpointIntervalIncremental
-        })
-    }
-
-    // -- case-1b --
-    // Backstop for an overdue full rewrite off the interval boundary. case-1 only fires at an
-    // interval boundary relative to the last AMT, and interval-boundary commits can be inlined.
-    // The inline path i.e. [[planMaintenanceAfterInlineWrite]] only schedules a full when it lands
-    // exactly on the full-rewrite cadence i.e. if checkpoint interval=10 and multiplier = 5 and
-    // last full is at 14 and then we say always have inline AMTs except 64/114/164/214 etc.). Such
-    // a table would never take case-1 and never get a follow-up full rewrite. Anchor this check to
-    // the last full rewrite (not the last AMT) and gate it on fullRewriteSpan: it fires the first
-    // version a full span has elapsed, and a racing follow-up that has not landed yet does not
-    // re-trigger on the very next commit (only once per interval), matching case-1's racing
-    // behavior.
-    if (isFullCheckpointOverdue(commitVersion, postCommitSnapshot, checkpointInterval)) {
-      return Some(AMTTriggerMode.CheckpointIntervalFull)
-    }
-
-
-    None
-  }
-
-  /**
-   * Whether a full rewrite is overdue at `commitVersion`: a full span has elapsed since the last
-   * full rewrite AND `commitVersion` sits on an interval boundary relative to that anchor. The
-   * boundary gate keeps this racing-safe -- while a scheduled follow-up is in flight it re-triggers
-   * at most once per interval, not on every commit -- matching `followUpTriggerMode`'s case-1.
-   */
-  private def isFullCheckpointOverdue(
-      commitVersion: Long,
-      postCommitSnapshot: Snapshot,
-      checkpointInterval: Long): Boolean = {
-    val fullRewriteSpan = checkpointInterval * fullRewriteCheckpointIntervalMultiplier
-    AMTWriteHelper.previousAMTContentRoot(postCommitSnapshot)
-      .flatMap(_.lastManifestCommitWithFullRewrite)
-      .exists { lastFull =>
-        val versionsSinceFull = commitVersion - lastFull
-        versionsSinceFull > 0 && versionsSinceFull % checkpointInterval == 0 &&
-          versionsSinceFull >= fullRewriteSpan
-      }
-  }
-
   private def largeCommitActionsCountThresholdForInlineManifestCommit: Long =
     spark.sessionState.conf.getConf(
       DeltaSQLConf.AMT_LARGE_COMMIT_ACTIONS_COUNT_THRESHOLD_FOR_INLINE_MANIFEST_COMMIT)
-
-  private def fullRewriteCheckpointIntervalMultiplier: Int =
-    spark.sessionState.conf.getConf(
-      DeltaSQLConf.AMT_FULL_REWRITE_CHECKPOINT_INTERVAL_MULTIPLIER)
 
   /**
    * Updates the pre-commit AMTCheckpointProvider after resolving conflicts via [[ConflictChecker]].
@@ -496,4 +376,137 @@ class AMTWriterManager(
     lastRebasedAMTVersion = foldedAMTVersion
     currentTransactionInfo.copy(actions = restampedActions)
   }
+}
+object AMTWriterManager {
+
+  /**
+   * The maintenance work a committed transaction should schedule for after it commits.
+   * The maintenance work will be done by CheckpointHook
+   */
+  def planMaintenance(
+      spark: SparkSession,
+      readSnapshot: Snapshot,
+      initialOperation: DeltaOperations.Operation,
+      commitVersion: Long,
+      postCommitSnapshot: Snapshot): MaintenanceOperation = {
+    // if the commit itself was to do a checkpoint, don't schedule any maintenance as part
+    // of its post-commit hook.
+    if (!AMTUtils.amtEnabled(readSnapshot)
+        || initialOperation.isInstanceOf[DeltaOperations.OptimizeCheckpoint]) {
+      return MaintenanceOperation()
+    }
+
+
+    val amtTriggerModeOpt =
+      followUpTriggerMode(spark, readSnapshot, commitVersion, postCommitSnapshot)
+    MaintenanceOperation(
+      shouldCheckpoint = amtTriggerModeOpt.isDefined,
+      amtTriggerModeOpt = amtTriggerModeOpt)
+  }
+
+  /**
+   * The maintenance work to schedule after a large commit wrote its AMT inline.
+   *
+   * An inline write is always incremental. If a table keeps getting inline AMTs, we still want it
+   * to get a full AMT once in a while when the last full AMT was older than
+   * checkpointInterval * fullRewriteCheckpointIntervalMultiplier.
+   */
+  def planMaintenanceAfterInlineWrite(
+      spark: SparkSession,
+      readSnapshot: Snapshot,
+      initialOperation: DeltaOperations.Operation,
+      commitVersion: Long,
+      postCommitSnapshot: Snapshot): MaintenanceOperation = {
+    // The follow-up OPTIMIZE CHECKPOINT commit itself must never schedule more maintenance.
+    if (!AMTUtils.amtEnabled(readSnapshot)
+        || initialOperation.isInstanceOf[DeltaOperations.OptimizeCheckpoint]) {
+      return MaintenanceOperation()
+    }
+    val checkpointInterval = readSnapshot.deltaLog.checkpointInterval(postCommitSnapshot.metadata)
+    if (isFullCheckpointOverdue(spark, commitVersion, postCommitSnapshot, checkpointInterval)) {
+      MaintenanceOperation(
+        shouldCheckpoint = true,
+        amtTriggerModeOpt = Some(AMTTriggerMode.CheckpointIntervalFull))
+    } else {
+      MaintenanceOperation()
+    }
+  }
+
+  /** [[AMTTriggerMode]] for a followup AMT Checkpoint commit if any. */
+  private def followUpTriggerMode(
+      spark: SparkSession,
+      readSnapshot: Snapshot,
+      commitVersion: Long,
+      postCommitSnapshot: Snapshot): Option[AMTTriggerMode] = {
+    val checkpointInterval = readSnapshot.deltaLog.checkpointInterval(postCommitSnapshot.metadata)
+    // -- case-1 --
+    // Assume v0 has an AMT. This is to make sure future AMTs land on even boundaries
+    // e.g. 10/20/30 instead of 9/19/29 (as classic checkpoints do).
+    val lastCheckpointVersion = postCommitSnapshot.logSegment.checkpointProvider.version
+    val lastAMTVersion = math.max(0L, lastCheckpointVersion)
+    val versionDiff = commitVersion - lastAMTVersion
+    // Emit only on the exact interval boundary (versionDiff a positive multiple of the interval),
+    // not >= the interval. This is what CheckpointTrigger does: if v10's follow-up AMT has not
+    // landed yet, a racing v11 still sees lastAMTVersion == 0, but 11 % 10 != 0 so it does not
+    // re-trigger; only v10, v20, ... do.
+    if (versionDiff > 0 && versionDiff % checkpointInterval == 0) {
+      // If checkpointInterval is 200 and fullRewriteCheckpointIntervalMultiplier is 5
+      // Then if 10220 is full tree, then 10420, 10620, 10820, 11020 will be incremental
+      // and then 11220 will be full tree again.
+      val fullRewriteSpan =
+        checkpointInterval.toLong * fullRewriteCheckpointIntervalMultiplier(spark)
+      val needsFullRewrite = AMTWriteHelper.previousAMTContentRoot(postCommitSnapshot)
+        .flatMap(_.lastManifestCommitWithFullRewrite)
+        .forall(lastFull => commitVersion - lastFull >= fullRewriteSpan)
+      return Some(
+        if (needsFullRewrite) {
+          AMTTriggerMode.CheckpointIntervalFull
+        } else {
+          AMTTriggerMode.CheckpointIntervalIncremental
+        })
+    }
+
+    // -- case-1b --
+    // Backstop for an overdue full rewrite off the interval boundary. case-1 only fires at an
+    // interval boundary relative to the last AMT, and interval-boundary commits can be inlined.
+    // The inline path i.e. [[planMaintenanceAfterInlineWrite]] only schedules a full when it lands
+    // exactly on the full-rewrite cadence i.e. if checkpoint interval=10 and multiplier = 5 and
+    // last full is at 14 and then we say always have inline AMTs except 64/114/164/214 etc.). Such
+    // a table would never take case-1 and never get a follow-up full rewrite. Anchor this check to
+    // the last full rewrite (not the last AMT) and gate it on fullRewriteSpan: it fires the first
+    // version a full span has elapsed, and a racing follow-up that has not landed yet does not
+    // re-trigger on the very next commit (only once per interval), matching case-1's racing
+    // behavior.
+    if (isFullCheckpointOverdue(spark, commitVersion, postCommitSnapshot, checkpointInterval)) {
+      return Some(AMTTriggerMode.CheckpointIntervalFull)
+    }
+
+
+    None
+  }
+
+  /**
+   * Whether a full rewrite is overdue at `commitVersion`: a full span has elapsed since the last
+   * full rewrite AND `commitVersion` sits on an interval boundary relative to that anchor. The
+   * boundary gate keeps this racing-safe -- while a scheduled follow-up is in flight it re-triggers
+   * at most once per interval, not on every commit -- matching `followUpTriggerMode`'s case-1.
+   */
+  private def isFullCheckpointOverdue(
+      spark: SparkSession,
+      commitVersion: Long,
+      postCommitSnapshot: Snapshot,
+      checkpointInterval: Long): Boolean = {
+    val fullRewriteSpan = checkpointInterval * fullRewriteCheckpointIntervalMultiplier(spark)
+    AMTWriteHelper.previousAMTContentRoot(postCommitSnapshot)
+      .flatMap(_.lastManifestCommitWithFullRewrite)
+      .exists { lastFull =>
+        val versionsSinceFull = commitVersion - lastFull
+        versionsSinceFull > 0 && versionsSinceFull % checkpointInterval == 0 &&
+          versionsSinceFull >= fullRewriteSpan
+      }
+  }
+
+  private def fullRewriteCheckpointIntervalMultiplier(spark: SparkSession): Int =
+    spark.sessionState.conf.getConf(
+      DeltaSQLConf.AMT_FULL_REWRITE_CHECKPOINT_INTERVAL_MULTIPLIER)
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/backfill/RowTrackingBackfillBatch.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/backfill/RowTrackingBackfillBatch.scala
@@ -47,7 +47,7 @@ case class RowTrackingBackfillBatch(filesInBatch: Seq[AddFile]) extends Backfill
     }
 
     val filesToCommit = filesInBatch.map(_.copy(dataChange = false))
-    // Base Row IDs are added as part of the OptimisticTransaction.prepareCommit(), so we don't
+    // Base Row IDs are added as part of OptimisticTransaction.prepareInitialActions(), so we don't
     // need to do anything here other than recommit the files.
     // Note: A backfill commit can be empty ,i.e. have no file actions, at commit time due to
     // files being removed by concurrent conflict resolution.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsUtils.scala
@@ -68,11 +68,11 @@ object CatalogOwnedTableUtils extends DeltaLogging {
       txn.updateProtocol(protocol = p)
       // Force a metadata update to trigger ICT (In-Commit Timestamp) enablement.
       // CatalogOwnedTableFeature requires ICT to be enabled in the metadata, but
-      // updateMetadataAndProtocolWithRequiredFeatures in prepareCommit only runs
+      // updateMetadataAndProtocolWithRequiredFeatures in prepareInitialActions only runs
       // when there's an explicit metadata change (metadataChanges.headOption is non-empty).
       // Since we're only updating the protocol here without changing metadata content,
       // we need to explicitly call updateMetadata to ensure metadataChanges is non-empty
-      // during prepareCommit, which will then enable ICT in the metadata.
+      // during prepareInitialActions, which will then enable ICT in the metadata.
       // Without this, generateInCommitTimestampForFirstCommitAttempt would return None,
       // causing UCCommitCoordinatorClient to fail with DELTA_MISSING_COMMIT_TIMESTAMP.
       txn.updateMetadata(proposedNewMetadata = txn.metadata)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/metering/DeltaLogging.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/metering/DeltaLogging.scala
@@ -209,7 +209,7 @@ trait DeltaLogging
       throwable: Throwable,
       deltaLog: DeltaLog = null,
       data: AnyRef = null,
-      path: Option[Path] = None,
+      path: Option[Path] = None
     ): Unit = {
     if (!check) {
       recordDeltaEvent(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/metering/DeltaLogging.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/metering/DeltaLogging.scala
@@ -172,6 +172,58 @@ trait DeltaLogging
     }
   }
 
+  /**
+   * A variation of [[deltaAssert]] that only logs the assertion error and
+   * does not add an assertion in test. This is useful for writing negative tests
+   * that validates the behaviour of executing the code after the [[deltaAssert]] call.
+   * The assertion in test prevents us from testing the production behaviour.
+   */
+  protected def deltaAssertLogOnly(
+      check: => Boolean,
+      name: String,
+      msg: String,
+      deltaLog: DeltaLog = null,
+      data: AnyRef = null,
+      path: Option[Path] = None
+    ): Unit = {
+    if (!check) {
+      recordDeltaEvent(
+        provider = deltaLog,
+        opType = s"delta.assertions.$name",
+        data = data,
+        path = path
+      )
+      logWarning(msg)
+    }
+  }
+
+  /**
+   * A variation of [[deltaAssert]] that logs the assertion error and throws a throwable.
+   * We don't need an assertion in test since if it fails we want the same throwable in
+   * test and in production.
+   */
+  protected def deltaAssertAndThrow(
+      check: => Boolean,
+      name: String,
+      msg: String,
+      throwable: Throwable,
+      deltaLog: DeltaLog = null,
+      data: AnyRef = null,
+      path: Option[Path] = None,
+    ): Unit = {
+    if (!check) {
+      recordDeltaEvent(
+        provider = deltaLog,
+        opType = s"delta.assertions.$name",
+        data = data,
+        path = path
+      )
+      logError(msg)
+
+      throw throwable
+    }
+  }
+
   protected def recordFrameProfile[T](group: String, name: String)(thunk: => T): T = {
     // future work to capture runtime information ...
     thunk

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -539,6 +539,17 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .booleanConf
       .createWithDefault(false)
 
+  val DELTA_COMMIT_IDEMPOTENCY_CHECK_VALIDATE_PREPARED_ACTIONS_ENABLED =
+    buildConf("commit.idempotencyCheck.validatePreparedActions.enabled")
+      .internal()
+      .doc("When enabled, on an idempotent self-commit (the write landed but the response was " +
+        "lost, detected on a later retry), validate that the prepared actions we finalize with " +
+        "match the actions read back from the landed commit, ignoring CommitInfo.version. This " +
+        "is a correctness check with a performance cost, intended to be removed once the " +
+        "idempotent self-commit finalization path is proven.")
+      .booleanConf
+      .createWithDefault(true)
+
   val FEATURE_ENABLEMENT_CONFLICT_RESOLUTION_ENABLED =
     buildConf("featureEnablement.conflictResolution.enabled")
       .internal()


### PR DESCRIPTION
## Description

Refactors the commit path in `OptimisticTransaction` by pulling the per-attempt commit-preparation
logic out of `doCommit`, so `doCommit` is left to persist an already-prepared commit.

- Introduces `PrepareCommitResult`, which carries the fully prepared state of a single commit
  attempt: the finalized actions to write, the transaction info, and preparation metrics.
- `prepareCommit` prepares the first attempt; `rebaseCurrentTransactionInfo` resolves conflicts and
  re-prepares the transaction on a conflict retry. Together they are the only places that edit the
  `CurrentTransactionInfo` once a commit attempt has begun, which keeps prepared state from leaking
  into a later conflict check.
- Renames `prepareCommitActions` to `prepareInitialActions` to distinguish the once-per-commit
  initial action preparation from `prepareCommit`, which runs on every attempt.
- Handles the idempotent self-commit case: when a commit's write landed but the response was lost
  and we discover that on a later retry, the commit is finalized from the prepared result of the
  attempt that landed instead of being re-issued. A flag gates a validation that the prepared
  actions match the actions read back from the landed commit (ignoring `CommitInfo.version`, which
  is not stored in the commit file and is only stamped on read-back).

## How was this patch tested?

Existing commit and conflict-retry suites, plus a suite covering the idempotent self-commit retry
path.
