### PR TITLE
[Kernel] Allow time travel across catalogManaged transitions

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/table/SnapshotFactory.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/table/SnapshotFactory.java
@@ -208,9 +208,7 @@ public class SnapshotFactory {
       metadata = result.metadata;
     }
 
-    // We require maxCatalogVersion to be provided for catalogManaged tables. We cannot validate
-    // this earlier since we need to first load the protocol.
-    validateMaxCatalogVersionPresence(protocol);
+    validateMaxCatalogVersionPresence(engine, protocol);
 
     // TODO: When LogReplay becomes static utilities, we can create it inside of SnapshotImpl
     final LogReplay logReplay = new LogReplay(engine, tablePath, lazyLogSegment, lazyCrcInfo);
@@ -275,7 +273,39 @@ public class SnapshotFactory {
     return Optional.empty();
   }
 
-  private void validateMaxCatalogVersionPresence(Protocol protocol) {
+  /**
+   * Validates maxCatalogVersion presence for the current query.
+   *
+   * <p>Latest queries validate against the loaded protocol, and timestamp queries validate against
+   * their supplied latest snapshot. Version time travel is already bounded when maxCatalogVersion
+   * is present or the target snapshot is filesystem-managed. Without either, a catalogManaged
+   * target is ambiguous: it could be a valid historical version after downgrade or an incorrect
+   * path-based read of a current catalogManaged table. In that case only, load the latest protocol
+   * to distinguish the two.
+   */
+  private void validateMaxCatalogVersionPresence(Engine engine, Protocol snapshotProtocol) {
+    if (!ctx.versionOpt.isPresent()) {
+      Protocol latestProtocol =
+          ctx.timestampQueryContextOpt
+              .map(query -> query._1.getProtocol())
+              .orElse(snapshotProtocol);
+      validateMaxCatalogVersionPresenceAgainstProtocol(latestProtocol);
+      return;
+    }
+
+    if (ctx.maxCatalogVersion.isPresent()
+        || !TableFeatures.isCatalogManagedSupported(snapshotProtocol)) {
+      return;
+    }
+
+    SnapshotQueryContext latestContext =
+        SnapshotQueryContext.forLatestSnapshot(tablePath.toString());
+    Protocol latestProtocol =
+        new SnapshotManager(tablePath).buildLatestSnapshot(engine, latestContext).getProtocol();
+    validateMaxCatalogVersionPresenceAgainstProtocol(latestProtocol);
+  }
+
+  private void validateMaxCatalogVersionPresenceAgainstProtocol(Protocol protocol) {
     boolean isCatalogManaged = TableFeatures.isCatalogManagedSupported(protocol);
     if (isCatalogManaged) {
       checkArgument(

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/catalogManaged/SnapshotBuilderSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/catalogManaged/SnapshotBuilderSuite.scala
@@ -421,27 +421,12 @@ class SnapshotBuilderSuite extends AnyFunSuite
       .build(emptyMockEngine)
   }
 
-  test("validateMaxCatalogVersionPresence: catalogManaged table requires maxCatalogVersion") {
-    val exMsg = intercept[IllegalArgumentException] {
-      TableManager.loadSnapshot(dataPath.toString)
-        .atVersion(1)
-        .withProtocolAndMetadata(protocolWithCatalogManagedSupport, metadata)
-        .build(emptyMockEngine)
-    }.getMessage
-
-    assert(exMsg === "Must provide maxCatalogVersion for catalogManaged tables")
+  test("version time travel with maxCatalogVersion skips protocol-presence validation") {
+    TableManager.loadSnapshot(dataPath.toString)
+      .atVersion(1)
+      .withProtocolAndMetadata(protocol, metadata)
+      .withMaxCatalogVersion(1)
+      .build(emptyMockEngine)
   }
 
-  test(
-    "validateMaxCatalogVersionPresence: non-catalogManaged table cannot have maxCatalogVersion") {
-    val exMsg = intercept[IllegalArgumentException] {
-      TableManager.loadSnapshot(dataPath.toString)
-        .atVersion(1)
-        .withProtocolAndMetadata(protocol, metadata) // protocol without catalogManaged
-        .withMaxCatalogVersion(1)
-        .build(emptyMockEngine)
-    }.getMessage
-
-    assert(exMsg === "Should not provide maxCatalogVersion for file-system managed tables")
-  }
 }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/catalogManaged/CatalogManagedE2EReadSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/catalogManaged/CatalogManagedE2EReadSuite.scala
@@ -23,7 +23,7 @@ import io.delta.kernel.CommitRangeBuilder.CommitBoundary
 import io.delta.kernel.defaults.engine.hadoopio.HadoopFileIO
 import io.delta.kernel.defaults.utils.{TestRow, TestUtilsWithTableManagerAPIs, WriteUtilsWithV2Builders}
 import io.delta.kernel.exceptions.KernelException
-import io.delta.kernel.internal.DeltaHistoryManager
+import io.delta.kernel.internal.{DeltaHistoryManager, SnapshotImpl}
 import io.delta.kernel.internal.commitrange.CommitRangeImpl
 import io.delta.kernel.internal.files.{ParsedCatalogCommitData, ParsedLogData}
 import io.delta.kernel.internal.fs.Path
@@ -309,8 +309,6 @@ class CatalogManagedE2EReadSuite extends AnyFunSuite
     }
   }
 
-  // We test this in the unit tests as well, but since those use the withProtocolAndMetadata API
-  // we also test it here with a real table where we load the P&M from the log
   test("reading a catalogManaged table without providing maxCatalogVersion fails") {
     withCatalogOwnedPreviewTestTable { (tablePath, parsedLogData) =>
       // With logData
@@ -320,13 +318,34 @@ class CatalogManagedE2EReadSuite extends AnyFunSuite
           .withLogData(parsedLogData.asJava)
           .build(defaultEngine)
       }
-      // Without logData (and with time-travel-version)
+      // Without logData
       intercept[IllegalArgumentException] {
         TableManager
           .loadSnapshot(tablePath)
-          .atVersion(0)
           .build(defaultEngine)
       }
+    }
+  }
+
+  test("path-based catalogManaged version time travel after latest fails") {
+    withCatalogOwnedPreviewTestTable { (tablePath, parsedLogData) =>
+      val latestSnapshot = TableManager
+        .loadSnapshot(tablePath)
+        .atVersion(2)
+        .withLogData(parsedLogData.asJava)
+        .withMaxCatalogVersion(2)
+        .build(defaultEngine)
+        .asInstanceOf[SnapshotImpl]
+
+      val e = intercept[IllegalArgumentException] {
+        TableManager
+          .loadSnapshot(tablePath)
+          .atVersion(3)
+          // Bypass target-version file loading to isolate validation against the latest protocol.
+          .withProtocolAndMetadata(latestSnapshot.getProtocol, latestSnapshot.getMetadata)
+          .build(defaultEngine)
+      }
+      assert(e.getMessage === "Must provide maxCatalogVersion for catalogManaged tables")
     }
   }
 
