### PR TITLE
Move column mapping advice for DROP/RENAME COLUMN errors into error subclasses

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -3395,8 +3395,17 @@
   },
   "DELTA_UNSUPPORTED_DROP_COLUMN" : {
     "message" : [
-      "DROP COLUMN is not supported for your Delta table. <advice>"
+      "DROP COLUMN is not supported for your Delta table."
     ],
+    "subClass" : {
+      "ENABLE_COLUMN_MAPPING" : {
+        "message" : [
+          "Enable Column Mapping on your Delta table with mapping mode 'name' by running:",
+          "ALTER TABLE table_name SET TBLPROPERTIES ('delta.columnMapping.mode' = 'name').",
+          "If your table is not on the required protocol version it will be upgraded. Column mapping requires at least protocol (<readerVersion>, <writerVersion>)."
+        ]
+      }
+    },
     "sqlState" : "0AKDC"
   },
   "DELTA_UNSUPPORTED_DROP_NESTED_COLUMN_FROM_NON_STRUCT_TYPE" : {
@@ -3540,8 +3549,17 @@
   },
   "DELTA_UNSUPPORTED_RENAME_COLUMN" : {
     "message" : [
-      "Column rename is not supported for your Delta table. <advice>"
+      "Column rename is not supported for your Delta table."
     ],
+    "subClass" : {
+      "ENABLE_COLUMN_MAPPING" : {
+        "message" : [
+          "Enable Column Mapping on your Delta table with mapping mode 'name' by running:",
+          "ALTER TABLE table_name SET TBLPROPERTIES ('delta.columnMapping.mode' = 'name').",
+          "If your table is not on the required protocol version it will be upgraded. Column mapping requires at least protocol (<readerVersion>, <writerVersion>)."
+        ]
+      }
+    },
     "sqlState" : "0AKDC"
   },
   "DELTA_UNSUPPORTED_SCHEMA_DURING_READ" : {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -124,7 +124,6 @@ trait DocsPath {
     "concurrentModificationExceptionMsg",
     "incorrectLogStoreImplementationException",
     "sourceNotDeterministicInMergeException",
-    "columnMappingAdviceMessage",
     "icebergClassMissing",
     "tableFeatureReadRequiresWriteException",
     "tableFeatureRequiresHigherReaderProtocolVersion",
@@ -2556,29 +2555,32 @@ trait DeltaErrorsBase
         mode.name))
   }
 
