### PR TITLE
[Spark] Implement DeltaV2TableManager with uncached snapshots

### DIFF
--- a/spark-unified/src/test/scala/io/delta/spark/internal/v2/tablemanager/DeltaV2TableManagerCacheSuite.scala
+++ b/spark-unified/src/test/scala/io/delta/spark/internal/v2/tablemanager/DeltaV2TableManagerCacheSuite.scala
@@ -19,25 +19,21 @@ import java.util.Collections
 import java.util.concurrent.{CountDownLatch, Executors, TimeUnit}
 import java.util.concurrent.atomic.AtomicInteger
 
-import io.delta.spark.internal.v2.tablemanager.DeltaV2TableManagerCache.CacheKey
-
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.v2.interop.DeltaV2SnapshotManager
-
 import com.google.common.base.Ticker
+
 import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTable, CatalogTableType}
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.StructType
 
-class DeltaV2TableManagerCacheSuite
-    extends QueryTest
-    with SharedSparkSession {
+class DeltaV2TableManagerCacheSuite extends QueryTest with SharedSparkSession {
 
   /** Creates a cache key from a data directory using the public factory. */
-  private def makeKey(dataPath: String): CacheKey =
-    CacheKey.from(spark, dataPath, Collections.emptyMap())
+  private def makeKey(dataPath: String): DeltaV2TableManagerCache.CacheKey =
+    DeltaV2TableManagerCache.CacheKey.from(spark, dataPath, Collections.emptyMap())
 
   // Process-global companion tests use unsetCache for isolation.
   override def beforeEach(): Unit = {
@@ -234,8 +230,10 @@ class DeltaV2TableManagerCacheSuite
     val stubs = Iterator(stubA, stubB)
     withTempDir { dir =>
       val sharedLogPath = makeKey(dir.getCanonicalPath).path
-      val keyA = CacheKey(sharedLogPath, Map("fs.s3a.access.key" -> "AAA"))
-      val keyB = CacheKey(sharedLogPath, Map("fs.s3a.access.key" -> "BBB"))
+      val keyA = DeltaV2TableManagerCache.CacheKey(
+        sharedLogPath, Map("fs.s3a.access.key" -> "AAA"))
+      val keyB = DeltaV2TableManagerCache.CacheKey(
+        sharedLogPath, Map("fs.s3a.access.key" -> "BBB"))
       val cache = new DeltaV2TableManagerCache(
         maxSize = 1000, ttlMinutes = 60,
         managerFactory = (_, _) => stubs.next())
@@ -307,8 +305,10 @@ class DeltaV2TableManagerCacheSuite
         val sessionB = spark.newSession()
         sessionB.conf.set(DeltaSQLConf.DELTA_LOG_CACHE_SIZE.key, "500")
 
-        val keyA = CacheKey.from(sessionA, dir.getCanonicalPath, Collections.emptyMap())
-        val keyB = CacheKey.from(sessionB, dir.getCanonicalPath, Collections.emptyMap())
+        val keyA = DeltaV2TableManagerCache.CacheKey.from(
+          sessionA, dir.getCanonicalPath, Collections.emptyMap())
+        val keyB = DeltaV2TableManagerCache.CacheKey.from(
+          sessionB, dir.getCanonicalPath, Collections.emptyMap())
 
         val fromA = DeltaV2TableManagerCache.getOrCreate(sessionA.sessionState.conf, keyA)
         val fromB = DeltaV2TableManagerCache.getOrCreate(sessionB.sessionState.conf, keyB)
@@ -369,8 +369,10 @@ class DeltaV2TableManagerCacheSuite
 
     withTempDir { dirA =>
       withTempDir { dirB =>
-        val keyA = CacheKey.from(sessionA, dirA.getCanonicalPath, Collections.emptyMap())
-        val keyB = CacheKey.from(sessionB, dirB.getCanonicalPath, Collections.emptyMap())
+        val keyA = DeltaV2TableManagerCache.CacheKey.from(
+          sessionA, dirA.getCanonicalPath, Collections.emptyMap())
+        val keyB = DeltaV2TableManagerCache.CacheKey.from(
+          sessionB, dirB.getCanonicalPath, Collections.emptyMap())
 
         // Session A loads key A -- initializes singleton (size 1).
         val originalA = DeltaV2TableManagerCache.getOrCreate(sessionA.sessionState.conf, keyA)
@@ -424,7 +426,7 @@ private[tablemanager] class StubTableManager(val id: String) extends DeltaV2Tabl
   override private[v2] def kernelContext:
       io.delta.spark.internal.v2.kernel.KernelContext =
     throw new UnsupportedOperationException("stub")
-  override def snapshotManager: DeltaV2SnapshotManager =
+  override def snapshotManager(catalogTableOpt: Option[CatalogTable]): DeltaV2SnapshotManager =
     throw new UnsupportedOperationException("stub")
   override def retire(): Unit = { retired = true }
 }

--- a/spark-unified/src/test/scala/io/delta/spark/internal/v2/tablemanager/DeltaV2TableManagerCacheSuite.scala
+++ b/spark-unified/src/test/scala/io/delta/spark/internal/v2/tablemanager/DeltaV2TableManagerCacheSuite.scala
@@ -19,7 +19,6 @@ import java.util.Collections
 import java.util.concurrent.{CountDownLatch, Executors, TimeUnit}
 import java.util.concurrent.atomic.AtomicInteger
 
-import io.delta.spark.internal.v2.kernel.KernelContext
 import io.delta.spark.internal.v2.tablemanager.DeltaV2TableManagerCache.CacheKey
 
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
@@ -77,7 +76,7 @@ class DeltaV2TableManagerCacheSuite
     }
   }
 
-  test("per-instance: cache hit preserves initial and publishes latest catalog table") {
+  test("per-instance: cache hit preserves initialCatalogTableOpt from first load") {
     val cache = new DeltaV2TableManagerCache(maxSize = 1000, ttlMinutes = 60)
     withTempDir { dir =>
       val key = makeKey(dir.getCanonicalPath)
@@ -93,19 +92,11 @@ class DeltaV2TableManagerCacheSuite
         schema = new StructType())
 
       val first = cache.getOrCreate(key, Some(catalogA))
-      val impl = first.asInstanceOf[DeltaV2TableManagerImpl]
-      assert(impl.initialCatalogTableOpt === Some(catalogA))
-      assert(impl.unsafeVolatileCatalogTable === Some(catalogA),
-        "initial catalog table should seed the volatile reference")
-
       val second = cache.getOrCreate(key, Some(catalogB))
-      val third = cache.getOrCreate(key, None)
       assert(first eq second)
-      assert(second eq third)
+      val impl = first.asInstanceOf[DeltaV2TableManagerImpl]
       assert(impl.initialCatalogTableOpt === Some(catalogA),
-        "initial catalog table should remain construction provenance")
-      assert(impl.unsafeVolatileCatalogTable === Some(catalogB),
-        "latest present catalog table should replace the previous value")
+        "initial catalog should be from first load")
     }
   }
 
@@ -408,7 +399,6 @@ class DeltaV2TableManagerCacheSuite
       assert(impl.qualifiedTableDataPath.toUri.getPath.contains(dir.getName))
       assert(impl.sessionInvariantFsOptions.isEmpty)
       assert(impl.initialCatalogTableOpt.isEmpty)
-      assert(impl.unsafeVolatileCatalogTable.isEmpty)
       val tableStore = impl.logStore
       val tableKernelContext = impl.kernelContext
       assert(tableKernelContext.logStore eq tableStore)
@@ -431,11 +421,10 @@ private[tablemanager] class TestTicker extends Ticker {
 
 private[tablemanager] class StubTableManager(val id: String) extends DeltaV2TableManager {
   @volatile var retired: Boolean = false
-  override private[v2] def kernelContext: KernelContext =
+  override private[v2] def kernelContext:
+      io.delta.spark.internal.v2.kernel.KernelContext =
     throw new UnsupportedOperationException("stub")
-  override def snapshotManager(): DeltaV2SnapshotManager =
+  override def snapshotManager: DeltaV2SnapshotManager =
     throw new UnsupportedOperationException("stub")
-  override private[tablemanager] def withUnsafeVolatileCatalogTable(
-      table: CatalogTable): DeltaV2TableManager = this
   override def retire(): Unit = { retired = true }
 }

--- a/spark-unified/src/test/scala/io/delta/spark/internal/v2/tablemanager/DeltaV2TableManagerCacheSuite.scala
+++ b/spark-unified/src/test/scala/io/delta/spark/internal/v2/tablemanager/DeltaV2TableManagerCacheSuite.scala
@@ -435,7 +435,7 @@ private[tablemanager] class StubTableManager(val id: String) extends DeltaV2Tabl
     throw new UnsupportedOperationException("stub")
   override def snapshotManager(): DeltaV2SnapshotManager =
     throw new UnsupportedOperationException("stub")
-  override private[tablemanager] def updateCatalogTable(
-      latestCatalogTableOpt: Option[CatalogTable]): Unit = {}
+  override private[tablemanager] def withUnsafeVolatileCatalogTable(
+      table: CatalogTable): DeltaV2TableManager = this
   override def retire(): Unit = { retired = true }
 }

--- a/spark-unified/src/test/scala/io/delta/spark/internal/v2/tablemanager/DeltaV2TableManagerCacheSuite.scala
+++ b/spark-unified/src/test/scala/io/delta/spark/internal/v2/tablemanager/DeltaV2TableManagerCacheSuite.scala
@@ -19,6 +19,7 @@ import java.util.Collections
 import java.util.concurrent.{CountDownLatch, Executors, TimeUnit}
 import java.util.concurrent.atomic.AtomicInteger
 
+import io.delta.spark.internal.v2.kernel.KernelContext
 import io.delta.spark.internal.v2.tablemanager.DeltaV2TableManagerCache.CacheKey
 
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
@@ -76,7 +77,7 @@ class DeltaV2TableManagerCacheSuite
     }
   }
 
