### PR TITLE
[Spark] Canonicalize deletion vector paths for AMT checksum validation

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/Checksum.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Checksum.scala
@@ -878,9 +878,14 @@ trait ValidateChecksum extends DeltaLogging { self: Snapshot =>
     }
     // AMT manifest trees do not yet round-trip every AddFile field: `DataEntry.toAddFile` zeroes
     // `modificationTime`, forces `dataChange = false`, drops `tags`, and reduces `stats` to
-    // `{"numRecords":n}`. Project both sides through that lossy lens before comparing.
+    // `{"numRecords":n}`. Project those lossy fields before comparing.
     if (AMTUtils.amtEnabled(self)) {
       def normalizeForAmtTreeRoundTrip(f: AddFile): AddFile = f.copy(
+        // CRC and AMT reconstruction may use different path encodings for the same on-disk DV,
+        // so normalize both to absolute paths before comparing.
+        deletionVector = Option(f.deletionVector)
+          .map(_.copyWithAbsolutePath(deltaLog.dataPath))
+          .orNull,
         modificationTime = 0L,
         dataChange = false,
         tags = null,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTAllFilesInCrcSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/amt/AMTAllFilesInCrcSuite.scala
@@ -16,11 +16,14 @@
 
 package org.apache.spark.sql.delta.amt
 
+import org.apache.spark.sql.delta.{DeletionVectorsTestUtils, DeltaOperations}
+import org.apache.spark.sql.delta.actions.DeletionVectorDescriptor
+import org.apache.spark.sql.delta.deletionvectors.RoaringBitmapArray
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 
 import org.apache.spark.SparkConf
 
-class AMTAllFilesInCrcSuite extends AMTCheckpointTestBase {
+class AMTAllFilesInCrcSuite extends AMTCheckpointTestBase with DeletionVectorsTestUtils {
 
   override protected def sparkConf: SparkConf = super.sparkConf
     .set(DeltaSQLConf.DELTA_ALL_FILES_IN_CRC_ENABLED.key, "true")
@@ -57,6 +60,37 @@ class AMTAllFilesInCrcSuite extends AMTCheckpointTestBase {
     // And the CRC verifies clean (byte-identical) against a fresh state reconstruction.
     assert(snapshot.validateFileListAgainstCRC(crc, contextOpt = Some("AMTAllFilesInCrcSuite")),
       "a root-only AMT CRC must agree with state reconstruction.")
+  }
+
+  testAcrossAMTCheckpointScenarios(
+      "CRC validation canonicalizes equivalent deletion-vector path encodings",
+      "amt_crc_dv",
+      sqlConfs = Seq(DeltaSQLConf.DELTA_HISTORY_METRICS_ENABLED.key -> "false"))(
+      setup = name => appendRowsAsSeparateFiles(name, numFiles = 1, rowsPerFile = 2),
+      inlineCheckpointTriggerActionsOrSQL = Some { name =>
+        val log = deltaLogForName(name)
+        val files = log.update().allFiles.collect()
+        assert(files.length == 1)
+        Left((
+          writeFileWithDVOnDisk(log, files.head, RoaringBitmapArray(0L)),
+          DeltaOperations.Delete(predicate = Seq.empty)))
+      }) { context =>
+    val snapshot = context.postCheckpointSnapshot
+    assert(context.provider.leaves.isEmpty, "the AMT must be root-only.")
+
+    val crc = snapshot.deltaLog.readChecksum(snapshot.version).getOrElse(
+      fail(s"expected a CRC at version ${snapshot.version}."))
+    val crcFiles = crc.allFiles.getOrElse(
+      fail("a root-only AMT must persist allFiles in its CRC."))
+    val reconstructedFiles = snapshot.allFilesViaStateReconstruction.collect()
+    assert(crcFiles.length == 1 && reconstructedFiles.length == 1)
+
+    val crcDv = crcFiles.head.deletionVector
+    val reconstructedDv = reconstructedFiles.head.deletionVector
+    assert(crcDv.storageType == DeletionVectorDescriptor.UUID_DV_MARKER)
+    assert(reconstructedDv.storageType == DeletionVectorDescriptor.RELATIVE_DV_MARKER)
+    assert(snapshot.validateFileListAgainstCRC(
+      crc, contextOpt = Some("AMTAllFilesInCrcSuite")))
   }
 
   test("AMT tree with leaf manifests keeps its files out of the CRC") {


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

A root-only Adaptive Metadata Tree (AMT) checkpoint can persist a deletion vector in the checksum using a different path encoding from the descriptor produced by state reconstruction. Although both descriptors identify the same on-disk deletion vector, their raw representations compare unequal and checksum validation reports a mismatch.

This change canonicalizes deletion vector descriptors to absolute paths as part of the existing AMT round-trip normalization before comparing file lists. Other deletion vector fields remain part of the comparison.

## How was this patch tested?

- Added a regression test in `AMTAllFilesInCrcSuite` covering root-only AMT checkpoints with on-disk deletion vectors across inline incremental, deferred incremental, and deferred full checkpoints.
- Ran the three focused scenarios and the full `AMTAllFilesInCrcSuite` (9 tests).
- Ran Scala formatting checks.

## Does this PR introduce _any_ user-facing changes?

No. This corrects checksum comparison without changing table semantics, APIs, or the storage format.