### PR TITLE
Round-trip stats column names after DROP COLUMN

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -2440,6 +2440,14 @@ trait DeltaSQLConfBase extends DeltaSQLConfUtils {
       .booleanConf
       .createWithDefault(true)
 
+  val DELTA_DROP_STATS_COLUMNS_ESCAPE_NAMES =
+    buildConf("stats.dropStatsColumns.escapeNames")
+      .internal()
+      .doc("Whether to properly escape surviving data skipping stats column names after dropping " +
+        "a column.")
+      .booleanConf
+      .createWithDefault(true)
+
   val DELTA_ALTER_TABLE_DROP_COLUMN_ENABLED =
     buildConf("alterTable.dropColumn.enabled")
       .internal()

--- a/spark/src/main/scala/org/apache/spark/sql/delta/stats/StatisticsCollection.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/stats/StatisticsCollection.scala
@@ -630,6 +630,7 @@ object StatisticsCollection extends DeltaCommand {
     val deltaStatsColumnSpec = configuredDeltaStatsColumnSpec(metadata)
     deltaStatsColumnSpec.deltaStatsColumnNamesOpt.map { deltaColumnsNames =>
       val droppedColumnSet = columnsToDrop.toSet
+      val escapeNames = SQLConf.get.getConf(DeltaSQLConf.DELTA_DROP_STATS_COLUMNS_ESCAPE_NAMES)
       val deltaStatsColumnStr = deltaColumnsNames
         .map(_.nameParts)
         .filterNot { attributeNameParts =>
@@ -640,7 +641,13 @@ object StatisticsCollection extends DeltaCommand {
             commonPrefix == droppedColumnParts.size
           }.nonEmpty
         }
-        .map(columnParts => UnresolvedAttribute(columnParts).name)
+        .map { columnParts =>
+          if (escapeNames) {
+            UnresolvedAttribute(columnParts).sql
+          } else {
+            UnresolvedAttribute(columnParts).name
+          }
+        }
         .mkString(",")
       Map(DeltaConfigs.DATA_SKIPPING_STATS_COLUMNS.key -> deltaStatsColumnStr)
     }.getOrElse(Map.empty[String, String])

--- a/spark/src/test/scala/org/apache/spark/sql/delta/stats/StatsCollectionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/stats/StatsCollectionSuite.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.stats.StatisticsCollection.{ASCII_MAX_CHARACTER, UTF8_MAX_CHARACTER}
 import org.apache.spark.sql.delta.test.{DeltaExceptionTestUtils, DeltaSQLCommandTest, DeltaSQLTestUtils, TestsStatistics}
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
-import org.apache.spark.sql.delta.util.{FileNames, JsonUtils}
+import org.apache.spark.sql.delta.util.{DeltaSqlParserUtils, FileNames, JsonUtils}
 import org.apache.hadoop.fs.Path
 import org.scalatest.exceptions.TestFailedException
 
@@ -481,6 +481,41 @@ class StatsCollectionSuite
         .toSeq
       val result1 = Seq(("delta.dataSkippingStatsColumns", "`c1.`,`c2*`,`c3,`,`c-4`"))
       assert(dataSkippingStatsColumns == result1)
+    }
+  }
+
+  test("drop Delta statistics columns round-trips escaped names") {
+    val tableName = "delta_table"
+    withTable(tableName) {
+      // Delta requires column mapping for DROP COLUMN, so use name mode for the ALTER TABLE path.
+      sql(
+        s"""CREATE TABLE $tableName (
+           |  `a,b` LONG,
+           |  `x.y` LONG,
+           |  x STRUCT<y: LONG>,
+           |  `a``b` LONG,
+           |  `a````b` LONG,
+           |  `a/b` LONG,
+           |  d LONG)
+           |USING delta
+           |TBLPROPERTIES (
+           |  'delta.dataSkippingStatsColumns' =
+           |    '`a,b`,`x.y`,x.y,`a``b`,`a````b`,`a/b`,d',
+           |  'delta.columnMapping.mode' = 'name')""".stripMargin)
+      sql(s"ALTER TABLE $tableName DROP COLUMN d")
+
+      val metadata = DeltaLog.forTable(spark, TableIdentifier(tableName)).update().metadata
+      val statsColumns = DeltaConfigs.DATA_SKIPPING_STATS_COLUMNS.fromMetaData(metadata).get
+      assert(statsColumns == "`a,b`,`x.y`,x.y,`a``b`,`a````b`,`a/b`")
+      assert(
+        DeltaSqlParserUtils.parseMultipartColumnList(statsColumns).get.map(_.nameParts) == Seq(
+          Seq("a,b"),
+          Seq("x.y"),
+          Seq("x", "y"),
+          Seq("a`b"),
+          Seq("a``b"),
+          Seq("a/b")))
+      StatisticsCollection.validateDeltaStatsColumns(metadata)
     }
   }
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [x] Spark

## Description

When a column is dropped from a Delta table, the surviving data skipping stats
column names (`delta.dataSkippingStatsColumns`) were re-serialized using their
raw names rather than properly escaped identifiers. Column names containing
special characters — commas, dots, backticks, or slashes — could then no longer
be parsed back into their original multipart form, leaving the stored
stats-columns configuration invalid.

This change escapes the surviving stats column names using the SQL identifier
form so they round-trip correctly through a `DROP COLUMN`. The behavior is
guarded by the new `stats.dropStatsColumns.escapeNames` conf, enabled by default.

## How was this patch tested?

Added a unit test in `StatsCollectionSuite` that drops a column from a table
whose data skipping stats columns contain special characters and asserts the
surviving names round-trip and re-parse to their original multipart form.

## Does this PR introduce _any_ user-facing changes?

No.