-  test("per-instance: cache hit preserves initialCatalogTableOpt from first load") {
+  test("per-instance: cache hit preserves initial and publishes latest catalog table") {
     val cache = new DeltaV2TableManagerCache(maxSize = 1000, ttlMinutes = 60)
     withTempDir { dir =>
       val key = makeKey(dir.getCanonicalPath)
@@ -92,11 +93,19 @@ class DeltaV2TableManagerCacheSuite
         schema = new StructType())
 
       val first = cache.getOrCreate(key, Some(catalogA))
-      val second = cache.getOrCreate(key, Some(catalogB))
-      assert(first eq second)
       val impl = first.asInstanceOf[DeltaV2TableManagerImpl]
+      assert(impl.initialCatalogTableOpt === Some(catalogA))
+      assert(impl.unsafeVolatileCatalogTable === Some(catalogA),
+        "initial catalog table should seed the volatile reference")
+
+      val second = cache.getOrCreate(key, Some(catalogB))
+      val third = cache.getOrCreate(key, None)
+      assert(first eq second)
+      assert(second eq third)
       assert(impl.initialCatalogTableOpt === Some(catalogA),
-        "initial catalog should be from first load")
+        "initial catalog table should remain construction provenance")
+      assert(impl.unsafeVolatileCatalogTable === Some(catalogB),
+        "latest present catalog table should replace the previous value")
     }
   }
 
@@ -399,6 +408,7 @@ class DeltaV2TableManagerCacheSuite
       assert(impl.qualifiedTableDataPath.toUri.getPath.contains(dir.getName))
       assert(impl.sessionInvariantFsOptions.isEmpty)
       assert(impl.initialCatalogTableOpt.isEmpty)
+      assert(impl.unsafeVolatileCatalogTable.isEmpty)
       val tableStore = impl.logStore
       val tableKernelContext = impl.kernelContext
       assert(tableKernelContext.logStore eq tableStore)
@@ -421,7 +431,11 @@ private[tablemanager] class TestTicker extends Ticker {
 
 private[tablemanager] class StubTableManager(val id: String) extends DeltaV2TableManager {
   @volatile var retired: Boolean = false
+  override private[v2] def kernelContext: KernelContext =
+    throw new UnsupportedOperationException("stub")
   override def snapshotManager(): DeltaV2SnapshotManager =
     throw new UnsupportedOperationException("stub")
+  override private[tablemanager] def updateCatalogTable(
+      latestCatalogTableOpt: Option[CatalogTable]): Unit = {}
   override def retire(): Unit = { retired = true }
 }

--- a/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
+++ b/spark/v2/src/main/java/io/delta/spark/internal/v2/catalog/DeltaV2Table.java
@@ -27,12 +27,12 @@ import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.spark.internal.v2.exception.NoRecreatableHistoryException;
 import io.delta.spark.internal.v2.exception.TableNotFoundException;
 import io.delta.spark.internal.v2.exception.TimestampOutOfRangeException;
-import io.delta.spark.internal.v2.kernel.KernelEngineFactory;
 import io.delta.spark.internal.v2.read.DeltaV2ScanUtils;
 import io.delta.spark.internal.v2.read.MetadataEvolutionHandler;
 import io.delta.spark.internal.v2.read.cdc.CDCSchemaContext;
 import io.delta.spark.internal.v2.shims.CatalogV2UtilShims;
-import io.delta.spark.internal.v2.snapshot.SnapshotManagerFactory;
+import io.delta.spark.internal.v2.tablemanager.DeltaV2TableManager;
+import io.delta.spark.internal.v2.tablemanager.DeltaV2TableManagerCache$;
 import io.delta.spark.internal.v2.write.DeltaRowLevelOperationBuilder;
 import io.delta.spark.internal.v2.write.DeltaV2WriteBuilder;
 import java.util.ArrayList;
@@ -87,6 +87,7 @@ import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+import scala.Option;
 import scala.jdk.javaapi.CollectionConverters;
 
 /** DataSource V2 Table implementation for Delta Lake using the Delta Kernel API. */
@@ -232,20 +233,24 @@ public class DeltaV2Table extends DeltaV2TableShimsWithLogging
     this.identifier = requireNonNull(identifier, "identifier is null");
     this.tablePath = requireNonNull(tablePath, "tablePath is null");
     this.catalogTable = catalogTable;
+    Option<CatalogTable> catalogTableOpt = toScalaOption(catalogTable);
     // Merge options: file system options from catalog + user options (user takes precedence)
     // This follows the same pattern as DeltaTableV2 in delta-spark
     Map<String, String> merged =
         new HashMap<>(
             scala.collection.JavaConverters.mapAsJavaMap(
-                DeltaFileSystemOptions.extractCatalogTableFsOptions(toScalaOption(catalogTable))));
+                DeltaFileSystemOptions.extractCatalogTableFsOptions(catalogTableOpt)));
     // User options override catalog properties
     merged.putAll(userOptions);
     this.options = Collections.unmodifiableMap(merged);
 