@@ -341,6 +360,102 @@ class CatalogManagedE2EReadSuite extends AnyFunSuite
           .withMaxCatalogVersion(0)
           .build(engine)
       }
+    }
+  }
+
+  test("file-system version time travel after latest fails") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      createEmptyTable(tablePath = tablePath, schema = testSchema)
+
+      val e = intercept[KernelException] {
+        TableManager
+          .loadSnapshot(tablePath)
+          .atVersion(1)
+          .build(engine)
+      }
+      assert(e.getMessage.contains("latest available version is 0"))
+    }
+  }
+
+  test("time travel across catalogManaged upgrade") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      createEmptyTable(
+        engine = engine,
+        tablePath = tablePath,
+        schema = testSchema,
+        tableProperties = Map("delta.enableInCommitTimestamps" -> "true"))
+      val v0Snapshot = TableManager.loadSnapshot(tablePath).build(engine)
+      val v0Timestamp = v0Snapshot.getTimestamp(engine)
+
+      val catalogManagedCommit = getTestResourceFilePath(
+        "catalog-owned-preview/_delta_log/00000000000000000000.json")
+      val catalogManagedProtocol = java.nio.file.Files
+        .readAllLines(java.nio.file.Paths.get(catalogManagedCommit))
+        .asScala
+        .find(_.startsWith("{\"protocol\""))
+        .get
+      val upgradeCommit =
+        s"""{"commitInfo":{"inCommitTimestamp":${v0Timestamp + 1},""" +
+          s""""timestamp":${v0Timestamp + 1}}}""" + "\n" +
+          catalogManagedProtocol + "\n"
+      val logPath = new Path(tablePath, "_delta_log")
+      java.nio.file.Files.write(
+        java.nio.file.Paths.get(FileNames.deltaFile(logPath, 1)),
+        upgradeCommit.getBytes(java.nio.charset.StandardCharsets.UTF_8))
+
+      val versionSnapshot = TableManager
+        .loadSnapshot(tablePath)
+        .atVersion(0)
+        .withMaxCatalogVersion(1)
+        .build(engine)
+      assert(versionSnapshot.getVersion === 0)
+
+      val latestSnapshot = TableManager
+        .loadSnapshot(tablePath)
+        .withMaxCatalogVersion(1)
+        .build(engine)
+      val timestampSnapshot = TableManager
+        .loadSnapshot(tablePath)
+        .atTimestamp(v0Timestamp, latestSnapshot)
+        .withMaxCatalogVersion(1)
+        .build(engine)
+      assert(timestampSnapshot.getVersion === 0)
+    }
+  }
+
+  test("time travel across catalogManaged downgrade") {
+    withTempDir { tempDir =>
+      val source = new java.io.File(getTestResourceFilePath("catalog-owned-preview"))
+      org.apache.commons.io.FileUtils.copyDirectory(source, tempDir)
+
+      val logPath = new Path(tempDir.getCanonicalPath, "_delta_log")
+      val v0Timestamp = 1749830855993L
+      val protocolAction =
+        """{"protocol":{"minReaderVersion":3,"minWriterVersion":7,"readerFeatures":[],""" +
+          """"writerFeatures":["inCommitTimestamp","invariants","appendOnly",""" +
+          """"checkpointProtection"]}}""" + "\n"
+      val downgradeCommit =
+        s"""{"commitInfo":{"inCommitTimestamp":${v0Timestamp + 1},""" +
+          s""""timestamp":${v0Timestamp + 1}}}""" + "\n" +
+          protocolAction
+      java.nio.file.Files.write(
+        java.nio.file.Paths.get(FileNames.deltaFile(logPath, 1)),
+        downgradeCommit.getBytes(java.nio.charset.StandardCharsets.UTF_8))
+
+      val versionSnapshot = TableManager
+        .loadSnapshot(tempDir.getCanonicalPath)
+        .atVersion(0)
+        .build(defaultEngine)
+      assert(versionSnapshot.getVersion === 0)
+
+      val latestSnapshot = TableManager
+        .loadSnapshot(tempDir.getCanonicalPath)
+        .build(defaultEngine)
+      val timestampSnapshot = TableManager
+        .loadSnapshot(tempDir.getCanonicalPath)
+        .atTimestamp(v0Timestamp, latestSnapshot)
+        .build(defaultEngine)
+      assert(timestampSnapshot.getVersion === 0)
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Previously, the `validateMaxCatalogVersionPresence` check was too restrictive. If a table was upgraded from path-based to catalog-managed, then using Kernel to time travel to a version before the upgrade would fail because maxCatalogVersion would be present but catalogManaged is missing in that snapshot's Protocol. Similarly, if a table was downgraded from catalog-managed to path-based, then using Kernel to time travel to a version before the downgrade would fail because maxCatalogVersion would be missing but catalogManaged was present in that snapshot's Protocol.

This PR relaxes those checks to only validate max catalog version presence for:
* Latest version and timestamp-based time travel snapshot loads
* Version-based time travel snapshot loads if maxCatalogVersion is absent and the target version is catalogManaged

Version-based time travel has looser validations because version-based time travel snapshot loads do not load the latest snapshot. Thus, always validating maxCatalogVersion with respect to the latest Protocol would require an extra snapshot, which would be a performance regression. The only case where maxCatalogVersion is required in version-based time travel would be if the time travel version and latest version are both catalogManaged. If the latest version is file-based, it is ok for maxCatalogVersion to be missing.

Although it would technically be invalid for maxCatalogVersion to be present when the latest Protocol indicates a filesystem-based table, there is no real harm in allowing such a case, and it's not worth introducing an extra snapshot load for.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

Added unit tests and e2e tests for time travel across catalogManaged upgrade/downgrade versions

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No