-  protected def columnMappingAdviceMessage(
-      requiredProtocol: Protocol = ColumnMappingTableFeature.minProtocolVersion): String = {
-    val readerVersion = requiredProtocol.minReaderVersion
-    val writerVersion = requiredProtocol.minWriterVersion
-    s"""
-       |Please enable Column Mapping on your Delta table with mapping mode 'name'.
-       |You can use one of the following commands.
-       |
-       |ALTER TABLE table_name SET TBLPROPERTIES ('delta.columnMapping.mode' = 'name')
-       |
-       |Note, if your table is not on the required protocol version it will be upgraded.
-       |Column mapping requires at least protocol ($readerVersion, $writerVersion)
-       |""".stripMargin
+  /**
+   * Returns the error class (either `mainErrorClass` or `mainErrorClass.<subClass>`) and message
+   * parameters for the "enable Column Mapping" advice. When `suggestUpgrade` is false the advice is
+   * omitted and the bare `mainErrorClass` is returned.
+   */
+  protected def withColumnMappingAdviceSubClass(
+      mainErrorClass: String, suggestUpgrade: Boolean): (String, Array[String]) = {
+    if (!suggestUpgrade) {
+      return (mainErrorClass, Array.empty[String])
+    }
+    val readerVersion = ColumnMappingTableFeature.minProtocolVersion.minReaderVersion
+    val writerVersion = ColumnMappingTableFeature.minProtocolVersion.minWriterVersion
+    (s"$mainErrorClass.ENABLE_COLUMN_MAPPING",
+      Array(readerVersion.toString, writerVersion.toString))
   }
 
   def columnRenameNotSupported: Throwable = {
-    val adviceMsg = columnMappingAdviceMessage()
-    new DeltaAnalysisException("DELTA_UNSUPPORTED_RENAME_COLUMN", Array(adviceMsg))
+    val (errorClass, params) =
+      withColumnMappingAdviceSubClass("DELTA_UNSUPPORTED_RENAME_COLUMN", suggestUpgrade = true)
+    new DeltaAnalysisException(errorClass, params)
   }
 
   def dropColumnNotSupported(suggestUpgrade: Boolean): Throwable = {
-    val adviceMsg = if (suggestUpgrade) columnMappingAdviceMessage() else ""
-    new DeltaAnalysisException("DELTA_UNSUPPORTED_DROP_COLUMN", Array(adviceMsg))
+    val (errorClass, params) =
+      withColumnMappingAdviceSubClass("DELTA_UNSUPPORTED_DROP_COLUMN", suggestUpgrade)
+    new DeltaAnalysisException(errorClass, params)
   }
 
   def dropNestedColumnsFromNonStructTypeException(struct : DataType) : Throwable = {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaColumnRenameSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaColumnRenameSuite.scala
@@ -126,8 +126,11 @@ class DeltaColumnRenameSuite extends QueryTest
        val e = intercept[AnalysisException] {
         spark.sql(s"Alter table t1 RENAME COLUMN map to map1")
        }
-      assert(e.getMessage.contains("enable Column Mapping") &&
-        e.getMessage.contains("mapping mode 'name'"))
+      checkError(
+        e,
+        "DELTA_UNSUPPORTED_RENAME_COLUMN.ENABLE_COLUMN_MAPPING",
+        sqlState = Some("0AKDC"),
+        parameters = Map("readerVersion" -> "2", "writerVersion" -> "5"))
 
       alterTableWithProps("t1", Map(
         DeltaConfigs.COLUMN_MAPPING_MODE.key -> "name",
@@ -179,8 +182,11 @@ class DeltaColumnRenameSuite extends QueryTest
        val e = intercept[AnalysisException] {
         spark.sql(s"Alter table t1 RENAME COLUMN map to map1")
        }
-      assert(e.getMessage.contains("enable Column Mapping") &&
-        e.getMessage.contains("mapping mode 'name'"))
+      checkError(
+        e,
+        "DELTA_UNSUPPORTED_RENAME_COLUMN.ENABLE_COLUMN_MAPPING",
+        sqlState = Some("0AKDC"),
+        parameters = Map("readerVersion" -> "2", "writerVersion" -> "5"))
 
       // Upgrading this schema shouldn't cause any errors even if there are leaf column name
       // duplications such as a.c, b.c.

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -43,7 +43,7 @@ import org.apache.hadoop.fs.Path
 import org.json4s.JString
 import org.scalatest.GivenWhenThen
 
-import org.apache.spark.{SparkContext, SparkThrowable}
+import org.apache.spark.{ErrorClassesJsonReader, SparkContext, SparkThrowable}
 import org.apache.spark.sql.{AnalysisException, QueryTest, SparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
@@ -52,6 +52,7 @@ import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, ExprId, Length, LessThanOrEqual, Literal, SparkVersion}
 import org.apache.spark.sql.catalyst.expressions.Uuid
 import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
+import org.apache.spark.sql.catalyst.util.sideBySide
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
 import org.apache.spark.sql.connector.catalog.Identifier
 import org.apache.spark.sql.errors.QueryErrorsBase
@@ -90,8 +91,6 @@ trait DeltaErrorsSuiteBase
       DeltaErrors.incorrectLogStoreImplementationException(sparkConf, new Throwable()),
     "sourceNotDeterministicInMergeException" ->
       DeltaErrors.sourceNotDeterministicInMergeException(spark),
-    "columnMappingAdviceMessage" ->
-      DeltaErrors.columnRenameNotSupported,
     "icebergClassMissing" -> DeltaErrors.icebergClassMissing(sparkConf, new Throwable()),
     "tableFeatureReadRequiresWriteException" ->
       DeltaErrors.tableFeatureReadRequiresWriteException(requiredWriterVersion = 7),
@@ -3049,6 +3048,66 @@ trait DeltaErrorsSuiteBase
     }
     checkError(wrapped, "DELTA_CHANGELOG_READ_FAILED.PLAN_INPUT_PARTITIONS", "XXKDS",
       Map.empty[String, String])
+  }
+
+  // Message templates keyed by the fully-qualified error class (including any sub-class).
+  protected lazy val deltaErrorClassToInfoMap =
+    new ErrorClassesJsonReader(Seq(DeltaThrowableHelper.deltaErrorClassSource)).errorInfoMap
+
+  /**
+   * Asserts that the message of sub-class `subClass` is byte-for-byte identical across every error
+   * class in `errorClasses`. Duplicated messages that are meant to stay in sync drift apart over
+   * time; this check catches accidental divergence so a single edit cannot silently desync them.
+   */
+  protected def assertIdenticalSubClassMessage(
+      errorClasses: Seq[String], subClass: String): Unit = {
+    // Group the error classes by their message for `subClass`. They must all share one message,
+    // i.e. the grouping must collapse to a single entry.
+    val classesByMessage = errorClasses.groupBy { errorClass =>
+      deltaErrorClassToInfoMap(errorClass).subClass.getOrElse(Map.empty)(subClass).messageTemplate
+    }
+    if (classesByMessage.size > 1) {
+      val groups =
+        classesByMessage.values.map(_.sorted.mkString("{", ", ", "}")).mkString(", ")
+      val differingMessages = classesByMessage.keys.take(2).toSeq
+      val diff = sideBySide(differingMessages(0), differingMessages(1)).mkString("\n")
+      fail(
+        s"The '$subClass' sub-class message must be identical across " +
+          s"${errorClasses.mkString(", ")}, but these groups use different messages: " +
+          s"$groups\nExample difference:\n$diff")
+    }
+  }
+
+  test("ENABLE_COLUMN_MAPPING advice is identical across the DROP/RENAME COLUMN errors") {
+    assertIdenticalSubClassMessage(
+      Seq("DELTA_UNSUPPORTED_DROP_COLUMN", "DELTA_UNSUPPORTED_RENAME_COLUMN"),
+      "ENABLE_COLUMN_MAPPING")
+  }
+
+  test("DROP/RENAME COLUMN advise enabling column mapping") {
+    val minProtocol = ColumnMappingTableFeature.minProtocolVersion
+    val versionParams = Map(
+      "readerVersion" -> minProtocol.minReaderVersion.toString,
+      "writerVersion" -> minProtocol.minWriterVersion.toString)
+
+    // Without a column-mapping suggestion, only the base message (no sub-class) is used.
+    checkError(
+      intercept[DeltaAnalysisException] {
+        throw DeltaErrors.dropColumnNotSupported(suggestUpgrade = false)
+      },
+      "DELTA_UNSUPPORTED_DROP_COLUMN", "0AKDC", Map.empty[String, String])
+
+    checkError(
+      intercept[DeltaAnalysisException] {
+        throw DeltaErrors.dropColumnNotSupported(suggestUpgrade = true)
+      },
+      "DELTA_UNSUPPORTED_DROP_COLUMN.ENABLE_COLUMN_MAPPING", "0AKDC", versionParams)
+
+    checkError(
+      intercept[DeltaAnalysisException] {
+        throw DeltaErrors.columnRenameNotSupported
+      },
+      "DELTA_UNSUPPORTED_RENAME_COLUMN.ENABLE_COLUMN_MAPPING", "0AKDC", versionParams)
   }
 
   private def setCustomContext(session: SparkSession, context: SparkContext): Unit = {


### PR DESCRIPTION
## Description

`DELTA_UNSUPPORTED_DROP_COLUMN` and `DELTA_UNSUPPORTED_RENAME_COLUMN` previously injected their multi-line "enable column mapping" advice through an `<advice>` message parameter. Passing English message text through a parameter keeps it out of the error-class JSON, where it cannot be audited, documented, or localized.

This change moves that advice into an `ENABLE_COLUMN_MAPPING` error subclass on each of the two error classes, so the full message text lives in `delta-error-classes.json`. The subclass carries the required protocol reader/writer versions as `<readerVersion>`/`<writerVersion>` parameters. The wording is also tightened to an assertive tone (e.g. "Enable Column Mapping ..." instead of "Please enable Column Mapping ...").

## How was this patch tested?

Updated `DeltaErrorsSuite` and `DeltaColumnRenameSuite`:
- New `checkError` coverage asserting that DROP/RENAME COLUMN advise enabling column mapping.
- A test asserting the `ENABLE_COLUMN_MAPPING` advice is identical across the DROP and RENAME COLUMN errors.
- The rename-not-supported assertions now use `checkError` instead of inspecting message text.

## Does this PR introduce _any_ user-facing changes?

Yes. The rendered text of `DELTA_UNSUPPORTED_DROP_COLUMN` and `DELTA_UNSUPPORTED_RENAME_COLUMN` changes slightly: the column-mapping advice is now delivered as an error subclass rather than an inline parameter, and its wording is tightened. The error conditions and SQLSTATEs are unchanged.
