### PR TITLE
[Delta Sharing] Fix stale DeltaLog cache hit after drop-and-recreate of a shared table

### DIFF
--- a/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingFileIndex.scala
+++ b/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingFileIndex.scala
@@ -96,6 +96,13 @@ case class DeltaSharingFileIndex(
       overrideLimit: Option[Long]): DeltaLog = {
     val jsonPredicateHints = DeltaSharingJsonPredicates.convert(
       partitionFilters, dataFilters, params.spark.sessionState.conf)
+    // Include the Delta table id (Metadata.id) in the query-params hash. Without it, dropping and
+    // recreating a shared table (same name, version rolls back to 0) produces the same hash, so
+    // the second query hits `DeltaLog.forTable`'s cache.
+    val metadataId = Option(params.deltaSharingTableMetadata.metadata)
+      .flatMap(m => Option(m.deltaMetadata))
+      .map(_.id)
+      .getOrElse("")
     val queryParamsHashId = DeltaSharingUtils.getQueryParamsHashId(
       params.options,
       // Using .sql instead of toString because it doesn't include class pointer, which
@@ -104,7 +111,8 @@ case class DeltaSharingFileIndex(
       dataFilters.map(_.sql).mkString(";"),
       jsonPredicateHints.getOrElse(""),
       overrideLimit.map(_.toString).getOrElse(""),
-      params.deltaSharingTableMetadata.version
+      params.deltaSharingTableMetadata.version,
+      metadataId
     )
     // listFiles will be called twice or more in a spark query, with this check we can avoid
     // duplicated work of making expensive rpc and constructing the delta log.

--- a/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingUtils.scala
+++ b/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingUtils.scala
@@ -330,10 +330,11 @@ object DeltaSharingUtils extends Logging {
       dataFiltersString: String,
       jsonPredicateHints: String,
       limitHint: String,
-      version: Long): String = {
+      version: Long,
+      metadataId: String): String = {
     val fullQueryString = s"${options.versionAsOf}_${options.timestampAsOf}_" +
       s"${partitionFiltersString}_${dataFiltersString}_${jsonPredicateHints}_${limitHint}_" +
-      s"${version}"
+      s"${metadataId}_${version}"
     Hashing.sha256().hashString(fullQueryString, UTF_8).toString
   }
 

--- a/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingUtilsSuite.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingUtilsSuite.scala
@@ -442,4 +442,27 @@ class DeltaSharingUtilsSuite extends SparkFunSuite with SharedSparkContext {
     assert(v1Lines.contains(headProtocol.json),
       s"v1 log should contain the unversioned head protocol, got: $v1Lines")
   }
+
+  private def hashWith(metadataId: String, version: Long = 0L): String = {
+    DeltaSharingUtils.getQueryParamsHashId(
+      options = new DeltaSharingOptions(Map("path" -> "share.schema.table")),
+      partitionFiltersString = "",
+      dataFiltersString = "",
+      jsonPredicateHints = "",
+      limitHint = "",
+      version = version,
+      metadataId = metadataId
+    )
+  }
+
+  test("getQueryParamsHashId is deterministic and sensitive to metadataId and version") {
+    // Same (metadataId, version) => same hash.
+    assert(hashWith("table-uuid-a", version = 1L) == hashWith("table-uuid-a", version = 1L))
+
+    // Same version, different metadataId => different hash.
+    assert(hashWith("table-uuid-a", version = 0L) != hashWith("table-uuid-b", version = 0L))
+
+    // Same metadataId, different version => different hash.
+    assert(hashWith("table-uuid-a", version = 0L) != hashWith("table-uuid-a", version = 1L))
+  }
 }


### PR DESCRIPTION
## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

OSS Spark reads a Delta Sharing table (USING deltaSharing) against a Databricks share. After a query touches the table, the user drops it in Unity Catalog and recreates it under the same name(when databricks grants privileges at the database/schema level, the table can be dropped) . Subsequent queries in the same session then show:

1. Stale reads — returns rows from the old snapshot.
2. Delayed URL-refresh failure (some time later) — :  cannot find url for id <fileId>....

### Root Cause
DeltaLog.forTable(spark, "delta-sharing-log:///<path>_<queryParamsHashId>") is backed by a process-wide cache keyed purely on the path. When old and new incarnations both sit at version=0 and every other query param is equal, queryParamsHashId collides — the second query gets back the old DeltaLog and its cached AddFiles / file-id → URL mapping in CachedTableManager. The URL refresher then keeps refreshing file ids the server no longer knows about → the IllegalStateException above.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Add new ut

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No