-    this.hadoopConf =
-        SparkSession.active().sessionState().newHadoopConfWithOptions(toScalaMap(options));
-    this.kernelEngine = KernelEngineFactory.createDefaultEngine(this.hadoopConf);
-    this.snapshotManager = SnapshotManagerFactory.create(tablePath, kernelEngine, catalogTable);
+    SparkSession activeSession = SparkSession.active();
+    this.hadoopConf = activeSession.sessionState().newHadoopConfWithOptions(toScalaMap(options));
+    DeltaV2TableManager tableManager =
+        DeltaV2TableManagerCache$.MODULE$.forTable(
+            activeSession, tablePath, options, catalogTableOpt);
+    this.kernelEngine = tableManager.kernelContext().getDefaultEngine();
+    this.snapshotManager = tableManager.snapshotManager(catalogTableOpt);
     try {
       if (timeTravelVersion.isPresent()) {
         this.initialSnapshot =

--- a/spark/v2/src/main/scala/io/delta/spark/internal/v2/tablemanager/DeltaV2TableManager.scala
+++ b/spark/v2/src/main/scala/io/delta/spark/internal/v2/tablemanager/DeltaV2TableManager.scala
@@ -21,26 +21,19 @@ import io.delta.spark.internal.v2.kernel.KernelContext
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
 
 /**
- * Composite contract for a process-cached Delta table manager.
- *
- * Table identity (path, catalog table) is seeded at construction and determines cache-key affinity.
+ * Contract for a Delta table manager used by the DSv2 connector.
  */
 private[v2] trait DeltaV2TableManager {
 
-  /** Returns the table-scoped context that owns Kernel resources. */
+  /** Returns the table-scoped Kernel context. */
   private[v2] def kernelContext: KernelContext
 
-  /** Returns a per-request snapshot manager backed by this composite's shared snapshot state. */
+  /** Returns a snapshot manager for the table. */
   def snapshotManager(): DeltaV2SnapshotManager
 
-  private[tablemanager] def updateCatalogTable(
-      latestCatalogTableOpt: Option[CatalogTable]): Unit
+  private[tablemanager] def withUnsafeVolatileCatalogTable(
+      table: CatalogTable): DeltaV2TableManager
 
-  /**
-   * Idempotently prevents future acquisitions and releases exclusively owned state when safe.
-   *
-   * Default no-op: the single production implementation overrides this. Test stubs inherit the
-   * no-op safely.
-   */
+  /** Retires this manager and releases any resources it owns. */
   def retire(): Unit = {}
 }

--- a/spark/v2/src/main/scala/io/delta/spark/internal/v2/tablemanager/DeltaV2TableManager.scala
+++ b/spark/v2/src/main/scala/io/delta/spark/internal/v2/tablemanager/DeltaV2TableManager.scala
@@ -16,6 +16,9 @@
 package io.delta.spark.internal.v2.tablemanager
 
 import org.apache.spark.sql.delta.v2.interop.DeltaV2SnapshotManager
+import io.delta.spark.internal.v2.kernel.KernelContext
+
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
 
 /**
  * Composite contract for a process-cached Delta table manager.
@@ -24,8 +27,14 @@ import org.apache.spark.sql.delta.v2.interop.DeltaV2SnapshotManager
  */
 private[v2] trait DeltaV2TableManager {
 
+  /** Returns the table-scoped context that owns Kernel resources. */
+  private[v2] def kernelContext: KernelContext
+
   /** Returns a per-request snapshot manager backed by this composite's shared snapshot state. */
   def snapshotManager(): DeltaV2SnapshotManager
+
+  private[tablemanager] def updateCatalogTable(
+      latestCatalogTableOpt: Option[CatalogTable]): Unit
 
   /**
    * Idempotently prevents future acquisitions and releases exclusively owned state when safe.

--- a/spark/v2/src/main/scala/io/delta/spark/internal/v2/tablemanager/DeltaV2TableManager.scala
+++ b/spark/v2/src/main/scala/io/delta/spark/internal/v2/tablemanager/DeltaV2TableManager.scala
@@ -18,8 +18,6 @@ package io.delta.spark.internal.v2.tablemanager
 import org.apache.spark.sql.delta.v2.interop.DeltaV2SnapshotManager
 import io.delta.spark.internal.v2.kernel.KernelContext
 
-import org.apache.spark.sql.catalyst.catalog.CatalogTable
-
 /**
  * Contract for a Delta table manager used by the DSv2 connector.
  */
@@ -28,11 +26,8 @@ private[v2] trait DeltaV2TableManager {
   /** Returns the table-scoped Kernel context. */
   private[v2] def kernelContext: KernelContext
 
-  /** Returns a snapshot manager for the table. */
-  def snapshotManager(): DeltaV2SnapshotManager
-
-  private[tablemanager] def withUnsafeVolatileCatalogTable(
-      table: CatalogTable): DeltaV2TableManager
+  /** Returns the table's snapshot manager. */
+  def snapshotManager: DeltaV2SnapshotManager
 
   /** Retires this manager and releases any resources it owns. */
   def retire(): Unit = {}

--- a/spark/v2/src/main/scala/io/delta/spark/internal/v2/tablemanager/DeltaV2TableManager.scala
+++ b/spark/v2/src/main/scala/io/delta/spark/internal/v2/tablemanager/DeltaV2TableManager.scala
@@ -18,6 +18,8 @@ package io.delta.spark.internal.v2.tablemanager
 import org.apache.spark.sql.delta.v2.interop.DeltaV2SnapshotManager
 import io.delta.spark.internal.v2.kernel.KernelContext
 
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
+
 /**
  * Contract for a Delta table manager used by the DSv2 connector.
  */
@@ -26,8 +28,8 @@ private[v2] trait DeltaV2TableManager {
   /** Returns the table-scoped Kernel context. */
   private[v2] def kernelContext: KernelContext
 
-  /** Returns the table's snapshot manager. */
-  def snapshotManager: DeltaV2SnapshotManager
+  /** Returns a snapshot manager using the caller's current catalog metadata. */
+  def snapshotManager(catalogTableOpt: Option[CatalogTable]): DeltaV2SnapshotManager
 
   /** Retires this manager and releases any resources it owns. */
   def retire(): Unit = {}

--- a/spark/v2/src/main/scala/io/delta/spark/internal/v2/tablemanager/DeltaV2TableManagerCache.scala
+++ b/spark/v2/src/main/scala/io/delta/spark/internal/v2/tablemanager/DeltaV2TableManagerCache.scala
@@ -69,12 +69,12 @@ private[tablemanager] class DeltaV2TableManagerCache(
   // the original Delta error class, SQLSTATE, and cause chain rather than exposing Guava wrappers.
   def getOrCreate(
       key: CacheKey,
-      initialCatalogTableOpt: Option[CatalogTable] = None
+      latestCatalogTableOpt: Option[CatalogTable] = None
   ): DeltaV2TableManager = {
-    try {
+    val manager = try {
       cache.get(key, () => {
         recordFrameProfile("tableManagerCache.createManager") {
-          managerFactory(key, initialCatalogTableOpt)
+          managerFactory(key, latestCatalogTableOpt)
         }
       })
     } catch {
@@ -84,6 +84,8 @@ private[tablemanager] class DeltaV2TableManagerCache(
         logWarning(log"Cache loader failed; rethrowing original cause", cause)
         throw cause
     }
+    manager.updateCatalogTable(latestCatalogTableOpt)
+    manager
   }
 
   def invalidate(key: CacheKey): Unit = cache.invalidate(key)
@@ -210,25 +212,28 @@ private[v2] object DeltaV2TableManagerCache extends DeltaV2Logging {
    * @param spark the active SparkSession, used for filesystem resolution and configuration.
    * @param dataPath the table's data directory path as a string.
    * @param options reader/writer options (Java map).
-   * @param initialCatalogTableOpt optional catalog table whose storage properties contribute
-   *   additional filesystem options.
+   * @param latestCatalogTableOpt optional latest catalog table. Its storage properties contribute
+   *   filesystem options to the key, and its metadata is published to the returned manager.
    */
   def forTable(
       spark: SparkSession,
       dataPath: String,
       options: java.util.Map[String, String],
-      initialCatalogTableOpt: Option[CatalogTable] = None
+      latestCatalogTableOpt: Option[CatalogTable] = None
   ): DeltaV2TableManager = {
     recordFrameProfile("tableManagerCache.forTable") {
-      val key = CacheKey.from(spark, dataPath, options, initialCatalogTableOpt)
+      val key = CacheKey.from(spark, dataPath, options, latestCatalogTableOpt)
       val sqlConf = spark.sessionState.conf
       if (!isEnabled(sqlConf)) {
-        return new DeltaV2TableManagerImpl(
+        val manager = new DeltaV2TableManagerImpl(
           key.path.getParent,
           key.sessionInvariantFsOptions,
-          initialCatalogTableOpt)
+          latestCatalogTableOpt)
+        manager.updateCatalogTable(latestCatalogTableOpt)
+        manager
+      } else {
+        getOrCreateInstance(sqlConf).getOrCreate(key, latestCatalogTableOpt)
       }
-      getOrCreateInstance(sqlConf).getOrCreate(key, initialCatalogTableOpt)
     }
   }
 
@@ -238,16 +243,19 @@ private[v2] object DeltaV2TableManagerCache extends DeltaV2Logging {
   private[tablemanager] def getOrCreate(
       sqlConf: SQLConf,
       key: CacheKey,
-      initialCatalogTableOpt: Option[CatalogTable] = None
+      latestCatalogTableOpt: Option[CatalogTable] = None
   ): DeltaV2TableManager = {
     recordFrameProfile("tableManagerCache.getOrCreate") {
       if (!isEnabled(sqlConf)) {
-        return new DeltaV2TableManagerImpl(
+        val manager = new DeltaV2TableManagerImpl(
           key.path.getParent,
           key.sessionInvariantFsOptions,
-          initialCatalogTableOpt)
+          latestCatalogTableOpt)
+        manager.updateCatalogTable(latestCatalogTableOpt)
+        manager
+      } else {
+        getOrCreateInstance(sqlConf).getOrCreate(key, latestCatalogTableOpt)
       }
-      getOrCreateInstance(sqlConf).getOrCreate(key, initialCatalogTableOpt)
     }
   }
 

--- a/spark/v2/src/main/scala/io/delta/spark/internal/v2/tablemanager/DeltaV2TableManagerCache.scala
+++ b/spark/v2/src/main/scala/io/delta/spark/internal/v2/tablemanager/DeltaV2TableManagerCache.scala
@@ -44,7 +44,10 @@ private[tablemanager] class DeltaV2TableManagerCache(
     managerFactory: (
         DeltaV2TableManagerCache.CacheKey,
         Option[CatalogTable]) => DeltaV2TableManager =
-      DeltaV2TableManagerCache.createManager
+      (key, catalog) => new DeltaV2TableManagerImpl(
+        key.path.getParent,
+        key.sessionInvariantFsOptions,
+        catalog)
 ) extends DeltaV2Logging {
   import DeltaV2TableManagerCache.CacheKey
 
@@ -66,12 +69,12 @@ private[tablemanager] class DeltaV2TableManagerCache(
   // the original Delta error class, SQLSTATE, and cause chain rather than exposing Guava wrappers.
   def getOrCreate(
       key: CacheKey,
-      catalogTableOpt: Option[CatalogTable] = None
+      initialCatalogTableOpt: Option[CatalogTable] = None
   ): DeltaV2TableManager = {
-    val manager = try {
+    try {
       cache.get(key, () => {
         recordFrameProfile("tableManagerCache.createManager") {
-          managerFactory(key, catalogTableOpt)
+          managerFactory(key, initialCatalogTableOpt)
         }
       })
     } catch {
@@ -81,7 +84,6 @@ private[tablemanager] class DeltaV2TableManagerCache(
         logWarning(log"Cache loader failed; rethrowing original cause", cause)
         throw cause
     }
-    catalogTableOpt.fold(manager)(manager.withUnsafeVolatileCatalogTable)
   }
 
   def invalidate(key: CacheKey): Unit = cache.invalidate(key)
@@ -116,14 +118,6 @@ private[tablemanager] class DeltaV2TableManagerCache(
  * exposed outside the `tablemanager` package.
  */
 private[v2] object DeltaV2TableManagerCache extends DeltaV2Logging {
-
-  private[tablemanager] def createManager(
-      key: CacheKey,
-      catalogTableOpt: Option[CatalogTable]): DeltaV2TableManager =
-    new DeltaV2TableManagerImpl(
-      key.path.getParent,
-      key.sessionInvariantFsOptions,
-      catalogTableOpt)
 
   // === Cache key ==================================================
 
@@ -216,23 +210,25 @@ private[v2] object DeltaV2TableManagerCache extends DeltaV2Logging {
    * @param spark the active SparkSession, used for filesystem resolution and configuration.
    * @param dataPath the table's data directory path as a string.
    * @param options reader/writer options (Java map).
-   * @param catalogTableOpt optional catalog table. Its storage properties contribute filesystem
-   *   options to the key, and its metadata is published to the returned manager.
+   * @param initialCatalogTableOpt optional catalog table whose storage properties contribute
+   *   additional filesystem options.
    */
   def forTable(
       spark: SparkSession,
       dataPath: String,
       options: java.util.Map[String, String],
-      catalogTableOpt: Option[CatalogTable] = None
+      initialCatalogTableOpt: Option[CatalogTable] = None
   ): DeltaV2TableManager = {
     recordFrameProfile("tableManagerCache.forTable") {
-      val key = CacheKey.from(spark, dataPath, options, catalogTableOpt)
+      val key = CacheKey.from(spark, dataPath, options, initialCatalogTableOpt)
       val sqlConf = spark.sessionState.conf
       if (!isEnabled(sqlConf)) {
-        createManager(key, catalogTableOpt)
-      } else {
-        getOrCreateInstance(sqlConf).getOrCreate(key, catalogTableOpt)
+        return new DeltaV2TableManagerImpl(
+          key.path.getParent,
+          key.sessionInvariantFsOptions,
+          initialCatalogTableOpt)
       }
+      getOrCreateInstance(sqlConf).getOrCreate(key, initialCatalogTableOpt)
     }
   }
 
@@ -242,14 +238,16 @@ private[v2] object DeltaV2TableManagerCache extends DeltaV2Logging {
   private[tablemanager] def getOrCreate(
       sqlConf: SQLConf,
       key: CacheKey,
-      catalogTableOpt: Option[CatalogTable] = None
+      initialCatalogTableOpt: Option[CatalogTable] = None
   ): DeltaV2TableManager = {
     recordFrameProfile("tableManagerCache.getOrCreate") {
       if (!isEnabled(sqlConf)) {
-        createManager(key, catalogTableOpt)
-      } else {
-        getOrCreateInstance(sqlConf).getOrCreate(key, catalogTableOpt)
+        return new DeltaV2TableManagerImpl(
+          key.path.getParent,
+          key.sessionInvariantFsOptions,
+          initialCatalogTableOpt)
       }
+      getOrCreateInstance(sqlConf).getOrCreate(key, initialCatalogTableOpt)
     }
   }
 

--- a/spark/v2/src/main/scala/io/delta/spark/internal/v2/tablemanager/DeltaV2TableManagerCache.scala
+++ b/spark/v2/src/main/scala/io/delta/spark/internal/v2/tablemanager/DeltaV2TableManagerCache.scala
@@ -44,10 +44,7 @@ private[tablemanager] class DeltaV2TableManagerCache(
     managerFactory: (
         DeltaV2TableManagerCache.CacheKey,
         Option[CatalogTable]) => DeltaV2TableManager =
-      (key, catalog) => new DeltaV2TableManagerImpl(
-        key.path.getParent,
-        key.sessionInvariantFsOptions,
-        catalog)
+      DeltaV2TableManagerCache.createManager
 ) extends DeltaV2Logging {
   import DeltaV2TableManagerCache.CacheKey
 
@@ -69,12 +66,12 @@ private[tablemanager] class DeltaV2TableManagerCache(
   // the original Delta error class, SQLSTATE, and cause chain rather than exposing Guava wrappers.
   def getOrCreate(
       key: CacheKey,
-      latestCatalogTableOpt: Option[CatalogTable] = None
+      catalogTableOpt: Option[CatalogTable] = None
   ): DeltaV2TableManager = {
     val manager = try {
       cache.get(key, () => {
         recordFrameProfile("tableManagerCache.createManager") {
-          managerFactory(key, latestCatalogTableOpt)
+          managerFactory(key, catalogTableOpt)
         }
       })
     } catch {
@@ -84,8 +81,7 @@ private[tablemanager] class DeltaV2TableManagerCache(
         logWarning(log"Cache loader failed; rethrowing original cause", cause)
         throw cause
     }
-    manager.updateCatalogTable(latestCatalogTableOpt)
-    manager
+    catalogTableOpt.fold(manager)(manager.withUnsafeVolatileCatalogTable)
   }
 
   def invalidate(key: CacheKey): Unit = cache.invalidate(key)
@@ -120,6 +116,14 @@ private[tablemanager] class DeltaV2TableManagerCache(
  * exposed outside the `tablemanager` package.
  */
 private[v2] object DeltaV2TableManagerCache extends DeltaV2Logging {
+
+  private[tablemanager] def createManager(
+      key: CacheKey,
+      catalogTableOpt: Option[CatalogTable]): DeltaV2TableManager =
+    new DeltaV2TableManagerImpl(
+      key.path.getParent,
+      key.sessionInvariantFsOptions,
+      catalogTableOpt)
 
   // === Cache key ==================================================
 
@@ -212,27 +216,22 @@ private[v2] object DeltaV2TableManagerCache extends DeltaV2Logging {
    * @param spark the active SparkSession, used for filesystem resolution and configuration.
    * @param dataPath the table's data directory path as a string.
    * @param options reader/writer options (Java map).
-   * @param latestCatalogTableOpt optional latest catalog table. Its storage properties contribute
-   *   filesystem options to the key, and its metadata is published to the returned manager.
+   * @param catalogTableOpt optional catalog table. Its storage properties contribute filesystem
+   *   options to the key, and its metadata is published to the returned manager.
    */
   def forTable(
       spark: SparkSession,
       dataPath: String,
       options: java.util.Map[String, String],
-      latestCatalogTableOpt: Option[CatalogTable] = None
+      catalogTableOpt: Option[CatalogTable] = None
   ): DeltaV2TableManager = {
     recordFrameProfile("tableManagerCache.forTable") {
-      val key = CacheKey.from(spark, dataPath, options, latestCatalogTableOpt)
+      val key = CacheKey.from(spark, dataPath, options, catalogTableOpt)
       val sqlConf = spark.sessionState.conf
       if (!isEnabled(sqlConf)) {
-        val manager = new DeltaV2TableManagerImpl(
-          key.path.getParent,
-          key.sessionInvariantFsOptions,
-          latestCatalogTableOpt)
-        manager.updateCatalogTable(latestCatalogTableOpt)
-        manager
+        createManager(key, catalogTableOpt)
       } else {
-        getOrCreateInstance(sqlConf).getOrCreate(key, latestCatalogTableOpt)
+        getOrCreateInstance(sqlConf).getOrCreate(key, catalogTableOpt)
       }
     }
   }
@@ -243,18 +242,13 @@ private[v2] object DeltaV2TableManagerCache extends DeltaV2Logging {
   private[tablemanager] def getOrCreate(
       sqlConf: SQLConf,
       key: CacheKey,
-      latestCatalogTableOpt: Option[CatalogTable] = None
+      catalogTableOpt: Option[CatalogTable] = None
   ): DeltaV2TableManager = {
     recordFrameProfile("tableManagerCache.getOrCreate") {
       if (!isEnabled(sqlConf)) {
-        val manager = new DeltaV2TableManagerImpl(
-          key.path.getParent,
-          key.sessionInvariantFsOptions,
-          latestCatalogTableOpt)
-        manager.updateCatalogTable(latestCatalogTableOpt)
-        manager
+        createManager(key, catalogTableOpt)
       } else {
-        getOrCreateInstance(sqlConf).getOrCreate(key, latestCatalogTableOpt)
+        getOrCreateInstance(sqlConf).getOrCreate(key, catalogTableOpt)
       }
     }
   }

--- a/spark/v2/src/main/scala/io/delta/spark/internal/v2/tablemanager/DeltaV2TableManagerImpl.scala
+++ b/spark/v2/src/main/scala/io/delta/spark/internal/v2/tablemanager/DeltaV2TableManagerImpl.scala
@@ -54,9 +54,10 @@ private[tablemanager] class DeltaV2TableManagerImpl(
   override private[v2] lazy val kernelContext =
     KernelContext(sessionInvariantFsOptions, logStore)
 
-  override def snapshotManager: DeltaV2SnapshotManager =
+  override def snapshotManager(
+      catalogTableOpt: Option[CatalogTable]): DeltaV2SnapshotManager =
     SnapshotManagerFactory.create(
       tablePath.toString,
       kernelContext.getDefaultEngine(),
-      initialCatalogTableOpt.toJava)
+      catalogTableOpt.toJava)
 }

--- a/spark/v2/src/main/scala/io/delta/spark/internal/v2/tablemanager/DeltaV2TableManagerImpl.scala
+++ b/spark/v2/src/main/scala/io/delta/spark/internal/v2/tablemanager/DeltaV2TableManagerImpl.scala
@@ -20,6 +20,7 @@ import java.util.concurrent.atomic.AtomicReference
 import scala.jdk.OptionConverters._
 
 import org.apache.spark.sql.delta.storage.LogStoreProvider
+import io.delta.spark.internal.v2.DeltaV2Logging
 import org.apache.spark.sql.delta.v2.interop.DeltaV2SnapshotManager
 import io.delta.spark.internal.v2.kernel.KernelContext
 import io.delta.spark.internal.v2.snapshot.SnapshotManagerFactory
@@ -46,21 +47,32 @@ private[tablemanager] class DeltaV2TableManagerImpl(
     val sessionInvariantFsOptions: Map[String, String],
     val initialCatalogTableOpt: Option[CatalogTable])
     extends DeltaV2TableManager
+    with DeltaV2Logging
     with LogStoreProvider
 {
 
   private val _unsafeVolatileCatalogTable =
-    new AtomicReference[CatalogTable](initialCatalogTableOpt.orNull)
+    new AtomicReference[CatalogTable]()
 
   private[tablemanager] def unsafeVolatileCatalogTable: Option[CatalogTable] =
     Option(_unsafeVolatileCatalogTable.get())
 
-  override private[tablemanager] def updateCatalogTable(
-      latestCatalogTableOpt: Option[CatalogTable]): Unit = {
-    latestCatalogTableOpt.foreach { catalogTable =>
-      _unsafeVolatileCatalogTable.set(catalogTable)
+  override private[tablemanager] def withUnsafeVolatileCatalogTable(
+      table: CatalogTable): DeltaV2TableManager = {
+    val oldTable = _unsafeVolatileCatalogTable.getAndSet(table)
+    if (oldTable != null && oldTable.identifier != table.identifier) {
+      recordDeltaEvent(
+        null,
+        "deltaV2.catalog.multipleTablesForSameLog",
+        data = Map(
+          "oldTableIdentifier" -> oldTable.identifier,
+          "newTableIdentifier" -> table.identifier),
+        path = Some(tablePath))
     }
+    this
   }
+
+  initialCatalogTableOpt.foreach(withUnsafeVolatileCatalogTable)
 
   /** The table's data directory, fully qualified. */
   def tablePath: Path = qualifiedTableDataPath

--- a/spark/v2/src/main/scala/io/delta/spark/internal/v2/tablemanager/DeltaV2TableManagerImpl.scala
+++ b/spark/v2/src/main/scala/io/delta/spark/internal/v2/tablemanager/DeltaV2TableManagerImpl.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.catalyst.catalog.CatalogTable
 /**
  * Process-cached [[DeltaV2TableManager]] implementation.
  *
- * The manager owns the table-scoped [[KernelContext]] and snapshot manager.
+ * Creates uncached snapshot managers using the table-scoped [[KernelContext]].
  *
  * @param qualifiedTableDataPath the fully-qualified table data directory (parent of `_delta_log`).
  * @param sessionInvariantFsOptions filesystem-prefixed credential options (`fs.*`, `dfs.*`) that
@@ -54,7 +54,7 @@ private[tablemanager] class DeltaV2TableManagerImpl(
   override private[v2] lazy val kernelContext =
     KernelContext(sessionInvariantFsOptions, logStore)
 
-  override lazy val snapshotManager: DeltaV2SnapshotManager =
+  override def snapshotManager: DeltaV2SnapshotManager =
     SnapshotManagerFactory.create(
       tablePath.toString,
       kernelContext.getDefaultEngine(),

--- a/spark/v2/src/main/scala/io/delta/spark/internal/v2/tablemanager/DeltaV2TableManagerImpl.scala
+++ b/spark/v2/src/main/scala/io/delta/spark/internal/v2/tablemanager/DeltaV2TableManagerImpl.scala
@@ -15,12 +15,9 @@
  */
 package io.delta.spark.internal.v2.tablemanager
 
-import java.util.concurrent.atomic.AtomicReference
-
 import scala.jdk.OptionConverters._
 
 import org.apache.spark.sql.delta.storage.LogStoreProvider
-import io.delta.spark.internal.v2.DeltaV2Logging
 import org.apache.spark.sql.delta.v2.interop.DeltaV2SnapshotManager
 import io.delta.spark.internal.v2.kernel.KernelContext
 import io.delta.spark.internal.v2.snapshot.SnapshotManagerFactory
@@ -32,9 +29,7 @@ import org.apache.spark.sql.catalyst.catalog.CatalogTable
 /**
  * Process-cached [[DeltaV2TableManager]] implementation.
  *
- * The manager owns the table-scoped [[KernelContext]] but does not retain snapshot state. Each
- * [[snapshotManager]] call uses [[SnapshotManagerFactory]] to create an uncached manager backed by
- * the Kernel Engine shared through that context.
+ * The manager owns the table-scoped [[KernelContext]] and snapshot manager.
  *
  * @param qualifiedTableDataPath the fully-qualified table data directory (parent of `_delta_log`).
  * @param sessionInvariantFsOptions filesystem-prefixed credential options (`fs.*`, `dfs.*`) that
@@ -47,32 +42,8 @@ private[tablemanager] class DeltaV2TableManagerImpl(
     val sessionInvariantFsOptions: Map[String, String],
     val initialCatalogTableOpt: Option[CatalogTable])
     extends DeltaV2TableManager
-    with DeltaV2Logging
     with LogStoreProvider
 {
-
-  private val _unsafeVolatileCatalogTable =
-    new AtomicReference[CatalogTable]()
-
-  private[tablemanager] def unsafeVolatileCatalogTable: Option[CatalogTable] =
-    Option(_unsafeVolatileCatalogTable.get())
-
-  override private[tablemanager] def withUnsafeVolatileCatalogTable(
-      table: CatalogTable): DeltaV2TableManager = {
-    val oldTable = _unsafeVolatileCatalogTable.getAndSet(table)
-    if (oldTable != null && oldTable.identifier != table.identifier) {
-      recordDeltaEvent(
-        null,
-        "deltaV2.catalog.multipleTablesForSameLog",
-        data = Map(
-          "oldTableIdentifier" -> oldTable.identifier,
-          "newTableIdentifier" -> table.identifier),
-        path = Some(tablePath))
-    }
-    this
-  }
-
-  initialCatalogTableOpt.foreach(withUnsafeVolatileCatalogTable)
 
   /** The table's data directory, fully qualified. */
   def tablePath: Path = qualifiedTableDataPath
@@ -83,9 +54,9 @@ private[tablemanager] class DeltaV2TableManagerImpl(
   override private[v2] lazy val kernelContext =
     KernelContext(sessionInvariantFsOptions, logStore)
 
-  override def snapshotManager(): DeltaV2SnapshotManager =
+  override lazy val snapshotManager: DeltaV2SnapshotManager =
     SnapshotManagerFactory.create(
       tablePath.toString,
       kernelContext.getDefaultEngine(),
-      unsafeVolatileCatalogTable.toJava)
+      initialCatalogTableOpt.toJava)
 }

--- a/spark/v2/src/main/scala/io/delta/spark/internal/v2/tablemanager/DeltaV2TableManagerImpl.scala
+++ b/spark/v2/src/main/scala/io/delta/spark/internal/v2/tablemanager/DeltaV2TableManagerImpl.scala
@@ -15,19 +15,25 @@
  */
 package io.delta.spark.internal.v2.tablemanager
 
+import java.util.concurrent.atomic.AtomicReference
+
+import scala.jdk.OptionConverters._
+
 import org.apache.spark.sql.delta.storage.LogStoreProvider
 import org.apache.spark.sql.delta.v2.interop.DeltaV2SnapshotManager
 import io.delta.spark.internal.v2.kernel.KernelContext
+import io.delta.spark.internal.v2.snapshot.SnapshotManagerFactory
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
 
 /**
- * Process-cached [[DeltaV2TableManager]] composite.
+ * Process-cached [[DeltaV2TableManager]] implementation.
  *
- * Placeholder: inherits default trait stubs. The real implementation (snapshot lifecycle and
- * freshness control) is added in a follow-up layer.
+ * The manager owns the table-scoped [[KernelContext]] but does not retain snapshot state. Each
+ * [[snapshotManager]] call uses [[SnapshotManagerFactory]] to create an uncached manager backed by
+ * the Kernel Engine shared through that context.
  *
  * @param qualifiedTableDataPath the fully-qualified table data directory (parent of `_delta_log`).
  * @param sessionInvariantFsOptions filesystem-prefixed credential options (`fs.*`, `dfs.*`) that
@@ -43,15 +49,31 @@ private[tablemanager] class DeltaV2TableManagerImpl(
     with LogStoreProvider
 {
 
+  private val _unsafeVolatileCatalogTable =
+    new AtomicReference[CatalogTable](initialCatalogTableOpt.orNull)
+
+  private[tablemanager] def unsafeVolatileCatalogTable: Option[CatalogTable] =
+    Option(_unsafeVolatileCatalogTable.get())
+
+  override private[tablemanager] def updateCatalogTable(
+      latestCatalogTableOpt: Option[CatalogTable]): Unit = {
+    latestCatalogTableOpt.foreach { catalogTable =>
+      _unsafeVolatileCatalogTable.set(catalogTable)
+    }
+  }
+
   /** The table's data directory, fully qualified. */
   def tablePath: Path = qualifiedTableDataPath
 
   /** Used to read and write physical log files and checkpoints. */
   private[tablemanager] lazy val logStore = createLogStore(SparkSession.active)
 
-  private[tablemanager] lazy val kernelContext = KernelContext(sessionInvariantFsOptions, logStore)
+  override private[v2] lazy val kernelContext =
+    KernelContext(sessionInvariantFsOptions, logStore)
 
-  // Placeholder until snapshot lifecycle is implemented.
   override def snapshotManager(): DeltaV2SnapshotManager =
-    throw new UnsupportedOperationException("snapshotManager not yet implemented")
+    SnapshotManagerFactory.create(
+      tablePath.toString,
+      kernelContext.getDefaultEngine(),
+      unsafeVolatileCatalogTable.toJava)
 }

--- a/spark/v2/src/main/scala/io/delta/spark/internal/v2/tablemanager/DeltaV2TableManagerImpl.scala
+++ b/spark/v2/src/main/scala/io/delta/spark/internal/v2/tablemanager/DeltaV2TableManagerImpl.scala
@@ -54,6 +54,7 @@ private[tablemanager] class DeltaV2TableManagerImpl(
   override private[v2] lazy val kernelContext =
     KernelContext(sessionInvariantFsOptions, logStore)
 
+  // TODO: Replace this factory-created snapshot manager with the cached data member.
   override def snapshotManager(
       catalogTableOpt: Option[CatalogTable]): DeltaV2SnapshotManager =
     SnapshotManagerFactory.create(

--- a/spark/v2/src/test/java/io/delta/spark/internal/v2/catalog/DeltaV2TableTest.java
+++ b/spark/v2/src/test/java/io/delta/spark/internal/v2/catalog/DeltaV2TableTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -34,6 +35,8 @@ import io.delta.spark.internal.v2.adapters.KernelMetadataAdapter;
 import io.delta.spark.internal.v2.adapters.KernelProtocolAdapter;
 import io.delta.spark.internal.v2.read.cdc.CDCSchemaContext;
 import io.delta.spark.internal.v2.snapshot.PathBasedSnapshotManager;
+import io.delta.spark.internal.v2.tablemanager.DeltaV2TableManager;
+import io.delta.spark.internal.v2.tablemanager.DeltaV2TableManagerCache$;
 import java.io.File;
 import java.lang.reflect.Method;
 import java.net.URI;
@@ -45,9 +48,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.Callable;
 import java.util.function.BiFunction;
 import java.util.stream.Stream;
 import org.apache.hadoop.fs.Path;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.TableIdentifier;
 import org.apache.spark.sql.catalyst.catalog.CatalogTable;
 import org.apache.spark.sql.catalyst.expressions.FileSourceConstantMetadataStructField;
@@ -58,6 +64,7 @@ import org.apache.spark.sql.connector.catalog.SupportsWrite;
 import org.apache.spark.sql.connector.expressions.Transform;
 import org.apache.spark.sql.connector.write.LogicalWriteInfo;
 import org.apache.spark.sql.delta.DeltaOptions;
+import org.apache.spark.sql.delta.Snapshot;
 import org.apache.spark.sql.delta.catalog.DeltaTableV2;
 import org.apache.spark.sql.delta.sources.DeltaSQLConf;
 import org.apache.spark.sql.delta.sources.DeltaSourceMetadataTrackingLog;
@@ -71,6 +78,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import scala.Option;
 
@@ -530,6 +538,101 @@ public class DeltaV2TableTest extends DeltaV2TestBase {
         "0",
         tableAtV0.version(),
         "version() should remain pinned to the construction-time snapshot");
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @EnumSource(ConstructionMethod.class)
+  public void testUsesTableManagerKernelContextAndLoadsSnapshotsAcrossSessions(
+      ConstructionMethod method, @TempDir File tempDir) throws Exception {
+    String path = tempDir.getAbsolutePath();
+    String tableName = "test_table_manager_" + method.name().toLowerCase();
+    spark.sql(String.format("CREATE TABLE %s (id INT) USING delta LOCATION '%s'", tableName, path));
+    Identifier identifier = Identifier.of(new String[] {"default"}, tableName);
+    SparkSession sessionA = spark.newSession();
+    SparkSession sessionB = spark.newSession();
+
+    DeltaV2TableManagerCache$.MODULE$.clearCache();
+    try {
+      CatalogTable catalogTableA =
+          withActiveSession(
+              sessionA,
+              () ->
+                  sessionA
+                      .sessionState()
+                      .catalog()
+                      .getTableMetadata(new TableIdentifier(tableName)));
+      CatalogTable catalogTableB =
+          withActiveSession(
+              sessionB,
+              () ->
+                  sessionB
+                      .sessionState()
+                      .catalog()
+                      .getTableMetadata(new TableIdentifier(tableName)));
+      Option<CatalogTable> catalogTableOptA =
+          method == ConstructionMethod.FROM_PATH ? Option.empty() : Option.apply(catalogTableA);
+      Option<CatalogTable> catalogTableOptB =
+          method == ConstructionMethod.FROM_PATH ? Option.empty() : Option.apply(catalogTableB);
+      DeltaV2Table table =
+          withActiveSession(
+              sessionA,
+              () ->
+                  method == ConstructionMethod.FROM_PATH
+                      ? new DeltaV2Table(identifier, path)
+                      : new DeltaV2Table(identifier, catalogTableA, Collections.emptyMap()));
+      DeltaV2TableManager managerA =
+          DeltaV2TableManagerCache$.MODULE$.forTable(
+              sessionA, path, Collections.emptyMap(), catalogTableOptA);
+      DeltaV2TableManager managerB =
+          DeltaV2TableManagerCache$.MODULE$.forTable(
+              sessionB, path, Collections.emptyMap(), catalogTableOptB);
+
+      assertTrue(table.getSnapshotManager() instanceof PathBasedSnapshotManager);
+      assertSame(managerA, managerB);
+      assertSame(managerA.kernelContext().getDefaultEngine(), table.kernelEngine());
+      assertEquals("0", table.version());
+
+      withActiveSession(
+          sessionA,
+          () -> {
+            sessionA.sql(String.format("INSERT INTO %s VALUES (1)", tableName));
+            assertLatestSnapshot(table, sessionA, 1L, 1L);
+            return null;
+          });
+      withActiveSession(
+          sessionB,
+          () -> {
+            sessionB.sql(String.format("INSERT INTO %s VALUES (2)", tableName));
+            assertLatestSnapshot(table, sessionB, 2L, 2L);
+            return null;
+          });
+    } finally {
+      DeltaV2TableManagerCache$.MODULE$.clearCache();
+      spark.sql(String.format("DROP TABLE IF EXISTS %s", tableName));
+    }
+  }
+
+  private static void assertLatestSnapshot(
+      DeltaV2Table table, SparkSession activeSession, long expectedVersion, long expectedFiles) {
+    Snapshot snapshot = table.getSnapshotManager().loadLatestSnapshot();
+    Dataset<?> allFiles = snapshot.allFiles();
+    assertEquals(expectedVersion, snapshot.version());
+    assertSame(activeSession, allFiles.sparkSession());
+    assertEquals(expectedFiles, allFiles.count());
+  }
+
+  private static <T> T withActiveSession(SparkSession session, Callable<T> body) throws Exception {
+    Option<SparkSession> originalSession = SparkSession.getActiveSession();
+    SparkSession.setActiveSession(session);
+    try {
+      return body.call();
+    } finally {
+      if (originalSession.isDefined()) {
+        SparkSession.setActiveSession(originalSession.get());
+      } else {
+        SparkSession.clearActiveSession();
+      }
+    }
   }
 
   @Test

--- a/spark/v2/src/test/scala/io/delta/spark/internal/v2/tablemanager/DeltaV2TableManagerImplSuite.scala
+++ b/spark/v2/src/test/scala/io/delta/spark/internal/v2/tablemanager/DeltaV2TableManagerImplSuite.scala
@@ -47,7 +47,7 @@ class DeltaV2TableManagerImplSuite
   }
 
   private def forPathAndCatalogManagers(
-      path: String)(testFn: DeltaV2TableManagerImpl => Unit): Unit = {
+      path: String)(testFn: (DeltaV2TableManagerImpl, Option[CatalogTable]) => Unit): Unit = {
     val catalogTable = CatalogTable(
       identifier = TableIdentifier("test_table"),
       tableType = CatalogTableType.EXTERNAL,
@@ -61,7 +61,7 @@ class DeltaV2TableManagerImplSuite
             .forTable(spark, path, Collections.emptyMap(), catalogTableOpt)
             .asInstanceOf[DeltaV2TableManagerImpl]
           assert(manager.initialCatalogTableOpt === catalogTableOpt)
-          testFn(manager)
+          testFn(manager, catalogTableOpt)
         }
     }
   }
@@ -73,11 +73,11 @@ class DeltaV2TableManagerImplSuite
       spark.range(1, 2, 1, 1).write.format("delta").mode("append").save(path)
       spark.range(2, 3, 1, 1).write.format("delta").mode("append").save(path)
 
-      forPathAndCatalogManagers(path) { manager =>
+      forPathAndCatalogManagers(path) { (manager, catalogTableOpt) =>
         val kernelEngine = manager.kernelContext.getDefaultEngine()
-        val atVersionZeroManager = manager.snapshotManager
-        val atVersionOneManager = manager.snapshotManager
-        val latestManager = manager.snapshotManager
+        val atVersionZeroManager = manager.snapshotManager(catalogTableOpt)
+        val atVersionOneManager = manager.snapshotManager(catalogTableOpt)
+        val latestManager = manager.snapshotManager(catalogTableOpt)
 
         assert(atVersionZeroManager ne atVersionOneManager)
         assert(atVersionOneManager ne latestManager)

--- a/spark/v2/src/test/scala/io/delta/spark/internal/v2/tablemanager/DeltaV2TableManagerImplSuite.scala
+++ b/spark/v2/src/test/scala/io/delta/spark/internal/v2/tablemanager/DeltaV2TableManagerImplSuite.scala
@@ -1,0 +1,97 @@
+/*
+ * Copyright (2026) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.spark.internal.v2.tablemanager
+
+import java.util.Collections
+
+import org.apache.spark.sql.delta.catalog.DeltaCatalog
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.test.SharedSparkSession
+
+class DeltaV2TableManagerImplSuite
+    extends QueryTest
+    with SharedSparkSession {
+
+  override protected def sparkConf: SparkConf = super.sparkConf
+    .set("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
+    .set("spark.sql.catalog.spark_catalog", classOf[DeltaCatalog].getName)
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    DeltaV2TableManagerCache.clearCache()
+  }
+
+  override def afterEach(): Unit = {
+    DeltaV2TableManagerCache.clearCache()
+    super.afterEach()
+  }
+
+  test("snapshotManager returns a new uncached manager using the shared Kernel Engine") {
+    withTempDir { dir =>
+      spark.range(1).write.format("delta").save(dir.getCanonicalPath)
+      val impl = DeltaV2TableManagerCache
+        .forTable(spark, dir.getCanonicalPath, Collections.emptyMap())
+        .asInstanceOf[DeltaV2TableManagerImpl]
+
+      val kernelEngine = impl.kernelContext.getDefaultEngine()
+      val first = impl.snapshotManager()
+      val second = impl.snapshotManager()
+
+      assert(!(first eq second))
+      assert(impl.kernelContext.getDefaultEngine() eq kernelEngine)
+      assert(first.loadLatestSnapshot().version == 0)
+      assert(second.loadLatestSnapshot().version == 0)
+    }
+  }
+
+  test("retire remains a no-op for the uncached implementation") {
+    withTempDir { dir =>
+      val impl = DeltaV2TableManagerCache
+        .forTable(spark, dir.getCanonicalPath, Collections.emptyMap())
+        .asInstanceOf[DeltaV2TableManagerImpl]
+      val snapshotManager = impl.snapshotManager()
+
+      impl.retire()
+
+      assert(!(impl.snapshotManager() eq snapshotManager))
+    }
+  }
+
+  test("cached composite reuses the table manager and Kernel Engine") {
+    withSQLConf(DeltaSQLConf.DELTA_LOG_CACHE_SIZE.key -> "1000") {
+      withTempDir { dir =>
+        val first = DeltaV2TableManagerCache
+          .forTable(
+            spark,
+            dir.getCanonicalPath,
+            Collections.emptyMap())
+          .asInstanceOf[DeltaV2TableManagerImpl]
+        val second = DeltaV2TableManagerCache
+          .forTable(
+            spark,
+            dir.getCanonicalPath,
+            Collections.emptyMap())
+          .asInstanceOf[DeltaV2TableManagerImpl]
+
+        assert(first eq second)
+        assert(first.kernelContext.getDefaultEngine() eq second.kernelContext.getDefaultEngine())
+      }
+    }
+  }
+}

--- a/spark/v2/src/test/scala/io/delta/spark/internal/v2/tablemanager/DeltaV2TableManagerImplSuite.scala
+++ b/spark/v2/src/test/scala/io/delta/spark/internal/v2/tablemanager/DeltaV2TableManagerImplSuite.scala
@@ -42,7 +42,7 @@ class DeltaV2TableManagerImplSuite
     super.afterEach()
   }
 
-  test("snapshotManager reuses an uncached delegate and the shared Kernel Engine") {
+  test("snapshotManager creates uncached delegates using the shared Kernel Engine") {
     withTempDir { dir =>
       spark.range(1).write.format("delta").save(dir.getCanonicalPath)
       val impl = DeltaV2TableManagerCache
@@ -53,7 +53,7 @@ class DeltaV2TableManagerImplSuite
       val first = impl.snapshotManager
       val second = impl.snapshotManager
 
-      assert(first eq second)
+      assert(first ne second)
       assert(impl.kernelContext.getDefaultEngine() eq kernelEngine)
       assert(first.loadLatestSnapshot().version == 0)
       assert(second.loadLatestSnapshot().version == 0)

--- a/spark/v2/src/test/scala/io/delta/spark/internal/v2/tablemanager/DeltaV2TableManagerImplSuite.scala
+++ b/spark/v2/src/test/scala/io/delta/spark/internal/v2/tablemanager/DeltaV2TableManagerImplSuite.scala
@@ -15,6 +15,7 @@
  */
 package io.delta.spark.internal.v2.tablemanager
 
+import java.io.File
 import java.util.Collections
 
 import org.apache.spark.sql.delta.catalog.DeltaCatalog
@@ -22,7 +23,10 @@ import org.apache.spark.sql.delta.sources.DeltaSQLConf
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTable, CatalogTableType}
 import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.StructType
 
 class DeltaV2TableManagerImplSuite
     extends QueryTest
@@ -42,21 +46,55 @@ class DeltaV2TableManagerImplSuite
     super.afterEach()
   }
 
-  test("snapshotManager creates uncached delegates using the shared Kernel Engine") {
+  private def forPathAndCatalogManagers(
+      path: String)(testFn: DeltaV2TableManagerImpl => Unit): Unit = {
+    val catalogTable = CatalogTable(
+      identifier = TableIdentifier("test_table"),
+      tableType = CatalogTableType.EXTERNAL,
+      storage = CatalogStorageFormat.empty.copy(locationUri = Some(new File(path).toURI)),
+      schema = new StructType())
+    Seq("path-based" -> None, "catalog-backed" -> Some(catalogTable)).foreach {
+      case (label, catalogTableOpt) =>
+        DeltaV2TableManagerCache.clearCache()
+        withClue(s"$label manager: ") {
+          val manager = DeltaV2TableManagerCache
+            .forTable(spark, path, Collections.emptyMap(), catalogTableOpt)
+            .asInstanceOf[DeltaV2TableManagerImpl]
+          assert(manager.initialCatalogTableOpt === catalogTableOpt)
+          testFn(manager)
+        }
+    }
+  }
+
+  test("snapshotManager loads table history through path and catalog managers") {
     withTempDir { dir =>
-      spark.range(1).write.format("delta").save(dir.getCanonicalPath)
-      val impl = DeltaV2TableManagerCache
-        .forTable(spark, dir.getCanonicalPath, Collections.emptyMap())
-        .asInstanceOf[DeltaV2TableManagerImpl]
+      val path = dir.getCanonicalPath
+      spark.range(0, 1, 1, 1).write.format("delta").save(path)
+      spark.range(1, 2, 1, 1).write.format("delta").mode("append").save(path)
+      spark.range(2, 3, 1, 1).write.format("delta").mode("append").save(path)
 
-      val kernelEngine = impl.kernelContext.getDefaultEngine()
-      val first = impl.snapshotManager
-      val second = impl.snapshotManager
+      forPathAndCatalogManagers(path) { manager =>
+        val kernelEngine = manager.kernelContext.getDefaultEngine()
+        val atVersionZeroManager = manager.snapshotManager
+        val atVersionOneManager = manager.snapshotManager
+        val latestManager = manager.snapshotManager
 
-      assert(first ne second)
-      assert(impl.kernelContext.getDefaultEngine() eq kernelEngine)
-      assert(first.loadLatestSnapshot().version == 0)
-      assert(second.loadLatestSnapshot().version == 0)
+        assert(atVersionZeroManager ne atVersionOneManager)
+        assert(atVersionOneManager ne latestManager)
+        assert(manager.kernelContext.getDefaultEngine() eq kernelEngine)
+
+        val atVersionZero = atVersionZeroManager.loadSnapshotAt(0)
+        assert(atVersionZero.version == 0)
+        assert(atVersionZero.allFiles.count() == 1)
+
+        val atVersionOne = atVersionOneManager.loadSnapshotAt(1)
+        assert(atVersionOne.version == 1)
+        assert(atVersionOne.allFiles.count() == 2)
+
+        val latest = latestManager.loadLatestSnapshot()
+        assert(latest.version == 2)
+        assert(latest.allFiles.count() == 3)
+      }
     }
   }
 

--- a/spark/v2/src/test/scala/io/delta/spark/internal/v2/tablemanager/DeltaV2TableManagerImplSuite.scala
+++ b/spark/v2/src/test/scala/io/delta/spark/internal/v2/tablemanager/DeltaV2TableManagerImplSuite.scala
@@ -42,7 +42,7 @@ class DeltaV2TableManagerImplSuite
     super.afterEach()
   }
 
-  test("snapshotManager returns a new uncached manager using the shared Kernel Engine") {
+  test("snapshotManager reuses an uncached delegate and the shared Kernel Engine") {
     withTempDir { dir =>
       spark.range(1).write.format("delta").save(dir.getCanonicalPath)
       val impl = DeltaV2TableManagerCache
@@ -50,26 +50,13 @@ class DeltaV2TableManagerImplSuite
         .asInstanceOf[DeltaV2TableManagerImpl]
 
       val kernelEngine = impl.kernelContext.getDefaultEngine()
-      val first = impl.snapshotManager()
-      val second = impl.snapshotManager()
+      val first = impl.snapshotManager
+      val second = impl.snapshotManager
 
-      assert(!(first eq second))
+      assert(first eq second)
       assert(impl.kernelContext.getDefaultEngine() eq kernelEngine)
       assert(first.loadLatestSnapshot().version == 0)
       assert(second.loadLatestSnapshot().version == 0)
-    }
-  }
-
-  test("retire remains a no-op for the uncached implementation") {
-    withTempDir { dir =>
-      val impl = DeltaV2TableManagerCache
-        .forTable(spark, dir.getCanonicalPath, Collections.emptyMap())
-        .asInstanceOf[DeltaV2TableManagerImpl]
-      val snapshotManager = impl.snapshotManager()
-
-      impl.retire()
-
-      assert(!(impl.snapshotManager() eq snapshotManager))
     }
   }
 


### PR DESCRIPTION
## What changes

- Add a DeltaV2TableManager implementation that owns table-scoped Kernel context.
- Route DeltaV2Table construction through the table manager cache and its Kernel engine.
- Construct a fresh uncached snapshot manager for each request using caller catalog metadata.
- Preserve cache lifecycle and loader error-unwrapping behavior.
- Add focused coverage for snapshot construction, engine reuse, and cross-session snapshot loading in the Spark V2 module.

## Testing

- `sparkV2/testOnly io.delta.spark.internal.v2.catalog.DeltaV2TableTest`
- `sparkV2/testOnly io.delta.spark.internal.v2.tablemanager.DeltaV2TableManagerImplSuite`
- `spark/testOnly io.delta.spark.internal.v2.tablemanager.DeltaV2TableManagerCacheSuite`
- `sparkV2/Compile/javafmtCheck`
- `sparkV2/Test/javafmtCheck`
- `sparkV2/Test/scalafmtCheck`